### PR TITLE
Lookup ApplicationInstanceReference matching an ApplicationId

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ApplicationId.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ApplicationId.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
-import com.google.inject.Inject;
 import com.yahoo.cloud.config.ApplicationIdConfig;
 
 /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
-import com.yahoo.log.LogLevel;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.applicationmodel.ApplicationInstance;
 import com.yahoo.vespa.applicationmodel.ServiceCluster;

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/ApplicationIdNotFoundException.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/ApplicationIdNotFoundException.java
@@ -7,4 +7,12 @@ package com.yahoo.vespa.orchestrator;
  * @author <a href="mailto:smorgrav@yahoo-inc.com">Toby</a>
  */
 public class ApplicationIdNotFoundException extends Exception {
+
+    public ApplicationIdNotFoundException() {
+        super();
+    }
+
+    public ApplicationIdNotFoundException(String reason) {
+        super(reason);
+    }
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
@@ -136,7 +136,7 @@ public class OrchestratorImpl implements Orchestrator {
     @Override
     public ApplicationInstanceStatus getApplicationInstanceStatus(
             final ApplicationId appId) throws ApplicationIdNotFoundException {
-        ApplicationInstanceReference appRef = OrchestratorUtil.toApplicationInstanceReference(appId);
+        ApplicationInstanceReference appRef = OrchestratorUtil.toApplicationInstanceReference(appId,instanceLookupService);
         return statusService.forApplicationInstance(appRef).getApplicationInstanceStatus();
     }
 
@@ -271,7 +271,8 @@ public class OrchestratorImpl implements Orchestrator {
             final ApplicationId appId,
             final ApplicationInstanceStatus status) throws ApplicationStateChangeDeniedException, ApplicationIdNotFoundException{
 
-        ApplicationInstanceReference appRef = OrchestratorUtil.toApplicationInstanceReference(appId);
+
+        ApplicationInstanceReference appRef = OrchestratorUtil.toApplicationInstanceReference(appId, instanceLookupService);
         try (MutableStatusRegistry statusRegistry =
                      statusService.lockApplicationInstance_forCurrentThreadOnly(appRef)) {
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
@@ -120,7 +120,7 @@ public class OrchestratorUtil {
                 .collect(Collectors.toList());
 
         if (appRefList.size() > 1) {
-            String msg = String.format("ApplicationId '%s' was not unique but mapped to '%s", appId, appRefList);
+            String msg = String.format("ApplicationId '%s' was not unique but mapped to '%s'", appId, appRefList);
             throw new ApplicationIdNotFoundException(msg);
         }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
@@ -116,7 +116,6 @@ public class OrchestratorUtil {
         Set<ApplicationInstanceReference> appRefs = instanceLookupService.knownInstances();
         List<ApplicationInstanceReference> appRefList = appRefs.stream()
                 .filter(a -> OrchestratorUtil.toApplicationId(a).equals(appId))
-                .filter(a -> a.equals(appId))
                 .collect(Collectors.toList());
 
         if (appRefList.size() > 1) {

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyInstanceLookupService.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyInstanceLookupService.java
@@ -37,7 +37,7 @@ public class DummyInstanceLookupService implements InstanceLookupService {
     static {
         apps.add(new ApplicationInstance<>(
                 new TenantId("test-tenant-id"),
-                new ApplicationInstanceId("application:instance"),
+                new ApplicationInstanceId("application:prod:utopia-1:instance"),
                 TestUtil.makeServiceClusterSet(
                         new ServiceCluster<>(
                                 new ClusterId("test-cluster-id-1"),
@@ -49,7 +49,7 @@ public class DummyInstanceLookupService implements InstanceLookupService {
                                                 ServiceMonitorStatus.UP),
                                         new ServiceInstance<>(
                                                 new ConfigId("storage/storage/2"),
-                                                new HostName("test2.prod.utpoia-1.vespahosted.ut1.yahoo.com"),
+                                                new HostName("test2.prod.utopoia-1.vespahosted.ut1.yahoo.com"),
                                                 ServiceMonitorStatus.UP))),
                         new ServiceCluster<>(
                                 new ClusterId("clustercontroller"),
@@ -65,7 +65,7 @@ public class DummyInstanceLookupService implements InstanceLookupService {
 
         apps.add(new ApplicationInstance<>(
                 new TenantId("mediasearch"),
-                new ApplicationInstanceId("imagesearch:default"),
+                new ApplicationInstanceId("imagesearch:prod:utopia-1:default"),
                 TestUtil.makeServiceClusterSet(
                         new ServiceCluster<>(
                                 new ClusterId("image"),
@@ -93,7 +93,7 @@ public class DummyInstanceLookupService implements InstanceLookupService {
 
         apps.add(new ApplicationInstance<>(
                 new TenantId("tenant-id-3"),
-                new ApplicationInstanceId("application-instance-3:default"),
+                new ApplicationInstanceId("application-instance-3:prod:utopia-1:default"),
                 TestUtil.makeServiceClusterSet(
                         new ServiceCluster<>(
                                 new ClusterId("cluster-id-3"),

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
@@ -216,7 +216,7 @@ public class OrchestratorImplTest {
         InstanceLookupService service = new DummyInstanceLookupService();
         String applicationInstanceId = service.findInstanceByHost(DummyInstanceLookupService.TEST1_HOST_NAME).get()
                 .reference().toString();
-        assertEquals("test-tenant-id:application:instance", applicationInstanceId);
+        assertEquals("test-tenant-id:application:prod:utopia-1:instance", applicationInstanceId);
     }
 
     @Test

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
@@ -291,7 +291,7 @@ public class OrchestratorImplTest {
 
     private boolean isInMaintenance(ApplicationId appId, HostName hostName) throws ApplicationIdNotFoundException {
         for (ApplicationInstance<ServiceMonitorStatus> app : DummyInstanceLookupService.getApplications()) {
-            if (app.reference().equals(OrchestratorUtil.toApplicationInstanceReference(appId))) {
+            if (app.reference().equals(OrchestratorUtil.toApplicationInstanceReference(appId,new DummyInstanceLookupService()))) {
                 return clustercontroller.isInMaintenance(app, hostName);
             }
         }

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorUtilTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorUtilTest.java
@@ -18,12 +18,12 @@ public class OrchestratorUtilTest {
 
     private static final ApplicationId APPID_1 = ApplicationId.from(
             TenantName.from("mediasearch"),
-            ApplicationName.from("tumblr-search"),
+            ApplicationName.from("imagesearch"),
             InstanceName.defaultName());
 
     private static final ApplicationInstanceReference APPREF_1 = new ApplicationInstanceReference(
-            new TenantId("test-tenant"),
-            new ApplicationInstanceId("test-application:test-environment:test-region:test-instance-key"));
+            new TenantId("test-tenant-id"),
+            new ApplicationInstanceId("application:prod:utopia-1:instance"));
 
     /**
      * Here we don't care how the internal of the different application

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorUtilTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorUtilTest.java
@@ -35,14 +35,14 @@ public class OrchestratorUtilTest {
     public void applicationid_conversion_are_symmetric() throws Exception {
 
         // From appId to appRef and back
-        ApplicationInstanceReference appRef = OrchestratorUtil.toApplicationInstanceReference(APPID_1);
+        ApplicationInstanceReference appRef = OrchestratorUtil.toApplicationInstanceReference(APPID_1, new DummyInstanceLookupService());
         ApplicationId appIdRoundTrip = OrchestratorUtil.toApplicationId(appRef);
 
         Assert.assertEquals(APPID_1, appIdRoundTrip);
 
         // From appRef to appId and back
         ApplicationId appId = OrchestratorUtil.toApplicationId(APPREF_1);
-        ApplicationInstanceReference appRefRoundTrip = OrchestratorUtil.toApplicationInstanceReference(appId);
+        ApplicationInstanceReference appRefRoundTrip = OrchestratorUtil.toApplicationInstanceReference(appId, new DummyInstanceLookupService());
 
         Assert.assertEquals(APPREF_1, appRefRoundTrip);
     }


### PR DESCRIPTION
We are using ApplicationId in our APIs but ApplicationInstanceReferences internally. The latter has more information than the ApplicationID and thus cannot be constructed (but it is still 1-1). 

Here we look at all ApplicationInstanceReferences to find the match given an ApplicationId.

@hakonhall  
