### PR TITLE
Fixup flushengine prune strategy (tls pruning).

### DIFF
--- a/searchcore/src/tests/proton/flushengine/prepare_restart_flush_strategy/prepare_restart_flush_strategy_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/prepare_restart_flush_strategy/prepare_restart_flush_strategy_test.cpp
@@ -72,7 +72,7 @@ public:
                                                                       targetType,
                                                                       flushedSerial,
                                                                       approxDiskBytes);
-        _result.push_back(std::make_shared<FlushContext>(handler, target, 0, 0));
+        _result.push_back(std::make_shared<FlushContext>(handler, target, 0));
         return *this;
     }
     ContextsBuilder &add(const vespalib::string &handlerName,

--- a/searchcore/src/tests/proton/server/memoryflush/memoryflush_test.cpp
+++ b/searchcore/src/tests/proton/server/memoryflush/memoryflush_test.cpp
@@ -105,7 +105,7 @@ public:
         return *this;
     }
     ContextBuilder &add(const IFlushTarget::SP &target, SerialNum lastSerial = 0) {
-        FlushContext::SP ctx(new FlushContext(_handler, target, 0, lastSerial));
+        FlushContext::SP ctx(new FlushContext(_handler, target, lastSerial));
         return add(ctx);
     }
     const FlushContext::List &list() const { return _list; }
@@ -282,22 +282,22 @@ requireThatWeCanOrderByTlsSize()
            (handler1,
             createTargetT("t2", TimeStamp(now.val() - 10 * TimeStamp::SEC),
                           1900),
-            2000, 2000)).
+            2000)).
         add(std::make_shared<FlushContext>
             (handler2,
              createTargetT("t1", TimeStamp(now.val() - 5 * TimeStamp::SEC),
                            1000),
-             2000, 2000)).
+             2000)).
         add(std::make_shared<FlushContext>
             (handler1,
              createTargetT("t4", TimeStamp(),
                            1000),
-             2000, 2000)).
+             2000)).
         add(std::make_shared<FlushContext>
             (handler2,
              createTargetT("t3", TimeStamp(now.val() - 15 * TimeStamp::SEC),
                            1900),
-             2000, 2000));
+             2000));
     { // sum of tls sizes above limit, trigger sort order based on tls size
         MemoryFlush flush({1000, 3 * gibi, 1.0, 1000, 1.0, 2000, TimeStamp(2 * TimeStamp::SEC)}, start);
         EXPECT_TRUE(assertOrder(StringList().add("t4").add("t1").add("t2").add("t3"),

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.cpp
@@ -10,13 +10,11 @@ namespace proton {
 FlushContext::FlushContext(
         const IFlushHandler::SP &handler,
         const IFlushTarget::SP &target,
-        search::SerialNum oldestFlushable,
         search::SerialNum lastSerial)
     : _name(createName(*handler, *target)),
       _handler(handler),
       _target(target),
       _task(),
-      _oldestFlushable(oldestFlushable),
       _lastSerial(lastSerial)
 {
     // empty

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.h
@@ -19,7 +19,6 @@ private:
     IFlushHandler::SP                 _handler;
     IFlushTarget::SP                  _target;
     searchcorespi::FlushTask::UP      _task;
-    search::SerialNum _oldestFlushable;
     search::SerialNum _lastSerial;
 
 public:
@@ -43,7 +42,6 @@ public:
      */
     FlushContext(const IFlushHandler::SP &handler,
                  const IFlushTarget::SP &target,
-                 search::SerialNum oldestFlushable,
                  search::SerialNum lastSerial);
 
     /**
@@ -81,13 +79,6 @@ public:
      * @return The target.
      */
     const IFlushTarget::SP & getTarget() const { return _target; }
-
-    /**
-     * Returns the oldest flushable serial number.
-     *
-     * @return The oldest flushable serial number
-     */
-    search::SerialNum getOldestFlushable() const { return _oldestFlushable; }
 
     /**
      * Returns the last serial number.

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -22,16 +22,13 @@ namespace {
 
 search::SerialNum
 findOldestFlushedSerial(const IFlushTarget::List &lst,
-                        const IFlushHandler &handler,
-                        const IFlushTarget *self)
+                        const IFlushHandler &handler)
 {
     search::SerialNum ret(handler.getCurrentSerialNumber());
     for (const IFlushTarget::SP & target : lst) {
-        if (self != target.get()) {
-            ret = std::min(ret, target->getFlushedSerialNum());
-        }
+        ret = std::min(ret, target->getFlushedSerialNum());
     }
-    LOG(debug, "Oldest flushed serial for '%s' will be %" PRIu64 " after flush.", handler.getName().c_str(), ret);
+    LOG(debug, "Oldest flushed serial for '%s' is %" PRIu64 ".", handler.getName().c_str(), ret);
     return ret;
 }
 
@@ -55,11 +52,10 @@ FlushEngine::FlushInfo::FlushInfo(uint32_t taskId,
 FlushEngine::FlushEngine(std::shared_ptr<flushengine::ITlsStatsFactory>
                          tlsStatsFactory,
                          IFlushStrategy::SP strategy, uint32_t numThreads,
-                         uint32_t idleIntervalMS, bool enableAutoPrune)
+                         uint32_t idleIntervalMS)
     : _closed(false),
       _maxConcurrent(numThreads),
       _idleIntervalMS(idleIntervalMS),
-      _enableAutoPrune(enableAutoPrune),
       _taskId(0),
       _threadPool(128 * 1024),
       _strategy(strategy),
@@ -70,7 +66,8 @@ FlushEngine::FlushEngine(std::shared_ptr<flushengine::ITlsStatsFactory>
       _flushing(),
       _strategyLock(),
       _strategyMonitor(),
-      _tlsStatsFactory(tlsStatsFactory)
+      _tlsStatsFactory(tlsStatsFactory),
+      _pendingPrune()
 {
     // empty
 }
@@ -128,10 +125,10 @@ bool
 FlushEngine::wait(size_t minimumWaitTimeIfReady)
 {
     MonitorGuard guard(_monitor);
-    if ( (minimumWaitTimeIfReady > 0) && canFlushMore(guard)) {
+    if ( (minimumWaitTimeIfReady > 0) && canFlushMore(guard) && _pendingPrune.empty()) {
         guard.wait(minimumWaitTimeIfReady);
     }
-    while ( ! canFlushMore(guard) ) {
+    while ( ! canFlushMore(guard) && _pendingPrune.empty()) {
         guard.wait(1000); // broadcast when flush done
     }
     return !_closed;
@@ -146,6 +143,9 @@ FlushEngine::Run(FastOS_ThreadInterface *thread, void *arg)
     vespalib::string prevFlushName;
     while (wait(shouldIdle ? _idleIntervalMS : 0)) {
         shouldIdle = false;
+        if (prune()) {
+            continue; // Prune attempted on one or more handlers
+        }
         prevFlushName = flushNextTarget(prevFlushName);
         if ( ! prevFlushName.empty()) {
             // Sleep at least 10 ms after a successful flush in order to avoid busy loop in case
@@ -154,23 +154,26 @@ FlushEngine::Run(FastOS_ThreadInterface *thread, void *arg)
         } else {
             shouldIdle = true;
         }
-        if (_enableAutoPrune) {
-            prune();
-        }
         LOG(debug, "Making another wait(idle=%s, timeMS=%d) last was '%s'", shouldIdle ? "true" : "false", shouldIdle ? _idleIntervalMS : 0, prevFlushName.c_str());
     }
 }
 
-void FlushEngine::prune()
+bool
+FlushEngine::prune()
 {
-    if (_flushing.empty()) {
+    std::set<IFlushHandler::SP> toPrune;
+    {
         MonitorGuard guard(_monitor);
-        for (const auto & it : _handlers) {
-            IFlushHandler & handler(*it.second);
-            IFlushTarget::List lst = handler.getFlushTargets();
-            handler.flushDone(findOldestFlushedSerial(lst, handler, NULL));
+        if (_pendingPrune.empty()) {
+            return false;
         }
+        _pendingPrune.swap(toPrune);
     }
+    for (const auto &handler : toPrune) {
+        IFlushTarget::List lst = handler->getFlushTargets();
+        handler->flushDone(findOldestFlushedSerial(lst, *handler));
+    }
+    return true;
 }
 
 bool FlushEngine::isFlushing(const MonitorGuard & guard, const vespalib::string & name) const
@@ -201,7 +204,6 @@ FlushEngine::getTargetList(bool includeFlushingTargets) const
                 if (!isFlushing(guard, FlushContext::createName(handler, *target)) || includeFlushingTargets) {
                     ret.push_back(FlushContext::SP(new FlushContext(it.second,
                                                                     IFlushTarget::SP(new CachedFlushTarget(target)),
-                                                                    findOldestFlushedSerial(lst, handler, target.get()),
                                                                     serial)));
                 } else {
                     LOG(debug, "Target '%s' with flushedSerialNum = %ld already has a flush going. Local last serial = %ld.",
@@ -263,7 +265,7 @@ FlushEngine::flushAll(const FlushContext::List &lst)
                            ctx->getName().c_str(),
                            ctx->getTarget()->getFlushedSerialNum() + 1,
                            ctx->getHandler()->getCurrentSerialNumber());
-                _executor.execute(Task::UP(new FlushTask(initFlush(*ctx), *this, ctx, ctx->getOldestFlushable())));
+                _executor.execute(Task::UP(new FlushTask(initFlush(*ctx), *this, ctx)));
             } else {
                 LOG(debug, "Target '%s' failed to initiate flush of transactions %" PRIu64 " through %" PRIu64 ".",
                            ctx->getName().c_str(),
@@ -303,7 +305,7 @@ FlushEngine::flushNextTarget(const vespalib::string & name)
                   name.c_str(), lst.first.size());
         FastOS_Thread::Sleep(1000);
     }
-    _executor.execute(Task::UP(new FlushTask(initFlush(*ctx), *this, ctx, ctx->getOldestFlushable())));
+    _executor.execute(Task::UP(new FlushTask(initFlush(*ctx), *this, ctx)));
     return ctx->getName();
 }
 
@@ -340,6 +342,8 @@ FlushEngine::flushDone(const FlushContext &ctx, uint32_t taskId)
     LOG(debug, "FlushEngine::flushDone(taskId='%d') took '%f' secs", taskId, duration.sec());
     MonitorGuard guard(_monitor);
     _flushing.erase(taskId);
+    assert(ctx.getHandler());
+    _pendingPrune.insert(ctx.getHandler());
     guard.broadcast();
 }
 
@@ -348,7 +352,12 @@ FlushEngine::putFlushHandler(const DocTypeName &docTypeName,
                              const IFlushHandler::SP &flushHandler)
 {
     MonitorGuard guard(_monitor);
-    return _handlers.putHandler(docTypeName, flushHandler);
+    IFlushHandler::SP result(_handlers.putHandler(docTypeName, flushHandler));
+    if (result) {
+        _pendingPrune.erase(result);
+    }
+    _pendingPrune.insert(flushHandler);
+    return std::move(result);
 }
 
 IFlushHandler::SP
@@ -362,7 +371,9 @@ IFlushHandler::SP
 FlushEngine::removeFlushHandler(const DocTypeName &docTypeName)
 {
     MonitorGuard guard(_monitor);
-    return _handlers.removeHandler(docTypeName);
+    IFlushHandler::SP result(_handlers.removeHandler(docTypeName));
+    _pendingPrune.erase(result);
+    return std::move(result);
 }
 
 FlushEngine::FlushMetaSet

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtask.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtask.cpp
@@ -9,12 +9,10 @@ namespace proton {
 
 FlushTask::FlushTask(uint32_t taskId,
                      FlushEngine &engine,
-                     const FlushContext::SP &ctx,
-                     search::SerialNum serial)
+                     const FlushContext::SP &ctx)
     : _taskId(taskId),
       _engine(engine),
-      _context(ctx),
-      _serial(serial)
+      _context(ctx)
 {
     LOG_ASSERT(_context.get() != NULL);
 }
@@ -34,7 +32,6 @@ FlushTask::run()
     }
     task->run();
     task.reset();
-    _context->getHandler()->flushDone(_serial);
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtask.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtask.h
@@ -25,13 +25,10 @@ public:
      * @param taskId The identifier used by IFlushStrategy.
      * @param engine The running flush engine.
      * @param ctx    The context of the flush to perform.
-     * @param serial The oldest unflushed serial available in the handler once
-     *               this task has been run.
      */
     FlushTask(uint32_t taskId,
               FlushEngine &engine,
-              const FlushContext::SP &ctx,
-              search::SerialNum serial);
+              const FlushContext::SP &ctx);
 
     /**
      * Destructor. Notifies the engine that the flush is done to prevent the

--- a/searchcore/src/vespa/searchcore/proton/flushengine/iflushhandler.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/iflushhandler.h
@@ -76,9 +76,10 @@ public:
      * up to the given serial number can be pruned from the domain of this
      * handler. This method is called by an arbitrary worker thread.
      *
-     * @param oldestSerial The oldest transaction that is still in use.
+     * @param flushedSerial Serial number flushed for all flush
+     *                      targets belonging to this handler.
      */
-    virtual void flushDone(SerialNum oldestSerial) = 0;
+    virtual void flushDone(SerialNum flushedSerial) = 0;
 
     /*
      * This method is called to sync tls to stable media, up to and

--- a/searchcore/src/vespa/searchcore/proton/server/configstore.h
+++ b/searchcore/src/vespa/searchcore/proton/server/configstore.h
@@ -33,6 +33,12 @@ struct ConfigStore : FeedConfigStore {
                             SerialNum serialNum) = 0;
 
     virtual void removeInvalid() = 0;
+    /**
+     * Perform prune after everything up to and including serialNum has been
+     * flushed to stable storage.
+     *
+     * @param serialNum The serial number flushed to stable storage.
+     */
     virtual void prune(SerialNum serialNum) = 0;
 
     virtual SerialNum getBestSerialNum() const = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -648,13 +648,13 @@ DocumentDB::onTransactionLogReplayDone()
 
 
 void
-DocumentDB::onPerformPrune(SerialNum oldestSerial)
+DocumentDB::onPerformPrune(SerialNum flushedSerial)
 {
     if (!getAllowPrune()) {
         assert(_state.getClosed());
         return;
     }
-    _config_store->prune(oldestSerial);
+    _config_store->prune(flushedSerial);
 }
 
 
@@ -760,9 +760,9 @@ DocumentDB::getFlushTargets()
 }
 
 void
-DocumentDB::flushDone(SerialNum oldestSerial)
+DocumentDB::flushDone(SerialNum flushedSerial)
 {
-    _feedHandler.flushDone(oldestSerial);
+    _feedHandler.flushDone(flushedSerial);
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -201,7 +201,7 @@ private:
      * Implements FeedHandler::IOwner
      */
     virtual void onTransactionLogReplayDone() __attribute__((noinline));
-    virtual void onPerformPrune(SerialNum oldestSerial);
+    virtual void onPerformPrune(SerialNum flushedSerial);
     virtual bool isFeedBlockedByRejectedConfig();
 
     /**
@@ -391,7 +391,7 @@ public:
     getDocsums(const search::engine::DocsumRequest & request);
 
     IFlushTarget::List getFlushTargets();
-    void flushDone(SerialNum oldestSerial);
+    void flushDone(SerialNum flushedSerial);
 
     virtual SerialNum
     getCurrentSerialNumber() const

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
@@ -62,7 +62,7 @@ public:
         virtual void performWipeHistory() = 0;
         virtual void onTransactionLogReplayDone() = 0;
         virtual void enterRedoReprocessState() = 0;
-        virtual void onPerformPrune(SerialNum oldestSerial) = 0;
+        virtual void onPerformPrune(SerialNum flushedSerial) = 0;
         virtual bool isFeedBlockedByRejectedConfig() = 0;
         virtual bool getAllowPrune() const = 0;
     };
@@ -153,10 +153,10 @@ private:
      * Used when flushing is done
      */
     void
-    performFlushDone(SerialNum oldestSerial);
+    performFlushDone(SerialNum flushedSerial);
 
     void
-    performPrune(SerialNum oldestSerial);
+    performPrune(SerialNum flushedSerial);
 
 public:
     void
@@ -240,10 +240,10 @@ public:
     /**
      * Called when a flush is done and allows pruning of the transaction log.
      *
-     * @param oldestSerial The oldest serial number that is still in use.
+     * @param flushedSerial serial number flushed for all relevant flush targets.
      */
     void
-    flushDone(SerialNum oldestSerial);
+    flushDone(SerialNum flushedSerial);
 
     /**
      * Used to flip between normal and recovery feed states.

--- a/searchcore/src/vespa/searchcore/proton/server/flushhandlerproxy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/flushhandlerproxy.cpp
@@ -36,9 +36,9 @@ FlushHandlerProxy::getCurrentSerialNumber(void) const
 
 
 void
-FlushHandlerProxy::flushDone(SerialNum oldestSerial)
+FlushHandlerProxy::flushDone(SerialNum flushedSerial)
 {
-    _documentDB->flushDone(oldestSerial);
+    _documentDB->flushDone(flushedSerial);
 }
 
 

--- a/searchcore/src/vespa/searchcore/proton/server/flushhandlerproxy.h
+++ b/searchcore/src/vespa/searchcore/proton/server/flushhandlerproxy.h
@@ -28,7 +28,7 @@ public:
     getCurrentSerialNumber(void) const;
 
     virtual void
-    flushDone(SerialNum oldestSerial);
+    flushDone(SerialNum flushedSerial);
 
     virtual void
     syncTls(SerialNum syncTo);

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -300,7 +300,7 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
     vespalib::chdir(protonConfig.basedir);
     _tls->start();
     _flushEngine.reset(new FlushEngine(std::make_shared<flushengine::TlsStatsFactory>(_tls->getTransLogServer()),
-                                       strategy, flush.maxconcurrent, flush.idleinterval*1000, true));
+                                       strategy, flush.maxconcurrent, flush.idleinterval*1000));
     _fs4Server.reset(new TransportServer(*_matchEngine, *_summaryEngine, *this, protonConfig.ptport, TransportServer::DEBUG_ALL));
     _fs4Server->setTCPNoDelay(true);
     _metricsEngine->addExternalMetrics(_fs4Server->getMetrics());


### PR DESCRIPTION
Stop calculating how much can be pruned in tls before starting a
flush task.  The state can be different after flush has been completed
due to other flush targets for same flush handler triggering tasks that
are run at the same time.

@geirst, please review
