### PR TITLE
the "Logger" is a Daemon thread

### DIFF
--- a/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
+++ b/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
@@ -45,6 +45,7 @@ public class LogFileHandler extends StreamHandler {
         LogFileHandler logFileHandler;
         public LogThread(LogFileHandler logFile) {
             super("Logger");
+            setDaemon(true);
             logFileHandler = logFile;
         }
         @Override


### PR DESCRIPTION
- this ensures the container can exit normally even if the access
  logging module isn't shutdown properly.

@gv as discussed, please merge
