### PR TITLE
Take lock at start of FlushEngine::setStrategy to avoid crash

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -395,6 +395,7 @@ FlushEngine::initFlush(const IFlushHandler::SP &handler, const IFlushTarget::SP 
 void
 FlushEngine::setStrategy(IFlushStrategy::SP strategy)
 {
+    vespalib::LockGuard strategyLock(_strategyLock);
     MonitorGuard strategyGuard(_strategyMonitor);
     if (_closed) {
         return;


### PR DESCRIPTION
issues with concurrent calls.

@geirst, please review
@ean, FYI
