### PR TITLE
ForceLoad must use Class.forName()

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/system/ForceLoad.java
+++ b/vespajlib/src/main/java/com/yahoo/system/ForceLoad.java
@@ -22,7 +22,7 @@ public class ForceLoad {
         try {
             for (String className : classNames) {
                 fullClassName = packageName + "." + className;
-                loader.loadClass(fullClassName);
+                Class.forName(fullClassName, true, loader);
             }
         } catch (Exception e) {
             throw new ForceLoadError(fullClassName, e);


### PR DESCRIPTION
- turns out that using ClassLoader.loadClass() won't run
  static initializers, so we must keep on using forName(),
  but now with extra arguments to specify which classloader
  to use.

@gv @bratseth @balder @ean FYI
