### PR TITLE
ignore SIGQUIT

### DIFF
--- a/vespalog/src/logger/runserver.cpp
+++ b/vespalog/src/logger/runserver.cpp
@@ -314,6 +314,8 @@ int main(int argc, char *argv[])
     const char *pidfile = "vespa-runserver.pid"; // XXX bad default?
     const char *killcmd = NULL;
 
+    signal(SIGQUIT, SIG_IGN);
+
     int ch;
     while ((ch = getopt(argc, argv, "k:s:r:p:Sh")) != -1) {
         switch (ch) {


### PR DESCRIPTION
- workaround for systemtest framework sending QUIT
  signal to processes that mention configserver on
  the command line.

@musum @ean FYI
