### PR TITLE
vespa/metrics is not a test

### DIFF
--- a/metrics/CMakeLists.txt
+++ b/metrics/CMakeLists.txt
@@ -7,10 +7,12 @@ vespa_define_module(
     staging_vespalib
     config_cloudconfig
 
+    LIBS
+    src/vespa/metrics
+
     TEST_EXTERNAL_DEPENDS
     cppunit
 
     TESTS
     src/tests
-    src/vespa/metrics
 )


### PR DESCRIPTION
- avoids getting cppunit as a dependency

@hmusum or @voffeloff please review and merge
