### PR TITLE
Treat POST as PATCH if override header is present

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -14,10 +14,10 @@ import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Configuration;
+import com.yahoo.vespa.hosted.provision.node.NodeFlavors;
 import com.yahoo.vespa.hosted.provision.node.filter.ApplicationFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
-import com.yahoo.vespa.hosted.provision.node.NodeFlavors;
 import com.yahoo.vespa.hosted.provision.node.filter.ParentHostFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.StateFilter;
 import com.yahoo.vespa.hosted.provision.restapi.v2.NodesResponse.ResponseType;
@@ -232,7 +232,14 @@ public class NodesApiHandler extends LoggingRequestHandler {
     private boolean isPatchOverride(HttpRequest request) {
         //Since Jersey's HttpUrlConnector does not support PATCH we support this by override this on POST requests.
         String override = request.getHeader("X-HTTP-Method-Override");
-        return override != null && override.equals("PATCH");
+        if (override != null) {
+            if (override.equals("PATCH")) {
+                return true;
+            } else {
+                String msg = String.format("Illegal X-HTTP-Method-Override header for POST request. Accepts 'PATCH' but got '%s'", override);
+                throw new IllegalArgumentException(msg);
+            }
+        }
+        return false;
     }
-
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -57,7 +57,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
             switch (request.getMethod()) {
                 case GET: return handleGET(request);
                 case PUT: return handlePUT(request);
-                case POST: return handlePOST(request);
+                case POST: return isPatchOverride(request) ? handlePATCH(request) : handlePOST(request);
                 case DELETE: return handleDELETE(request);
                 case PATCH: return handlePATCH(request);
                 default: return ErrorResponse.methodNotAllowed("Method '" + request.getMethod() + "' is not supported");
@@ -227,6 +227,12 @@ public class NodesApiHandler extends LoggingRequestHandler {
         int lastSlash = path.lastIndexOf("/");
         if (lastSlash < 0) return path;
         return path.substring(lastSlash + 1, path.length());
+    }
+
+    private boolean isPatchOverride(HttpRequest request) {
+        //Since Jersey's HttpUrlConnector does not support PATCH we support this by override this on POST requests.
+        String override = request.getHeader("X-HTTP-Method-Override");
+        return override != null && override.equals("PATCH");
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -151,6 +151,22 @@ public class RestApiTest {
     }
 
     @Test
+    public void post_with_patch_method_override_in_header_is_handled_as_patch() throws IOException  {
+        Request req = new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+                Utf8.toBytes("{\"currentRestartGeneration\": 1}"), Request.Method.POST);
+        req.getHeaders().add("X-HTTP-Method-Override", "PATCH");
+        assertResponse(req, "{\"message\":\"Updated host4.yahoo.com\"}");
+    }
+
+    @Test
+    public void post_with_invalid_method_override_in_header_gives_sane_error_message() throws IOException  {
+        Request req = new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+                Utf8.toBytes("{\"currentRestartGeneration\": 1}"), Request.Method.POST);
+        req.getHeaders().add("X-HTTP-Method-Override", "GET");
+        assertResponse(req, 400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Illegal X-HTTP-Method-Override header for POST request. Accepts 'PATCH' but got 'GET'\"}");
+    }
+
+    @Test
     public void testInvalidRequests() throws IOException {
         // Attempt to DELETE a node which is not put in failed first
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host8.yahoo.com",


### PR DESCRIPTION
Jersey's HttpUrlConnector does not support PATCH so to get to this rest api we support this with POST requests with a certain header included. 

@vekterli 
