### PR TITLE
Install searchlib as a bundle

### DIFF
--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -118,5 +118,10 @@
       <artifactId>config-bundle</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>searchlib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -118,6 +118,7 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>searchlib</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>com.yahoo.vespa</groupId>
@@ -155,17 +156,18 @@
           <Bundle-Activator>com.yahoo.container.jdisc.osgi.ContainerBundleActivator</Bundle-Activator>
           <discApplicationClass>com.yahoo.container.jdisc.ConfiguredApplication</discApplicationClass>
             <discPreInstallBundle>
+                component-jar-with-dependencies.jar,
                 config-bundle-jar-with-dependencies.jar,
                 configdefinitions-jar-with-dependencies.jar,
                 container-jersey2-jar-with-dependencies.jar,
                 container-search-and-docproc-jar-with-dependencies.jar,
+                defaults-jar-with-dependencies.jar,
                 docprocs-jar-with-dependencies.jar,
                 jdisc_http_service-jar-with-dependencies.jar,
                 persistence-jar-with-dependencies.jar,
-                vespaclient-container-plugin-jar-with-dependencies.jar,
+                searchlib-jar-with-dependencies.jar,
                 simplemetrics-jar-with-dependencies.jar,
-                defaults-jar-with-dependencies.jar,
-                component-jar-with-dependencies.jar,
+                vespaclient-container-plugin-jar-with-dependencies.jar,
                 <!-- jersey2 -->
                 aopalliance-repackaged-2.3.0-b05.jar,
                 hk2-api-2.3.0-b05.jar,

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -82,10 +82,6 @@
           <groupId>com.yahoo.vespa</groupId>
           <artifactId>jrt</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.yahoo.vespa</groupId>
-          <artifactId>searchlib</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -121,10 +117,6 @@
         <exclusion>
           <groupId>com.yahoo.vespa</groupId>
           <artifactId>jrt</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.yahoo.vespa</groupId>
-          <artifactId>searchlib</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -106,6 +106,7 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>searchlib</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
@bjorncs 
FYI: @bratseth, @ean 

.. instead of embedding into the container-disc bundle
- Add searchlib as a direct dependency of container-dev, as it
  was until now pulled in via container-search
- Remove invalid exclusions of searchlib
  - it's not pulled in transitively anymore, as it's been set to
    provided scope in container-search and container-disc
