### PR TITLE
simplify searchlib libraries

### DIFF
--- a/searchlib/src/vespa/searchlib/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/CMakeLists.txt
@@ -2,31 +2,35 @@
 vespa_add_library(searchlib
     SOURCES
     $<TARGET_OBJECTS:searchlib_aggregation>
-    $<TARGET_OBJECTS:searchlib_grouping>
     $<TARGET_OBJECTS:searchlib_attribute>
+    $<TARGET_OBJECTS:searchlib_bitcompression>
     $<TARGET_OBJECTS:searchlib_btree>
     $<TARGET_OBJECTS:searchlib_common>
+    $<TARGET_OBJECTS:searchlib_diskindex>
     $<TARGET_OBJECTS:searchlib_docstore>
     $<TARGET_OBJECTS:searchlib_engine>
     $<TARGET_OBJECTS:searchlib_expression>
+    $<TARGET_OBJECTS:searchlib_features>
+    $<TARGET_OBJECTS:searchlib_features_fieldmatch>
+    $<TARGET_OBJECTS:searchlib_features_rankingexpression>
     $<TARGET_OBJECTS:searchlib_fef>
     $<TARGET_OBJECTS:searchlib_fef_test>
     $<TARGET_OBJECTS:searchlib_fef_test_plugin>
+    $<TARGET_OBJECTS:searchlib_grouping>
+    $<TARGET_OBJECTS:searchlib_memoryindex>
     $<TARGET_OBJECTS:searchlib_parsequery>
     $<TARGET_OBJECTS:searchlib_predicate>
+    $<TARGET_OBJECTS:searchlib_query>
+    $<TARGET_OBJECTS:searchlib_query_tree>
+    $<TARGET_OBJECTS:searchlib_queryeval>
+    $<TARGET_OBJECTS:searchlib_queryeval_wand>
     $<TARGET_OBJECTS:searchlib_sconfig>
-    $<TARGET_OBJECTS:searchlib_searchlib_bitcompression>
-    $<TARGET_OBJECTS:searchlib_searchlib_diskindex>
     $<TARGET_OBJECTS:searchlib_searchlib_index>
-    $<TARGET_OBJECTS:searchlib_searchlib_memoryindex>
-    $<TARGET_OBJECTS:searchlib_translog>
+    $<TARGET_OBJECTS:searchlib_transactionlog>
     $<TARGET_OBJECTS:searchlib_util>
+
     INSTALL lib64
     DEPENDS
-    searchlib_features
-    searchlib_query
-    searchlib_queryeval
-    searchlib_queryeval_test
     staging_vespalib
     icuuc
     atomic

--- a/searchlib/src/vespa/searchlib/bitcompression/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/bitcompression/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_searchlib_bitcompression OBJECT
+vespa_add_library(searchlib_bitcompression OBJECT
     SOURCES
     compression.cpp
     countcompression.cpp

--- a/searchlib/src/vespa/searchlib/diskindex/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/diskindex/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_searchlib_diskindex OBJECT
+vespa_add_library(searchlib_diskindex OBJECT
     SOURCES
     bitvectordictionary.cpp
     bitvectorfile.cpp

--- a/searchlib/src/vespa/searchlib/features/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/features/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_features
+vespa_add_library(searchlib_features OBJECT
     SOURCES
     agefeature.cpp
     array_parser.cpp
@@ -57,8 +57,5 @@ vespa_add_library(searchlib_features
     utils.cpp
     valuefeature.cpp
     weighted_set_parser.cpp
-    $<TARGET_OBJECTS:searchlib_fieldmatch>
-    $<TARGET_OBJECTS:searchlib_rankingexpression>
-    INSTALL lib64
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/features/fieldmatch/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/features/fieldmatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_fieldmatch OBJECT
+vespa_add_library(searchlib_features_fieldmatch OBJECT
     SOURCES
     computer.cpp
     metrics.cpp

--- a/searchlib/src/vespa/searchlib/features/rankingexpression/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/features/rankingexpression/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_rankingexpression OBJECT
+vespa_add_library(searchlib_features_rankingexpression OBJECT
     SOURCES
     feature_name_extractor.cpp
     DEPENDS

--- a/searchlib/src/vespa/searchlib/memoryindex/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/memoryindex/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_searchlib_memoryindex OBJECT
+vespa_add_library(searchlib_memoryindex OBJECT
     SOURCES
     compact_document_words_store.cpp
     dictionary.cpp

--- a/searchlib/src/vespa/searchlib/query/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/query/CMakeLists.txt
@@ -1,12 +1,10 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_query
+vespa_add_library(searchlib_query OBJECT
     SOURCES
     queryterm.cpp
     querynode.cpp
     base.cpp
     query.cpp
     querynoderesultbase.cpp
-    $<TARGET_OBJECTS:searchlib_tree>
-    INSTALL lib64
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/query/tree/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/query/tree/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_tree OBJECT
+vespa_add_library(searchlib_query_tree OBJECT
     SOURCES
     intermediate.cpp
     intermediatenodes.cpp

--- a/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_queryeval
+vespa_add_library(searchlib_queryeval OBJECT
     SOURCES
     andnotsearch.cpp
     andsearch.cpp
@@ -48,7 +48,5 @@ vespa_add_library(searchlib_queryeval
     unpackinfo.cpp
     weighted_set_term_blueprint.cpp
     weighted_set_term_search.cpp
-    $<TARGET_OBJECTS:searchlib_queryeval_wand>
-    INSTALL lib64
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/test/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/test/CMakeLists.txt
@@ -5,7 +5,7 @@ vespa_add_library(searchlib_test
     statestring.cpp
     initrange.cpp
     document_weight_attribute_helper.cpp
-    $<TARGET_OBJECTS:searchlib_fakedata>
+    $<TARGET_OBJECTS:searchlib_test_fakedata>
     $<TARGET_OBJECTS:searchlib_searchlib_test_diskindex>
     DEPENDS
     searchlib_searchlib_test_memoryindex

--- a/searchlib/src/vespa/searchlib/test/fakedata/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/test/fakedata/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_fakedata OBJECT
+vespa_add_library(searchlib_test_fakedata OBJECT
     SOURCES
     fakeword.cpp
     fakewordset.cpp

--- a/searchlib/src/vespa/searchlib/transactionlog/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/transactionlog/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(searchlib_translog OBJECT
+vespa_add_library(searchlib_transactionlog OBJECT
     SOURCES
     common.cpp
     domain.cpp


### PR DESCRIPTION
- only searchlib will be installed
- other libraries under searchlib are all OBJECTS
- names updated to reflect directory structure
- fixes problem where linking failed on Ubuntu

@voffeloff please review and merge
