### PR TITLE
add back some configurable options

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#set -x
+
 if [ -z "${VESPA_HOME}" ]; then
     echo "Missing VESPA_HOME variable"
     exit 1
@@ -14,6 +16,8 @@ if [ -z "${VESPA_CONFIG_ID}" ]; then
     exit 1
 fi
 cd ${VESPA_HOME} || { echo "Cannot cd to ${VESPA_HOME}" 1>&2; exit 1; }
+
+. libexec/vespa/common-env.sh
 
 DISCRIMINATOR=`echo ${VESPA_CONFIG_ID} | md5sum | cut -d' ' -f1`
 CONTAINER_HOME="${VESPA_HOME}var/jdisc_container/${DISCRIMINATOR}/"
@@ -29,9 +33,6 @@ export LD_LIBRARY_PATH=${VESPA_HOME}lib64
 cfpfile=${CONTAINER_HOME}/jdisc.properties
 bundlecachedir=${CONTAINER_HOME}/bundlecache
 
-export JAVAVM_LD_PRELOAD=
-unset LD_PRELOAD
-
 # class path
 CP="${VESPA_HOME}lib/jars/jdisc_core-jar-with-dependencies.jar"
 
@@ -41,32 +42,108 @@ printenv > $cfpfile || exit 1
 # ??? TODO ??? XXX ???
 # LANG=en_US.utf8
 # LC_ALL=C
-# later, somewhere:
-# export YELL_MA_EURO=INXIGHT
 
-if [ "$PRELOAD" ]; then
-    export JAVAVM_LD_PRELOAD="$PRELOAD"
-    export LD_PRELOAD="$PRELOAD"
-fi
+
+getconfig() {
+    qrstartcfg=""
+    case "${VESPA_CONFIG_ID}" in
+	dir:*)
+            config_dir=${VESPA_CONFIG_ID#dir:}
+	    qrstartcfg="`cat ${config_dir}/qr-start.cfg`"
+	    ;;
+	*)
+            qrstartcfg="`getvespaconfig -w 10 -n search.config.qr-start -i ${VESPA_CONFIG_ID}`"
+	    ;;
+    esac
+    cmds=`echo "$qrstartcfg" | perl -ne 's/^(\w+)\.(\w+) (.*)/$1_$2=$3/ && print'`
+    eval "$cmds"
+}
+
+configure_memory() {
+    consider_fallback jvm_heapsize 1536
+    consider_fallback jvm_stacksize 512
+    consider_fallback jvm_baseMaxDirectMemorySize 75
+    consider_fallback jvm_directMemorySizeCache 0
+
+    if (( jvm_heapSizeAsPercentageOfPhysicalMemory > 0 && jvm_heapSizeAsPercentageOfPhysicalMemory < 100 )); then
+	available=`free -m | grep Mem | tr -s ' ' | cut -f2 -d' '`
+	jvm_heapsize=$[available * jvm_heapSizeAsPercentageOfPhysicalMemory / 100]
+	if (( jvm_heapsize < 1024 )); then
+            jvm_heapsize=1024
+	fi
+    fi
+    maxDirectMemorySize=$(( ${jvm_baseMaxDirectMemorySize} + ${jvm_heapsize}/8 + ${jvm_directMemorySizeCache} ))
+
+    memory_options="-Xms${jvm_heapsize}m -Xmx${jvm_heapsize}m"
+    memory_options="${memory_options} -XX:ThreadStackSize=${jvm_stacksize}"
+    memory_options="${memory_options} -XX:MaxDirectMemorySize=${maxDirectMemorySize}m"    
+
+    if [ "${VESPA_USE_HUGEPAGES}" ]; then
+	memory_options="${memory_options} -XX:+UseLargePages"
+    fi
+}
+
+configure_gcopts() {
+    consider_fallback jvm_gcopts "-XX:+UseConcMarkSweepGC -XX:MaxTenuringThreshold=15 -XX:NewRatio=1"
+    if [ "$jvm_verbosegc" = "true" ]; then
+	jvm_gcopts="${jvm_gcopts} -verbose:gc"
+    fi
+}
+
+configure_env_vars() {
+    if [ "$qrs_env" ]; then
+	for setting in ${qrs_env} ; do
+	    case $setting in
+		*"="*)
+		    eval "$setting";
+		    export ${setting%%=*}
+		    ;;
+		*)
+		    echo "warning	ignoring invalid qrs_env setting '$setting' from '$qrs_env'"
+		    ;;
+	    esac
+	done
+    fi
+}
+
+configure_classpath () {
+    if [ "${jdisc_classpath_extra}" ]; then
+	CP="${CP}:${jdisc_classpath_extra}"
+    fi
+}
+
+configure_preload () {
+    export JAVAVM_LD_PRELOAD=
+    unset LD_PRELOAD
+    if [ "$PRELOAD" ]; then
+	export JAVAVM_LD_PRELOAD="$PRELOAD"
+	export LD_PRELOAD="$PRELOAD"
+    fi
+}
+
+getconfig
+configure_memory
+configure_gcopts
+configure_env_vars
+configure_classpath
+# note: should be last thing here:
+configure_preload
 
 exec java \
-	-Xms1536m -Xmx1536m \
-	-XX:MaxDirectMemorySize=267m \
-	-XX:ThreadStackSize=512 \
-	-XX:+UseConcMarkSweepGC \
-	-XX:MaxTenuringThreshold=15 \
-	-XX:NewRatio=1 \
-	-XX:MaxJavaStackTraceDepth=-1 \
 	-Dconfig.id="${VESPA_CONFIG_ID}" \
-	-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="${VESPA_HOME}var/crash" \
+        ${memory_options} \
+        ${jvm_gcopts} \
+	-XX:MaxJavaStackTraceDepth=-1 \
+	-XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath="${VESPA_HOME}var/crash" \
 	-XX:OnOutOfMemoryError='kill -9 %p' \
 	-Djava.library.path="${VESPA_HOME}lib64" \
 	-Djava.awt.headless=true \
+	-Djavax.net.ssl.keyStoreType=JKS \
 	-Dsun.rmi.dgc.client.gcInterval=3600000 \
 	-Dsun.net.client.defaultConnectTimeout=5000 -Dsun.net.client.defaultReadTimeout=60000 \
-	-Djavax.net.ssl.keyStoreType=JKS \
 	-Djdisc.config.file="$cfpfile" \
-	-Djdisc.export.packages= \
+	-Djdisc.export.packages=${jdisc_export_packages} \
 	-Djdisc.cache.path="$bundlecachedir" \
 	-Djdisc.debug.resources=false \
 	-Djdisc.bundle.path="${VESPA_HOME}lib/jars" \
@@ -75,7 +152,8 @@ exec java \
 	-Djdisc.logger.tag="${VESPA_CONFIG_ID}" \
 	-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Jdk14Logger \
 	-Dvespa.log.control.dir="${VESPA_LOG_CONTROL_DIR}" \
-	-Dfile.encoding=UTF-8 \
 	-Dzookeeperlogfile="${ZOOKEEPER_LOG_FILE}" \
+	-Dfile.encoding=UTF-8 \
 	-cp "$CP" \
+        "$@" \
 	com.yahoo.jdisc.core.StandaloneMain file:${VESPA_HOME}lib/jars/container-disc-jar-with-dependencies.jar


### PR DESCRIPTION
- pass command-line arguments on (as jvm overrides)
- configure memory from qr-start config
- use extra classpath and export packages from qr-start config
- use environment variables from qr-start config
- take PRELOAD environment variable into account
- order arguments so config id is first (to make it easier to find the right
  process when looking at ps output)

@eirik please review and merge
@hmusum @bratseth FYI - should fix jvmtuning tests at least
