### PR TITLE
Rename to avoid reference to yinst

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/ComponentsProviderImpl.java
@@ -33,7 +33,7 @@ public class ComponentsProviderImpl implements ComponentsProvider{
         String baseHostName = java.util.Optional.ofNullable(System.getenv(ENV_HOSTNAME))
                 .orElseThrow(() -> new IllegalStateException("Environment variable " + ENV_HOSTNAME + " unset"));
 
-        Set<HostName> configServerHosts = Environment.getConfigServerHostsFromYinstSetting();
+        Set<HostName> configServerHosts = Environment.getConfigServerHosts();
         if (configServerHosts.isEmpty()) {
             throw new IllegalStateException("Environment setting for config servers missing or empty.");
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
@@ -232,7 +232,7 @@ public class DockerImpl implements Docker {
                                     .networkMode("none")
                                     .binds(applicationStorageToMount(containerName.asString()))
                                     .build())
-                    .env("CONFIG_SERVER_ADDRESS=" + Joiner.on(',').join(Environment.getConfigServerHostsFromYinstSetting())).
+                    .env("CONFIG_SERVER_ADDRESS=" + Joiner.on(',').join(Environment.getConfigServerHosts())).
                             hostname(hostName.s());
             if (minMainMemoryAvailableGb > 0.00001) {
                 containerConfigBuilder.memory((long) (GIGA * minMainMemoryAvailableGb));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorImpl.java
@@ -119,7 +119,7 @@ public class OrchestratorImpl implements Orchestrator {
     }
 
     public static OrchestratorImpl createOrchestratorFromSettings() {
-        final Set<HostName> configServerHosts = Environment.getConfigServerHostsFromYinstSetting();
+        final Set<HostName> configServerHosts = Environment.getConfigServerHosts();
         if (configServerHosts.isEmpty()) {
             throw new IllegalStateException("Environment setting for config servers missing or empty.");
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/Environment.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/Environment.java
@@ -22,13 +22,13 @@ public class Environment {
 
     public enum NetworkType { normal, local, vm }
 
-    public static Set<HostName> getConfigServerHostsFromYinstSetting() {
-        final String yinstSetting = System.getenv(ENV_CONFIGSERVERS);
-        if (yinstSetting == null) {
+    public static Set<HostName> getConfigServerHosts() {
+        final String configServerHosts = System.getenv(ENV_CONFIGSERVERS);
+        if (configServerHosts == null) {
             return Collections.emptySet();
         }
 
-        final List<String> hostNameStrings = Arrays.asList(yinstSetting.split("[,\\s]+"));
+        final List<String> hostNameStrings = Arrays.asList(configServerHosts.split("[,\\s]+"));
         return hostNameStrings.stream()
                 .map(HostName::new)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
- We get the value from an environment variable, even though
  it traditionally has been set with yinst

@hakonhall please review
