### PR TITLE
Loosen up version pattern requirements

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
@@ -272,7 +272,9 @@ public class DockerImpl implements Docker {
 
     // Returns empty if vespa version cannot be parsed.
     static Optional<String> parseVespaVersion(final String rawVespaVersion) {
-        final Matcher matcher = VESPA_VERSION_PATTERN.matcher(rawVespaVersion);
+        if (rawVespaVersion == null) return Optional.empty();
+
+        final Matcher matcher = VESPA_VERSION_PATTERN.matcher(rawVespaVersion.trim());
         return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
@@ -67,7 +67,7 @@ public class DockerImpl implements Docker {
     private static final int SECONDS_TO_WAIT_BEFORE_KILLING = 10;
     private static final String FRAMEWORK_CONTAINER_PREFIX = "/";
     static final String[] COMMAND_GET_VESPA_VERSION = new String[]{"vespa-nodectl", "vespa-version"};
-    private static final Pattern VESPA_VERSION_PATTERN = Pattern.compile("^(\\d+\\.\\d+\\S*)", Pattern.MULTILINE);
+    private static final Pattern VESPA_VERSION_PATTERN = Pattern.compile("^(\\S*)$", Pattern.MULTILINE);
 
     private static final String LABEL_NAME_MANAGEDBY = "com.yahoo.vespa.managedby";
     private static final String LABEL_VALUE_MANAGEDBY = "node-admin";

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImplTest.java
@@ -91,8 +91,10 @@ public class DockerImplTest {
     }
 
     @Test
-    public void vespaVersionIsParsedWithTrailingNewline() {
+    public void vespaVersionIsParsedWithSpacesAndNewlines() {
         assertThat(DockerImpl.parseVespaVersion("5.119.53\n"), is(Optional.of("5.119.53")));
+        assertThat(DockerImpl.parseVespaVersion(" 5.119.53 \n"), is(Optional.of("5.119.53")));
+        assertThat(DockerImpl.parseVespaVersion("\n 5.119.53 \n"), is(Optional.of("5.119.53")));
     }
 
     @Test
@@ -103,7 +105,7 @@ public class DockerImplTest {
         assertThat(DockerImpl.parseVespaVersion("119"), is(Optional.of("119")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void vespaVersionIsNotParsedFromNull() {
         assertThat(DockerImpl.parseVespaVersion(null), is(Optional.empty()));
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImplTest.java
@@ -99,6 +99,8 @@ public class DockerImplTest {
     public void vespaVersionIsParsedWithIrregularVersionScheme() {
         assertThat(DockerImpl.parseVespaVersion("7.2"), is(Optional.of("7.2")));
         assertThat(DockerImpl.parseVespaVersion("8.0-beta"), is(Optional.of("8.0-beta")));
+        assertThat(DockerImpl.parseVespaVersion("foo"), is(Optional.of("foo")));
+        assertThat(DockerImpl.parseVespaVersion("119"), is(Optional.of("119")));
     }
 
     @Test(expected = NullPointerException.class)
@@ -113,11 +115,6 @@ public class DockerImplTest {
 
     @Test
     public void vespaVersionIsNotParsedFromUnexpectedContent() {
-        assertThat(DockerImpl.parseVespaVersion("foo"), is(Optional.empty()));
-        assertThat(DockerImpl.parseVespaVersion("119"), is(Optional.empty()));
-        assertThat(DockerImpl.parseVespaVersion("vespa-5.119.53"), is(Optional.empty()));
-        assertThat(DockerImpl.parseVespaVersion("vespa- 5.119.53"), is(Optional.empty()));
-        assertThat(DockerImpl.parseVespaVersion("vespa-"), is(Optional.empty()));
         assertThat(DockerImpl.parseVespaVersion("No such command 'vespanodectl'"), is(Optional.empty()));
     }
 


### PR DESCRIPTION
Per discussion in a previous PR. How about this, which allows pretty much all versions that are strings
consisting of non-whitespace characters.

@hakonhall
