### PR TITLE
This one will never trigger....

### DIFF
--- a/slobrok/src/vespa/slobrok/server/rpchooks.cpp
+++ b/slobrok/src/vespa/slobrok/server/rpchooks.cpp
@@ -352,7 +352,7 @@ RPCHooks::rpc_wantAdd(FRT_RPCRequest *req)
     const char *dSpec  = args[2]._string._str;
     FRT_Values &retval = *req->GetReturn();
     OkState state = _rpcsrvmanager.addRemReservation(remsb, dName, dSpec);
-    if (state.failed() > 1) {
+    if (state.failed()) {
         req->SetError(FRTE_RPC_METHOD_FAILED, state.errorMsg.c_str());
     }
     retval.AddInt32(state.errorCode);


### PR DESCRIPTION
I got this one with gcc 6.1.

/home/balder/git/vespa/slobrok/src/vespa/slobrok/server/rpchooks.cpp: In member function 'void slobrok::RPCHooks::rpc_wantAdd(FRT_RPCRequest*)':
/home/balder/git/vespa/slobrok/src/vespa/slobrok/server/rpchooks.cpp:355:24: error: comparison of constant '1' with boolean expression is always false [-Werror=bool-compare]
     if (state.failed() > 1) {
         ~~~~~~~~~~~~~~~^~~
@arnej27959 PR
