### PR TITLE
fix race condition in legacy http server

### DIFF
--- a/fastlib/src/vespa/fastlib/net/httpserver.cpp
+++ b/fastlib/src/vespa/fastlib/net/httpserver.cpp
@@ -406,7 +406,7 @@ void
 Fast_HTTPServer::Stop(void) {
   _runningMutex.Lock();
   _stopSignalled = true;
-  if (_isRunning) {
+  if (_acceptThread) {
     _acceptThread->SetBreakFlag();
   }
   _runningMutex.Unlock();


### PR DESCRIPTION
this is a minimal fix to avoid shutdown hang when http server
start/stop gets reordered.

@arnej27959 please review
