### PR TITLE
simplify slobrok dependencies

### DIFF
--- a/messagebus/CMakeLists.txt
+++ b/messagebus/CMakeLists.txt
@@ -7,7 +7,6 @@ vespa_define_module(
     vespalib
     staging_vespalib
     fnet
-    slobrok
     slobrok_slobrokserver
 
     LIBS

--- a/slobrok/src/apps/slobrok/CMakeLists.txt
+++ b/slobrok/src/apps/slobrok/CMakeLists.txt
@@ -6,5 +6,4 @@ vespa_add_executable(slobrok_app
     INSTALL bin
     DEPENDS
     slobrok_slobrokserver
-    slobrok
 )

--- a/slobrok/src/tests/backoff/CMakeLists.txt
+++ b/slobrok/src/tests/backoff/CMakeLists.txt
@@ -3,7 +3,6 @@ vespa_add_executable(slobrok_backoff_test_app TEST
     SOURCES
     testbackoff.cpp
     DEPENDS
-    slobrok
     slobrok_slobrokserver
 )
 vespa_add_test(NAME slobrok_backoff_test_app COMMAND slobrok_backoff_test_app)

--- a/slobrok/src/tests/configure/CMakeLists.txt
+++ b/slobrok/src/tests/configure/CMakeLists.txt
@@ -8,7 +8,6 @@ vespa_add_executable(slobrok_configure_test_app TEST
     SOURCES
     configure.cpp
     DEPENDS
-    slobrok
     slobrok_slobrokserver
 )
 vespa_add_test(

--- a/slobrok/src/tests/mirrorapi/CMakeLists.txt
+++ b/slobrok/src/tests/mirrorapi/CMakeLists.txt
@@ -3,7 +3,6 @@ vespa_add_executable(slobrok_mirrorapi_test_app TEST
     SOURCES
     mirrorapi.cpp
     DEPENDS
-    slobrok
     slobrok_slobrokserver
 )
 vespa_add_test(NAME slobrok_mirrorapi_test_app COMMAND slobrok_mirrorapi_test_app)

--- a/slobrok/src/tests/oldapi/CMakeLists.txt
+++ b/slobrok/src/tests/oldapi/CMakeLists.txt
@@ -4,7 +4,6 @@ vespa_add_executable(slobrok_oldapi_test_app TEST
     old.cpp
     mirror.cpp
     DEPENDS
-    slobrok
     slobrok_slobrokserver
 )
 vespa_add_test(NAME slobrok_oldapi_test_app COMMAND slobrok_oldapi_test_app)

--- a/slobrok/src/tests/registerapi/CMakeLists.txt
+++ b/slobrok/src/tests/registerapi/CMakeLists.txt
@@ -3,7 +3,6 @@ vespa_add_executable(slobrok_registerapi_test_app TEST
     SOURCES
     registerapi.cpp
     DEPENDS
-    slobrok
     slobrok_slobrokserver
 )
 vespa_add_test(NAME slobrok_registerapi_test_app COMMAND slobrok_registerapi_test_app)

--- a/slobrok/src/tests/standalone/CMakeLists.txt
+++ b/slobrok/src/tests/standalone/CMakeLists.txt
@@ -4,6 +4,5 @@ vespa_add_executable(slobrok_standalone_test_app TEST
     standalone.cpp
     DEPENDS
     slobrok_slobrokserver
-    slobrok
 )
 vespa_add_test(NAME slobrok_standalone_test_app COMMAND slobrok_standalone_test_app)

--- a/slobrok/src/vespa/slobrok/server/CMakeLists.txt
+++ b/slobrok/src/vespa/slobrok/server/CMakeLists.txt
@@ -23,4 +23,5 @@ vespa_add_library(slobrok_slobrokserver
     metrics_producer.cpp
     INSTALL lib64
     DEPENDS
+    slobrok
 )


### PR DESCRIPTION
- the slobrokserver library needs classes from the slobrok
  client / utility library.  Modules that just want the server
  shouldn't need to worry about that explicitly.

@voffeloff please review and merge
