### PR TITLE
add "set -e" in jrt_test scripted tests

### DIFF
--- a/jrt_test/src/tests/echo/echo_test.sh
+++ b/jrt_test/src/tests/echo/echo_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 . ../../binref/env.sh
 sh dotest.sh || (sh $BINREF/progctl.sh progdefs.sh stop all; false)
 sh $BINREF/progctl.sh progdefs.sh stop all

--- a/jrt_test/src/tests/mandatory-methods/mandatory-methods_test.sh
+++ b/jrt_test/src/tests/mandatory-methods/mandatory-methods_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 . ../../binref/env.sh
 export PORT_1

--- a/jrt_test/src/tests/mockup-invoke/mockup-invoke_test.sh
+++ b/jrt_test/src/tests/mockup-invoke/mockup-invoke_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 . ../../binref/env.sh
 

--- a/jrt_test/src/tests/rpc-error/rpc-error_test.sh
+++ b/jrt_test/src/tests/rpc-error/rpc-error_test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 . ../../binref/env.sh
 


### PR DESCRIPTION
@voffeloff please review and merge

this "just works" for me:

$ grep jrt.test ctest.log.all 
        Start 115: jrt_test_mockup-server_app
        Start 116: jrt_test_test-errors_app
        Start 114: jrt_test_extract-reflection_app
 41/637 Test #115: jrt_test_mockup-server_app .......................................   Passed    8.76 sec
 42/637 Test #116: jrt_test_test-errors_app .........................................   Passed    4.42 sec
 43/637 Test #114: jrt_test_extract-reflection_app ..................................   Passed    2.33 sec
        Start 113: jrt_test_echo-client_app
231/637 Test #113: jrt_test_echo-client_app .........................................   Passed    1.40 sec
