### PR TITLE
Only log when not able to delete image

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerImpl.java
@@ -477,7 +477,9 @@ public class DockerImpl implements Docker {
             log.info("Deleting docker image " + dockerImage);
             final List<RemovedImage> removedImages = docker.removeImage(dockerImage.asString());
             for (RemovedImage removedImage : removedImages) {
-                log.info("Result of deleting docker image " + dockerImage + ": " + removedImage);
+                if (removedImage.type() != RemovedImage.Type.DELETED) {
+                    log.info("Result of deleting docker image " + dockerImage + ": " + removedImage);
+                }
             }
         } catch (InterruptedException e) {
             throw new RuntimeException("Unexpected interrupt", e);


### PR DESCRIPTION
- Exception is thrown when deleting image fails, this just prints something
  when removed image is not of type deleted.

@dybis or @freva 
