### PR TITLE
Support querying for one node from multiple states at the time

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -79,21 +79,24 @@ public class NodeRepository extends AbstractComponent {
 
     // ---------------- Query API ----------------------------------------------------------------
 
-    /** Finds and returns the node with the given hostname */
-    public Optional<Node> getNode(String hostname) {
-        for (Node.State state : Node.State.values()) {
-            Optional<Node> node = getNode(state, hostname);
-            if (node.isPresent())
-                return node;
-        }
-        return Optional.empty();
+    /** 
+     * Finds and returns the node with the hostname in any of the given states, or empty if not found 
+     * 
+     * @param hostname the full host name of the node
+     * @param inState the states the node may be in. If no states are given, it will be returned from any state
+     * @return the node, or empty if it was not found in any of the given states
+     */
+    public Optional<Node> getNode(String hostname, Node.State ... inState) {
+        return zkClient.getNode(hostname, inState);
     }
 
-    /** Finds and returns the node with the given state and hostname, or empty if not found */
-    public Optional<Node> getNode(Node.State state, String hostname) {
-        return zkClient.getNode(state, hostname);
-    }
-
+    /**
+     * Finds and returns the nodes of the given type in any of the given states.
+     *
+     * @param type the node type to return
+     * @param inState the states to return nodes from. If no states are given, all nodes of the given type is returned
+     * @return the node, or empty if it was not found in any of the given states
+     */
     public List<Node> getNodes(Node.Type type, Node.State ... inState) {
         return zkClient.getNodes(inState).stream().filter(node -> node.type().equals(type)).collect(Collectors.toList());
     }
@@ -185,9 +188,7 @@ public class NodeRepository extends AbstractComponent {
      * Use this to recycle failed nodes which have been repaired or put on hold. 
      */
     public Node deallocate(String hostname) {
-        Optional<Node> nodeToDeallocate = getNode(Node.State.failed, hostname);
-        if ( ! nodeToDeallocate.isPresent())
-            nodeToDeallocate = getNode(Node.State.parked, hostname);
+        Optional<Node> nodeToDeallocate = getNode(hostname, Node.State.failed, Node.State.parked);
         if ( ! nodeToDeallocate.isPresent())
             throw new IllegalArgumentException("Could not deallocate " + hostname + ": No such node in the failed or parked state");
         return deallocate(Collections.singletonList(nodeToDeallocate.get())).get(0);
@@ -238,9 +239,7 @@ public class NodeRepository extends AbstractComponent {
      * @return true if the node was removed, false if it was not found
      */
     public boolean remove(String hostname) {
-        Optional<Node> nodeToRemove = getNode(Node.State.failed, hostname);
-        if ( ! nodeToRemove.isPresent())
-            nodeToRemove = getNode(Node.State.parked, hostname);
+        Optional<Node> nodeToRemove = getNode(hostname, Node.State.failed, Node.State.parked);
         if ( ! nodeToRemove.isPresent()) 
             return false;
         try (Mutex lock = lock(nodeToRemove.get())) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -94,7 +94,7 @@ public class NodeRepository extends AbstractComponent {
      * Finds and returns the nodes of the given type in any of the given states.
      *
      * @param type the node type to return
-     * @param inState the states to return nodes from. If no states are given, all nodes of the given type is returned
+     * @param inState the states to return nodes from. If no states are given, all nodes of the given type are returned
      * @return the node, or empty if it was not found in any of the given states
      */
     public List<Node> getNodes(Node.Type type, Node.State ... inState) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -97,7 +97,7 @@ public class NodeFailer extends Maintainer {
         for (ApplicationInstance<ServiceMonitorStatus> application : serviceMonitor.queryStatusOfAllApplicationInstances().values()) {
             for (ServiceCluster<ServiceMonitorStatus> cluster : application.serviceClusters()) {
                 for (ServiceInstance<ServiceMonitorStatus> service : cluster.serviceInstances()) {
-                    Optional<Node> node = nodeRepository().getNode(Node.State.active, service.hostName().s());
+                    Optional<Node> node = nodeRepository().getNode(service.hostName().s(), Node.State.active);
                     if ( ! node.isPresent()) continue; // we also get status from infrastructure nodes, which are not in the repo
 
                     if (service.serviceStatus().equals(ServiceMonitorStatus.DOWN))
@@ -120,7 +120,7 @@ public class NodeFailer extends Maintainer {
         if (node.history().event(History.Event.Type.down).isPresent()) return node; // already down: Don't change down timestamp
 
         try (Mutex lock = nodeRepository().lock(node.allocation().get().owner())) {
-            node = nodeRepository().getNode(Node.State.active, node.hostname()).get(); // re-get inside lock
+            node = nodeRepository().getNode(node.hostname(), Node.State.active).get(); // re-get inside lock
             return nodeRepository().write(node.setDown(clock.instant()));
         }
     }
@@ -129,7 +129,7 @@ public class NodeFailer extends Maintainer {
         if ( ! node.history().event(History.Event.Type.down).isPresent()) return;
 
         try (Mutex lock = nodeRepository().lock(node.allocation().get().owner())) {
-            node = nodeRepository().getNode(Node.State.active, node.hostname()).get(); // re-get inside lock
+            node = nodeRepository().getNode(node.hostname(), Node.State.active).get(); // re-get inside lock
             nodeRepository().write(node.setUp());
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 /**
  * Client which reads and writes nodes to a curator database.
  * Nodes are stored in files named <code>/provision/v1/[nodestate]/[hostname]</code>.
+ *
  * The responsibility of this class is to turn operations on the level of node states, applications and nodes
  * into operations on the level of file paths and bytes.
  *
@@ -194,14 +195,20 @@ public class CuratorDatabaseClient {
         return nodes;
     }
 
-    /** Returns all nodes allocated to the given application which are in one of the given states */
+    /** 
+     * Returns all nodes allocated to the given application which are in one of the given states 
+     * If no states are given this returns all nodes.
+     */
     public List<Node> getNodes(ApplicationId applicationId, Node.State ... states) {
         List<Node> nodes = getNodes(states);
         nodes.removeIf(node -> ! node.allocation().isPresent() || ! node.allocation().get().owner().equals(applicationId));
         return nodes;
     }
 
-    /** Returns a particular node, or empty if there is no such node in this state */
+    /** 
+     * Returns a particular node, or empty if this noe is not in any of the given states.
+     * If no states are given this returns the node if it is present in any state.
+     */
     public Optional<Node> getNode(String hostname, Node.State ... states) {
         if (states.length == 0)
             states = Node.State.values();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/legacy/ProvisionResource.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/legacy/ProvisionResource.java
@@ -73,11 +73,9 @@ public class ProvisionResource {
     @PUT
     @Path("/node/ready")
     public void setReady(String hostName) {
-        if ( nodeRepository.getNode(Node.State.ready, hostName).isPresent()) return; // node already 'ready'
+        if ( nodeRepository.getNode(hostName, Node.State.ready).isPresent()) return; // node already 'ready'
 
-        Optional<Node> node = nodeRepository.getNode(Node.State.provisioned, hostName);
-        if ( ! node.isPresent())
-            node = nodeRepository.getNode(Node.State.dirty, hostName);
+        Optional<Node> node = nodeRepository.getNode(hostName, Node.State.provisioned, Node.State.dirty);
         if ( ! node.isPresent())
             throw new IllegalArgumentException("Could not set " + hostName + " ready: Not registered as provisioned or dirty");
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -211,16 +211,11 @@ public class NodesApiHandler extends LoggingRequestHandler {
     // TODO: Move most of this to node repo
     public String setNodeReady(String path) {
         String hostname = lastElement(path);
-        if ( nodeRepository.getNode(Node.State.ready, hostname).isPresent())
+        if ( nodeRepository.getNode(hostname, Node.State.ready).isPresent())
             return "Nothing done; " + hostname + " is already ready";
 
-        Optional<Node> node = nodeRepository.getNode(Node.State.provisioned, hostname);
-        if ( ! node.isPresent())
-            node = nodeRepository.getNode(Node.State.dirty, hostname);
-        if ( ! node.isPresent())
-            node = nodeRepository.getNode(Node.State.failed, hostname);
-        if ( ! node.isPresent())
-            node = nodeRepository.getNode(Node.State.parked, hostname);
+        Optional<Node> node = nodeRepository.getNode(hostname, Node.State.provisioned, Node.State.dirty, Node.State.failed, Node.State.parked);
+
         if ( ! node.isPresent())
             throw new IllegalArgumentException("Could not set " + hostname + " ready: Not registered as provisioned, dirty, failed or parked");
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -164,7 +164,7 @@ public class ProvisioningTester implements AutoCloseable {
     }
 
     public void fail(HostSpec host) {
-        int beforeFailCount = nodeRepository.getNode(Node.State.active, host.hostname()).get().status().failCount();
+        int beforeFailCount = nodeRepository.getNode(host.hostname(), Node.State.active).get().status().failCount();
         Node failedNode = nodeRepository.fail(host.hostname());
         assertTrue(nodeRepository.getNodes(Node.Type.tenant, Node.State.failed).contains(failedNode));
         assertEquals(beforeFailCount + 1, failedNode.status().failCount());


### PR DESCRIPTION
@dybis please review

Just a refactoring to avoid these:

if ( ! node.isPresent())
    node = nodeRepository.getNode(Node.State.dirty, hostname);
if ( ! node.isPresent())
    node = nodeRepository.getNode(Node.State.failed, hostname);
if ( ! node.isPresent())
    node = nodeRepository.getNode(Node.State.parked, hostname);
