### PR TITLE
We must use the same fieldId space for both insert and remove.

### DIFF
--- a/searchlib/src/vespa/searchlib/memoryindex/documentinverter.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/documentinverter.cpp
@@ -167,12 +167,20 @@ DocumentInverter::invertDocument(uint32_t docId, const Document &doc)
 void
 DocumentInverter::removeDocument(uint32_t docId)
 {
-    uint32_t fieldId = 0;
-    for (auto &inverter : _inverters) {
+    for (uint32_t fieldId : _schemaIndexFields._textFields) {
+        FieldInverter *inverter = _inverters[fieldId].get();
         _invertThreads.execute(fieldId,
-                               [inverter(inverter.get()), docId]()
+                               [inverter, docId]()
                                { inverter->removeDocument(docId); });
-        ++fieldId;
+    }
+    uint32_t urlId = 0;
+    for (const auto & fi : _schemaIndexFields._uriFields) {
+        uint32_t fieldId = fi._all;
+        UrlFieldInverter *inverter = _urlInverters[urlId].get();
+        _invertThreads.execute(fieldId,
+                               [inverter, docId]()
+                               { inverter->removeDocument(docId); });
+        ++urlId;
     }
 }
 

--- a/searchlib/src/vespa/searchlib/memoryindex/urlfieldinverter.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/urlfieldinverter.cpp
@@ -354,6 +354,19 @@ UrlFieldInverter::invertField(uint32_t docId, const FieldValue::UP &val)
     endDoc();
 }
 
+void
+UrlFieldInverter::removeDocument(uint32_t docId)
+{
+    _all->removeDocument(docId);
+    _scheme->removeDocument(docId);
+    _host->removeDocument(docId);
+    _port->removeDocument(docId);
+    _path->removeDocument(docId);
+    _query->removeDocument(docId);
+    _fragment->removeDocument(docId);
+    _hostname->removeDocument(docId);
+}
+
 
 UrlFieldInverter::UrlFieldInverter(index::Schema::CollectionType collectionType,
                                    FieldInverter *all,

--- a/searchlib/src/vespa/searchlib/memoryindex/urlfieldinverter.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/urlfieldinverter.h
@@ -67,6 +67,7 @@ public:
                      FieldInverter *hostname);
 
     void invertField(uint32_t docId, const document::FieldValue::UP &field);
+    void removeDocument(uint32_t docId);
 
     void setUseAnnotations(bool useAnnotations) {
         _useAnnotations = useAnnotations;


### PR DESCRIPTION
This is essential as the fieldId selects the correct thread. If not race conditions are next.
@toregge and @geirst PR
