### PR TITLE
link with libraries used

### DIFF
--- a/fastos/src/vespa/fastos/CMakeLists.txt
+++ b/fastos/src/vespa/fastos/CMakeLists.txt
@@ -24,6 +24,7 @@ vespa_add_library(fastos
     vtag.cpp
     INSTALL lib64
     DEPENDS
+    ${CMAKE_DL_LIBS}
 )
 find_package(Threads REQUIRED)
 target_link_libraries(fastos PUBLIC ${CMAKE_THREAD_LIBS_INIT})

--- a/fsa/src/vespa/fsamanagers/CMakeLists.txt
+++ b/fsa/src/vespa/fsamanagers/CMakeLists.txt
@@ -10,6 +10,8 @@ vespa_add_library(fsamanagers
     INSTALL lib64
     DEPENDS
 )
+find_package(Threads REQUIRED)
+target_link_libraries(fsamanagers PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
 install(FILES
     conceptnethandle.h

--- a/searchsummary/src/vespa/searchsummary/CMakeLists.txt
+++ b/searchsummary/src/vespa/searchsummary/CMakeLists.txt
@@ -5,4 +5,5 @@ vespa_add_library(searchsummary
     $<TARGET_OBJECTS:searchsummary_docsummary>
     INSTALL lib64
     DEPENDS
+    z
 )


### PR DESCRIPTION
- fastos uses dlopen(), link with -ldl if needed
- fsamanagers uses pthread functions, link with thread library
- searchsummary uses compress(), link with zlib

@baldersheim please review and merge
