### PR TITLE
remove SetPriority from fastos

### DIFF
--- a/fastos/src/tests/processtest.cpp
+++ b/fastos/src/tests/processtest.cpp
@@ -69,13 +69,10 @@ private:
    ThreadRunJob(const ThreadRunJob&);
    ThreadRunJob& operator=(const ThreadRunJob&);
 
-   FastOS_Process::Priority _processPriority;
    const char *_processCmdLine;
    int _timeSpent;
 public:
-   ThreadRunJob (FastOS_Process::Priority processPriority,
-                 const char *commandLine) :
-      _processPriority(processPriority),
+   ThreadRunJob (const char *commandLine) :
       _processCmdLine(commandLine),
       _timeSpent(0)
    {
@@ -94,7 +91,6 @@ public:
 
       if(xproc.Create())
       {
-         xproc.SetPriority(_processPriority);
          xproc.Wait(&returnCode);
       }
 
@@ -423,27 +419,6 @@ public:
       PrintSeparator();
    }
 
-   void PriorityTest ()
-   {
-      TestHeader("Process Priority Test");
-
-      ThreadRunJob job1(FastOS_Process::PRIORITY_LOWEST, _argv[2]);
-      ThreadRunJob job2(FastOS_Process::PRIORITY_HIGHEST, _argv[2]);
-      FastOS_ThreadPool pool(128*1024);
-      Progress(true, "Starting usecpu-processes with low and high priority...");
-      pool.NewThread(&job1);
-      pool.NewThread(&job2);
-      Progress(true, "Waiting for proccesses to finish...");
-      pool.Close();
-      int timeJob1 = job1.GetTimeSpent();
-      int timeJob2 = job2.GetTimeSpent();
-
-      Progress(timeJob1 > timeJob2, "Job1 (low priority) %d ms", timeJob1);
-      Progress(timeJob1 > timeJob2, "Job2 (high priority) %d ms", timeJob2);
-
-      PrintSeparator();
-   }
-
    void NoInheritTest ()
    {
       TestHeader("No Inherit Test");
@@ -480,7 +455,6 @@ public:
       printf("grep for the string '%s' to detect failures.\n\n", failString);
 
       NoInheritTest();
-      PriorityTest();
       PollWaitTest();
       IPCTest();
       ProcessTests(false, true, false);

--- a/fastos/src/vespa/fastos/process.h
+++ b/fastos/src/vespa/fastos/process.h
@@ -100,18 +100,6 @@ public:
     };
 
     /**
-     * Process priorities.
-     */
-    enum Priority
-    {
-        PRIORITY_LOWEST          = -2,
-        PRIORITY_BELOW_NORMAL    = -1,
-        PRIORITY_NORMAL          =  0,
-        PRIORITY_ABOVE_NORMAL    =  1,
-        PRIORITY_HIGHEST         =  2
-    };
-
-    /**
      * Constructor. Does not start the process, use @ref Create or
      * @ref CreateWithShell to actually start the process.
      * @param  cmdLine           Command line
@@ -294,15 +282,6 @@ public:
     {
         return _cmdLine;
     }
-
-    /**
-     * Set process priority. Higher priorities than normal might
-     * require adminstrator privileges. PRIORITY_BELOW_NORMAL and
-     * PRIORITY_ABOVE_NORMAL are on some OSes mapped to
-     * PRIORITY_LOWEST and PRIORITY_HIGHEST, respectively.
-     * @return                   Boolean success / failure
-     */
-    virtual bool SetPriority (Priority priority) = 0;
 };
 
 #include <vespa/fastos/unix_process.h>

--- a/fastos/src/vespa/fastos/thread.h
+++ b/fastos/src/vespa/fastos/thread.h
@@ -350,26 +350,6 @@ public:
     static bool Sleep(int ms);
 
     /**
-     * Thread priorities. The range is -2..2. A higher number
-     * indicates higher priority.
-     */
-    enum Priority
-    {
-        PRIORITY_LOWEST          = -2,
-        PRIORITY_BELOW_NORMAL    = -1,
-        PRIORITY_NORMAL          =  0,
-        PRIORITY_ABOVE_NORMAL    =  1,
-        PRIORITY_HIGHEST         =  2
-    };
-
-    /**
-     * Set thread priority.
-     * @param priority  New thread priority.
-     * @return   Boolean success / failure
-     */
-    virtual bool SetPriority (const Priority priority) = 0;
-
-    /**
      * Instruct a thread to exit. This could be used in conjunction with
      * @ref GetBreakFlag() in a worker thread, to have cooperative thread
      * termination. When a threadpool closes, all threads in the pool will

--- a/fastos/src/vespa/fastos/unix_process.cpp
+++ b/fastos/src/vespa/fastos/unix_process.cpp
@@ -1979,22 +1979,3 @@ bool FastOS_UNIX_ProcessStarter::Detach(FastOS_UNIX_Process *process)
     process->_app->ProcessUnlock();
     return rc;
 }
-
-bool FastOS_UNIX_Process::SetPriority (Priority priority)
-{
-    int newPriority;
-
-    switch (priority)
-    {
-    case PRIORITY_LOWEST:        newPriority = 20;    break;
-    case PRIORITY_BELOW_NORMAL:  newPriority = 10;    break;
-    case PRIORITY_NORMAL:        newPriority = 0;    break;
-    case PRIORITY_ABOVE_NORMAL:  newPriority = -10;   break;
-    case PRIORITY_HIGHEST:       newPriority = -20;   break;
-    default:
-        newPriority = 0;
-    }
-
-    return (setpriority(PRIO_PROCESS, _pid, newPriority) == 0);
-
-}

--- a/fastos/src/vespa/fastos/unix_process.h
+++ b/fastos/src/vespa/fastos/unix_process.h
@@ -227,7 +227,6 @@ public:
         return true;
     }
 
-    bool SetPriority (Priority pri);
     void SetRunDir(const char *runDir);
     void SetStdoutRedirName(const char *stdoutRedirName);
     void SetStderrRedirName(const char *stderrRedirName);

--- a/fastos/src/vespa/fastos/unix_thread.cpp
+++ b/fastos/src/vespa/fastos/unix_thread.cpp
@@ -62,47 +62,12 @@ bool FastOS_UNIX_Thread::Initialize (int stackSize, int stackGuardSize)
 
     pthread_attr_destroy(&attr);
 
-    if (rc && pthread_getschedparam(_handle, &_normal_policy,
-                                    &_normal_schedparam) == 0)
-    {
-        _schedparams_ok = true;
-    }
-    _schedparams_changed = false;
-
     return rc;
 }
 
 void FastOS_UNIX_Thread::PreEntry ()
 {
-    if (_schedparams_changed) {
-        _schedparams_changed = false;
-        SetPriority(FastOS_Thread::PRIORITY_NORMAL);
-    }
 }
-
-bool FastOS_UNIX_Thread::SetPriority (const Priority priority)
-{
-    bool rc=false;
-
-    if(_schedparams_ok)
-    {
-        struct sched_param schedparam;
-
-        schedparam = _normal_schedparam;
-        schedparam.sched_priority = (priority +
-                                     _normal_schedparam.sched_priority);
-
-        if (pthread_setschedparam(_handle, _normal_policy,
-                                  &schedparam) == 0)
-        {
-            rc = true;
-            _schedparams_changed = true;
-        }
-    }
-
-    return rc;
-}
-
 
 FastOS_UNIX_Thread::~FastOS_UNIX_Thread(void)
 {

--- a/fastos/src/vespa/fastos/unix_thread.h
+++ b/fastos/src/vespa/fastos/unix_thread.h
@@ -19,11 +19,7 @@ private:
 
 protected:
     pthread_t _handle;
-    struct sched_param _normal_schedparam;
-    int _normal_policy;
     bool _handleValid;
-    bool _schedparams_ok;
-    bool _schedparams_changed;
 
     bool Initialize (int stackSize, int stackGuardSize);
     void PreEntry ();
@@ -35,11 +31,7 @@ public:
     FastOS_UNIX_Thread(FastOS_ThreadPool *pool)
         : FastOS_ThreadInterface(pool),
           _handle(),
-          _normal_schedparam(),
-          _normal_policy(0),
-          _handleValid(false),
-          _schedparams_ok(false),
-          _schedparams_changed(false)
+          _handleValid(false)
     {}
 
     virtual ~FastOS_UNIX_Thread(void);
@@ -56,7 +48,6 @@ public:
         return rc;
     }
 
-    bool SetPriority (const Priority priority);
     FastOS_ThreadId GetThreadId ();
     static bool CompareThreadIds (FastOS_ThreadId a,
                                   FastOS_ThreadId b);


### PR DESCRIPTION
- the FastOS mechanism for setting priority on processes
  and threads wasn't used anywhere, and it did not work
  on linux anyway.

@toregge please review and merge
@baldersheim @havardpe FYI
