### PR TITLE
Fix Id conversion and REST API path to clustercontroller

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
@@ -134,7 +134,16 @@ public class OrchestratorUtil {
 
         String appNameStr = appRef.toString();
         String[] appNameParts = appNameStr.split(":");
-        // TODO model ApplicationInstanceReference properly and validate this there
+
+        // Env, region and instance seems to be optional due to the hardcoded config server app
+        // Assume here that first two are tenant and application name.
+        if (appNameParts.length > 1 && appNameParts.length < 5) {
+            return ApplicationId.from(TenantName.from(appNameParts[0]),
+                    ApplicationName.from(appNameParts[1]),
+                    InstanceName.defaultName());
+        }
+
+        // Other normal application should have 5 parts.
         if (appNameParts.length != 5)  {
             throw new IllegalArgumentException("Application reference not valid (not 5 parts): " + appRef);
         }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorUtil.java
@@ -137,7 +137,7 @@ public class OrchestratorUtil {
 
         // Env, region and instance seems to be optional due to the hardcoded config server app
         // Assume here that first two are tenant and application name.
-        if (appNameParts.length > 1 && appNameParts.length < 5) {
+        if (appNameParts.length == 2) {
             return ApplicationId.from(TenantName.from(appNameParts[0]),
                     ApplicationName.from(appNameParts[1]),
                     InstanceName.defaultName());

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerJaxRsApi.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerJaxRsApi.java
@@ -22,7 +22,7 @@ public interface ClusterControllerJaxRsApi {
             ClusterControllerStateRequest request);
 
     @POST
-    @Path("/cluster/v2/{clusterName}/storage")
+    @Path("/cluster/v2/{clusterName}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     ClusterControllerStateResponse setClusterState(

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorUtilTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorUtilTest.java
@@ -25,6 +25,10 @@ public class OrchestratorUtilTest {
             new TenantId("test-tenant-id"),
             new ApplicationInstanceId("application:prod:utopia-1:instance"));
 
+    private static final ApplicationInstanceReference APPREF_2 = new ApplicationInstanceReference(
+            new TenantId("hosted-vespa"),
+            new ApplicationInstanceId("zone-config-servers"));
+
     /**
      * Here we don't care how the internal of the different application
      * id/reference look like as long as we get back to exactly where we
@@ -45,5 +49,14 @@ public class OrchestratorUtilTest {
         ApplicationInstanceReference appRefRoundTrip = OrchestratorUtil.toApplicationInstanceReference(appId, new DummyInstanceLookupService());
 
         Assert.assertEquals(APPREF_1, appRefRoundTrip);
+    }
+
+    @Test
+    public void applicationid_from_zone_confg_server_appref_is_working() throws Exception {
+        ApplicationId appId = OrchestratorUtil.toApplicationId(APPREF_2);
+        Assert.assertEquals(ApplicationId.from(
+                TenantName.from("hosted-vespa"),
+                ApplicationName.from("zone-config-servers"),
+                InstanceName.defaultName()),appId);
     }
 }


### PR DESCRIPTION
I discovered two errors with current implementation.
1. We have a special hardcoded ApplicationInstanceReference for the config server that did not fit the assumption made in the ID conversion to ApplicationId
2. The cluster controller path to set all nodes in a cluster in maintenance was wrong. 

Both have been tested in the dev environment. The clustercontroller path was tested with:

GLOBAL [smorgrav@tool:~]$ curl -X POST -s --data '{ "state": { "user": { "state": "maintenance", "reason": "test" } }, "condition": "FORCE" }'  http://oxy-oxygen-0a4ae537.corp.bf1.yahoo.com:19050/cluster/v2/ecsearch-staging | jq '.'
{
  "wasModified": true,
  "reason": "ok"
}

@hakonhall Please review
