### PR TITLE
Reduce docid limit in feed view before reducing it for each

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.cpp
@@ -94,11 +94,11 @@ FastAccessFeedView::FastAccessFeedView(const StoreOnlyFeedView::Context &storeOn
 void
 FastAccessFeedView::handleCompactLidSpace(const CompactLidSpaceOperation &op)
 {
-    getAttributeWriter()->compactLidSpace(op.getLidLimit(), op.getSerialNum());
-    Parent::handleCompactLidSpace(op);
     // Drain pending PutDoneContext and ForceCommitContext objects
     _writeService.sync();
     _docIdLimit.set(op.getLidLimit());
+    getAttributeWriter()->compactLidSpace(op.getLidLimit(), op.getSerialNum());
+    Parent::handleCompactLidSpace(op);
 }
 
 void


### PR DESCRIPTION
attribute in order to prevent new searches from using too high
old docid limit on newly shrunk attribute vectors.

@geirst, please review.
@baldersheim, FYI
