### PR TITLE
Always request data for all znodes on master election dir watch callback

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
@@ -90,7 +90,7 @@ public class MasterDataGatherer {
                 for (String node : nodes) {
                     int index = Integer.parseInt(node);
                     nextMasterData.put(index, null);
-                    log.log(LogLevel.INFO, "Fleetcontroller " + nodeIndex + ": Attempting to fetch data in node '"
+                    log.log(LogLevel.DEBUG, "Fleetcontroller " + nodeIndex + ": Attempting to fetch data in node '"
                             + zooKeeperRoot + index + "' to see vote");
                     session.getData(zooKeeperRoot + "indexes/" + index, changeWatcher, nodeListener, null);
                     // Invocation of cycleCompleted() for fully accumulated election state will happen
@@ -105,7 +105,7 @@ public class MasterDataGatherer {
 
         public void processResult(int code, String path, Object context, byte[] rawdata, Stat stat) {
             String data = rawdata == null ? null : new String(rawdata, utf8);
-            log.log(LogLevel.INFO, "Fleetcontroller " + nodeIndex + ": Got change in vote data from path " + path +
+            log.log(LogLevel.INFO, "Fleetcontroller " + nodeIndex + ": Got vote data from path " + path +
                     " with code " + code + " and data " + data);
 
             int index = getIndex(path);


### PR DESCRIPTION
@hakonhall Please review

The previous version of the code attempted to optimize by only requesting
node data for nodes that had changed, but there existed an edge case where
it would mistakenly fail to request new data for nodes that _had_ changed.
This could happen if the callback was invoked when nextMasterData already
contained entries for the same set of node indices returned as part of the
directory callback.

Always clearing our internal state and requesting all znodes is a more
robust option. The number of cluster controllers should always be so low
that the expected added overhead is negligible.
