### PR TITLE
stop faking input after EOF

### DIFF
--- a/configd/src/apps/sentinel/line-splitter.cpp
+++ b/configd/src/apps/sentinel/line-splitter.cpp
@@ -71,9 +71,6 @@ LineSplitter::fill()
         }
     } else if (readLen == 0) {
         _eof = true;
-        if (_buffer[_writePos] != '\n') {
-            _buffer[_writePos++] = '\n'; // Fake a final separator
-        }
     } else {
         _writePos += readLen;
     }
@@ -90,6 +87,9 @@ LineSplitter::getLine()
 	if (bufLen > 0) {
             char *start = &_buffer[_readPos];
             char *end = static_cast<char *>(memchr(start, '\n', bufLen));
+            if (_eof && !end) {
+                end = &_buffer[_writePos-1]; // pretend last byte sent was \n
+            }
             if (end) {
                 *end = '\0';
                 if (end - start > 0 && end[-1] == '\r') {

--- a/configd/src/apps/sentinel/line-splitter.h
+++ b/configd/src/apps/sentinel/line-splitter.h
@@ -23,7 +23,7 @@ private:
 public:
     explicit LineSplitter(int fd);
     char *getLine();
-    bool eof() const { return _eof; }
+    bool eof() const { return _eof && _readPos >= _writePos; }
 
     ~LineSplitter();
 };


### PR DESCRIPTION
- don't add extra newline after EOF received
- eof() should only return true after all input is consumed
- still need to handle EOF-without-newline, but
  do it in a more conservative manner.

@eirik please review and merge
