### PR TITLE
Reintroduce correct options when building vespammaloc. They disappear…

### DIFF
--- a/vespamalloc/CMakeLists.txt
+++ b/vespamalloc/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+add_compile_options(-fvisibility=hidden -DPARANOID_LEVEL=0)
+add_compile_options(-DPARANOID_LEVEL=0)
+
 vespa_define_module(
     DEPENDS
     fastos

--- a/vespamalloc/CMakeLists.txt
+++ b/vespamalloc/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-add_compile_options(-fvisibility=hidden -DPARANOID_LEVEL=0)
+add_compile_options(-fvisibility=hidden)
 add_compile_options(-DPARANOID_LEVEL=0)
 
 vespa_define_module(


### PR DESCRIPTION
…ed when moving to cmake.
@arnej27959 or @voffeloff PR
