### PR TITLE
less spurious warnings at shutdown

### DIFF
--- a/configd/src/apps/sentinel/line-splitter.cpp
+++ b/configd/src/apps/sentinel/line-splitter.cpp
@@ -88,7 +88,11 @@ LineSplitter::getLine()
             char *start = &_buffer[_readPos];
             char *end = static_cast<char *>(memchr(start, '\n', bufLen));
             if (_eof && !end) {
-                end = &_buffer[_writePos-1]; // pretend last byte sent was \n
+                if (_writePos < _size) {
+                    end = &_buffer[_writePos]; // pretend last byte sent was followed by \n
+                } else {
+                    end = &_buffer[_writePos-1]; // pretend last byte sent was \n
+                }
             }
             if (end) {
                 *end = '\0';

--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -129,9 +129,9 @@ namespace {
             if (sigtramp == 0) _exit(EXIT_FAILURE);
             // note: this is not totally safe, sigtramp is not protected by a lock
             sigtramp->handleSignal(sig);
-        } else {
+        } else if (_G_signalCount > 2) {
             fprintf(stderr, "Received another shutdown signal %u while "
-                    "shutdown in progress (count=%u)",
+                    "shutdown in progress (count=%u)\n",
                     sig, _G_signalCount);
         }
     }


### PR DESCRIPTION
- the storageserver didn't like getting the TERM signal both from
  runserver (via killpg) and sentinel, so it would print a warning
  to stderr.  But the warning didn't end with a newline.
- the line-splitter used by config-sentinel didn't handle input
  that didn't end with newline before EOF well, so the warning
  was never handled and sent to the vespa.log file earlier.
- only print warning if too many signals seen (> 2), and end
  it with a newline.
- don't ignore last byte of input if we can avoid it.

@ean please review and merge
