### PR TITLE
Suspend only active nodes

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdmin.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdmin.java
@@ -37,6 +37,11 @@ public interface NodeAdmin {
     Set<HostName> getListOfHosts();
 
     /**
+     * Returns list of hosts with active nodes.
+     */
+    Set<HostName> getHostNamesOfActiveNodes();
+
+    /**
      * Returns a map containing all relevant NodeAdmin variables and their current values.
      * Do not try to parse output or use in tests.
      */

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.node.admin.docker.Container;
 import com.yahoo.vespa.hosted.node.admin.docker.Docker;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgent;
+import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -85,6 +86,16 @@ public class NodeAdminImpl implements NodeAdmin {
 
     public Set<HostName> getListOfHosts() {
         return nodeAgents.keySet();
+    }
+
+    public Set<HostName> getHostNamesOfActiveNodes() {
+        Set<HostName> activeHostnames = new HashSet<>();
+        for (NodeAgent nodeAgent : nodeAgents.values()) {
+            if (nodeAgent.getContainerState() != NodeAgentImpl.ContainerState.ABSENT) {
+                activeHostnames.add(nodeAgent.getHostName());
+            }
+        }
+        return activeHostnames;
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -79,7 +79,7 @@ public class NodeAdminStateUpdater extends AbstractComponent {
                     return Optional.of("Not all node agents are frozen.");
                 }
                 List<String> hosts = new ArrayList<>();
-                nodeAdmin.getListOfHosts().forEach(host -> hosts.add(host.toString()));
+                nodeAdmin.getHostNamesOfActiveNodes().forEach(host -> hosts.add(host.toString()));
                 return orchestrator.suspend(baseHostName, hosts);
             } else {
                 nodeAdmin.unfreeze();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
@@ -1,6 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.nodeagent;
 
+import com.yahoo.vespa.applicationmodel.HostName;
+
 import java.util.Map;
 
 /**
@@ -49,4 +51,15 @@ public interface NodeAgent {
      * method returns, no more actions will be taken by the agent.
      */
     void stop();
+
+    /**
+     * Returns host name that this NodeAgent handles.
+     */
+    HostName getHostName();
+
+    /**
+     * Returns current state of Docker container for this node agent.
+     */
+    NodeAgentImpl.ContainerState getContainerState();
+
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -61,9 +61,10 @@ public class NodeAgentImpl implements NodeAgent {
         RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN,
         RUNNING
     }
-    ContainerState containerState = ABSENT;
 
-    // The attributes of the last successful noderepo attribute update for this node. Used to avoid redundant calls.
+    private ContainerState containerState = ABSENT;
+
+    // The attributes of the last successful node repo attribute update for this node. Used to avoid redundant calls.
     private NodeAttributes lastAttributesSet = null;
     private ContainerNodeSpec lastNodeSpec = null;
 
@@ -153,6 +154,16 @@ public class NodeAgentImpl implements NodeAgent {
         } catch (InterruptedException e1) {
             logger.severe("Interrupted; Could not stop host thread " + hostname);
         }
+    }
+
+    @Override
+    public HostName getHostName() {
+        return hostname;
+    }
+
+    @Override
+    public ContainerState getContainerState() {
+        return containerState;
     }
 
     private void runLocalResumeScriptIfNeeded(final ContainerNodeSpec nodeSpec) {


### PR DESCRIPTION
- Suspend only those nodes that should be running, as Orchestrator
  expects that a node that should be suspended should belong to
  an application

I am not sure that this is all that is needed for suspension of nodes for
a Docker hosts to work in all circumstances, but I think the client should only
ask for suspension of nodes it knows are running anyway.

@hakonhall please review
