### PR TITLE
Add host filtering option to config status util

### DIFF
--- a/configutil/CMakeLists.txt
+++ b/configutil/CMakeLists.txt
@@ -19,4 +19,5 @@ vespa_define_module(
     src/tests/config_status
     src/tests/model_inspect
     src/tests/tags
+    src/tests/host_filter
     )

--- a/configutil/src/lib/configstatus.cpp
+++ b/configutil/src/lib/configstatus.cpp
@@ -139,10 +139,14 @@ ConfigStatus::action()
 
     for (size_t i = 0; i < _cfg->hosts.size(); i++) {
         const cloud::config::ModelConfig::Hosts &hconf = _cfg->hosts[i];
+        // TODO PERF: don't fetch entire model when we're only looking for
+        // a subset of hosts.
+        if (!_flags.host_filter.includes(hconf.name)) {
+            continue;
+        }
 
         for (size_t j = 0; j < hconf.services.size(); j++) {
             const cloud::config::ModelConfig::Hosts::Services &svc = hconf.services[j];
-
             if (svc.type == "configserver") {
                 continue;
             }

--- a/configutil/src/lib/configstatus.h
+++ b/configutil/src/lib/configstatus.h
@@ -1,6 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "hostfilter.h"
 #include <vespa/config-model.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/config/config.h>
@@ -9,9 +10,15 @@ class ConfigStatus
 {
 public:
     struct Flags {
+        HostFilter host_filter;
         bool verbose;
         Flags()
-            : verbose(false)
+            : host_filter(), verbose(false)
+        {}
+
+        explicit Flags(const HostFilter& filter)
+            : host_filter(filter),
+              verbose(false)
         {}
     };
 

--- a/configutil/src/lib/hostfilter.h
+++ b/configutil/src/lib/hostfilter.h
@@ -1,0 +1,49 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <unordered_set>
+#include <string>
+
+/**
+ * Simple host filter which in its default empty state implicitly includes all
+ * hosts, or only an explicit subset iff at least one host has been provided
+ * to the filter as part of construction.
+ */
+class HostFilter {
+public:
+    using HostSet = std::unordered_set<std::string>;
+private:
+    HostSet _hosts;
+public:
+    /**
+     * Empty host filter; all hosts are implicitly included.
+     */
+    HostFilter() : _hosts() {}
+
+    /**
+     * Explicitly given host set; only the hosts whose name exactly match
+     * one of the provided names will pass the includes(name) check.
+     */
+    explicit HostFilter(const std::unordered_set<std::string>& hosts)
+        : _hosts(hosts)
+    {
+    }
+
+    explicit HostFilter(std::unordered_set<std::string>&& hosts)
+        : _hosts(std::move(hosts))
+    {
+    }
+
+    HostFilter(HostFilter&&) = default;
+    HostFilter& operator=(HostFilter&&) = default;
+
+    HostFilter(const HostFilter&) = default;
+    HostFilter& operator=(const HostFilter&) = default;
+
+    bool includes(const std::string& candidate) const {
+        if (_hosts.empty()) {
+            return true;
+        }
+        return (_hosts.find(candidate) != _hosts.end());
+    }
+};

--- a/configutil/src/testlist.txt
+++ b/configutil/src/testlist.txt
@@ -1,3 +1,4 @@
 tests/config_status
 tests/model_inspect
 tests/tags
+tests/host_filter

--- a/configutil/src/tests/config_status/config_status_test.cpp
+++ b/configutil/src/tests/config_status/config_status_test.cpp
@@ -57,7 +57,7 @@ public:
     ConfigStatus::Flags flags;
     std::unique_ptr<ConfigStatus> status;
 
-    Status(int httpport,
+    Status(int http_port,
            const ConfigStatus::Flags& cfg_flags,
            const std::vector<std::string>& model_hosts)
         : flags(cfg_flags)
@@ -68,7 +68,7 @@ public:
         cloud::config::ModelConfigBuilder builder;
         
         cloud::config::ModelConfigBuilder::Hosts::Services::Ports port;
-        port.number = httpport;
+        port.number = http_port;
         port.tags = "http state";
 
         cloud::config::ModelConfigBuilder::Hosts::Services service;
@@ -93,8 +93,8 @@ public:
         status = std::move(s);
     }
 
-    Status(int httpport)
-        : Status(httpport, ConfigStatus::Flags(), {{"localhost"}})
+    Status(int http_port)
+        : Status(http_port, ConfigStatus::Flags(), {{"localhost"}})
     {}
 
     ~Status() {

--- a/configutil/src/tests/host_filter/CMakeLists.txt
+++ b/configutil/src/tests/host_filter/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(configutil_host_filter_test_app TEST
+    SOURCES
+    host_filter_test.cpp
+    DEPENDS
+    configutil_util
+)
+vespa_add_test(NAME configutil_host_filter_test_app COMMAND configutil_host_filter_test_app)

--- a/configutil/src/tests/host_filter/host_filter_test.cpp
+++ b/configutil/src/tests/host_filter/host_filter_test.cpp
@@ -1,0 +1,18 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include <vespa/vespalib/testkit/testapp.h>
+#include <lib/hostfilter.h>
+
+TEST("empty hostfilter includes any and all hosts") {
+    HostFilter filter;
+    EXPECT_TRUE(filter.includes("foo.yahoo.com"));
+}
+
+TEST("explicit host set limits to provided hosts only") {
+    HostFilter::HostSet hosts({"bar.yahoo.com", "zoidberg.yahoo.com"});
+    HostFilter filter(std::move(hosts));
+    EXPECT_TRUE(filter.includes("bar.yahoo.com"));
+    EXPECT_TRUE(filter.includes("zoidberg.yahoo.com"));
+    EXPECT_FALSE(filter.includes("foo.yahoo.com"));
+}
+
+TEST_MAIN() { TEST_RUN_ALL(); }


### PR DESCRIPTION
@voffeloff Please review

If the argument is not specified, services on all hosts in the model
will be queried as before. Iff the filter argument is specified, only
services on the hosts explicitly given will be queried.
