### PR TITLE
add retries in timing-dependent test

### DIFF
--- a/container-search/src/test/java/com/yahoo/prelude/cache/test/CacheTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cache/test/CacheTestCase.java
@@ -130,10 +130,22 @@ public class CacheTestCase extends TestCase {
 
     public void testExpire() throws InterruptedException {
         Cache cache=new Cache(10*1024,50, 10000, Statistics.nullImplementation); // 10 KB, 50ms expire
-        cache.put("foo", "bar");
-        cache.put("hey", "ho");
-        assertEquals(cache.get("foo"), "bar");
-        assertEquals(cache.get("hey"), "ho");
+        boolean success = false;
+        for (int tries = 0; tries < 10; tries++) {
+            long before = System.currentTimeMillis();
+            cache.put("foo", "bar");
+            cache.put("hey", "ho");
+            Object got1 = cache.get("foo");
+            Object got2 = cache.get("hey");
+            long after = System.currentTimeMillis();
+            if (after - before < 50) {
+                assertEquals(got1, "bar");
+                assertEquals(got2, "ho");
+                success = true;
+                break;
+            }
+        }
+        assertTrue(success);
         Thread.sleep(100);
         assertNull(cache.get("foo"));
         assertNull(cache.get("hey"));


### PR DESCRIPTION
- if too much time passes between putting thing into
  the cache and taking them out again, they might be
  removed as "too old".  Measure the time around the
  critical region and retry if it was possibly too long.

@bjorncs please review and merge
