### PR TITLE
Un-break Javadoc building

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorDataQueue.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorDataQueue.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
  * visiting not to halt. The class is thread safe.
  *
  * @author Håkon Humberset
- * @author @vekterli
+ * @author vekterli
  */
 public class VisitorDataQueue extends VisitorDataHandler {
 


### PR DESCRIPTION
@bjorncs This is a 1-line breakfix, so please review after the fact. Or anyone else who stumbles over this PR.

Turns out Javadoc gets reaaal angry if you don't pet it the right way.
