### PR TITLE
vsm must be built after config to avoid non existing header file.

### DIFF
--- a/vsm/src/vespa/vsm/vsm/CMakeLists.txt
+++ b/vsm/src/vespa/vsm/vsm/CMakeLists.txt
@@ -11,4 +11,6 @@ vespa_add_library(vsm_vsmbase OBJECT
     docsumconfig.cpp
     DEPENDS
     vsm_vconfig
+    AFTER
+    vsm_vconfig
 )


### PR DESCRIPTION
@ean 
