### PR TITLE
Destroy proton instance after shutting down service layer process but…

### DIFF
--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -246,6 +246,7 @@ App::Main()
                 spiProton->shutdown();
                 EV_STOPPING("servicelayer", "clean shutdown");
             }
+            protonUP.reset();
             EV_STOPPING("proton", "clean shutdown");
         }
     } catch (const vespalib::InvalidCommandLineArgumentsException &e) {


### PR DESCRIPTION
… before

destroying it, to keep document type repos live until indexing activity has
been drained.  This should prevent crashes when visibility is enabled and
proton is stopped right after feeding has ended.

@havardpe, please review
