### PR TITLE
Do not coredump when you do not get config. Just log the stopping eve…

### DIFF
--- a/filedistribution/src/apps/filedistributor/filedistributor.cpp
+++ b/filedistribution/src/apps/filedistributor/filedistributor.cpp
@@ -328,6 +328,10 @@ FileDistributorApplication::Main() {
         std::string s = boost::diagnostic_information(e);
         EV_STOPPING(programName, s.c_str());
         return 3;
+    } catch(const config::ConfigTimeoutException & e) {
+        std::string s = boost::diagnostic_information(e);
+        EV_STOPPING(programName, s.c_str());
+        return 4;
     } catch(const ZKGenericException & e) {
         std::string s = boost::diagnostic_information(e);
         EV_STOPPING(programName, s.c_str());


### PR DESCRIPTION
…nt and restart. See bug jira VESPA-4168.
@geirst or @havardpe PR
