### PR TITLE
Remove unused SummaryAdapter::update method.

### DIFF
--- a/searchcore/src/tests/proton/documentdb/configurer/configurer_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/configurer/configurer_test.cpp
@@ -222,8 +222,6 @@ struct MySummaryAdapter : public ISummaryAdapter
 {
     virtual void put(search::SerialNum, const document::Document &, const search::DocumentIdT) {}
     virtual void remove(search::SerialNum, const search::DocumentIdT) {}
-    virtual void update(search::SerialNum, const document::DocumentUpdate &,
-            const search::DocumentIdT, const document::DocumentTypeRepo &) {}
     virtual void heartBeat(search::SerialNum) {}
     virtual const search::IDocumentStore &getDocumentStore() const {
         const search::IDocumentStore *store = NULL;

--- a/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
@@ -239,10 +239,6 @@ struct MySummaryAdapter : public ISummaryAdapter
         _store.remove(serialNum, lid);
         _removes.push_back(lid);
     }
-    virtual void update(SerialNum serialNum, const document::DocumentUpdate &upd,
-           const DocumentIdT lid, const document::DocumentTypeRepo &repo) {
-        (void) serialNum; (void) upd; (void) lid; (void) repo;
-    }
     virtual void heartBeat(SerialNum) {}
     virtual const search::IDocumentStore &getDocumentStore() const {
         return _store;

--- a/searchcore/src/tests/proton/documentdb/storeonlyfeedview/storeonlyfeedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/storeonlyfeedview/storeonlyfeedview_test.cpp
@@ -51,9 +51,6 @@ public:
     virtual void put(SerialNum, const Document &, DocumentIdT)
     { ++ _put_count; }
     virtual void remove(SerialNum, DocumentIdT) { ++_rm_count; }
-    virtual void update(SerialNum, const DocumentUpdate &, DocumentIdT,
-                        const DocumentTypeRepo &) {}
-
     virtual void heartBeat(SerialNum) { ++_heartbeat_count; }
     virtual const search::IDocumentStore &getDocumentStore() const
     { return *reinterpret_cast<const search::IDocumentStore *>(0); }

--- a/searchcore/src/vespa/searchcore/proton/server/isummaryadapter.h
+++ b/searchcore/src/vespa/searchcore/proton/server/isummaryadapter.h
@@ -25,10 +25,6 @@ public:
                      const search::DocumentIdT lid) = 0;
     virtual void remove(search::SerialNum serialNum,
                         const search::DocumentIdT lid) = 0;
-    virtual void update(search::SerialNum serialNum,
-                        const document::DocumentUpdate &upd,
-                        const search::DocumentIdT lid,
-                        const document::DocumentTypeRepo &repo) = 0;
 
     virtual void
     heartBeat(search::SerialNum serialNum) = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/summaryadapter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/summaryadapter.cpp
@@ -48,30 +48,6 @@ SummaryAdapter::remove(search::SerialNum serialNum,
 }
 
 void
-SummaryAdapter::update(search::SerialNum serialNum,
-                       const document::DocumentUpdate &upd,
-                       const search::DocumentIdT lid,
-                       const document::DocumentTypeRepo &repo)
-{
-    if ( ! ignore(serialNum) ) {
-        search::IDocumentStore &store = _mgr->getBackingStore();
-        document::Document::UP doc = store.read(lid, repo);
-        if (doc.get() == NULL) {
-            LOG(warning, "Did not find document '%s' to update.",
-                upd.getId().toString().c_str());
-            return;
-        }
-        upd.applyTo(*doc);
-
-        LOG(spam, "SummaryAdapter::update(docId = '%s', lid = %u, update = '%s')",
-            upd.getId().toString().c_str(), lid, upd.toString().c_str());
-        _mgr->putDocument(serialNum, *doc, lid);
-        _lastSerial = serialNum;
-    }
-}
-
-
-void
 SummaryAdapter::heartBeat(search::SerialNum serialNum)
 {
     if (serialNum > _lastSerial) {

--- a/searchcore/src/vespa/searchcore/proton/server/summaryadapter.h
+++ b/searchcore/src/vespa/searchcore/proton/server/summaryadapter.h
@@ -25,10 +25,6 @@ public:
                      const search::DocumentIdT lid);
     virtual void remove(search::SerialNum serialNum,
                         const search::DocumentIdT lid);
-    virtual void update(search::SerialNum serialNum,
-                        const document::DocumentUpdate &upd,
-                        const search::DocumentIdT lid,
-                        const document::DocumentTypeRepo &repo);
 
     virtual void
     heartBeat(search::SerialNum serialNum);


### PR DESCRIPTION
StoreOnlyFeedView::updateIndexAndDocumentStore() handles partial updates that
are propagated to document store.

@geirst, please review
