### PR TITLE
Test serialization/deserialization of tensor assign value update.

### DIFF
--- a/document/src/tests/documentupdatetestcase.cpp
+++ b/document/src/tests/documentupdatetestcase.cpp
@@ -983,6 +983,7 @@ DocumentUpdateTest::testTensorAssignUpdate()
     CPPUNIT_ASSERT(!doc->getValue("tensor"));
     Document updated(*doc);
     FieldValue::UP new_value(createTensorFieldValue());
+    testValueUpdate(AssignValueUpdate(*new_value), *DataType::TENSOR);
     DocumentUpdate upd(*doc->getDataType(), doc->getId());
     upd.addUpdate(FieldUpdate(upd.getType().getField("tensor")).
                   addUpdate(AssignValueUpdate(*new_value)));

--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -376,8 +376,8 @@ void
 VespaDocumentDeserializer::read(TensorFieldValue &value)
 {
     size_t length = _stream.getInt1_4Bytes();
-    if (length < _stream.size()) {
-        throw DeserializeException(vespalib::make_string("Stream failed size(%zu), needed(%zu)", _stream.size(), length),
+    if (length > _stream.size()) {
+        throw DeserializeException(vespalib::make_string("Stream failed size(%zu), needed(%zu) to deserialize tensor field value", _stream.size(), length),
                                    VESPA_STRLOC);
     }
     std::unique_ptr<vespalib::tensor::Tensor> tensor;


### PR DESCRIPTION
Handle deserialization of tensor field value in document update.

@geirst, please review
