### PR TITLE
Remove check for changed payload without changed generation

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/protocol/SlimeClientConfigRequest.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/SlimeClientConfigRequest.java
@@ -5,7 +5,6 @@ import com.yahoo.jrt.*;
 import com.yahoo.slime.*;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.config.ConfigKey;
-import com.yahoo.vespa.config.ErrorCode;
 import com.yahoo.vespa.config.util.ConfigUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -185,12 +184,6 @@ public abstract class SlimeClientConfigRequest implements JRTClientConfigRequest
             return false;
         } else if (!checkReturnTypes(request)) {
             log.warning("Invalid return types for config response: " + errorMessage());
-            return false;
-        }
-        if (hasUpdatedConfig() && ! hasUpdatedGeneration()) {
-            request.setError(ErrorCode.OUTDATED_CONFIG, "Config payload has changed (old config md5:" +
-                    getRequestConfigMd5() + ", new config md5: " + getNewConfigMd5() +"), but new generation " +
-                    getNewGeneration() + " is not newer than current generation " + getRequestGeneration()  + ".");
             return false;
         }
         return true;


### PR DESCRIPTION
VESPA-4039
- Remove check, as this has bitten us where the config payload has
  changed, but config generation has not changed. This happens when
  a config server goes down and the client changes config server, which
  might lead to e.g. a map being in a different order than expected. If
  this happens many times, we might miss a config change, since the
  reconnect delay might be so large that we miss one generation.

@gjoranv please review
