### PR TITLE
Depend on lz4

### DIFF
--- a/docker-api/pom.xml
+++ b/docker-api/pom.xml
@@ -29,15 +29,19 @@
             <version>3.0.3</version>
             <exclusions>
                 <exclusion>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
-            <exclusion>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-            </exclusion>
-
-     </exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.jpountz.lz4</groupId>
+            <artifactId>lz4</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- node-admin fails loading docker-api bundle without this

Starting node-admin jdisc container now fails in CI with:
 Unresolved constraint in bundle docker-api [61]: Unable to resolve 61.0: missing requirement [61.0] osgi.wiring.package; (&(osgi.wiring.package=net.jpountz.xxhash)(version>=1.3.0)(!(version>=2.0.0)))

This seems to fix it, although I am not sure what actually uses this code and why we need this dependency. We might want to add a note about it

@dybis or @hakonhall or @freva 
