### PR TITLE
Use correct thread count for visitor config propagation

### DIFF
--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -207,10 +207,10 @@ VisitorManager::configure(std::unique_ptr<vespa::config::content::core::StorVisi
     _maxFixedConcurrentVisitors = maxConcurrentVisitorsFixed;
     _maxVariableConcurrentVisitors = maxConcurrentVisitorsVariable;
     _maxVisitorQueueSize = config->maxvisitorqueuesize;
-    std::shared_ptr<PropagateVisitorConfig> cmd(
-            new PropagateVisitorConfig(*config));
-    for (int32_t i=0; i<config->visitorthreads; ++i) {
-        _visitorThread[i].first->processMessage(0, cmd);
+
+    auto cmd = std::make_shared<PropagateVisitorConfig>(*config);
+    for (auto& thread : _visitorThread) {
+        thread.first->processMessage(0, cmd);
     }
 }
 


### PR DESCRIPTION
@hakonhall Please review.

We do not support live reconfig of thread counts. When the old code
attempted to index into the thread array based on the new config's
thread count, bad things unsurprisingly happened.
