### PR TITLE
Proper shell exit values.

### DIFF
--- a/searchlib/src/tests/datastore/logdatastore_test.sh
+++ b/searchlib/src/tests/datastore/logdatastore_test.sh
@@ -15,4 +15,4 @@ truncate --size 3830 bug-7257706-truncated/1422358701368384000.idx
 fail=0
 VESPA_LOG_TARGET=file:vlog2.txt $VALGRIND ./searchlib_logdatastore_test_app || fail=1
 rm -rf bug-7257706-truncated dangling-test
-return fail
+exit $fail


### PR DESCRIPTION
@toregge This was a blunder on #544 Breakfixing
