### PR TITLE
Only schedule bucket integrity checker runs when on VDS

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/IntegrityCheckerProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/IntegrityCheckerProducer.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.content.storagecluster;
 import com.yahoo.vespa.config.content.core.StorIntegritycheckerConfig;
 import com.yahoo.config.model.ConfigModelUtils;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
+import com.yahoo.vespa.model.content.cluster.ContentCluster;
 
 /**
  * Serves stor-integritychecker config for storage clusters.
@@ -11,7 +12,11 @@ import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 public class IntegrityCheckerProducer implements StorIntegritycheckerConfig.Producer {
 
     public static class Builder {
-        protected IntegrityCheckerProducer build(ModelElement clusterElem) {
+        protected IntegrityCheckerProducer build(ContentCluster cluster, ModelElement clusterElem) {
+            if (!cluster.isMemfilePersistence()) {
+                return integrityCheckerDisabled();
+            }
+
             ModelElement tuning = clusterElem.getChild("tuning");
 
             if (tuning == null) {
@@ -61,6 +66,12 @@ public class IntegrityCheckerProducer implements StorIntegritycheckerConfig.Prod
         this.startTime = startTime;
         this.stopTime = stopTime;
         this.weeklyCycle = weeklyCycle;
+    }
+
+    private static IntegrityCheckerProducer integrityCheckerDisabled() {
+        // Leave start/start times at default, but mark each day of the week as
+        // not allowing the integrity checker to be run.
+        return new IntegrityCheckerProducer(null, null, "-------");
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
@@ -32,12 +32,13 @@ public class StorageCluster extends AbstractConfigProducer<StorageNode>
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<StorageCluster> {
         @Override
         protected StorageCluster doBuild(AbstractConfigProducer ancestor, Element producerSpec) {
-            ModelElement clusterElem = new ModelElement(producerSpec);
+            final ModelElement clusterElem = new ModelElement(producerSpec);
+            final ContentCluster cluster = (ContentCluster)ancestor;
 
             return new StorageCluster(ancestor,
                                       ContentCluster.getClusterName(clusterElem),
-                                      new FileStorProducer.Builder().build(((ContentCluster)ancestor), clusterElem),
-                                      new IntegrityCheckerProducer.Builder().build(clusterElem),
+                                      new FileStorProducer.Builder().build(cluster, clusterElem),
+                                      new IntegrityCheckerProducer.Builder().build(cluster, clusterElem),
                                       new StorServerProducer.Builder().build(clusterElem),
                                       new StorVisitorProducer.Builder().build(clusterElem),
                                       new PersistenceProducer.Builder().build(clusterElem));


### PR DESCRIPTION
@baldersheim Please review.

Non-VDS providers today do not implement explicit bucket integrity checking,
so no point in using CPU time on what's effectively a bunch of no-ops.
