### PR TITLE
Only refer to plugin, do not specify any details...

### DIFF
--- a/container-accesslogging/pom.xml
+++ b/container-accesslogging/pom.xml
@@ -74,17 +74,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWarnings>true</showWarnings>
-          <optimize>true</optimize>
-          <showDeprecation>false</showDeprecation>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
     </plugins>
     <outputDirectory>${buildOutputDirectory}</outputDirectory>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -272,17 +272,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWarnings>true</showWarnings>
-          <optimize>true</optimize>
-          <showDeprecation>false</showDeprecation>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
     </plugins>
     <outputDirectory>${buildOutputDirectory}</outputDirectory>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -197,17 +197,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWarnings>true</showWarnings>
-          <optimize>true</optimize>
-          <showDeprecation>false</showDeprecation>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -241,17 +241,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWarnings>true</showWarnings>
-          <optimize>true</optimize>
-          <showDeprecation>false</showDeprecation>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -261,13 +261,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jaxrs_client_utils/pom.xml
+++ b/jaxrs_client_utils/pom.xml
@@ -73,6 +73,10 @@
         <artifactId>bundle-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jdisc_messagebus_service/pom.xml
+++ b/jdisc_messagebus_service/pom.xml
@@ -46,17 +46,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <showWarnings>true</showWarnings>
-                    <optimize>true</optimize>
-                    <showDeprecation>false</showDeprecation>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/orchestrator/pom.xml
+++ b/orchestrator/pom.xml
@@ -149,6 +149,10 @@
         <artifactId>bundle-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/socket_test/pom.xml
+++ b/socket_test/pom.xml
@@ -12,9 +12,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
               <artifactId>maven-assembly-plugin</artifactId>

--- a/standalone-container/pom.xml
+++ b/standalone-container/pom.xml
@@ -91,6 +91,10 @@
           <jdiscPrivilegedActivator>true</jdiscPrivilegedActivator>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
 
       <plugin>
         <groupId>org.scala-tools</groupId>


### PR DESCRIPTION
@gv @ean @hakonhall PR
Only specifying the minimum worked fine. However if you specified version it failed.
I have cleaned up everything for #555 + what was needed for a full rebuild in IntelliJ.
I see there are still 1.5 warnings, but that is in modules that have 1.5 compliant code. I am not able to see which modules that are.
