### PR TITLE
Temporarily skip updating node repo with current attributes

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -171,6 +171,7 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     private void updateNodeRepoAndMarkNodeAsReady(ContainerNodeSpec nodeSpec) throws IOException {
+        /*
         publishStateToNodeRepoIfChanged(
                 nodeSpec.hostname,
                 // Clear current Docker image and vespa version, as nothing is running on this node
@@ -178,6 +179,7 @@ public class NodeAgentImpl implements NodeAgent {
                         nodeSpec.wantedRestartGeneration.get(),
                         new DockerImage(""),
                         ""));
+                        */
         nodeRepository.markAsReady(nodeSpec.hostname);
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -275,8 +275,10 @@ public class NodeAgentImplTest {
         verify(dockerOperations, never()).startContainerIfNeeded(any());
         verify(orchestrator, never()).resume(any(HostName.class));
         // current Docker image and vespa version should be cleared
-        verify(nodeRepository, times(1)).updateNodeAttributes(
-                any(HostName.class), anyLong(), eq(new DockerImage("")), eq(""));
+        //verify(nodeRepository, times(1)).updateNodeAttributes(
+        //        any(HostName.class), anyLong(), eq(new DockerImage("")), eq(""));
+        verify(nodeRepository, never()).updateNodeAttributes(
+                any(HostName.class), anyLong(), any(DockerImage.class), any(String.class));
     }
 
     @Test


### PR DESCRIPTION
- It's not legal to update with current restart generation unless
  node is allocated, need to refactor code to make this work again

@dybis @frevar
