### PR TITLE
Add back removed constructor

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadBuilder.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadBuilder.java
@@ -26,11 +26,15 @@ public class ConfigPayloadBuilder {
      * Construct a payload builder that is not a leaf.
      */
     public ConfigPayloadBuilder() {
-        this(null, null);
+        this(null, (String)null);
     }
 
     public ConfigPayloadBuilder(ConfigDefinition configDefinition) {
-        this(configDefinition, null);
+        this(configDefinition, (String)null);
+    }
+
+    public ConfigPayloadBuilder(ConfigDefinition configDefinition, List<String> warnings) {
+        this(configDefinition);
     }
 
     /**


### PR DESCRIPTION
VESPA-4497
- After ConfigPayloadBuilder(ConfigDefinition, List<String>) was removed it
  seems like some code is expecting this to be available, even though config
  should be bundled with each config model, so changes like this should not
  be a problem.

@bratseth 
