### PR TITLE
Terminate jvm on Error during reconfiguration

### DIFF
--- a/container-di/src/main/scala/com/yahoo/container/di/componentgraph/core/ComponentNode.scala
+++ b/container-di/src/main/scala/com/yahoo/container/di/componentgraph/core/ComponentNode.scala
@@ -99,14 +99,19 @@ class ComponentNode(componentId: ComponentId,
       constructor.newInstance(actualArguments: _*)
     } catch {
       case e: InvocationTargetException =>
-        throw removeStackTrace(new RuntimeException(s"An exception occurred while constructing $idAndType",
-          cutStackTraceAtConstructor(e.getCause)))
-
+        throw removeStackTrace(constructThrowable(cutStackTraceAtConstructor(e.getCause), s"Error constructing $idAndType"))
     }
 
     initId(instance)
   }
-
+  
+  private def constructThrowable(cause: Throwable, message: String) : Throwable = {
+    if (cause != null && cause.isInstanceOf[Error]) // don't convert Errors to RuntimeExceptions
+      new Error(message, cause)
+    else
+      new RuntimeException(message, cause)
+  }
+  
   private def initId(component: AnyRef) = {
     def checkAndSetId(c: AbstractComponent) {
       if (c.hasInitializedId && c.getId != componentId )

--- a/container-di/src/main/scala/com/yahoo/container/di/package.scala
+++ b/container-di/src/main/scala/com/yahoo/container/di/package.scala
@@ -28,7 +28,7 @@ package object di {
     clazz.asInstanceOf[Class[SUPER]]
   }
 
-  def removeStackTrace(exception: RuntimeException): RuntimeException = {
+  def removeStackTrace(exception: Throwable): Throwable = {
     if (preserveStackTrace) exception
     else {
       exception.setStackTrace(Array())


### PR DESCRIPTION
This avoids entering a zombie state due to a destructive reconfiguration attempt.
LinkageError is exempted as that is a normal consequence of OSGi loading problems.

@gjoranv please review. 
It seems this code was not unit tested and I did not attempt to add that  due to: Is Scala
