### PR TITLE
Use 64-bit bit-offsets for sparse sparse file in dictionary.

### DIFF
--- a/searchlib/src/vespa/searchlib/bitcompression/pagedict4.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/pagedict4.cpp
@@ -1293,7 +1293,7 @@ PageDict4SSReader::setup(DC &ssd)
     uint32_t l7StrideCheck = 0;
     uint32_t l7Ref = noL7Ref();	// Last L6 entry not after this L7 entry
 
-    uint32_t l6Offset = dL6.getReadOffset();
+    uint64_t l6Offset = dL6.getReadOffset();
     uint64_t l6WordNum = 1;
     bool forceL7Entry = false;
     bool overflow = false;
@@ -1416,7 +1416,7 @@ lookup(const vespalib::stringref &key)
     StartOffset startOffset;
     uint64_t pageNum = _pFirstPageNum;
     uint32_t sparsePageNum = _spFirstPageNum;
-    uint32_t l6Offset = _ssStartOffset;
+    uint64_t l6Offset = _ssStartOffset;
     uint64_t l6WordNum = 1;
     uint64_t wordNum = l6WordNum;
 
@@ -2357,7 +2357,7 @@ PageDict4Reader::decodeSPWord(vespalib::string &word)
 void
 PageDict4Reader::decodeSSWord(vespalib::string &word)
 {
-    uint32_t l6Offset = _ssd.getReadOffset();
+    uint64_t l6Offset = _ssd.getReadOffset();
 
     while (l6Offset < _ssReader._ssFileBitLen) {
         UC64_DECODECONTEXT(o);

--- a/searchlib/src/vespa/searchlib/bitcompression/pagedict4.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/pagedict4.h
@@ -566,7 +566,7 @@ public:
         vespalib::string _l7Word;
         StartOffset      _l7StartOffset;	// Offsets in data files
         uint64_t _l7WordNum;
-        uint32_t _l6Offset;	// Offset in L6+overflow stream
+        uint64_t _l6Offset;	// Offset in L6+overflow stream
         uint32_t _sparsePageNum;// page number for sparse file
         uint64_t _pageNum;	// page number in full file
         uint32_t _l7Ref;	// L7 entry before overflow, or self-ref if L6
@@ -585,7 +585,7 @@ public:
         L7Entry(const vespalib::stringref &l7Word,
                 const StartOffset         &l7StartOffset,
                 uint64_t l7WordNum,
-                uint32_t l6Offset,
+                uint64_t l6Offset,
                 uint32_t sparsePageNum,
                 uint64_t pageNum,
                 uint32_t l7Ref)


### PR DESCRIPTION
This allows the sparse sparse file to be larger than 512MiB
which can happen when dictionary contains many long words.

@geirst, please review
@baldersheim, FYI
