### PR TITLE
ignore SIGTERM during valgrind startup

### DIFF
--- a/vespabase/src/start-cbinaries.sh
+++ b/vespabase/src/start-cbinaries.sh
@@ -232,6 +232,8 @@ else
     else
         export LD_PRELOAD=""
     fi
+    # ignore signal until shared libraries have loaded, etc:
+    trap "" SIGTERM
     log_debug_message "Starting : " \
          valgrind $VESPA_VALGRIND_OPT --log-file=/home/y/tmp/valgrind.$bname.log.$$ $0-bin "$@"
     exec valgrind $VESPA_VALGRIND_OPT --log-file=/home/y/tmp/valgrind.$bname.log.$$ $0-bin "$@"


### PR DESCRIPTION
- we've seen some false valgrind positives when the application
  didn't finish loading shared libraries, etc before shutdown
  (TERM signal) happened.  We may need to reset SIGTERM handling
  to default in some more places, but most of our programs already
  catch and handle it with controlled shutdown.

@balder as discussed
