### PR TITLE
Use hostname to check if host is remote or not

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -185,13 +185,10 @@ public class ClusterSearcher extends Searcher {
      * Returns false if this host is local.
      */
     boolean isRemote(String host) throws UnknownHostException {
-        InetAddress dispatchHost = InetAddress.getByName(host);
-        if (dispatchHost.isLoopbackAddress()) {
+        if (InetAddress.getByName(host).isLoopbackAddress())
             return false;
-        } else {
-            String localName = HostName.getLocalhost();
-            return !localName.equals(dispatchHost.getCanonicalHostName());
-        }
+        else
+            return !host.equals(HostName.getLocalhost());
     }
 
     private static ClusterParams makeClusterParams(int searchclusterIndex,


### PR DESCRIPTION
- The code as it is now does not work with the new network setup
  on Docker hosts

We get an error in the log now (in constructor in same class).  Not sure
if that is correct level either, as things still work, but haven't changed 
that in this PR. 

This change should work on all network setups and be simpler.

@bratseth please review
