### PR TITLE
get rid of intermediate shell process

### DIFF
--- a/vespalib/src/tests/exception_classes/silenceuncaught_test.cpp
+++ b/vespalib/src/tests/exception_classes/silenceuncaught_test.cpp
@@ -6,43 +6,43 @@
 using namespace vespalib;
 
 TEST("that uncaught exception causes negative exitcode.") {
-    SlaveProc proc("./vespalib_caught_uncaught_app uncaught");
+    SlaveProc proc("exec ./vespalib_caught_uncaught_app uncaught");
     proc.wait();
     EXPECT_LESS(proc.getExitCode(), 0);
 }
 
 TEST("that uncaught silenced exception causes exitcode 66") {
-    SlaveProc proc("./vespalib_caught_uncaught_app silenced_and_uncaught");
+    SlaveProc proc("exec ./vespalib_caught_uncaught_app silenced_and_uncaught");
     proc.wait();
     EXPECT_EQUAL(proc.getExitCode(), 66);
 }
 
 TEST("that caught silenced exception followed by an uncaught causes negative exitcode.") {
-    SlaveProc proc("./vespalib_caught_uncaught_app uncaught_after_silenced_and_caught");
+    SlaveProc proc("exec ./vespalib_caught_uncaught_app uncaught_after_silenced_and_caught");
     proc.wait();
     EXPECT_LESS(proc.getExitCode(), 0);
 }
 
 TEST("that caught silenced exception causes exitcode 0") {
-    SlaveProc proc("./vespalib_caught_uncaught_app silenced_and_caught");
+    SlaveProc proc("exec ./vespalib_caught_uncaught_app silenced_and_caught");
     proc.wait();
     EXPECT_EQUAL(proc.getExitCode(), 0);
 }
 
 TEST("that mmap within limits are fine cause exitcode 0") {
-    SlaveProc proc("./vespalib_mmap_app 100000000 10485760 1");
+    SlaveProc proc("exec ./vespalib_mmap_app 100000000 10485760 1");
     proc.wait();
     EXPECT_EQUAL(proc.getExitCode(), 0);
 }
 
 TEST("that mmap beyond limits cause negative exitcode.") {
-    SlaveProc proc("./vespalib_mmap_app 100000000 10485760 10");
+    SlaveProc proc("exec ./vespalib_mmap_app 100000000 10485760 10");
     proc.wait();
     EXPECT_LESS(proc.getExitCode(), 0);
 }
 
 TEST("that mmap beyond limits with set VESPA_SILENCE_CORE_ON_OOM cause exitcode 66.") {
-    SlaveProc proc("VESPA_SILENCE_CORE_ON_OOM=1 ./vespalib_mmap_app 100000000 10485760 10");
+    SlaveProc proc("VESPA_SILENCE_CORE_ON_OOM=1 exec ./vespalib_mmap_app 100000000 10485760 10");
     proc.wait();
     EXPECT_EQUAL(proc.getExitCode(), 66);
 }


### PR DESCRIPTION
- we want to get the actual exit code directly,
  so use "exec" to avoid an intermediate shell.

@baldersheim please review and merge
