### PR TITLE
Allow source directories in standalone application.

### DIFF
--- a/standalone-container/src/main/scala/com/yahoo/container/standalone/StandaloneContainerApplication.scala
+++ b/standalone-container/src/main/scala/com/yahoo/container/standalone/StandaloneContainerApplication.scala
@@ -166,7 +166,7 @@ object StandaloneContainerApplication {
                            networkingOption: Networking,
                            configModelRepo: ConfigModelRepo = new ConfigModelRepo): (MockRoot, Container) = {
     val logger = new BaseDeployLogger
-    val rawApplicationPackage = new FilesApplicationPackage.Builder(applicationPath.toFile).preprocessedDir(preprocessedApplicationDir).build()
+    val rawApplicationPackage = new FilesApplicationPackage.Builder(applicationPath.toFile).includeSourceFiles(true).preprocessedDir(preprocessedApplicationDir).build()
     // TODO: Needed until we get rid of semantic rules
     val applicationPackage = rawApplicationPackage.preprocess(Zone.defaultZone(), new RuleConfigDeriver {
       override def derive(ruleBaseDir: String, outputDir: String): Unit = {}


### PR DESCRIPTION
This allows Application instances to run tests referencing config definitions without
first building the jar containing those config definitions.
Application currently instantiates Vespa models directly and (via dependency injection)
through standalone container.
