### PR TITLE
Add back to make config server work with older models

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Quota.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Quota.java
@@ -1,0 +1,25 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+/**
+ * @author hmusum
+ */
+// TODO: Remove when there is no release older than 6.33 in use
+@SuppressWarnings("unused")
+public class Quota {
+
+    private final int numberOfHosts;
+
+    public Quota() {
+        this(Integer.MAX_VALUE);
+    }
+
+    public Quota(int numberOfHosts) {
+        this.numberOfHosts = numberOfHosts;
+    }
+
+    public int getNumberOfHosts() {
+        return numberOfHosts;
+    }
+
+}


### PR DESCRIPTION
- Still needed, getting NoClassDefFoundError

I convinced myself that Quota was not needed when reviewing https://github.com/yahoo/vespa/pull/689 since config-provisioning jar is in config-model-fat, but I guess I there is some other
dependencies that makes it use the class from another bundle or something.

@bratseth 
