### PR TITLE
No need to suspend if there are no active nodes

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -89,6 +89,7 @@ public class NodeAdminStateUpdater extends AbstractComponent {
                 } catch (IOException e) {
                     return Optional.of("Failed to get nodes from node repo:" + e.getMessage());
                 }
+                // Avoids media type issues (HTTP ERROR: 415 Unsupported Media Type), probably related to having empty node list.
                 if (nodesInActiveState.size() == 0) return Optional.empty();
                 return orchestrator.suspend(dockerHostHostName, nodesInActiveState);
             } else {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -89,6 +89,7 @@ public class NodeAdminStateUpdater extends AbstractComponent {
                 } catch (IOException e) {
                     return Optional.of("Failed to get nodes from node repo:" + e.getMessage());
                 }
+                if (nodesInActiveState.size() == 0) return Optional.empty();
                 return orchestrator.suspend(dockerHostHostName, nodesInActiveState);
             } else {
                 nodeAdmin.unfreezeNodeAgents();


### PR DESCRIPTION
I don't think there is any need to call Orchestrator if there are no active nodes, but there could be some corner case here I haven't thought through.

@hakonhall please review
