### PR TITLE
Remove unused z89

### DIFF
--- a/vespalib/src/vespa/vespalib/eval/test/tensor_conformance.cpp
+++ b/vespalib/src/vespa/vespalib/eval/test/tensor_conformance.cpp
@@ -113,7 +113,6 @@ Domain y() { return Domain("y", {}); }
 Domain y(size_t size) { return Domain("y", size); }
 Domain y(const std::vector<vespalib::string> &keys) { return Domain("y", keys); }
 
-Domain z() { return Domain("z", {}); }
 Domain z(size_t size) { return Domain("z", size); }
 Domain z(const std::vector<vespalib::string> &keys) { return Domain("z", keys); }
 


### PR DESCRIPTION
@havardpe PR
You need a fresh vespa_build_dev requiring gcc 6.2
