### PR TITLE
- Bracing and style

### DIFF
--- a/fastlib/src/vespa/fastlib/io/bufferedinputstream.h
+++ b/fastlib/src/vespa/fastlib/io/bufferedinputstream.h
@@ -1,61 +1,37 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-//************************************************************************
-/**
- * Class definitions for Fast_BufferedInputStream
- *
- * @author  Markus Bjartveit Kr�ger
- * @version $Id$
- */
- /*
- * Creation date    : 2001-10-29
- * Copyright (c)    : 1997-2002 Fast Search & Transfer ASA
- *                    ALL RIGHTS RESERVED
- *************************************************************************/
 #pragma once
 
 #include <vespa/fastlib/io/filterinputstream.h>
 
-
-
-
-
 class Fast_BufferedInputStream : public Fast_FilterInputStream
 {
-  private:
-
-    // Prevent use of:
-    Fast_BufferedInputStream(const Fast_BufferedInputStream &);
-    Fast_BufferedInputStream & operator=(const Fast_BufferedInputStream &);
-
-
   protected:
-
     // Buffer attributes
-    char    *_buffer;
-    size_t   _bufferSize;
-    size_t   _bufferUsed;       // Amount of buffer currently holding data
-    size_t   _bufferRead;       // How far buffer has been read
-    bool     _nextWillFail;
+    char          *_buffer;
+    const size_t   _bufferSize;
+    size_t         _bufferUsed;       // Amount of buffer currently holding data
+    size_t         _bufferRead;       // How far buffer has been read
+    bool           _nextWillFail;
 
 
   public:
+    Fast_BufferedInputStream(const Fast_BufferedInputStream &) = delete;
+    Fast_BufferedInputStream & operator = (const Fast_BufferedInputStream &) = delete;
 
     // Constructor
     Fast_BufferedInputStream(Fast_InputStream &in, size_t bufferSize = 1024);
 
     // Destructor
-    virtual ~Fast_BufferedInputStream(void);
+    virtual ~Fast_BufferedInputStream();
 
     // Subclassed methods
-    virtual ssize_t  Available(void);
-    virtual bool     Close(void);
-    virtual ssize_t  Skip(size_t skipNBytes);
-    virtual ssize_t  Read(void *targetBuffer, size_t length);
+    ssize_t  Available() override;
+    bool     Close() override;
+    ssize_t  Skip(size_t skipNBytes) override;
+    ssize_t  Read(void *targetBuffer, size_t length) override;
 
     // Additional methods
-    ssize_t  ReadBufferFullUntil(void *targetBuffer,
-                                 size_t maxlength,
-                                 char stopChar);
+    ssize_t  ReadBufferFullUntil(void *targetBuffer, size_t maxlength, char stopChar);
 };
 
 

--- a/fastlib/src/vespa/fastlib/net/httpheaderparser.cpp
+++ b/fastlib/src/vespa/fastlib/net/httpheaderparser.cpp
@@ -81,8 +81,9 @@ Fast_HTTPHeaderParser::ReadHeader(const char *&name, const char *&value)
     idx++;
   }
 
-  while ((idx + 1) < _bufferSize) {
-    size_t readLen = _input->ReadBufferFullUntil(&_lineBuffer[idx], _bufferSize - idx, '\n');
+  constexpr size_t ROOM_FOR_PUSH_BACK = 1u;
+  while ((idx + ROOM_FOR_PUSH_BACK) < _bufferSize) {
+    size_t readLen = _input->ReadBufferFullUntil(&_lineBuffer[idx], _bufferSize - idx - ROOM_FOR_PUSH_BACK, '\n');
     if (readLen <= 0) {
       return false;
     }

--- a/fastlib/src/vespa/fastlib/net/httpheaderparser.cpp
+++ b/fastlib/src/vespa/fastlib/net/httpheaderparser.cpp
@@ -81,8 +81,8 @@ Fast_HTTPHeaderParser::ReadHeader(const char *&name, const char *&value)
     idx++;
   }
 
-  while (idx < (_bufferSize-1)) {
-    size_t readLen = _input->ReadBufferFullUntil(&_lineBuffer[idx], _bufferSize - idx - 1, '\n');
+  while ((idx + 1) < _bufferSize) {
+    size_t readLen = _input->ReadBufferFullUntil(&_lineBuffer[idx], _bufferSize - idx, '\n');
     if (readLen <= 0) {
       return false;
     }

--- a/fastlib/src/vespa/fastlib/net/httpheaderparser.cpp
+++ b/fastlib/src/vespa/fastlib/net/httpheaderparser.cpp
@@ -3,50 +3,40 @@
 #include <vespa/fastlib/io/bufferedinputstream.h>
 #include <vespa/fastlib/net/httpheaderparser.h>
 
-
-
 Fast_HTTPHeaderParser::Fast_HTTPHeaderParser(Fast_BufferedInputStream &in)
   : _pushBack(0),
     _isPushBacked(false),
+    _bufferSize(16384),
+    _lineBuffer(new char[_bufferSize]),
     _input(&in)
 {
 }
 
-
-
 Fast_HTTPHeaderParser::~Fast_HTTPHeaderParser(void)
 {
+    delete [] _lineBuffer;
 }
 
-
-
-bool Fast_HTTPHeaderParser::ReadRequestLine(const char *&method,
-                                            const char *&url,
-                                            int &versionMajor,
-                                            int &versionMinor)
+bool
+Fast_HTTPHeaderParser::ReadRequestLine(const char *&method, const char *&url, int &versionMajor, int &versionMinor)
 {
   // Read a single line from input.  Repeat if line is blank, to cope
   // with buggy HTTP/1.1 clients that print extra empty lines at the
   // end of requests.
 
-  do
-  {
+  do {
     int idx = 0;
-    size_t readLen =
-      _input->ReadBufferFullUntil(_lineBuffer,
-                                  static_cast<size_t>
-                                  (HTTPHEADERPARSER_LINE_BUFFER_SIZE),
-                                  '\n');
+    size_t readLen = _input->ReadBufferFullUntil(_lineBuffer, _bufferSize, '\n');
     if (readLen <= 0) {
       return false;
     }
     idx = readLen-1;
 
-    if (idx == 0 || _lineBuffer[idx] != '\n')
+    if (idx == 0 || _lineBuffer[idx] != '\n') {
       return false;
+    }
     _lineBuffer[idx--] = '\0';
-    if (_lineBuffer[idx] == '\r')
-    {
+    if (_lineBuffer[idx] == '\r') {
       _lineBuffer[idx] = '\0';
     }
   } while (_lineBuffer[0] == '\0');
@@ -58,20 +48,17 @@ bool Fast_HTTPHeaderParser::ReadRequestLine(const char *&method,
 
   method = p;
   p = strchr(p, ' ');
-  if (p != NULL)
-  {
+  if (p != NULL) {
     *p++ = '\0';
     url = p;
     p = strchr(p, ' ');
-    if (p != NULL)
-    {
+    if (p != NULL) {
       *p++ = '\0';
       version = p;
     }
   }
 
-  if (sscanf(version, "HTTP/%d.%d", &versionMajor, &versionMinor) != 2)
-  {
+  if (sscanf(version, "HTTP/%d.%d", &versionMajor, &versionMinor) != 2) {
     versionMajor = versionMinor = -1;
     return false;
   }
@@ -79,37 +66,30 @@ bool Fast_HTTPHeaderParser::ReadRequestLine(const char *&method,
   return true;
 }
 
-bool Fast_HTTPHeaderParser::ReadHeader(const char *&name, const char *&value)
+bool
+Fast_HTTPHeaderParser::ReadHeader(const char *&name, const char *&value)
 {
-  int idx = 0;
+  size_t idx = 0;
 
   name  = NULL;
   value = NULL;
 
-  if (_isPushBacked)
-  {
+  if (_isPushBacked) {
     idx = 0;
     _lineBuffer[idx] = _pushBack;
     _isPushBacked = false;
     idx++;
   }
 
-  while (idx<HTTPHEADERPARSER_LINE_BUFFER_SIZE-1)
-  {
-
-    size_t readLen =
-      _input->ReadBufferFullUntil(&_lineBuffer[idx],
-                                  static_cast<size_t>
-                                  (HTTPHEADERPARSER_LINE_BUFFER_SIZE),
-                                  '\n');
+  while (idx < (_bufferSize-1)) {
+    size_t readLen = _input->ReadBufferFullUntil(&_lineBuffer[idx], _bufferSize - idx - 1, '\n');
     if (readLen <= 0) {
       return false;
     }
     idx += readLen - 1;
     // Empty line == end of headers.
     // handle case with \r\n as \n
-    if (idx == 0 || (_lineBuffer[0] == '\r' && idx == 1))
-    {
+    if (idx == 0 || (_lineBuffer[0] == '\r' && idx == 1)) {
       idx = 0;
       break;
     }
@@ -123,52 +103,44 @@ bool Fast_HTTPHeaderParser::ReadHeader(const char *&name, const char *&value)
     }
 
     // Check if header continues on next line.
-    if (_input->Read(&_pushBack, 1) != 1)
+    if (_input->Read(&_pushBack, 1) != 1) {
       break;
-    if (_pushBack == ' ' || _pushBack == '\t')
-    {
+    }
+    if (_pushBack == ' ' || _pushBack == '\t') {
       // Header does continue on next line.
       // Replace newline with horizontal whitespace.
       _lineBuffer[idx] = _pushBack;
       idx++;
-    }
-    else
-    {
+    } else {
       _isPushBacked = true;
       // break out of while loop
       break;
     }
-
   }
 
-  if (idx != 0)
-  {
+  if (idx != 0) {
     _lineBuffer[idx] = '\0';
     char *p = _lineBuffer;
     name = p;
 
     // Find end of header name.
-    while (*p != ':' && *p != '\0')
-    {
+    while (*p != ':' && *p != '\0') {
       p++;
     }
 
     // If end of header name is not end of header, parse header value.
-    if (*p != '\0')
-    {
+    if (*p != '\0') {
       // Terminate header name.
       *p++ = '\0';
 
       // Skip leading whitespace before header value.
-      while (*p == ' ' || *p == '\t')
-      {
+      while (*p == ' ' || *p == '\t') {
         p++;
       }
       value = p;
       // Strip trailing whitespace.
       p += strlen(p);
-      while (p > value && (*(p-1) == ' ' || *(p-1) == '\t'))
-      {
+      while (p > value && (*(p-1) == ' ' || *(p-1) == '\t')) {
         p--;
       }
       *p = '\0';

--- a/fastlib/src/vespa/fastlib/net/httpheaderparser.h
+++ b/fastlib/src/vespa/fastlib/net/httpheaderparser.h
@@ -1,53 +1,26 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author          Markus Bjartveit Kr�ger
-* @date            Creation date: 2000-11-22
-* @version         $Id$
-*
-* @file
-*
-* HTTP header parser.
-*
-* Copyright (c)  : 2001 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
-
 
 #pragma once
 
-
+#include <vector>
 
 class Fast_BufferedInputStream;
 
-
-#define HTTPHEADERPARSER_LINE_BUFFER_SIZE  4096
-
-
 class Fast_HTTPHeaderParser
 {
-  private:
-    // Prevent use of:
-    Fast_HTTPHeaderParser(const Fast_HTTPHeaderParser &);
-    Fast_HTTPHeaderParser & operator=(const Fast_HTTPHeaderParser &);
-  protected:
-    char _pushBack;
-    bool _isPushBacked;
-    char _lineBuffer[HTTPHEADERPARSER_LINE_BUFFER_SIZE];
-    Fast_BufferedInputStream *_input;
-
   public:
+    Fast_HTTPHeaderParser(const Fast_HTTPHeaderParser &) = delete;
+    Fast_HTTPHeaderParser & operator = (const Fast_HTTPHeaderParser &) = delete;
     Fast_HTTPHeaderParser(Fast_BufferedInputStream &in);
-    virtual ~Fast_HTTPHeaderParser(void);
-
+    ~Fast_HTTPHeaderParser();
 
     // Methods
-    bool ReadRequestLine(const char *&method, const char *&url,
-                         int &versionMajor, int &versionMinor);
+    bool ReadRequestLine(const char *&method, const char *&url, int &versionMajor, int &versionMinor);
     bool ReadHeader(const char *&name, const char *&value);
+  private:
+    char                      _pushBack;
+    bool                      _isPushBacked;
+    const size_t              _bufferSize;
+    char                     *_lineBuffer;
+    Fast_BufferedInputStream *_input;
 };
-
-
-

--- a/fastlib/src/vespa/fastlib/net/httpheaderparser.h
+++ b/fastlib/src/vespa/fastlib/net/httpheaderparser.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <vector>
-
 class Fast_BufferedInputStream;
 
 class Fast_HTTPHeaderParser


### PR DESCRIPTION
- Buffer on heap, not stack.
- Do not read past buffer.
  @havardpe and @vekterli PR This fixes bad handling of port attack.
  99% is style. The actual fix is saying how much of the buffer is actually available in the call to ReadBufferUntil() method
