### PR TITLE
We must drop the lidguard that is kept inside the bucketcompacter.

### DIFF
--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -465,8 +465,9 @@ void LogDataStore::compactFile(FileId fileId)
         flushFileAndWait(guard, compactTo, 0);
         compactTo.freeze();
     }
+    compacter.reset();
 
-    std::this_thread::sleep_for(10s);
+    std::this_thread::sleep_for(1s);
     uint64_t currentGeneration;
     {
         LockGuard guard(_updateLock);


### PR DESCRIPTION
If not we will not move forward.
@toregge PR after the fact. I will merge it to verify that performance tests finish.
