### PR TITLE
Rename classes to get more consistent naming:

### DIFF
--- a/vespalib/src/tests/tensor/sparse_tensor_builder/sparse_tensor_builder_test.cpp
+++ b/vespalib/src/tests/tensor/sparse_tensor_builder/sparse_tensor_builder_test.cpp
@@ -28,7 +28,7 @@ assertCellValue(double expValue, const TensorAddress &address,
         addressBuilder.add("");
         ++dimsItr;
     }
-    CompactTensorAddressRef addressRef(addressBuilder.getAddressRef());
+    SparseTensorAddressRef addressRef(addressBuilder.getAddressRef());
     auto itr = cells.find(addressRef);
     EXPECT_FALSE(itr == cells.end());
     EXPECT_EQUAL(expValue, itr->second);

--- a/vespalib/src/vespa/vespalib/tensor/sparse/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_library(vespalib_vespalib_tensor_sparse OBJECT
     sparse_tensor_match.cpp
     sparse_tensor_product.cpp
     sparse_tensor_builder.cpp
-    compact_tensor_unsorted_address_builder.cpp
+    sparse_tensor_unsorted_address_builder.cpp
     DEPENDS
 )

--- a/vespalib/src/vespa/vespalib/tensor/sparse/direct_sparse_tensor_builder.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/direct_sparse_tensor_builder.h
@@ -21,7 +21,7 @@ public:
     using Dimensions = typename TensorImplType::Dimensions;
     using Cells = typename TensorImplType::Cells;
     using AddressBuilderType = SparseTensorAddressBuilder;
-    using AddressRefType = CompactTensorAddressRef;
+    using AddressRefType = SparseTensorAddressRef;
 
 private:
     Stash _stash;
@@ -33,8 +33,8 @@ public:
     copyCells(const Cells &cells_in)
     {
         for (const auto &cell : cells_in) {
-            CompactTensorAddressRef oldRef = cell.first;
-            CompactTensorAddressRef newRef(oldRef, _stash);
+            SparseTensorAddressRef oldRef = cell.first;
+            SparseTensorAddressRef newRef(oldRef, _stash);
             _cells[newRef] = cell.second;
         }
     }
@@ -46,8 +46,8 @@ public:
                                                    cells_in_dimensions);
         for (const auto &cell : cells_in) {
             addressPadder.padAddress(cell.first);
-            CompactTensorAddressRef oldRef = addressPadder.getAddressRef();
-            CompactTensorAddressRef newRef(oldRef, _stash);
+            SparseTensorAddressRef oldRef = addressPadder.getAddressRef();
+            SparseTensorAddressRef newRef(oldRef, _stash);
             _cells[newRef] = cell.second;
         }
     }
@@ -96,20 +96,20 @@ public:
     }
 
     template <class Function>
-    void insertCell(CompactTensorAddressRef address, double value,
+    void insertCell(SparseTensorAddressRef address, double value,
                     Function &&func)
     {
-        CompactTensorAddressRef oldRef(address);
+        SparseTensorAddressRef oldRef(address);
         auto res = _cells.insert(std::make_pair(oldRef, value));
         if (res.second) {
             // Replace key with own copy
-            res.first->first = CompactTensorAddressRef(oldRef, _stash);
+            res.first->first = SparseTensorAddressRef(oldRef, _stash);
         } else {
             res.first->second = func(res.first->second, value);
         }
     }
 
-    void insertCell(CompactTensorAddressRef address, double value) {
+    void insertCell(SparseTensorAddressRef address, double value) {
         // This address should not already exist and a new cell should be inserted.
         insertCell(address, value, [](double, double) -> double { abort(); });
     }

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.cpp
@@ -25,14 +25,14 @@ void
 copyCells(Cells &cells, const Cells &cells_in, Stash &stash)
 {
     for (const auto &cell : cells_in) {
-        CompactTensorAddressRef oldRef = cell.first;
-        CompactTensorAddressRef newRef(oldRef, stash);
+        SparseTensorAddressRef oldRef = cell.first;
+        SparseTensorAddressRef newRef(oldRef, stash);
         cells[newRef] = cell.second;
     }
 }
 
 void
-printAddress(std::ostream &out, const CompactTensorAddressRef &ref,
+printAddress(std::ostream &out, const SparseTensorAddressRef &ref,
              const TensorDimensions &dimensions)
 {
     out << "{";

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.h
@@ -5,7 +5,7 @@
 #include <vespa/vespalib/tensor/cell_function.h>
 #include <vespa/vespalib/tensor/tensor.h>
 #include <vespa/vespalib/tensor/tensor_address.h>
-#include "compact_tensor_address_ref.h"
+#include "sparse_tensor_address_ref.h"
 #include <vespa/vespalib/tensor/types.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/vespalib/stllike/string.h>
@@ -22,7 +22,7 @@ namespace tensor {
 class SparseTensor : public Tensor
 {
 public:
-    typedef vespalib::hash_map<CompactTensorAddressRef, double> Cells;
+    typedef vespalib::hash_map<SparseTensorAddressRef, double> Cells;
     typedef TensorDimensions Dimensions;
 
     static constexpr size_t STASH_CHUNK_SIZE = 16384u;

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_builder.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_builder.h
@@ -4,7 +4,7 @@
 
 #include <vespa/vespalib/stllike/string.h>
 #include <vector>
-#include "compact_tensor_address_ref.h"
+#include "sparse_tensor_address_ref.h"
 
 namespace vespalib {
 namespace tensor {
@@ -36,8 +36,8 @@ public:
     void add(vespalib::stringref label) { append(label); }
     void addUndefined() { _address.emplace_back('\0'); }
     void clear() { _address.clear(); }
-    CompactTensorAddressRef getAddressRef() const {
-        return CompactTensorAddressRef(&_address[0], _address.size());
+    SparseTensorAddressRef getAddressRef() const {
+        return SparseTensorAddressRef(&_address[0], _address.size());
     }
     bool empty() const { return _address.empty(); }
 };

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_decoder.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_decoder.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <vespa/vespalib/stllike/string.h>
-#include "compact_tensor_address_ref.h"
+#include "sparse_tensor_address_ref.h"
 
 namespace vespalib {
 
@@ -18,7 +18,7 @@ class SparseTensorAddressDecoder
     const char *_cur;
     const char *_end;
 public:
-    SparseTensorAddressDecoder(CompactTensorAddressRef ref)
+    SparseTensorAddressDecoder(SparseTensorAddressRef ref)
         : _cur(static_cast<const char *>(ref.start())),
           _end(_cur + ref.size())
     {

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_padder.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_padder.h
@@ -47,7 +47,7 @@ public:
     }
 
     void
-    padAddress(CompactTensorAddressRef ref)
+    padAddress(SparseTensorAddressRef ref)
     {
         clear();
         SparseTensorAddressDecoder addr(ref);

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_ref.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_address_ref.h
@@ -16,24 +16,24 @@ namespace tensor {
 /**
  * A reference to a compact sparse immutable address to a tensor cell.
  */
-class CompactTensorAddressRef
+class SparseTensorAddressRef
 {
     const void *_start;
     size_t _size;
     size_t _hash;
 public:
-    CompactTensorAddressRef()
+    SparseTensorAddressRef()
         : _start(nullptr), _size(0u), _hash(0u)
     {
     }
 
-    CompactTensorAddressRef(const void *start_in, size_t size_in)
+    SparseTensorAddressRef(const void *start_in, size_t size_in)
         : _start(start_in), _size(size_in),
           _hash(calcHash())
     {
     }
 
-    CompactTensorAddressRef(const CompactTensorAddressRef rhs, Stash &stash)
+    SparseTensorAddressRef(const SparseTensorAddressRef rhs, Stash &stash)
         : _start(nullptr),
           _size(rhs._size),
           _hash(rhs._hash)
@@ -47,7 +47,7 @@ public:
 
     size_t calcHash() const { return hashValue(_start, _size); }
 
-    bool operator<(const CompactTensorAddressRef &rhs) const {
+    bool operator<(const SparseTensorAddressRef &rhs) const {
         size_t minSize = std::min(_size, rhs._size);
         int res = memcmp(_start, rhs._start, minSize);
         if (res != 0) {
@@ -56,7 +56,7 @@ public:
         return _size < rhs._size;
     }
 
-    bool operator==(const CompactTensorAddressRef &rhs) const
+    bool operator==(const SparseTensorAddressRef &rhs) const
     {
         if (_size != rhs._size || _hash != rhs._hash) {
             return false;

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_builder.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_builder.cpp
@@ -65,9 +65,9 @@ SparseTensorBuilder::add_cell(double value)
         makeSortedDimensions();
     }
     _addressBuilder.buildTo(_normalizedAddressBuilder, _sortedDimensions);
-    CompactTensorAddressRef taddress(_normalizedAddressBuilder.getAddressRef());
+    SparseTensorAddressRef taddress(_normalizedAddressBuilder.getAddressRef());
     // Make a persistent copy of sparse tensor address owned by _stash
-    CompactTensorAddressRef address(taddress, _stash);
+    SparseTensorAddressRef address(taddress, _stash);
     _cells[address] = value;
     _addressBuilder.clear();
     _normalizedAddressBuilder.clear();

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_builder.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_builder.h
@@ -4,7 +4,7 @@
 
 #include "sparse_tensor.h"
 #include "sparse_tensor_address_builder.h"
-#include "compact_tensor_unsorted_address_builder.h"
+#include "sparse_tensor_unsorted_address_builder.h"
 #include <vespa/vespalib/tensor/tensor_builder.h>
 #include <vespa/vespalib/tensor/tensor_address.h>
 #include <vespa/vespalib/stllike/hash_map.h>
@@ -18,7 +18,7 @@ namespace tensor {
  */
 class SparseTensorBuilder : public TensorBuilder
 {
-    CompactTensorUnsortedAddressBuilder _addressBuilder; // unsorted dimensions
+    SparseTensorUnsortedAddressBuilder _addressBuilder; // unsorted dimensions
     SparseTensorAddressBuilder _normalizedAddressBuilder; // sorted dimensions
     SparseTensor::Cells _cells;
     Stash _stash;

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_dimension_sum.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_dimension_sum.cpp
@@ -36,7 +36,7 @@ buildReduceOps(const TensorDimensions &dims,
 
 void
 reduceAddress(SparseTensorAddressBuilder &builder,
-              CompactTensorAddressRef ref,
+              SparseTensorAddressRef ref,
               const ReduceOps &ops)
 {
     builder.clear();

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_match.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_match.cpp
@@ -45,7 +45,7 @@ buildTransformOps(std::vector<AddressOp> &ops,
 
 bool
 transformAddress(SparseTensorAddressBuilder &builder,
-                 CompactTensorAddressRef ref,
+                 SparseTensorAddressRef ref,
                  const std::vector<AddressOp> &ops)
 {
     builder.clear();
@@ -99,7 +99,7 @@ SparseTensorMatch::slowMatch(const TensorImplType &lhs,
         if (!transformAddress(addressBuilder, lhsCell.first, ops)) {
             continue;
         }
-        CompactTensorAddressRef ref(addressBuilder.getAddressRef());
+        SparseTensorAddressRef ref(addressBuilder.getAddressRef());
         auto rhsItr = rhs.cells().find(ref);
         if (rhsItr != rhs.cells().end()) {
             addressPadder.padAddress(lhsCell.first);

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_product.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_product.cpp
@@ -48,8 +48,8 @@ buildCombineOps(const TensorDimensions &lhs,
 
 bool
 combineAddresses(SparseTensorAddressBuilder &builder,
-                 CompactTensorAddressRef lhsRef,
-                 CompactTensorAddressRef rhsRef,
+                 SparseTensorAddressRef lhsRef,
+                 SparseTensorAddressRef rhsRef,
                  const CombineOps &ops)
 {
     builder.clear();

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_unsorted_address_builder.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_unsorted_address_builder.cpp
@@ -1,14 +1,14 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/fastos/fastos.h>
-#include "compact_tensor_unsorted_address_builder.h"
+#include "sparse_tensor_unsorted_address_builder.h"
 #include "sparse_tensor_address_builder.h"
 #include <algorithm>
 
 namespace vespalib {
 namespace tensor {
 
-CompactTensorUnsortedAddressBuilder::CompactTensorUnsortedAddressBuilder()
+SparseTensorUnsortedAddressBuilder::SparseTensorUnsortedAddressBuilder()
     : _elementStrings(),
       _elements()
 {
@@ -16,7 +16,7 @@ CompactTensorUnsortedAddressBuilder::CompactTensorUnsortedAddressBuilder()
 
 
 void
-CompactTensorUnsortedAddressBuilder::buildTo(SparseTensorAddressBuilder &
+SparseTensorUnsortedAddressBuilder::buildTo(SparseTensorAddressBuilder &
                                              builder,
                                              const TensorDimensions &
                                              dimensions)

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_unsorted_address_builder.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_unsorted_address_builder.h
@@ -15,7 +15,7 @@ class SparseTensorAddressBuilder;
  * A builder that buffers up a tensor address with unsorted
  * dimensions.
  */
-class CompactTensorUnsortedAddressBuilder
+class SparseTensorUnsortedAddressBuilder
 {
     struct ElementStringRef
     {
@@ -61,7 +61,7 @@ class CompactTensorUnsortedAddressBuilder
     }
 
 public:
-    CompactTensorUnsortedAddressBuilder();
+    SparseTensorUnsortedAddressBuilder();
     bool empty() const { return _elementStrings.empty(); }
     void add(vespalib::stringref dimension, vespalib::stringref label)
     {


### PR DESCRIPTION
  CompactTensorUnsortedAddressBuilder -> SparseTensorUnsortedAddressBuilder
  CompactTensorAddressRef             -> SparseTensorAddressRef

@geirst, please review
