### PR TITLE
- Add testcase for german umlaut.

### DIFF
--- a/vsm/src/tests/searcher/searcher.cpp
+++ b/vsm/src/tests/searcher/searcher.cpp
@@ -545,10 +545,14 @@ SearcherTest::testUTF8ExactStringFieldSearcher()
 {
     UTF8ExactStringFieldSearcher fs(0);
     // regular
-    assertString(fs, "vespa", "vespa", Hits().add(0));
-    assertString(fs, "vespa", "vespa vespa", Hits());
-    assertString(fs, "vesp",  "vespa", Hits());
-    assertString(fs, "vesp*",  "vespa", Hits().add(0));
+    TEST_DO(assertString(fs, "vespa", "vespa", Hits().add(0)));
+    TEST_DO(assertString(fs, "vespar", "vespa", Hits()));
+    TEST_DO(assertString(fs, "vespa", "vespar", Hits()));
+    TEST_DO(assertString(fs, "vespa", "vespa vespa", Hits()));
+    TEST_DO(assertString(fs, "vesp",  "vespa", Hits()));
+    TEST_DO(assertString(fs, "vesp*",  "vespa", Hits().add(0)));
+    TEST_DO(assertString(fs, "hutte",  "hutte", Hits().add(0)));
+    TEST_DO(assertString(fs, "hütte",  "hütte", Hits().add(0)));
 }
 
 void

--- a/vsm/src/vespa/vsm/searcher/utf8stringfieldsearcherbase.cpp
+++ b/vsm/src/vespa/vsm/searcher/utf8stringfieldsearcherbase.cpp
@@ -139,7 +139,7 @@ UTF8StringFieldSearcherBase::matchTermExact(const FieldRef & f, QueryTerm & qt)
     termsize_t tsz = qt.term(term);
     const cmptype_t * eterm = term+tsz;
     const byte * e = n + f.size();
-    if ((tsz == f.size()) || ((tsz < f.size()) && qt.isPrefix())) {
+    if (tsz <= f.size()) {
         bool equal(true);
         for (; equal && (n < e) && (term < eterm); term++) {
             if (*term < 0x80) {


### PR DESCRIPTION
- Remove requirement that term and field must have equal length. As length depends on
  encoding we do not know ucs4 length until after processing.
  @geirst PR
