### PR TITLE
Initialize number of running containers metric

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -115,6 +115,9 @@ public class DockerImpl implements Docker {
 
         numberOfRunningContainersGauge = metricReceiver.declareGauge("containers.running");
         numberOfDockerDaemonFails = metricReceiver.declareCounter("daemon.api_fails");
+
+        // Some containers could already be running, count them and intialize to that value
+        numberOfRunningContainersGauge.sample(getAllManagedContainers().size());
     }
 
     static DefaultDockerClientConfig.Builder buildDockerClientConfig(DockerConfig config) {


### PR DESCRIPTION
When node-admin is restarted, it showed the number of running containers as 0 until a container was started/deleted
