### PR TITLE
- Add negative tests.

### DIFF
--- a/vsm/src/tests/searcher/searcher.cpp
+++ b/vsm/src/tests/searcher/searcher.cpp
@@ -553,6 +553,10 @@ SearcherTest::testUTF8ExactStringFieldSearcher()
     TEST_DO(assertString(fs, "vesp*",  "vespa", Hits().add(0)));
     TEST_DO(assertString(fs, "hutte",  "hutte", Hits().add(0)));
     TEST_DO(assertString(fs, "hütte",  "hütte", Hits().add(0)));
+    TEST_DO(assertString(fs, "hutte",  "hütte", Hits()));
+    TEST_DO(assertString(fs, "hütte",  "hutte", Hits()));
+    TEST_DO(assertString(fs, "hütter", "hütte", Hits()));
+    TEST_DO(assertString(fs, "hütte",  "hütter", Hits()));
 }
 
 void

--- a/vsm/src/vespa/vsm/searcher/utf8stringfieldsearcherbase.cpp
+++ b/vsm/src/vespa/vsm/searcher/utf8stringfieldsearcherbase.cpp
@@ -149,7 +149,7 @@ UTF8StringFieldSearcherBase::matchTermExact(const FieldRef & f, QueryTerm & qt)
                 equal = (*term == c);
             }
         }
-        if (equal && (qt.isPrefix() || (n == e))) {
+        if (equal && (term == eterm) && (qt.isPrefix() || (n == e))) {
             addHit(qt,0);
         }
     }


### PR DESCRIPTION
- Also verify that we have exhausted the input.
  @geirst PR
