### PR TITLE
catch and abort on unknown exception to avoid std::thread doing it si…

### DIFF
--- a/filedistribution/src/vespa/filedistribution/distributor/filedistributortrackerimpl.cpp
+++ b/filedistribution/src/vespa/filedistribution/distributor/filedistributortrackerimpl.cpp
@@ -166,6 +166,9 @@ void asioWorker(asio::io_service& ioService)
             ioService.run();
         } catch (const ZKConnectionLossException & e) {
             LOG(info, "Connection loss in asioWorker thread, resuming. %s", e.what());
+        } catch (const std::exception & e) {
+            LOG(fatal, "Unknow exception in asioWorker. %s", e.what());
+            assert(false);
         }
     }
 }


### PR DESCRIPTION
…lently for you.
@havardpe PR
std::thread catches everything you don't.... That was unfortunate.
