### PR TITLE
Revert "catch and abort on unknown exception to avoid std::thread doing it si…"

### DIFF
--- a/filedistribution/src/vespa/filedistribution/distributor/filedistributortrackerimpl.cpp
+++ b/filedistribution/src/vespa/filedistribution/distributor/filedistributortrackerimpl.cpp
@@ -166,9 +166,6 @@ void asioWorker(asio::io_service& ioService)
             ioService.run();
         } catch (const ZKConnectionLossException & e) {
             LOG(info, "Connection loss in asioWorker thread, resuming. %s", e.what());
-        } catch (const std::exception & e) {
-            LOG(fatal, "Unknow exception in asioWorker. %s", e.what());
-            assert(false);
         }
     }
 }


### PR DESCRIPTION
Reverts yahoo/vespa#749
@havardpe Since we can now control std::thread behaviour this is no longer necessary.
