### PR TITLE
Add reduce method to vespalib::tensor::Tensor API.

### DIFF
--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.h
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.h
@@ -52,6 +52,9 @@ public:
     virtual Tensor::UP match(const Tensor &arg) const override;
     virtual Tensor::UP apply(const CellFunction &func) const override;
     virtual Tensor::UP sum(const vespalib::string &dimension) const override;
+    virtual Tensor::UP reduce(const eval::BinaryOperation &op,
+                              const std::vector<vespalib::string> &dimensions)
+        const override;
     virtual bool equals(const Tensor &arg) const override;
     virtual void print(std::ostream &out) const override;
     virtual vespalib::string toString() const override;

--- a/vespalib/src/vespa/vespalib/tensor/tensor.h
+++ b/vespalib/src/vespa/vespalib/tensor/tensor.h
@@ -10,6 +10,7 @@
 #include <vespa/vespalib/eval/value_type.h>
 
 namespace vespalib {
+namespace eval { class BinaryOperation; }
 namespace tensor {
 
 class TensorVisitor;
@@ -38,6 +39,13 @@ struct Tensor : public eval::Tensor
     virtual Tensor::UP match(const Tensor &arg) const = 0;
     virtual Tensor::UP apply(const CellFunction &func) const = 0;
     virtual Tensor::UP sum(const vespalib::string &dimension) const = 0;
+    virtual Tensor::UP reduce(const eval::BinaryOperation &op,
+                              const std::vector<vespalib::string> &dimensions)
+        const {
+        (void) op;
+        (void) dimensions;
+        return Tensor::UP();
+    }
     virtual bool equals(const Tensor &arg) const = 0;
     virtual void print(std::ostream &out) const = 0;
     virtual vespalib::string toString() const = 0;


### PR DESCRIPTION
Implement reduce method for sparse tensors.
Return double value when last tensor dimension has been reduced.
Add empty address with zero value to tensor spec when generating
tensor spec from empty sparse tensor with no dimensions.

@geirst, please review
@havardpe, FYI
