### PR TITLE
Do less work on IOThread.close as it is sequential. Catch exception w…

### DIFF
--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
@@ -114,8 +114,8 @@ public class ClusterConnection implements AutoCloseable {
         IOThread ioThread = ioThreads.get(hash % ioThreads.size());
         try {
             ioThread.post(document);
-        } catch (InterruptedException e) {
-            throw new EndpointIOException(ioThread.getEndpoint(), "While sending", e);
+        } catch (Throwable t) {
+            throw new EndpointIOException(ioThread.getEndpoint(), "While sending", t);
         }
     }
 


### PR DESCRIPTION
…hen document queue is closed on retries. Add a unit test.
@hmusum plz review, should theoretically fix Canary
