### PR TITLE
Ensure closing of http response

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/util/ConfigServerHttpRequestExecutorTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/util/ConfigServerHttpRequestExecutorTest.java
@@ -7,8 +7,9 @@ import com.yahoo.collections.ArraySet;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
@@ -22,6 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,12 +43,12 @@ public class ConfigServerHttpRequestExecutorTest {
     final StringBuilder mockLog = new StringBuilder();
     int mockReturnCode = 200;
 
-    private HttpClient createClientMock() throws IOException {
-        HttpClient httpMock = mock(HttpClient.class);
+    private CloseableHttpClient createClientMock() throws IOException {
+        CloseableHttpClient httpMock = mock(CloseableHttpClient.class);
         when(httpMock.execute(any())).thenAnswer((Answer<HttpResponse>) invocationOnMock -> {
             HttpGet get = (HttpGet) invocationOnMock.getArguments()[0];
             mockLog.append(get.getMethod()).append(" ").append(get.getURI()).append("  ");
-            HttpResponse response = mock(HttpResponse.class);
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
             StatusLine statusLine = mock(StatusLine.class);
             when(statusLine.getStatusCode()).thenReturn(mockReturnCode);
             when(response.getStatusLine()).thenReturn(statusLine);
@@ -57,6 +59,7 @@ public class ConfigServerHttpRequestExecutorTest {
             when(entity.getContent()).thenReturn(stream);
             return response;
         });
+        doNothing().when(httpMock).close();
         return httpMock;
     }
 


### PR DESCRIPTION
TL;DR Closing of HTTP response and client may fix hang in resume call from node
admin to config server.

I have been investigating docker2.perf.cd-us-east-1.vespahosted.bf2.yahoo.com:
There's no log output to the node admin log. kill -3 shows all node agents
hangs at:

```
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
    at org.apache.http.pool.PoolEntryFuture.await(PoolEntryFuture.java:138)
    at org.apache.http.pool.AbstractConnPool.getPoolEntryBlocking(AbstractConnPool.java:306)
    at org.apache.http.pool.AbstractConnPool.access$000(AbstractConnPool.java:64)
    at org.apache.http.pool.AbstractConnPool$2.getPoolEntry(AbstractConnPool.java:192)
    at org.apache.http.pool.AbstractConnPool$2.getPoolEntry(AbstractConnPool.java:185)
    at org.apache.http.pool.PoolEntryFuture.get(PoolEntryFuture.java:107)
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:276)
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:263)
    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:190)
    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
    at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
    at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:55)
    at com.yahoo.vespa.hosted.node.admin.util.ConfigServerHttpRequestExecutor.tryAllConfigServers(ConfigServerHttpRequestExecutor.java:70)
    at com.yahoo.vespa.hosted.node.admin.util.ConfigServerHttpRequestExecutor.delete(ConfigServerHttpRequestExecutor.java:114)
    at com.yahoo.vespa.hosted.node.admin.orchestrator.OrchestratorImpl.resume(OrchestratorImpl.java:90)
```

There's some discussion on the net that one has to be careful to close the HTTP
response, and there's some documentation about the need to close the HTTP
client too. This PR closes those resources in the hope it fixes the problem.
