### PR TITLE
Fix recursively delete /home/y/var

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -125,7 +125,8 @@ public class StorageMaintainer {
 
         File yVarDir = maintainer.pathInNodeAdminFromPathInNode(containerName, "/home/y/var").toFile();
         if (yVarDir.exists()) {
-            DeleteOldAppData.deleteDirectories(yVarDir.getAbsolutePath(), 0, null);
+            logger.info("Recursively deleting " + yVarDir);
+            DeleteOldAppData.recursiveDelete(yVarDir);
         }
 
         Path from = maintainer.pathInNodeAdminFromPathInNode(containerName, "/");

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -364,7 +364,7 @@ public class NodeAgentImpl implements NodeAgent {
                 storageMaintainer.removeOldFilesFromNode(nodeSpec.containerName);
                 removeContainerIfNeededUpdateContainerState(nodeSpec);
                 logger.info("State is " + nodeSpec.nodeState + ", will delete application storage and mark node as ready");
-                storageMaintainer.deleteContainerStorage(nodeSpec.containerName);
+                storageMaintainer.archiveNodeData(nodeSpec.containerName);
                 updateNodeRepoAndMarkNodeAsReady(nodeSpec);
                 break;
             case parked:

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/DeleteOldAppData.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/DeleteOldAppData.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.hosted.node.maintenance;
 import com.yahoo.vespa.hosted.node.admin.util.PrefixLogger;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -107,6 +109,22 @@ public class DeleteOldAppData {
                 }
             }
         }
+    }
+
+    /**
+     * Similar to rm -rf file:
+     *   - It's not an error if file doesn't exist
+     *   - If file is a directory, it and all content is removed
+     *   - For symlinks: Only the symlink is removed, not what the symlink points to
+     */
+    public static void recursiveDelete(File file) throws IOException {
+        if (file.isDirectory()) {
+            for (File childFile : file.listFiles()) {
+                recursiveDelete(childFile);
+            }
+        }
+
+        Files.deleteIfExists(file.toPath());
     }
 
     private static File[] getContentsOfDirectory(String directoryPath) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
@@ -32,7 +32,7 @@ public class StorageMaintainerMock extends StorageMaintainer {
     }
 
     @Override
-    public void deleteContainerStorage(ContainerName containerName) throws IOException {
+    public void archiveNodeData(ContainerName containerName) throws IOException {
         callOrderVerifier.add("DeleteContainerStorage with ContainerName: " + containerName);
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -317,7 +317,7 @@ public class NodeAgentImplTest {
         final InOrder inOrder = inOrder(storageMaintainer, dockerOperations, nodeRepository);
         inOrder.verify(storageMaintainer, times(1)).removeOldFilesFromNode(eq(containerName));
         inOrder.verify(dockerOperations, times(1)).removeContainerIfNeeded(eq(nodeSpec), eq(hostName), any());
-        inOrder.verify(storageMaintainer, times(1)).deleteContainerStorage(eq(containerName));
+        inOrder.verify(storageMaintainer, times(1)).archiveNodeData(eq(containerName));
         inOrder.verify(nodeRepository, times(1)).markAsReady(eq(hostName));
 
         verify(dockerOperations, never()).startContainerIfNeeded(any());

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/maintenance/DeleteOldAppDataTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/maintenance/DeleteOldAppDataTest.java
@@ -9,12 +9,14 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author valerijf
@@ -194,6 +196,48 @@ public class DeleteOldAppDataTest {
         assertThat(getNumberOfFilesAndDirectoriesIn(folder.getRoot()), is(51));
     }
 
+    @Test
+    public void testRecursivelyDeleteDirectory() throws IOException {
+        initSubDirectories();
+        DeleteOldAppData.recursiveDelete(folder.getRoot());
+        assertTrue(!folder.getRoot().exists());
+    }
+
+    @Test
+    public void testRecursivelyDeleteRegularFile() throws IOException {
+        File file = folder.newFile();
+        assertTrue(file.exists());
+        assertTrue(file.isFile());
+        DeleteOldAppData.recursiveDelete(file);
+        assertTrue(!file.exists());
+    }
+
+    @Test
+    public void testRecursivelyDeleteNonExistingFile() throws IOException {
+        File file = folder.getRoot().toPath().resolve("non-existing-file.json").toFile();
+        assertTrue(!file.exists());
+        DeleteOldAppData.recursiveDelete(file);
+        assertTrue(!file.exists());
+    }
+
+    @Test
+    public void testInitSubDirectories() throws IOException {
+        initSubDirectories();
+        assertTrue(folder.getRoot().exists());
+        assertTrue(folder.getRoot().isDirectory());
+
+        Path test_folder1 = folder.getRoot().toPath().resolve("test_folder1");
+        assertTrue(test_folder1.toFile().exists());
+        assertTrue(test_folder1.toFile().isDirectory());
+
+        Path test_folder2 = folder.getRoot().toPath().resolve("test_folder2");
+        assertTrue(test_folder2.toFile().exists());
+        assertTrue(test_folder2.toFile().isDirectory());
+
+        Path subSubFolder2 = test_folder2.resolve("subSubFolder2");
+        assertTrue(subSubFolder2.toFile().exists());
+        assertTrue(subSubFolder2.toFile().isDirectory());
+    }
 
     private void initSubDirectories() throws IOException {
         File subFolder1 = folder.newFolder("test_folder1");


### PR DESCRIPTION
The canary spit out lots of warnings on failure to delete directories under
/home/y/var for the different containers. This commit simplifies the code and
actually deletes it.
