### PR TITLE
Use a metric consumer of "statereporter" by default

### DIFF
--- a/staging_vespalib/src/tests/state_server/state_server_test.cpp
+++ b/staging_vespalib/src/tests/state_server/state_server_test.cpp
@@ -322,15 +322,22 @@ struct EchoConsumer : MetricsProducer {
     }
 };
 
+TEST_FFFF("require that empty metrics consumer defaults to 'statereporter'",
+          SimpleHealthProducer(), EchoConsumer(), SimpleComponentConfigProducer(),
+          StateApi(f1, f2, f3))
+{
+    std::map<vespalib::string,vespalib::string> my_params;
+    EXPECT_EQUAL("{\"status\":{\"code\":\"up\"},\"metrics\":[\"statereporter\"]}", f4.get(host_tag, metrics_path, empty_params));
+    EXPECT_EQUAL("[\"statereporter\"]", f4.get(host_tag, total_metrics_path, empty_params));
+}
+
 TEST_FFFF("require that metrics consumer is passed correctly",
           SimpleHealthProducer(), EchoConsumer(), SimpleComponentConfigProducer(),
           StateApi(f1, f2, f3))
 {
     std::map<vespalib::string,vespalib::string> my_params;
     my_params["consumer"] = "ME";
-    EXPECT_EQUAL("{\"status\":{\"code\":\"up\"},\"metrics\":[\"\"]}", f4.get(host_tag, metrics_path, empty_params));
     EXPECT_EQUAL("{\"status\":{\"code\":\"up\"},\"metrics\":[\"ME\"]}", f4.get(host_tag, metrics_path, my_params));
-    EXPECT_EQUAL("[\"\"]", f4.get(host_tag, total_metrics_path, empty_params));
     EXPECT_EQUAL("[\"ME\"]", f4.get(host_tag, total_metrics_path, my_params));
 }
 

--- a/staging_vespalib/src/vespa/vespalib/net/state_api.cpp
+++ b/staging_vespalib/src/vespa/vespalib/net/state_api.cpp
@@ -56,7 +56,9 @@ void build_health_status(JSONStringer &json, const HealthProducer &healthProduce
 vespalib::string get_consumer(const std::map<vespalib::string,vespalib::string> &params) {
     auto consumer_lookup = params.find("consumer");
     if (consumer_lookup == params.end()) {
-        return "";
+        // Using a 'statereporter' consumer removes many uninteresting per-thread
+        // metrics but retains their aggregates.
+        return "statereporter";
     }
     return consumer_lookup->second;
 }


### PR DESCRIPTION
@havardpe Please review.

This matches how the storageserver state reporter does things and will
avoid including per-thread metrics in the metric output.
