### PR TITLE
Add guard so that we do not update metrics unless container is running

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -460,6 +460,7 @@ public class NodeAgentImpl implements NodeAgent {
         }
 
         if (nodeSpec == null || nodeSpec.nodeState != Node.State.active) return;
+        if ( ! dockerOperations.getContainer(nodeSpec.hostname).isPresent()) return;
 
         Docker.ContainerStats stats = dockerOperations.getContainerStats(nodeSpec.containerName);
         Dimensions.Builder dimensionsBuilder = new Dimensions.Builder()

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -460,7 +460,8 @@ public class NodeAgentImpl implements NodeAgent {
         }
 
         if (nodeSpec == null || nodeSpec.nodeState != Node.State.active) return;
-        if ( ! dockerOperations.getContainer(nodeSpec.hostname).isPresent()) return;
+        final Optional<Container> container = dockerOperations.getContainer(nodeSpec.hostname);
+        if ( ! container.isPresent() || ! container.get().isRunning ) return;
 
         Docker.ContainerStats stats = dockerOperations.getContainerStats(nodeSpec.containerName);
         Dimensions.Builder dimensionsBuilder = new Dimensions.Builder()

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -419,6 +419,9 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("cont-name");
         when(dockerOperations.getContainerStats(eq(containerName))).thenReturn(stats);
 
+        when(dockerOperations.getContainer(eq(hostName)))
+                .thenReturn(Optional.of(new Container(hostName, new DockerImage("wantedDockerImage"), containerName, true)));
+
         Optional<String> version = Optional.of("1.2.3");
         ContainerNodeSpec.Owner owner = new ContainerNodeSpec.Owner("tester", "testapp", "testinstance");
         ContainerNodeSpec.Membership membership = new ContainerNodeSpec.Membership("clustType", "clustId", "grp", 3, false);


### PR DESCRIPTION
If node is active but the container is not running (e.g. we are downloading the image needed to run the container) we should not try to update metrics

@freva please review
