### PR TITLE
Reset the lastCpuMetric variable when we (temporarily) take down the …

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -393,6 +393,7 @@ public class NodeAgentImpl implements NodeAgent {
                 // If we transition from active, to not active state, unset the current metrics
                 if (lastNodeSpec != null && lastNodeSpec.nodeState == Node.State.active && nodeSpec.nodeState != Node.State.active) {
                     metricReceiver.unsetMetricsForContainer(hostname);
+                    lastCpuMetric = new CpuUsageReporter();
                 }
                 addDebugMessage("Loading new node spec: " + nodeSpec.toString());
                 lastNodeSpec = nodeSpec;


### PR DESCRIPTION
…container so that we dont get negative cpu usage when we start it again
