### PR TITLE
Balder/do move it

### DIFF
--- a/config/src/vespa/config/frt/protocol.cpp
+++ b/config/src/vespa/config/frt/protocol.cpp
@@ -59,7 +59,7 @@ const Memory RESPONSE_COMPRESSION_INFO_UNCOMPRESSED_SIZE = "uncompressedSize";
 DecompressedData
 decompress_lz4(const char * input, uint32_t inputLen, int uncompressedLength)
 {
-    Alloc memory( DefaultAlloc::create(uncompressedLength));
+    Alloc memory( Alloc::alloc(uncompressedLength));
     int sz = LZ4_decompress_safe(input, static_cast<char *>(memory.get()), inputLen, uncompressedLength);
     if (sz >= 0 && sz != uncompressedLength) {
         if (LOG_WOULD_LOG(debug)) {

--- a/document/src/vespa/document/fieldvalue/fieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/fieldvalue.cpp
@@ -23,7 +23,6 @@
 
 using vespalib::FieldBase;
 using vespalib::nbostream;
-using vespalib::DefaultAlloc;
 
 namespace document {
 

--- a/document/src/vespa/document/util/bytebuffer.cpp
+++ b/document/src/vespa/document/util/bytebuffer.cpp
@@ -22,7 +22,6 @@
 #define LOG_DEBUG4(a,b,c,d) LOG_DEBUG1(vespalib::make_string(a,b,c,d));
 
 using vespalib::alloc::Alloc;
-using vespalib::DefaultAlloc;
 
 namespace document {
 
@@ -60,7 +59,7 @@ ByteBuffer::ByteBuffer() :
 }
 
 ByteBuffer::ByteBuffer(size_t len) :
-    ByteBuffer(DefaultAlloc::create(len), len)
+    ByteBuffer(Alloc::alloc(len), len)
 {
 }
 
@@ -115,7 +114,7 @@ ByteBuffer& ByteBuffer::operator=(const ByteBuffer & org)
     if (this != & org) {
         cleanUp();
         if (org._len > 0 && org._buffer) {
-            DefaultAlloc::create(org._len + 1).swap(_ownedBuffer);
+            Alloc::alloc(org._len + 1).swap(_ownedBuffer);
             _buffer = static_cast<char *>(_ownedBuffer.get());
             memcpy(_buffer,org._buffer,org._len);
             _buffer[org._len] = 0;
@@ -190,7 +189,7 @@ ByteBuffer::sliceFrom(const ByteBuffer& buf, size_t from, size_t to) // throw (B
         // Slicing from someone that doesn't own their buffer, must make own copy.
         if (( buf._ownedBuffer.get() == NULL ) && (buf._bufHolder == NULL)) {
             cleanUp();
-            DefaultAlloc::create(to-from + 1).swap(_ownedBuffer);
+            Alloc::alloc(to-from + 1).swap(_ownedBuffer);
             _buffer = static_cast<char *>(_ownedBuffer.get());
             memcpy(_buffer, buf._buffer + from, to-from);
             _buffer[to-from] = 0;
@@ -219,7 +218,7 @@ ByteBuffer::sliceFrom(const ByteBuffer& buf, size_t from, size_t to) // throw (B
 ByteBuffer* ByteBuffer::copyBuffer(const char* buffer, size_t len)
 {
     if (buffer && len) {
-        Alloc newBuf = DefaultAlloc::create(len + 1);
+        Alloc newBuf = Alloc::alloc(len + 1);
         memcpy(newBuf.get(), buffer, len);
         static_cast<char *>(newBuf.get())[len] = 0;
         return new ByteBuffer(std::move(newBuf), len);

--- a/document/src/vespa/document/util/compressor.cpp
+++ b/document/src/vespa/document/util/compressor.cpp
@@ -12,7 +12,6 @@ LOG_SETUP(".document.compressor");
 #include <lz4hc.h>
 
 using vespalib::alloc::Alloc;
-using vespalib::DefaultAlloc;
 using vespalib::ConstBufferRef;
 using vespalib::DataBuffer;
 using vespalib::make_string;
@@ -30,10 +29,10 @@ LZ4Compressor::process(const CompressionConfig& config, const void * inputV, siz
     char * output(static_cast<char *>(outputV));
     int sz(-1);
     if (config.compressionLevel > 6) {
-        Alloc state = DefaultAlloc::create(LZ4_sizeofStateHC());
+        Alloc state = Alloc::alloc(LZ4_sizeofStateHC());
         sz = LZ4_compressHC2_withStateHC(state.get(), input, output, inputLen, config.compressionLevel);
     } else {
-        Alloc state = DefaultAlloc::create(LZ4_sizeofState());
+        Alloc state = Alloc::alloc(LZ4_sizeofState());
         sz = LZ4_compress_withState(state.get(), input, output, inputLen);
     }
     if (sz != 0) {

--- a/document/src/vespa/document/util/serializable.cpp
+++ b/document/src/vespa/document/util/serializable.cpp
@@ -6,8 +6,6 @@
 #include <stdio.h>
 #include <vespa/document/util/bytebuffer.h>
 
-using vespalib::DefaultAlloc;
-
 namespace document {
 
 IMPLEMENT_IDENTIFIABLE_ABSTRACT(Serializable, vespalib::Identifiable);

--- a/fastlib/src/vespa/fastlib/io/bufferedfile.cpp
+++ b/fastlib/src/vespa/fastlib/io/bufferedfile.cpp
@@ -392,7 +392,7 @@ size_t computeBufLen(size_t buflen)
 Fast_BufferedFile::Fast_BufferedFile(FastOS_FileInterface *file, size_t bufferSize) :
     FastOS_FileInterface(),
     _fileleft(static_cast<uint64_t>(-1)),
-    _buf(vespalib::alloc::MMapAllocFactory::create(computeBufLen(bufferSize))),
+    _buf(vespalib::alloc::Alloc::allocMMap(computeBufLen(bufferSize))),
     _bufi(NULL),
     _bufe(NULL),
     _filepos(0),

--- a/fnet/src/vespa/fnet/databuffer.cpp
+++ b/fnet/src/vespa/fnet/databuffer.cpp
@@ -3,8 +3,6 @@
 #include <vespa/fastos/fastos.h>
 #include <vespa/fnet/fnet.h>
 
-using vespalib::DefaultAlloc;
-
 FNET_DataBuffer::FNET_DataBuffer(uint32_t len)
     : _bufstart(NULL),
       _bufend(NULL),
@@ -15,7 +13,7 @@ FNET_DataBuffer::FNET_DataBuffer(uint32_t len)
         len = 256;
 
     if (len > 0) {
-       DefaultAlloc::create(len).swap(_ownedBuf);
+       Alloc::alloc(len).swap(_ownedBuf);
        memset(_ownedBuf.get(), 0x55, len);
         _bufstart = static_cast<char *>(_ownedBuf.get());
         assert(_bufstart != NULL);
@@ -72,7 +70,7 @@ FNET_DataBuffer::Shrink(uint32_t newsize)
         return false;
     }
     
-    Alloc newBuf(DefaultAlloc::create(newsize));
+    Alloc newBuf(Alloc::alloc(newsize));
     memset(newBuf.get(), 0x55, newsize);
     memcpy(newBuf.get(), _datapt, GetDataLen());
     _ownedBuf.swap(newBuf);
@@ -97,7 +95,7 @@ FNET_DataBuffer::Pack(uint32_t needbytes)
         while (bufsize - GetDataLen() < needbytes)
             bufsize *= 2;
 
-        Alloc newBuf(DefaultAlloc::create(bufsize));
+        Alloc newBuf(Alloc::alloc(bufsize));
         memset(newBuf.get(), 0x55, bufsize);
         memcpy(newBuf.get(), _datapt, GetDataLen());
         _ownedBuf.swap(newBuf);

--- a/fnet/src/vespa/fnet/frt/values.h
+++ b/fnet/src/vespa/fnet/frt/values.h
@@ -71,13 +71,14 @@ class FRT_Values
 public:
     class LocalBlob : public FRT_ISharedBlob
     {
+        using Alloc = vespalib::alloc::Alloc;
     public:
-        LocalBlob(vespalib::alloc::Alloc data, uint32_t len) :
+        LocalBlob(Alloc data, uint32_t len) :
             _data(std::move(data)),
             _len(len)
         { }
         LocalBlob(const char *data, uint32_t len) :
-            _data(vespalib::DefaultAlloc::create(len)),
+            _data(Alloc::alloc(len)),
             _len(len)
         {
             if (data != NULL) {
@@ -85,7 +86,7 @@ public:
             }
         }
         void addRef() override {}
-        void subRef() override { vespalib::alloc::Alloc().swap(_data); }
+        void subRef() override { Alloc().swap(_data); }
         uint32_t getLen() override { return _len; }
         const char *getData() override { return static_cast<const char *>(_data.get()); }
         char *getInternalData() { return static_cast<char *>(_data.get()); }
@@ -93,7 +94,7 @@ public:
         LocalBlob(const LocalBlob &);
         LocalBlob &operator=(const LocalBlob &);
 
-        vespalib::alloc::Alloc _data;
+        Alloc _data;
         uint32_t _len;
     };
 

--- a/memfilepersistence/src/vespa/memfilepersistence/mapper/buffer.cpp
+++ b/memfilepersistence/src/vespa/memfilepersistence/mapper/buffer.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <stdlib.h>
 
-using vespalib::DefaultAlloc;
 using vespalib::alloc::MemoryAllocator;
 using vespalib::alloc::Alloc;
 
@@ -16,7 +15,7 @@ namespace memfile {
 // It is crucial that any backing buffer type returns an address that is
 // 512-byte aligned, or direct IO will scream at us and fail everything.
 Buffer::Buffer(size_t size)
-    : _buffer(DefaultAlloc::create(size, MemoryAllocator::HUGEPAGE_SIZE, 512)),
+    : _buffer(Alloc::alloc(size, MemoryAllocator::HUGEPAGE_SIZE, 512)),
       _size(size)
 {
 }

--- a/memfilepersistence/src/vespa/memfilepersistence/mapper/simplememfileiobuffer.h
+++ b/memfilepersistence/src/vespa/memfilepersistence/mapper/simplememfileiobuffer.h
@@ -77,7 +77,7 @@ public:
 
         typedef vespalib::LinkedPtr<SharedBuffer> LP;
         explicit SharedBuffer(size_t totalSize)
-            : _buf(vespalib::alloc::MMapAllocFactory::create(totalSize)),
+            : _buf(vespalib::alloc::Alloc::allocMMap(totalSize)),
               _usedSize(0)
         {
         }

--- a/messagebus/src/vespa/messagebus/blob.h
+++ b/messagebus/src/vespa/messagebus/blob.h
@@ -14,6 +14,7 @@ namespace mbus {
  **/
 class Blob
 {
+    using Alloc = vespalib::alloc::Alloc;
 public:
     /**
      * Create a blob that will contain uninitialized memory with the
@@ -22,7 +23,7 @@ public:
      * @param s size of the data to be created
      **/
     Blob(uint32_t s) :
-        _payload(vespalib::DefaultAlloc::create(s)),
+        _payload(Alloc::alloc(s)),
         _sz(s)
     { }
     Blob(Blob && rhs) :
@@ -55,11 +56,11 @@ public:
      **/
     const char *data() const { return static_cast<const char *>(_payload.get()); }
 
-    vespalib::alloc::Alloc & payload() { return _payload; }
-    const vespalib::alloc::Alloc & payload() const { return _payload; }
+    Alloc & payload() { return _payload; }
+    const Alloc & payload() const { return _payload; }
     size_t size() const { return _sz; }
 private:
-    vespalib::alloc::Alloc _payload;
+    Alloc  _payload;
     size_t _sz;
 };
 

--- a/searchcore/src/apps/vespa-gen-testdocs/vespa-gen-testdocs.cpp
+++ b/searchcore/src/apps/vespa-gen-testdocs/vespa-gen-testdocs.cpp
@@ -17,7 +17,6 @@ typedef vespalib::hash_set<uint32_t> UIntSet;
 typedef std::vector<vespalib::string> StringArray;
 typedef std::shared_ptr<StringArray> StringArraySP;
 using namespace vespalib::alloc;
-using vespalib::DefaultAlloc;
 using vespalib::string;
 
 void
@@ -49,7 +48,7 @@ shafile(const string &baseDir,
     string fullFile(prependBaseDir(baseDir, file));
     FastOS_File f;
     std::ostringstream os;
-    Alloc buf = DefaultAlloc::create(65536, MemoryAllocator::HUGEPAGE_SIZE, 0x1000);
+    Alloc buf = Alloc::alloc(65536, MemoryAllocator::HUGEPAGE_SIZE, 0x1000);
     f.EnableDirectIO();
     bool openres = f.OpenReadOnly(fullFile.c_str());
     if (!openres) {

--- a/searchlib/src/tests/datastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/datastore/logdatastore_test.cpp
@@ -20,7 +20,6 @@ using document::BucketId;
 using namespace search::docstore;
 using namespace search;
 using namespace vespalib::alloc;
-using vespalib::DefaultAlloc;
 using search::index::DummyFileHeaderContext;
 
 class MyTlSyncer : public transactionlog::SyncProxy {
@@ -146,7 +145,7 @@ TEST("test that DirectIOPadding works accordng to spec") {
     FastOS_File file("directio.test");
     file.EnableDirectIO();
     EXPECT_TRUE(file.OpenReadWrite());
-    Alloc buf(DefaultAlloc::create(FILE_SIZE, MemoryAllocator::HUGEPAGE_SIZE, 4096));
+    Alloc buf(Alloc::alloc(FILE_SIZE, MemoryAllocator::HUGEPAGE_SIZE, 4096));
     memset(buf.get(), 'a', buf.size());
     EXPECT_EQUAL(FILE_SIZE, file.Write2(buf.get(), FILE_SIZE));
     size_t padBefore(0);

--- a/searchlib/src/vespa/searchlib/attribute/loadedstringvalue.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/loadedstringvalue.cpp
@@ -4,7 +4,7 @@
 #include "loadedstringvalue.h"
 
 using vespalib::Array;
-using vespalib::alloc::MMapAllocFactory;
+using vespalib::alloc::Alloc;
 
 namespace search {
 
@@ -13,7 +13,7 @@ namespace attribute {
 void
 sortLoadedByValue(LoadedStringVectorReal &loaded)
 {
-    Array<unsigned> radixScratchPad(loaded.size(), MMapAllocFactory::create());
+    Array<unsigned> radixScratchPad(loaded.size(), Alloc::allocMMap());
     for(size_t i(0), m(loaded.size()); i < m; i++) {
         loaded[i].prepareRadixSort();
     }

--- a/searchlib/src/vespa/searchlib/btree/bufferstate.cpp
+++ b/searchlib/src/vespa/searchlib/btree/bufferstate.cpp
@@ -3,7 +3,6 @@
 #include "bufferstate.h"
 #include <limits>
 
-using vespalib::DefaultAlloc;
 using vespalib::alloc::Alloc;
 
 namespace search {
@@ -125,7 +124,7 @@ BufferState::BufferState(void)
       _typeId(0),
       _clusterSize(0),
       _compacting(false),
-      _buffer(DefaultAlloc::create())
+      _buffer(Alloc::alloc())
 {
 }
 
@@ -216,7 +215,7 @@ BufferState::onFree(void *&buffer)
     assert(_deadElems <= _usedElems);
     assert(_holdElems == _usedElems - _deadElems);
     _typeHandler->destroyElements(buffer, _usedElems);
-    DefaultAlloc::create().swap(_buffer);
+    Alloc::alloc().swap(_buffer);
     _typeHandler->onFree(_usedElems);
     buffer = NULL;
     _usedElems = 0;

--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
@@ -11,14 +11,13 @@ using vespalib::nbostream;
 using vespalib::GenerationHeldBase;
 using vespalib::GenerationHeldAlloc;
 using vespalib::GenerationHolder;
-using vespalib::DefaultAlloc;
 
 void AllocatedBitVector::alloc()
 {
     uint32_t words = capacityWords();
     words += (-words & 15);	// Pad to 64 byte alignment
     const size_t sz(words * sizeof(Word));
-    DefaultAlloc::create(sz).swap(_alloc);
+    Alloc::alloc(sz).swap(_alloc);
     assert(_alloc.size()/sizeof(Word) >= words);
     // Clear padding
     memset(static_cast<char *>(_alloc.get()) + sizeBytes(), 0, sz - sizeBytes());

--- a/searchlib/src/vespa/searchlib/common/bitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/bitvector.cpp
@@ -14,7 +14,7 @@ using vespalib::make_string;
 using vespalib::IllegalArgumentException;
 using vespalib::hwaccelrated::IAccelrated;
 using vespalib::Optimized;
-using vespalib::DefaultAlloc;
+using vespalib::alloc::Alloc;
 
 namespace {
 
@@ -323,7 +323,7 @@ BitVector::create(Index numberOfElements,
         size_t vectorsize = getFileBytes(numberOfElements);
         file.DirectIOPadding(offset, vectorsize, padbefore, padafter);
         assert((padbefore & (getAlignment() - 1)) == 0);
-        AllocatedBitVector::Alloc alloc = DefaultAlloc::create(padbefore + vectorsize + padafter, 0x1000000, 0x1000);
+        AllocatedBitVector::Alloc alloc = Alloc::alloc(padbefore + vectorsize + padafter, 0x1000000, 0x1000);
         void * alignedBuffer = alloc.get();
         file.ReadBuf(alignedBuffer, alloc.size(), offset - padbefore);
         bv.reset(new AllocatedBitVector(numberOfElements, std::move(alloc), padbefore));

--- a/searchlib/src/vespa/searchlib/common/partialbitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/partialbitvector.cpp
@@ -5,13 +5,13 @@
 #include <vespa/fastos/fastos.h>
 #include "partialbitvector.h"
 
-using vespalib::DefaultAlloc;
-
 namespace search {
+
+using vespalib::alloc::Alloc;
 
 PartialBitVector::PartialBitVector(Index start, Index end) :
     BitVector(),
-    _alloc(DefaultAlloc::create(numActiveBytes(start, end), 0x1000000, 0x1000))
+    _alloc(Alloc::alloc(numActiveBytes(start, end), 0x1000000, 0x1000))
 {
     init(_alloc.get(), start, end);
     clear();

--- a/searchlib/src/vespa/searchlib/common/resultset.cpp
+++ b/searchlib/src/vespa/searchlib/common/resultset.cpp
@@ -6,7 +6,6 @@
 #include <vespa/searchlib/common/resultset.h>
 #include <vespa/searchlib/common/bitvector.h>
 
-using vespalib::DefaultAlloc;
 using vespalib::alloc::Alloc;
 
 namespace search {
@@ -51,7 +50,7 @@ void
 ResultSet::allocArray(unsigned int arrayAllocated)
 {
     if (arrayAllocated > 0) {
-        DefaultAlloc::create(arrayAllocated * sizeof(RankedHit), MMAP_LIMIT).swap(_rankedHitsArray);
+        Alloc::alloc(arrayAllocated * sizeof(RankedHit), MMAP_LIMIT).swap(_rankedHitsArray);
     } else {
         Alloc().swap(_rankedHitsArray);
     }
@@ -99,7 +98,7 @@ ResultSet::mergeWithBitOverflow(void)
     uint32_t        bidx     = bitVector->getFirstTrueBit();
 
     uint32_t  actualHits = getNumHits();
-    Alloc newHitsAlloc = DefaultAlloc::create(actualHits*sizeof(RankedHit), MMAP_LIMIT);
+    Alloc newHitsAlloc = Alloc::alloc(actualHits*sizeof(RankedHit), MMAP_LIMIT);
     RankedHit *newHitsArray = static_cast<RankedHit *>(newHitsAlloc.get());
 
     RankedHit * tgtA    = newHitsArray;

--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -9,6 +9,8 @@ LOG_SETUP(".searchlib.docstore.compacter");
 namespace search {
 namespace docstore {
 
+using vespalib::alloc::Alloc;
+
 void
 Compacter::write(LockGuard guard, uint32_t chunkId, uint32_t lid, const void *buffer, size_t sz) {
     (void) chunkId;
@@ -24,7 +26,7 @@ BucketCompacter::BucketCompacter(size_t maxSignificantBucketBits, const Compress
     _bucketizer(bucketizer),
     _writeCount(0),
     _lock(),
-    _backingMemory(vespalib::DefaultAlloc::create(0x40000000), &_lock),
+    _backingMemory(Alloc::alloc(0x40000000), &_lock),
     _tmpStore(),
     _lidGuard(ds.getLidReadGuard()),
     _bucketizerGuard(bucketizer.getGuard()),

--- a/searchlib/src/vespa/searchlib/docstore/documentstore.h
+++ b/searchlib/src/vespa/searchlib/docstore/documentstore.h
@@ -159,6 +159,7 @@ private:
     class WrapVisitorProgress;
     class Value {
     public:
+        using Alloc = vespalib::alloc::Alloc;
         typedef std::unique_ptr<Value> UP;
         Value() : _compressedSize(0), _uncompressedSize(0), _compression(document::CompressionConfig::NONE) { }
 
@@ -173,7 +174,7 @@ private:
             _compressedSize(rhs._compressedSize),
             _uncompressedSize(rhs._uncompressedSize),
             _compression(rhs._compression),
-            _buf(vespalib::DefaultAlloc::create(rhs.size()))
+            _buf(Alloc::alloc(rhs.size()))
         {
             memcpy(get(), rhs.get(), size());
         }
@@ -213,7 +214,7 @@ private:
         size_t _compressedSize;
         size_t _uncompressedSize;
         document::CompressionConfig::Type _compression;
-        vespalib::alloc::Alloc _buf;
+        Alloc  _buf;
     };
     class BackingStore {
     public:

--- a/searchlib/src/vespa/searchlib/docstore/visitcache.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/visitcache.cpp
@@ -10,7 +10,6 @@ using vespalib::LockGuard;
 using vespalib::DataBuffer;
 using vespalib::alloc::Alloc;
 using vespalib::alloc::MemoryAllocator;
-using vespalib::DefaultAlloc;
 
 KeySet::KeySet(uint32_t key) :
     _keys()
@@ -31,7 +30,7 @@ KeySet::contains(const KeySet &rhs) const {
 
 BlobSet::BlobSet() :
     _positions(),
-    _buffer(DefaultAlloc::create(0, 16 * MemoryAllocator::HUGEPAGE_SIZE), 0)
+    _buffer(Alloc::alloc(0, 16 * MemoryAllocator::HUGEPAGE_SIZE), 0)
 { }
 
 namespace {
@@ -92,7 +91,7 @@ BlobSet
 CompressedBlobSet::getBlobSet() const
 {
     // These are frequent lage allocations that are to expensive to mmap.
-    DataBuffer uncompressed(0, 1, DefaultAlloc::create(0, 16 * MemoryAllocator::HUGEPAGE_SIZE));
+    DataBuffer uncompressed(0, 1, Alloc::alloc(0, 16 * MemoryAllocator::HUGEPAGE_SIZE));
     if ( ! _positions.empty() ) {
         document::decompress(_compression, getBufferSize(_positions), ConstBufferRef(_buffer.c_str(), _buffer.size()), uncompressed, false);
     }

--- a/searchlib/src/vespa/searchlib/grouping/sketch.h
+++ b/searchlib/src/vespa/searchlib/grouping/sketch.h
@@ -233,7 +233,7 @@ decompress_buckets_from(char *buffer, uint32_t size) {
 template <int BucketBits, typename HashT>
 void NormalSketch<BucketBits, HashT>::
 serialize(vespalib::Serializer &os) const {
-    vespalib::alloc::Alloc backing(vespalib::DefaultAlloc::create(LZ4_compressBound(BUCKET_COUNT)));
+    vespalib::alloc::Alloc backing(vespalib::alloc::Alloc::alloc(LZ4_compressBound(BUCKET_COUNT)));
     char * compress_array(static_cast<char *>(backing.get()));
     uint32_t size = compress_buckets_into(compress_array, backing.size());
     os << BUCKET_COUNT << size;

--- a/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.cpp
@@ -250,7 +250,7 @@ void PredicateBlueprint::fetchPostings(bool) {
     }
 
     PredicateAttribute::MinFeatureHandle mfh = predicate_attribute().getMinFeatureVector();
-    vespalib::alloc::Alloc kv(vespalib::DefaultAlloc::create(mfh.second));
+    Alloc kv(Alloc::alloc(mfh.second));
     _kVBacking.swap(kv);
     _kV = BitVectorCache::CountVector(static_cast<uint8_t *>(_kVBacking.get()), mfh.second);
     _index.computeCountVector(_cachedFeatures, _kV);

--- a/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
@@ -58,6 +58,7 @@ private:
     using VectorIterator = predicate::SimpleIndex<btree::EntryRef>::VectorIterator;
     template <typename T>
     using optional = std::experimental::optional<T>;
+    using Alloc = vespalib::alloc::Alloc;
 
     const PredicateAttribute & predicate_attribute() const {
         return _attribute;
@@ -72,7 +73,7 @@ private:
 
     const PredicateAttribute & _attribute;
     const predicate::PredicateIndex &_index;
-    vespalib::alloc::Alloc _kVBacking;
+    Alloc _kVBacking;
     BitVectorCache::CountVector _kV;
     BitVectorCache::KeySet _cachedFeatures;
 

--- a/searchlib/src/vespa/searchlib/transactionlog/domainpart.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/domainpart.cpp
@@ -21,18 +21,16 @@ using vespalib::getLastErrorString;
 using vespalib::IllegalHeaderException;
 using vespalib::LockGuard;
 using vespalib::nbostream;
+using vespalib::alloc::Alloc;
 using search::common::FileHeaderContext;
 using std::runtime_error;
 
-namespace search
-{
+namespace search {
 
-namespace transactionlog
-{
+namespace transactionlog {
 
+namespace {
 
-namespace
-{
 
 void
 handleSync(FastOS_FileInterface &file) __attribute__ ((noinline));
@@ -221,7 +219,7 @@ DomainPart::buildPacketMapping(bool allowTruncate)
         SerialNum lastSerial(0);
         int64_t firstPos(currPos);
         bool full(false);
-        vespalib::alloc::Alloc buf;
+        Alloc buf;
         for(size_t i(0); !full && (currPos < fSize); i++) {
             Packet::Entry e;
             if (read(transLog, e, buf, allowTruncate)) {
@@ -552,7 +550,7 @@ DomainPart::visit(FastOS_FileInterface &file, SerialNumRange &r, Packet &packet)
     }
     if (retval) {
         Packet newPacket;
-        vespalib::alloc::Alloc buf;
+        Alloc buf;
         for (bool full(false);!full && retval && (r.from() < r.to());) {
             Packet::Entry e;
             int64_t fPos = file.GetPosition();
@@ -612,7 +610,7 @@ DomainPart::write(FastOS_FileInterface &file, const Packet::Entry &entry)
 bool
 DomainPart::read(FastOS_FileInterface &file,
                  Packet::Entry &entry,
-                 vespalib::alloc::Alloc & buf,
+                 Alloc & buf,
                  bool allowTruncate)
 {
     bool retval(true);
@@ -625,7 +623,7 @@ DomainPart::read(FastOS_FileInterface &file,
     his >> version >> len;
     if ((retval = (rlen == sizeof(tmp)))) {
         if ( ! (retval = (version == ccitt_crc32) || version == xxh64)) {
-            vespalib::string msg(make_string("Version mismatch. Expected 'ccitt_crc32=1' or 'xxh64=2',"
+            string msg(make_string("Version mismatch. Expected 'ccitt_crc32=1' or 'xxh64=2',"
                                              " got %d from '%s' at position %ld",
                                              version, file.GetFileName(), lastKnownGoodPos));
             if ((version == 0) && (len == 0) && tailOfFileIsZero(file, lastKnownGoodPos)) {
@@ -636,7 +634,7 @@ DomainPart::read(FastOS_FileInterface &file,
             }
         }
         if (len > buf.size()) {
-            vespalib::DefaultAlloc::create(len).swap(buf);
+            Alloc::alloc(len).swap(buf);
         }
         rlen = file.Read(buf.get(), len);
         retval = rlen == len;

--- a/staging_vespalib/src/tests/memorydatastore/memorydatastore.cpp
+++ b/staging_vespalib/src/tests/memorydatastore/memorydatastore.cpp
@@ -21,7 +21,7 @@ public:
 void
 MemoryDataStoreTest::testMemoryDataStore()
 {
-    MemoryDataStore s(DefaultAlloc::create(256));
+    MemoryDataStore s(Alloc::alloc(256));
     std::vector<MemoryDataStore::Reference> v;
     v.push_back(s.push_back("mumbo", 5));
     for (size_t i(0); i < 50; i++) {

--- a/staging_vespalib/src/tests/memorydatastore/memorydatastore.cpp
+++ b/staging_vespalib/src/tests/memorydatastore/memorydatastore.cpp
@@ -21,7 +21,7 @@ public:
 void
 MemoryDataStoreTest::testMemoryDataStore()
 {
-    MemoryDataStore s(Alloc::alloc(256));
+    MemoryDataStore s(alloc::Alloc::alloc(256));
     std::vector<MemoryDataStore::Reference> v;
     v.push_back(s.push_back("mumbo", 5));
     for (size_t i(0); i < 50; i++) {

--- a/staging_vespalib/src/vespa/vespalib/data/databuffer.h
+++ b/staging_vespalib/src/vespa/vespalib/data/databuffer.h
@@ -33,7 +33,7 @@ namespace vespalib {
 class DataBuffer
 {
 private:
-    using Alloc = vespalib::alloc::Alloc;
+    using Alloc = alloc::Alloc;
     size_t         _alignment;
     char          *_externalBuf;
     char          *_bufstart;
@@ -53,7 +53,7 @@ public:
      * @param len the initial size of the buffer.
      * @param alignment required memory alignment for data start
      **/
-    DataBuffer(size_t len = 1024, size_t alignment = 1, const Alloc & initial = vespalib::DefaultAlloc::create(0));
+    DataBuffer(size_t len = 1024, size_t alignment = 1, const Alloc & initial = Alloc::alloc(0));
 
     /**
      * Construct a databuffer using externally allocated memory. Note
@@ -70,7 +70,7 @@ public:
         _bufend(buf + len),
         _datapt(_bufstart),
         _freept(_bufstart),
-        _buffer(vespalib::DefaultAlloc::create(0))
+        _buffer(Alloc::alloc(0))
     { }
 
     DataBuffer(const char *buf, size_t len) :
@@ -80,7 +80,7 @@ public:
         _bufend(_bufstart + len),
         _datapt(_bufstart),
         _freept(_bufend),
-        _buffer(vespalib::DefaultAlloc::create(0))
+        _buffer(Alloc::alloc(0))
     { }
 
     /**

--- a/staging_vespalib/src/vespa/vespalib/util/growablebytebuffer.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/growablebytebuffer.cpp
@@ -5,7 +5,7 @@
 using namespace vespalib;
 
 GrowableByteBuffer::GrowableByteBuffer(uint32_t initialLen) :
-    _buffer(DefaultAlloc::create(initialLen)),
+    _buffer(Alloc::alloc(initialLen)),
     _position(0)
 {
 }
@@ -16,7 +16,7 @@ GrowableByteBuffer::allocate(uint32_t len)
     size_t need(_position + len);
     if (need > _buffer.size()) {
         uint32_t newSize = vespalib::roundUp2inN(need);
-        Alloc newBuf(DefaultAlloc::create(newSize));
+        Alloc newBuf(Alloc::alloc(newSize));
         memcpy(newBuf.get(), _buffer.get(), _position);
         _buffer.swap(newBuf);
     }

--- a/storageapi/src/vespa/storageapi/mbusprot/storagereply.cpp
+++ b/storageapi/src/vespa/storageapi/mbusprot/storagereply.cpp
@@ -4,7 +4,6 @@
 
 #include <vespa/storageapi/mbusprot/storagecommand.h>
 
-using vespalib::DefaultAlloc;
 using vespalib::alloc::Alloc;
 using vespalib::IllegalStateException;
 
@@ -14,7 +13,7 @@ namespace mbusprot {
 StorageReply::StorageReply(const mbus::BlobRef& data,
                            const ProtocolSerialization& serializer)
     : _serializer(&serializer),
-      _buffer(DefaultAlloc::create(data.size())),
+      _buffer(Alloc::alloc(data.size())),
       _mbusType(0),
       _reply()
 {

--- a/vespalib/src/tests/alloc/alloc_test.cpp
+++ b/vespalib/src/tests/alloc/alloc_test.cpp
@@ -48,13 +48,13 @@ void
 Test::testBasic()
 {
     {
-        Alloc h = HeapAllocFactory::create(100);
+        Alloc h = Alloc::allocHeap(100);
         EXPECT_EQUAL(100u, h.size());
         EXPECT_TRUE(h.get() != nullptr);
     }
     {
-        EXPECT_EXCEPTION(AlignedHeapAllocFactory::create(100, 7), IllegalArgumentException, "AlignedHeapAllocFactory::create(100, 7) does not support 7 alignment");
-        Alloc h = AlignedHeapAllocFactory::create(100, 1024);
+        EXPECT_EXCEPTION(Alloc::allocAlignedHeap(100, 7), IllegalArgumentException, "Alloc::allocAlignedHeapAlloc(100, 7) does not support 7 alignment");
+        Alloc h = Alloc::allocAlignedHeapAlloc(100, 1024);
         EXPECT_EQUAL(100u, h.size());
         EXPECT_TRUE(h.get() != nullptr);
     }
@@ -64,7 +64,7 @@ Test::testBasic()
         EXPECT_TRUE(h.get() != nullptr);
     }
     {
-        Alloc a = HeapAllocFactory::create(100), b = HeapAllocFactory::create(200);
+        Alloc a = Alloc::allocHeap(100), b = Alloc::allocHeap(200);
         testSwap(a, b);
     }
     {
@@ -72,17 +72,17 @@ Test::testBasic()
         testSwap(a, b);
     }
     {
-        Alloc a = AlignedHeapAllocFactory::create(100, 1024), b = AlignedHeapAllocFactory::create(200, 1024);
+        Alloc a = Alloc::allocAlignedHeap(100, 1024), b = Alloc::allocAlignedHeap(200, 1024);
         testSwap(a, b);
     }
     {
-        Alloc a = HeapAllocFactory::create(100);
+        Alloc a = Alloc::allocHeap(100);
         Alloc b = MMapAllocFactory::create(200);
         testSwap(a, b);
     }
     {
-        Alloc a = HeapAllocFactory::create(100);
-        Alloc b = HeapAllocFactory::create(100);
+        Alloc a = Alloc::allocHeap(100);
+        Alloc b = Alloc::allocHeap(100);
         a = std::move(b);
         EXPECT_TRUE(b.get() == nullptr);
     }

--- a/vespalib/src/tests/alloc/alloc_test.cpp
+++ b/vespalib/src/tests/alloc/alloc_test.cpp
@@ -50,18 +50,18 @@ Test::testBasic()
     {
         Alloc h = HeapAllocFactory::create(100);
         EXPECT_EQUAL(100u, h.size());
-        EXPECT_TRUE(h.get() != NULL);
+        EXPECT_TRUE(h.get() != nullptr);
     }
     {
         EXPECT_EXCEPTION(AlignedHeapAllocFactory::create(100, 7), IllegalArgumentException, "AlignedHeapAllocFactory::create(100, 7) does not support 7 alignment");
         Alloc h = AlignedHeapAllocFactory::create(100, 1024);
         EXPECT_EQUAL(100u, h.size());
-        EXPECT_TRUE(h.get() != NULL);
+        EXPECT_TRUE(h.get() != nullptr);
     }
     {
         Alloc h = MMapAllocFactory::create(100);
         EXPECT_EQUAL(100u, h.size());
-        EXPECT_TRUE(h.get() != NULL);
+        EXPECT_TRUE(h.get() != nullptr);
     }
     {
         Alloc a = HeapAllocFactory::create(100), b = HeapAllocFactory::create(200);
@@ -79,6 +79,12 @@ Test::testBasic()
         Alloc a = HeapAllocFactory::create(100);
         Alloc b = MMapAllocFactory::create(200);
         testSwap(a, b);
+    }
+    {
+        Alloc a = HeapAllocFactory::create(100);
+        Alloc b = HeapAllocFactory::create(100);
+        a = std::move(b);
+        EXPECT_TRUE(b.get() == nullptr);
     }
 }
 

--- a/vespalib/src/tests/alloc/alloc_test.cpp
+++ b/vespalib/src/tests/alloc/alloc_test.cpp
@@ -53,13 +53,13 @@ Test::testBasic()
         EXPECT_TRUE(h.get() != nullptr);
     }
     {
-        EXPECT_EXCEPTION(Alloc::allocAlignedHeap(100, 7), IllegalArgumentException, "Alloc::allocAlignedHeapAlloc(100, 7) does not support 7 alignment");
-        Alloc h = Alloc::allocAlignedHeapAlloc(100, 1024);
+        EXPECT_EXCEPTION(Alloc::allocAlignedHeap(100, 7), IllegalArgumentException, "Alloc::allocAlignedHeap(100, 7) does not support 7 alignment");
+        Alloc h = Alloc::allocAlignedHeap(100, 1024);
         EXPECT_EQUAL(100u, h.size());
         EXPECT_TRUE(h.get() != nullptr);
     }
     {
-        Alloc h = MMapAllocFactory::create(100);
+        Alloc h = Alloc::allocMMap(100);
         EXPECT_EQUAL(100u, h.size());
         EXPECT_TRUE(h.get() != nullptr);
     }
@@ -68,7 +68,7 @@ Test::testBasic()
         testSwap(a, b);
     }
     {
-        Alloc a = MMapAllocFactory::create(100), b = MMapAllocFactory::create(200);
+        Alloc a = Alloc::allocMMap(100), b = Alloc::allocMMap(200);
         testSwap(a, b);
     }
     {
@@ -77,7 +77,7 @@ Test::testBasic()
     }
     {
         Alloc a = Alloc::allocHeap(100);
-        Alloc b = MMapAllocFactory::create(200);
+        Alloc b = Alloc::allocMMap(200);
         testSwap(a, b);
     }
     {
@@ -92,13 +92,13 @@ void
 Test::testAlignedAllocation()
 {
     {
-        Alloc buf = AutoAllocFactory::create(10, MemoryAllocator::HUGEPAGE_SIZE, 1024);
+        Alloc buf = Alloc::alloc(10, MemoryAllocator::HUGEPAGE_SIZE, 1024);
         EXPECT_TRUE(reinterpret_cast<ptrdiff_t>(buf.get()) % 1024 == 0);
     }
 
     {
         // Mmapped pointers are page-aligned, but sanity test anyway.
-        Alloc buf = AutoAllocFactory::create(3000000, MemoryAllocator::HUGEPAGE_SIZE, 512);
+        Alloc buf = Alloc::alloc(3000000, MemoryAllocator::HUGEPAGE_SIZE, 512);
         EXPECT_TRUE(reinterpret_cast<ptrdiff_t>(buf.get()) % 512 == 0);
     }
 }

--- a/vespalib/src/tests/alloc/allocate_and_core.cpp
+++ b/vespalib/src/tests/alloc/allocate_and_core.cpp
@@ -6,9 +6,9 @@ using namespace vespalib::alloc;
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
-    Alloc small(MMapAllocFactory::create(0x400000)); //4M
+    Alloc small(Alloc::allocMMap(0x400000)); //4M
     memset(small.get(), 0x55, small.size());
-    Alloc large(MMapAllocFactory::create(0x4000000)); //640M
+    Alloc large(Alloc::allocMMap(0x4000000)); //640M
     memset(large.get(), 0x66, large.size());
     assert(false);
 }

--- a/vespalib/src/tests/exception_classes/mmap.cpp
+++ b/vespalib/src/tests/exception_classes/mmap.cpp
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
     assert(setrlimit(RLIMIT_AS, &virtualLimit) == 0);
     std::vector<Alloc> mappings;
     for (size_t i(0); i < numBlocks; i++) {
-        mappings.emplace_back(MMapAllocFactory::create(blockSize));
+        mappings.emplace_back(Alloc::allocMMap(blockSize));
         memset(mappings.back().get(), 0xa5, mappings.back().size());
     }
     return 0;

--- a/vespalib/src/vespa/vespalib/data/memorydatastore.cpp
+++ b/vespalib/src/vespa/vespalib/data/memorydatastore.cpp
@@ -41,7 +41,7 @@ MemoryDataStore::push_back(const void * data, const size_t sz)
 
 VariableSizeVector::VariableSizeVector(size_t initialSize) :
     _vector(),
-    _store(DefaultAlloc::create(initialSize))
+    _store(Alloc::alloc(initialSize))
 {
 }
 

--- a/vespalib/src/vespa/vespalib/data/memorydatastore.h
+++ b/vespalib/src/vespa/vespalib/data/memorydatastore.h
@@ -23,7 +23,7 @@ public:
     private:
         void   * _data;
     };
-    MemoryDataStore(alloc::Alloc && initialAlloc=DefaultAlloc::create(256), Lock * lock=nullptr);
+    MemoryDataStore(alloc::Alloc && initialAlloc=alloc::Alloc::alloc(256), Lock * lock=nullptr);
     MemoryDataStore(const MemoryDataStore &) = delete;
     MemoryDataStore & operator = (const MemoryDataStore &) = delete;
     ~MemoryDataStore();

--- a/vespalib/src/vespa/vespalib/util/alloc.cpp
+++ b/vespalib/src/vespa/vespalib/util/alloc.cpp
@@ -373,7 +373,7 @@ Alloc::allocAlignedHeap(size_t sz, size_t alignment)
     } else if (alignment == 0x1000) {
         return Alloc(&AlignedHeapAllocator::get4K(), sz);
     } else {
-        throw IllegalArgumentException(make_string("Alloc::allocAlignedHeap::create(%zu, %zu) does not support %zu alignment", sz, alignment, alignment));
+        throw IllegalArgumentException(make_string("Alloc::allocAlignedHeap(%zu, %zu) does not support %zu alignment", sz, alignment, alignment));
     }
 }
 

--- a/vespalib/src/vespa/vespalib/util/alloc.cpp
+++ b/vespalib/src/vespa/vespalib/util/alloc.cpp
@@ -356,13 +356,13 @@ AutoAllocator::free(PtrAndSize alloc) const {
 }
 
 Alloc
-HeapAllocFactory::create(size_t sz)
+Alloc::allocHeap(size_t sz)
 {
     return Alloc(&HeapAllocator::getDefault(), sz);
 }
 
 Alloc
-AlignedHeapAllocFactory::create(size_t sz, size_t alignment)
+Alloc::allocAlignedHeap(size_t sz, size_t alignment)
 {
     if (alignment == 0) {
         return Alloc(&AlignedHeapAllocator::getDefault(), sz);
@@ -373,18 +373,18 @@ AlignedHeapAllocFactory::create(size_t sz, size_t alignment)
     } else if (alignment == 0x1000) {
         return Alloc(&AlignedHeapAllocator::get4K(), sz);
     } else {
-        throw IllegalArgumentException(make_string("AlignedHeapAllocFactory::create(%zu, %zu) does not support %zu alignment", sz, alignment, alignment));
+        throw IllegalArgumentException(make_string("Alloc::allocAlignedHeap::create(%zu, %zu) does not support %zu alignment", sz, alignment, alignment));
     }
 }
 
 Alloc
-MMapAllocFactory::create(size_t sz)
+Alloc::allocMMap(size_t sz)
 {
     return Alloc(&MMapAllocator::getDefault(), sz);
 }
 
 Alloc
-AutoAllocFactory::create(size_t sz, size_t mmapLimit, size_t alignment)
+Alloc::alloc(size_t sz, size_t mmapLimit, size_t alignment)
 {
     return Alloc(&AutoAllocator::getAllocator(mmapLimit, alignment), sz);
 }

--- a/vespalib/src/vespa/vespalib/util/alloc.h
+++ b/vespalib/src/vespa/vespalib/util/alloc.h
@@ -47,13 +47,17 @@ public:
         _sz(rhs._sz),
         _allocator(rhs._allocator)
     {
-        rhs._buf = nullptr;
-        rhs._sz = 0;
-        rhs._allocator = 0;
+        rhs.clear();
     }
     Alloc & operator=(Alloc && rhs) {
         if (this != & rhs) {
-            swap(rhs);
+            if (_buf != nullptr) {
+                _allocator->free(_buf, _sz);
+            }
+            _sz = rhs._sz;
+            _buf = rhs._buf;
+            _allocator = rhs._allocator;
+            rhs.clear();
         }
         return *this;
     }
@@ -73,7 +77,12 @@ public:
     Alloc create(size_t sz) const {
         return Alloc(_allocator, sz);
     }
-protected:
+private:
+    void clear() {
+        _buf = nullptr;
+        _sz = 0;
+        _allocator = 0;
+    }
     void                  * _buf;
     size_t                  _sz;
     const MemoryAllocator * _allocator;

--- a/vespalib/src/vespa/vespalib/util/array.h
+++ b/vespalib/src/vespa/vespalib/util/array.h
@@ -108,12 +108,12 @@ public:
     typedef T value_type;
     typedef size_t size_type;
 
-    Array(const Alloc & initial=DefaultAlloc::create()) : _array(initial.create(0)), _sz(0) { }
-    Array(size_t sz, const Alloc & initial=DefaultAlloc::create());
+    Array(const Alloc & initial=Alloc::alloc()) : _array(initial.create(0)), _sz(0) { }
+    Array(size_t sz, const Alloc & initial=Alloc::alloc());
     Array(Alloc && buf, size_t sz);
     Array(Array &&rhs);
-    Array(size_t sz, T value, const Alloc & initial=DefaultAlloc::create());
-    Array(const_iterator begin, const_iterator end, const Alloc & initial=DefaultAlloc::create());
+    Array(size_t sz, T value, const Alloc & initial=Alloc::alloc());
+    Array(const_iterator begin, const_iterator end, const Alloc & initial=Alloc::alloc());
     Array(const Array & rhs);
     Array & operator =(const Array & rhs) {
         if (&rhs != this) {


### PR DESCRIPTION
@havardpe PR
There was a bug in the previous big one. When mmapping the size is adjusted up to a mutiple of HUGEPAGE_SIZE. However this adjustment took place without telling the user about it. Hence when this allocation was unmapped only the requested size was unmapped, and not the actual mapped  one, leading to leaking the last section of the buffer if it was not already a multiple of HUGEPAGE_SIZE. This also caused fragmentation and after a while the OS had nothing to give you even with memory still available.
