### PR TITLE
Use std::move() to enable move-constructor when setting up argument to

### DIFF
--- a/vespalib/src/vespa/vespalib/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/dense/dense_tensor_address_combiner.cpp
@@ -116,7 +116,7 @@ DenseTensorAddressCombiner::combineDimensions(const eval::ValueType &lhs,
     }
     return (result.empty() ?
             eval::ValueType::double_type() :
-            eval::ValueType::tensor_type(result));
+            eval::ValueType::tensor_type(std::move(result)));
 }
 
 } // namespace vespalib::tensor

--- a/vespalib/src/vespa/vespalib/tensor/dense/dense_tensor_builder.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/dense/dense_tensor_builder.cpp
@@ -38,7 +38,7 @@ validateLabelNotSpecified(size_t oldLabel, const vespalib::string &dimension)
 }
 
 eval::ValueType
-makeValueType(const std::vector<eval::ValueType::Dimension> &&dimensions) {
+makeValueType(std::vector<eval::ValueType::Dimension> &&dimensions) {
     return (dimensions.empty() ?
             eval::ValueType::double_type() :
             eval::ValueType::tensor_type(std::move(dimensions)));

--- a/vespalib/src/vespa/vespalib/tensor/serialization/dense_binary_format.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/serialization/dense_binary_format.cpp
@@ -14,7 +14,7 @@ namespace tensor {
 namespace {
 
 eval::ValueType
-makeValueType(const std::vector<eval::ValueType::Dimension> &&dimensions) {
+makeValueType(std::vector<eval::ValueType::Dimension> &&dimensions) {
     return (dimensions.empty() ?
             eval::ValueType::double_type() :
             eval::ValueType::tensor_type(std::move(dimensions)));

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor.cpp
@@ -92,7 +92,7 @@ SparseTensor::combineDimensionsWith(const SparseTensor &rhs) const
                    { return lhsDim.name < rhsDim.name; });
     return (result.empty() ?
             eval::ValueType::double_type() :
-            eval::ValueType::tensor_type(result));
+            eval::ValueType::tensor_type(std::move(result)));
 }
 
 eval::ValueType

--- a/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_builder.cpp
+++ b/vespalib/src/vespa/vespalib/tensor/sparse/sparse_tensor_builder.cpp
@@ -36,7 +36,7 @@ SparseTensorBuilder::makeType()
     }
     _type = (dimensions.empty() ?
              eval::ValueType::double_type() :
-             eval::ValueType::tensor_type(dimensions));
+             eval::ValueType::tensor_type(std::move(dimensions)));
     _type_made = true;
 }
 


### PR DESCRIPTION
vespalib::eval::ValueType::tensor_type().

Argument to std::move() should never be const.

@geirst, please review
@havardpe, FYI
