### PR TITLE
Only set ulimit if needed

### DIFF
--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -153,8 +153,16 @@ fixlimits () {
     elif [ `ulimit -n` -lt 16384 ]; then
         ulimit -n 16384 || exit 1
     fi
-    ulimit -c unlimited # core file size
-    ulimit -u 409600    # number of processes/threads
+
+    # core file size
+    if [ `ulimit -c` != "unlimited" ]; then
+        ulimit -c unlimited
+    fi
+
+    # number of processes/threads
+    if [ `ulimit -u` -lt 409600 ]; then
+        ulimit -u 409600
+    fi
 }
 
 checkjava () {


### PR DESCRIPTION
When testing Docker on local machine we want to avoid scripts failing due to not being able to set ulimit, so only set them if needed

@arnej27959 please review

@freva FYI
