### PR TITLE
Bratseth/document api in container dev

### DIFF
--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateSourcesMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateSourcesMojo.java
@@ -75,13 +75,9 @@ public class GenerateSourcesMojo extends AbstractMojo {
         if (configGenVersion != null && !configGenVersion.isEmpty()) {
             return configGenVersion;
         }
-        Dependency containerDev = getVespaDependency("container-dev");
-        if (containerDev != null)
-            return containerDev.getVersion();
-
-        Dependency prelude = getVespaDependency("prelude");
-        if (prelude != null)
-            return prelude.getVersion();
+        Dependency containerInternal = getVespaDependency("container-dev");
+        if (containerInternal != null)
+            return containerInternal.getVersion();
 
         Dependency  docproc = getVespaDependency("docproc");
         if (docproc != null)

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -56,11 +56,11 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
         Set<ComponentSpecification> inherited = new TreeSet<>();
 
         SearchChain vespaGetChain = new SearchChain(new ChainSpecification(new ComponentId("vespaget"),
-                new ChainSpecification.Inheritance(inherited, null), new ArrayList<Phase>(), new TreeSet<ComponentSpecification>()));
+                new ChainSpecification.Inheritance(inherited, null), new ArrayList<>(), new TreeSet<>()));
         vespaGetChain.addInnerComponent(newVespaClientSearcher("com.yahoo.storage.searcher.GetSearcher"));
 
         SearchChain vespaVisitChain = new SearchChain(new ChainSpecification(new ComponentId("vespavisit"),
-                new ChainSpecification.Inheritance(inherited, null), new ArrayList<Phase>(), new TreeSet<ComponentSpecification>()));
+                new ChainSpecification.Inheritance(inherited, null), new ArrayList<>(), new TreeSet<>()));
         vespaVisitChain.addInnerComponent(newVespaClientSearcher("com.yahoo.storage.searcher.VisitSearcher"));
 
         SearchChains chains;

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -76,8 +76,8 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
             ContainerSearch containerSearch = new ContainerSearch(cluster, chains, new ContainerSearch.Options());
             cluster.setSearch(containerSearch);
 
-            final ProcessingHandler<SearchChains> searchHandler = new ProcessingHandler<>(
-                    chains, "com.yahoo.search.handler.SearchHandler");
+            ProcessingHandler<SearchChains> searchHandler = new ProcessingHandler<>(chains, 
+                                                                                    "com.yahoo.search.handler.SearchHandler");
             searchHandler.addServerBindings("http://*/search/*", "https://*/search/*");
             cluster.addComponent(searchHandler);
         }
@@ -162,4 +162,5 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
             this.docprocChain = docprocChain;
         }
     }
+
 }

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <!-- Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<!-- This module collects all common dependencies of Vespa-internal modules, i.e the non-leaf container modules -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0

--- a/container/OWNERS
+++ b/container/OWNERS
@@ -1,0 +1,1 @@
+gjoranv

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!-- Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.  -->
+<!-- This module collects all dependencies applications need to create container components.                         -->
+<!-- It should be considered an external Vespa API.                                                                  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.vespa</groupId>
+    <artifactId>parent</artifactId>
+    <version>6-SNAPSHOT</version>
+  </parent>
+  <artifactId>container</artifactId>
+  <version>6-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-dev</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vespaclient-container-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>application</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/docker/enter-build-container.sh
+++ b/docker/enter-build-container.sh
@@ -12,5 +12,5 @@ cd $DIR
 DOCKER_IMAGE="vespabuild"
 
 docker build -t "$DOCKER_IMAGE" -f Dockerfile.build .
-docker run -ti --rm -v $(pwd)/..:/vespa --entrypoint /vespa/docker/enter-build-container-dev.sh "$DOCKER_IMAGE"
+docker run -ti --rm -v $(pwd)/..:/vespa --entrypoint /vespa/docker/enter-build-container-internal.sh "$DOCKER_IMAGE"
 

--- a/docker/enter-build-container.sh
+++ b/docker/enter-build-container.sh
@@ -12,5 +12,5 @@ cd $DIR
 DOCKER_IMAGE="vespabuild"
 
 docker build -t "$DOCKER_IMAGE" -f Dockerfile.build .
-docker run -ti --rm -v $(pwd)/..:/vespa --entrypoint /vespa/docker/enter-build-container-internal.sh "$DOCKER_IMAGE"
+docker run -ti --rm -v $(pwd)/..:/vespa --entrypoint /vespa/docker/enter-build-container-dev.sh "$DOCKER_IMAGE"
 

--- a/pom.xml
+++ b/pom.xml
@@ -1119,6 +1119,7 @@
         <module>config-proxy</module>
         <module>configserver</module>
         <module>config_test</module>
+        <module>container</module>
         <module>container-core</module>
         <module>container-accesslogging</module>
         <module>container-dev</module>

--- a/vespaclient-container-plugin/pom.xml
+++ b/vespaclient-container-plugin/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <!-- Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<!-- Implementation of document-api in the container. -->
+<!-- TODO: Rename to container-documentapi on Vespa 7 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
@gv please review

I added a new module "container" which external applications should depend on instead of "container-dev", such that we avoid exposing our internal module structure when they need something which is not in container-dev (and everything cannot be put in container-dev without lots of duplication, because our own modules depend on it).

Concretely, applications currently need to add an explicit dependency on vespaclient-container-plugin (ugh), and on application. 
