### PR TITLE
Freva/docker config params

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -20,7 +20,9 @@ public class DockerTestUtils {
             .caCertPath(    operatingSystem == OS.Mac_OS_X ? prefix + "ca.pem" : "")
             .clientCertPath(operatingSystem == OS.Mac_OS_X ? prefix + "cert.pem" : "")
             .clientKeyPath( operatingSystem == OS.Mac_OS_X ? prefix + "key.pem" : "")
-            .uri(           operatingSystem == OS.Mac_OS_X ? "tcp://192.168.99.100:2376" : "tcp://localhost:2376"));
+            .uri(           operatingSystem == OS.Mac_OS_X ? "tcp://192.168.99.100:2376" : "tcp://localhost:2376")
+            .connectTimeoutMillis(100)
+            .secondsToWaitBeforeKillingContainer(0));
     private static DockerImpl docker;
 
     public static boolean dockerDaemonIsPresent() {
@@ -46,7 +48,6 @@ public class DockerTestUtils {
                     dockerConfig,
                     false, /* fallback to 1.23 on errors */
                     false, /* try setup network */
-                    100 /* dockerConnectTimeoutMillis */,
                     new MetricReceiverWrapper(MetricReceiver.nullImplementation));
         }
 

--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -5,3 +5,9 @@ caCertPath string default = ""
 clientCertPath string default = ""
 clientKeyPath string default = ""
 uri string default = "unix:///host/var/run/docker.sock"
+
+secondsToWaitBeforeKillingContainer int default = 10
+maxPerRouteConnections int default = 10
+maxTotalConnections int default = 100
+connectTimeoutMillis int default = 100000 # 100 sec
+readTimeoutMillis int default = 1800000 # 30 min

--- a/docker-api/src/test/resources/simple-ipv6-server/Dockerfile
+++ b/docker-api/src/test/resources/simple-ipv6-server/Dockerfile
@@ -6,8 +6,8 @@ FROM gliderlabs/alpine:3.4
 RUN apk-install python curl
 
 # Copy source
-ADD src/ server/src
+ADD src/ pysrc
 
 # Run http server on port 80
 EXPOSE  80
-CMD ["python", "server/src/server.py"]
+CMD ["python", "/pysrc/server.py"]

--- a/docker-api/src/test/resources/simple-ipv6-server/src/fillmem.py
+++ b/docker-api/src/test/resources/simple-ipv6-server/src/fillmem.py
@@ -1,0 +1,11 @@
+# Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+import sys
+import time
+
+megabyte = [0] * (1024 * 1024 / 8)
+data = megabyte * int(sys.argv[1])
+
+while True:
+    time.sleep(1)
+    data.extend(megabyte)


### PR DESCRIPTION
- Moves docker daemon/docker-java parameters to DockerConfig for easier specification in tests
- Adds test that OOM on one container should not affect the other
