### PR TITLE
Avoid scheduling download of the same image many times

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -326,7 +326,7 @@ public class NodeAgentImpl implements NodeAgent {
 
     private void scheduleDownLoadIfNeeded(ContainerNodeSpec nodeSpec) {
         if (dockerOperations.shouldScheduleDownloadOfImage(nodeSpec.wantedDockerImage.get())) {
-            if (imageBeingDownloaded == nodeSpec.wantedDockerImage.get()) {
+            if (nodeSpec.wantedDockerImage.get().equals(imageBeingDownloaded)) {
                 // Downloading already scheduled, but not done.
                 return;
             }


### PR DESCRIPTION
- Logs shows that the same image is scheduled for download repeatedly,
  fix by checking for equality instead of identity since we will get
  a new node object every time we check state in node repo

@freva please review
