### PR TITLE
Clearer OutOfCapacity messages

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -85,18 +85,18 @@ class GroupPreparer {
                 nodeList.update(nodeRepository.reserve(accepted));
             }
 
-            if (nodeList.fullfilled()) return nodeList.finalNodes(surplusActiveNodes);
-
-            // Could not be fulfilled
-            if (nodeList.wouldBeFulfilledWithRetiredNodes())
-                throw new OutOfCapacityException("Could not satisfy " + requestedNodes + " for " + cluster +
-                                                 " because we want to retire existing nodes.");
-            else if (nodeList.wouldBeFulfilledWithClashingParentHost())
-                throw new OutOfCapacityException("Could not satisfy " + requestedNodes + " for " + cluster +
-                                                 " because too many have same parentHost.");
+            if (nodeList.fullfilled()) 
+                return nodeList.finalNodes(surplusActiveNodes);
             else
-                throw new OutOfCapacityException("Could not satisfy " + requestedNodes + " for " + cluster + ".");
+                throw new OutOfCapacityException("Could not satisfy " + requestedNodes + " for " + cluster + 
+                                                 outOfCapacityDetails(nodeList));
         }
+    }
+    
+    private String outOfCapacityDetails(NodeList nodeList) {
+        if (nodeList.wouldBeFulfilledWithClashingParentHost()) 
+            return  ": Not enough nodes available on separate physical hosts.";
+        return ".";
     }
 
     /** 


### PR DESCRIPTION
Dropping the "because we want to retire existing nodes" message as it is confusing at best with the normal cause of this state which is that the user want to change from one flavor to another.

@jobergum please review
