### PR TITLE
Freva/yamas routing and dimensions fix

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/metrics/MetricReceiverWrapper.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/metrics/MetricReceiverWrapper.java
@@ -100,11 +100,17 @@ public class MetricReceiverWrapper implements Iterable<MetricReceiverWrapper.Dim
         }
 
         public String toSecretAgentReport() throws JsonProcessingException {
+            final Map<String, Object> routing = new HashMap<>();
+            final Map<String, Object> routingYamas = new HashMap<>();
+            routing.put("yamas", routingYamas);
+            routingYamas.put("namespaces", new String[]{"Vespa"});
+
             Map<String, Object> report = new LinkedHashMap<>();
             report.put("application", "docker");
             report.put("timestamp", System.currentTimeMillis() / 1000);
             report.put("dimensions", dimensions.dimensionsMap);
             report.put("metrics", metrics);
+            report.put("routing", routing);
 
             return objectMapper.writeValueAsString(report);
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.nodeagent;
 
-import com.yahoo.net.HostName;
 import com.yahoo.vespa.hosted.dockerapi.Container;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
@@ -86,7 +85,6 @@ public class NodeAgentImpl implements NodeAgent {
     private NodeAttributes lastAttributesSet = null;
     ContainerNodeSpec lastNodeSpec = null;
     CpuUsageReporter lastCpuMetric = new CpuUsageReporter();
-    String parentHostname;
 
     public NodeAgentImpl(
             final String hostName,
@@ -107,7 +105,6 @@ public class NodeAgentImpl implements NodeAgent {
         this.metricReceiver = metricReceiver;
         this.environment = environment;
         this.maintainer = maintainer;
-        this.parentHostname = HostName.getLocalhost();
     }
 
     @Override
@@ -476,7 +473,7 @@ public class NodeAgentImpl implements NodeAgent {
                 .add("flavor", nodeSpec.nodeFlavor)
                 .add("state", nodeSpec.nodeState.toString())
                 .add("zone", environment.getZone())
-                .add("parentHostname", parentHostname);
+                .add("parentHostname", environment.getParentHostHostname());
 
         if (nodeSpec.owner.isPresent()) {
             dimensionsBuilder
@@ -552,7 +549,7 @@ public class NodeAgentImpl implements NodeAgent {
                 .withTag("flavor", nodeSpec.nodeFlavor)
                 .withTag("state", nodeSpec.nodeState.toString())
                 .withTag("zone", environment.getZone())
-                .withTag("parentHostname", parentHostname);
+                .withTag("parentHostname", environment.getParentHostHostname());
 
         if (nodeSpec.owner.isPresent()) scheduleMaker
                 .withTag("tenantName", nodeSpec.owner.get().tenant)

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -67,7 +67,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
                 nodeRepository, nodeAdmin, INITIAL_SCHEDULER_DELAY_MILLIS, NODE_ADMIN_STATE_INTERVAL_MILLIS, orchestrator, baseHostName);
 
         metricReceiverWrapper = metricReceiver;
-        initializeNodeAgentSecretAgent(docker, environment.getZone());
+        initializeNodeAgentSecretAgent(docker);
     }
 
     @Override
@@ -81,14 +81,14 @@ public class ComponentsProviderImpl implements ComponentsProvider {
     }
 
 
-    private void initializeNodeAgentSecretAgent(Docker docker, String zone) {
+    private void initializeNodeAgentSecretAgent(Docker docker) {
         ContainerName nodeAdminName = new ContainerName("node-admin");
         final Path yamasAgentFolder = Paths.get("/etc/yamas-agent/");
         docker.executeInContainer(nodeAdminName, "sudo", "chmod", "a+w", yamasAgentFolder.toString());
 
         Path nodeAdminCheckPath = Paths.get("/usr/bin/curl");
         SecretAgentScheduleMaker scheduleMaker = new SecretAgentScheduleMaker("node-admin", 60, nodeAdminCheckPath,
-                "localhost:4080/rest/metrics").withTag("zone", zone);
+                "localhost:4080/rest/metrics");
 
         try {
             scheduleMaker.writeTo(yamasAgentFolder);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/Environment.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/Environment.java
@@ -1,6 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.util;
 
+import com.yahoo.net.HostName;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -23,22 +25,26 @@ public class Environment {
     private final Set<String> configServerHosts;
     private final String environment;
     private final String region;
+    private final String parentHostHostname;
     private final InetAddressResolver inetAddressResolver;
 
     public Environment() {
         this(getConfigServerHostsFromEnvironment(),
              getEnvironmentVariable(ENVIRONMENT),
              getEnvironmentVariable(REGION),
+             HostName.getLocalhost(),
              new InetAddressResolver());
     }
 
     public Environment(Set<String> configServerHosts,
                        String environment,
                        String region,
+                       String parentHostHostname,
                        InetAddressResolver inetAddressResolver) {
         this.configServerHosts = configServerHosts;
         this.environment = environment;
         this.region = region;
+        this.parentHostHostname = parentHostHostname;
         this.inetAddressResolver = inetAddressResolver;
     }
 
@@ -50,6 +56,10 @@ public class Environment {
 
     public String getRegion() {
         return region;
+    }
+
+    public String getParentHostHostname() {
+        return parentHostHostname;
     }
 
     private static String getEnvironmentVariable(String name) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/SecretAgentScheduleMaker.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/SecretAgentScheduleMaker.java
@@ -57,7 +57,7 @@ public class SecretAgentScheduleMaker {
             }
         }
 
-        stringBuilder.append("  tags:\n").append("    namespace: Vespa\n");
+        if (!tags.isEmpty()) stringBuilder.append("  tags:\n");
         tags.forEach((key, value) -> stringBuilder.append("    ").append(key).append(": ").append(value).append("\n"));
 
         return stringBuilder.toString();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
@@ -24,9 +24,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DockerOperationsImplTest {
-    Environment environment = new Environment(Collections.emptySet(),
+    private final Environment environment = new Environment(Collections.emptySet(),
                                               "dev",
                                               "us-east-1",
+                                              "parent.host.name.yahoo.com",
                                               new InetAddressResolver());
     private final Docker docker = mock(Docker.class);
     private final DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment, new Maintainer());

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
@@ -34,6 +34,7 @@ public class ComponentsProviderWithMocks implements ComponentsProvider {
     private Environment environment = new Environment(Collections.emptySet(),
                                                       "dev",
                                                       "us-east-1",
+                                                      "parent.host.name.yahoo.com",
                                                       new InetAddressResolver());
     private final MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
     private final Function<String, NodeAgent> nodeAgentFactory =

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -54,6 +54,7 @@ public class DockerTester implements AutoCloseable {
         Environment environment = new Environment(Collections.emptySet(),
                                                   "dev",
                                                   "us-east-1",
+                                                  "parent.host.name.yahoo.com",
                                                   inetAddressResolver);
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -55,6 +55,7 @@ public class MultiDockerTest {
         Environment environment = new Environment(Collections.emptySet(),
                                                   "dev",
                                                   "us-east-1",
+                                                  "parent.host.name.yahoo.com",
                                                   inetAddressResolver);
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeStateTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeStateTest.java
@@ -59,6 +59,7 @@ public class NodeStateTest {
         Environment environment = new Environment(Collections.emptySet(),
                                                   "dev",
                                                   "us-east-1",
+                                                  "parent.host.name.yahoo.com",
                                                   inetAddressResolver);
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -48,6 +48,7 @@ public class RestartTest {
         Environment environment = new Environment(Collections.emptySet(),
                                                   "dev",
                                                   "us-east-1",
+                                                  "parent.host.name.yahoo.com",
                                                   inetAddressResolver);
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ResumeTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ResumeTest.java
@@ -49,6 +49,7 @@ public class ResumeTest {
         Environment environment = new Environment(Collections.emptySet(),
                                                   "dev",
                                                   "us-east-1",
+                                                  "parent.host.name.yahoo.com",
                                                   inetAddressResolver);
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -64,6 +64,7 @@ public class NodeAgentImplTest {
     Environment environment = new Environment(Collections.emptySet(),
                                               "dev",
                                               "us-east-1",
+                                              "parent.host.name.yahoo.com",
                                               new InetAddressResolver());
     private final NodeAgentImpl nodeAgent = new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
             storageMaintainer, metricReceiver, environment, maintainer);
@@ -433,7 +434,6 @@ public class NodeAgentImplTest {
         ContainerNodeSpec.Membership membership = new ContainerNodeSpec.Membership("clustType", "clustId", "grp", 3, false);
         nodeAgent.lastNodeSpec = new ContainerNodeSpec(hostName, null, containerName, Node.State.active, "tenants",
                 "docker", version, Optional.of(owner), Optional.of(membership), null, null, null, null, null);
-        nodeAgent.parentHostname = "parent.host.name.yahoo.com";
 
         long totalContainerCpuTime = (long) ((Map) cpu_stats.get("cpu_usage")).get("total_usage");
         long totalSystemCpuTime = (long) cpu_stats.get("system_cpu_usage");

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -433,6 +433,7 @@ public class NodeAgentImplTest {
         ContainerNodeSpec.Membership membership = new ContainerNodeSpec.Membership("clustType", "clustId", "grp", 3, false);
         nodeAgent.lastNodeSpec = new ContainerNodeSpec(hostName, null, containerName, Node.State.active, "tenants",
                 "docker", version, Optional.of(owner), Optional.of(membership), null, null, null, null, null);
+        nodeAgent.parentHostname = "parent.host.name.yahoo.com";
 
         long totalContainerCpuTime = (long) ((Map) cpu_stats.get("cpu_usage")).get("total_usage");
         long totalSystemCpuTime = (long) cpu_stats.get("system_cpu_usage");

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/util/SecretAgentScheduleMakerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/util/SecretAgentScheduleMakerTest.java
@@ -35,7 +35,6 @@ public class SecretAgentScheduleMakerTest {
                 "    - arg1\n" +
                 "    - arg2 with space\n" +
                 "  tags:\n" +
-                "    namespace: Vespa\n" +
                 "    tenantName: vespa\n" +
                 "    app: canary-docker.default\n" +
                 "    clustertype: container\n" +
@@ -56,9 +55,7 @@ public class SecretAgentScheduleMakerTest {
                 "- id: system-checks\n" +
                 "  interval: 60\n" +
                 "  user: nobody\n" +
-                "  check: /some/test\n" +
-                "  tags:\n" +
-                "    namespace: Vespa\n", scheduleMaker.toString());
+                "  check: /some/test\n", scheduleMaker.toString());
     }
 
     @Test
@@ -70,8 +67,6 @@ public class SecretAgentScheduleMakerTest {
                 "- id: system-checks\n" +
                 "  interval: 60\n" +
                 "  user: yahoo\n" +
-                "  check: /some/test\n" +
-                "  tags:\n" +
-                "    namespace: Vespa\n", scheduleMaker.toString());
+                "  check: /some/test\n", scheduleMaker.toString());
     }
 }

--- a/node-admin/src/test/resources/docker.stats.metrics.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.expected.json
@@ -3,7 +3,7 @@
     "application":"docker",
     "dimensions":{
       "flavor":"docker",
-      "app":"testapp",
+      "app":"testapp.testinstance",
       "clustertype":"clustType",
       "role":"tenants",
       "tenantName":"tester",
@@ -11,38 +11,52 @@
       "vespaVersion":"1.2.3",
       "state":"active",
       "clusterid":"clustId",
+      "parentHostname":"parent.host.name.yahoo.com",
+      "zone":"dev.us-east-1",
       "interface":"eth1"
     },
     "metrics":{
       "node.network.bytes_sent":5.4246745E7,
       "node.network.bytes_rcvd":3245766.0
+    },
+    "routing":{
+      "yamas":{
+        "namespaces": ["Vespa"]
+      }
     }
   },
   {
     "application":"docker",
     "dimensions":{
       "flavor":"docker",
-      "app":"testapp",
+      "app":"testapp.testinstance",
       "clustertype":"clustType",
       "role":"tenants",
       "tenantName":"tester",
       "host":"hostname",
       "vespaVersion":"1.2.3",
       "state":"active",
-      "clusterid":"clustId"
+      "clusterid":"clustId",
+      "parentHostname":"parent.host.name.yahoo.com",
+      "zone":"dev.us-east-1"
     },
     "metrics":{
       "node.cpu.busy.pct": 45.6789123,
       "node.cpu.throttled_time": 4523.0,
       "node.memory.usage":1.752707072E9,
       "node.memory.limit":4.294967296E9
+    },
+    "routing":{
+      "yamas":{
+        "namespaces": ["Vespa"]
+      }
     }
   },
   {
     "application":"docker",
     "dimensions":{
       "flavor":"docker",
-      "app":"testapp",
+      "app":"testapp.testinstance",
       "clustertype":"clustType",
       "role":"tenants",
       "tenantName":"tester",
@@ -50,11 +64,18 @@
       "vespaVersion":"1.2.3",
       "state":"active",
       "clusterid":"clustId",
+      "parentHostname":"parent.host.name.yahoo.com",
+      "zone":"dev.us-east-1",
       "interface":"eth0"
     },
     "metrics":{
       "node.network.bytes_sent":2.0303455E7,
       "node.network.bytes_rcvd":1.949927E7
+    },
+    "routing":{
+      "yamas":{
+        "namespaces": ["Vespa"]
+      }
     }
   }
 ]


### PR DESCRIPTION
- Adds `instance` name to `app` dimension
- Moves `zone` from `.yaml` file to dimension to have all dimensions in one place
- Moves `namespace` from `.yaml` to metrics as a `routing` JSON object
- Adds `parentHostname` dimension

FYI: @ldalves 
