### PR TITLE
build tensor IR for sum(tensor_input*tensor_input) sub-expressions

### DIFF
--- a/vespalib/src/vespa/vespalib/eval/interpreted_function.h
+++ b/vespalib/src/vespa/vespalib/eval/interpreted_function.h
@@ -91,6 +91,7 @@ public:
     InterpretedFunction(const TensorEngine &engine, const Function &function, const NodeTypes &types)
         : InterpretedFunction(engine, function.root(), function.num_params(), types) {}
     InterpretedFunction(InterpretedFunction &&rhs) = default;
+    size_t program_size() const { return _program.size(); }
     size_t num_params() const { return _num_params; }
     const Value &eval(Context &ctx) const;
 };

--- a/vespalib/src/vespa/vespalib/eval/test/eval_spec.cpp
+++ b/vespalib/src/vespa/vespalib/eval/test/eval_spec.cpp
@@ -112,12 +112,14 @@ EvalSpec::add_function_call_cases() {
         .add_case({my_nan}, 1.0).add_case({my_inf}, 0.0).add_case({-my_inf}, 0.0);
     add_rule({"a", -1.0, 1.0}, "relu(a)", [](double a){ return std::max(a, 0.0); });
     add_rule({"a", -1.0, 1.0}, "sigmoid(a)", [](double a){ return 1.0 / (1.0 + std::exp(-1.0 * a)); });
+    add_rule({"a", -1.0, 1.0}, "sum(a)", [](double a){ return a; });
     add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "atan2(a,b)", [](double a, double b){ return std::atan2(a, b); });
     add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "ldexp(a,b)", [](double a, double b){ return std::ldexp(a, b); });
     add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "pow(a,b)", [](double a, double b){ return std::pow(a, b); });
     add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "fmod(a,b)", [](double a, double b){ return std::fmod(a, b); });
     add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "min(a,b)", [](double a, double b){ return std::min(a, b); });
     add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "max(a,b)", [](double a, double b){ return std::max(a, b); });
+    add_rule({"a", -1.0, 1.0}, {"b", -1.0, 1.0}, "match(a,b)", [](double a, double b){ return (a * b); });
 }
 
 void


### PR DESCRIPTION
also fix evaluation of sum(double) in interpreted context and add it
to the test spec for plain number evaluation.

@geirst please review
@toregge FYI
