### PR TITLE
Revert "Bump jetty version to 9.3.13"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1083,7 +1083,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.3.13.v20161014</jetty.version>
+        <jetty.version>9.3.12.v20160915</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>


### PR DESCRIPTION
Reverts yahoo/vespa#920
@bjorncs or @gv This one had a significant drop in performance. Reverting until you figure out why. http 1.1 test was down 50%
See http://factory-web.vespa.corp.gq1.yahoo.com/versions/1/builds/15215/products/2/tests/78142/testruns/8446538/graph?orig_testid=8446538
