### PR TITLE
Docker image should not be considered when allocating nodes

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
@@ -70,7 +70,19 @@ public final class ClusterSpec {
         return true;
     }
 
+    /** Returns whether this is equal, disregarding the group value and wanted docker image */
+    public boolean equalsIgnoringGroupAndDockerImage(Object o) {
+        if (o == this) return true;
+        if ( ! (o instanceof ClusterSpec)) return false;
+        ClusterSpec other = (ClusterSpec)o;
+        if ( ! other.type.equals(this.type)) return false;
+        if ( ! other.id.equals(this.id)) return false;
+        return true;
+    }
+
+    // TODO: Remove when no version older than 6.41 is used
     /** Returns whether this is equal, disregarding the group value */
+    @Deprecated
     public boolean equalsIgnoringGroup(Object o) {
         if (o == this) return true;
         if ( ! (o instanceof ClusterSpec)) return false;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/provision/StaticProvisioner.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/provision/StaticProvisioner.java
@@ -36,7 +36,7 @@ public class StaticProvisioner implements HostProvisioner {
         if (requestedCluster.group().isPresent()) // we are requesting a specific group
             return nodeCluster.equals(requestedCluster);
         else // we are requesting nodes of all groups in this cluster
-            return nodeCluster.equalsIgnoringGroup(requestedCluster);
+            return nodeCluster.equalsIgnoringGroupAndDockerImage(requestedCluster);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -216,7 +216,7 @@ class GroupPreparer {
                 if (offered.allocation().isPresent()) {
                     ClusterMembership membership = offered.allocation().get().membership();
                     if ( ! offered.allocation().get().owner().equals(application)) continue; // wrong application
-                    if ( ! membership.cluster().equalsIgnoringGroup(cluster)) continue; // wrong cluster id/type
+                    if ( ! membership.cluster().equalsIgnoringGroupAndDockerImage(cluster)) continue; // wrong cluster id/type
                     if ((! canChangeGroup || saturated()) && ! membership.cluster().group().equals(cluster.group())) continue; // wrong group and we can't or have no reason to change it
                     if ( offered.allocation().get().isRemovable()) continue; // don't accept; causes removal
                     if ( indexes.contains(membership.index())) continue; // duplicate index (just to be sure)

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -189,7 +189,7 @@ public class ProvisioningTester implements AutoCloseable {
         Set<Integer> indices = new HashSet<>();
         for (HostSpec host : hosts) {
             ClusterSpec nodeCluster = host.membership().get().cluster();
-            assertTrue(requestedCluster.equalsIgnoringGroup(nodeCluster));
+            assertTrue(requestedCluster.equalsIgnoringGroupAndDockerImage(nodeCluster));
             if (requestedCluster.group().isPresent())
                 assertEquals(requestedCluster.group(), nodeCluster.group());
             else


### PR DESCRIPTION
- Ignore (wanted) docker image when allocating nodes, since this
  is not an attribute of the node as it is used today, it might
  change at any time (e.g. when upgrading Vespa)

@bratseth please review. This is the minimal fix needed to get this working, I'd like to move docker image out of ClusterSpec, but let's discuss how to do it.
