### PR TITLE
Freva/docker image gc

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
@@ -6,7 +6,6 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -73,9 +72,9 @@ public interface Docker {
     void buildImage(File dockerfile, DockerImage dockerImage);
 
     /**
-     * Deletes the local images that are currently not in use by any container and not in the except set.
+     * Deletes the local images that are currently not in use by any container and not recently used.
      */
-    void deleteUnusedDockerImages(Set<DockerImage> except);
+    void deleteUnusedDockerImages();
 
     /**
      * TODO: Make this function interruptible, see https://github.com/spotify/docker-client/issues/421

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollector.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollector.java
@@ -1,0 +1,115 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.dockerapi;
+
+import com.github.dockerjava.api.model.Image;
+import com.github.dockerjava.api.model.Container;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author freva
+ */
+public class DockerImageGarbageCollector {
+    private final Duration MIN_AGE_IMAGE_GC;
+    private Map<String, Instant> lastTimeUsedByImageId = new HashMap<>();
+
+    public DockerImageGarbageCollector(Duration minAgeImageToDelete) {
+        MIN_AGE_IMAGE_GC = minAgeImageToDelete;
+    }
+
+    public void updateLastUsedTimeFor(String imageId) {
+        updateLastUsedTimeFor(imageId, Instant.now());
+    }
+
+    void updateLastUsedTimeFor(String imageId, Instant at) {
+        lastTimeUsedByImageId.put(imageId, at);
+    }
+
+    /**
+     * Generates lists of images that are safe to delete, in the order that is safe to delete them (children before
+     * parents). The function starts with the set of all local images and then filters out images that are used now
+     * and images that have been used recently (because they might be re-used again in near future).
+     *
+     * @param images List of all the local images
+     * @param containers List of all the containers, including the ones that are stopped
+     * @return List of image tags of unused images, if unused image has no tag, will return image ID instead.
+     */
+    public List<DockerImage> getUnusedDockerImages(List<Image> images, List<Container> containers) {
+        Map<String, Image> dockerImageByImageId = images.stream().collect(Collectors.toMap(Image::getId, img -> img));
+        Map<String, Image> unusedImagesByContainers = filterOutImagesUsedByContainers(dockerImageByImageId, containers);
+        Map<String, Image> unusedImagesByRecent = filterOutRecentImages(unusedImagesByContainers);
+
+        return unusedImagesByRecent.keySet().stream()
+                .sorted((o1, o2) -> {
+                    // If image2 is parent of image1, image1 comes before image2
+                    if (imageIsDescendantOf(unusedImagesByRecent, o1, o2)) return -1;
+                    // If image1 is parent of image2, image2 comes before image1
+                    else if (imageIsDescendantOf(unusedImagesByRecent, o2, o1)) return 1;
+                    // Otherwise, sort lexicographically by image name (For testing)
+                    else return o1.compareTo(o2);
+                })
+                .flatMap(imageId -> {
+                    // Deleting an image by image ID with multiple tags will fail -> map IDs to all the tags refering to the ID
+                    String[] repoTags = unusedImagesByRecent.get(imageId).getRepoTags();
+                    return (repoTags == null) ? Stream.of(imageId) : Stream.of(repoTags);
+                })
+                .map(DockerImage::new)
+                .collect(Collectors.toList());
+    }
+
+    private Map<String, Image> filterOutImagesUsedByContainers(
+            Map<String, Image> dockerImagesByImageId, List<com.github.dockerjava.api.model.Container> containerList) {
+        Map<String, Image> filteredDockerImagesByImageId = new HashMap<>(dockerImagesByImageId);
+
+        for (com.github.dockerjava.api.model.Container container : containerList) {
+            String imageToSpare = container.getImageId();
+            do {
+                // May be null if two images have have the same parent, the first image will remove the parent, the
+                // second will get null.
+                Image sparedImage = filteredDockerImagesByImageId.remove(imageToSpare);
+                imageToSpare = sparedImage == null ? "" : sparedImage.getParentId();
+            } while (!imageToSpare.isEmpty());
+        }
+
+        return filteredDockerImagesByImageId;
+    }
+
+    private Map<String, Image> filterOutRecentImages(Map<String, Image> dockerImageByImageId) {
+        Map<String, Image> filteredDockerImagesByImageId = new HashMap<>(dockerImageByImageId);
+
+        final Instant now = Instant.now();
+        filteredDockerImagesByImageId.keySet().forEach(imageId -> {
+            if (! lastTimeUsedByImageId.containsKey(imageId)) lastTimeUsedByImageId.put(imageId, now);
+        });
+
+        lastTimeUsedByImageId.entrySet().stream()
+                .filter(entry -> Duration.between(entry.getValue(), now).minus(MIN_AGE_IMAGE_GC).isNegative())
+                .map(Map.Entry::getKey)
+                .forEach(image -> {
+                    String imageToSpare = image;
+                    do {
+                        Image sparedImage = filteredDockerImagesByImageId.remove(imageToSpare);
+                        imageToSpare = sparedImage == null ? "" : sparedImage.getParentId();
+                    } while (!imageToSpare.isEmpty());
+                });
+        return filteredDockerImagesByImageId;
+    }
+
+    /**
+     * Returns true if ancestor is a parent or grand-parent or grand-grand-parent, etc. of img
+     */
+    private boolean imageIsDescendantOf(Map<String, Image> imageIdToImage, String img, String ancestor) {
+        while (imageIdToImage.containsKey(img)) {
+            img = imageIdToImage.get(img).getParentId();
+            if (img == null) return false;
+            if (ancestor.equals(img)) return true;
+        }
+        return false;
+    }
+}

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -21,7 +21,8 @@ public class DockerTestUtils {
             .clientKeyPath( operatingSystem == OS.Mac_OS_X ? prefix + "key.pem" : "")
             .uri(           operatingSystem == OS.Mac_OS_X ? "tcp://192.168.99.100:2376" : "tcp://localhost:2376")
             .connectTimeoutMillis(100)
-            .secondsToWaitBeforeKillingContainer(0));
+            .secondsToWaitBeforeKillingContainer(0)
+            .imageGCEnabled(false));
     private static DockerImpl docker;
 
     public static boolean dockerDaemonIsPresent() {

--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -11,3 +11,6 @@ maxPerRouteConnections int default = 10
 maxTotalConnections int default = 100
 connectTimeoutMillis int default = 100000 # 100 sec
 readTimeoutMillis int default = 1800000 # 30 min
+
+imageGCEnabled bool default = true
+imageGCMinTimeToLiveMinutes int default = 120

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollectionTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollectionTest.java
@@ -1,0 +1,222 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.dockerapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.model.Image;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author freva
+ */
+public class DockerImageGarbageCollectionTest {
+    @Test
+    public void noImagesMeansNoUnusedImages() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages()
+                .expectUnusedImages();
+    }
+
+    @Test
+    public void singleImageWithoutContainersIsUnused() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(new ImageBuilder("image-1"))
+                .expectUnusedImages("image-1");
+    }
+
+    @Test
+    public void singleImageWithContainerIsUsed() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(ImageBuilder.forId("image-1"))
+                .andExistingContainers(ContainerBuilder.forId("container-1").withImageId("image-1"))
+                .expectUnusedImages();
+    }
+
+    @Test
+    public void onlyLeafImageIsUnused() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(
+                        ImageBuilder.forId("parent-image"),
+                        ImageBuilder.forId("leaf-image").withParentId("parent-image"))
+                .expectUnusedImages("leaf-image", "parent-image");
+    }
+
+    @Test
+    public void multipleUnusedImagesAreIdentified() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(
+                        ImageBuilder.forId("image-1"),
+                        ImageBuilder.forId("image-2"))
+                .expectUnusedImages("image-1", "image-2");
+    }
+
+    @Test
+    public void multipleUnusedLeavesAreIdentified() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(
+                        ImageBuilder.forId("parent-image"),
+                        ImageBuilder.forId("image-1").withParentId("parent-image"),
+                        ImageBuilder.forId("image-2").withParentId("parent-image"))
+                .expectUnusedImages("image-1", "image-2", "parent-image");
+    }
+
+    @Test
+    public void unusedLeafWithUsedSiblingIsIdentified() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(
+                        ImageBuilder.forId("parent-image"),
+                        ImageBuilder.forId("image-1").withParentId("parent-image").withTags("latest"),
+                        ImageBuilder.forId("image-2").withParentId("parent-image").withTags("1.24"))
+                .andExistingContainers(ContainerBuilder.forId("vespa-node-1").withImageId("image-1"))
+                .expectUnusedImages("1.24");
+    }
+
+    @Test
+    public void unusedImagesWithMultipleTags() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(
+                        ImageBuilder.forId("parent-image"),
+                        ImageBuilder.forId("image-1").withParentId("parent-image")
+                                .withTags("vespa-6", "vespa-6.28", "vespa:latest"))
+                .expectUnusedImages("vespa-6", "vespa-6.28", "vespa:latest", "parent-image");
+    }
+
+    @Test
+    public void taggedImageWithNoContainersIsUnused() throws Exception {
+        new ImageGcTester(0)
+                .withExistingImages(ImageBuilder.forId("image-1").withTags("vespa-6"))
+                .expectUnusedImages("vespa-6");
+    }
+
+    @Test
+    public void unusedImagesWithSimpleImageGc() throws Exception {
+        new ImageGcTester(20)
+                .withExistingImages(
+                        ImageBuilder.forId("parent-image").withLastUsedMinutesAgo(25),
+                        ImageBuilder.forId("image-1").withParentId("parent-image").withLastUsedMinutesAgo(5))
+                .expectUnusedImages();
+    }
+
+    @Test
+    public void unusedImagesWithImageGc() throws Exception {
+        new ImageGcTester(20)
+                .withExistingImages(
+                        ImageBuilder.forId("parent-1").withLastUsedMinutesAgo(40),
+                        ImageBuilder.forId("parent-2").withTags("p-tag:1").withLastUsedMinutesAgo(10),
+                        ImageBuilder.forId("image-1-1").withParentId("parent-1").withTags("i-tag:1", "i-tag:2", "i-tag-3").withLastUsedMinutesAgo(5),
+                        ImageBuilder.forId("image-1-2").withParentId("parent-1").withLastUsedMinutesAgo(25),
+                        ImageBuilder.forId("image-2-1").withParentId("parent-2").withTags("i-tag:4").withLastUsedMinutesAgo(30))
+                .andExistingContainers(
+                        ContainerBuilder.forId("cont-1").withImageId("image-1-1"))
+                .expectUnusedImages("image-1-2", "i-tag:4");
+    }
+
+    private static class ImageGcTester {
+        private static DockerImageGarbageCollector imageGC;
+
+        private List<Image> existingImages = Collections.emptyList();
+        private List<com.github.dockerjava.api.model.Container> existingContainers = Collections.emptyList();
+
+        private ImageGcTester(int imageGcMinTimeInMinutes) {
+            imageGC = new DockerImageGarbageCollector(Duration.ofMinutes(imageGcMinTimeInMinutes));
+        }
+
+        private ImageGcTester withExistingImages(final ImageBuilder... images) {
+            this.existingImages = Arrays.stream(images)
+                    .map(ImageBuilder::toImage)
+                    .collect(Collectors.toList());
+            return this;
+        }
+
+        private ImageGcTester andExistingContainers(final ContainerBuilder... containers) {
+            this.existingContainers = Arrays.stream(containers)
+                    .map(ContainerBuilder::toContainer)
+                    .collect(Collectors.toList());
+            return this;
+        }
+
+        private void expectUnusedImages(final String... imageIds) throws Exception {
+            final List<DockerImage> expectedUnusedImages = Arrays.stream(imageIds)
+                    .map(DockerImage::new)
+                    .collect(Collectors.toList());
+
+            assertThat(imageGC.getUnusedDockerImages(existingImages, existingContainers), is(expectedUnusedImages));
+        }
+    }
+
+    /**
+     * Serializes object to a JSON string using Jackson, then deserializes it to an instance of toClass
+     * (again using Jackson). This can be used to create Jackson classes with no public constructors.
+     * @throws IllegalArgumentException if Jackson fails to serialize or deserialize.
+     */
+    private static <T> T createFrom(Class<T> toClass, Object object) throws IllegalArgumentException {
+        final String serialized;
+        try {
+            serialized = new ObjectMapper().writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize object " + object + " to "
+                    + toClass + " with Jackson: " + e, e);
+        }
+        try {
+            return new ObjectMapper().readValue(serialized, toClass);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to convert " + serialized + " to "
+                    + toClass + " with Jackson: " + e, e);
+        }
+    }
+
+    // Workaround for Image class that can't be instantiated directly in Java (instantiate via Jackson instead).
+    private static class ImageBuilder {
+        // Json property names must match exactly the property names in the Image class.
+        @JsonProperty("Id")
+        private final String id;
+
+        @JsonProperty("ParentId")
+        private String parentId = ""; // docker-java returns empty string and not null if the parent is not present
+
+        @JsonProperty("RepoTags")
+        private String[] repoTags = null;
+
+        private ImageBuilder(String id) { this.id = id; }
+
+        private static ImageBuilder forId(String id) { return new ImageBuilder(id); }
+        private ImageBuilder withParentId(String parentId) { this.parentId = parentId; return this; }
+        private ImageBuilder withTags(String... tags) { this.repoTags = tags; return this; }
+        private ImageBuilder withLastUsedMinutesAgo(int minutesAgo) {
+            ImageGcTester.imageGC.updateLastUsedTimeFor(id, Instant.now().minus(Duration.ofMinutes(minutesAgo)));
+            return this;
+        }
+
+        private Image toImage() { return createFrom(Image.class, this); }
+    }
+
+    // Workaround for Container class that can't be instantiated directly in Java (instantiate via Jackson instead).
+    private static class ContainerBuilder {
+        // Json property names must match exactly the property names in the Container class.
+        @JsonProperty("Id")
+        private final String id;
+
+        @JsonProperty("ImageID")
+        private String imageId;
+
+        private ContainerBuilder(String id) { this.id = id; }
+        private static ContainerBuilder forId(final String id) { return new ContainerBuilder(id); }
+        private ContainerBuilder withImageId(String imageId) { this.imageId = imageId; return this; }
+
+        private com.github.dockerjava.api.model.Container toContainer() {
+            return createFrom(com.github.dockerjava.api.model.Container.class, this);
+        }
+    }
+}

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImplTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImplTest.java
@@ -1,18 +1,12 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.dockerapi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.ExecStartCmd;
 import com.github.dockerjava.api.command.InspectExecCmd;
 import com.github.dockerjava.api.command.InspectExecResponse;
-import com.github.dockerjava.api.command.ListContainersCmd;
-import com.github.dockerjava.api.command.ListImagesCmd;
-import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
 import org.junit.Test;
@@ -23,11 +17,6 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -128,223 +117,5 @@ public class DockerImplTest {
         final Docker docker = new DockerImpl(dockerClient);
         final ProcessResult result = docker.executeInContainer(new ContainerName(containerId), command);
         assertThat(result.getExitStatus(), is(exitCode));
-    }
-
-    @Test
-    public void noImagesMeansNoUnusedImages() throws Exception {
-        ImageGcTester
-                .withExistingImages()
-                .expectUnusedImages();
-    }
-
-    @Test
-    public void singleImageWithoutContainersIsUnused() throws Exception {
-        ImageGcTester
-                .withExistingImages(new ImageBuilder("image-1"))
-                .expectUnusedImages("image-1");
-    }
-
-    @Test
-    public void singleImageWithContainerIsUsed() throws Exception {
-        ImageGcTester
-                .withExistingImages(ImageBuilder.forId("image-1"))
-                .andExistingContainers(ContainerBuilder.forId("container-1").withImageId("image-1"))
-                .expectUnusedImages();
-    }
-
-    @Test
-    public void onlyLeafImageIsUnused() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("parent-image"),
-                        ImageBuilder.forId("leaf-image").withParentId("parent-image"))
-                .expectUnusedImages("leaf-image", "parent-image");
-    }
-
-    @Test
-    public void multipleUnusedImagesAreIdentified() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("image-1"),
-                        ImageBuilder.forId("image-2"))
-                .expectUnusedImages("image-1", "image-2");
-    }
-
-    @Test
-    public void multipleUnusedLeavesAreIdentified() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("parent-image"),
-                        ImageBuilder.forId("image-1").withParentId("parent-image"),
-                        ImageBuilder.forId("image-2").withParentId("parent-image"))
-                .expectUnusedImages("image-1", "image-2", "parent-image");
-    }
-
-    @Test
-    public void unusedLeafWithUsedSiblingIsIdentified() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("parent-image"),
-                        ImageBuilder.forId("image-1").withParentId("parent-image").withTags("latest"),
-                        ImageBuilder.forId("image-2").withParentId("parent-image").withTags("1.24"))
-                .andExistingContainers(ContainerBuilder.forId("vespa-node-1").withImageId("image-1"))
-                .expectUnusedImages("1.24");
-    }
-
-    @Test
-    public void unusedImagesWithMultipleTags() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("parent-image"),
-                        ImageBuilder.forId("image-1").withParentId("parent-image")
-                                .withTags("vespa-6", "vespa-6.28", "vespa:latest"))
-                .expectUnusedImages("vespa-6", "vespa-6.28", "vespa:latest", "parent-image");
-    }
-
-    @Test
-    public void taggedImageWithNoContainersIsUnused() throws Exception {
-        ImageGcTester
-                .withExistingImages(ImageBuilder.forId("image-1").withTags("vespa-6"))
-                .expectUnusedImages("vespa-6");
-    }
-
-    @Test
-    public void unusedImagesWithMultipleTagsAndExcept() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("parent-image"),
-                        ImageBuilder.forId("image-1").withParentId("parent-image")
-                                .withTags("vespa-6", "vespa-6.28", "vespa:latest"))
-                .andExceptImages("vespa-6.28")
-                .expectUnusedImages("vespa-6", "vespa:latest");
-    }
-
-    @Test
-    public void unusedImagesWithExcept() throws Exception {
-        ImageGcTester
-                .withExistingImages(
-                        ImageBuilder.forId("parent-1"),
-                        ImageBuilder.forId("parent-2").withTags("p-tag:1"),
-                        ImageBuilder.forId("image-1-1").withParentId("parent-1").withTags("i-tag:1", "i-tag:2", "i-tag-3"),
-                        ImageBuilder.forId("image-1-2").withParentId("parent-1"),
-                        ImageBuilder.forId("image-2-1").withParentId("parent-2").withTags("i-tag:4"))
-                .andExceptImages("image-1-2")
-                .andExistingContainers(
-                        ContainerBuilder.forId("cont-1").withImageId("image-1-1"))
-                .expectUnusedImages("i-tag:4", "p-tag:1");
-    }
-
-    private static class ImageGcTester {
-        private final List<Image> existingImages;
-        private Set<DockerImage> exceptImages = Collections.emptySet();
-        private List<com.github.dockerjava.api.model.Container> existingContainers = Collections.emptyList();
-
-        private ImageGcTester(final List<Image> images) {
-            this.existingImages = images;
-        }
-
-        private static ImageGcTester withExistingImages(final ImageBuilder... images) {
-            final List<Image> existingImages = Arrays.stream(images)
-                    .map(ImageBuilder::toImage)
-                    .collect(Collectors.toList());
-            return new ImageGcTester(existingImages);
-        }
-
-        private ImageGcTester andExistingContainers(final ContainerBuilder... containers) {
-            this.existingContainers = Arrays.stream(containers)
-                    .map(ContainerBuilder::toContainer)
-                    .collect(Collectors.toList());
-            return this;
-        }
-
-        private ImageGcTester andExceptImages(final String... images) {
-            this.exceptImages = Arrays.stream(images)
-                    .map(DockerImage::new)
-                    .collect(Collectors.toSet());
-            return this;
-        }
-
-        private void expectUnusedImages(final String... imageIds) throws Exception {
-            final DockerClient dockerClient = mock(DockerClient.class);
-            final DockerImpl docker = new DockerImpl(dockerClient);
-            final ListImagesCmd listImagesCmd = mock(ListImagesCmd.class);
-            final ListContainersCmd listContainersCmd = mock(ListContainersCmd.class);
-
-            when(dockerClient.listImagesCmd()).thenReturn(listImagesCmd);
-            when(listImagesCmd.withShowAll(true)).thenReturn(listImagesCmd);
-            when(listImagesCmd.exec()).thenReturn(existingImages);
-
-            when(dockerClient.listContainersCmd()).thenReturn(listContainersCmd);
-            when(listContainersCmd.withShowAll(true)).thenReturn(listContainersCmd);
-            when(listContainersCmd.exec()).thenReturn(existingContainers);
-
-            final List<DockerImage> expectedUnusedImages = Arrays.stream(imageIds)
-                    .map(DockerImage::new)
-                    .collect(Collectors.toList());
-            assertThat(
-                    docker.getUnusedDockerImages(exceptImages),
-                    is(expectedUnusedImages));
-
-        }
-    }
-
-    /**
-     * Serializes object to a JSON string using Jackson, then deserializes it to an instance of toClass
-     * (again using Jackson). This can be used to create Jackson classes with no public constructors.
-     * @throws IllegalArgumentException if Jackson fails to serialize or deserialize.
-     */
-    private static <T> T createFrom(Class<T> toClass, Object object) throws IllegalArgumentException {
-        final String serialized;
-        try {
-            serialized = new ObjectMapper().writeValueAsString(object);
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Failed to serialize object " + object + " to "
-                    + toClass + " with Jackson: " + e, e);
-        }
-        try {
-            return new ObjectMapper().readValue(serialized, toClass);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to convert " + serialized + " to "
-                    + toClass + " with Jackson: " + e, e);
-        }
-    }
-
-    // Workaround for Image class that can't be instantiated directly in Java (instantiate via Jackson instead).
-    private static class ImageBuilder {
-        // Json property names must match exactly the property names in the Image class.
-        @JsonProperty("Id")
-        private final String id;
-
-        @JsonProperty("ParentId")
-        private String parentId = ""; // docker-java returns empty string and not null if the parent is not present
-
-        @JsonProperty("RepoTags")
-        private String[] repoTags = null;
-
-        private ImageBuilder(String id) { this.id = id; }
-
-        private static ImageBuilder forId(String id) { return new ImageBuilder(id); }
-        private ImageBuilder withParentId(String parentId) { this.parentId = parentId; return this; }
-        private ImageBuilder withTags(String... tags) { this.repoTags = tags; return this; }
-
-        private Image toImage() { return createFrom(Image.class, this); }
-    }
-
-    // Workaround for Container class that can't be instantiated directly in Java (instantiate via Jackson instead).
-    private static class ContainerBuilder {
-        // Json property names must match exactly the property names in the Container class.
-        @JsonProperty("Id")
-        private final String id;
-
-        @JsonProperty("ImageID")
-        private String imageId;
-
-        private ContainerBuilder(String id) { this.id = id; }
-        private static ContainerBuilder forId(final String id) { return new ContainerBuilder(id); }
-        private ContainerBuilder withImageId(String imageId) { this.imageId = imageId; return this; }
-
-        private com.github.dockerjava.api.model.Container toContainer() {
-            return createFrom(com.github.dockerjava.api.model.Container.class, this);
-        }
     }
 }

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerTest.java
@@ -41,6 +41,7 @@ public class DockerTest {
     private static final String CONTAINER_NAME_DOCKER_TEST_PREFIX = "docker-test-";
 
     // It is ignored since it is a bit slow and unstable, at least on Mac.
+    @Ignore
     @Test
     public void testDockerImagePullDelete() throws ExecutionException, InterruptedException {
         DockerImage dockerImage = new DockerImage("busybox:1.24.0");
@@ -56,7 +57,7 @@ public class DockerTest {
 
     // Ignored because the test is very slow (several minutes) when swap is enabled, to disable: (Linux)
     // $ sudo swapoff -a
-
+    @Ignore
     @Test
     public void testOutOfMemoryDoesNotAffectOtherContainers() throws InterruptedException, ExecutionException, IOException {
         String hostName1 = "docker10.test.yahoo.com";

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -37,7 +37,7 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
  * @author dybis
  */
 public class DockerOperationsImpl implements DockerOperations {
-    private static final String NODE_PROGRAM = Defaults.getDefaults().underVespaHome("bin/vespa-nodectl");
+    public static final String NODE_PROGRAM = Defaults.getDefaults().underVespaHome("bin/vespa-nodectl");
     private static final String[] GET_VESPA_VERSION_COMMAND = new String[]{NODE_PROGRAM, "vespa-version"};
 
     private static final String[] RESUME_NODE_COMMAND = new String[] {NODE_PROGRAM, "resume"};

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
@@ -42,16 +44,16 @@ public class DockerFailTest {
             CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             callOrderVerifier.assertInOrder(
                     "createContainerCommand with DockerImage: DockerImage { imageId=dockerImage }, HostName: hostName, ContainerName: ContainerName { name=container }",
-                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]");
+                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
 
             dockerTester.deleteContainer(containerNodeSpec.containerName);
 
             callOrderVerifier.assertInOrder(
                     "deleteContainer with ContainerName: ContainerName { name=container }",
                     "createContainerCommand with DockerImage: DockerImage { imageId=dockerImage }, HostName: hostName, ContainerName: ContainerName { name=container }",
-                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]");
+                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                    "executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
         }
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
-import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -145,7 +145,7 @@ public class DockerMock implements Docker {
     }
 
     @Override
-    public void deleteUnusedDockerImages(Set<DockerImage> except) {
+    public void deleteUnusedDockerImages() {
 
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
@@ -45,19 +46,19 @@ public class MultiDockerTest {
             CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             callOrderVerifier.assertInOrder(
                     "createContainerCommand with DockerImage: DockerImage { imageId=image1 }, HostName: host1, ContainerName: ContainerName { name=container1 }",
-                    "executeInContainer with ContainerName: ContainerName { name=container1 }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                    "executeInContainer with ContainerName: ContainerName { name=container1 }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]",
+                    "executeInContainer with ContainerName: ContainerName { name=container1 }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                    "executeInContainer with ContainerName: ContainerName { name=container1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]",
 
                     "createContainerCommand with DockerImage: DockerImage { imageId=image2 }, HostName: host2, ContainerName: ContainerName { name=container2 }",
-                    "executeInContainer with ContainerName: ContainerName { name=container2 }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                    "executeInContainer with ContainerName: ContainerName { name=container2 }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]",
+                    "executeInContainer with ContainerName: ContainerName { name=container2 }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                    "executeInContainer with ContainerName: ContainerName { name=container2 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]",
 
                     "stopContainer with ContainerName: ContainerName { name=container2 }",
                     "deleteContainer with ContainerName: ContainerName { name=container2 }",
 
                     "createContainerCommand with DockerImage: DockerImage { imageId=image1 }, HostName: host3, ContainerName: ContainerName { name=container3 }",
-                    "executeInContainer with ContainerName: ContainerName { name=container3 }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                    "executeInContainer with ContainerName: ContainerName { name=container3 }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]");
+                    "executeInContainer with ContainerName: ContainerName { name=container3 }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                    "executeInContainer with ContainerName: ContainerName { name=container3 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
 
             callOrderVerifier.assertInOrderWithAssertMessage("Maintainer did not receive call to delete application storage",
                                                              "deleteContainer with ContainerName: ContainerName { name=container2 }",
@@ -96,8 +97,8 @@ public class MultiDockerTest {
 
         tester.getCallOrderVerifier().assertInOrder(
                 "createContainerCommand with DockerImage: " + dockerImage.get() + ", HostName: " + hostName + ", ContainerName: " + containerName,
-                "executeInContainer with ContainerName: " + containerName + ", args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                "executeInContainer with ContainerName: " + containerName + ", args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]");
+                "executeInContainer with ContainerName: " + containerName + ", args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                "executeInContainer with ContainerName: " + containerName + ", args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
 
         return containerNodeSpec;
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeStateTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeStateTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
@@ -45,8 +46,8 @@ public class NodeStateTest {
 
         tester.getCallOrderVerifier().assertInOrder(
                 "createContainerCommand with DockerImage: DockerImage { imageId=dockerImage }, HostName: host1, ContainerName: ContainerName { name=container }",
-                "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                "executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]");
+                "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                "executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
     }
 
 
@@ -77,8 +78,8 @@ public class NodeStateTest {
                                    .get().nodeState, is(Node.State.ready));
 
             dockerTester.getCallOrderVerifier()
-                        .assertInOrder("executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                                       "executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, stop]",
+                        .assertInOrder("executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                                       "executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", stop]",
                                        "stopContainer with ContainerName: ContainerName { name=container }",
                                        "deleteContainer with ContainerName: ContainerName { name=container }");
         }
@@ -126,8 +127,8 @@ public class NodeStateTest {
             callOrderVerifier.assertInOrderWithAssertMessage("Node not started again after being put to active state",
                                                              "deleteContainer with ContainerName: ContainerName { name=container }",
                                                              "createContainerCommand with DockerImage: DockerImage { imageId=newDockerImage }, HostName: host1, ContainerName: ContainerName { name=container }",
-                                                             "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, /opt/yahoo/vespa/bin/vespa-nodectl]",
-                                                             "executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, resume]");
+                                                             "executeInContainer with ContainerName: ContainerName { name=container }, args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
+                                                             "executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
         }
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
@@ -4,9 +4,9 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdmin;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
-import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgent;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
@@ -16,9 +16,7 @@ import java.util.Optional;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests rebooting of Docker host
@@ -58,7 +56,7 @@ public class RebootTest {
 
             assertTrue(nodeAdmin.freezeNodeAgentsAndCheckIfAllFrozen());
 
-            callOrderVerifier.assertInOrder("executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, stop]");
+            callOrderVerifier.assertInOrder("executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", stop]");
         }
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
@@ -40,7 +41,7 @@ public class RestartTest {
             dockerTester.updateContainerNodeSpec(createContainerNodeSpec(wantedRestartGeneration, currentRestartGeneration));
 
             callOrderVerifier.assertInOrder("Suspend for host1",
-                                            "executeInContainer with ContainerName: ContainerName { name=container }, args: [/opt/yahoo/vespa/bin/vespa-nodectl, restart]");
+                                            "executeInContainer with ContainerName: ContainerName { name=container }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", restart]");
         }
     }
 


### PR DESCRIPTION
- Created `DockerImageGarbageCollection` that keeps track of last used time for an image and implements methods to find unused images.
- Fixes tests that stopped working after setting `$VESPA_HOME`
