### PR TITLE
Revert to jetty default bufferpool.

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -264,7 +264,7 @@ public class ConnectorFactory {
                 final Server server,
                 final ServerSocketChannel channelOpenedByActivator,
                 final ConnectionFactory... factories) {
-            super(server, null, null, new BufferPool(), -1, -1, factories);
+            super(server, factories);
             this.channelOpenedByActivator = channelOpenedByActivator;
             this.tcpKeepAlive = config.tcpKeepAliveEnabled();
             this.tcpNoDelay = config.tcpNoDelay();


### PR DESCRIPTION
@bjorncs Let us revert to default jetty bufferpool on factory. We now have enough context to continue investigation.
