### PR TITLE
Missing container exception fix

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
@@ -51,6 +51,11 @@ class CreateContainerCommandImpl implements Docker.CreateContainerCommand {
         return this;
     }
 
+    public Docker.CreateContainerCommand withManagedBy(String manager) {
+        labels.put(DockerImpl.LABEL_NAME_MANAGEDBY, manager);
+        return this;
+    }
+
     @Override
     public Docker.CreateContainerCommand withUlimit(String name, int softLimit, int hardLimit) {
         ulimits.add(new Ulimit(name, softLimit, hardLimit));

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
@@ -22,6 +22,7 @@ public interface Docker {
         CreateContainerCommand withIpAddress(InetAddress address);
         CreateContainerCommand withUlimit(String name, int softLimit, int hardLimit);
         CreateContainerCommand withEntrypoint(String... entrypoint);
+        CreateContainerCommand withManagedBy(String manager);
 
         void create();
     }
@@ -37,7 +38,7 @@ public interface Docker {
         Optional<Integer> getPid();
     }
 
-    ContainerInfo inspectContainer(ContainerName containerName);
+    Optional<ContainerInfo> inspectContainer(ContainerName containerName);
 
 
     interface ContainerStats {
@@ -47,7 +48,7 @@ public interface Docker {
         Map<String, Object> getBlkioStats();
     }
 
-    ContainerStats getContainerStats(ContainerName containerName);
+    Optional<ContainerStats> getContainerStats(ContainerName containerName);
     
     void startContainer(ContainerName containerName);
 
@@ -59,7 +60,7 @@ public interface Docker {
 
     void copyArchiveToContainer(String sourcePath, ContainerName destinationContainer, String destinationPath);
 
-    List<Container> getAllManagedContainers();
+    List<Container> getAllContainersManagedBy(String manager);
 
     Optional<Container> getContainer(String hostname);
 

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -60,6 +60,7 @@ public class DockerTestUtils {
                     false, /* fallback to 1.23 on errors */
                     false, /* try setup network */
                     new MetricReceiverWrapper(MetricReceiver.nullImplementation));
+            createDockerTestNetworkIfNeeded(docker);
         }
 
         return docker;

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.node.admin.orchestrator.Orchestrator;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DockerOperations {
@@ -36,5 +37,12 @@ public interface DockerOperations {
 
     void trySuspendNode(ContainerName containerName);
 
-    Docker.ContainerStats getContainerStats(ContainerName containerName);
+    Optional<Docker.ContainerStats> getContainerStats(ContainerName containerName);
+
+    /**
+     * Returns the list of containers managed by node-admin
+     */
+    List<Container> getAllManagedContainers();
+
+    void deleteUnusedDockerImages();
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -467,10 +467,10 @@ public class NodeAgentImpl implements NodeAgent {
         }
 
         if (nodeSpec == null || nodeSpec.nodeState != Node.State.active) return;
-        final Optional<Container> container = dockerOperations.getContainer(nodeSpec.hostname);
-        if ( ! container.isPresent() || ! container.get().isRunning ) return;
+        Optional<Docker.ContainerStats> containerStats = dockerOperations.getContainerStats(nodeSpec.containerName);
+        if ( ! containerStats.isPresent()) return;
 
-        Docker.ContainerStats stats = dockerOperations.getContainerStats(nodeSpec.containerName);
+        Docker.ContainerStats stats = containerStats.get();
         Dimensions.Builder dimensionsBuilder = new Dimensions.Builder()
                 .add("host", hostname)
                 .add("role", "tenants")

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
@@ -1,9 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.docker;
 
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.ProcessResult;
+import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 import com.yahoo.vespa.hosted.node.admin.util.InetAddressResolver;
 import com.yahoo.vespa.hosted.node.maintenance.Maintainer;
@@ -30,7 +32,8 @@ public class DockerOperationsImplTest {
                                               "parent.host.name.yahoo.com",
                                               new InetAddressResolver());
     private final Docker docker = mock(Docker.class);
-    private final DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment, new Maintainer());
+    private final DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment,
+            new Maintainer(), new MetricReceiverWrapper(MetricReceiver.nullImplementation));
 
     @Test
     public void absenceOfNodeProgramIsSuccess() throws Exception {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
@@ -85,7 +85,7 @@ public class LocalZoneUtils {
                 .replaceAll("\\$NODE_ADMIN_FROM_IMAGE", vespaBaseImage.asString())
                 .replaceAll("\\$VESPA_HOME", Defaults.getDefaults().vespaHome());
 
-        /**
+        /*
          * Because the daemon could be running on a remote machine, docker build command will upload the entire
          * build path to daemon and then execute the Dockerfile. This means that:
          * 1. We cant use relative paths in Dockerfile

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdmin;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminImpl;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
@@ -37,13 +38,13 @@ public class ComponentsProviderWithMocks implements ComponentsProvider {
                                                       "parent.host.name.yahoo.com",
                                                       new InetAddressResolver());
     private final MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
+    private final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, maintainer, mr);
     private final Function<String, NodeAgent> nodeAgentFactory =
             (hostName) -> new NodeAgentImpl(hostName,
-                                            nodeRepositoryMock, orchestratorMock,
-                                            new DockerOperationsImpl(dockerMock, environment, maintainer),
+                                            nodeRepositoryMock, orchestratorMock, dockerOperations,
                                             maintenanceSchedulerMock, mr,
                                             environment, maintainer);
-    private NodeAdmin nodeAdmin = new NodeAdminImpl(dockerMock, nodeAgentFactory, maintenanceSchedulerMock, 100, mr);
+    private NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, maintenanceSchedulerMock, 100, mr);
 
 
     @Override

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 /**
  * Mock with some simple logic
  *
- * @author valerijf
+ * @author freva
  */
 public class DockerMock implements Docker {
     private List<Container> containers = new ArrayList<>();
@@ -57,12 +57,19 @@ public class DockerMock implements Docker {
     }
 
     @Override
-    public ContainerInfo inspectContainer(ContainerName containerName) {
-        return () -> Optional.of(2);
+    public List<Container> getAllContainersManagedBy(String manager) {
+        synchronized (monitor) {
+            return new ArrayList<>(containers);
+        }
     }
 
     @Override
-    public ContainerStats getContainerStats(ContainerName containerName) {
+    public Optional<ContainerInfo> inspectContainer(ContainerName containerName) {
+        return Optional.of(() -> Optional.of(2));
+    }
+
+    @Override
+    public Optional<ContainerStats> getContainerStats(ContainerName containerName) {
         return null;
     }
 
@@ -91,13 +98,6 @@ public class DockerMock implements Docker {
             containers = containers.stream()
                     .filter(container -> !container.name.equals(containerName))
                     .collect(Collectors.toList());
-        }
-    }
-
-    @Override
-    public List<Container> getAllManagedContainers() {
-        synchronized (monitor) {
-            return new ArrayList<>(containers);
         }
     }
 
@@ -196,6 +196,11 @@ public class DockerMock implements Docker {
 
         @Override
         public CreateContainerCommand withEntrypoint(String... entrypoint) {
+            return this;
+        }
+
+        @Override
+        public CreateContainerCommand withManagedBy(String manager) {
             return this;
         }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
@@ -7,8 +7,8 @@ import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.dockerapi.Container;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
-import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.maintenance.StorageMaintainer;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgent;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl;
@@ -48,11 +48,11 @@ public class NodeAdminImplTest {
 
     @Test
     public void nodeAgentsAreProperlyLifeCycleManaged() throws Exception {
-        final Docker docker = mock(Docker.class);
+        final DockerOperations dockerOperations = mock(DockerOperations.class);
         final Function<String, NodeAgent> nodeAgentFactory = mock(NodeAgentFactory.class);
         final StorageMaintainer storageMaintainer = mock(StorageMaintainer.class);
 
-        final NodeAdminImpl nodeAdmin = new NodeAdminImpl(docker, nodeAgentFactory, storageMaintainer, 100,
+        final NodeAdminImpl nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer, 100,
                 new MetricReceiverWrapper(MetricReceiver.nullImplementation));
 
         final NodeAgent nodeAgent1 = mock(NodeAgentImpl.class);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -60,8 +60,7 @@ public class NodeAgentImplTest {
     private final Maintainer maintainer = mock(Maintainer.class);
     private final MetricReceiverWrapper metricReceiver = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
 
-
-    Environment environment = new Environment(Collections.emptySet(),
+    private final Environment environment = new Environment(Collections.emptySet(),
                                               "dev",
                                               "us-east-1",
                                               "parent.host.name.yahoo.com",
@@ -92,7 +91,7 @@ public class NodeAgentImplTest {
 
         Docker.ContainerStats containerStats = new ContainerStatsImpl(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>());
         when(dockerOperations.getContainer(eq(hostName))).thenReturn(Optional.of(new Container(hostName, dockerImage, containerName, true)));
-        when(dockerOperations.getContainerStats(any())).thenReturn(containerStats);
+        when(dockerOperations.getContainerStats(any())).thenReturn(Optional.of(containerStats));
         when(dockerOperations.shouldScheduleDownloadOfImage(any())).thenReturn(false);
         when(dockerOperations.startContainerIfNeeded(eq(nodeSpec))).thenReturn(false);
         when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(vespaVersion);
@@ -140,7 +139,7 @@ public class NodeAgentImplTest {
 
         Docker.ContainerStats containerStats = new ContainerStatsImpl(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>());
         when(dockerOperations.getContainer(eq(hostName))).thenReturn(Optional.empty());
-        when(dockerOperations.getContainerStats(any())).thenReturn(containerStats);
+        when(dockerOperations.getContainerStats(any())).thenReturn(Optional.of(containerStats));
         when(dockerOperations.shouldScheduleDownloadOfImage(any())).thenReturn(false);
         when(dockerOperations.startContainerIfNeeded(eq(nodeSpec))).thenReturn(true);
         when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(vespaVersion);
@@ -412,7 +411,7 @@ public class NodeAgentImplTest {
                 MIN_DISK_AVAILABLE_GB);
 
         Docker.ContainerStats containerStats = new ContainerStatsImpl(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>());
-        when(dockerOperations.getContainerStats(any())).thenReturn(containerStats);
+        when(dockerOperations.getContainerStats(any())).thenReturn(Optional.of(containerStats));
         when(dockerOperations.getContainer(eq(hostName))).thenReturn(Optional.of(new Container(hostName, wantedDockerImage, containerName, true)));
         when(nodeRepository.getContainerNodeSpec(eq(hostName))).thenReturn(Optional.of(nodeSpec));
         when(dockerOperations.shouldScheduleDownloadOfImage(eq(wantedDockerImage))).thenReturn(false);
@@ -458,7 +457,7 @@ public class NodeAgentImplTest {
         Docker.ContainerStats stats = new ContainerStatsImpl(networks, cpu_stats, memory_stats, blkio_stats);
 
         final ContainerName containerName = new ContainerName("cont-name");
-        when(dockerOperations.getContainerStats(eq(containerName))).thenReturn(stats);
+        when(dockerOperations.getContainerStats(eq(containerName))).thenReturn(Optional.of(stats));
 
         when(dockerOperations.getContainer(eq(hostName)))
                 .thenReturn(Optional.of(new Container(hostName, new DockerImage("wantedDockerImage"), containerName, true)));


### PR DESCRIPTION
- Adds `NotFoundException` catch around all `docker-java` methods that may throw it.
- Adds `CreateContainerCommand.withManagedBy()` and `Docker.getAllContainersManagedBy(String)` to easily label containers per test.
- Moves `docker.containers.running` metric to `DockerOperationsImpl`
