### PR TITLE
Only name source once. Fix compile errors.

### DIFF
--- a/fastos/src/vespa/fastos/CMakeLists.txt
+++ b/fastos/src/vespa/fastos/CMakeLists.txt
@@ -1,56 +1,44 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_library(fastos_objects OBJECT 
+    SOURCES
+    app.cpp
+    backtrace.c
+    file.cpp
+    linux_file.cpp
+    serversocket.cpp
+    socket.cpp
+    socketevent.cpp
+    thread.cpp
+    time.cpp
+    timestamp.cpp
+    unix_app.cpp
+    unix_cond.cpp
+    unix_dynamiclibrary.cpp
+    unix_file.cpp
+    unix_ipc.cpp
+    unix_mutex.cpp
+    unix_process.cpp
+    unix_socket.cpp
+    unix_thread.cpp
+    unix_time.cpp
+)
+  
 vespa_add_library(fastos
     SOURCES
-    app.cpp
-    backtrace.c
-    file.cpp
-    linux_file.cpp
-    serversocket.cpp
-    socket.cpp
-    socketevent.cpp
-    thread.cpp
-    time.cpp
-    timestamp.cpp
-    unix_app.cpp
-    unix_cond.cpp
-    unix_dynamiclibrary.cpp
-    unix_file.cpp
-    unix_ipc.cpp
-    unix_mutex.cpp
-    unix_process.cpp
-    unix_socket.cpp
-    unix_thread.cpp
-    unix_time.cpp
+    $<TARGET_OBJECTS:fastos_objects>
     INSTALL lib64
     DEPENDS
     ${CMAKE_DL_LIBS}
 )
+  
 vespa_add_library(fastos_static STATIC
     SOURCES
-    app.cpp
-    backtrace.c
-    file.cpp
-    linux_file.cpp
-    serversocket.cpp
-    socket.cpp
-    socketevent.cpp
-    thread.cpp
-    time.cpp
-    timestamp.cpp
-    unix_app.cpp
-    unix_cond.cpp
-    unix_dynamiclibrary.cpp
-    unix_file.cpp
-    unix_ipc.cpp
-    unix_mutex.cpp
-    unix_process.cpp
-    unix_socket.cpp
-    unix_thread.cpp
-    unix_time.cpp
+    $<TARGET_OBJECTS:fastos_objects>
     INSTALL lib64
     DEPENDS
     ${CMAKE_DL_LIBS}
 )
+  
 find_package(Threads REQUIRED)
 target_link_libraries(fastos PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(fastos_static PUBLIC ${CMAKE_THREAD_LIBS_INIT})

--- a/fbench/src/test/CMakeLists.txt
+++ b/fbench/src/test/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_executable(fbench_httpclient_splitstring_app TEST
     httpclient_splitstring.cpp
     DEPENDS
     fbench_util
+    fbench_httpclient
 )
 vespa_add_test(NAME fbench_httpclient_splitstring_app COMMAND fbench_httpclient_splitstring_app)
 vespa_add_executable(fbench_httpclient_app
@@ -25,5 +26,6 @@ vespa_add_executable(fbench_clientstatus_app TEST
     clientstatus.cpp
     DEPENDS
     fbench_util
+    fastos_static
 )
 vespa_add_test(NAME fbench_clientstatus_app COMMAND fbench_clientstatus_app)

--- a/fbench/src/test/clientstatus.cpp
+++ b/fbench/src/test/clientstatus.cpp
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <util/timer.h>
-#include <util/httpclient.h>
 #include <util/filereader.h>
+#include <httpclient/httpclient.h>
 #include <fbench/client.h>
 
 int

--- a/fbench/src/test/httpclient_splitstring.cpp
+++ b/fbench/src/test/httpclient_splitstring.cpp
@@ -1,6 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <util/httpclient.h>
+#include <httpclient/httpclient.h>
 
 class DebugHTTPClient : public HTTPClient
 {


### PR DESCRIPTION
@baldersheim 
Only name source files once. Fix compile errors. Passes compile and unit test.