### PR TITLE
initialize metric

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/ThreadPoolProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ThreadPoolProvider.java
@@ -98,6 +98,10 @@ public class ThreadPoolProvider extends AbstractComponent implements Provider<Ex
             this.metric = metric;
             this.processTerminator = processTerminator;
             this.maxThreadExecutionTimeMillis = maxThreadExecutionTimeMillis;
+
+            metric.set(MetricNames.THREAD_POOL_SIZE, wrapped.getPoolSize(), null);
+            metric.set(MetricNames.ACTIVE_THREADS, wrapped.getActiveCount(), null);
+            metric.add(MetricNames.REJECTED_REQUEST, 0, null);
         }
 
         /**


### PR DESCRIPTION
* even if we don't receive requests, we want to make sure these
  metrics exist and are observable.

@bratseth please review and merge