### PR TITLE
Bjorncs/jetty experimentation

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -156,7 +156,8 @@ class HttpRequestDispatch {
                         servletInputStream,
                         requestContentChannel,
                         jDiscContext.janitor,
-                        metricReporter);
+                        metricReporter,
+                        servletResponseController);
 
         servletInputStream.setReadListener(servletRequestReader);
         return servletRequestReader;

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletRequestReader.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletRequestReader.java
@@ -108,7 +108,9 @@ class ServletRequestReader implements ReadListener {
     @Override
     public void onDataAvailable() throws IOException {
         while (servletInputStream.isReady()) {
-            final byte[] buffer = new byte[MIN_BUFFER_SIZE_BYTES];
+            final int estimatedNumBytesAvailable = servletInputStream.available();
+            final int bufferSizeBytes = Math.max(estimatedNumBytesAvailable, MIN_BUFFER_SIZE_BYTES);
+            final byte[] buffer = new byte[bufferSizeBytes];
             final int numBytesRead = servletInputStream.read(buffer);
             if (numBytesRead < 0) {
                 // End of stream; there should be no more data available, ever.

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -18,7 +18,6 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -192,6 +191,12 @@ public class ServletResponseController {
     private void commitResponse() {
         synchronized (monitor) {
             responseCommitted = true;
+        }
+    }
+
+    public boolean isResponseCommitted() {
+        synchronized (monitor) {
+            return responseCommitted;
         }
     }
 


### PR DESCRIPTION
@baldersheim 

Complete the AsyncContext on _ReadListener.allDataRead()_ callback if response is already committed. If not, we have to wait for RequestHandler to complete so that any exceptions can be transformed into an error response.