### PR TITLE
Use a static variable to communicate

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/jdisc/HttpRequest.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/HttpRequest.java
@@ -359,17 +359,15 @@ public class HttpRequest {
     public static HttpRequest createRequest(CurrentContainer container,
                                             URI uri, Method method, InputStream requestData,
                                             Map<String, String> properties) {
-
-        final com.yahoo.jdisc.http.HttpRequest clientRequest = com.yahoo.jdisc.http.HttpRequest
-                .newClientRequest(new Request(container, uri), uri, method);
+        com.yahoo.jdisc.http.HttpRequest clientRequest = 
+                com.yahoo.jdisc.http.HttpRequest.newClientRequest(new Request(container, uri), uri, method);
         setProperties(clientRequest, properties);
         return new HttpRequest(clientRequest, requestData);
     }
 
     private static void setProperties(com.yahoo.jdisc.http.HttpRequest clientRequest, Map<String, String> properties) {
-        if (properties == null) {
-            return;
-        }
+        if (properties == null) return;
+
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             clientRequest.parameters().put(entry.getKey(), wrap(entry.getValue()));
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author bratseth
@@ -26,9 +26,9 @@ public class ZooKeeperAccessMaintainerTest {
         tester.curator().setConnectionSpec("server1:1234,server2:5678");
         ZooKeeperAccessMaintainer maintainer = new ZooKeeperAccessMaintainer(tester.nodeRepository(), 
                                                                              tester.curator(), Duration.ofHours(1));
-        assertNull(System.getProperty(ZooKeeperServer.ZOOKEEPER_VESPA_CLIENTS_PROPERTY));
+        assertFalse(ZooKeeperServer.getAllowedClientHostnames().isPresent());
         maintainer.maintain();
-        assertEquals(asSet("server1,server2"), asSet(System.getProperty(ZooKeeperServer.ZOOKEEPER_VESPA_CLIENTS_PROPERTY)));
+        assertEquals(asSet("server1,server2"), ZooKeeperServer.getAllowedClientHostnames().get());
 
         tester.addNode("id1", "host1", "default", NodeType.tenant);
         tester.addNode("id2", "host2", "default", NodeType.tenant);
@@ -37,7 +37,7 @@ public class ZooKeeperAccessMaintainerTest {
 
         assertEquals(3, tester.getNodes(NodeType.tenant).size());
         assertEquals(0, tester.getNodes(NodeType.proxy).size());
-        assertEquals(asSet("host1,host2,host3,server1,server2"), asSet(System.getProperty(ZooKeeperServer.ZOOKEEPER_VESPA_CLIENTS_PROPERTY)));
+        assertEquals(asSet("host1,host2,host3,server1,server2"), ZooKeeperServer.getAllowedClientHostnames().get());
 
         tester.addNode("proxy1", "host4", "default", NodeType.proxy);
         tester.addNode("proxy2", "host5", "default", NodeType.proxy);
@@ -45,7 +45,7 @@ public class ZooKeeperAccessMaintainerTest {
 
         assertEquals(3, tester.getNodes(NodeType.tenant).size());
         assertEquals(2, tester.getNodes(NodeType.proxy).size());
-        assertEquals(asSet("host1,host2,host3,host4,host5,server1,server2"), asSet(System.getProperty(ZooKeeperServer.ZOOKEEPER_VESPA_CLIENTS_PROPERTY)));
+        assertEquals(asSet("host1,host2,host3,host4,host5,server1,server2"), ZooKeeperServer.getAllowedClientHostnames().get());
 
         tester.nodeRepository().move("host2", Node.State.parked);
         assertTrue(tester.nodeRepository().remove("host2"));
@@ -53,7 +53,7 @@ public class ZooKeeperAccessMaintainerTest {
 
         assertEquals(2, tester.getNodes(NodeType.tenant).size());
         assertEquals(2, tester.getNodes(NodeType.proxy).size());
-        assertEquals(asSet("host1,host3,host4,host5,server1,server2"), asSet(System.getProperty(ZooKeeperServer.ZOOKEEPER_VESPA_CLIENTS_PROPERTY)));
+        assertEquals(asSet("host1,host3,host4,host5,server1,server2"), ZooKeeperServer.getAllowedClientHostnames().get());
     }
 
     private Set<String> asSet(String s) {


### PR DESCRIPTION
Some third party code somewhere is calling setProperties,
wiping all properties set inside the VM at random times,
so communicate through a static variable instead.

@hmusum please review