### PR TITLE
Make 'vespa' the default metrics consumer, instead of 'yamas'.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricConsumers.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricConsumers.java
@@ -5,15 +5,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * This class sets up the default metrics and the default 'vespa' metrics consumer.
- *
- * TODO: remove for Vespa 7 or when the 'metric-consumers' element in 'admin' has been removed.
+ * This class sets up the default 'vespa' metrics consumer.
  *
  * @author <a href="mailto:trygve@yahoo-inc.com">Trygve Bolsø Berdal</a>
  * @author gjoranv
  */
-@SuppressWarnings("UnusedDeclaration") // All public apis are used by model amenders
 public class DefaultMetricConsumers {
+
+    public static final String VESPA_CONSUMER_ID = "vespa";
 
     private static final MetricSet vespaMetricSet = new VespaMetricSet();
 
@@ -26,12 +25,8 @@ public class DefaultMetricConsumers {
     @SuppressWarnings("UnusedDeclaration")
     public static Map<String, MetricsConsumer> getDefaultMetricsConsumers() {
         Map<String, MetricsConsumer> metricsConsumers = new LinkedHashMap<>();
-        metricsConsumers.put("yamas", getYamasConsumer());
+        metricsConsumers.put(VESPA_CONSUMER_ID, new MetricsConsumer(VESPA_CONSUMER_ID, vespaMetricSet));
         return metricsConsumers;
-    }
-
-    private static MetricsConsumer getYamasConsumer(){
-        return new MetricsConsumer("yamas", vespaMetricSet);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
@@ -1,9 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.admin.monitoring;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 /**
  * This class sets up the default 'vespa' metrics consumer.
  *
@@ -16,17 +13,9 @@ public class DefaultMetricsConsumer {
 
     private static final MetricSet vespaMetricSet = new VespaMetricSet();
 
-    /**
-     * Populates a map of with consumer as key and metrics for that consumer as value. The metrics
-     * are to be forwarded to consumers.
-     *
-     * @return A map of default metric consumers and default metrics for that consumer.
-     */
     @SuppressWarnings("UnusedDeclaration")
-    public static Map<String, MetricsConsumer> getDefaultMetricsConsumers() {
-        Map<String, MetricsConsumer> metricsConsumers = new LinkedHashMap<>();
-        metricsConsumers.put(VESPA_CONSUMER_ID, new MetricsConsumer(VESPA_CONSUMER_ID, vespaMetricSet));
-        return metricsConsumers;
+    public static MetricsConsumer getDefaultMetricsConsumer() {
+        return new MetricsConsumer(VESPA_CONSUMER_ID, vespaMetricSet);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * @author <a href="mailto:trygve@yahoo-inc.com">Trygve Bolsø Berdal</a>
  * @author gjoranv
  */
-public class DefaultMetricConsumers {
+public class DefaultMetricsConsumer {
 
     public static final String VESPA_CONSUMER_ID = "vespa";
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.admin.monitoring.builder.xml;
 
 import com.yahoo.text.XML;
+import com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers;
 import com.yahoo.vespa.model.admin.monitoring.Metric;
 import com.yahoo.vespa.model.admin.monitoring.MetricSet;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
@@ -14,12 +15,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers.VESPA_CONSUMER_ID;
+
 /**
  * @author gjoranv
  */
 public class MetricsBuilder {
 
     private static final String ID_ATTRIBUTE = "id";
+
     private final Map<String, MetricSet> availableMetricSets;
 
     public MetricsBuilder(Map<String, MetricSet> availableMetricSets) {
@@ -30,6 +34,9 @@ public class MetricsBuilder {
         Metrics metrics = new Metrics();
         for (Element consumerElement : XML.getChildren(metricsElement, "consumer")) {
             String consumerId = consumerElement.getAttribute(ID_ATTRIBUTE);
+            if (consumerId.equals(VESPA_CONSUMER_ID))
+                throw new IllegalArgumentException("'vespa' is not allowed as metric consumer id.");
+
             MetricSet metricSet = buildMetricSet(consumerId, consumerElement);
             metrics.addConsumer(new MetricsConsumer(consumerId, metricSet));
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
@@ -2,20 +2,18 @@
 package com.yahoo.vespa.model.admin.monitoring.builder.xml;
 
 import com.yahoo.text.XML;
-import com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers;
 import com.yahoo.vespa.model.admin.monitoring.Metric;
 import com.yahoo.vespa.model.admin.monitoring.MetricSet;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.admin.monitoring.builder.Metrics;
 import org.w3c.dom.Element;
 
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers.VESPA_CONSUMER_ID;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricsConsumer.VESPA_CONSUMER_ID;
 
 /**
  * @author gjoranv

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomMetricBuilderHelper.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomMetricBuilderHelper.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers.VESPA_CONSUMER_ID;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricsConsumer.VESPA_CONSUMER_ID;
 
 /**
  * Helper class for parsing yamasmetric config.

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomMetricBuilderHelper.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomMetricBuilderHelper.java
@@ -13,14 +13,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers.VESPA_CONSUMER_ID;
+
 /**
  * Helper class for parsing yamasmetric config.
+ *
+ * TODO: Remove when 'metric-consumers' under 'admin' is disallowed
  *
  * @author trygve
  * @since 5.1
  */
 public class DomMetricBuilderHelper {
 
+    private static final String LEGACY_DEFAULT_CONSUMER_ID = "yamas";
 
     /**
      * Build metricConsumer config
@@ -32,7 +37,7 @@ public class DomMetricBuilderHelper {
         Map<String, MetricsConsumer> metricsConsumers = new LinkedHashMap<>();
         List<Element> consumersElem = XML.getChildren(spec, "consumer");
         for (Element consumer : consumersElem) {
-            String consumerName = consumer.getAttribute("name");
+            String consumerName = getConsumerName(consumer);
             Set<Metric> metrics = new LinkedHashSet<>();
             List<Element> metricsEl = XML.getChildren(consumer, "metric");
             if (metricsEl != null) {
@@ -47,6 +52,15 @@ public class DomMetricBuilderHelper {
             metricsConsumers.put(consumerName, metricsConsumer);
         }
         return metricsConsumers;
+    }
+
+    // Converts the old default consumer id to the new default id.
+    private static String getConsumerName(Element consumerElement) {
+        String givenName = consumerElement.getAttribute("name");
+        if (givenName.equals(LEGACY_DEFAULT_CONSUMER_ID))
+            return VESPA_CONSUMER_ID;
+        else
+            return givenName;
     }
 
     private static String metricSetId(String consumerName) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
@@ -9,6 +9,7 @@ import com.yahoo.config.model.provision.Hosts;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers;
 import com.yahoo.vespa.model.admin.monitoring.Metric;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.admin.monitoring.Yamas;
@@ -19,6 +20,7 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers.VESPA_CONSUMER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
@@ -84,7 +86,7 @@ public class DedicatedAdminV4Test {
         assertEquals("vespa.routing", yamas.getClustername());
         assertEquals(60L, (long)yamas.getIntervalSeconds());
         
-        MetricsConsumer consumer = model.getAdmin().getLegacyUserMetricsConsumers().get("yamas");
+        MetricsConsumer consumer = model.getAdmin().getLegacyUserMetricsConsumers().get(VESPA_CONSUMER_ID);
         assertNotNull(consumer);
         assertEquals(3, consumer.getMetrics().size());
         Metric metric = consumer.getMetrics().get("nginx.upstreams.down.last");

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
@@ -9,7 +9,6 @@ import com.yahoo.config.model.provision.Hosts;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.vespa.model.VespaModel;
-import com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers;
 import com.yahoo.vespa.model.admin.monitoring.Metric;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.admin.monitoring.Yamas;
@@ -20,7 +19,7 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricConsumers.VESPA_CONSUMER_ID;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricsConsumer.VESPA_CONSUMER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
@jobergum / @ldalves 

- Prohibit custom consumers with id 'vespa'
- Convert id 'yamas' -> 'vespa' for the legacy xml syntax
  to preserve current behaviour.