### PR TITLE
Revert "Reboot dirty nodes"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -164,9 +164,6 @@ public class CuratorDatabaseClient {
     private Status newNodeStatus(Node node, Node.State toState) {
         if (node.state() != Node.State.failed && toState == Node.State.failed) return node.status().withIncreasedFailCount();
         if (node.state() == Node.State.failed && toState == Node.State.active) return node.status().withDecreasedFailCount(); // fail undo
-        // Increase reboot generation when node is moved to dirty. This is done to reset the state on the node
-        // (e.g. get rid of lingering processes).
-        if (toState == Node.State.dirty) return node.status().withReboot(node.status().reboot().withIncreasedWanted());
         return node.status();
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -5,24 +5,32 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.test.ManualClock;
+import com.yahoo.transaction.NestedTransaction;
+import com.yahoo.vespa.curator.Curator;
+import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.History;
-import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
+import com.yahoo.vespa.hosted.provision.node.NodeFlavors;
+import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
+import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.hosted.provision.testutils.FlavorConfigBuilder;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -32,73 +40,61 @@ import static org.junit.Assert.assertFalse;
  */
 public class InactiveAndFailedExpirerTest {
 
-    private final ApplicationId applicationId = ApplicationId.from(TenantName.from("foo"), ApplicationName.from("bar"),
-            InstanceName.from("fuz"));
+    private Curator curator = new MockCurator();
 
     @Test
     public void ensure_inactive_and_failed_times_out() throws InterruptedException {
-        ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")));
-        List<Node> nodes = tester.makeReadyNodes(2, "default");
-        ApplicationId applicationId = ApplicationId.from(TenantName.from("foo"), ApplicationName.from("bar"), InstanceName.from("fuz"));
+        ManualClock clock = new ManualClock();
+        NodeFlavors nodeFlavors = FlavorConfigBuilder.createDummies("default");
+        NodeRepository nodeRepository = new NodeRepository(nodeFlavors, curator, clock);
+        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, Zone.defaultZone(), clock);
+
+        List<Node> nodes = new ArrayList<>(2);
+        nodes.add(nodeRepository.createNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant));
+        nodes.add(nodeRepository.createNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant));
+        nodeRepository.addNodes(nodes);
+
+        List<Node> hostNodes = new ArrayList<>(2);
+        hostNodes.add(nodeRepository.createNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.host));
+        hostNodes.add(nodeRepository.createNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.host));
+        nodeRepository.addNodes(hostNodes);
 
         // Allocate then deallocate 2 nodes
+        nodeRepository.setReady(nodes);
+        ApplicationId applicationId = ApplicationId.from(TenantName.from("foo"), ApplicationName.from("bar"), InstanceName.from("fuz"));
         ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test"), Optional.empty());
-        tester.prepare(applicationId, cluster, Capacity.fromNodeCount(2), 1);
-        tester.activate(applicationId, asHosts(nodes));
-        assertEquals(2, tester.getNodes(applicationId, Node.State.active).size());
-        tester.deactivate(applicationId);
-        List<Node> inactiveNodes = tester.getNodes(applicationId, Node.State.inactive).asList();
-        assertEquals(2, inactiveNodes.size());
+        provisioner.prepare(applicationId, cluster, Capacity.fromNodeCount(2), 1, null);
+        NestedTransaction transaction = new NestedTransaction().add(new CuratorTransaction(curator));
+        provisioner.activate(transaction, applicationId, asHosts(nodes));
+        transaction.commit();
+        assertEquals(2, nodeRepository.getNodes(NodeType.tenant, Node.State.active).size());
+        NestedTransaction deactivateTransaction = new NestedTransaction();
+        nodeRepository.deactivate(applicationId, deactivateTransaction);
+        deactivateTransaction.commit();
+        assertEquals(2, nodeRepository.getNodes(NodeType.tenant, Node.State.inactive).size());
 
         // Inactive times out
-        tester.advanceTime(Duration.ofMinutes(14));
-        new InactiveExpirer(tester.nodeRepository(), tester.clock(), Duration.ofMinutes(10)).run();
-        assertEquals(0, tester.nodeRepository().getNodes(Node.State.inactive).size());
-        List<Node> dirty = tester.nodeRepository().getNodes(Node.State.dirty);
+        clock.advance(Duration.ofMinutes(14));
+        new InactiveExpirer(nodeRepository, clock, Duration.ofMinutes(10)).run();
+
+        assertEquals(0, nodeRepository.getNodes(NodeType.tenant, Node.State.inactive).size());
+        List<Node> dirty = nodeRepository.getNodes(NodeType.tenant, Node.State.dirty);
         assertEquals(2, dirty.size());
         assertFalse(dirty.get(0).allocation().isPresent());
         assertFalse(dirty.get(1).allocation().isPresent());
 
         // One node is set back to ready
-        Node ready = tester.nodeRepository().setReady(Collections.singletonList(dirty.get(0))).get(0);
+        Node ready = nodeRepository.setReady(Collections.singletonList(dirty.get(0))).get(0);
         assertEquals("Allocated history is removed on readying", 1, ready.history().events().size());
         assertEquals(History.Event.Type.readied, ready.history().events().iterator().next().type());
 
         // Dirty times out for the other one
-        tester.advanceTime(Duration.ofMinutes(14));
-        new DirtyExpirer(tester.nodeRepository(), tester.clock(), Duration.ofMinutes(10)).run();
-        assertEquals(0, tester.nodeRepository().getNodes(NodeType.tenant, Node.State.dirty).size());
-        List<Node> failed = tester.nodeRepository().getNodes(NodeType.tenant, Node.State.failed);
+        clock.advance(Duration.ofMinutes(14));
+        new DirtyExpirer(nodeRepository, clock, Duration.ofMinutes(10)).run();
+        assertEquals(0, nodeRepository.getNodes(NodeType.tenant, Node.State.dirty).size());
+        List<Node> failed = nodeRepository.getNodes(NodeType.tenant, Node.State.failed);
         assertEquals(1, failed.size());
         assertEquals(1, failed.get(0).status().failCount());
-    }
-
-    @Test
-    public void ensure_reboot_generation_is_increased_when_node_moves_to_dirty() {
-        ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")));
-        List<Node> nodes = tester.makeReadyNodes(1, "default");
-
-        // Allocate and deallocate a single node
-        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test"), Optional.empty());
-        tester.prepare(applicationId, cluster, Capacity.fromNodeCount(1), 1);
-        tester.activate(applicationId, asHosts(nodes));
-        assertEquals(1, tester.getNodes(applicationId, Node.State.active).size());
-        tester.deactivate(applicationId);
-        List<Node> inactiveNodes = tester.getNodes(applicationId, Node.State.inactive).asList();
-        assertEquals(1, inactiveNodes.size());
-
-        // Check reboot generation before node is moved
-        long wantedRebootGeneration = inactiveNodes.get(0).status().reboot().wanted();
-        assertEquals(0, wantedRebootGeneration);
-
-        // Inactive times out and node is moved to dirty
-        tester.advanceTime(Duration.ofMinutes(14));
-        new InactiveExpirer(tester.nodeRepository(), tester.clock(), Duration.ofMinutes(10)).run();
-        List<Node> dirty = tester.nodeRepository().getNodes(Node.State.dirty);
-        assertEquals(1, dirty.size());
-
-        // Reboot generation is increased
-        assertEquals(wantedRebootGeneration + 1, dirty.get(0).status().reboot().wanted());
     }
 
     private Set<HostSpec> asHosts(List<Node> nodes) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -17,19 +17,20 @@ import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.config.nodes.NodeRepositoryConfig;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
-import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.hosted.provision.testutils.FlavorConfigBuilder;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Flavor;
 import com.yahoo.vespa.hosted.provision.node.NodeFlavors;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
-import com.yahoo.vespa.hosted.provision.testutils.FlavorConfigBuilder;
+import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 
 import java.io.IOException;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -103,6 +104,19 @@ public class ProvisioningTester implements AutoCloseable {
         return b.build();
     }
 
+    private NodeRepositoryConfig.Flavor.Builder addFlavor(String flavorName, NodeRepositoryConfig.Builder b) {
+        NodeRepositoryConfig.Flavor.Builder flavor = new NodeRepositoryConfig.Flavor.Builder();
+        flavor.name(flavorName);
+        b.flavor(flavor);
+        return flavor;
+    }
+
+    private void addReplaces(String replaces, NodeRepositoryConfig.Flavor.Builder flavor) {
+        NodeRepositoryConfig.Flavor.Replaces.Builder flavorReplaces = new NodeRepositoryConfig.Flavor.Replaces.Builder();
+        flavorReplaces.name(replaces);
+        flavor.replaces(flavorReplaces);
+    }
+
     @Override
     public void close() throws IOException {
         //testingServer.close();
@@ -114,6 +128,7 @@ public class ProvisioningTester implements AutoCloseable {
     public NodeRepositoryProvisioner provisioner() { return provisioner; }
     public CapacityPolicies capacityPolicies() { return capacityPolicies; }
     public NodeList getNodes(ApplicationId id, Node.State ... inState) { return new NodeList(nodeRepository.getNodes(id, inState)); }
+    public NodeFlavors flavors() { return nodeFlavors; }
 
     public void patchNode(Node node) { nodeRepository.write(node); }
 
@@ -139,12 +154,6 @@ public class ProvisioningTester implements AutoCloseable {
         provisioner.activate(transaction, application, hosts);
         transaction.commit();
         assertEquals(toHostNames(hosts), toHostNames(nodeRepository.getNodes(application, Node.State.active)));
-    }
-
-    public void deactivate(ApplicationId applicationId) {
-        NestedTransaction deactivateTransaction = new NestedTransaction();
-        nodeRepository.deactivate(applicationId, deactivateTransaction);
-        deactivateTransaction.commit();
     }
 
     public Set<String> toHostNames(Set<HostSpec> hosts) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -12,7 +12,7 @@
   "description":"Flavor-name-is-default",
   "minCpuCores":2.0,
   "environment":"BARE_METAL",
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "hardwareFailure" : false,


### PR DESCRIPTION
Reverts yahoo/vespa#1045

Nodes in CI are in a reboot loop. Looking at this PR it seems to me that Chef on the node will update current reboot generation after rebooting, which will lead ta PATCH request to config server, which will write new node state to ZooKeeper, but only after calling newNodeStatus(), which will end up with wanted reboot generation being increased again => endless loop

@bratseth or @martinp 