### PR TITLE
I assume the intention was to first run clean, then make all.

### DIFF
--- a/config-model/src/test/sh/test-schema.sh
+++ b/config-model/src/test/sh/test-schema.sh
@@ -2,7 +2,7 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 set -e
 
-pushd src/main && make clean all
+pushd src/main && make clean && make all
 popd
 
 jar="target/jing.jar"


### PR DESCRIPTION
Specifying both will make then race each other when building with many threads.
@gv or @bratseth or @hmusum PR