### PR TITLE
Lower image GC time to 45mins

### DIFF
--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -13,4 +13,4 @@ connectTimeoutMillis int default = 100000 # 100 sec
 readTimeoutMillis int default = 1800000 # 30 min
 
 imageGCEnabled bool default = true
-imageGCMinTimeToLiveMinutes int default = 120
+imageGCMinTimeToLiveMinutes int default = 45


### PR DESCRIPTION
Lowers minimum time an unused image lives before it is deleted to 45mins. Time >60min may cause problems since node-admin may restart once every hour due to new version coming out.