### PR TITLE
Add missing Java DocumentProtocol error name printing

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java
@@ -412,6 +412,8 @@ public class DocumentProtocol implements Protocol {
         switch (code) {
         case ERROR_MESSAGE_IGNORED:
             return "MESSAGE_IGNORED";
+        case ERROR_POLICY_FAILURE:
+            return "POLICY_FAILURE";
         case ERROR_DOCUMENT_NOT_FOUND:
             return "DOCUMENT_NOT_FOUND";
         case ERROR_DOCUMENT_EXISTS:
@@ -438,6 +440,8 @@ public class DocumentProtocol implements Protocol {
             return "PROCESSING_FAILURE";
         case ERROR_TIMESTAMP_EXIST:
             return "TIMESTAMP_EXIST";
+        case ERROR_STALE_TIMESTAMP:
+            return "STALE_TIMESTAMP";
         case ERROR_NODE_NOT_READY:
             return "NODE_NOT_READY";
         case ERROR_WRONG_DISTRIBUTION:

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/ErrorCodesTest.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/ErrorCodesTest.java
@@ -83,4 +83,14 @@ public class ErrorCodesTest {
         codes.put("ERROR_STALE_TIMESTAMP", DocumentProtocol.ERROR_STALE_TIMESTAMP);
         codes.put("ERROR_SUSPENDED", DocumentProtocol.ERROR_SUSPENDED);
     }
+
+    @Test
+    public void getErrorNameIsDefinedForAllKnownProtocolErrorCodes() {
+        final NamedErrorCodes codes = new NamedErrorCodes();
+        enumerateAllDocumentProtocolErrorCodes(codes);
+        codes.nameAndCode.entrySet().forEach(kv -> {
+            // Error names are not prefixed by "ERROR_" unlike their enum counterparts.
+            assertEquals(kv.getKey(), "ERROR_" + DocumentProtocol.getErrorName(kv.getValue()));
+        });
+    }
 }


### PR DESCRIPTION
@dybis Please review. Couple of error code enum values have been missing stringification all along and will have shown up as "UNKNOWN(error number)" to clients.