### PR TITLE
Enable aborting ops from outdated distributors by default

### DIFF
--- a/configdefinitions/src/vespa/persistence.def
+++ b/configdefinitions/src/vespa/persistence.def
@@ -24,7 +24,7 @@ abort_outdated_mutating_ideal_state_ops bool default=true
 ## belong to. As with the abort_outdated_mutating_ideal_state_ops option,
 ## this is a check that happens whenever a message arrives, not when the state
 ## changes.
-abort_outdated_mutating_external_load_ops bool default=false
+abort_outdated_mutating_external_load_ops bool default=true
 
 ## Whether or not to disable partitions when they report I/O errors
 fail_partition_on_error bool default=true


### PR DESCRIPTION
@hakonhall Please review. Re: offline discussion.

This lets a content node inspect all incoming mutating external
operations and reject them if their source distributor is not the
current ideal distributor for the operation's bucket. Will only trigger
during bucket handover edges (cluster state transitions).

This config switch should have been done ages ago, but was lost to the
sands of time. Better late than never.