### PR TITLE
Allow hosts to connect to zk

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainer.java
@@ -38,6 +38,8 @@ public class ZooKeeperAccessMaintainer extends Maintainer {
             hosts.add(node.hostname());
         for (Node node : nodeRepository().getNodes(NodeType.proxy))
             hosts.add(node.hostname());
+        for (Node node : nodeRepository().getNodes(NodeType.host))
+            hosts.add(node.hostname());
         for (String hostPort : curator.connectionSpec().split(","))
             hosts.add(hostPort.split(":")[0]);
 


### PR DESCRIPTION
IPv4 requests from docker containers are NAT'ed through the hosts,
so connections from the hosts must be allowed even if they don't
really make connections themselves.

@hmusum please review