### PR TITLE
Add testrunner dependencies to parallelized tests

### DIFF
--- a/document/src/tests/CMakeLists.txt
+++ b/document/src/tests/CMakeLists.txt
@@ -38,4 +38,5 @@ vespa_add_executable(document_testrunner_app TEST
 vespa_add_test(
     NAME document_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
+    DEPENDS document_testrunner_app
 )

--- a/memfilepersistence/src/tests/CMakeLists.txt
+++ b/memfilepersistence/src/tests/CMakeLists.txt
@@ -14,4 +14,5 @@ vespa_add_executable(memfilepersistence_testrunner_app TEST
 vespa_add_test(
     NAME memfilepersistence_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:memfilepersistence_testrunner_app>
+    DEPENDS memfilepersistence_testrunner_app
 )

--- a/metrics/src/tests/CMakeLists.txt
+++ b/metrics/src/tests/CMakeLists.txt
@@ -20,4 +20,5 @@ vespa_add_executable(metrics_testrunner_app TEST
 vespa_add_test(
     NAME metrics_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
+    DEPENDS metrics_testrunner_app
 )

--- a/persistence/src/tests/CMakeLists.txt
+++ b/persistence/src/tests/CMakeLists.txt
@@ -11,4 +11,5 @@ vespa_add_executable(persistence_testrunner_app TEST
 vespa_add_test(
     NAME persistence_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
+    DEPENDS persistence_testrunner_app
 )

--- a/storage/src/tests/CMakeLists.txt
+++ b/storage/src/tests/CMakeLists.txt
@@ -21,4 +21,5 @@ vespa_add_executable(storage_testrunner_app TEST
 vespa_add_test(
     NAME storage_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storage_testrunner_app>
+    DEPENDS storage_testrunner_app
 )

--- a/storageapi/src/tests/CMakeLists.txt
+++ b/storageapi/src/tests/CMakeLists.txt
@@ -13,4 +13,5 @@ vespa_add_executable(storageapi_testrunner_app TEST
 vespa_add_test(
     NAME storageapi_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
+    DEPENDS storageapi_testrunner_app
 )

--- a/storageframework/src/tests/CMakeLists.txt
+++ b/storageframework/src/tests/CMakeLists.txt
@@ -13,4 +13,5 @@ vespa_add_executable(storageframework_testrunner_app TEST
 vespa_add_test(
     NAME storageframework_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
+    DEPENDS storageframework_testrunner_app
 )

--- a/storageserver/src/tests/CMakeLists.txt
+++ b/storageserver/src/tests/CMakeLists.txt
@@ -15,4 +15,5 @@ vespa_add_executable(storageserver_testrunner_app TEST
 vespa_add_test(
     NAME storageserver_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
+    DEPENDS storageserver_testrunner_app
 )

--- a/vdslib/src/tests/CMakeLists.txt
+++ b/vdslib/src/tests/CMakeLists.txt
@@ -13,4 +13,5 @@ vespa_add_executable(vdslib_testrunner_app TEST
 vespa_add_test(
     NAME vdslib_testrunner_app
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
+    DEPENDS vdslib_testrunner_app
 )

--- a/vdstestlib/src/tests/cppunit/CMakeLists.txt
+++ b/vdstestlib/src/tests/cppunit/CMakeLists.txt
@@ -12,4 +12,5 @@ vespa_add_test(
     NAME vdstestlib_testrunner_app
     NO_VALGRIND
     COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
+    DEPENDS vdstestlib_testrunner_app
 )


### PR DESCRIPTION
Should fix breakage. Review after the fact





















![little_gray_14](https://cloud.githubusercontent.com/assets/153559/20391772/160a2bb8-acd5-11e6-81e3-c5947fedc8c1.png)
