### PR TITLE
Resolve ip when becoming ready

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -137,7 +137,7 @@ public class NodeRepository extends AbstractComponent {
         node.allocation().ifPresent(allocation -> trustedNodes.addAll(getNodes(allocation.owner())));
 
         // Add proxy nodes
-        trustedNodes.addAll(getNodes(NodeType.proxy));
+        trustedNodes.addAll(getNodes(NodeType.proxy, Node.State.active));
 
         // Add config servers
         // TODO: Revisit this when config servers are added to the repository
@@ -146,6 +146,7 @@ public class NodeRepository extends AbstractComponent {
                 .map(host -> createNode(host, host, Optional.empty(),
                         flavors.getFlavorOrThrow("v-4-8-100"), // Must be a flavor that exists in Hosted Vespa
                         NodeType.config))
+                .map(n -> n.withIpAddress(nameResolver.getByNameOrThrow(node.hostname())))
                 .forEach(trustedNodes::add);
 
         return Collections.unmodifiableList(trustedNodes);
@@ -156,7 +157,7 @@ public class NodeRepository extends AbstractComponent {
     /** Creates a new node object, without adding it to the node repo */
     public Node createNode(String openStackId, String hostname, Optional<String> parentHostname,
                            Flavor flavor, NodeType type) {
-        return Node.create(openStackId, nameResolver.getByNameOrThrow(hostname), hostname, parentHostname, flavor, type);
+        return Node.create(openStackId, hostname, parentHostname, flavor, type);
     }
 
     /** Adds a list of (newly created) nodes to the node repository as <i>provisioned</i> nodes */
@@ -171,16 +172,23 @@ public class NodeRepository extends AbstractComponent {
         }
     }
 
-    /** Sets a list of nodes ready and returns the nodes in the ready state */
+    /**
+     * Sets a list of nodes ready and returns the nodes in the ready state.
+     * Ready nodes must have an ip address; If the node is newly provisioned and its ip address has not yet
+     * propagated this call will fail and must be retried later.
+     */
     public List<Node> setReady(List<Node> nodes) {
         for (Node node : nodes)
             if (node.state() != Node.State.provisioned && node.state() != Node.State.dirty)
                 throw new IllegalArgumentException("Can not set " + node + " ready. It is not provisioned or dirty.");
+        
+        nodes = resolveIp(nodes);
+        
         try (Mutex lock = lockUnallocated()) {
             return zkClient.writeTo(Node.State.ready, nodes);
         }
     }
-
+    
     /** Reserve nodes. This method does <b>not</b> lock the node repository */
     public List<Node> reserve(List<Node> nodes) { return zkClient.writeTo(Node.State.reserved, nodes); }
 
@@ -370,7 +378,18 @@ public class NodeRepository extends AbstractComponent {
         }
         return resultingNodes;
     }
-
+    
+    private List<Node> resolveIp(List<Node> nodes) {
+        List<Node> resolvedNodes = new ArrayList<>();
+        for (Node node : nodes) {
+            if (node.ipAddress().isPresent())
+                resolvedNodes.add(node);
+            else
+                resolvedNodes.add(node.withIpAddress(nameResolver.getByNameOrThrow(node.hostname())));
+        }
+        return resolvedNodes;
+    }
+    
     /** Create a lock which provides exclusive rights to making changes to the given application */
     public Mutex lock(ApplicationId application) { return zkClient.lock(application); }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
@@ -1,8 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.persistence;
 
-import com.yahoo.log.LogLevel;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.logging.Logger;
@@ -22,8 +20,7 @@ public interface NameResolver {
         try {
             return InetAddress.getByName(hostname).getHostAddress();
         } catch (UnknownHostException e) {
-            log.log(LogLevel.ERROR, String.format("Failed to resolve hostname %s: %s", hostname, e.getMessage()));
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to resolve the ip of " + hostname, e);
         }
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeAclResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeAclResponse.java
@@ -40,7 +40,7 @@ public class NodeAclResponse extends HttpResponse {
         Node node = nodeRepository.getNode(hostname)
                 .orElseThrow(() -> new IllegalArgumentException("No node with hostname '" + hostname + "'"));
 
-        if (node.state() == Node.State.provisioned) return; // empty response; don't have ip address yet
+        if ( ! node.ipAddress().isPresent()) return; // empty response
         toSlime(node, nodeRepository.getTrustedNodes(node), object);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeAclResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeAclResponse.java
@@ -37,14 +37,16 @@ public class NodeAclResponse extends HttpResponse {
     }
 
     private void toSlime(String hostname, Cursor object) {
-        final Node node = nodeRepository.getNode(hostname)
+        Node node = nodeRepository.getNode(hostname)
                 .orElseThrow(() -> new IllegalArgumentException("No node with hostname '" + hostname + "'"));
+
+        if (node.state() == Node.State.provisioned) return; // empty response; don't have ip address yet
         toSlime(node, nodeRepository.getTrustedNodes(node), object);
     }
 
     private void toSlime(Node node, List<Node> trustedNodes, Cursor object) {
         object.setString("hostname", node.hostname());
-        object.setString("ipAddress", node.ipAddress());
+        object.setString("ipAddress", node.ipAddress().get());
         toSlime(trustedNodes, object.setArray("trustedNodes"));
     }
 
@@ -52,7 +54,7 @@ public class NodeAclResponse extends HttpResponse {
         trustedNodes.forEach(node -> {
             Cursor object = array.addObject();
             object.setString("hostname", node.hostname());
-            object.setString("ipAddress", node.ipAddress());
+            object.setString("ipAddress", node.ipAddress().get());
         });
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -24,6 +24,8 @@ public class NodeRepositoryTest {
 
         assertEquals(3, tester.getNodes(NodeType.tenant).size());
         
+        tester.nodeRepository().setReady(tester.getNodes(NodeType.tenant));
+        
         tester.nodeRepository().move("host2", Node.State.parked);
         assertTrue(tester.nodeRepository().remove("host2"));
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -32,6 +32,7 @@ public class ZooKeeperAccessMaintainerTest {
         tester.addNode("id1", "host1", "default", NodeType.tenant);
         tester.addNode("id2", "host2", "default", NodeType.tenant);
         tester.addNode("id3", "host3", "default", NodeType.tenant);
+        tester.nodeRepository().setReady(tester.getNodes(NodeType.tenant, Node.State.provisioned));
         maintainer.maintain();
 
         assertEquals(3, tester.getNodes(NodeType.tenant).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -255,27 +255,29 @@ public class SerializationTest {
 
     @Test
     public void serialize_parentHostname() {
-        final String parentHostname = "parent.yahoo.com";
-        Node node = Node.create("myId", "myIp", "myHostname", Optional.of(parentHostname), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant);
+        String parentHostname = "parent.yahoo.com";
+        Node node = Node.create("myId", "myHostname", Optional.of(parentHostname), 
+                                nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant);
 
         Node deserializedNode = nodeSerializer.fromJson(State.provisioned, nodeSerializer.toJson(node));
         assertEquals(parentHostname, deserializedNode.parentHostname().get());
+        assertFalse(node.ipAddress().isPresent());
     }
 
-
+    // TODO: This can be removed after 6.48 is live everywhere
     @Test
     public void resolves_hostname_when_deserializing() throws Exception {
         nameResolver.addRecord("node1.yahoo.tld", "127.0.0.1");
         byte[] nodeWithoutIp = createNodeJson("node1.yahoo.tld");
-        Node deserializedNode = nodeSerializer.fromJson(State.provisioned, nodeWithoutIp);
-        assertEquals("127.0.0.1", deserializedNode.ipAddress());
+        Node deserializedNode = nodeSerializer.fromJson(State.ready, nodeWithoutIp);
+        assertEquals("127.0.0.1", deserializedNode.ipAddress().get());
     }
 
     @Test
     public void throws_when_hostname_cannot_be_resolved() throws Exception {
         byte[] nodeWithoutIp = createNodeJson("node2.yahoo.tld");
         try {
-            nodeSerializer.fromJson(State.provisioned, nodeWithoutIp);
+            nodeSerializer.fromJson(State.ready, nodeWithoutIp);
             assertTrue("Expected exception to be thrown", false);
         } catch (RuntimeException ignored) {
         }
@@ -285,8 +287,16 @@ public class SerializationTest {
     public void resolver_is_not_invoked_when_ip_address_is_present() throws Exception {
         nameResolver.failIfInvoked();
         byte[] nodeWithIp = createNodeJson("node3.yahoo.tld", "127.0.0.3");
-        Node deserializedNode = nodeSerializer.fromJson(State.provisioned, nodeWithIp);
-        assertEquals("127.0.0.3", deserializedNode.ipAddress());
+        Node deserializedNode = nodeSerializer.fromJson(State.ready, nodeWithIp);
+        assertEquals("127.0.0.3", deserializedNode.ipAddress().get());
+    }
+
+    @Test
+    public void resolver_is_not_invoked_for_provisioned_node() throws Exception {
+        nameResolver.failIfInvoked();
+        byte[] nodeWithoutIp = createNodeJson("node2.yahoo.tld");
+        Node deserializedNode = nodeSerializer.fromJson(State.provisioned, nodeWithoutIp);
+        assertFalse(deserializedNode.ipAddress().isPresent());
     }
 
     private byte[] createNodeJson(String hostname, String ipAddress) {
@@ -303,7 +313,7 @@ public class SerializationTest {
     }
 
     private Node createNode() {
-        return Node.create("myId", "myIp", "myHostname", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.host);
+        return Node.create("myId", "myHostname", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.host);
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
@@ -2,11 +2,15 @@
 package com.yahoo.vespa.hosted.provision.provisioning;
 
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostSpec;
+import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Before;
@@ -17,6 +21,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester.createConfig;
@@ -45,13 +50,15 @@ public class AclProvisioningTest {
 
         // Populate repo
         tester.makeReadyNodes(10, "default");
+
         List<Node> proxyNodes = tester.makeReadyNodes(3, "default", NodeType.proxy);
+        tester.activateProxies();
 
         ApplicationId applicationId = tester.makeApplicationId();
 
         // Allocate 2 nodes
-        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test"),
-                Optional.empty());
+        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test"), 
+                                                  Optional.empty());
         List<HostSpec> prepared = tester.prepare(applicationId, cluster, Capacity.fromNodeCount(2), 1);
         tester.activate(applicationId, new HashSet<>(prepared));
         List<Node> activeNodes = tester.getNodes(applicationId, Node.State.active).asList();
@@ -76,6 +83,7 @@ public class AclProvisioningTest {
         // Populate repo
         List<Node> readyNodes = tester.makeReadyNodes(10, "default");
         List<Node> proxyNodes = tester.makeReadyNodes(3, "default", NodeType.proxy);
+        tester.activateProxies();
 
         // Get trusted nodes for the first ready node
         Node node = readyNodes.get(0);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -145,6 +145,14 @@ public class ProvisioningTester implements AutoCloseable {
         deactivateTransaction.commit();
     }
 
+    public void activateProxies() {
+        ApplicationId proxyApplicationId = new ApplicationId.Builder().applicationName("hosted").build();
+        List<HostSpec> hosts = prepare(proxyApplicationId,
+                                       ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("default"), Optional.empty()),
+                                       Capacity.fromRequiredNodeType(NodeType.proxy), 0);
+        activate(proxyApplicationId, new HashSet<>(hosts));
+    }
+
     public Set<String> toHostNames(Set<HostSpec> hosts) {
         return hosts.stream().map(HostSpec::hostname).collect(Collectors.toSet());
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -164,7 +164,7 @@ public class RestApiTest {
     @Test
     public void post_with_invalid_method_override_in_header_gives_sane_error_message() throws Exception  {
         Request req = new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-                Utf8.toBytes("{\"currentRestartGeneration\": 1}"), Request.Method.POST);
+                                  Utf8.toBytes("{\"currentRestartGeneration\": 1}"), Request.Method.POST);
         req.getHeaders().add("X-HTTP-Method-Override", "GET");
         assertResponse(req, 400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Illegal X-HTTP-Method-Override header for POST request. Accepts 'PATCH' but got 'GET'\"}");
     }
@@ -212,19 +212,22 @@ public class RestApiTest {
 
     @Test
     public void acl_request() throws Exception {
-        String hostName = "foo.yahoo.com";
+        String hostname = "foo.yahoo.com";
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                        ("[" + asNodeJson(hostName, "default") + "]").
+                        ("[" + asNodeJson(hostname, "default") + "]").
                                 getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
                 "{\"message\":\"Added 1 nodes to the provisioned state\"}");
+        assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/" + hostname,
+                                   new byte[0], Request.Method.PUT),
+                       "{\"message\":\"Moved foo.yahoo.com to ready\"}");
         Pattern responsePattern = Pattern.compile("\\{\"hostname\":\"foo.yahoo.com\",\"ipAddress\":\".+?\"," +
                 "\"trustedNodes\":\\[" +
                 "\\{\"hostname\":\"cfg1\",\"ipAddress\":\".+?\"}," +
                 "\\{\"hostname\":\"cfg2\",\"ipAddress\":\".+?\"}," +
                 "\\{\"hostname\":\"cfg3\",\"ipAddress\":\".+?\"}" +
                 "]}");
-        assertResponseMatches(new Request("http://localhost:8080/nodes/v2/acl/" + hostName), responsePattern);
+        assertResponseMatches(new Request("http://localhost:8080/nodes/v2/acl/" + hostname), responsePattern);
     }
 
     @Test
@@ -361,8 +364,9 @@ public class RestApiTest {
     }
 
     private void assertResponseMatches(Request request, Pattern pattern) throws IOException {
+        // System.out.println(container.handleRequest(request).getBodyAsString());
         assertTrue("Response matches " + pattern.toString(),
-                pattern.matcher(container.handleRequest(request).getBodyAsString()).matches());
+                   pattern.matcher(container.handleRequest(request).getBodyAsString()).matches());
     }
 
     private void assertFile(Request request, String responseFile) throws IOException {


### PR DESCRIPTION
Docker hosts are not resolvable when they are provisioned, so
we make ip resolution a part of the transition to ready.

Note the folling consequences of this:
- Only active proxy nodes will be allowed access
- Nodes in "provisioned" will receive an empty JSON map as response if asking for their acl

@martinp please review

@hakonhall fyi