### PR TITLE
Don't restrict to only config servers

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainer.java
@@ -38,8 +38,11 @@ public class ZooKeeperAccessMaintainer extends Maintainer {
             hosts.add(node.hostname());
         for (Node node : nodeRepository().getNodes(NodeType.proxy))
             hosts.add(node.hostname());
-        for (String hostPort : curator.connectionSpec().split(","))
-            hosts.add(hostPort.split(":")[0]);
+
+        if ( ! hosts.isEmpty()) { // no nodes -> not a hosted instance: Pass an empty list to deactivate restriction
+            for (String hostPort : curator.connectionSpec().split(","))
+                hosts.add(hostPort.split(":")[0]);
+        }
 
         ZooKeeperServer.setAllowedClientHostnames(hosts);
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -27,7 +27,7 @@ public class ZooKeeperAccessMaintainerTest {
                                                                              tester.curator(), Duration.ofHours(1));
         assertTrue(ZooKeeperServer.getAllowedClientHostnames().isEmpty());
         maintainer.maintain();
-        assertEquals(asSet("server1,server2"), ZooKeeperServer.getAllowedClientHostnames());
+        assertTrue("We don't restrict to only config servers", ZooKeeperServer.getAllowedClientHostnames().isEmpty());
 
         tester.addNode("id1", "host1", "default", NodeType.tenant);
         tester.addNode("id2", "host2", "default", NodeType.tenant);


### PR DESCRIPTION
We want zk access limitation to be deactivated by default for self-hosted applications.
However, these also run the node repo and will would therefore restrict to config servers
only as the node repo is empty. This changes to passing an empty access restriction list
instead if the node repo is empty.

@martinp please review