### PR TITLE
Resolve correct config server hostnames

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -140,14 +140,7 @@ public class NodeRepository extends AbstractComponent {
         trustedNodes.addAll(getNodes(NodeType.proxy, Node.State.active));
 
         // Add config servers
-        // TODO: Revisit this when config servers are added to the repository
-        Arrays.stream(curator.connectionSpec().split(","))
-                .map(hostPort -> hostPort.split(":")[0])
-                .map(host -> createNode(host, host, Optional.empty(),
-                        flavors.getFlavorOrThrow("v-4-8-100"), // Must be a flavor that exists in Hosted Vespa
-                        NodeType.config))
-                .map(n -> n.withIpAddress(nameResolver.getByNameOrThrow(node.hostname())))
-                .forEach(trustedNodes::add);
+        trustedNodes.addAll(getConfigNodes());
 
         return Collections.unmodifiableList(trustedNodes);
     }
@@ -388,6 +381,17 @@ public class NodeRepository extends AbstractComponent {
                 resolvedNodes.add(node.withIpAddress(nameResolver.getByNameOrThrow(node.hostname())));
         }
         return resolvedNodes;
+    }
+
+    private List<Node> getConfigNodes() {
+        // TODO: Revisit this when config servers are added to the repository
+        return Arrays.stream(curator.connectionSpec().split(","))
+                .map(hostPort -> hostPort.split(":")[0])
+                .map(host -> createNode(host, host, Optional.empty(),
+                        flavors.getFlavorOrThrow("v-4-8-100"), // Must be a flavor that exists in Hosted Vespa
+                        NodeType.config))
+                .map(n -> n.withIpAddress(nameResolver.getByNameOrThrow(n.hostname())))
+                .collect(Collectors.toList());
     }
     
     /** Create a lock which provides exclusive rights to making changes to the given application */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
@@ -46,11 +46,11 @@ public class MockNameResolver implements NameResolver {
         if (!allowInvocation) {
             throw new IllegalStateException("Expected getByName to not be invoked for hostname: " + hostname);
         }
-        if (mockAnyLookup) {
-            return UUID.randomUUID().toString();
-        }
         if (records.containsKey(hostname)) {
             return records.get(hostname);
+        }
+        if (mockAnyLookup) {
+            return UUID.randomUUID().toString();
         }
         throw new RuntimeException(new UnknownHostException("Could not resolve: " + hostname));
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -25,6 +25,7 @@ import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Flavor;
 import com.yahoo.vespa.hosted.provision.node.NodeFlavors;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
+import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 import com.yahoo.vespa.hosted.provision.testutils.FlavorConfigBuilder;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
 
@@ -64,16 +65,15 @@ public class ProvisioningTester implements AutoCloseable {
     }
 
     public ProvisioningTester(Zone zone, NodeRepositoryConfig config) {
-        this(zone, config, new MockCurator());
+        this(zone, config, new MockCurator(), new MockNameResolver().mockAnyLookup());
     }
 
-    public ProvisioningTester(Zone zone, NodeRepositoryConfig config, Curator curator) {
+    public ProvisioningTester(Zone zone, NodeRepositoryConfig config, Curator curator, NameResolver nameResolver) {
         try {
             this.nodeFlavors = new NodeFlavors(config);
             this.clock = new ManualClock();
             this.curator = curator;
-            this.nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
-                    new MockNameResolver().mockAnyLookup());
+            this.nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, nameResolver);
             this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, clock);
             this.capacityPolicies = new CapacityPolicies(zone, nodeFlavors);
             this.provisionLogger = new NullProvisionLogger();


### PR DESCRIPTION
Fixes bug introduced in #1147. It would incorrectly return the IP address of the node itself for every config server.

@bratseth 