### PR TITLE
Freva/docker systest build image and run

### DIFF
--- a/docker-api/.gitignore
+++ b/docker-api/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -69,7 +69,9 @@ public class DockerTestUtils {
     public static void createDockerTestNetworkIfNeeded(DockerImpl docker) {
         if (! docker.dockerClient.listNetworksCmd().withNameFilter(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME).exec().isEmpty()) return;
 
-        Network.Ipam ipam = new Network.Ipam().withConfig(new Network.Ipam.Config().withSubnet("172.18.0.0/16"));
+        Network.Ipam ipam = new Network.Ipam().withConfig(new Network.Ipam.Config()
+                .withSubnet("172.18.0.0/16")
+                .withGateway("172.18.0.1"));
         docker.dockerClient.createNetworkCmd()
                 .withName(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME).withDriver("bridge").withIpam(ipam).exec();
     }

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
@@ -1,55 +1,107 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.dockerapi;
 
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InspectExecResponse;
+import com.github.dockerjava.core.command.ExecStartResultCallback;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * Systemtests image must be manually built because docker-java does not support --ulimit argument for docker build
- * yet (Novemeber 2016). To build, run:
- * $ sudo docker build --tag vespa-systest:latest --ulimit nofile=16384 --ulimit nproc=409600 --ulimit core=-1 docker-api/src/test/resources/systest/
- * from the root of this project.
+ * Requires docker daemon, see {@link com.yahoo.vespa.hosted.dockerapi.DockerTestUtils} for more details.
+ *
+ * To get started:
+ *  1. Add system test host hostnames to /etc/hosts:
+ *      $ sudo ./vespa/node-admin/scripts/etc-hosts.sh
+ *  2. Set environmental variable in shell or e.g. ~/.bashrc:
+ *      VESPA_DOCKER_REGISTRY="<registry hostname>:<port>"
  *
  * @author freva
  */
 public class RunSystemTests {
-    private static final ContainerName SYSTEM_TESTS_CONTAINER_NAME = new ContainerName("systest");
+    private static final DockerImage VESPA_BASE_IMAGE = new DockerImage(
+            System.getenv("VESPA_DOCKER_REGISTRY") + "/vespa/ci:6.50.111");
     private static final DockerImage SYSTEM_TEST_DOCKER_IMAGE = new DockerImage("vespa-systest:latest");
+    private static final Path PATH_TO_SYSTEM_TESTS_IN_CONTAINER = Paths.get("/systemtests");
 
+    private final Logger logger = Logger.getLogger("RunVespaLocal");
 
-    public void runBasicSearch() {
-        Docker docker = DockerTestUtils.getDocker();
+//    @Test
+    public void runBasicSearch() throws IOException, InterruptedException {
+        DockerImpl docker = DockerTestUtils.getDocker();
+        ContainerName systemTestContainerName = new ContainerName("stest-1");
+        Path testToRunPath = PATH_TO_SYSTEM_TESTS_IN_CONTAINER.resolve("tests/search/basicsearch/basic_search.rb");
 
+        logger.info("Building " + SYSTEM_TEST_DOCKER_IMAGE.asString());
+        buildVespaSystestDockerImage(docker, VESPA_BASE_IMAGE);
+
+        logger.info("Starting systemtests host");
         Path pathToSystemsTestsRepo = Paths.get("/home/valerijf/dev/systemtests/");
-        startSystemTestNode(docker, "cnode-20", pathToSystemsTestsRepo);
+        startSystemTestNodeIfNeeded(docker, systemTestContainerName, pathToSystemsTestsRepo);
+
+        logger.info("Running test " + testToRunPath);
+        Integer testExitCode = executeTestInHost(docker, testToRunPath, systemTestContainerName);
+        assertEquals("Test did not finish with exit code 0", Integer.valueOf(0), testExitCode);
     }
 
-    private static void startSystemTestNode(Docker docker, String hostname, Path pathToSystemsTestsRepo) {
-        try {
-            InetAddress nodeInetAddress = InetAddress.getByName(hostname);
+    private Integer executeTestInHost(DockerImpl docker, Path pathToTest, ContainerName hostToExecuteTest) throws InterruptedException {
+        ExecCreateCmdResponse response = docker.dockerClient.execCreateCmd(hostToExecuteTest.asString())
+                .withCmd(PATH_TO_SYSTEM_TESTS_IN_CONTAINER.resolve("bin/run_test.rb").toString(), pathToTest.toString())
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec();
 
-            docker.createContainerCommand(
-                    SYSTEM_TEST_DOCKER_IMAGE,
-                    SYSTEM_TESTS_CONTAINER_NAME,
-                    hostname)
-                    .withNetworkMode(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME)
-                    .withIpAddress(nodeInetAddress)
-                    .withEnvironment("USER", "root")
-                    .withUlimit("nofile", 16384, 16384)
-                    .withUlimit("nproc", 409600, 409600)
-                    .withUlimit("core", -1, -1)
-                    .withVolume("/etc/hosts", "/etc/hosts")
-                    .withVolume(pathToSystemsTestsRepo.toString(), "/systemtests")
-                    .create();
+        ExecStartCmd execStartCmd = docker.dockerClient.execStartCmd(response.getId());
+        execStartCmd.exec(new ExecStartResultCallback(System.out, System.err)).awaitCompletion();
 
-            docker.startContainer(SYSTEM_TESTS_CONTAINER_NAME);
-            docker.executeInContainer(SYSTEM_TESTS_CONTAINER_NAME, "nohup", "/systemtests/bin/node_server.rb", "&");
-        } catch (UnknownHostException e) {
-            throw new RuntimeException("Failed to create container " + SYSTEM_TESTS_CONTAINER_NAME.asString(), e);
+        InspectExecResponse state = docker.dockerClient.inspectExecCmd(execStartCmd.getExecId()).exec();
+        return state.getExitCode();
+    }
+
+    private void startSystemTestNodeIfNeeded(Docker docker, ContainerName containerName, Path pathToSystemsTestsRepo) throws UnknownHostException {
+        Optional<Container> container = docker.getContainer(containerName.asString());
+        if (container.isPresent()) {
+            if (container.get().isRunning) return;
+            else docker.deleteContainer(containerName);
         }
+
+        InetAddress nodeInetAddress = InetAddress.getByName(containerName.asString());
+        docker.createContainerCommand(
+                SYSTEM_TEST_DOCKER_IMAGE,
+                containerName,
+                containerName.asString())
+                .withNetworkMode(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME)
+                .withIpAddress(nodeInetAddress)
+                .withEnvironment("USER", "root")
+                .withUlimit("nofile", 16384, 16384)
+                .withUlimit("nproc", 409600, 409600)
+                .withUlimit("core", -1, -1)
+                .withVolume("/etc/hosts", "/etc/hosts")
+                .withVolume(pathToSystemsTestsRepo.toString(), PATH_TO_SYSTEM_TESTS_IN_CONTAINER.toString())
+                .create();
+
+        docker.startContainer(containerName);
+    }
+
+    private void buildVespaSystestDockerImage(Docker docker, DockerImage vespaBaseImage) throws IOException {
+        Path systestBuildDirectory = Paths.get("src/test/resources/systest/");
+        Path systestDockerfile = systestBuildDirectory.resolve("Dockerfile");
+
+        String dockerfileTemplate = new String(Files.readAllBytes(systestBuildDirectory.resolve("Dockerfile.template")))
+                .replaceAll("\\$VESPA_BASE_IMAGE", vespaBaseImage.asString());
+        Files.write(systestDockerfile, dockerfileTemplate.getBytes());
+
+        docker.buildImage(systestDockerfile.toFile(), SYSTEM_TEST_DOCKER_IMAGE);
     }
 }

--- a/docker-api/src/test/resources/systest/Dockerfile.template
+++ b/docker-api/src/test/resources/systest/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM docker-registry.ops.yahoo.com:4443/vespa/ci:6.50.12
+FROM $VESPA_BASE_IMAGE
 
 # Don't autostart anything when building image
 RUN yinst set root.autostart=off

--- a/node-admin/scripts/etc-hosts.sh
+++ b/node-admin/scripts/etc-hosts.sh
@@ -9,8 +9,12 @@ declare -r CONFIG_SERVER_IP="$NETWORK_PREFIX.1.1"
 
 declare -r APP_HOSTNAME_PREFIX=cnode-
 declare -r APP_NETWORK_PREFIX="$NETWORK_PREFIX.2"
-
 declare -r NUM_APP_CONTAINERS=20  # Statically allocated number of nodes.
+
+declare -r SYSTEM_TEST_HOSTNAME_PREFIX=stest-
+declare -r SYSTEM_TEST_NETWORK_PREFIX="$NETWORK_PREFIX.3"
+declare -r NUM_SYSTEM_TEST_CONTAINERS=5  # Statically allocated number of nodes.
+
 declare -r HOSTS_FILE=/etc/hosts
 declare -r HOSTS_LINE_SUFFIX=" # Managed by etc-hosts.sh"
 
@@ -87,6 +91,14 @@ function StartAsRoot {
     do
         local ip="$APP_NETWORK_PREFIX.$index"
         local container_name="$APP_HOSTNAME_PREFIX$index"
+        AddHost "$ip" "$container_name" "$HOSTS_FILE"
+    done
+
+    local -i index=1
+    for ((; index <= NUM_SYSTEM_TEST_CONTAINERS; ++index))
+    do
+        local ip="$SYSTEM_TEST_NETWORK_PREFIX.$index"
+        local container_name="$SYSTEM_TEST_HOSTNAME_PREFIX$index"
         AddHost "$ip" "$container_name" "$HOSTS_FILE"
     done
 }


### PR DESCRIPTION
* Adds `stest-*` hostnames to `/etc/hosts`
* Use `Dockerfile.template` to easily change Vespa base image version
* Now that `autostart` is `off`, we don't need to set `ulimit` ⇒ Can build image via `docker-java`
* Run system test inside the container and forward `stdout` and `stderr` to `System.out` and `System.err`