### PR TITLE
Bjorncs/sync write listener registration

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ErrorResponseContentCreator.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ErrorResponseContentCreator.java
@@ -1,3 +1,4 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.server.jetty;
 
 import org.eclipse.jetty.util.ByteArrayISO8859Writer;

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -70,6 +70,7 @@ class HttpRequestDispatch {
 
         this.async = servletRequest.startAsync();
         async.setTimeout(0);
+        servletResponseController.registerWriteListener();
     }
 
     public void dispatch() throws IOException {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -67,6 +67,9 @@ public class ServletResponseController {
                 new ServletOutputStreamWriter(servletResponse.getOutputStream(), executor, metricReporter);
     }
 
+    public void registerWriteListener() {
+        servletOutputStreamWriter.registerWriteListener();
+    }
 
     private static int getStatusCode(Throwable t) {
         if (t instanceof BindingNotFoundException) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -147,6 +147,7 @@ public class ServletResponseController {
             servletResponse.setContentLength(errorContent.length);
             servletOutputStreamWriter.sendErrorContentAndCloseAsync(ByteBuffer.wrap(errorContent));
         } else {
+            servletResponse.setContentLength(0);
             servletOutputStreamWriter.close(null);
         }
     }

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/ErrorResponseContentCreatorTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/ErrorResponseContentCreatorTest.java
@@ -1,3 +1,4 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.server.jetty;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
Register Servlet `WriteListener` during request dispatch. The write listener was previously registered on the first write from a `RequestHandler`. This is a workaround for a bug in Jetty (https://github.com/eclipse/jetty.project/issues/1047). This PR fixes the issues resulting in `ReadPendingException` and corrupted Jetty buffers.