### PR TITLE
Allow all node types access to Zookeeper

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainer.java
@@ -1,6 +1,5 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -12,8 +11,8 @@ import java.util.Set;
 
 /**
  * Maintains the list of hosts that should be allowed to access ZooKeeper in this runtime.
- * These are the zokeeper servers and all tenant and proxy nodes. This is maintained in the background because
- * nodes could be added or removed on another server. 
+ * These are the zookeeper servers and all nodes in node repository. This is maintained in the background
+ * because nodes could be added or removed on another server.
  * 
  * We could limit access to the <i>active</i> subset of nodes, but that 
  * does not seem to have any particular operational or security benefits and might make it more problematic
@@ -29,14 +28,12 @@ public class ZooKeeperAccessMaintainer extends Maintainer {
         super(nodeRepository, maintenanceInterval);
         this.curator = curator;
     }
-    
+
     @Override
     protected void maintain() {
         Set<String> hosts = new HashSet<>();
 
-        for (Node node : nodeRepository().getNodes(NodeType.tenant))
-            hosts.add(node.hostname());
-        for (Node node : nodeRepository().getNodes(NodeType.proxy))
+        for (Node node : nodeRepository().getNodes())
             hosts.add(node.hostname());
 
         if ( ! hosts.isEmpty()) { // no nodes -> not a hosted instance: Pass an empty list to deactivate restriction

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -53,6 +53,11 @@ public class ZooKeeperAccessMaintainerTest {
         assertEquals(2, tester.getNodes(NodeType.tenant).size());
         assertEquals(2, tester.getNodes(NodeType.proxy).size());
         assertEquals(asSet("host1,host3,host4,host5,server1,server2"), ZooKeeperServer.getAllowedClientHostnames());
+
+        tester.addNode("docker-host-1", "host6", "default", NodeType.host);
+        tester.addNode("docker-host-2", "host7", "default", NodeType.host);
+        maintainer.maintain();
+        assertEquals(asSet("host1,host3,host4,host5,host6,host7,server1,server2"), ZooKeeperServer.getAllowedClientHostnames());
     }
 
     private Set<String> asSet(String s) {


### PR DESCRIPTION
Docker hosts need access to Zookeeper too (since containers might use IPv4, requests will look as if they are coming from the host).
YAKL rules allow access to config server, since node-admin is running on host, this change makes the rule for config server Zookeeper access and config server access rules handled by YAKL the same.

@martinp please review