### PR TITLE
Remove broken assert. newLid can be equal to lid if tree hasn't yet been

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -669,8 +669,7 @@ DocumentMetaStore::getGidEvenIfMoved(DocId lid, GlobalId &gid) const
     gid = getRawGid(lid);
     if ( ! validLid(lid) ) {
         uint32_t newLid(0);
-        if (getLid(gid, newLid)) {
-        } else {
+        if (!getLid(gid, newLid)) {
             return false;
         }
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -670,7 +670,6 @@ DocumentMetaStore::getGidEvenIfMoved(DocId lid, GlobalId &gid) const
     if ( ! validLid(lid) ) {
         uint32_t newLid(0);
         if (getLid(gid, newLid)) {
-            assert(newLid < lid);
         } else {
             return false;
         }


### PR DESCRIPTION
frozen again since lid was moved or removed, and newLid can be larger than
lid if document was removed then added again.

@geirst, please review