### PR TITLE
RunSystemTests improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Testing
 /build.ninja
 /rules.ninja
 *_test_app
+*/target_container/*

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ Testing
 /build.ninja
 /rules.ninja
 *_test_app
-*/target_container/*

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
@@ -26,7 +26,21 @@ import static org.junit.Assert.assertEquals;
  *  1. Add system test host hostnames to /etc/hosts:
  *      $ sudo ./vespa/node-admin/scripts/etc-hosts.sh
  *
- *</pre>
+ *
+ * Example usage:
+     DockerImage vespaDockerBase = new DockerImage("docker-registry.ops.yahoo.com:4443/vespa/ci:6.52.35");
+     Path pathToSystemtestsInHost = Paths.get("/home/valerijf/dev/systemtests");
+     RunSystemTests runSystemTests = new RunSystemTests(vespaDockerBase, pathToSystemtestsInHost);
+
+     ContainerName systemtestsHost = new ContainerName("stest-1");
+     // Update maven local repository and /home/y/lib/jars with the current version of these modules...
+     runSystemTests.mavenInstallModules(systemtestsHost, "docproc", "container-search-and-docproc", "container-dev");
+
+     Path systemTestToRun = Paths.get("tests/search/basicsearch/basic_search.rb");
+     // When using mavenInstallModules(), add --vespa-version argument
+     runSystemTests.runSystemTest(systemtestsHost, systemTestToRun, "--vespa-version=6-SNAPSHOT");
+ * </pre>
+ *
  * @author freva
  */
 public class RunSystemTests {

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
@@ -13,51 +13,141 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 
 /**
+ * <pre>
  * Requires docker daemon, see {@link com.yahoo.vespa.hosted.dockerapi.DockerTestUtils} for more details.
  *
  * To get started:
  *  1. Add system test host hostnames to /etc/hosts:
  *      $ sudo ./vespa/node-admin/scripts/etc-hosts.sh
  *  2. Set environmental variable in shell or e.g. ~/.bashrc:
- *      VESPA_DOCKER_REGISTRY="<registry hostname>:<port>"
+ *      VESPA_DOCKER_REGISTRY="docker.registry.hostname.com:1234"
+ *      SYSTEMTESTS_PATH="/path/to/git/repo/systemtests/"
  *
+ *
+ * To run systemtests with SNAPSHOT Vespa:
+ *  1. Add "--vespa-version=6-SNAPSHOT" argument to {@link #runTest(DockerImpl, ContainerName, Path, String... arguments)}
+ *  2. List all the modules that need to be built and added to local repository in order in
+ *          {@link #mavenInstallModules(DockerImpl, ContainerName, String... listOfModules)}
+ *  3. Copy jars from {@code PATH_TO_VESPA_REPO_IN_CONTAINER.resolve(module).resolve(CONTAINER_TARGET_DIRECTORY).resolve(module.jar}
+ *
+ *</pre>
  * @author freva
  */
 public class RunSystemTests {
     private static final DockerImage VESPA_BASE_IMAGE = new DockerImage(
             System.getenv("VESPA_DOCKER_REGISTRY") + "/vespa/ci:6.50.111");
-    private static final DockerImage SYSTEM_TEST_DOCKER_IMAGE = new DockerImage("vespa-systest:latest");
-    private static final Path PATH_TO_SYSTEM_TESTS_IN_CONTAINER = Paths.get("/systemtests");
+    private static final DockerImage SYSTEMTESTS_DOCKER_IMAGE = new DockerImage("vespa-systest:latest");
+    private static final String CONTAINER_TARGET_DIRECTORY = "target_container";
 
-    private final Logger logger = Logger.getLogger("RunVespaLocal");
+    private final Path PATH_TO_SYSTEMTESTS_IN_HOST = Paths.get(System.getenv("SYSTEMTESTS_PATH"));
+    private final Path PATH_TO_SYSTEMTESTS_IN_CONTAINER = Paths.get("/systemtests");
+    private final Path PATH_TO_VESPA_REPO_IN_HOST = Paths.get("").toAbsolutePath().getParent();
+    private final Path PATH_TO_VESPA_REPO_IN_CONTAINER = Paths.get("/vespa");
+    private final Path PATH_TO_TEST_RUNNER = PATH_TO_SYSTEMTESTS_IN_CONTAINER.resolve("bin/run_test.rb");
 
-//    @Test
+    private final Logger logger = Logger.getLogger("systemtest");
+
+    @Test
     public void runBasicSearch() throws IOException, InterruptedException {
         DockerImpl docker = DockerTestUtils.getDocker();
         ContainerName systemTestContainerName = new ContainerName("stest-1");
-        Path testToRunPath = PATH_TO_SYSTEM_TESTS_IN_CONTAINER.resolve("tests/search/basicsearch/basic_search.rb");
+        Path testToRunPath = PATH_TO_SYSTEMTESTS_IN_CONTAINER.resolve("tests/search/basicsearch/basic_search.rb");
 
-        logger.info("Building " + SYSTEM_TEST_DOCKER_IMAGE.asString());
+        logger.info("Building " + SYSTEMTESTS_DOCKER_IMAGE.asString());
         buildVespaSystestDockerImage(docker, VESPA_BASE_IMAGE);
 
         logger.info("Starting systemtests host");
-        Path pathToSystemsTestsRepo = Paths.get("/home/valerijf/dev/systemtests/");
-        startSystemTestNodeIfNeeded(docker, systemTestContainerName, pathToSystemsTestsRepo);
+        startSystemTestNodeIfNeeded(docker, systemTestContainerName);
+
+//        mavenInstallModules(docker, systemTestContainerName, "docproc", "container-dev");
+//        executeInContainer(docker, systemTestContainerName, "cp",
+//                PATH_TO_VESPA_REPO_IN_CONTAINER.resolve("docproc").resolve(CONTAINER_TARGET_DIRECTORY).resolve("docproc.jar").toString(),
+//                "/home/y/lib/jars/");
 
         logger.info("Running test " + testToRunPath);
-        Integer testExitCode = executeTestInHost(docker, testToRunPath, systemTestContainerName);
+        Integer testExitCode = runTest(docker, systemTestContainerName, testToRunPath);
         assertEquals("Test did not finish with exit code 0", Integer.valueOf(0), testExitCode);
     }
 
-    private Integer executeTestInHost(DockerImpl docker, Path pathToTest, ContainerName hostToExecuteTest) throws InterruptedException {
-        ExecCreateCmdResponse response = docker.dockerClient.execCreateCmd(hostToExecuteTest.asString())
-                .withCmd(PATH_TO_SYSTEM_TESTS_IN_CONTAINER.resolve("bin/run_test.rb").toString(), pathToTest.toString())
+    /**
+     * This method runs mvn install inside container to update container's local repository, but because it runs as
+     * root we have to move around the target/ otherwise mvn will fail on host next time you run it.
+     */
+    private void mavenInstallModules(DockerImpl docker, ContainerName containerName, String... modules) throws InterruptedException, IOException {
+        for (String module : modules) {
+            Path pathToModule = PATH_TO_VESPA_REPO_IN_CONTAINER.resolve(module);
+            Path pathToTarget = PATH_TO_VESPA_REPO_IN_HOST.resolve(module).resolve("target");
+            Path pathToTargetBackup = PATH_TO_VESPA_REPO_IN_HOST.resolve(module).resolve("target_bcp");
+
+            if (Files.exists(pathToTarget)) {
+                Files.move(pathToTarget, pathToTargetBackup, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            try {
+                assert 0 == executeInContainer(docker, containerName, "mvn", "-DskipTests", "-e",
+                        "-f=" + pathToModule.resolve("pom.xml"), "install");
+            } finally {
+                executeInContainer(docker, containerName, "mv",
+                        PATH_TO_VESPA_REPO_IN_CONTAINER.resolve(module).resolve("target").toString(),
+                        PATH_TO_VESPA_REPO_IN_CONTAINER.resolve(module).resolve(CONTAINER_TARGET_DIRECTORY).toString());
+
+                if (Files.exists(pathToTargetBackup)) {
+                    Files.move(pathToTargetBackup, pathToTarget);
+                }
+            }
+        }
+    }
+
+    private void startSystemTestNodeIfNeeded(Docker docker, ContainerName containerName) throws UnknownHostException, InterruptedException {
+        Optional<Container> container = docker.getContainer(containerName.asString());
+        if (container.isPresent()) {
+            if (container.get().isRunning) return;
+            else docker.deleteContainer(containerName);
+        }
+
+        InetAddress nodeInetAddress = InetAddress.getByName(containerName.asString());
+        docker.createContainerCommand(
+                SYSTEMTESTS_DOCKER_IMAGE,
+                containerName,
+                containerName.asString())
+                .withNetworkMode(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME)
+                .withIpAddress(nodeInetAddress)
+                .withEnvironment("USER", "root")
+                .withUlimit("nofile", 16384, 16384)
+                .withUlimit("nproc", 409600, 409600)
+                .withUlimit("core", -1, -1)
+                .withVolume(Paths.get(System.getProperty("user.home")).resolve(".m2/settings.xml").toString(), "/root/.m2/settings.xml")
+                .withVolume("/etc/hosts", "/etc/hosts")
+                .withVolume(PATH_TO_SYSTEMTESTS_IN_HOST.toString(), PATH_TO_SYSTEMTESTS_IN_CONTAINER.toString())
+                .withVolume(PATH_TO_VESPA_REPO_IN_HOST.toString(), PATH_TO_VESPA_REPO_IN_CONTAINER.toString())
+                .create();
+
+        docker.startContainer(containerName);
+        // TODO: Should check something to see if node_server.rb is ready
+        Thread.sleep(1000);
+    }
+
+    private void buildVespaSystestDockerImage(Docker docker, DockerImage vespaBaseImage) throws IOException {
+        Path systestBuildDirectory = Paths.get("src/test/resources/systest/");
+        Path systestDockerfile = systestBuildDirectory.resolve("Dockerfile");
+
+        String dockerfileTemplate = new String(Files.readAllBytes(systestBuildDirectory.resolve("Dockerfile.template")))
+                .replaceAll("\\$VESPA_BASE_IMAGE", vespaBaseImage.asString());
+        Files.write(systestDockerfile, dockerfileTemplate.getBytes());
+
+        docker.buildImage(systestDockerfile.toFile(), SYSTEMTESTS_DOCKER_IMAGE);
+    }
+
+    private static Integer executeInContainer(DockerImpl docker, ContainerName containerName, String... args) throws InterruptedException {
+        ExecCreateCmdResponse response = docker.dockerClient.execCreateCmd(containerName.asString())
+                .withCmd(args)
                 .withAttachStdout(true)
                 .withAttachStderr(true)
                 .exec();
@@ -69,39 +159,12 @@ public class RunSystemTests {
         return state.getExitCode();
     }
 
-    private void startSystemTestNodeIfNeeded(Docker docker, ContainerName containerName, Path pathToSystemsTestsRepo) throws UnknownHostException {
-        Optional<Container> container = docker.getContainer(containerName.asString());
-        if (container.isPresent()) {
-            if (container.get().isRunning) return;
-            else docker.deleteContainer(containerName);
-        }
+    private Integer runTest(DockerImpl docker, ContainerName containerName, Path testToRun, String... args) throws InterruptedException {
+        String[] combinedArgs = new String[args.length + 2];
+        combinedArgs[0] = PATH_TO_TEST_RUNNER.toString();
+        combinedArgs[1] = testToRun.toString();
+        System.arraycopy(args, 0, combinedArgs, 2, args.length);
 
-        InetAddress nodeInetAddress = InetAddress.getByName(containerName.asString());
-        docker.createContainerCommand(
-                SYSTEM_TEST_DOCKER_IMAGE,
-                containerName,
-                containerName.asString())
-                .withNetworkMode(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME)
-                .withIpAddress(nodeInetAddress)
-                .withEnvironment("USER", "root")
-                .withUlimit("nofile", 16384, 16384)
-                .withUlimit("nproc", 409600, 409600)
-                .withUlimit("core", -1, -1)
-                .withVolume("/etc/hosts", "/etc/hosts")
-                .withVolume(pathToSystemsTestsRepo.toString(), PATH_TO_SYSTEM_TESTS_IN_CONTAINER.toString())
-                .create();
-
-        docker.startContainer(containerName);
-    }
-
-    private void buildVespaSystestDockerImage(Docker docker, DockerImage vespaBaseImage) throws IOException {
-        Path systestBuildDirectory = Paths.get("src/test/resources/systest/");
-        Path systestDockerfile = systestBuildDirectory.resolve("Dockerfile");
-
-        String dockerfileTemplate = new String(Files.readAllBytes(systestBuildDirectory.resolve("Dockerfile.template")))
-                .replaceAll("\\$VESPA_BASE_IMAGE", vespaBaseImage.asString());
-        Files.write(systestDockerfile, dockerfileTemplate.getBytes());
-
-        docker.buildImage(systestDockerfile.toFile(), SYSTEM_TEST_DOCKER_IMAGE);
+        return executeInContainer(docker, containerName, combinedArgs);
     }
 }

--- a/docker-api/src/test/resources/systest/Dockerfile.template
+++ b/docker-api/src/test/resources/systest/Dockerfile.template
@@ -5,4 +5,6 @@ RUN yinst set root.autostart=off
 
 RUN yinst install -branch test vespa_systemtest_base vespa_systemtest_gems
 
-ENTRYPOINT /systemtests/bin/node_server.rb
+# Start node_server through bash to avoid zombie processes, see
+# https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/
+ENTRYPOINT ["/bin/bash", "-c", "set -e && /systemtests/bin/node_server.rb"]

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
@@ -43,6 +43,7 @@ public class LocalZoneUtils {
     private static final String APP_HOSTNAME_PREFIX = "cnode-";
     private static final String TENANT_NAME = "localtenant";
     private static final String APPLICATION_NAME = "default";
+    private static final Path PROJECT_ROOT = Paths.get("").toAbsolutePath();
 
     public static boolean startConfigServerIfNeeded(Docker docker, Environment environment) throws UnknownHostException {
         Optional<Container> container = docker.getContainer(CONFIG_SERVER_HOSTNAME);
@@ -83,7 +84,7 @@ public class LocalZoneUtils {
     }
 
     public static void buildVespaLocalDockerImage(Docker docker, DockerImage vespaBaseImage) throws IOException {
-        Path dockerfileTemplatePath = Paths.get("Dockerfile.template");
+        Path dockerfileTemplatePath = Paths.get("node-admin/Dockerfile.template");
 
         String dockerfileTemplate = new String(Files.readAllBytes(dockerfileTemplatePath))
                 .replaceAll("\\$NODE_ADMIN_FROM_IMAGE", vespaBaseImage.asString())
@@ -97,12 +98,11 @@ public class LocalZoneUtils {
          *
          * Therefore, copy docker-api jar to node-admin/target and used node-admin as build root instead of vespa/
           */
-        Path projectRoot = Paths.get("").toAbsolutePath().getParent();
-        Files.copy(projectRoot.resolve("docker-api/target/docker-api-jar-with-dependencies.jar"),
-                projectRoot.resolve("node-admin/target/docker-api-jar-with-dependencies.jar"),
+        Files.copy(PROJECT_ROOT.resolve("docker-api/target/docker-api-jar-with-dependencies.jar"),
+                PROJECT_ROOT.resolve("node-admin/target/docker-api-jar-with-dependencies.jar"),
                 StandardCopyOption.REPLACE_EXISTING);
 
-        Path dockerfilePath = Paths.get("Dockerfile").toAbsolutePath();
+        Path dockerfilePath = PROJECT_ROOT.resolve("node-admin/Dockerfile");
 
         Files.write(dockerfilePath, dockerfileTemplate.getBytes());
         docker.buildImage(dockerfilePath.getParent().toFile(), VESPA_LOCAL_IMAGE);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
+ * <pre>
  * Requires docker daemon, see {@link com.yahoo.vespa.hosted.dockerapi.DockerTestUtils} for more details.
  *
  * To get started:
@@ -48,10 +49,16 @@ import static org.mockito.Mockito.when;
  * Linux only:
  *  1. Create /home/docker/container-storage with read/write permissions
  *
+ * Example usage:
+     DockerImage vespaDockerBase = new DockerImage("docker-registry.ops.yahoo.com:4443/vespa/ci:6.52.35");
+     Path pathToAppToDeploy = Paths.get("/home/valerijf/dev/basic-search/target/application.zip");
+     RunVespaLocal runVespaLocal = new RunVespaLocal(vespaDockerBase, pathToAppToDeploy);
+     runVespaLocal.runVespaLocalTest();
  *
  * Issues:
  *  1. If you cannot make Docker Toolbox start, try starting Virtualbox and turn off the "default" machine
  *  2. If the above is not enough try "sudo ifconfig vboxnet0 down && sudo ifconfig vboxnet0 up" (see https://github.com/docker/kitematic/issues/1193)
+ * </pre>
  *
  * @author freva
  */


### PR DESCRIPTION
* Fixes issue with zombie processes inside the container that made test shutdown very slow
* Makes it possible to run systems test with Vespa `6-SNAPSHOT`