### PR TITLE
Require valid IP address for node

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -1,14 +1,15 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision;
 
+import com.google.common.net.InetAddresses;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Flavor;
+import com.yahoo.vespa.hosted.provision.node.Generation;
 import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.node.Status;
-import com.yahoo.vespa.hosted.provision.node.Generation;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -55,7 +56,7 @@ public final class Node {
                 Flavor flavor, Status status, State state, Optional<Allocation> allocation,
                 History history, NodeType type) {
         Objects.requireNonNull(openStackId, "A node must have an openstack id");
-        requireNonEmptyString(ipAddress, "A node must have an IP address");
+        requireIpAddress(ipAddress, "A node must have a valid IP address");
         requireNonEmptyString(hostname, "A node must have a hostname");
         requireNonEmptyString(parentHostname, "A parent host name must be a proper value");
         Objects.requireNonNull(flavor, "A node must have a flavor");
@@ -212,6 +213,14 @@ public final class Node {
         Objects.requireNonNull(value, message);
         if (value.trim().isEmpty())
             throw new IllegalArgumentException(message + ", but was '" + value + "'");
+    }
+
+    private void requireIpAddress(String value, String message) {
+        try {
+            InetAddresses.forString(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(message, e);
+        }
     }
     
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
@@ -6,7 +6,7 @@ import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A mock DNS resolver. Can be configured to only answer specific lookups or any lookup.
@@ -50,8 +50,17 @@ public class MockNameResolver implements NameResolver {
             return records.get(hostname);
         }
         if (mockAnyLookup) {
-            return UUID.randomUUID().toString();
+            return randomIpAddress();
         }
         throw new RuntimeException(new UnknownHostException("Could not resolve: " + hostname));
+    }
+
+    private static String randomIpAddress() {
+        // Generate a random IP in 127/8 (loopback block)
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        return String.format("127.%d.%d.%d",
+                random.nextInt(1, 255 + 1),
+                random.nextInt(1, 255 + 1),
+                random.nextInt(1, 255 + 1));
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -256,7 +256,7 @@ public class SerializationTest {
     @Test
     public void serialize_parentHostname() {
         final String parentHostname = "parent.yahoo.com";
-        Node node = Node.create("myId", "myIp", "myHostname", Optional.of(parentHostname), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant);
+        Node node = Node.create("myId", "127.0.0.1", "myHostname", Optional.of(parentHostname), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant);
 
         Node deserializedNode = nodeSerializer.fromJson(State.provisioned, nodeSerializer.toJson(node));
         assertEquals(parentHostname, deserializedNode.parentHostname().get());
@@ -303,7 +303,7 @@ public class SerializationTest {
     }
 
     private Node createNode() {
-        return Node.create("myId", "myIp", "myHostname", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.host);
+        return Node.create("myId", "127.0.0.1", "myHostname", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.host);
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -172,10 +172,24 @@ public class RestApiTest {
     @Test
     public void post_node_with_ip_address() throws Exception {
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                        ("[" + asNodeJson("host-with-ip.yahoo.com", "127.0.0.1", "default") + "]").
+                        ("[" + asNodeJson("ipv4-host.yahoo.com", "127.0.0.1", "default") + "]").
                                 getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
                 "{\"message\":\"Added 1 nodes to the provisioned state\"}");
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node",
+                        ("[" + asNodeJson("ipv6-host.yahoo.com", "::1", "default") + "]").
+                                getBytes(StandardCharsets.UTF_8),
+                        Request.Method.POST),
+                "{\"message\":\"Added 1 nodes to the provisioned state\"}");
+    }
+
+    @Test
+    public void post_node_with_invalid_ip_address() throws Exception {
+        Request req = new Request("http://localhost:8080/nodes/v2/node",
+                ("[" + asNodeJson("host-with-ip.yahoo.com", "foo", "default") + "]").
+                        getBytes(StandardCharsets.UTF_8),
+                Request.Method.POST);
+        assertResponse(req, 400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"A node must have a valid IP address: 'foo' is not an IP string literal.\"}");
     }
 
     @Test


### PR DESCRIPTION
@hmusum 

Since the `ipAddress` field can be provided when provisioning a new node we should validate it.