### PR TITLE
Always use 16 distribution bits on hosted systems

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -60,7 +60,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
     // TODO: Make private
     private String documentSelection;
     ContentSearchCluster search;
-    final Map<String, NewDocumentType> documentDefinitions;
+    private final Map<String, NewDocumentType> documentDefinitions;
     com.yahoo.vespa.model.content.StorageGroup rootGroup;
     StorageCluster storageNodes;
     DistributorCluster distributorNodes;
@@ -69,6 +69,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
     PersistenceEngine.PersistenceFactory persistenceFactory;
     String clusterName;
     Integer maxNodesPerMerge;
+    private final boolean hostedVespa;
 
     /**
      * If multitenant or a cluster controller was explicitly configured in this cluster:
@@ -462,6 +463,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
         this.documentDefinitions = documentDefinitions;
         this.documentSelection = routingSelection;
         this.redundancy = redundancy;
+        this.hostedVespa = parent.getRoot().getDeployState().getProperties().hostedVespa();
     }
 
     public void prepare() {
@@ -578,13 +580,13 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
 
     /**
      * Returns the distribution bits this cluster should use.
-     * OnHosted Vespa this is hardcoded not computed from the nodes because reducing the number of nodes is a common
+     * On Hosted Vespa this is hardcoded not computed from the nodes because reducing the number of nodes is a common
      * operation while reducing the number of distribution bits can lead to consistency problems.
      * This hardcoded value should work fine from 1-200 nodes. Those who have more will need to set this value
      * in config and not remove it again if they reduce the node count.
      */
     public int distributionBits() {
-        // if (hostedVespa) return 16; TODO: Re-enable this later (Nov 2015, ref VESPA-1702)
+        if (hostedVespa) return 16;
         return DistributionBitCalculator.getDistributionBits(getNodeCountPerGroup(), getDistributionMode());
     }
 

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -457,7 +457,7 @@ public class ModelProvisioningTest {
         assertEquals("default12", clusterControllers.getContainers().get(2).getHostName());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(8, cluster.getRootGroup().getSubgroups().size());
-        assertEquals(8, cluster.distributionBits());
+        assertEquals(16, cluster.distributionBits());
         // first group
         assertThat(cluster.getRootGroup().getSubgroups().get(0).getIndex(), is("0"));
         assertThat(cluster.getRootGroup().getSubgroups().get(0).getNodes().size(), is(1));
@@ -506,7 +506,7 @@ public class ModelProvisioningTest {
         // Check content clusters
         ContentCluster cluster = model.getContentClusters().get("bar");
         ContainerCluster clusterControllers = cluster.getClusterControllers();
-        assertEquals( 8, cluster.distributionBits());
+        assertEquals( 16, cluster.distributionBits());
         assertEquals("We get the closest odd numer", 5, clusterControllers.getContainers().size());
         assertEquals("bar-controllers", clusterControllers.getName());
         assertEquals("default10", clusterControllers.getContainers().get(0).getHostName());

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerMicroBenchmark.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerMicroBenchmark.java
@@ -14,10 +14,10 @@ public class QueryCanonicalizerMicroBenchmark {
 
     public void run() {
         System.out.println("Running ...");
-        for (int i = 0; i < 10*1000; i++)
+        for (int i = 0; i < 10 * 1000; i++)
             canonicalize();
         long startTime = System.currentTimeMillis();
-        int repetitions = 10 * 1000 * 1000;
+        int repetitions = 10* 1000 * 1000;
         for (int i = 0; i < repetitions; i++)
             canonicalize();
         long totalTime = System.currentTimeMillis() - startTime;


### PR DESCRIPTION
This avoids distribution skew with few bits and massive redistribution
events when nodes are deactivated after reducing the number of nodes.

@vekterli please review