### PR TITLE
Move processed core dumps outside of container storage

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -89,8 +89,6 @@ public class StorageMaintainer {
     }
 
     public void removeOldFilesFromNode(ContainerName containerName) {
-        PrefixLogger logger = PrefixLogger.getNodeAgentLogger(StorageMaintainer.class, containerName);
-
         String[] pathsToClean = {"/home/y/logs/elasticsearch2", "/home/y/logs/logstash2",
                 "/home/y/logs/daemontools_y", "/home/y/logs/nginx", "/home/y/logs/vespa"};
         for (String pathToClean : pathsToClean) {
@@ -110,8 +108,6 @@ public class StorageMaintainer {
         if (fileDistrDir.exists()) {
             DeleteOldAppData.deleteFiles(fileDistrDir.getAbsolutePath(), Duration.ofDays(31).getSeconds(), null, false);
         }
-
-        Maintainer.cleanCoreDumps(logger);
     }
 
     public void handleCoreDumpsForContainer(ContainerNodeSpec nodeSpec, Environment environment) {
@@ -123,6 +119,7 @@ public class StorageMaintainer {
     public void cleanNodeAdmin() {
         Maintainer.deleteOldAppData(NODE_ADMIN_LOGGER);
         Maintainer.cleanHome(NODE_ADMIN_LOGGER);
+        Maintainer.cleanCoreDumps(NODE_ADMIN_LOGGER);
 
         File nodeAdminJDiskLogsPath = maintainer.pathInNodeAdminFromPathInNode(new ContainerName("node-admin"),
                 "/home/y/logs/jdisc_core/").toFile();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/maintenance/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/maintenance/CoredumpHandlerTest.java
@@ -91,7 +91,7 @@ public class CoredumpHandlerTest {
         when(coreCollector.collect(any())).thenReturn(metadata);
 
         CoredumpHandler coredumpHandler = new CoredumpHandler(httpClient, coreCollector, attributes);
-        coredumpHandler.processCoredumps(coredumpPath);
+        coredumpHandler.processCoredumps(crashPath);
 
         // Contents of 'crash' should be only the 'processing' directory
         Set<Path> expectedContentsOfCrash = Collections.singleton(crashPath.resolve(CoredumpHandler.PROCESSING_DIRECTORY_NAME));


### PR DESCRIPTION
* Moves processed (done) core-dumps to `/home/docker/container-storage/processed_coredumps` so that they are not deleted when container goes down.
* Adds field `parent_hostname` to core-dump report