### PR TITLE
Freva/node agent fixes

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/ContainerNodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/ContainerNodeSpec.java
@@ -250,13 +250,35 @@ public class ContainerNodeSpec {
         private Optional<Double> minMainMemoryAvailableGb = Optional.of(1d);
         private Optional<Double> minDiskAvailableGb = Optional.of(1d);
 
+        public Builder() {}
+
+        public Builder(ContainerNodeSpec nodeSpec) {
+            hostname(nodeSpec.hostname);
+            containerName(nodeSpec.containerName);
+            nodeState(nodeSpec.nodeState);
+            nodeType(nodeSpec.nodeType);
+            nodeFlavor(nodeSpec.nodeFlavor);
+
+            nodeSpec.wantedDockerImage.ifPresent(this::wantedDockerImage);
+            nodeSpec.vespaVersion.ifPresent(this::vespaVersion);
+            nodeSpec.owner.ifPresent(this::owner);
+            nodeSpec.membership.ifPresent(this::membership);
+            nodeSpec.wantedRestartGeneration.ifPresent(this::wantedRestartGeneration);
+            nodeSpec.currentRestartGeneration.ifPresent(this::currentRestartGeneration);
+            nodeSpec.wantedRebootGeneration.ifPresent(this::wantedRebootGeneration);
+            nodeSpec.currentRebootGeneration.ifPresent(this::currentRebootGeneration);
+            nodeSpec.minCpuCores.ifPresent(this::minCpuCores);
+            nodeSpec.minMainMemoryAvailableGb.ifPresent(this::minMainMemoryAvailableGb);
+            nodeSpec.minDiskAvailableGb.ifPresent(this::minDiskAvailableGb);
+        }
+
         public Builder hostname(String hostname) {
             this.hostname = hostname;
             return this;
         }
 
-        public Builder wantedDockerImage(Optional<DockerImage> wantedDockerImage) {
-            this.wantedDockerImage = wantedDockerImage;
+        public Builder wantedDockerImage(DockerImage wantedDockerImage) {
+            this.wantedDockerImage = Optional.of(wantedDockerImage);
             return this;
         }
 
@@ -279,53 +301,53 @@ public class ContainerNodeSpec {
             return this;
         }
 
-        public Builder vespaVersion(Optional<String> vespaVersion) {
-            this.vespaVersion = vespaVersion;
+        public Builder vespaVersion(String vespaVersion) {
+            this.vespaVersion = Optional.of(vespaVersion);
             return this;
         }
 
-        public Builder owner(Optional<Owner> owner) {
-            this.owner = owner;
+        public Builder owner(Owner owner) {
+            this.owner = Optional.of(owner);
             return this;
         }
 
-        public Builder membership(Optional<Membership> membership) {
-            this.membership = membership;
+        public Builder membership(Membership membership) {
+            this.membership = Optional.of(membership);
             return this;
         }
 
-        public Builder wantedRestartGeneration(Optional<Long> wantedRestartGeneration) {
-            this.wantedRestartGeneration = wantedRestartGeneration;
+        public Builder wantedRestartGeneration(long wantedRestartGeneration) {
+            this.wantedRestartGeneration = Optional.of(wantedRestartGeneration);
             return this;
         }
 
-        public Builder currentRestartGeneration(Optional<Long> currentRestartGeneration) {
-            this.currentRestartGeneration = currentRestartGeneration;
+        public Builder currentRestartGeneration(long currentRestartGeneration) {
+            this.currentRestartGeneration = Optional.of(currentRestartGeneration);
             return this;
         }
 
-        public Builder wantedRebootGeneration(Optional<Long> wantedRebootGeneration) {
-            this.wantedRebootGeneration = wantedRebootGeneration;
+        public Builder wantedRebootGeneration(long wantedRebootGeneration) {
+            this.wantedRebootGeneration = Optional.of(wantedRebootGeneration);
             return this;
         }
 
-        public Builder currentRebootGeneration(Optional<Long> currentRebootGeneration) {
-            this.currentRebootGeneration = currentRebootGeneration;
+        public Builder currentRebootGeneration(long currentRebootGeneration) {
+            this.currentRebootGeneration = Optional.of(currentRebootGeneration);
             return this;
         }
 
-        public Builder minCpuCores(Optional<Double> minCpuCores) {
-            this.minCpuCores = minCpuCores;
+        public Builder minCpuCores(double minCpuCores) {
+            this.minCpuCores = Optional.of(minCpuCores);
             return this;
         }
 
-        public Builder minMainMemoryAvailableGb(Optional<Double> minMainMemoryAvailableGb) {
-            this.minMainMemoryAvailableGb = minMainMemoryAvailableGb;
+        public Builder minMainMemoryAvailableGb(double minMainMemoryAvailableGb) {
+            this.minMainMemoryAvailableGb = Optional.of(minMainMemoryAvailableGb);
             return this;
         }
 
-        public Builder minDiskAvailableGb(Optional<Double> minDiskAvailableGb) {
-            this.minDiskAvailableGb = minDiskAvailableGb;
+        public Builder minDiskAvailableGb(double minDiskAvailableGb) {
+            this.minDiskAvailableGb = Optional.of(minDiskAvailableGb);
             return this;
         }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -199,8 +199,9 @@ public class NodeAgentImpl implements NodeAgent {
                 nodeSpec.hostname,
                 // Clear current Docker image and vespa version, as nothing is running on this node
                 new NodeAttributes()
+                        .withRestartGeneration(nodeSpec.wantedRestartGeneration.orElse(0L))
+                        .withRebootGeneration(nodeSpec.wantedRebootGeneration.orElse(0L))
                         .withDockerImage(new DockerImage(""))
-                        .withRebootGeneration(nodeSpec.wantedRebootGeneration.orElse(null))
                         .withVespaVersion(""));
         nodeRepository.markAsReady(nodeSpec.hostname);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -295,30 +295,30 @@ public class NodeAgentImpl implements NodeAgent {
             dockerOperations.stopServicesOnNode(containerName);
     }
 
-    private Optional<String> shouldRemoveContainer(ContainerNodeSpec nodeSpec, Optional<Container> existingContainer) {
+    private Optional<String> shouldRemoveContainer(ContainerNodeSpec nodeSpec, Container existingContainer) {
         final Node.State nodeState = nodeSpec.nodeState;
         if (nodeState == Node.State.dirty || nodeState == Node.State.provisioned) {
             return Optional.of("Node in state " + nodeState + ", container should no longer be running");
         }
-        if (nodeSpec.wantedDockerImage.isPresent() && !nodeSpec.wantedDockerImage.get().equals(existingContainer.get().image)) {
+        if (nodeSpec.wantedDockerImage.isPresent() && !nodeSpec.wantedDockerImage.get().equals(existingContainer.image)) {
             return Optional.of("The node is supposed to run a new Docker image: "
-                                       + existingContainer.get() + " -> " + nodeSpec.wantedDockerImage.get());
+                                       + existingContainer + " -> " + nodeSpec.wantedDockerImage.get());
         }
-        if (!existingContainer.get().isRunning) {
+        if (!existingContainer.isRunning) {
             return Optional.of("Container no longer running");
         }
         return Optional.empty();
     }
 
     // Returns true if container is absent on return
-    public boolean removeContainerIfNeeded(ContainerNodeSpec nodeSpec, String hostname, Orchestrator orchestrator)
+    private boolean removeContainerIfNeeded(ContainerNodeSpec nodeSpec, String hostname, Orchestrator orchestrator)
             throws Exception {
         Optional<Container> existingContainer = dockerOperations.getContainer(hostname);
         if (!existingContainer.isPresent()) {
             return true;
         }
 
-        Optional<String> removeReason = shouldRemoveContainer(nodeSpec, existingContainer);
+        Optional<String> removeReason = shouldRemoveContainer(nodeSpec, existingContainer.get());
         if (removeReason.isPresent()) {
             logger.info("Will remove container " + existingContainer.get() + ": " + removeReason.get());
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
@@ -8,10 +8,8 @@ import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
-import java.util.Optional;
-
 /**
- * @author valerijf
+ * @author freva
  */
 public class DockerFailTest {
 
@@ -20,13 +18,13 @@ public class DockerFailTest {
         try (DockerTester dockerTester = new DockerTester()) {
             ContainerNodeSpec containerNodeSpec = new ContainerNodeSpec.Builder()
                     .hostname("hostName")
-                    .wantedDockerImage(Optional.of(new DockerImage("dockerImage")))
+                    .wantedDockerImage(new DockerImage("dockerImage"))
                     .containerName(new ContainerName("container"))
                     .nodeState(Node.State.active)
                     .nodeType("tenant")
                     .nodeFlavor("docker")
-                    .wantedRestartGeneration(Optional.of(1L))
-                    .currentRestartGeneration(Optional.of(1L))
+                    .wantedRestartGeneration(1L)
+                    .currentRestartGeneration(1L)
                     .build();
             dockerTester.addContainerNodeSpec(containerNodeSpec);
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.node.admin.integrationTests;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
-import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
@@ -16,7 +15,6 @@ import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 import com.yahoo.vespa.hosted.node.admin.util.InetAddressResolver;
 import com.yahoo.vespa.hosted.node.maintenance.Maintainer;
-import com.yahoo.vespa.hosted.provision.Node;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -82,34 +80,6 @@ public class DockerTester implements AutoCloseable {
 
     public int getNumberOfContainerSpecs() {
         return nodeRepositoryMock.getNumberOfContainerSpecs();
-    }
-
-    public void updateContainerNodeSpec(final String hostname,
-                                        final Optional<DockerImage> wantedDockerImage,
-                                        final ContainerName containerName,
-                                        final Node.State nodeState,
-                                        final String nodeType,
-                                        final String nodeFlavor,
-                                        final Optional<Long> wantedRestartGeneration,
-                                        final Optional<Long> currentRestartGeneration,
-                                        final Optional<Double> minCpuCores,
-                                        final Optional<Double> minMainMemoryAvailableGb,
-                                        final Optional<Double> minDiskAvailableGb) {
-
-        nodeRepositoryMock.updateContainerNodeSpec(
-                new ContainerNodeSpec.Builder()
-                        .hostname(hostname)
-                        .wantedDockerImage(wantedDockerImage)
-                        .containerName(containerName)
-                        .nodeState(nodeState)
-                        .nodeType(nodeType)
-                        .nodeFlavor(nodeFlavor)
-                        .wantedRestartGeneration(wantedRestartGeneration)
-                        .currentRestartGeneration(currentRestartGeneration)
-                        .minCpuCores(minCpuCores)
-                        .minMainMemoryAvailableGb(minMainMemoryAvailableGb)
-                        .minDiskAvailableGb(minDiskAvailableGb)
-                        .build());
     }
 
     public void updateContainerNodeSpec(ContainerNodeSpec containerNodeSpec) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -67,10 +67,10 @@ public class MultiDockerTest {
                                                              "DeleteContainerStorage with ContainerName: ContainerName { name=container2 }");
 
             callOrderVerifier.assertInOrder(
-                    "updateNodeAttributes with HostName: host1, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=null, dockerImage=DockerImage { imageId=image1 }, vespaVersion='null'}",
-                    "updateNodeAttributes with HostName: host2, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=null, dockerImage=DockerImage { imageId=image2 }, vespaVersion='null'}",
+                    "updateNodeAttributes with HostName: host1, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=DockerImage { imageId=image1 }, vespaVersion=''}",
+                    "updateNodeAttributes with HostName: host2, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=DockerImage { imageId=image2 }, vespaVersion=''}",
                     "markAsReady with HostName: host2",
-                    "updateNodeAttributes with HostName: host3, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=null, dockerImage=DockerImage { imageId=image1 }, vespaVersion='null'}");
+                    "updateNodeAttributes with HostName: host3, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=DockerImage { imageId=image1 }, vespaVersion=''}");
         }
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -12,29 +12,21 @@ import java.io.IOException;
 import java.util.Optional;
 
 /**
- * @author valerijf
+ * @author freva
  */
 public class MultiDockerTest {
 
     @Test
     public void test() throws InterruptedException, IOException {
         try (DockerTester dockerTester = new DockerTester()) {
-            addAndWaitForNode(dockerTester, "host1", new ContainerName("container1"), Optional.of(new DockerImage("image1")));
+            addAndWaitForNode(dockerTester, "host1", new ContainerName("container1"), new DockerImage("image1"));
             ContainerNodeSpec containerNodeSpec2 =
-                    addAndWaitForNode(dockerTester, "host2", new ContainerName("container2"), Optional.of(new DockerImage("image2")));
+                    addAndWaitForNode(dockerTester, "host2", new ContainerName("container2"), new DockerImage("image2"));
 
             dockerTester.updateContainerNodeSpec(
-                    containerNodeSpec2.hostname,
-                    containerNodeSpec2.wantedDockerImage,
-                    containerNodeSpec2.containerName,
-                    Node.State.dirty,
-                    containerNodeSpec2.nodeType,
-                    containerNodeSpec2.nodeFlavor,
-                    containerNodeSpec2.wantedRestartGeneration,
-                    containerNodeSpec2.currentRestartGeneration,
-                    containerNodeSpec2.minCpuCores,
-                    containerNodeSpec2.minMainMemoryAvailableGb,
-                    containerNodeSpec2.minDiskAvailableGb);
+                    new ContainerNodeSpec.Builder(containerNodeSpec2)
+                            .nodeState(Node.State.dirty)
+                            .build());
 
             // Wait until it is marked ready
             Optional<ContainerNodeSpec> tempContainerNodeSpec;
@@ -43,7 +35,7 @@ public class MultiDockerTest {
                 Thread.sleep(10);
             }
 
-            addAndWaitForNode(dockerTester, "host3", new ContainerName("container3"), Optional.of(new DockerImage("image1")));
+            addAndWaitForNode(dockerTester, "host3", new ContainerName("container3"), new DockerImage("image1"));
 
             CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             callOrderVerifier.assertInOrder(
@@ -74,7 +66,7 @@ public class MultiDockerTest {
         }
     }
 
-    private ContainerNodeSpec addAndWaitForNode(DockerTester tester, String hostName, ContainerName containerName, Optional<DockerImage> dockerImage) throws InterruptedException {
+    private ContainerNodeSpec addAndWaitForNode(DockerTester tester, String hostName, ContainerName containerName, DockerImage dockerImage) throws InterruptedException {
         ContainerNodeSpec containerNodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
                 .wantedDockerImage(dockerImage)
@@ -82,8 +74,8 @@ public class MultiDockerTest {
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(1L))
-                .currentRestartGeneration(Optional.of(1L))
+                .wantedRestartGeneration(1L)
+                .currentRestartGeneration(1L)
                 .build();
 
         tester.addContainerNodeSpec(containerNodeSpec);
@@ -94,7 +86,7 @@ public class MultiDockerTest {
         }
 
         tester.getCallOrderVerifier().assertInOrder(
-                "createContainerCommand with DockerImage: " + dockerImage.get() + ", HostName: " + hostName + ", ContainerName: " + containerName,
+                "createContainerCommand with DockerImage: " + dockerImage + ", HostName: " + hostName + ", ContainerName: " + containerName,
                 "executeInContainer with ContainerName: " + containerName + ", args: [/usr/bin/env, test, -x, " + DockerOperationsImpl.NODE_PROGRAM + "]",
                 "executeInContainer with ContainerName: " + containerName + ", args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
@@ -56,19 +56,11 @@ public class NodeRepoMock implements NodeRepository {
 
         synchronized (monitor) {
             if (cns.isPresent()) {
-                updateContainerNodeSpec(new ContainerNodeSpec.Builder()
-                                                .hostname(cns.get().hostname)
-                                                .wantedDockerImage(cns.get().wantedDockerImage)
-                                                .containerName(cns.get().containerName)
-                                                .nodeState(Node.State.ready)
-                                                .nodeType("tenant")
-                                                .nodeFlavor("docker")
-                                                .wantedRestartGeneration(cns.get().wantedRestartGeneration)
-                                                .currentRestartGeneration(cns.get().currentRestartGeneration)
-                                                .minCpuCores(cns.get().minCpuCores)
-                                                .minMainMemoryAvailableGb(cns.get().minMainMemoryAvailableGb)
-                                                .minDiskAvailableGb(cns.get().minDiskAvailableGb)
-                                                .build());
+                updateContainerNodeSpec(new ContainerNodeSpec.Builder(cns.get())
+                        .nodeState(Node.State.ready)
+                        .nodeType("tenant")
+                        .nodeFlavor("docker")
+                        .build());
             }
             callOrderVerifier.add("markAsReady with HostName: " + hostName);
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
@@ -64,14 +64,14 @@ public class RebootTest {
     private ContainerNodeSpec createContainerNodeSpec() {
         return new ContainerNodeSpec.Builder()
                 .hostname("host1")
-                .wantedDockerImage(Optional.of(new DockerImage("dockerImage")))
+                .wantedDockerImage(new DockerImage("dockerImage"))
                 .containerName(new ContainerName("container"))
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .vespaVersion(Optional.of("6.50.0"))
-                .wantedRestartGeneration(Optional.of(1L))
-                .currentRestartGeneration(Optional.of(1L))
+                .vespaVersion("6.50.0")
+                .wantedRestartGeneration(1L)
+                .currentRestartGeneration(1L)
                 .build();
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -34,7 +34,7 @@ public class RestartTest {
             CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             // Check that the container is started and NodeRepo has received the PATCH update
             callOrderVerifier.assertInOrder("createContainerCommand with DockerImage: DockerImage { imageId=dockerImage }, HostName: host1, ContainerName: ContainerName { name=container }",
-                                            "updateNodeAttributes with HostName: host1, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=null, dockerImage=DockerImage { imageId=dockerImage }, vespaVersion='null'}");
+                                            "updateNodeAttributes with HostName: host1, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=DockerImage { imageId=dockerImage }, vespaVersion=''}");
 
             wantedRestartGeneration = 2;
             currentRestartGeneration = 1;

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -9,7 +9,6 @@ import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
-import java.util.Optional;
 
 /**
  * Tests that different wanted and current restart generation leads to execution of restart command
@@ -48,13 +47,13 @@ public class RestartTest {
     private ContainerNodeSpec createContainerNodeSpec(long wantedRestartGeneration, long currentRestartGeneration) {
         return new ContainerNodeSpec.Builder()
                 .hostname("host1")
-                .wantedDockerImage(Optional.of(new DockerImage("dockerImage")))
+                .wantedDockerImage(new DockerImage("dockerImage"))
                 .containerName(new ContainerName("container"))
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(wantedRestartGeneration))
-                .currentRestartGeneration(Optional.of(currentRestartGeneration))
+                .wantedRestartGeneration(wantedRestartGeneration)
+                .currentRestartGeneration(currentRestartGeneration)
                 .build();
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ResumeTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ResumeTest.java
@@ -48,7 +48,7 @@ public class ResumeTest {
             CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             // Check that the container is started and NodeRepo has received the PATCH update
             callOrderVerifier.assertInOrder("createContainerCommand with DockerImage: DockerImage { imageId=dockerImage }, HostName: host1, ContainerName: ContainerName { name=container }",
-                                            "updateNodeAttributes with HostName: host1, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=null, dockerImage=DockerImage { imageId=dockerImage }, vespaVersion='null'}");
+                                            "updateNodeAttributes with HostName: host1, NodeAttributes: NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=DockerImage { imageId=dockerImage }, vespaVersion=''}");
 
             // Force orchestrator to reject the suspend
             orchestratorMock.setForceGroupSuspendResponse(Optional.of("Orchestrator reject suspend"));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ResumeTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ResumeTest.java
@@ -30,13 +30,13 @@ public class ResumeTest {
 
             dockerTester.addContainerNodeSpec(new ContainerNodeSpec.Builder()
                                                       .hostname("host1")
-                                                      .wantedDockerImage(Optional.of(new DockerImage("dockerImage")))
+                                                      .wantedDockerImage(new DockerImage("dockerImage"))
                                                       .containerName(new ContainerName("container"))
                                                       .nodeState(Node.State.active)
                                                       .nodeType("tenant")
                                                       .nodeFlavor("docker")
-                                                      .wantedRestartGeneration(Optional.of(1L))
-                                                      .currentRestartGeneration(Optional.of(1L))
+                                                      .wantedRestartGeneration(1L)
+                                                      .currentRestartGeneration(1L)
                                                       .build());
 
             // Wait for node admin to be notified with node repo state and the docker container has been started

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RunInContainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RunInContainerTest.java
@@ -112,13 +112,13 @@ public class RunInContainerTest {
         ComponentsProviderWithMocks.nodeRepositoryMock
                 .addContainerNodeSpec(new ContainerNodeSpec.Builder()
                                               .hostname("hostName")
-                                              .wantedDockerImage(Optional.of(new DockerImage("dockerImage")))
+                                              .wantedDockerImage(new DockerImage("dockerImage"))
                                               .containerName(new ContainerName("container"))
                                               .nodeState(Node.State.active)
                                               .nodeType("tenant")
                                               .nodeFlavor("docker")
-                                              .wantedRestartGeneration(Optional.of(1L))
-                                              .currentRestartGeneration(Optional.of(1L))
+                                              .wantedRestartGeneration(1L)
+                                              .currentRestartGeneration(1L)
                                               .build());
         ComponentsProviderWithMocks.orchestratorMock.setForceGroupSuspendResponse(Optional.of("Denied"));
         assertThat(doPutCall("suspend"), is(false));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
@@ -39,9 +39,9 @@ import static org.mockito.Mockito.when;
  * @author bakksjo
  */
 public class NodeAdminImplTest {
-    private static final Optional<Double> MIN_CPU_CORES = Optional.of(1.0);
-    private static final Optional<Double> MIN_MAIN_MEMORY_AVAILABLE_GB = Optional.of(1.0);
-    private static final Optional<Double> MIN_DISK_AVAILABLE_GB = Optional.of(1.0);
+    private static final double MIN_CPU_CORES = 1.0;
+    private static final double MIN_MAIN_MEMORY_AVAILABLE_GB = 1.0;
+    private static final double MIN_DISK_AVAILABLE_GB = 1.0;
 
     // Trick to allow mocking of typed interface without casts/warnings.
     private interface NodeAgentFactory extends Function<String, NodeAgent> {}
@@ -66,7 +66,7 @@ public class NodeAdminImplTest {
         final Container existingContainer = new Container(hostName, dockerImage, containerName, isRunning);
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(dockerImage))
+                .wantedDockerImage(dockerImage)
                 .containerName(containerName)
                 .nodeState(Node.State.active)
                 .nodeType("tenant")

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -47,10 +47,10 @@ import static org.mockito.Mockito.when;
  * @author bakksjo
  */
 public class NodeAgentImplTest {
-    private static final Optional<Double> MIN_CPU_CORES = Optional.of(1.0);
-    private static final Optional<Double> MIN_MAIN_MEMORY_AVAILABLE_GB = Optional.of(1.0);
-    private static final Optional<Double> MIN_DISK_AVAILABLE_GB = Optional.of(1.0);
-    private static final Optional<String> vespaVersion = Optional.of("7.8.9");
+    private static final double MIN_CPU_CORES = 1.0;
+    private static final double MIN_MAIN_MEMORY_AVAILABLE_GB = 1.0;
+    private static final double MIN_DISK_AVAILABLE_GB = 1.0;
+    private static final String vespaVersion = "7.8.9";
 
     private final String hostName = "hostname";
     private final DockerOperations dockerOperations = mock(DockerOperations.class);
@@ -76,14 +76,14 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(dockerImage))
+                .wantedDockerImage(dockerImage)
                 .containerName(containerName)
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(restartGeneration))
-                .currentRestartGeneration(Optional.of(restartGeneration))
-                .wantedRebootGeneration(Optional.of(rebootGeneration))
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration)
+                .wantedRebootGeneration(rebootGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -94,7 +94,7 @@ public class NodeAgentImplTest {
         when(dockerOperations.getContainerStats(any())).thenReturn(Optional.of(containerStats));
         when(dockerOperations.shouldScheduleDownloadOfImage(any())).thenReturn(false);
         when(dockerOperations.startContainerIfNeeded(eq(nodeSpec))).thenReturn(false);
-        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(vespaVersion);
+        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(Optional.of(vespaVersion));
         when(nodeRepository.getContainerNodeSpec(hostName)).thenReturn(Optional.of(nodeSpec));
 
         nodeAgent.tick();
@@ -113,7 +113,7 @@ public class NodeAgentImplTest {
                         .withRestartGeneration(restartGeneration)
                         .withRebootGeneration(rebootGeneration)
                         .withDockerImage(dockerImage)
-                        .withVespaVersion(vespaVersion.get()));
+                        .withVespaVersion(vespaVersion));
         inOrder.verify(orchestrator).resume(hostName);
     }
 
@@ -125,14 +125,14 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(dockerImage))
+                .wantedDockerImage(dockerImage)
                 .containerName(containerName)
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(restartGeneration))
-                .currentRestartGeneration(Optional.of(restartGeneration))
-                .wantedRebootGeneration(Optional.of(rebootGeneration))
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration)
+                .wantedRebootGeneration(rebootGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -143,7 +143,7 @@ public class NodeAgentImplTest {
         when(dockerOperations.getContainerStats(any())).thenReturn(Optional.of(containerStats));
         when(dockerOperations.shouldScheduleDownloadOfImage(any())).thenReturn(false);
         when(dockerOperations.startContainerIfNeeded(eq(nodeSpec))).thenReturn(true);
-        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(vespaVersion);
+        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(Optional.of(vespaVersion));
         when(maintainer.pathInNodeAdminFromPathInNode(any(ContainerName.class), any(String.class))).thenReturn(Files.createTempDirectory("foo"));
         when(nodeRepository.getContainerNodeSpec(hostName)).thenReturn(Optional.of(nodeSpec));
 
@@ -160,7 +160,7 @@ public class NodeAgentImplTest {
                         .withRestartGeneration(restartGeneration)
                         .withRebootGeneration(rebootGeneration)
                         .withDockerImage(dockerImage)
-                        .withVespaVersion(vespaVersion.get()));
+                        .withVespaVersion(vespaVersion));
         inOrder.verify(orchestrator).resume(hostName);
     }
 
@@ -173,13 +173,13 @@ public class NodeAgentImplTest {
         final long currentRestartGeneration = 1;
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(newDockerImage))
+                .wantedDockerImage(newDockerImage)
                 .containerName(containerName)
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(wantedRestartGeneration))
-                .currentRestartGeneration(Optional.of(currentRestartGeneration))
+                .wantedRestartGeneration(wantedRestartGeneration)
+                .currentRestartGeneration(currentRestartGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -208,13 +208,13 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(dockerImage))
+                .wantedDockerImage(dockerImage)
                 .containerName(containerName)
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(wantedRestartGeneration))
-                .currentRestartGeneration(Optional.of(currentRestartGeneration))
+                .wantedRestartGeneration(wantedRestartGeneration)
+                .currentRestartGeneration(currentRestartGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -240,13 +240,12 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.empty())
                 .containerName(containerName)
                 .nodeState(Node.State.failed)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(restartGeneration))
-                .currentRestartGeneration(Optional.of(restartGeneration))
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -276,14 +275,13 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.empty())
                 .containerName(containerName)
                 .nodeState(Node.State.ready)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(restartGeneration))
-                .currentRestartGeneration(Optional.of(restartGeneration))
-                .wantedRebootGeneration(Optional.of(rebootGeneration))
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration)
+                .wantedRebootGeneration(rebootGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -314,14 +312,13 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.empty())
                 .containerName(containerName)
                 .nodeState(Node.State.inactive)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(restartGeneration))
-                .currentRestartGeneration(Optional.of(restartGeneration))
-                .wantedRebootGeneration(Optional.of(rebootGeneration))
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration)
+                .wantedRebootGeneration(rebootGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -350,19 +347,22 @@ public class NodeAgentImplTest {
             throws Exception {
         final DockerImage dockerImage = new DockerImage("dockerImage");
         final ContainerName containerName = new ContainerName("container-name");
-        final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
+        final ContainerNodeSpec.Builder nodeSpecBuilder = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(dockerImage))
+                .wantedDockerImage(dockerImage)
                 .containerName(containerName)
                 .nodeState(nodeState)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(wantedRestartGeneration)
-                .currentRestartGeneration(wantedRestartGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
-                .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
-                .build();
+                .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB);
+
+        wantedRestartGeneration.ifPresent(restartGeneration -> nodeSpecBuilder
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration));
+
+        final ContainerNodeSpec nodeSpec = nodeSpecBuilder.build();
 
         when(nodeRepository.getContainerNodeSpec(hostName)).thenReturn(Optional.of(nodeSpec));
         when(dockerOperations.getContainer(eq(hostName))).thenReturn(
@@ -409,13 +409,13 @@ public class NodeAgentImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .hostname(hostName)
-                .wantedDockerImage(Optional.of(wantedDockerImage))
+                .wantedDockerImage(wantedDockerImage)
                 .containerName(containerName)
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .wantedRestartGeneration(Optional.of(restartGeneration))
-                .currentRestartGeneration(Optional.of(restartGeneration))
+                .wantedRestartGeneration(restartGeneration)
+                .currentRestartGeneration(restartGeneration)
                 .minCpuCores(MIN_CPU_CORES)
                 .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
                 .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB)
@@ -426,7 +426,7 @@ public class NodeAgentImplTest {
         when(dockerOperations.getContainer(eq(hostName))).thenReturn(Optional.of(new Container(hostName, wantedDockerImage, containerName, true)));
         when(nodeRepository.getContainerNodeSpec(eq(hostName))).thenReturn(Optional.of(nodeSpec));
         when(dockerOperations.shouldScheduleDownloadOfImage(eq(wantedDockerImage))).thenReturn(false);
-        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(vespaVersion);
+        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(Optional.of(vespaVersion));
 
         verify(dockerOperations, never()).removeContainer(any(), any(), any());
 
@@ -482,8 +482,8 @@ public class NodeAgentImplTest {
                 .nodeState(Node.State.active)
                 .nodeType("tenant")
                 .nodeFlavor("docker")
-                .owner(Optional.of(owner))
-                .membership(Optional.of(membership))
+                .owner(owner)
+                .membership(membership)
                 .build();
 
         long totalContainerCpuTime = (long) ((Map) cpu_stats.get("cpu_usage")).get("total_usage");

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -383,7 +383,11 @@ public class NodeAgentImplTest {
         verify(orchestrator, never()).resume(any(String.class));
         // current Docker image and vespa version should be cleared
         verify(nodeRepository, times(1)).updateNodeAttributes(
-                any(String.class), eq(new NodeAttributes().withDockerImage(new DockerImage("")).withVespaVersion("")));
+                any(String.class), eq(new NodeAttributes()
+                        .withRestartGeneration(wantedRestartGeneration.orElse(0L))
+                        .withRebootGeneration(0L)
+                        .withDockerImage(new DockerImage(""))
+                        .withVespaVersion("")));
     }
 
     @Test


### PR DESCRIPTION
* Updates node repo attributes each tick regardless of node state. Node repo already supports empty docker image ([RestAPITest](https://github.com/yahoo/vespa/blob/master/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java#L347))
* Always reports a value for reboot generation, vespa version and docker image when updating attributes
* Removed `Optional` arguments from methods in `ContainerNodeSpec.Builder`