### PR TITLE
Do not set current restart generation unless in spec

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -199,7 +199,7 @@ public class NodeAgentImpl implements NodeAgent {
                 nodeSpec.hostname,
                 // Clear current Docker image and vespa version, as nothing is running on this node
                 new NodeAttributes()
-                        .withRestartGeneration(nodeSpec.wantedRestartGeneration.orElse(0L))
+                        .withRestartGeneration(nodeSpec.wantedRestartGeneration.orElse(null))
                         .withRebootGeneration(nodeSpec.wantedRebootGeneration.orElse(0L))
                         .withDockerImage(new DockerImage(""))
                         .withVespaVersion(""));
@@ -208,7 +208,7 @@ public class NodeAgentImpl implements NodeAgent {
 
     private void updateNodeRepoWithCurrentAttributes(final ContainerNodeSpec nodeSpec) throws IOException {
         final NodeAttributes nodeAttributes = new NodeAttributes()
-                .withRestartGeneration(nodeSpec.wantedRestartGeneration.orElse(0L))
+                .withRestartGeneration(nodeSpec.wantedRestartGeneration.orElse(null))
                 // update reboot gen with wanted gen if set, we ignore reboot for Docker nodes but
                 // want the two to be equal in node repo
                 .withRebootGeneration(nodeSpec.wantedRebootGeneration.orElse(0L))

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -389,7 +389,7 @@ public class NodeAgentImplTest {
         // current Docker image and vespa version should be cleared
         verify(nodeRepository, times(1)).updateNodeAttributes(
                 any(String.class), eq(new NodeAttributes()
-                        .withRestartGeneration(wantedRestartGeneration.orElse(0L))
+                        .withRestartGeneration(wantedRestartGeneration.orElse(null))
                         .withRebootGeneration(0L)
                         .withDockerImage(new DockerImage(""))
                         .withVespaVersion("")));


### PR DESCRIPTION
* Node repo only allows updateing current restart generation for
  allocated nodes, set to null (so that it will not be a part of request)
  unless wanted restart generation exists