### PR TITLE
Use latest candidate cluster state when comparing against reported node states

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -299,10 +299,14 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         }
     }
 
+    private ClusterState latestCandidateClusterState() {
+        return stateVersionTracker.getLatestCandidateState().getClusterState();
+    }
+
     @Override
     public void handleNewNodeState(NodeInfo node, NodeState newState) {
         verifyInControllerThread();
-        stateChangeHandler.handleNewReportedNodeState(stateVersionTracker.getVersionedClusterState(), node, newState, this);
+        stateChangeHandler.handleNewReportedNodeState(latestCandidateClusterState(), node, newState, this);
     }
 
     @Override

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateVersionTrackerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateVersionTrackerTest.java
@@ -133,6 +133,12 @@ public class StateVersionTrackerTest {
     }
 
     @Test
+    public void init_progress_change_not_counted_as_changed_state() {
+        assertFalse(stateChangedBetween("distributor:2 storage:2 .0.s:i .0.i:0.5",
+                                        "distributor:2 storage:2 .0.s:i .0.i:0.6"));
+    }
+
+    @Test
     public void lowest_observed_distribution_bit_is_initially_16() {
         final StateVersionTracker versionTracker = createWithMockedMetrics();
         assertThat(versionTracker.getLowestObservedDistributionBits(), equalTo(16));


### PR DESCRIPTION
@hakonhall Please review.

Using just the versioned cluster state instead can cause the code to
erroneously believe that it is seeing repeated reported state changes
for the first time. This happens when the diffs in the reported node
states are not in and by themselves enough to trigger a new cluster state
version containing the changes.

This can in turn spam the logs and event buffers until a new cluster state
has been versioned.