### PR TITLE
Fix race condition in some http conformance test

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -99,11 +99,10 @@ public class ServletResponseController {
 
 
     public void trySendError(Throwable t) {
-        String reasonPhrase = getReasonPhrase(t, developerMode);
-        int statusCode = getStatusCode(t);
-
         final boolean responseWasCommitted;
         try {
+            String reasonPhrase = getReasonPhrase(t, developerMode);
+            int statusCode = getStatusCode(t);
             synchronized (monitor) {
                 responseWasCommitted = responseCommitted;
                 if (!responseCommitted) {


### PR DESCRIPTION
Make call to Exception.getMessage()/getReasonPhrase in synchronized
block to fix some flaky unit tests (eg testRequestContentCloseExceptionBeforeResponseWrite)