### PR TITLE
reduce feed block memory limit to 0.8

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -378,7 +378,7 @@ writefilter.attribute.multivaluelimit double default = 0.9
 
 ## Portion of physical memory that can be resident memory in anonymous mapping
 ## by the proton process before put and update portion of feed is blocked.
-writefilter.memorylimit double default = 0.9
+writefilter.memorylimit double default = 0.8
 
 ## Portion of space on disk partition that can be used or reserved before
 ## put and update portion of feed is blocked.


### PR DESCRIPTION
- I checked memory usage, for real tenants
- only geminiapps:gemini and mediasearch:imagepersonal are over 80% - and both have configured 0.9
- hence safe to set 0.8 now
- VESPA-5151

@geirst please merge
@bjormel @yngveaasheim FYI