### PR TITLE
Use Jetty 9.4.0

### DIFF
--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -185,6 +185,7 @@
           <discPreInstallBundle>
             asm-debug-all-${asm-debug-all.version}.jar,
             javax.servlet-api-3.1.0.jar,
+            jetty-client-${jetty.version}.jar,
             jetty-continuation-${jetty.version}.jar,
             jetty-http-${jetty.version}.jar,
             jetty-io-${jetty.version}.jar,

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/WebSocketRequestDispatch.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/WebSocketRequestDispatch.java
@@ -103,7 +103,7 @@ class WebSocketRequestDispatch extends WebSocketAdapter {
         final Response jdiscResponse = (Response)responseRef.getAndSet(new Object());
         if (jdiscResponse != null) {
             log.finer("Applying sync " + jdiscResponse.getStatus() + " response to websocket response.");
-            servletResponse.setStatus(jdiscResponse.getStatus());
+            servletResponse.setStatusCode(jdiscResponse.getStatus());
             WebSocketRequestFactory.copyHeaders(jdiscResponse, servletResponse);
         }
         return this;

--- a/pom.xml
+++ b/pom.xml
@@ -1083,7 +1083,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.3.14.v20161028</jetty.version>
+        <jetty.version>9.4.0.v20161208</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>


### PR DESCRIPTION
Same as https://github.com/yahoo/vespa/pull/1296, but also includes pre-install of jetty-client since  websocket-client has dependency on jetty-client as of Jetty 9.4.