### PR TITLE
Always use DNS when resolving hostname

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -17,6 +17,7 @@ import com.yahoo.vespa.hosted.provision.node.filter.NodeFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeListFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.StateFilter;
 import com.yahoo.vespa.hosted.provision.persistence.CuratorDatabaseClient;
+import com.yahoo.vespa.hosted.provision.persistence.DnsNameResolver;
 import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 
 import java.time.Clock;
@@ -72,7 +73,7 @@ public class NodeRepository extends AbstractComponent {
      */
     @Inject
     public NodeRepository(NodeFlavors flavors, Curator curator, Zone zone) {
-        this(flavors, curator, Clock.systemUTC(), zone, new NameResolver() {} /* use default implementation */);
+        this(flavors, curator, Clock.systemUTC(), zone, new DnsNameResolver());
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/DnsNameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/DnsNameResolver.java
@@ -1,0 +1,50 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.persistence;
+
+import com.google.common.collect.ImmutableSet;
+
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Implementation of a name resolver that always use a DNS server to resolve the given name. The intention is to avoid
+ * possibly incorrect/incomplete records in /etc/hosts.
+ *
+ * @author mpolden
+ */
+public class DnsNameResolver implements NameResolver {
+
+    private static final String TYPE_A = "A";
+    private static final String TYPE_AAAA = "AAAA";
+
+    /** Resolve IP addresses for given host name */
+    @Override
+    public Set<String> getAllByNameOrThrow(String hostname) {
+        try {
+            DirContext ctx = new InitialDirContext();
+            Attributes attributes = ctx.getAttributes("dns:/" + hostname, new String[] {TYPE_A, TYPE_AAAA});
+            Optional<String> inet4Address = getStringAttribute(attributes, TYPE_A);
+            Optional<String> inet6Address = getStringAttribute(attributes, TYPE_AAAA);
+
+            ImmutableSet.Builder<String> ipAddresses = ImmutableSet.builder();
+            inet4Address.ifPresent(ipAddresses::add);
+            inet6Address.ifPresent(ipAddresses::add);
+            return ipAddresses.build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<String> getStringAttribute(Attributes attributes, String key) throws NamingException {
+        Optional<Attribute> attribute = Optional.ofNullable(attributes.get(key));
+        if (attribute.isPresent()) {
+            return Optional.ofNullable(attribute.get().get()).map(Object::toString);
+        }
+        return Optional.empty();
+    }
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
@@ -1,32 +1,15 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.persistence;
 
-import com.google.common.collect.ImmutableSet;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Set;
 
 /**
- * Interface for a basic name to IP address resolver. Default implementation delegates to
- * {@link java.net.InetAddress#getAllByName(String)}.
+ * Interface for a basic name to IP address resolver.
  *
  * @author mpolden
  */
 public interface NameResolver {
 
-    /** Resolve IP addresses for given host name */
-    default Set<String> getAllByNameOrThrow(String hostname) {
-        try {
-            ImmutableSet.Builder<String> ipAddresses = ImmutableSet.builder();
-            Arrays.stream(InetAddress.getAllByName(hostname))
-                    .map(InetAddress::getHostAddress)
-                    .forEach(ipAddresses::add);
-            return ipAddresses.build();
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    Set<String> getAllByNameOrThrow(String hostname);
 
 }


### PR DESCRIPTION
@arnej27959 

I wasn't able to use `sun.net.spi.nameservice.dns.DNSNameService` since using a proprietary API is a compilation warning that can't be ignored and we compile with `-Werror`.