### PR TITLE
Expose ports on OS X as net=host does not work as expected.

### DIFF
--- a/docker/run-vespa.sh
+++ b/docker/run-vespa.sh
@@ -13,5 +13,10 @@ VESPA_VERSION=$1
 DOCKER_IMAGE=vesparun
 
 docker build -t "$DOCKER_IMAGE" -f Dockerfile.run .
-docker run -d -v $(pwd)/..:/vespa --net=host --privileged  --entrypoint /vespa/docker/run-vespa-internal.sh "$DOCKER_IMAGE" "$VESPA_VERSION"
 
+if [ "$(uname)" != "Darwin" ]; then
+  docker run -d -v $(pwd)/..:/vespa --net=host --privileged  --entrypoint /vespa/docker/run-vespa-internal.sh "$DOCKER_IMAGE" "$VESPA_VERSION"
+else
+  # On OS X, net=host does not work. Need to explicitly expose ports from localhost into container.
+  docker run -d -p 8080:8080 -p 19071:19071 -v $(pwd)/..:/vespa --privileged  --entrypoint /vespa/docker/run-vespa-internal.sh "$DOCKER_IMAGE" "$VESPA_VERSION"
+fi


### PR DESCRIPTION
@kkraune 

With this patch this works on my Mac:
cd docker
./build-vespa.sh 6.53.284
./run-vespa.sh 6.53.284
curl -s -X PUT "localhost:19071/application/v2/tenant/aressem"
tar -C ../sample-apps/basic-search/src/main/application -cf - . | gzip | curl -s --header "Content-Type: application/x-gzip" --data-binary @- "localhost:19071/application/v2/tenant/aressem/session"
curl -s -X PUT "localhost:19071/application/v2/tenant/aressem/session/2/prepared?applicationName=basic-search"
curl -s -X PUT "localhost:19071/application/v2/tenant/aressem/session/2/active"
curl -X POST --data-binary @../sample-apps/basic-search/music-data-1.json "localhost:8080/document/v1/music/music/docid/1"
curl -X POST --data-binary @../sample-apps/basic-search/music-data-2.json "localhost:8080/document/v1/music/music/docid/2"
curl "localhost:8080/search/?query=michael"