### PR TITLE
Increase number of buckets/sec processed by distributors

### DIFF
--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -65,12 +65,12 @@ maximum_nodes_per_merge int default=16
 start_distributor_thread bool default=true restart
 
 ## The number of ticks calls done before a wait is done.  This can be
-## set higher than 1 for the distributor to improve speed of bucket iterations
+## set higher than 10 for the distributor to improve speed of bucket iterations
 ## while still keep CPU load low/moderate.
-ticks_before_wait int default=1
+ticks_before_wait int default=10
 
-## The sleep time between ticks if there are no more queed tasks.
-ticks_wait_time_ms int default=5
+## The sleep time between ticks if there are no more queued tasks.
+ticks_wait_time_ms int default=1
 
 ## Max processing time used by deadlock detector.
 max_process_time_ms int default=5000


### PR DESCRIPTION
@hakonhall Please review.

This greatly reduces time to process large bucket databases, especially
when the number of buckets go into the millions. With the previous
defaults, this could take absolute ages and fail to get in sync within a
reasonable time.

If we do not observe any negative effects as part of this change, we'll
likely boost the `ticks_before_wait` default even more.