### PR TITLE
Use floating point timer for Get operation latency metric

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.cpp
@@ -54,7 +54,8 @@ GetOperation::GetOperation(DistributorComponent& manager,
       _returnCode(api::ReturnCode::OK),
       _doc((document::Document*)NULL),
       _lastModified(0),
-      _metric(metric)
+      _metric(metric),
+      _operationTimer(manager.getClock())
 {
     assignTargetNodeGroups();
 }
@@ -222,8 +223,7 @@ GetOperation::sendReply(DistributorMessageSender& sender)
             ++_metric.failures.notfound;
         }
 
-        framework::MilliSecTime currTime(_manager.getClock().getTimeInMillis());
-        _metric.latency.addValue((currTime - _startTime).getTime());
+        _metric.latency.addValue(_operationTimer.getElapsedTimeAsDouble());
 
         sender.sendReply(repl);
         _msg.reset();

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -90,6 +90,7 @@ private:
     api::Timestamp _lastModified;
 
     PersistenceOperationMetricSet& _metric;
+    framework::MilliSecTimer _operationTimer;
 
     void sendReply(DistributorMessageSender& sender);
     bool sendForChecksum(DistributorMessageSender& sender, const document::BucketId& id, GroupVector& res);


### PR DESCRIPTION
@baldersheim Please review. This explicit timer sampling was not caught when I changed to double metrics for the other distributor operation latencies a few weeks ago.