### PR TITLE
Use correct metric value increment method

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -1001,9 +1001,9 @@ VisitorOperation::updateReplyMetrics(const api::ReturnCode& result)
         return;
     }
     _metrics.latency.addValue(_operationTimer.getElapsedTimeAsDouble());
-    _metrics.buckets_per_visitor.inc(_visitorStatistics.getBucketsVisited());
-    _metrics.docs_per_visitor.inc(_visitorStatistics.getDocumentsVisited());
-    _metrics.bytes_per_visitor.inc(_visitorStatistics.getBytesVisited());
+    _metrics.buckets_per_visitor.addValue(_visitorStatistics.getBucketsVisited());
+    _metrics.docs_per_visitor.addValue(_visitorStatistics.getDocumentsVisited());
+    _metrics.bytes_per_visitor.addValue(_visitorStatistics.getBytesVisited());
 }
 
 void


### PR DESCRIPTION
@baldersheim Please review.

Turns out, inc() and addValue() have completely different semantics for
how values are actually aggregated. inc() maintains a running value
while addValue() treats each invocation as a separate sample (which is
what we want).

Not exactly what I would call intuitive, but at least it explains why the
visitor statistics metrics looked really weird.