### PR TITLE
Balder/vespamalloc should not depend on anything else

### DIFF
--- a/vespamalloc/CMakeLists.txt
+++ b/vespamalloc/CMakeLists.txt
@@ -3,7 +3,7 @@ add_compile_options(-fvisibility=hidden)
 add_definitions(-DPARANOID_LEVEL=0)
 
 vespa_define_module(
-    DEPENDS
+    TEST_DEPENDS
     fastos
     vespalib
     vespalog

--- a/vespamalloc/src/tests/allocfree/linklist.cpp
+++ b/vespamalloc/src/tests/allocfree/linklist.cpp
@@ -127,8 +127,6 @@ int Test::Main() {
     FastOS_ThreadPool      pool(128000);
     List::HeadPtr    sharedList;
     sharedList._tag = 1;
-    List::init();
-    List::enableThreadSupport();
     fprintf(stderr, "Start populating list\n");
     for (size_t i=0; i < NumBlocks; i++) {
         List * l(&globalList[i]);

--- a/vespamalloc/src/tests/allocfree/linklist.cpp
+++ b/vespamalloc/src/tests/allocfree/linklist.cpp
@@ -60,9 +60,9 @@ List globalList[NumBlocks];
 
 class LinkIn : public Consumer {
 public:
-    LinkIn(List::HeadPtr & list, uint32_t maxQueue, bool inverse);
+    LinkIn(List::AtomicHeadPtr & list, uint32_t maxQueue, bool inverse);
 private:
-    List::HeadPtr & _head;
+    List::AtomicHeadPtr & _head;
     virtual void consume(void * p) {
         List * l((List *) p);
         if ( ! ((l >= &globalList[0]) && (l < &globalList[NumBlocks]))) { abort(); }
@@ -70,7 +70,7 @@ private:
     }
 };
 
-LinkIn::LinkIn(List::HeadPtr & list, uint32_t maxQueue, bool inverse) :
+LinkIn::LinkIn(List::AtomicHeadPtr & list, uint32_t maxQueue, bool inverse) :
     Consumer (maxQueue, inverse),
     _head(list)
 {
@@ -80,10 +80,10 @@ LinkIn::LinkIn(List::HeadPtr & list, uint32_t maxQueue, bool inverse) :
 
 class LinkOut : public Producer {
 public:
-    LinkOut(List::HeadPtr & list, uint32_t cnt, LinkIn &target)
+    LinkOut(List::AtomicHeadPtr & list, uint32_t cnt, LinkIn &target)
         : Producer(cnt, target), _head(list) {}
 private:
-    List::HeadPtr & _head;
+    List::AtomicHeadPtr & _head;
     virtual void * produce()       {
         void *p = List::linkOut(_head);
         List *l((List *)p);
@@ -96,10 +96,10 @@ private:
 
 class LinkInOutAndIn : public ProducerConsumer {
 public:
-    LinkInOutAndIn(List::HeadPtr & list, uint32_t cnt, bool inverse)
+    LinkInOutAndIn(List::AtomicHeadPtr & list, uint32_t cnt, bool inverse)
         : ProducerConsumer(cnt, inverse), _head(list) { }
 private:
-    List::HeadPtr & _head;
+    List::AtomicHeadPtr & _head;
     virtual void * produce()       {
         void *p = List::linkOut(_head);
         List *l((List *)p);
@@ -125,8 +125,7 @@ int Test::Main() {
     ASSERT_EQUAL(1024ul, sizeof(List));
 
     FastOS_ThreadPool      pool(128000);
-    List::HeadPtr    sharedList;
-    sharedList._tag = 1;
+    List::AtomicHeadPtr    sharedList(List::HeadPtr(nullptr, 1));
     fprintf(stderr, "Start populating list\n");
     for (size_t i=0; i < NumBlocks; i++) {
         List * l(&globalList[i]);
@@ -141,7 +140,9 @@ int Test::Main() {
     List *n =  List::linkOut(sharedList);
     ASSERT_TRUE(n == NULL);
 
-    sharedList._tag = 1;
+    List::HeadPtr tmp(sharedList.load());
+    tmp._tag = 1;
+    sharedList.store(tmp);
     fprintf(stderr, "Start populating list\n");
     for (size_t i=0; i < NumBlocks; i++) {
         List * l(&globalList[i]);

--- a/vespamalloc/src/tests/test1/CMakeLists.txt
+++ b/vespamalloc/src/tests/test1/CMakeLists.txt
@@ -3,5 +3,6 @@ vespa_add_executable(vespamalloc_testatomic_app TEST
     SOURCES
     testatomic.cpp
     DEPENDS
+    atomic
 )
 vespa_add_test(NAME vespamalloc_testatomic_app NO_VALGRIND COMMAND vespamalloc_testatomic_app)

--- a/vespamalloc/src/tests/test1/testatomic.cpp
+++ b/vespamalloc/src/tests/test1/testatomic.cpp
@@ -110,8 +110,8 @@ int Test::Main()
         ASSERT_TRUE(uint64V.is_lock_free());
     }
     {
-        std::atomic<vespamalloc::Atomic::TaggedPtr> taggedPtr;
-        ASSERT_EQUAL(16, sizeof(vespamalloc::Atomic::TaggedPtr));
+        std::atomic<vespamalloc::TaggedPtr> taggedPtr;
+        ASSERT_EQUAL(16, sizeof(vespamalloc::TaggedPtr));
         ASSERT_TRUE(taggedPtr.is_lock_free());
     }
 

--- a/vespamalloc/src/tests/test1/testatomic.cpp
+++ b/vespamalloc/src/tests/test1/testatomic.cpp
@@ -1,10 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+#include <vespa/fastos/thread.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/atomic.h>
-#include <vector>
-
-using vespalib::Atomic;
+#include <vespamalloc/malloc/allocchunk.h>
 
 class Test : public vespalib::TestApp
 {
@@ -39,10 +37,10 @@ void Test::testSwap(T initial)
 {
     T value(initial);
 
-    ASSERT_TRUE(Atomic::cmpSwap(&value, initial+1, initial));
+    ASSERT_TRUE(vespalib::Atomic::cmpSwap(&value, initial+1, initial));
     ASSERT_TRUE(value == initial+1);
 
-    ASSERT_TRUE(!Atomic::cmpSwap(&value, initial+2, initial));
+    ASSERT_TRUE(!vespalib::Atomic::cmpSwap(&value, initial+2, initial));
     ASSERT_TRUE(value == initial+1);
 }
 
@@ -91,7 +89,7 @@ template <typename T>
 void Stress<T>::stressSwap(T & value)
 {
     for (T old = value; old > 0; old = value) {
-        if (Atomic::cmpSwap(&value, old-1, old)) {
+        if (vespalib::Atomic::cmpSwap(&value, old-1, old)) {
             _successCount++;
         } else {
             _failedCount++;
@@ -102,6 +100,20 @@ void Stress<T>::stressSwap(T & value)
 int Test::Main()
 {
     TEST_INIT("atomic");
+
+    {
+        std::atomic<uint32_t> uint32V;
+        ASSERT_TRUE(uint32V.is_lock_free());
+    }
+    {
+        std::atomic<uint64_t> uint64V;
+        ASSERT_TRUE(uint64V.is_lock_free());
+    }
+    {
+        std::atomic<vespamalloc::Atomic::TaggedPtr> taggedPtr;
+        ASSERT_EQUAL(16, sizeof(vespamalloc::Atomic::TaggedPtr));
+        ASSERT_TRUE(taggedPtr.is_lock_free());
+    }
 
     testSwap<uint32_t>(6);
     testSwap<uint32_t>(7);

--- a/vespamalloc/src/vespamalloc/malloc/allocchunk.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/allocchunk.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespamalloc/malloc/allocchunk.h>
+#include "allocchunk.h"
 
 namespace vespamalloc {
 
@@ -12,9 +12,7 @@ void AFListBase::init()
     _link =  new (_atomicLinkSpace)AtomicLink();
 }
 
-AFListBase::LinkI::~LinkI()
-{
-}
+AFListBase::LinkI::~LinkI() { }
 
 void AFListBase::linkInList(HeadPtr & head, AFListBase * list)
 {

--- a/vespamalloc/src/vespamalloc/malloc/allocchunk.h
+++ b/vespamalloc/src/vespamalloc/malloc/allocchunk.h
@@ -1,15 +1,66 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespamalloc/malloc/common.h>
+#include "common.h"
 #include <algorithm>
 
 namespace vespamalloc {
 
+#define ATOMIC_TAGGEDPTR_ALIGNMENT __attribute__ ((aligned (16)))
+
+/**
+ * Copied from vespalib to avoid code dependencies.
+ */
+class Atomic {
+public:
+    /**
+     * @brief Pointer and tag - use instead of bare pointer for cmpSwap()
+     *
+     * When making a lock-free data structure by using cmpSwap
+     * on pointers, you'll often run into the "ABA problem", see
+     * http://en.wikipedia.org/wiki/ABA_problem for details.
+     * The TaggedPtr makes it easy to do the woraround with tag bits,
+     * but requires the double-word compare-and-swap instruction.
+     * Very early Amd K7/8 CPUs are lacking this and will fail (Illegal Instruction).
+     **/
+    struct TaggedPtr {
+        TaggedPtr() : _ptr(nullptr), _tag(0) {}
+
+        TaggedPtr(void *h, size_t t) : _ptr(h), _tag(t) {}
+
+        void *_ptr;
+        size_t _tag;
+    };
+
+    static bool cmpSwap(volatile TaggedPtr *dest, TaggedPtr newVal, TaggedPtr oldVal) {
+        char result;
+        void *ptr;
+        size_t tag;
+#if defined(__x86_64__)
+        __asm__ volatile ("lock ;"
+                          "cmpxchg16b %8;"
+                          "setz %1;"
+                          : "=m" (*dest),
+                            "=q" (result),
+                            "=a" (ptr),
+                            "=d" (tag)
+                          : "a" (oldVal._ptr),
+                            "d" (oldVal._tag),
+                            "b" (newVal._ptr),
+                            "c" (newVal._tag),
+                            "m" (*dest)
+                          : "memory");
+#else
+#error "Only supports X86_64"
+#endif
+        return result;
+    }
+};
+
 class AFListBase
 {
 public:
-    typedef Atomic::TaggedPtr HeadPtr;
+    using HeadPtr = Atomic::TaggedPtr;
     AFListBase() : _next(NULL) { }
     void setNext(AFListBase * csl)           { _next = csl; }
     static void init();

--- a/vespamalloc/src/vespamalloc/malloc/allocchunk.h
+++ b/vespamalloc/src/vespamalloc/malloc/allocchunk.h
@@ -24,9 +24,8 @@ public:
      * Very early Amd K7/8 CPUs are lacking this and will fail (Illegal Instruction).
      **/
     struct TaggedPtr {
-        TaggedPtr() : _ptr(nullptr), _tag(0) {}
-
-        TaggedPtr(void *h, size_t t) : _ptr(h), _tag(t) {}
+        TaggedPtr() noexcept : _ptr(nullptr), _tag(0) { }
+        TaggedPtr(void *h, size_t t) noexcept : _ptr(h), _tag(t) {}
 
         void *_ptr;
         size_t _tag;
@@ -64,41 +63,12 @@ public:
     AFListBase() : _next(NULL) { }
     void setNext(AFListBase * csl)           { _next = csl; }
     static void init();
-    static void enableThreadSupport()   { _link->enableThreadSupport(); }
     static void linkInList(HeadPtr & head, AFListBase * list);
-    static void linkIn(HeadPtr & head, AFListBase * csl, AFListBase * tail) {
-        _link->linkIn(head, csl, tail);
-    }
+    static void linkIn(HeadPtr & head, AFListBase * csl, AFListBase * tail);
 protected:
     AFListBase * getNext()                      { return _next; }
-    static AFListBase * linkOut(HeadPtr & head) { return _link->linkOut(head); }
+    static AFListBase * linkOut(HeadPtr & head);
 private:
-    class LinkI
-    {
-    public:
-        virtual ~LinkI();
-        virtual void enableThreadSupport() { }
-        virtual void linkIn(HeadPtr & head, AFListBase * csl, AFListBase * tail) = 0;
-        virtual AFListBase * linkOut(HeadPtr & head) = 0;
-    };
-    class AtomicLink : public LinkI
-    {
-    private:
-        virtual void linkIn(HeadPtr & head, AFListBase * csl, AFListBase * tail);
-        virtual AFListBase * linkOut(HeadPtr & head);
-    };
-    class LockedLink : public LinkI
-    {
-    public:
-        virtual void enableThreadSupport() { _mutex.init(); }
-    private:
-        virtual void linkIn(HeadPtr & head, AFListBase * csl, AFListBase * tail);
-        virtual AFListBase * linkOut(HeadPtr & head);
-        Mutex _mutex;
-    };
-    static char _atomicLinkSpace[sizeof(AtomicLink)];
-    static char _lockedLinkSpace[sizeof(LockedLink)];
-    static LinkI     *_link;
     AFListBase       *_next;
 };
 

--- a/vespamalloc/src/vespamalloc/malloc/common.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/common.cpp
@@ -1,10 +1,10 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespamalloc/malloc/common.h>
+#include "common.h"
 #include <pthread.h>
 
 namespace vespamalloc {
 
-uint32_t Mutex::_threadCount = 0;
+std::atomic<uint32_t> Mutex::_threadCount(0);
 bool     Mutex::_stopRecursion = true;
 
 void Mutex::lock()

--- a/vespamalloc/src/vespamalloc/malloc/datasegment.h
+++ b/vespamalloc/src/vespamalloc/malloc/datasegment.h
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <limits.h>
+#include <climits>
 #include <memory>
 #include <vespamalloc/malloc/common.h>
 #include <vespamalloc/util/traceutil.h>

--- a/vespamalloc/src/vespamalloc/malloc/globalpool.h
+++ b/vespamalloc/src/vespamalloc/malloc/globalpool.h
@@ -46,8 +46,8 @@ private:
     {
     public:
         AllocFree() : _full(), _empty() { }
-        typename ChunkSList::HeadPtr _full;
-        typename ChunkSList::HeadPtr _empty;
+        typename ChunkSList::AtomicHeadPtr _full;
+        typename ChunkSList::AtomicHeadPtr _empty;
     };
     class Stat
     {
@@ -73,7 +73,7 @@ private:
 
     Mutex                       _mutex;
     ChunkSList                * _chunkPool;
-    AllocFree                   _scList[NUM_SIZE_CLASSES] ATOMIC_TAGGEDPTR_ALIGNMENT;
+    AllocFree                   _scList[NUM_SIZE_CLASSES];
     DataSegment<MemBlockPtrT> & _dataSegment;
     std::atomic<size_t>         _getChunks;
     size_t                      _getChunksSum;

--- a/vespamalloc/src/vespamalloc/malloc/globalpool.h
+++ b/vespamalloc/src/vespamalloc/malloc/globalpool.h
@@ -1,9 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespamalloc/malloc/common.h>
-#include <vespamalloc/malloc/allocchunk.h>
-#include <vespamalloc/malloc/datasegment.h>
+#include "common.h"
+#include "allocchunk.h"
+#include "datasegment.h"
 #include <algorithm>
 
 #define USE_STAT2(a) a
@@ -58,13 +58,13 @@ private:
                  _exchangeFree(0),
                  _exactAlloc(0),
                  _return(0),_malloc(0) { }
-        size_t _getAlloc;
-        size_t _getFree;
-        size_t _exchangeAlloc;
-        size_t _exchangeFree;
-        size_t _exactAlloc;
-        size_t _return;
-        size_t _malloc;
+        std::atomic<size_t> _getAlloc;
+        std::atomic<size_t> _getFree;
+        std::atomic<size_t> _exchangeAlloc;
+        std::atomic<size_t> _exchangeFree;
+        std::atomic<size_t> _exactAlloc;
+        std::atomic<size_t> _return;
+        std::atomic<size_t> _malloc;
         bool isUsed()       const {
             // Do not count _getFree.
             return (_getAlloc || _exchangeAlloc || _exchangeFree || _exactAlloc || _return || _malloc);
@@ -73,11 +73,11 @@ private:
 
     Mutex                       _mutex;
     ChunkSList                * _chunkPool;
-    AllocFree                   _scList[NUM_SIZE_CLASSES] VESPALIB_ATOMIC_TAGGEDPTR_ALIGNMENT;
+    AllocFree                   _scList[NUM_SIZE_CLASSES] ATOMIC_TAGGEDPTR_ALIGNMENT;
     DataSegment<MemBlockPtrT> & _dataSegment;
-    size_t                      _getChunks;
+    std::atomic<size_t>         _getChunks;
     size_t                      _getChunksSum;
-    size_t                      _allocChunkList;
+    std::atomic<size_t>         _allocChunkList;
     Stat                        _stat[NUM_SIZE_CLASSES];
     static size_t               _threadCacheLimit __attribute__((visibility("hidden")));
     static size_t               _alwaysReuseLimit __attribute__((visibility("hidden")));

--- a/vespamalloc/src/vespamalloc/malloc/globalpool.hpp
+++ b/vespamalloc/src/vespamalloc/malloc/globalpool.hpp
@@ -20,7 +20,6 @@ AllocPoolT<MemBlockPtrT>::AllocPoolT(DataSegment<MemBlockPtrT> & ds)
       _getChunksSum(0),
       _allocChunkList(0)
 {
-    ChunkSList::init();
     memset(_scList, 0, sizeof(_scList));
 }
 
@@ -32,7 +31,6 @@ AllocPoolT<MemBlockPtrT>::~AllocPoolT()
 template <typename MemBlockPtrT>
 void AllocPoolT<MemBlockPtrT>::enableThreadSupport()
 {
-    ChunkSList::enableThreadSupport();
     _mutex.init();
 }
 

--- a/vespamalloc/src/vespamalloc/malloc/memorywatcher.h
+++ b/vespamalloc/src/vespamalloc/malloc/memorywatcher.h
@@ -7,7 +7,6 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include <fcntl.h>
-#include <vespa/defaults.h>
 #include <vespamalloc/malloc/malloc.h>
 #include <vespamalloc/util/callstack.h>
 

--- a/vespamalloc/src/vespamalloc/malloc/mmap.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/mmap.cpp
@@ -4,7 +4,6 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <vespa/vespalib/util/backtrace.h>
 
 extern "C" {
 
@@ -57,7 +56,7 @@ void * local_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t 
         }
     }
     if ((length >= getLogLimit()) && !isFromVespaMalloc(addr)) {
-        fprintf (stderr, "mmap requesting block of size %ld from %s\n", length, vespalib::getStackTrace(0).c_str());
+        fprintf (stderr, "mmap requesting block of size %ld from %s\n", length, "no backtrace");
     }
     return (*real_func)(addr, length, prot, flags, fd, offset);
 }
@@ -73,7 +72,7 @@ void * local_mmap64(void *addr, size_t length, int prot, int flags, int fd, off6
         }
     }
     if (length >= getLogLimit() && !isFromVespaMalloc(addr)) {
-        fprintf (stderr, "mmap requesting block of size %ld from %s\n", length, vespalib::getStackTrace(0).c_str());
+        fprintf (stderr, "mmap requesting block of size %ld from %s\n", length, "no backtrace");
     }
     return (*real_func)(addr, length, prot, flags, fd, offset);
 }
@@ -89,7 +88,7 @@ int local_munmap(void *addr, size_t length)
         }
     }
     if ((length >= getLogLimit()) && !isFromVespaMalloc(addr)) {
-        fprintf (stderr, "munmap releasing block of size %ld from %s\n", length, vespalib::getStackTrace(0).c_str());
+        fprintf (stderr, "munmap releasing block of size %ld from %s\n", length, "no backtrace");
     }
     return (*real_func)(addr, length);
 }

--- a/vespamalloc/src/vespamalloc/malloc/threadlist.h
+++ b/vespamalloc/src/vespamalloc/malloc/threadlist.h
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespamalloc/malloc/threadpool.h>
+#include "threadpool.h"
 
 namespace vespamalloc {
 
@@ -41,8 +41,8 @@ private:
     ThreadListT & operator = (const ThreadListT & tl);
     enum {ThreadStackSize=2048*1024};
     volatile bool              _isThreaded;
-    volatile size_t            _threadCount;
-    volatile size_t            _threadCountAccum;
+    std::atomic<size_t>        _threadCount;
+    std::atomic<size_t>        _threadCountAccum;
     ThreadPool                 _threadVector[NUM_THREADS];
     AllocPoolT<MemBlockPtrT> & _allocPool;
     static __thread ThreadPool * _myPool TLS_LINKAGE;

--- a/vespamalloc/src/vespamalloc/malloc/threadlist.hpp
+++ b/vespamalloc/src/vespamalloc/malloc/threadlist.hpp
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespamalloc/malloc/threadlist.h>
+#include "threadlist.h"
 
 namespace vespamalloc {
 
@@ -48,7 +48,7 @@ bool ThreadListT<MemBlockPtrT, ThreadStatT>::quitThisThread()
 {
     ThreadPool & tp = getCurrent();
     tp.quit();
-    Atomic::postDec(&_threadCount);
+    _threadCount.fetch_sub(1);
     return true;
 }
 
@@ -56,8 +56,8 @@ template <typename MemBlockPtrT, typename ThreadStatT>
 bool ThreadListT<MemBlockPtrT, ThreadStatT>::initThisThread()
 {
     bool retval(true);
-    Atomic::postInc(&_threadCount);
-    size_t lidAccum = Atomic::postInc(&_threadCountAccum);
+    _threadCount.fetch_add(1);
+    size_t lidAccum = _threadCountAccum.fetch_add(1);
     long localId(-1);
     for(size_t i = 0; (localId < 0) && (i < getMaxNumThreads()); i++) {
         ThreadPool & tp = _threadVector[i];

--- a/vespamalloc/src/vespamalloc/malloc/threadproxy.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/threadproxy.cpp
@@ -1,6 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "threadproxy.h"
 #include <dlfcn.h>
+#include <stdio.h>
+#include <errno.h>
+#include <pthread.h>
 
 namespace vespamalloc {
 

--- a/vespamalloc/src/vespamalloc/malloc/threadproxy.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/threadproxy.cpp
@@ -1,9 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespamalloc/malloc/threadproxy.h>
+#include "threadproxy.h"
 #include <dlfcn.h>
-#include <pthread.h>
-#include <cstdio>
-#include <cerrno>
 
 namespace vespamalloc {
 
@@ -34,7 +31,7 @@ typedef int (*pthread_create_function) (pthread_t *thread,
 int linuxthreads_pthread_getattr_np(pthread_t pid, pthread_attr_t *dst);
 
 static void * _G_mallocThreadProxyReturnAddress = NULL;
-static volatile size_t _G_threadCount = 1;  // You always have the main thread.
+static volatile std::atomic<size_t> _G_threadCount(1);  // You always have the main thread.
 
 static void cleanupThread(void * arg)
 {
@@ -42,7 +39,7 @@ static void cleanupThread(void * arg)
     delete ta;
     vespamalloc::_G_myMemP->quitThisThread();
     vespamalloc::Mutex::subThread();
-    vespalib::Atomic::postDec(&_G_threadCount);
+    _G_threadCount.fetch_sub(1);
 }
 
 void * mallocThreadProxy (void * arg)
@@ -79,7 +76,7 @@ VESPA_DLL_EXPORT int local_pthread_create (pthread_t *thread,
 {
     size_t numThreads;
     for (numThreads = _G_threadCount
-        ;(numThreads < vespamalloc::_G_myMemP->getMaxNumThreads()) && ! vespalib::Atomic::cmpSwap(&_G_threadCount, numThreads+1, numThreads)
+        ;(numThreads < vespamalloc::_G_myMemP->getMaxNumThreads()) && ! _G_threadCount.compare_exchange_strong(numThreads, numThreads+1)
         ; numThreads = _G_threadCount) {
     }
     if (numThreads >= vespamalloc::_G_myMemP->getMaxNumThreads()) {

--- a/vespamalloc/src/vespamalloc/malloc/threadproxy.h
+++ b/vespamalloc/src/vespamalloc/malloc/threadproxy.h
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespamalloc/malloc/common.h>
+#include "common.h"
 
 namespace vespamalloc {
 

--- a/vespamalloc/src/vespamalloc/util/index.h
+++ b/vespamalloc/src/vespamalloc/util/index.h
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespa/vespalib/util/atomic.h>
+#include <atomic>
 #include <stdio.h>
 
 namespace vespamalloc {
@@ -26,12 +26,12 @@ public:
     typedef size_t index_t;
     AtomicIndex(index_t index = 0) : _index(index) { }
     operator index_t ()       const { return _index; }
-    index_t operator ++ (int)       { return vespalib::Atomic::postInc(&_index); }
-    index_t operator -- (int)       { return vespalib::Atomic::postDec(&_index); }
-    index_t operator += (index_t v) { return _index += v; }
-    index_t operator -= (index_t v) { return _index -= v; }
+    index_t operator ++ (int)       { return _index.fetch_add(1); }
+    index_t operator -- (int)       { return _index.fetch_sub(1); }
+    index_t operator += (index_t v) { return _index.fetch_add(v); }
+    index_t operator -= (index_t v) { return _index.fetch_sub(v); }
 private:
-    index_t _index;
+    std::atomic<index_t> _index;
 };
 
 }

--- a/vespamalloc/src/vespamalloc/util/osmem.h
+++ b/vespamalloc/src/vespamalloc/util/osmem.h
@@ -1,11 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <ctype.h>
-#include <stdlib.h>
+#include <cctype>
+#include <cstdlib>
 #include <unistd.h>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include <algorithm>
 
 namespace vespamalloc {


### PR DESCRIPTION
@vekterli Here is one in your alley.  I am now using std::atomic decoupling all code from any vespa other modules. Still dependencies on test framework.