### PR TITLE
Fix docker core dump reporting

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/CoredumpHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/CoredumpHandler.java
@@ -59,6 +59,7 @@ public class CoredumpHandler {
                 .filter(path -> path.toFile().isFile() && ! path.getFileName().toString().startsWith("."))
                 .forEach(coredumpPath -> {
                     try {
+                        coredumpPath.toFile().setReadable(true, false);
                         coredumpPath = startProcessing(coredumpPath, processingCoredumpsPath);
 
                         Path metadataPath = coredumpPath.getParent().resolve(METADATA_FILE_NAME);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/Maintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/Maintainer.java
@@ -182,8 +182,6 @@ public class Maintainer {
             ContainerName containerName = new ContainerName(container);
 
             Logger logger = Logger.getLogger(ArchiveApplicationData.class.getName());
-            Maintainer maintainer = new Maintainer();
-
             File yVarDir = environment.pathInNodeAdminFromPathInNode(containerName, "/home/y/var").toFile();
             if (yVarDir.exists()) {
                 logger.info("Recursively deleting " + yVarDir);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 public class RunVespaLocal {
     private static final Environment.Builder environmentBuilder = new Environment.Builder()
             .configServerHosts(LocalZoneUtils.CONFIG_SERVER_HOSTNAME)
-            .environment("prod")
+            .environment("dev")
             .region("vespa-local")
             .parentHostHostname(HostName.getLocalhost())
             .inetAddressResolver(new InetAddressResolver());
@@ -144,6 +144,7 @@ public class RunVespaLocal {
     }
 
     void deleteApplication() {
+        logger.info("Deleting application");
         LocalZoneUtils.deleteApplication();
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/maintenance/CoreCollectorTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/maintenance/CoreCollectorTest.java
@@ -105,11 +105,11 @@ public class CoreCollectorTest {
 
     @Test
     public void extractsBacktraceUsingGdb() throws IOException, InterruptedException {
-        mockExec(new String[]{"/home/y/bin64/gdb -n -ex bt -batch /usr/bin/program /tmp/core.1234"},
+        mockExec(new String[]{"/home/y/bin64/gdb", "-n", "-ex", "bt", "-batch", "/usr/bin/program", "/tmp/core.1234"},
                 String.join("\n", GDB_BACKTRACE));
         assertEquals(GDB_BACKTRACE, coreCollector.readBacktrace(TEST_CORE_PATH, TEST_BIN_PATH, false));
 
-        mockExec(new String[]{"/home/y/bin64/gdb -n -ex bt -batch /usr/bin/program /tmp/core.1234"},
+        mockExec(new String[]{"/home/y/bin64/gdb", "-n", "-ex", "bt", "-batch", "/usr/bin/program", "/tmp/core.1234"},
                 "", "Failure");
         try {
             coreCollector.readBacktrace(TEST_CORE_PATH, TEST_BIN_PATH, false);
@@ -121,7 +121,8 @@ public class CoreCollectorTest {
 
     @Test
     public void extractsBacktraceFromAllThreadsUsingGdb() throws IOException, InterruptedException {
-        mockExec(new String[]{"/home/y/bin64/gdb -n -ex thread apply all bt -batch /usr/bin/program /tmp/core.1234"},
+        mockExec(new String[]{"/home/y/bin64/gdb", "-n", "-ex", "thread apply all bt", "-batch",
+                        "/usr/bin/program", "/tmp/core.1234"},
                 String.join("\n", GDB_BACKTRACE));
         assertEquals(GDB_BACKTRACE, coreCollector.readBacktrace(TEST_CORE_PATH, TEST_BIN_PATH, true));
     }
@@ -131,9 +132,10 @@ public class CoreCollectorTest {
         mockExec(new String[]{"file", TEST_CORE_PATH.toString()},
                 "/tmp/core.1234: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, from " +
                         "'/usr/bin/program'");
-        mockExec(new String[]{"/home/y/bin64/gdb -n -ex bt -batch /usr/bin/program /tmp/core.1234"},
+        mockExec(new String[]{"/home/y/bin64/gdb", "-n", "-ex", "bt", "-batch", "/usr/bin/program", "/tmp/core.1234"},
                 String.join("\n", GDB_BACKTRACE));
-        mockExec(new String[]{"/home/y/bin64/gdb -n -ex thread apply all bt -batch /usr/bin/program /tmp/core.1234"},
+        mockExec(new String[]{"/home/y/bin64/gdb", "-n", "-ex", "thread apply all bt", "-batch",
+                        "/usr/bin/program", "/tmp/core.1234"},
                 String.join("\n", GDB_BACKTRACE));
 
         Map<String, Object> expectedData = new HashMap<>();


### PR DESCRIPTION
* Compresses uncompressed core dumps
* Fixes `gdb` argument splitting 

See `VESPA-6066` for sample report