### PR TITLE
Freva/disable image gc locally

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -93,13 +93,15 @@ public class DockerImpl implements Docker {
                 true, /* fallback to 1.23 on errors */
                 metricReceiver);
 
-        Duration minAgeToDelete = Duration.ofMinutes(config.imageGCMinTimeToLiveMinutes());
-        dockerImageGC = Optional.of(new DockerImageGarbageCollector(minAgeToDelete));
+        if (! config.isRunningLocally()) {
+            Duration minAgeToDelete = Duration.ofMinutes(config.imageGCMinTimeToLiveMinutes());
+            dockerImageGC = Optional.of(new DockerImageGarbageCollector(minAgeToDelete));
 
-        try {
-            setupDockerNetworkIfNeeded();
-        } catch (Exception e) {
-            throw new RuntimeException("Could not setup docker network", e);
+            try {
+                setupDockerNetworkIfNeeded();
+            } catch (Exception e) {
+                throw new RuntimeException("Could not setup docker network", e);
+            }
         }
     }
 

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -27,8 +27,7 @@ public class DockerTestUtils {
             .clientKeyPath( operatingSystem == OS.Mac_OS_X ? prefix + "key.pem" : "")
             .uri(           operatingSystem == OS.Mac_OS_X ? "tcp://192.168.99.100:2376" : "tcp://localhost:2376")
             .connectTimeoutMillis(100)
-            .secondsToWaitBeforeKillingContainer(0)
-            .imageGCEnabled(false));
+            .secondsToWaitBeforeKillingContainer(0));
     private static DockerImpl docker;
 
     public static boolean dockerDaemonIsPresent() {
@@ -53,7 +52,6 @@ public class DockerTestUtils {
             docker = new DockerImpl(
                     dockerConfig,
                     false, /* fallback to 1.23 on errors */
-                    false, /* try setup network */
                     new MetricReceiverWrapper(MetricReceiver.nullImplementation));
             createDockerTestNetworkIfNeeded(docker);
         }

--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -12,5 +12,4 @@ maxTotalConnections int default = 100
 connectTimeoutMillis int default = 100000 # 100 sec
 readTimeoutMillis int default = 1800000 # 30 min
 
-imageGCEnabled bool default = true
 imageGCMinTimeToLiveMinutes int default = 45

--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -12,4 +12,5 @@ maxTotalConnections int default = 100
 connectTimeoutMillis int default = 100000 # 100 sec
 readTimeoutMillis int default = 1800000 # 30 min
 
+isRunningLocally bool default = false
 imageGCMinTimeToLiveMinutes int default = 45

--- a/node-admin/src/main/application/services.xml
+++ b/node-admin/src/main/application/services.xml
@@ -12,6 +12,7 @@
 
     <config name='vespa.hosted.dockerapi.docker'>
       <uri>tcp://localhost:2376</uri>
+      <isRunningLocally>false</isRunningLocally>
     </config>
 
     <config name='vespa.hosted.node.admin.node-admin'>


### PR DESCRIPTION
* Simplifies `DockerImpl` constructor used in local testing
* Replaces `imageGCEnabled` with `isRunningLocally` option - same as in `NodeAdminConfig` to disable docker image GC and setting up macvlan network
* Adds `<isRunningLocally>` tag for `dockerapi` in `services.xml` to disable image GC when running locally (See [LocalZoneUtils.java:147](https://github.com/yahoo/vespa/blob/master/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java#L147))