### PR TITLE
Move node from provisioned to dirty

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NoSuchNodeException.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NoSuchNodeException.java
@@ -6,10 +6,8 @@ package com.yahoo.vespa.hosted.provision;
  *
  * @author musum
  */
-public class NotFoundException extends RuntimeException {
+public class NoSuchNodeException extends RuntimeException {
 
-    public NotFoundException(String message) { super(message); }
-
-    public NotFoundException(String message, Throwable cause) { super(message, cause); }
+    public NoSuchNodeException(String message) { super(message); }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
  * @author bratseth
  */
 // Node state transitions:
-// 1) (new) - > provisioned -> ready -> reserved -> active -> inactive -> dirty -> ready
+// 1) (new) - > provisioned -> dirty -> ready -> reserved -> active -> inactive -> dirty -> ready
 // 2) inactive -> reserved
 // 3) reserved -> dirty
 // 3) * -> failed | parked -> dirty | active | (removed)
@@ -201,7 +201,7 @@ public class NodeRepository extends AbstractComponent {
         }
     }
 
-    /** Sets a list of nodes ready and returns the nodes in the ready state */
+    // Visible for testing purposes
     public List<Node> setReady(List<Node> nodes) {
         for (Node node : nodes)
             if (node.state() != Node.State.provisioned && node.state() != Node.State.dirty)
@@ -209,6 +209,28 @@ public class NodeRepository extends AbstractComponent {
         try (Mutex lock = lockUnallocated()) {
             return zkClient.writeTo(Node.State.ready, nodes);
         }
+    }
+
+    /**
+     * Set a node ready. The node may be moved to a intermediate state (e.g. dirty) and require a subsequent call to
+     * move to ready.
+     */
+    public Node setReady(Node node) {
+        List<Node.State> legalStates = Arrays.asList(Node.State.provisioned, Node.State.dirty, Node.State.failed, Node.State.parked);
+        if (!legalStates.contains(node.state())) {
+            throw new IllegalArgumentException("Could not set " + node.hostname() + " ready: Not registered as provisioned, " +
+                    "dirty, failed or parked");
+        }
+        if (node.allocation().isPresent()) {
+            throw new IllegalArgumentException("Could not set " + node.hostname() + " ready: Node is allocated and must be " +
+                    "moved to dirty instead");
+        }
+        // Provisioned nodes are moved to dirty. This ensures that any user data is cleaned up and that all packages and
+        // kernel are upgraded.
+        if (node.state() == Node.State.provisioned) {
+            return deallocate(Collections.singletonList(node)).get(0);
+        }
+        return setReady(Collections.singletonList(node)).get(0);
     }
 
     /** Reserve nodes. This method does <b>not</b> lock the node repository */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -297,7 +297,7 @@ public class NodeRepository extends AbstractComponent {
      * Fails this node and returns it in its new state.
      *
      * @return the node in its new state
-     * @throws NotFoundException if the node is not found
+     * @throws NoSuchNodeException if the node is not found
      */
     public Node fail(String hostname) {
         return move(hostname, Node.State.failed);
@@ -307,7 +307,7 @@ public class NodeRepository extends AbstractComponent {
      * Parks this node and returns it in its new state.
      *
      * @return the node in its new state
-     * @throws NotFoundException if the node is not found
+     * @throws NoSuchNodeException if the node is not found
      */
     public Node park(String hostname) {
         return move(hostname, Node.State.parked);
@@ -317,7 +317,7 @@ public class NodeRepository extends AbstractComponent {
      * Moves a previously failed or parked node back to the active state.
      *
      * @return the node in its new state
-     * @throws NotFoundException if the node is not found
+     * @throws NoSuchNodeException if the node is not found
      */
     public Node reactivate(String hostname) {
         return move(hostname, Node.State.active);
@@ -326,7 +326,7 @@ public class NodeRepository extends AbstractComponent {
     public Node move(String hostname, Node.State toState) {
         Optional<Node> node = getNode(hostname);
         if ( ! node.isPresent())
-            throw new NotFoundException("Could not move " + hostname + " to " + toState + ": Node not found");
+            throw new NoSuchNodeException("Could not move " + hostname + " to " + toState + ": Node not found");
         try (Mutex lock = lock(node.get())) {
             return zkClient.writeTo(toState, node.get());
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -27,7 +27,6 @@ import com.yahoo.yolean.Exceptions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -95,7 +94,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
         String path = request.getUri().getPath();
         // Check paths to disallow illegal state changes
         if (path.startsWith("/nodes/v2/state/ready/")) {
-            return new MessageResponse(setNodeReady(path));
+            return new MessageResponse(maybeSetNodeReady(path));
         }
         else if (path.startsWith("/nodes/v2/state/failed/")) {
             nodeRepository.fail(lastElement(path));
@@ -216,22 +215,17 @@ public class NodesApiHandler extends LoggingRequestHandler {
         }
     }
 
-    // TODO: Move most of this to node repo
-    public String setNodeReady(String path) {
+    private String maybeSetNodeReady(String path) {
         String hostname = lastElement(path);
-        if ( nodeRepository.getNode(hostname, Node.State.ready).isPresent())
+        Optional<Node> node = nodeRepository.getNode(hostname);
+        if (!node.isPresent()) {
+            throw new NotFoundException("No node with hostname '" + hostname + "'");
+        }
+        if (node.get().state() == Node.State.ready) {
             return "Nothing done; " + hostname + " is already ready";
-
-        Optional<Node> node = nodeRepository.getNode(hostname, Node.State.provisioned, Node.State.dirty, Node.State.failed, Node.State.parked);
-
-        if ( ! node.isPresent())
-            throw new IllegalArgumentException("Could not set " + hostname + " ready: Not registered as provisioned, dirty, failed or parked");
-
-        if (node.get().allocation().isPresent())
-            throw new IllegalArgumentException("Could not set " + hostname + " ready: Node is allocated and must be moved to dirty instead");
-
-        nodeRepository.setReady(Collections.singletonList(node.get()));
-        return "Moved " + hostname + " to ready";
+        }
+        Node updatedNode = nodeRepository.setReady(node.get());
+        return "Moved " + hostname + " to " + updatedNode.state().name();
     }
 
     public static NodeFilter toNodeFilter(HttpRequest request) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -12,6 +12,7 @@ import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
 import com.yahoo.vespa.config.SlimeUtils;
+import com.yahoo.vespa.hosted.provision.NoSuchNodeException;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.NodeFlavors;
@@ -66,7 +67,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
                 case PATCH: return handlePATCH(request);
                 default: return ErrorResponse.methodNotAllowed("Method '" + request.getMethod() + "' is not supported");
             }
-        } catch (NotFoundException | com.yahoo.vespa.hosted.provision.NotFoundException e) {
+        } catch (NotFoundException | NoSuchNodeException e) {
             return ErrorResponse.notFoundError(Exceptions.toMessageString(e));
         } catch (IllegalArgumentException e) {
             return ErrorResponse.badRequest(Exceptions.toMessageString(e));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -82,16 +82,21 @@ public class RestApiTest {
         assertFile(new Request("http://localhost:8080/nodes/v2/node/host11.yahoo.com"), "node11.json");
         assertFile(new Request("http://localhost:8080/nodes/v2/node/parent2.yahoo.com"), "parent2.json");
 
-        // PUT nodes ready
+        // PUT provisioned node ready moves the node to dirty
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/host8.yahoo.com",
                                    new byte[0], Request.Method.PUT),
-                       "{\"message\":\"Moved host8.yahoo.com to ready\"}");
+                       "{\"message\":\"Moved host8.yahoo.com to dirty\"}");
         assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/host8.yahoo.com"),
-                                           "\"state\":\"ready\"");
-        // calling ready again is a noop:
+                                           "\"state\":\"dirty\"");
+        // calling ready again readies the node
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/host8.yahoo.com",
                                   new byte[0], Request.Method.PUT),
-                       "{\"message\":\"Nothing done; host8.yahoo.com is already ready\"}");
+                "{\"message\":\"Moved host8.yahoo.com to ready\"}");
+
+        // calling ready again is a noop:
+        assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/host8.yahoo.com",
+                        new byte[0], Request.Method.PUT),
+                "{\"message\":\"Nothing done; host8.yahoo.com is already ready\"}");
 
         // PUT a node in failed ...
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/failed/host8.yahoo.com",
@@ -250,7 +255,7 @@ public class RestApiTest {
                 "{\"message\":\"Added 1 nodes to the provisioned state\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/" + hostname,
                                    new byte[0], Request.Method.PUT),
-                       "{\"message\":\"Moved foo.yahoo.com to ready\"}");
+                       "{\"message\":\"Moved foo.yahoo.com to dirty\"}");
         Pattern responsePattern = Pattern.compile("\\{\"trustedNodes\":\\[" +
                 "\\{\"hostname\":\"cfg1\",\"ipAddress\":\".+?\"}," +
                 "\\{\"hostname\":\"cfg2\",\"ipAddress\":\".+?\"}," +


### PR DESCRIPTION
I attempted to make the change to `setReady(List<Node> nodes)` directly, but it broke a lot of tests which assume that they can ready provisioned nodes. The method seems to only be used by tests.