### PR TITLE
Disable deprecation warnings from lz4.

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -20,7 +20,7 @@ set(AUTORUN_UNIT_TESTS FALSE CACHE BOOL "If TRUE, tests will be run immediately 
 set(WARN_OPTS "-Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wcomment -Wformat -Wparentheses -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings")
 
 # C and C++ compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -march=westmere -mtune=intel")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -DLZ4_DISABLE_DEPRECATE_WARNINGS -march=westmere -mtune=intel")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} -Wnon-virtual-dtor -fvisibility-inlines-hidden -fdiagnostics-color=auto")
 

--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -20,7 +20,7 @@ set(AUTORUN_UNIT_TESTS FALSE CACHE BOOL "If TRUE, tests will be run immediately 
 set(WARN_OPTS "-Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wcomment -Wformat -Wparentheses -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings")
 
 # C and C++ compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -DLZ4_DISABLE_DEPRECATE_WARNINGS -march=westmere -mtune=intel")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -march=westmere -mtune=intel")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} -Wnon-virtual-dtor -fvisibility-inlines-hidden -fdiagnostics-color=auto")
 

--- a/config/src/tests/frt/CMakeLists.txt
+++ b/config/src/tests/frt/CMakeLists.txt
@@ -8,3 +8,5 @@ vespa_add_executable(config_frt_test_app TEST
 vespa_add_test(NAME config_frt_test_app COMMAND config_frt_test_app)
 vespa_generate_config(config_frt_test_app ../../test/resources/configdefinitions/my.def)
 vespa_generate_config(config_frt_test_app ../../test/resources/configdefinitions/bar.def)
+
+set_source_files_properties(frt.cpp PROPERTIES COMPILE_FLAGS -DLZ4_DISABLE_DEPRECATE_WARNINGS)

--- a/document/src/vespa/document/util/CMakeLists.txt
+++ b/document/src/vespa/document/util/CMakeLists.txt
@@ -10,3 +10,5 @@ vespa_add_library(document_util OBJECT
     AFTER
     document_documentconfig
 )
+
+set_source_files_properties(compressor.cpp PROPERTIES COMPILE_FLAGS -DLZ4_DISABLE_DEPRECATE_WARNINGS)


### PR DESCRIPTION
lz4 on Cent OS 7 has deprecated some of the methods used by Vespa. Disable the deprecation warnings for now to avoid compile errors with -Werror.
@baldersheim 