### PR TITLE
Use Jetty 9.3.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.3.14.v20161028</jetty.version>
+        <jetty.version>9.3.15.v20161220</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>


### PR DESCRIPTION
Jetty released 9.3.15 December 20th (see http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00099.html).