### PR TITLE
Freva/remove redundant throws

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerInfoImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerInfoImpl.java
@@ -18,9 +18,8 @@ class ContainerInfoImpl implements Docker.ContainerInfo {
     @Override
     public Optional<Integer> getPid() {
         InspectContainerResponse.ContainerState state = inspectContainerResponse.getState();
-        Integer containerPid = -1;
         if (state.getRunning()) {
-            containerPid = state.getPid();
+            Integer containerPid = state.getPid();
             if (containerPid == null) {
                 throw new RuntimeException("PID of running container " + containerName + " is null");
             }

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -120,7 +120,7 @@ public class DockerImpl implements Docker {
         return dockerConfigBuilder;
     }
 
-    private void setupDockerNetworkIfNeeded() throws IOException, InterruptedException {
+    private void setupDockerNetworkIfNeeded() throws IOException {
         if (! dockerClient.listNetworksCmd().withNameFilter(DOCKER_CUSTOM_MACVLAN_NETWORK_NAME).exec().isEmpty()) return;
 
         // Use IPv6 address if there is a mix of IP4 and IPv6 by taking the longest address.

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerNetworkCreator.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerNetworkCreator.java
@@ -11,10 +11,10 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 
 /**
- * @author valerijf
+ * @author freva
  */
 class DockerNetworkCreator {
-    static InetAddress getDefaultGatewayLinux(boolean ipv6) throws IOException, InterruptedException {
+    static InetAddress getDefaultGatewayLinux(boolean ipv6) throws IOException {
         String command = ipv6 ? "route -A inet6 -n | grep 'UG[ \t]' | awk '{print $2}'" :
                 "route -n | grep 'UG[ \t]' | awk '{print $2}'";
 

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -6,8 +6,6 @@ import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Helper class for testing full integration with docker daemon, requires running daemon. To run these tests:
@@ -69,7 +67,7 @@ public class DockerTestUtils {
                 .withName(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME).withDriver("bridge").withIpam(ipam).exec();
     }
 
-    public static void buildSimpleHttpServerDockerImage(DockerImpl docker, DockerImage dockerImage) throws IOException, ExecutionException, InterruptedException {
+    public static void buildSimpleHttpServerDockerImage(DockerImpl docker, DockerImage dockerImage) {
         try {
             docker.deleteImage(dockerImage);
         } catch (Exception e) {

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/VespaSSLConfig.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/VespaSSLConfig.java
@@ -76,7 +76,7 @@ public class VespaSSLConfig implements SSLConfig {
     }
 
     public static KeyStore createKeyStore(final String keypem, final String certpem) throws NoSuchAlgorithmException,
-            InvalidKeySpecException, IOException, CertificateException, KeyStoreException {
+            IOException, CertificateException, KeyStoreException {
         PrivateKey privateKey = loadPrivateKey(keypem);
         requireNonNull(privateKey);
         List<Certificate> privateCertificates = loadCertificates(certpem);
@@ -128,8 +128,7 @@ public class VespaSSLConfig implements SSLConfig {
     /**
      * Return private key ("key.pem") from Reader
      */
-    private static PrivateKey loadPrivateKey(final Reader reader) throws IOException, NoSuchAlgorithmException,
-            InvalidKeySpecException {
+    private static PrivateKey loadPrivateKey(final Reader reader) throws IOException, NoSuchAlgorithmException {
         try (PEMParser pemParser = new PEMParser(reader)) {
             Object readObject = pemParser.readObject();
             while (readObject != null) {
@@ -175,8 +174,7 @@ public class VespaSSLConfig implements SSLConfig {
     /**
      * Return KeyPair from "key.pem"
      */
-    private static PrivateKey loadPrivateKey(final String keypem) throws IOException, NoSuchAlgorithmException,
-            InvalidKeySpecException {
+    private static PrivateKey loadPrivateKey(final String keypem) throws IOException, NoSuchAlgorithmException {
         try (StringReader certReader = new StringReader(keypem);
              BufferedReader reader = new BufferedReader(certReader)) {
             return loadPrivateKey(reader);

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollectionTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollectionTest.java
@@ -138,7 +138,7 @@ public class DockerImageGarbageCollectionTest {
             return this;
         }
 
-        private void expectUnusedImages(final String... imageIds) throws Exception {
+        private void expectUnusedImages(final String... imageIds) {
             final List<DockerImage> expectedUnusedImages = Arrays.stream(imageIds)
                     .map(DockerImage::new)
                     .collect(Collectors.toList());

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -6,7 +6,6 @@ import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
-import com.yahoo.vespa.hosted.node.admin.orchestrator.Orchestrator;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +23,7 @@ public interface DockerOperations {
 
     void scheduleDownloadOfImage(ContainerNodeSpec nodeSpec, Runnable callback);
 
-    void removeContainer(ContainerNodeSpec nodeSpec, Container existingContainer, Orchestrator orchestrator);
+    void removeContainer(ContainerNodeSpec nodeSpec, Container existingContainer);
 
     void executeCommandInContainer(ContainerName containerName, String[] command);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -24,8 +24,7 @@ public interface DockerOperations {
 
     void scheduleDownloadOfImage(ContainerNodeSpec nodeSpec, Runnable callback);
 
-    void removeContainer(ContainerNodeSpec nodeSpec, Container existingContainer, Orchestrator orchestrator)
-            throws Exception;
+    void removeContainer(ContainerNodeSpec nodeSpec, Container existingContainer, Orchestrator orchestrator);
 
     void executeCommandInContainer(ContainerName containerName, String[] command);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -307,8 +307,7 @@ public class DockerOperationsImpl implements DockerOperations {
     }
 
     @Override
-    public void removeContainer(final ContainerNodeSpec nodeSpec, final Container existingContainer, Orchestrator orchestrator)
-            throws Exception {
+    public void removeContainer(final ContainerNodeSpec nodeSpec, final Container existingContainer, Orchestrator orchestrator) {
         PrefixLogger logger = PrefixLogger.getNodeAgentLogger(DockerOperationsImpl.class, nodeSpec.containerName);
         final ContainerName containerName = existingContainer.name;
         if (existingContainer.isRunning) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -15,7 +15,6 @@ import com.yahoo.vespa.hosted.dockerapi.metrics.Dimensions;
 import com.yahoo.vespa.hosted.dockerapi.metrics.GaugeWrapper;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
-import com.yahoo.vespa.hosted.node.admin.orchestrator.Orchestrator;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 import com.yahoo.vespa.hosted.node.admin.util.PrefixLogger;
 
@@ -307,7 +306,7 @@ public class DockerOperationsImpl implements DockerOperations {
     }
 
     @Override
-    public void removeContainer(final ContainerNodeSpec nodeSpec, final Container existingContainer, Orchestrator orchestrator) {
+    public void removeContainer(final ContainerNodeSpec nodeSpec, final Container existingContainer) {
         PrefixLogger logger = PrefixLogger.getNodeAgentLogger(DockerOperationsImpl.class, nodeSpec.containerName);
         final ContainerName containerName = existingContainer.name;
         if (existingContainer.isRunning) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -16,7 +16,6 @@ import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgent;
 import com.yahoo.vespa.hosted.node.admin.util.PrefixLogger;
 import com.yahoo.vespa.hosted.provision.Node;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -236,15 +235,11 @@ public class NodeAdminImpl implements NodeAdmin {
                 return;
             }
 
-            try {
-                ensureNodeAgentForNodeIsStarted(nodeSpec.get());
-            } catch (IOException e) {
-                logger.warning("Failed to bring container to desired state", e);
-            }
+            ensureNodeAgentForNodeIsStarted(nodeSpec.get());
         });
     }
 
-    private void ensureNodeAgentForNodeIsStarted(final ContainerNodeSpec nodeSpec) throws IOException {
+    private void ensureNodeAgentForNodeIsStarted(final ContainerNodeSpec nodeSpec) {
         if (nodeAgents.containsKey(nodeSpec.hostname)) {
             return;
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
@@ -25,7 +25,7 @@ public interface NodeAgent {
      */
     void unfreeze();
 
-    void stopServices(ContainerName containerName) throws Exception;
+    void stopServices(ContainerName containerName);
 
     /**
      * Make NodeAgent check for work to be done.

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -329,7 +329,7 @@ public class NodeAgentImpl implements NodeAgent {
                 dockerOperations.trySuspendNode(containerName);
                 stopServices(containerName);
             }
-            dockerOperations.removeContainer(nodeSpec, existingContainer.get(), orchestrator);
+            dockerOperations.removeContainer(nodeSpec, existingContainer.get());
             metricReceiver.unsetMetricsForContainer(hostname);
             lastCpuMetric = new CpuUsageReporter();
             vespaVersion = Optional.empty();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -196,7 +196,7 @@ public class NodeAgentImpl implements NodeAgent {
         containerState = RUNNING;
     }
 
-    private void updateNodeRepoAndMarkNodeAsReady(ContainerNodeSpec nodeSpec) throws IOException {
+    private void updateNodeRepoAndMarkNodeAsReady(ContainerNodeSpec nodeSpec) {
         publishStateToNodeRepoIfChanged(
                 nodeSpec.hostname,
                 // Clear current Docker image and vespa version, as nothing is running on this node
@@ -208,7 +208,7 @@ public class NodeAgentImpl implements NodeAgent {
         nodeRepository.markAsReady(nodeSpec.hostname);
     }
 
-    private void updateNodeRepoWithCurrentAttributes(final ContainerNodeSpec nodeSpec) throws IOException {
+    private void updateNodeRepoWithCurrentAttributes(final ContainerNodeSpec nodeSpec) {
         final NodeAttributes nodeAttributes = new NodeAttributes()
                 .withRestartGeneration(nodeSpec.wantedRestartGeneration.orElse(null))
                 // update reboot gen with wanted gen if set, we ignore reboot for Docker nodes but
@@ -220,7 +220,7 @@ public class NodeAgentImpl implements NodeAgent {
         publishStateToNodeRepoIfChanged(nodeSpec.hostname, nodeAttributes);
     }
 
-    private void publishStateToNodeRepoIfChanged(String hostName, NodeAttributes currentAttributes) throws IOException {
+    private void publishStateToNodeRepoIfChanged(String hostName, NodeAttributes currentAttributes) {
         // TODO: We should only update if the new current values do not match the node repo's current values
         if (!currentAttributes.equals(lastAttributesSet)) {
             logger.info("Publishing new set of attributes to node repo: "
@@ -291,7 +291,7 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     @Override
-    public void stopServices(ContainerName containerName) throws Exception {
+    public void stopServices(ContainerName containerName) {
             logger.info("Stopping services for " + containerName);
             dockerOperations.stopServicesOnNode(containerName);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepository.java
@@ -14,9 +14,9 @@ import java.util.Optional;
 public interface NodeRepository {
     List<ContainerNodeSpec> getContainersToRun() throws IOException;
 
-    Optional<ContainerNodeSpec> getContainerNodeSpec(String hostName) throws IOException;
+    Optional<ContainerNodeSpec> getContainerNodeSpec(String hostName);
 
-    void updateNodeAttributes(String hostName, NodeAttributes nodeAttributes) throws IOException;
+    void updateNodeAttributes(String hostName, NodeAttributes nodeAttributes);
 
-    void markAsReady(String hostName) throws IOException;
+    void markAsReady(String hostName);
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -126,7 +126,7 @@ public class NodeRepositoryImpl implements NodeRepository {
     }
 
     @Override
-    public void updateNodeAttributes(final String hostName, final NodeAttributes nodeAttributes) throws IOException {
+    public void updateNodeAttributes(final String hostName, final NodeAttributes nodeAttributes) {
         UpdateNodeAttributesResponse response = requestExecutor.patch(
                 "/nodes/v2/node/" + hostName,
                 port,
@@ -140,7 +140,7 @@ public class NodeRepositoryImpl implements NodeRepository {
     }
     
     @Override
-    public void markAsReady(final String hostName) throws IOException {
+    public void markAsReady(final String hostName) {
         NodeReadyResponse response = requestExecutor.put(
                 "/nodes/v2/state/ready/" + hostName,
                 port,

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/CoreCollector.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/CoreCollector.java
@@ -136,7 +136,7 @@ public class CoreCollector {
         return path.toFile().getFreeSpace() > parseTotalMemorySize(memInfo);
     }
 
-    int parseTotalMemorySize(String memInfo) throws IOException {
+    int parseTotalMemorySize(String memInfo) {
         Matcher matcher = TOTAL_MEMORY_PATTERN.matcher(memInfo);
         if (!matcher.find()) throw new RuntimeException("Could not parse meminfo: " + memInfo);
         return Integer.valueOf(matcher.group("totalMem"));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/CoredumpHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/maintenance/CoredumpHandler.java
@@ -99,7 +99,7 @@ public class CoredumpHandler {
         return Files.move(coredumpPath, folder.resolve(coredumpPath.getFileName()));
     }
 
-    private Map<String, Object> collectMetadata(Path coredumpPath, Map<String, Object> nodeAttributes) throws IOException, InterruptedException {
+    private Map<String, Object> collectMetadata(Path coredumpPath, Map<String, Object> nodeAttributes) {
         Map<String, Object> metadata = coreCollector.collect(coredumpPath);
         metadata.putAll(nodeAttributes);
 
@@ -112,7 +112,7 @@ public class CoredumpHandler {
         Files.write(metadataPath, gson.toJson(metadata).getBytes());
     }
 
-    void report(Path coredumpDirectory) throws IOException, InterruptedException {
+    void report(Path coredumpDirectory) throws IOException {
         // Use core dump UUID as document ID
         String documentId = coredumpDirectory.getFileName().toString();
         String metadata = new String(Files.readAllBytes(coredumpDirectory.resolve(METADATA_FILE_NAME)));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
@@ -72,7 +72,7 @@ public class RunVespaLocal {
     /**
      * Starts config server, provisions numNodesToProvision and puts them in ready state
      */
-    void startLocalZoneWithNodes(int numNodesToProvision) throws IOException, InterruptedException, ExecutionException {
+    void startLocalZoneWithNodes(int numNodesToProvision) throws IOException {
         logger.info("Starting config-server");
         LocalZoneUtils.startConfigServerIfNeeded(docker, environmentBuilder.build());
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -15,7 +15,6 @@ import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 import com.yahoo.vespa.hosted.node.admin.util.InetAddressResolver;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
@@ -68,7 +67,7 @@ public class DockerTester implements AutoCloseable {
         nodeRepositoryMock.addContainerNodeSpec(containerNodeSpec);
     }
 
-    public Optional<ContainerNodeSpec> getContainerNodeSpec(String hostname) throws IOException {
+    public Optional<ContainerNodeSpec> getContainerNodeSpec(String hostname) {
         return nodeRepositoryMock.getContainerNodeSpec(hostname);
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
@@ -35,7 +35,7 @@ public class NodeRepoMock implements NodeRepository {
     }
 
     @Override
-    public Optional<ContainerNodeSpec> getContainerNodeSpec(String hostName) throws IOException {
+    public Optional<ContainerNodeSpec> getContainerNodeSpec(String hostName) {
         synchronized (monitor) {
             return containerNodeSpecs.stream()
                     .filter(containerNodeSpec -> containerNodeSpec.hostname.equals(hostName))
@@ -44,14 +44,14 @@ public class NodeRepoMock implements NodeRepository {
     }
 
     @Override
-    public void updateNodeAttributes(String hostName, NodeAttributes nodeAttributes) throws IOException {
+    public void updateNodeAttributes(String hostName, NodeAttributes nodeAttributes) {
         synchronized (monitor) {
             callOrderVerifier.add("updateNodeAttributes with HostName: " + hostName + ", " + nodeAttributes);
         }
     }
 
     @Override
-    public void markAsReady(String hostName) throws IOException {
+    public void markAsReady(String hostName) {
         Optional<ContainerNodeSpec> cns = getContainerNodeSpec(hostName);
 
         synchronized (monitor) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -102,7 +102,7 @@ public class NodeAgentImplTest {
 
         nodeAgent.tick();
 
-        verify(dockerOperations, never()).removeContainer(any(), any(), any());
+        verify(dockerOperations, never()).removeContainer(any(), any());
         verify(orchestrator, never()).suspend(any(String.class));
         verify(dockerOperations, never()).scheduleDownloadOfImage(any(), any());
 
@@ -152,7 +152,7 @@ public class NodeAgentImplTest {
 
         nodeAgent.tick();
 
-        verify(dockerOperations, never()).removeContainer(any(), any(), any());
+        verify(dockerOperations, never()).removeContainer(any(), any());
         verify(orchestrator, never()).suspend(any(String.class));
         verify(dockerOperations, never()).scheduleDownloadOfImage(any(), any());
 
@@ -196,7 +196,7 @@ public class NodeAgentImplTest {
 
         verify(orchestrator, never()).suspend(any(String.class));
         verify(orchestrator, never()).resume(any(String.class));
-        verify(dockerOperations, never()).removeContainer(any(), any(), any());
+        verify(dockerOperations, never()).removeContainer(any(), any());
 
         final InOrder inOrder = inOrder(dockerOperations);
         inOrder.verify(dockerOperations, times(1)).shouldScheduleDownloadOfImage(eq(newDockerImage));
@@ -261,7 +261,7 @@ public class NodeAgentImplTest {
 
         nodeAgent.tick();
 
-        verify(dockerOperations, never()).removeContainer(any(), any(), any());
+        verify(dockerOperations, never()).removeContainer(any(), any());
         verify(orchestrator, never()).resume(any(String.class));
         verify(nodeRepository).updateNodeAttributes(
                 hostName, new NodeAttributes()
@@ -298,7 +298,7 @@ public class NodeAgentImplTest {
 
         nodeAgent.tick();
 
-        verify(dockerOperations, never()).removeContainer(any(), any(), any());
+        verify(dockerOperations, never()).removeContainer(any(), any());
         verify(dockerOperations, never()).startContainerIfNeeded(eq(nodeSpec));
         verify(orchestrator, never()).resume(any(String.class));
         verify(nodeRepository).updateNodeAttributes(
@@ -338,7 +338,7 @@ public class NodeAgentImplTest {
 
         final InOrder inOrder = inOrder(storageMaintainer, dockerOperations);
         inOrder.verify(storageMaintainer, times(1)).removeOldFilesFromNode(eq(containerName));
-        inOrder.verify(dockerOperations, never()).removeContainer(eq(nodeSpec), any(), any());
+        inOrder.verify(dockerOperations, never()).removeContainer(eq(nodeSpec), any());
 
         verify(orchestrator, never()).resume(any(String.class));
         verify(nodeRepository).updateNodeAttributes(
@@ -381,7 +381,7 @@ public class NodeAgentImplTest {
 
         final InOrder inOrder = inOrder(storageMaintainer, dockerOperations, nodeRepository);
         inOrder.verify(storageMaintainer, times(1)).removeOldFilesFromNode(eq(containerName));
-        inOrder.verify(dockerOperations, times(1)).removeContainer(eq(nodeSpec), any(), any());
+        inOrder.verify(dockerOperations, times(1)).removeContainer(eq(nodeSpec), any());
         inOrder.verify(storageMaintainer, times(1)).archiveNodeData(eq(containerName));
         inOrder.verify(nodeRepository, times(1)).markAsReady(eq(hostName));
 
@@ -437,7 +437,7 @@ public class NodeAgentImplTest {
         when(nodeRepository.getContainerNodeSpec(eq(hostName))).thenReturn(Optional.of(nodeSpec));
         when(dockerOperations.shouldScheduleDownloadOfImage(eq(wantedDockerImage))).thenReturn(false);
 
-        verify(dockerOperations, never()).removeContainer(any(), any(), any());
+        verify(dockerOperations, never()).removeContainer(any(), any());
 
         doThrow(new RuntimeException("Failed 1st time"))
                 .doNothing()


### PR DESCRIPTION
* Removes redundant `throws` that actually were never thrown.
* Removes unused `orchestrator` argument in `DockerOperations.removeContainer()`