### PR TITLE
transfer state to merged reply

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/ReplyMerger.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/ReplyMerger.java
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.documentapi.messagebus.protocol;
 
 import com.yahoo.collections.Tuple2;
@@ -58,6 +58,8 @@ final class ReplyMerger {
         }
         if (error == null) {
             error = new EmptyReply();
+            r.swapState(error);
+            return;
         }
         for (int j = 0; j < r.getNumErrors(); ++j) {
             error.addError(r.getError(j));


### PR DESCRIPTION
* when merging a single error Reply to a new EmptyResult,
  we would lose state (like the carefully prepared retry
  delay setting).

@vekterli please review and merge
@baldersheim FYI