### PR TITLE
Revert "Revert "Revert "Revert "Revert "Revert "Revert "Revert "Balder/avoid costly notifyall in sharedsender""""""""

### DIFF
--- a/messagebus/src/test/java/com/yahoo/messagebus/network/local/LocalNetworkTest.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/network/local/LocalNetworkTest.java
@@ -109,7 +109,7 @@ public class LocalNetworkTest {
         assertEquals(ErrorCode.TIMEOUT, res.getError().getCode());
         assertTrue(res.getError().getMessage().endsWith("Timed out in sendQ"));
         long end = System.currentTimeMillis();
-        assertTrue(end - start >= TIMEOUT);
+        assertTrue(end - start >= (TIMEOUT*0.98)); // Different clocks are used....
         assertTrue(end - start < 2*TIMEOUT);
 
         msg = serverB.messages.poll(60, TimeUnit.SECONDS);

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/storage/searcher/GetSearcher.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/storage/searcher/GetSearcher.java
@@ -127,7 +127,7 @@ public class GetSearcher extends Searcher {
                 }
             }
 
-            return (numPending > 0);
+            return numPending > 0;
         }
 
         private void addDocumentHit(Reply reply) {

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -187,9 +187,9 @@ public class SharedSender implements ReplyHandler {
         if (owner != null) {
             metrics.addReply(r);
             OwnerState state = activeOwners.get(owner);
-            boolean active = owner.handleReply(r, state.getNumPending() - 1);
 
             if (state != null) {
+                boolean active = owner.handleReply(r, state.getNumPending() - 1);
                 if (log.isLoggable(LogLevel.SPAM)) {
                     log.log(LogLevel.SPAM, "Received reply for file " + owner.toString() + ", count was " + state.getNumPending());
                 }
@@ -207,7 +207,6 @@ public class SharedSender implements ReplyHandler {
             log.log(LogLevel.WARNING, "Received reply " + r + " for message " + r.getMessage() + " without context");
         }
     }
-
 
     public static class OwnerState {
 

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -6,9 +6,8 @@ import com.yahoo.jdisc.Metric;
 import com.yahoo.log.LogLevel;
 import com.yahoo.messagebus.*;
 import com.yahoo.clientmetrics.RouteMetricSet;
-
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 /**
@@ -26,8 +25,7 @@ public class SharedSender implements ReplyHandler {
     private final Object monitor = new Object();
     private RouteMetricSet metrics;
 
-    // Maps from filename to number of pending requests
-    private Map<ResultCallback, Integer> activeOwners = new HashMap<>();
+    private ConcurrentHashMap<ResultCallback, OwnerState> activeOwners = new ConcurrentHashMap<>();
 
     /**
      * Creates a new shared sender.
@@ -50,17 +48,13 @@ public class SharedSender implements ReplyHandler {
     }
 
     public void remove(ResultCallback owner) {
-        synchronized (monitor) {
-            activeOwners.remove(owner);
-        }
+        activeOwners.remove(owner);
     }
 
     public void shutdown() {
         try {
-            synchronized (monitor) {
-                while ( ! activeOwners.isEmpty()) {
-                    monitor.wait(180 * 1000);
-                }
+            while ( ! activeOwners.isEmpty()) {
+                Thread.sleep(10);
             }
         } catch (InterruptedException e) {
         }
@@ -76,36 +70,29 @@ public class SharedSender implements ReplyHandler {
      * @return true if there were no more pending, or false if the timeout expired.
      */
     public boolean waitForPending(ResultCallback owner, long timeoutMs) {
-        long timeStart = SystemTimer.INSTANCE.milliTime();
-        long timeLeft = timeoutMs;
-
-        try {
-            while (timeoutMs == -1 || timeLeft > 0) {
-                synchronized (monitor) {
-                    Integer count = activeOwners.get(owner);
-                    if (count == null || count == 0) {
-                        return true;
-                    } else if (timeLeft > 0) {
-                        monitor.wait(timeLeft);
-                    } else {
-                        monitor.wait();
-                    }
-                }
-
-                timeLeft = timeoutMs - (SystemTimer.INSTANCE.milliTime() - timeStart);
+        OwnerState state = activeOwners.get(owner);
+        if (state != null) {
+            try {
+                return state.waitPending(timeoutMs);
+            } catch (InterruptedException e) {
+                return false;
             }
-        } catch (InterruptedException e) {
         }
 
-        return false;
+        return true;
+    }
+
+    private OwnerState getNonNullState(ResultCallback owner) {
+        OwnerState state = activeOwners.get(owner);
+        if (state == null) {
+            throw new IllegalStateException("No active callback : " + owner.toString());
+        }
+        return state;
     }
 
     public int getPendingCount(ResultCallback owner) {
-        Integer count = activeOwners.get(owner);
-        if (count == null) {
-            return 0;
-        }
-        return count;
+        OwnerState state = activeOwners.get(owner);
+        return (state != null) ? state.getNumPending() : 0;
     }
 
     /**
@@ -125,7 +112,12 @@ public class SharedSender implements ReplyHandler {
      * @param owner the file to check for pending documents
      */
     public void waitForPending(ResultCallback owner) {
-        waitForPending(owner, -1);
+        OwnerState state = activeOwners.get(owner);
+        if (state != null) {
+            try {
+                state.waitPending();
+            } catch (InterruptedException e) { }
+        }
     }
 
     /**
@@ -153,33 +145,16 @@ public class SharedSender implements ReplyHandler {
             return;
         }
 
-        try {
-            synchronized (monitor) {
-                if (maxPendingPerOwner != -1 && blockingQueue) {
-                    while (true) {
-                        Integer count = activeOwners.get(owner);
-
-                        if (count != null && count >= maxPendingPerOwner) {
-                            log.log(LogLevel.INFO, "Owner " + owner + " already has " + count + " pending. Waiting for replies");
-                            monitor.wait(10000);
-                        } else {
-                            break;
-                        }
-                    }
-                }
-
-                Integer count = activeOwners.get(owner);
-
-                if (count == null) {
-                    activeOwners.put(owner, 1);
-                } else {
-                    activeOwners.put(owner, count + 1);
-                }
-            }
-        } catch (InterruptedException e) {
-            return;
+        OwnerState state = activeOwners.get(owner);
+        if (state == null) {
+            state = new OwnerState();
+            activeOwners.put(owner, state);
+        }
+        if (maxPendingPerOwner != -1 && blockingQueue) {
+            state.waitMaxPendingbelow(maxPendingPerOwner);
         }
 
+        state.addPending(1);
         msg.setContext(owner);
 
         try {
@@ -203,30 +178,91 @@ public class SharedSender implements ReplyHandler {
      */
     @Override
     public void handleReply(Reply r) {
-        synchronized (monitor) {
-            ResultCallback owner = (ResultCallback) r.getContext();
+        ResultCallback owner = (ResultCallback) r.getContext();
 
-            if (owner != null) {
-                metrics.addReply(r);
+        if (owner != null) {
+            metrics.addReply(r);
+            OwnerState state = activeOwners.get(owner);
+            boolean active = owner.handleReply(r, state.getNumPending() - 1);
 
-                Integer count = activeOwners.get(owner);
-
-                if (count != null) {
-                    if (log.isLoggable(LogLevel.SPAM)) {
-                        log.log(LogLevel.SPAM, "Received reply for file " + owner.toString() + " count was " + count);
-                    }
-
-                    if ( ! owner.handleReply(r, count - 1)) {
-                        activeOwners.remove(owner);
-                    } else {
-                        activeOwners.put(owner, count - 1);
-                    }
+            if (state != null) {
+                if (log.isLoggable(LogLevel.SPAM)) {
+                    log.log(LogLevel.SPAM, "Received reply for file " + owner.toString() + ", count was " + state.getNumPending());
+                }
+                if (!active) {
+                    state.clearPending();
+                    activeOwners.remove(owner);
+                } else {
+                    state.decPending(1);
                 }
             } else {
-                log.log(LogLevel.WARNING, "Received reply " + r + " for message " + r.getMessage() + " without context");
+                // TODO: should be debug level if at all.
+                log.log(LogLevel.WARNING, "Owner " + owner.toString() + " is not active");
             }
+        } else {
+            log.log(LogLevel.WARNING, "Received reply " + r + " for message " + r.getMessage() + " without context");
+        }
+    }
 
-            monitor.notifyAll();
+
+    public static class OwnerState {
+
+        final AtomicInteger numPending = new AtomicInteger(0);
+
+        int addPending(int count) {
+            return numPending.addAndGet(count);
+        }
+
+        int decPending(int count) {
+            int newValue = numPending.addAndGet(-count);
+            if (newValue <= 0) {
+                synchronized (numPending) {
+                    numPending.notify();
+                }
+            }
+            return newValue;
+        }
+
+        void waitMaxPendingbelow(int limit) {
+            try {
+                synchronized (numPending) {
+                    while (numPending.get() > limit) {
+                        numPending.wait(5);
+                    }
+                }
+            } catch (InterruptedException e) {
+            }
+        }
+
+        int getNumPending() {
+            return numPending.get();
+        }
+
+        void clearPending() {
+            numPending.set(0);
+            synchronized (numPending) {
+                numPending.notify();
+            }
+        }
+
+        boolean waitPending(long timeoutMS) throws InterruptedException {
+            long timeStart = SystemTimer.INSTANCE.milliTime();
+            long timeLeft = timeoutMS;
+            synchronized (numPending) {
+                while ((numPending.get() > 0) && (timeLeft > 0)) {
+                    numPending.wait(timeLeft);
+                    timeLeft = timeoutMS - (SystemTimer.INSTANCE.milliTime() - timeStart);
+                }
+            }
+            return numPending.get() <= 0;
+        }
+
+        void waitPending() throws InterruptedException {
+            synchronized (numPending) {
+                while (numPending.get() > 0) {
+                    numPending.wait();
+                }
+            }
         }
     }
 

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -223,10 +223,11 @@ public class SharedSender implements ReplyHandler {
         @Override
         protected boolean tryReleaseShared(int releases) {
             // Increment/Decrement count; signal when transition downwards to zero.
+            // releases == 0 means unblock all
             while ( true ) {
                 int c = getState();
                 if ((c == 0) && (releases >= 0)) { return false; }
-                int nextc = (c > releases) ? c - releases : 0;
+                int nextc = (c > releases) ? ((releases != 0) ? c - releases : 0) : 0;
                 if (compareAndSetState(c, nextc)) {
                     return nextc == 0;
                 }

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -203,8 +203,8 @@ public class SharedSender implements ReplyHandler {
     }
 
     private static final class Sync extends AbstractQueuedSynchronizer {
-        Sync(int count) {
-            setState(1);
+        Sync(int initialCount) {
+            setState(initialCount);
         }
 
         int getCount() {

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -143,8 +143,11 @@ public class SharedSender implements ReplyHandler {
 
         OwnerState state = activeOwners.get(owner);
         if (state == null) {
-            state = new OwnerState();
-            activeOwners.put(owner, state);
+            OwnerState newState = new OwnerState();
+            state = activeOwners.putIfAbsent(owner, newState);
+            if (state == null) {
+                state = newState;
+            }
         }
         if (maxPendingPerOwner != -1 && blockingQueue) {
             state.waitMaxPendingbelow(maxPendingPerOwner);

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -48,7 +48,10 @@ public class SharedSender implements ReplyHandler {
     }
 
     public void remove(ResultCallback owner) {
-        activeOwners.remove(owner);
+        OwnerState state = activeOwners.remove(owner);
+        if (state != null) {
+            state.clearPending();
+        }
     }
 
     public void shutdown() {

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -86,14 +86,6 @@ public class SharedSender implements ReplyHandler {
         return true;
     }
 
-    private OwnerState getNonNullState(ResultCallback owner) {
-        OwnerState state = activeOwners.get(owner);
-        if (state == null) {
-            throw new IllegalStateException("No active callback : " + owner.toString());
-        }
-        return state;
-    }
-
     public int getPendingCount(ResultCallback owner) {
         OwnerState state = activeOwners.get(owner);
         return (state != null) ? state.getNumPending() : 0;

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -24,6 +24,7 @@ public class SharedSender implements ReplyHandler {
     private SendSession sender;
     private RouteMetricSet metrics;
     private static final int REACT_LATENCY_ON_RACE = 5;
+    private static final int REACT_LATENCY_ON_WATERMARK = 5;
 
     private ConcurrentHashMap<ResultCallback, OwnerState> activeOwners = new ConcurrentHashMap<>();
 
@@ -230,7 +231,7 @@ public class SharedSender implements ReplyHandler {
             try {
                 synchronized (numPending) {
                     while (numPending.get() > limit) {
-                        numPending.wait(5);
+                        numPending.wait(REACT_LATENCY_ON_WATERMARK);
                     }
                 }
             } catch (InterruptedException e) {

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/SharedSender.java
@@ -191,15 +191,18 @@ public class SharedSender implements ReplyHandler {
             return;
         }
 
-        boolean active = owner.handleReply(r, state.getNumPending() - 1);
+        int numPending = state.getNumPending() - 1;
+        boolean noMorePending = state.decPending(1);
+        if (noMorePending) {
+            numPending = 0;
+        }
+        boolean active = owner.handleReply(r, numPending);
         if (log.isLoggable(LogLevel.SPAM)) {
             log.log(LogLevel.SPAM, "Received reply for file " + owner.toString() + ", count was " + state.getNumPending());
         }
         if (!active) {
             state.clearPending();
             activeOwners.remove(owner);
-        } else {
-            state.decPending(1);
         }
     }
 
@@ -241,8 +244,8 @@ public class SharedSender implements ReplyHandler {
             sync.releaseShared(-count);
         }
 
-        void decPending(int count) {
-            sync.releaseShared(count);
+        boolean decPending(int count) {
+            return sync.releaseShared(count);
         }
 
         void waitMaxPendingBelow(int limit) {


### PR DESCRIPTION
Reverts yahoo/vespa#1456
@vekterli and @dybis and @arnej27959 and @bratseth PR This needs a good review as it tries to be lockfree as far as possible.

You get a 25% gain on both throughput and 95% latency in the http://factory-web.vespa.corp.gq1.yahoo.com/versions/1/builds/17700/products/2/tests/89190/testruns/9781721/graph?orig_testid=9781721
This one has effect when you stay below sendblocking limit.
While #1437 fixes the overload case.