### PR TITLE
always optimize

### DIFF
--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -142,9 +142,6 @@ consider_fallback VESPA_USE_NO_VESPAMALLOC  $(get_var "no_vespamalloc_list")
 #     export VESPA_USE_HUGEPAGES="yes"
 # fi
 
-if [ -z "$YINST_RUNNING" ]; then
-    export VESPA_RUN_STANDALONE=true
-fi
 
 fixlimits () {
     # number of open files:

--- a/vespabase/src/start-cbinaries.sh
+++ b/vespabase/src/start-cbinaries.sh
@@ -189,7 +189,7 @@ if [ "$VESPA_USE_VESPAMALLOC_DST" = "all" ]; then
     suf=vespa/malloc/libvespamallocdst16.so
 fi
 
-if [[ ($no_valgrind || $use_callgrind) && -z $VESPA_RUN_STANDALONE ]]; then
+if $no_valgrind || $use_callgrind; then
     for tryfile in $p64/$suf $p32/$suf $pre/$suf ; do
         if [ -f $tryfile ]; then
                 LD_PRELOAD=$tryfile
@@ -207,9 +207,7 @@ fi
 
 if $no_valgrind || ! which valgrind >/dev/null ; then
     # log_debug_message $0-bin $@
-    if [ -z $VESPA_RUN_STANDALONE ]; then
-        ulimit -c unlimited
-    fi
+    ulimit -c unlimited
     if numactl --interleave all true &> /dev/null; then
         # We are allowed to use numactl
         if [ "$VESPA_AFFINITY_CPU_SOCKET" ]; then


### PR DESCRIPTION
* don't behave differently when running via yinst versus not.

@baldersheim please review