### PR TITLE
Update with new overrides.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ValidationId.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ValidationId.java
@@ -18,7 +18,7 @@ public enum ValidationId {
     configModelVersionMismatch("config-model-version-mismatch"),
     skipOldConfigModels("skip-old-config-models"),
     skipAutomaticTenantUpgradeTests("skip-automatic-tenant-upgrade-test"),
-    enableAutomaticTenantUpgradeTests("enable-automatic-tenant-upgrade-test");
+    forceAutomaticTenantUpgradeTests("force-automatic-tenant-upgrade-test");
 
     private final String id;
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ValidationId.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ValidationId.java
@@ -17,7 +17,8 @@ public enum ValidationId {
     contentClusterRemoval("content-cluster-removal"),
     configModelVersionMismatch("config-model-version-mismatch"),
     skipOldConfigModels("skip-old-config-models"),
-    skipVespaStagingTests("skip-vespa-staging-tests");
+    skipAutomaticTenantUpgradeTests("skip-automatic-tenant-upgrade-test"),
+    enableAutomaticTenantUpgradeTests("enable-automatic-tenant-upgrade-test");
 
     private final String id;
 


### PR DESCRIPTION
@bratseth plz review
Removing old staging override, not used, was intended for old screwdriver config.
Adding two new overrides. One is for enabling the tests while it is default off (in the beginnging)
and one for disabling it after it has been enabled as default.
The enable override should be deprecated after it has been turned on as default.