### PR TITLE
Update metrics even when not in active state

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -292,8 +292,8 @@ public class NodeAgentImpl implements NodeAgent {
 
     @Override
     public void stopServices(ContainerName containerName) {
-            logger.info("Stopping services for " + containerName);
-            dockerOperations.stopServicesOnNode(containerName);
+        logger.info("Stopping services for " + containerName);
+        dockerOperations.stopServicesOnNode(containerName);
     }
 
     private Optional<String> shouldRemoveContainer(ContainerNodeSpec nodeSpec, Container existingContainer) {
@@ -473,7 +473,7 @@ public class NodeAgentImpl implements NodeAgent {
             nodeSpec = lastNodeSpec;
         }
 
-        if (nodeSpec == null || nodeSpec.nodeState != Node.State.active) return;
+        if (nodeSpec == null || !vespaVersion.isPresent()) return;
         Optional<Docker.ContainerStats> containerStats = dockerOperations.getContainerStats(nodeSpec.containerName);
         if ( ! containerStats.isPresent()) return;
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
@@ -15,7 +15,6 @@ import com.yahoo.vespa.hosted.provision.Node;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -227,14 +226,14 @@ public class LocalZoneUtils {
 
     public static void packageApp(Path pathToApp) {
         try {
-            InputStream is = Runtime.getRuntime().exec("mvn package", null, pathToApp.toFile()).getInputStream();
-
-            InputStreamReader isr = new InputStreamReader(is);
-            BufferedReader buff = new BufferedReader (isr);
+            Process process = Runtime.getRuntime().exec("mvn package", null, pathToApp.toFile());
+            BufferedReader buff = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
             String line;
             while((line = buff.readLine()) != null) System.out.println(line);
-        } catch (IOException e) {
+
+            assert process.waitFor() == 0;
+        } catch (IOException | InterruptedException e) {
             throw new RuntimeException("Failed to package application", e);
         }
     }


### PR DESCRIPTION
* Currently we stop updating container metrics once they leave state `active`, but we still send metrics to yamas as long as the container is up (re-sending the last metrics when container was active). This change will update the metrics as long as the container is running.
* Minor change to local zone tester that will fail if `mvn package` fails in app-deploy step.