### PR TITLE
Fix race condition in some http conformance test

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -101,9 +101,9 @@ public class ServletResponseController {
     public void trySendError(Throwable t) {
         final boolean responseWasCommitted;
         try {
-            String reasonPhrase = getReasonPhrase(t, developerMode);
-            int statusCode = getStatusCode(t);
             synchronized (monitor) {
+                String reasonPhrase = getReasonPhrase(t, developerMode);
+                int statusCode = getStatusCode(t);
                 responseWasCommitted = responseCommitted;
                 if (!responseCommitted) {
                     responseCommitted = true;


### PR DESCRIPTION
Make call to Exception.getMessage()/getReasonPhrase in synchronized
block to fix some flaky unit tests (e.g. testRequestContentCloseExceptionBeforeResponseWrite)

Bug was supposed to be fixed in https://github.com/yahoo/vespa/pull/1300, this time after the morning coffee.

FYI @baldersheim 