### PR TITLE
Try to remove old buffers from lid info vector after expanding the ve…

### DIFF
--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -875,6 +875,8 @@ LogDataStore::setLid(const LockGuard & guard, uint32_t lid, const LidInfo & meta
         }
         _lidInfo.setGeneration(_genHandler.getNextGeneration());
         _genHandler.incGeneration();
+        _genHandler.updateFirstUsedGeneration();
+        _lidInfo.removeOldGenerations(_genHandler.getFirstUsedGeneration());
         setNextId(_lidInfo.size());
     }
     _lidInfo[lid] = meta;


### PR DESCRIPTION
…ctor.

This is to avoid a buildup of old buffers when we only set lids in increasing order.

@baldersheim please review
@toregge FYI