### PR TITLE
Add semi-unbound task limit, to replace unbound task limit when

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -123,8 +123,15 @@ indexing.read.io enum {NORMAL, DIRECTIO} default=DIRECTIO restart
 indexing.threads int default=1 restart
 
 ## Maximum number of pending operations for each of the internal
-## indexing threads.
+## indexing threads.  Only used when visibility delay is zero.
 indexing.tasklimit int default=1000 restart
+
+## Parameter used to calculate maximum number of pending operations
+## for each of the internal indexing threads when visibility delay is
+## nonzero. The number is divided by the number of indexing threads,
+## i.e.  when indexing.threads is 4 and indexing.semiunboundtasklimit
+## is 1000000 then effective task limit is 250000.
+indexing.semiunboundtasklimit int default = 1000000 restart
 
 ## How long a freshly loaded index shall be warmed up
 ## before being used for serving

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -91,6 +91,8 @@ private:
     DocTypeName                   _docTypeName;
     vespalib::string              _baseDir;
     uint32_t                      _defaultExecutorTaskLimit;
+    uint32_t                      _semiUnboundExecutorTaskLimit;
+    uint32_t                      _indexingThreads;
     // Only one thread per executor, or dropFeedView() will fail.
     ExecutorThreadingService      _writeService;
     // threads for initializer tasks during proton startup


### PR DESCRIPTION
visibility delay is non-zero.
This allows some degree of configurable resource capping.

@geirst, please review.