### PR TITLE
Avoid unnecessary registry creation

### DIFF
--- a/component/src/main/java/com/yahoo/component/provider/ComponentRegistry.java
+++ b/component/src/main/java/com/yahoo/component/provider/ComponentRegistry.java
@@ -38,7 +38,7 @@ public class ComponentRegistry<COMPONENT> {
     private Map<ComponentId, COMPONENT> componentsById =new LinkedHashMap<>();
 
     /** True when this cannot be changed any more */
-    private boolean frozen=false;
+    private boolean frozen = false;
 
     /**
      * Freezes this registry to prevent further changes. Override this to freeze internal data

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -84,7 +84,7 @@ import java.util.logging.Logger;
  * <p>
  * The identity of a query is determined by its content.
  *
- * @author <a href="mailto:arnebef@yahoo-inc.com">Arne Bergene Fossaa</a>
+ * @author Arne Bergene Fossaa
  * @author bratseth
  */
 public class Query extends com.yahoo.processing.Request implements Cloneable {
@@ -318,7 +318,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         }
         else { // bypass these complications if there is no query profile to get values from and validate against
             properties().
-                    chain(new QueryProperties(this, new CompiledQueryProfileRegistry())).
+                    chain(new QueryProperties(this, CompiledQueryProfileRegistry.empty)).
                     chain(new PropertyMap()).
                     chain(new DefaultProperties());
             setPropertiesFromRequestMap(requestMap, properties());

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
@@ -752,11 +752,11 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
      * @return the parent, or null if not present and created is false
      */
     private QueryProfile lookupParentExact(CompoundName name, boolean create, DimensionBinding dimensionBinding) {
-        CompoundName rest=name.rest();
+        CompoundName rest = name.rest();
         if (rest.isEmpty()) return this;
 
-        QueryProfile topmostParent= getQueryProfileExact(name.first(), create, dimensionBinding);
-        if (topmostParent==null) return null;
+        QueryProfile topmostParent = getQueryProfileExact(name.first(), create, dimensionBinding);
+        if (topmostParent == null) return null;
         return topmostParent.lookupParentExact(rest, create, dimensionBinding.createFor(topmostParent.getDimensions()));
     }
 
@@ -775,9 +775,9 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
         if (!create) return null;
 
         QueryProfile queryProfile=createSubProfile(localName,dimensionBinding);
-        if (type!=null) {
+        if (type != null) {
             Class<?> legalClass=type.getValueClass(localName);
-            if (legalClass==null || ! legalClass.isInstance(queryProfile))
+            if (legalClass == null || ! legalClass.isInstance(queryProfile))
                 throw new RuntimeException("'" + localName + "' is not a legal query profile reference name in " + this);
             queryProfile.setType(type.getType(localName));
         }
@@ -786,23 +786,23 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
     }
 
     /** Do a variant-aware content lookup in this - without looking in any wrapped content. But by matching variant bindings exactly only */
-    private Object localExactLookup(String name,DimensionBinding dimensionBinding) {
-        if (dimensionBinding.isNull()) return content==null ? null : content.get(name);
-        if (variants==null) return null;
-        QueryProfileVariant variant=variants.getVariant(dimensionBinding.getValues(),false);
-        if (variant==null) return null;
+    private Object localExactLookup(String name, DimensionBinding dimensionBinding) {
+        if (dimensionBinding.isNull()) return content == null ? null : content.get(name);
+        if (variants == null) return null;
+        QueryProfileVariant variant = variants.getVariant(dimensionBinding.getValues(),false);
+        if (variant == null) return null;
         return variant.values().get(name);
     }
 
     /** Sets a value directly in this query profile (unless frozen) */
-    private void localPut(String localName,Object value,DimensionBinding dimensionBinding) {
+    private void localPut(String localName,Object value, DimensionBinding dimensionBinding) {
         ensureNotFrozen();
 
-        if (type!=null)
-            localName=type.unalias(localName);
+        if (type != null)
+            localName = type.unalias(localName);
 
         validateName(localName);
-        value=convertToSubstitutionString(value);
+        value = convertToSubstitutionString(value);
 
         if (dimensionBinding.isNull()) {
             Object combinedValue;
@@ -815,8 +815,8 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
                 content.put(localName,combinedValue);
         }
         else {
-            if (variants==null)
-                variants=new QueryProfileVariants(dimensionBinding.getDimensions(), this);
+            if (variants == null)
+                variants = new QueryProfileVariants(dimensionBinding.getDimensions(), this);
             variants.set(localName,dimensionBinding.getValues(),value);
         }
     }

--- a/container-search/src/main/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistry.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistry.java
@@ -13,6 +13,9 @@ import com.yahoo.search.query.profile.types.QueryProfileTypeRegistry;
  */
 public class CompiledQueryProfileRegistry extends ComponentRegistry<CompiledQueryProfile> {
 
+    /** The empty, frozen registry */
+    public static final CompiledQueryProfileRegistry empty = CompiledQueryProfileRegistry.createFrozen();
+    
     private final QueryProfileTypeRegistry typeRegistry;
 
     /** Creates a compiled query profile registry with no types */
@@ -44,33 +47,40 @@ public class CompiledQueryProfileRegistry extends ComponentRegistry<CompiledQuer
      * which has a type which allows path matching is used. If there is no such profile, null is returned.
      */
     public CompiledQueryProfile findQueryProfile(String idString) {
-        if (idString==null || idString.isEmpty()) return getComponent("default");
-        ComponentSpecification id=new ComponentSpecification(idString);
-        CompiledQueryProfile profile=getComponent(id);
-        if (profile!=null) return profile;
+        if (idString == null || idString.isEmpty()) return getComponent("default");
+        ComponentSpecification id = new ComponentSpecification(idString);
+        CompiledQueryProfile profile = getComponent(id);
+        if (profile != null) return profile;
 
         return findPathParentQueryProfile(new ComponentSpecification(idString));
     }
 
     private CompiledQueryProfile findPathParentQueryProfile(ComponentSpecification id) {
         // Try the name with "/" appended - should have the same semantics with path matching
-        CompiledQueryProfile slashedProfile=getComponent(new ComponentSpecification(id.getName() + "/",id.getVersionSpecification()));
-        if (slashedProfile!=null && slashedProfile.getType()!=null && slashedProfile.getType().getMatchAsPath())
+        CompiledQueryProfile slashedProfile = getComponent(new ComponentSpecification(id.getName() + "/", 
+                                                                                      id.getVersionSpecification()));
+        if (slashedProfile != null && slashedProfile.getType() != null && slashedProfile.getType().getMatchAsPath())
             return slashedProfile;
 
         // Extract the parent (if any)
-        int slashIndex=id.getName().lastIndexOf("/");
-        if (slashIndex<1) return null;
-        String parentName=id.getName().substring(0,slashIndex);
+        int slashIndex = id.getName().lastIndexOf("/");
+        if (slashIndex < 1) return null;
+        String parentName = id.getName().substring(0, slashIndex);
         if (parentName.equals("")) return null;
 
-        ComponentSpecification parentId=new ComponentSpecification(parentName,id.getVersionSpecification());
+        ComponentSpecification parentId = new ComponentSpecification(parentName,id.getVersionSpecification());
 
-        CompiledQueryProfile pathParentProfile=getComponent(parentId);
+        CompiledQueryProfile pathParentProfile = getComponent(parentId);
 
-        if (pathParentProfile!=null && pathParentProfile.getType()!=null && pathParentProfile.getType().getMatchAsPath())
+        if (pathParentProfile!=null && pathParentProfile.getType() != null && pathParentProfile.getType().getMatchAsPath())
             return pathParentProfile;
         return findPathParentQueryProfile(parentId);
+    }
+    
+    private static CompiledQueryProfileRegistry createFrozen() {
+        CompiledQueryProfileRegistry registry = new CompiledQueryProfileRegistry();
+        registry.freeze();
+        return registry;
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -71,8 +71,8 @@ public class QueryProperties extends Properties {
 
     @SuppressWarnings("deprecation")
     @Override
-    public Object get(final CompoundName key, Map<String,String> context,
-                                com.yahoo.processing.request.Properties substitution) {
+    public Object get(CompoundName key, Map<String,String> context,
+                      com.yahoo.processing.request.Properties substitution) {
         if (key.size()==2 && key.first().equals(Model.MODEL)) {
             if (key.last().equals(Model.QUERY_STRING)) return query.getModel().getQueryString();
             if (key.last().equals(Model.TYPE)) return query.getModel().getType();
@@ -145,7 +145,7 @@ public class QueryProperties extends Properties {
 
     @SuppressWarnings("deprecation")
     @Override
-    public void set(final CompoundName key,Object value,Map<String,String> context) {
+    public void set(CompoundName key, Object value, Map<String,String> context) {
         // Note: The defaults here are never used
         try {
             if (key.size()==2 && key.first().equals(Model.MODEL)) {


### PR DESCRIPTION
Use a static empty compiled query profile registry when there are no query profiles
instead of recreating on every request as creating registries is expensive.

@baldersheim please review