### PR TITLE
Use serialized tensors in docsum blobs instead of slime objects.

### DIFF
--- a/searchcore/src/tests/proton/docsummary/summary.cfg
+++ b/searchcore/src/tests/proton/docsummary/summary.cfg
@@ -85,7 +85,7 @@ classes[3].fields[7].type "jsonstring"
 classes[3].fields[8].name "bi"
 classes[3].fields[8].type "jsonstring"
 classes[3].fields[9].name "bj"
-classes[3].fields[9].type "jsonstring"
+classes[3].fields[9].type "tensor"
 classes[4].name "class4"
 classes[4].id 4
 classes[4].fields[1]

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumfieldwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumfieldwriter.cpp
@@ -164,6 +164,7 @@ CopyDFW::insertField(uint32_t /*docid*/,
             target.insertString(value);
             break; }
 
+        case RES_TENSOR:
         case RES_LONG_DATA:
         case RES_DATA: {
             uint32_t    len;
@@ -259,6 +260,7 @@ CopyDFW::WriteField(uint32_t docid,
 
             break; }
 
+        case RES_TENSOR:
         case RES_LONG_DATA: {
 
             uint32_t flen = entry->_len;

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumformat.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumformat.cpp
@@ -97,6 +97,7 @@ DocsumFormat::addEmpty(ResType type, search::RawBuf &target)
     case RES_LONG_DATA:
     case RES_XMLSTRING:
     case RES_JSONSTRING:
+    case RES_TENSOR:
     case RES_FEATUREDATA:
         return addLongData(target, "", 0);
     }

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
@@ -151,6 +151,7 @@ DynamicDocsumWriter::RepackDocsum(GeneralResult *gres,
                     written += slen;
                     break; }
 
+                case RES_TENSOR:
                 case RES_LONG_DATA: {
                     uint32_t flen = entry->_len;
                     uint32_t dlen = entry->_get_length();
@@ -304,6 +305,7 @@ static void convertEntry(GetDocsumsState *state,
         inserter.insertString(Memory(ptr, len));
         break;
     case RES_DATA:
+    case RES_TENSOR:
     case RES_LONG_DATA:
         entry->_resolve_field(&ptr, &len, &state->_docSumFieldSpace);
         inserter.insertData(Memory(ptr, len));

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultclass.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultclass.h
@@ -31,6 +31,7 @@ enum ResType {
     RES_LONG_DATA,
     RES_XMLSTRING,
     RES_JSONSTRING,
+    RES_TENSOR,
     RES_FEATUREDATA
 };
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultconfig.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultconfig.cpp
@@ -55,6 +55,7 @@ ResultConfig::GetResTypeName(ResType type)
     case RES_LONG_DATA:   return "longdata";
     case RES_XMLSTRING:   return "xmlstring";
     case RES_JSONSTRING:  return "jsonstring";
+    case RES_TENSOR:  return "tensor";
     case RES_FEATUREDATA: return "featuredata";
     }
     return "unknown-type";
@@ -172,6 +173,8 @@ ResultConfig::ReadConfig(const vespa::config::search::SummaryConfig &cfg, const 
                 rc = resClass->AddConfigEntry(fieldname, RES_XMLSTRING);
             } else if (strcmp(fieldtype, "jsonstring") == 0) {
                 rc = resClass->AddConfigEntry(fieldname, RES_JSONSTRING);
+            } else if (strcmp(fieldtype, "tensor") == 0) {
+                rc = resClass->AddConfigEntry(fieldname, RES_TENSOR);
             } else if (strcmp(fieldtype, "featuredata") == 0) {
                 rc = resClass->AddConfigEntry(fieldname, RES_FEATUREDATA);
             } else {         // FAIL: unknown field type

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultconfig.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultconfig.h
@@ -164,6 +164,8 @@ public:
         case RES_DATA:
         case RES_LONG_DATA:
             return (b == RES_DATA || b == RES_LONG_DATA);
+        case RES_TENSOR:
+            return (b == RES_TENSOR);
         case RES_FEATUREDATA:
             return (b == RES_FEATUREDATA);
         }

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.cpp
@@ -121,6 +121,7 @@ ResultPacker::AddEmpty()
         case RES_JSONSTRING:
         case RES_FEATUREDATA:
         case RES_LONG_STRING: return AddLongString(NULL, 0);
+        case RES_TENSOR:      return AddSerializedTensor(NULL, 0);
         case RES_LONG_DATA:   return AddLongData(NULL, 0);
         }
     }
@@ -243,6 +244,17 @@ bool
 ResultPacker::AddLongData(const char *buf, uint32_t buflen)
 {
     if (CheckEntry(RES_LONG_DATA)) {
+        _buf.append(&buflen, sizeof(buflen));
+        _buf.append(buf, buflen);
+    }
+    return !_error;
+}
+
+
+bool
+ResultPacker::AddSerializedTensor(const char *buf, uint32_t buflen)
+{
+    if (CheckEntry(RES_TENSOR)) {
         _buf.append(&buflen, sizeof(buflen));
         _buf.append(buf, buflen);
     }

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.h
@@ -230,6 +230,14 @@ public:
      **/
     bool AddLongData(const char *buf, uint32_t buflen);
 
+    /*
+     * Add a 'tensor' field to the docsum blob we are currently creating.
+     *
+     * @return true(ok)/false(error).
+     * @param buf pointer to serialized tensor to add.
+     * @param buflen length of serialized tensor to add.
+     **/
+    bool AddSerializedTensor(const char *buf, uint32_t buflen);
 
     /**
      * Obtain a pointer to, and the length of, the created docsum

--- a/searchsummary/src/vespa/searchsummary/docsummary/urlresult.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/urlresult.cpp
@@ -419,6 +419,7 @@ GeneralResult::unpack(const char *buf, const size_t buflen)
             break;
         }
 
+        case RES_TENSOR:
         case RES_LONG_DATA: {
 
             uint32_t ldlen;


### PR DESCRIPTION
Pass tensors as serialized tensors in slime version of docsum blob.

@geirst, please review
@bratseth. FYI
