### PR TITLE
Bratseth/allow no nodes

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -54,8 +54,6 @@ import java.util.logging.Logger;
  */
 public class DeployState implements ConfigDefinitionStore {
 
-    private static final Logger log = Logger.getLogger(DeployState.class.getName());
-
     private final DeployLogger logger;
     private final FileRegistry fileRegistry;
     private final DocumentModel documentModel;

--- a/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducer.java
@@ -69,6 +69,8 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
 
     protected final void setParent(AbstractConfigProducer parent) { this.parent = parent; }
     public final String getSubId() { return subId; }
+    
+    /** Whether this is hosted Vespa: NOTE: This cannot be trusted to be correct  :-/  */
     public final boolean isHostedVespa() { return hostedVespa; }
 
     /**

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
@@ -181,6 +181,7 @@ public class VespaDomBuilder extends VespaModelBuilder {
         /**
          * Allocates a host to the service using host file or create service spec for provisioner to use later
          * Pre-condition: producerSpec is non-null
+         * 
          * @param service the service to allocate a host for
          * @param hostSystem a {@link HostSystem}
          * @param producerSpec xml element for the service

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -104,7 +104,7 @@ import static com.yahoo.container.core.BundleLoaderProperties.DISK_BUNDLE_PREFIX
 
 /**
  * @author gjoranv
- * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
+ * @author Einar M R Rosenvinge
  * @author tonytv
  */
 public final class ContainerCluster
@@ -133,6 +133,7 @@ public final class ContainerCluster
         ServletPathsConfig.Producer,
         RoutingProviderConfig.Producer,
         ConfigserverConfig.Producer {
+
     /**
      * URI prefix used for internal, usually programmatic, APIs. URIs using this
      * prefix should never considered available for direct use by customers, and

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -375,15 +375,17 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         cluster.addContainers(Collections.singleton(container));
     }
 
-    private void addNodesFromXml(ContainerCluster cluster, Element spec, ConfigModelContext context) {
-        Element nodesElement = XML.getChild(spec, "nodes");
+    private void addNodesFromXml(ContainerCluster cluster, Element containerElement, ConfigModelContext context) {
+        Element nodesElement = XML.getChild(containerElement, "nodes");
         if (nodesElement == null) { // default single node on localhost
-            Container container = new Container(cluster, "container.0", 0);
-            HostResource host = allocateSingleNodeHost(cluster, log);
-            container.setHostResource(host);
-            if ( ! container.isInitialized() ) // TODO: Fold this into initService
-                container.initService();
-            cluster.addContainers(Collections.singleton(container));
+            System.out.println("Is hosted vespa: " + cluster.getRoot().isHostedVespa());
+            System.out.println("Is hosted vespa according to deploy state: " + cluster.getRoot().getDeployState().isHosted());
+            Container node = new Container(cluster, "container.0", 0);
+            HostResource host = allocateSingleNodeHost(cluster, log, containerElement, context);
+            node.setHostResource(host);
+            if ( ! node.isInitialized() ) // TODO: Fold this into initService
+                node.initService();
+            cluster.addContainers(Collections.singleton(node));
         }
         else {
             List<Container> nodes = createNodes(cluster, nodesElement, context);
@@ -440,10 +442,17 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
     }
     
-    private HostResource allocateSingleNodeHost(ContainerCluster cluster, DeployLogger logger) {
+    /** Creates a single host when there is no nodes tag */
+    private HostResource allocateSingleNodeHost(ContainerCluster cluster, DeployLogger logger, Element containerElement, ConfigModelContext context) {
         if (cluster.isHostedVespa()) {
-            ClusterSpec clusterSpec = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from(cluster.getName()), Optional.empty());
-            return cluster.getHostSystem().allocateHosts(clusterSpec, Capacity.fromNodeCount(1), 1, logger).keySet().iterator().next();
+            Optional<HostResource> singleContentHost = getHostResourceFromContentClusters(cluster, containerElement, context);
+            if (singleContentHost.isPresent()) { // there is a content cluster; put the container on its first node 
+                return singleContentHost.get();
+            }
+            else { // request 1 node
+                ClusterSpec clusterSpec = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from(cluster.getName()), Optional.empty());
+                return cluster.getHostSystem().allocateHosts(clusterSpec, Capacity.fromNodeCount(1), 1, logger).keySet().iterator().next();
+            }
         } else {
             return cluster.getHostSystem().getHost(Container.SINGLENODE_CONTAINER_SERVICESPEC);
         }
@@ -490,6 +499,33 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                                             cluster.getRoot().getHostSystem(),
                                             context.getDeployLogger());
         return createNodesFromHosts(hosts, cluster);
+    }
+
+    /**
+     * This is used in case we are on hosted Vespa and no nodes tag is supplied:
+     * If there are content clusters this will pick the first host in the first cluster as the container node.
+     * If there are no content clusters this will return empty (such that the node can be created by the container here).
+     */
+    private Optional<HostResource> getHostResourceFromContentClusters(ContainerCluster cluster, Element containersElement, ConfigModelContext context) {
+        Optional<Element> services = servicesRootOf(containersElement);
+        if ( ! services.isPresent())
+            return Optional.empty();
+        List<Element> contentServices = XML.getChildren(services.get(), "content");
+        if ( contentServices.isEmpty() ) return Optional.empty();
+        Element contentNodesElementOrNull = XML.getChild(contentServices.get(0), "nodes");
+        
+        NodesSpecification nodesSpec;
+        if (contentNodesElementOrNull == null)
+            nodesSpec = NodesSpecification.nonDedicated(1);
+        else
+            nodesSpec = NodesSpecification.from(new ModelElement(contentNodesElementOrNull));
+
+        Map<HostResource, ClusterMembership> hosts =
+                StorageGroup.provisionHosts(nodesSpec,
+                                            contentServices.get(0).getAttribute("id"),
+                                            cluster.getRoot().getHostSystem(),
+                                            context.getDeployLogger());
+        return Optional.of(hosts.keySet().iterator().next());
     }
 
     /** Returns the services element above the given Element, or empty if there is no services element */

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -378,8 +378,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private void addNodesFromXml(ContainerCluster cluster, Element containerElement, ConfigModelContext context) {
         Element nodesElement = XML.getChild(containerElement, "nodes");
         if (nodesElement == null) { // default single node on localhost
-            System.out.println("Is hosted vespa: " + cluster.getRoot().isHostedVespa());
-            System.out.println("Is hosted vespa according to deploy state: " + cluster.getRoot().getDeployState().isHosted());
             Container node = new Container(cluster, "container.0", 0);
             HostResource host = allocateSingleNodeHost(cluster, log, containerElement, context);
             node.setHostResource(host);
@@ -444,7 +442,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     
     /** Creates a single host when there is no nodes tag */
     private HostResource allocateSingleNodeHost(ContainerCluster cluster, DeployLogger logger, Element containerElement, ConfigModelContext context) {
-        if (cluster.isHostedVespa()) {
+        if (cluster.getRoot().getDeployState().isHosted()) {
             Optional<HostResource> singleContentHost = getHostResourceFromContentClusters(cluster, containerElement, context);
             if (singleContentHost.isPresent()) { // there is a content cluster; put the container on its first node 
                 return singleContentHost.get();

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/engines/PersistenceEngine.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/engines/PersistenceEngine.java
@@ -17,8 +17,9 @@ public abstract class PersistenceEngine extends AbstractConfigProducer implement
     /**
      * Creates a config producer for the engines provider at a given node.
      */
-    public static interface PersistenceFactory {
-        public PersistenceEngine create(StorageNode storageNode, StorageGroup parentGroup, ModelElement storageNodeElement);
+    public interface PersistenceFactory {
+
+        PersistenceEngine create(StorageNode storageNode, StorageGroup parentGroup, ModelElement storageNodeElement);
 
         /**
          * If a write request succeeds on some nodes and fails on others, causing request to
@@ -26,7 +27,7 @@ public abstract class PersistenceEngine extends AbstractConfigProducer implement
          * reverts are supported. (Typically require backend to keep multiple entries of the
          * same document identifier persisted at the same time)
          */
-        public boolean supportRevert();
+        boolean supportRevert();
 
         /**
          * Multi level splitting can increase split performance a lot where documents have been
@@ -34,8 +35,10 @@ public abstract class PersistenceEngine extends AbstractConfigProducer implement
          * is cheap. Backends where split is cheaper than fetching document identifiers will
          * not want to enable multi level splitting.
          */
-        public boolean enableMultiLevelSplitting();
+        boolean enableMultiLevelSplitting();
 
-        public ContentCluster.DistributionMode getDefaultDistributionMode();
+        ContentCluster.DistributionMode getDefaultDistributionMode();
+
     }
+
 }

--- a/config-model/src/main/resources/schema/content.rnc
+++ b/config-model/src/main/resources/schema/content.rnc
@@ -112,7 +112,8 @@ Content = element content {
     # Here you can add document definitions that you also want to handle.
     # Search might want to know of them in advance.
     Documents? &
-    (ContentNodes | TopGroup) &
+    ContentNodes? &
+    TopGroup? &
     Controllers?
 }
 

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1060,8 +1060,7 @@ public class ModelProvisioningTest {
     public void testUsingHostaliasWithProvisioner() {
         String services =
                         "<?xml version='1.0' encoding='utf-8' ?>\n" +
-                        "<services>\n" +
-                        "\n" +
+                        "<services>" +
                         "<admin version='2.0'>" +
                         "  <adminserver hostalias='node1'/>\n"+
                         "</admin>\n" +
@@ -1074,9 +1073,8 @@ public class ModelProvisioningTest {
                         "  </nodes>" +
                         "</jdisc>" +
                         "</services>";
-        int numberOfHosts = 1;
         VespaModelTester tester = new VespaModelTester();
-        tester.addHosts(numberOfHosts);
+        tester.addHosts(1);
         VespaModel model = tester.createModel(services, true);
         assertEquals(1, model.getRoot().getHostSystem().getHosts().size());
         assertEquals(1, model.getAdmin().getSlobroks().size());
@@ -1096,6 +1094,28 @@ public class ModelProvisioningTest {
         VespaModel model = tester.createModel(services, true);
         assertThat(model.getHosts().size(), is(1));
         assertThat(model.getContainerClusters().size(), is(1));
+    }
+
+    @Test
+    public void testNoNodeTagMeans1Node() {
+        String services =
+                "<?xml version='1.0' encoding='utf-8' ?>\n" +
+                "<services>" +
+                "  <jdisc id='mydisc' version='1.0'>" +
+                "    <search/>" +
+                "    <document-api/>" +
+                "  </jdisc>" +
+                "  <content version='1.0' id='foo'>" +
+                "     <documents>" +
+                "       <document type='type1' mode='index'/>" +
+                "     </documents>" +
+                "  </content>" +
+                "</services>";
+        VespaModelTester tester = new VespaModelTester();
+        tester.addHosts(1);
+        VespaModel model = tester.createModel(services, true);
+        assertEquals(1, model.getRoot().getHostSystem().getHosts().size());
+        assertEquals(1, model.getAdmin().getSlobroks().size());
     }
 
     /** Recreate the combination used in some factory tests */

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1101,11 +1101,11 @@ public class ModelProvisioningTest {
         String services =
                 "<?xml version='1.0' encoding='utf-8' ?>\n" +
                 "<services>" +
-                "  <jdisc id='mydisc' version='1.0'>" +
+                "  <jdisc id='foo' version='1.0'>" +
                 "    <search/>" +
                 "    <document-api/>" +
                 "  </jdisc>" +
-                "  <content version='1.0' id='foo'>" +
+                "  <content version='1.0' id='bar'>" +
                 "     <documents>" +
                 "       <document type='type1' mode='index'/>" +
                 "     </documents>" +
@@ -1116,6 +1116,33 @@ public class ModelProvisioningTest {
         VespaModel model = tester.createModel(services, true);
         assertEquals(1, model.getRoot().getHostSystem().getHosts().size());
         assertEquals(1, model.getAdmin().getSlobroks().size());
+        assertEquals(1, model.getContainerClusters().get("foo").getContainers().size());
+        assertEquals(1, model.getContentClusters().get("bar").getRootGroup().countNodes());
+    }
+
+    @Test
+    public void testNoNodeTagMeans1NodeNonHosted() {
+        String services =
+                "<?xml version='1.0' encoding='utf-8' ?>\n" +
+                "<services>" +
+                "  <jdisc id='foo' version='1.0'>" +
+                "    <search/>" +
+                "    <document-api/>" +
+                "  </jdisc>" +
+                "  <content version='1.0' id='bar'>" +
+                "     <documents>" +
+                "       <document type='type1' mode='index'/>" +
+                "     </documents>" +
+                "  </content>" +
+                "</services>";
+        VespaModelTester tester = new VespaModelTester();
+        tester.setHosted(false);
+        tester.addHosts(1);
+        VespaModel model = tester.createModel(services, true);
+        assertEquals(1, model.getRoot().getHostSystem().getHosts().size());
+        assertEquals(1, model.getAdmin().getSlobroks().size());
+        assertEquals(1, model.getContainerClusters().get("foo").getContainers().size());
+        assertEquals(1, model.getContentClusters().get("bar").getRootGroup().countNodes());
     }
 
     /** Recreate the combination used in some factory tests */

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1121,6 +1121,24 @@ public class ModelProvisioningTest {
     }
 
     @Test
+    public void testNoNodeTagMeans1NodeNoContent() {
+        String services =
+                "<?xml version='1.0' encoding='utf-8' ?>\n" +
+                "<services>" +
+                "  <jdisc id='foo' version='1.0'>" +
+                "    <search/>" +
+                "    <document-api/>" +
+                "  </jdisc>" +
+                "</services>";
+        VespaModelTester tester = new VespaModelTester();
+        tester.addHosts(1);
+        VespaModel model = tester.createModel(services, true);
+        assertEquals(1, model.getRoot().getHostSystem().getHosts().size());
+        assertEquals(1, model.getAdmin().getSlobroks().size());
+        assertEquals(1, model.getContainerClusters().get("foo").getContainers().size());
+    }
+
+    @Test
     public void testNoNodeTagMeans1NodeNonHosted() {
         String services =
                 "<?xml version='1.0' encoding='utf-8' ?>\n" +
@@ -1133,6 +1151,33 @@ public class ModelProvisioningTest {
                 "     <documents>" +
                 "       <document type='type1' mode='index'/>" +
                 "     </documents>" +
+                "  </content>" +
+                "</services>";
+        VespaModelTester tester = new VespaModelTester();
+        tester.setHosted(false);
+        tester.addHosts(1);
+        VespaModel model = tester.createModel(services, true);
+        assertEquals(1, model.getRoot().getHostSystem().getHosts().size());
+        assertEquals(1, model.getAdmin().getSlobroks().size());
+        assertEquals(1, model.getContainerClusters().get("foo").getContainers().size());
+        assertEquals(1, model.getContentClusters().get("bar").getRootGroup().recursiveGetNodes().size());
+    }
+
+    @Test
+    public void testSingleNodeNonHosted() {
+        String services =
+                "<?xml version='1.0' encoding='utf-8' ?>\n" +
+                "<services>" +
+                "  <jdisc id='foo' version='1.0'>" +
+                "    <search/>" +
+                "    <document-api/>" +
+                "    <nodes><node hostalias='foo'/></nodes>"+
+                "  </jdisc>" +
+                "  <content version='1.0' id='bar'>" +
+                "     <documents>" +
+                "       <document type='type1' mode='index'/>" +
+                "     </documents>" +
+                "    <nodes><node hostalias='foo' distribution-key='0'/></nodes>"+
                 "  </content>" +
                 "</services>";
         VespaModelTester tester = new VespaModelTester();

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
@@ -24,7 +24,7 @@ public class DistributorTest {
 
     ContentCluster parseCluster(String xml) {
         try {
-            final List<String> searchDefs = ApplicationPackageUtils.generateSearchDefinitions("music", "movies", "bunnies");
+            List<String> searchDefs = ApplicationPackageUtils.generateSearchDefinitions("music", "movies", "bunnies");
             MockRoot root = ContentClusterUtils.createMockRoot(searchDefs);
             return ContentClusterUtils.createCluster(xml, root);
         } catch (Exception e) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -36,6 +36,8 @@ import java.util.Map;
 public class VespaModelTester {
 
     private final ConfigModelRegistry configModelRegistry;
+
+    private boolean hosted = true;
     private Map<String, Collection<Host>> hosts = new HashMap<>();
 
     public VespaModelTester() {
@@ -56,6 +58,9 @@ public class VespaModelTester {
         this.hosts.put(flavor.isEmpty() ? "default" : flavor, hosts);
         return new Hosts(hosts);
     }
+
+    /** Sets whether this sets up a model for a hosted system. Default: true */
+    public void setHosted(boolean hosted) { this.hosted = hosted; }
 
     /** Creates a model which uses 0 as start index and fails on out of capacity */
     public VespaModel createModel(String services, String ... retiredHostNames) {
@@ -79,7 +84,7 @@ public class VespaModelTester {
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(appPkg)
                 .modelHostProvisioner(new InMemoryProvisioner(hosts, failOnOutOfCapacity, startIndexForClusters, retiredHostNames))
-                .properties((new DeployProperties.Builder()).hostedVespa(true).build()).build();
+                .properties((new DeployProperties.Builder()).hostedVespa(hosted).build()).build();
         return modelCreatorWithMockPkg.create(false, deployState, configModelRegistry);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -4,11 +4,13 @@ package com.yahoo.vespa.model.test;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.ConfigModelRegistry;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.model.deploy.DeployProperties;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.provision.Host;
 import com.yahoo.config.model.provision.Hosts;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
+import com.yahoo.config.model.provision.SingleNodeProvisioner;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
@@ -81,9 +83,14 @@ public class VespaModelTester {
     public VespaModel createModel(String services, boolean failOnOutOfCapacity, int startIndexForClusters, String ... retiredHostNames) {
         VespaModelCreatorWithMockPkg modelCreatorWithMockPkg = new VespaModelCreatorWithMockPkg(null, services, ApplicationPackageUtils.generateSearchDefinition("type1"));
         ApplicationPackage appPkg = modelCreatorWithMockPkg.appPkg;
+
+        HostProvisioner provisioner = hosted ? 
+                                      new InMemoryProvisioner(hosts, failOnOutOfCapacity, startIndexForClusters, retiredHostNames) :
+                                      new SingleNodeProvisioner();
+
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(appPkg)
-                .modelHostProvisioner(new InMemoryProvisioner(hosts, failOnOutOfCapacity, startIndexForClusters, retiredHostNames))
+                .modelHostProvisioner(provisioner)
                 .properties((new DeployProperties.Builder()).hostedVespa(hosted).build()).build();
         return modelCreatorWithMockPkg.create(false, deployState, configModelRegistry);
     }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/parser/IdentifierTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/parser/IdentifierTestCase.java
@@ -9,17 +9,16 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  */
 public class IdentifierTestCase {
 
     @Test
     public void requireThatThereAreNoReservedWords() throws ParseException {
         List<String> tokens = Arrays.asList("attribute",
-                                            "base64_decode",
-                                            "base64_encode",
+                                            "base64decode",
+                                            "base64encode",
                                             "clear_state",
-                                            "compact_phrase",
                                             "create_if_non_existent",
                                             "echo",
                                             "exact",
@@ -35,7 +34,7 @@ public class IdentifierTestCase {
                                             "index",
                                             "join",
                                             "linguistics",
-                                            "lower_case",
+                                            "lowercase",
                                             "ngram",
                                             "normalize",
                                             "now",
@@ -47,7 +46,7 @@ public class IdentifierTestCase {
                                             "remove_ctrl_chars",
                                             "remove_if_zero",
                                             "remove_so_si",
-                                            "select_field",
+                                            "select_input",
                                             "set_language",
                                             "set_var",
                                             "split",
@@ -71,4 +70,5 @@ public class IdentifierTestCase {
             assertEquals(str, parser.identifier());
         }
     }
+
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/package-info.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/package-info.java
@@ -4,4 +4,4 @@ package com.yahoo.vespa.hosted.provision.provisioning;
 
 import com.yahoo.osgi.annotation.ExportPackage;
 
-/** Implements the provisioning API to perform node provisioning form a node repository */
+/** Implements the provisioning API to perform node provisioning from a node repository */


### PR DESCRIPTION
@gjoranv please review

This allows missing <nodes> elements in both content and container for both hosted and non-hosted ... I think. We want this because it allows us to use the same sample apps/examples for hosted and open Vespa.

The code related to this is in a bad shape and this made it worse, but I have no patience left for it right now.

@kkraune fyi