### PR TITLE
Add request property for filtering child ACLs

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -191,16 +191,17 @@ public class NodeRepository extends AbstractComponent {
      * Creates a list of node ACLs which identify which nodes the given node should trust
      *
      * @param node Node for which to generate ACLs
+     * @param children Return ACLs for the children of the given node (e.g. containers on a Docker host)
      * @return List of node ACLs
      */
-    public List<NodeAcl> getNodeAcls(Node node) {
+    public List<NodeAcl> getNodeAcls(Node node, boolean children) {
         final List<NodeAcl> nodeAcls = new ArrayList<>();
-        nodeAcls.add(new NodeAcl(node, getTrustedNodes(node)));
 
-        // If a host node requests ACLs, we include ACLs for children of the node (e.g. containers on Docker hosts)
-        if (node.type() == NodeType.host) {
-            final List<Node> children = getNodes(node);
-            children.forEach(child -> nodeAcls.add(new NodeAcl(child, getTrustedNodes(child))));
+        if (children) {
+            final List<Node> childNodes = getNodes(node);
+            childNodes.forEach(childNode -> nodeAcls.add(new NodeAcl(childNode, getTrustedNodes(childNode))));
+        } else {
+            nodeAcls.add(new NodeAcl(node, getTrustedNodes(node)));
         }
 
         return Collections.unmodifiableList(nodeAcls);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeAclResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeAclResponse.java
@@ -20,13 +20,17 @@ import java.util.List;
  */
 public class NodeAclResponse extends HttpResponse {
 
+    private static final String CHILDREN_REQUEST_PROPERTY = "children";
+
     private final NodeRepository nodeRepository;
     private final Slime slime;
+    private final boolean aclsForChildren;
 
     public NodeAclResponse(HttpRequest request, NodeRepository nodeRepository) {
         super(200);
         this.nodeRepository = nodeRepository;
         this.slime = new Slime();
+        this.aclsForChildren = request.getBooleanProperty(CHILDREN_REQUEST_PROPERTY);
 
         final Cursor root = slime.setObject();
         final String hostname = baseName(request.getUri().getPath());
@@ -41,7 +45,7 @@ public class NodeAclResponse extends HttpResponse {
         Node node = nodeRepository.getNode(hostname)
                 .orElseGet(() -> nodeRepository.getConfigNode(hostname)
                         .orElseThrow(() -> new NotFoundException("No node with hostname '" + hostname + "'")));
-        toSlime(nodeRepository.getNodeAcls(node), object.setArray("trustedNodes"));
+        toSlime(nodeRepository.getNodeAcls(node, aclsForChildren), object.setArray("trustedNodes"));
     }
 
     private void toSlime(List<NodeAcl> nodeAcls, Cursor array) {


### PR DESCRIPTION
This covers the following use-cases:

1) When Chef configures ACLs on the Docker host, it's only interested the ACLs
for the Docker host itself.

2) When node-admin configures ACLs it's only interested in the ACLs for the
containers.

This way we don't have to do any special filtering of the response in any case.