### PR TITLE
Remove docker-java connection/read timeouts for local running

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerTestUtils.java
@@ -24,8 +24,6 @@ public class DockerTestUtils {
             .clientCertPath(operatingSystem == OS.Mac_OS_X ? prefix + "cert.pem" : "")
             .clientKeyPath( operatingSystem == OS.Mac_OS_X ? prefix + "key.pem" : "")
             .uri(           operatingSystem == OS.Mac_OS_X ? "tcp://192.168.99.100:2376" : "tcp://localhost:2376")
-            .connectTimeoutMillis(5000)
-            .readTimeoutMillis(5000)
             .secondsToWaitBeforeKillingContainer(0));
     private static DockerImpl docker;
 

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
@@ -142,7 +142,7 @@ public class RunSystemTests {
             else docker.deleteContainer(containerName);
         }
 
-        logger.info("Starting systemtests host");
+        logger.info("Starting systemtests container " + containerName.asString());
         InetAddress nodeInetAddress = InetAddress.getByName(containerName.asString());
         docker.createContainerCommand(
                 SYSTEMTESTS_DOCKER_IMAGE,


### PR DESCRIPTION
Removes timeouts added in #1545, which caused `RunSystemTests` to timeout (Running systemtests locally in docker container). `docker-java` passes the connect/read timeouts to Jersey, where the default value is infinite already: https://jersey.java.net/apidocs/2.3.1/jersey/org/glassfish/jersey/client/ClientProperties.html#READ_TIMEOUT

