### PR TITLE
Add separate session-wide visitor timeout parameter

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -125,7 +125,8 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         } else if (query.properties().getString(streamingSelection) != null) {
             params.setDocumentSelection(query.properties().getString(streamingSelection));
         }
-        params.setTimeoutMs(query.getTimeout());
+        params.setTimeoutMs(query.getTimeout()); // Per bucket visitor timeout
+        params.setSessionTimeoutMs(query.getTimeout());
         params.setVisitorLibrary("searchvisitor");
         params.setLocalDataHandler(this);
         params.setVisitHeadersOnly(query.properties().getBoolean(streamingHeadersonly));

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
@@ -277,6 +277,7 @@ public class VdsVisitorTestCase {
 
         // Verify parameters based only on query
         assertEquals(qa.timeout*1000, params.getTimeoutMs());
+        assertEquals(qa.timeout*1000, params.getSessionTimeoutMs());
         assertEquals("searchvisitor", params.getVisitorLibrary());
         assertEquals(Integer.MAX_VALUE, params.getMaxPending());
         assertEquals(qa.traceLevel, params.getTraceLevel());

--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
@@ -23,6 +23,7 @@ public class VisitorParameters extends Parameters {
     private String visitorLibrary = "DumpVisitor";
     private int maxPending = 32;
     private long timeoutMs = -1;
+    private long sessionTimeoutMs = -1;
     private long fromTimestamp = 0;
     private long toTimestamp = 0;
     boolean visitRemoves = false;
@@ -113,8 +114,14 @@ public class VisitorParameters extends Parameters {
     /** @return The maximum number of messages each storage visitor will have pending before waiting for acks from client. */
     public int getMaxPending() { return maxPending; }
 
-    /** @return The timeout for the visitor in milliseconds. */
+    /** @return The timeout for each sent visitor operation in milliseconds. */
     public long getTimeoutMs() { return timeoutMs; }
+
+    /**
+     * @return Session timeout in milliseconds, or -1 if not timeout has been set. -1 implies
+     *         that session will run to completion without automatically timing out.
+     */
+    public long getSessionTimeoutMs() { return sessionTimeoutMs; }
 
     /** @return The minimum timestamp (in microsecs) of documents the visitor will visit. */
     public long getFromTimestamp() { return fromTimestamp; }
@@ -191,8 +198,18 @@ public class VisitorParameters extends Parameters {
     /** Set maximum pending messages one storage visitor will have pending to this client before stalling, waiting for acks. */
     public void setMaxPending(int maxPending) { this.maxPending = maxPending; }
 
-    /** Set the timeout for the visitor in milliseconds. */
+    /** Set the timeout for each visitor command in milliseconds. */
     public void setTimeoutMs(long timeoutMs) { this.timeoutMs = timeoutMs; }
+
+    /**
+     * Sets timeout for the entire visiting session, in milliseconds. -1 implies infinity.
+     *
+     * If the session takes more time than this to complete, it will automatically
+     * be failed with CompletionCode.TIMEOUT.
+     * If no session timeout has been explicitly set (or it has been set to -1), visiting will
+     * continue until it completes or abort()/destroy() is called on the session instance.
+     */
+    public void setSessionTimeoutMs(long timeoutMs) { this.sessionTimeoutMs = timeoutMs; }
 
     /** Set from timestamp in microseconds. Documents put/updated before this timestamp will not be visited. */
     public void setFromTimestamp(long timestamp) { fromTimestamp = timestamp; }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
@@ -949,15 +949,15 @@ public class MessageBusVisitorSession implements VisitorSession {
         return TimeUnit.NANOSECONDS.toMillis(clock.monotonicNanoTime() - startTimeNanos);
     }
 
-    private static boolean isInfiniteTimeout(long timeoutMs) {
-        return timeoutMs < 0;
+    private static boolean isInfiniteTimeout(long timeoutMillis) {
+        return timeoutMillis < 0;
     }
 
     private long computeBoundedMessageTimeoutMillis(long elapsedMs) {
-        final long messageTimeoutMs = messageTimeoutMillis();
+        final long messageTimeoutMillis = messageTimeoutMillis();
         return !isInfiniteTimeout(sessionTimeoutMillis())
-                ? Math.min(sessionTimeoutMillis() - elapsedMs, messageTimeoutMs)
-                : messageTimeoutMs;
+                ? Math.min(sessionTimeoutMillis() - elapsedMs, messageTimeoutMillis)
+                : messageTimeoutMillis;
     }
 
     /**

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
@@ -386,7 +386,7 @@ public class MessageBusVisitorSession implements VisitorSession {
                 return;
             }
             transitionTo(new StateDescription(State.WORKING));
-            taskExecutor.submitTask(new SendCreateVisitorsTask(sessionTimeoutMillis()));
+            taskExecutor.submitTask(new SendCreateVisitorsTask(computeBoundedMessageTimeoutMillis(0)));
         }
     }
 
@@ -937,12 +937,27 @@ public class MessageBusVisitorSession implements VisitorSession {
                     || enoughHitsReceived());
     }
 
+    private long messageTimeoutMillis() {
+        return !isInfiniteTimeout(params.getTimeoutMs()) ? params.getTimeoutMs() : 5 * 60 * 1000;
+    }
+
     private long sessionTimeoutMillis() {
-        return (params.getTimeoutMs() != -1) ? params.getTimeoutMs() : 5 * 60 * 1000;
+        return params.getSessionTimeoutMs();
     }
 
     private long elapsedTimeMillis() {
         return TimeUnit.NANOSECONDS.toMillis(clock.monotonicNanoTime() - startTimeNanos);
+    }
+
+    private static boolean isInfiniteTimeout(long timeoutMs) {
+        return timeoutMs < 0;
+    }
+
+    private long computeBoundedMessageTimeoutMillis(long elapsedMs) {
+        final long messageTimeoutMs = messageTimeoutMillis();
+        return !isInfiniteTimeout(sessionTimeoutMillis())
+                ? Math.min(sessionTimeoutMillis() - elapsedMs, messageTimeoutMs)
+                : messageTimeoutMs;
     }
 
     /**
@@ -952,9 +967,8 @@ public class MessageBusVisitorSession implements VisitorSession {
      */
     private void scheduleSendCreateVisitorsIfApplicable(long delay, TimeUnit unit) {
         final long elapsedMillis = elapsedTimeMillis();
-        final long timeoutMillis = sessionTimeoutMillis();
-        if (elapsedMillis >= timeoutMillis) {
-            transitionTo(new StateDescription(State.TIMED_OUT, String.format("Session timeout of %d ms expired", timeoutMillis)));
+        if (!isInfiniteTimeout(sessionTimeoutMillis()) && (elapsedMillis >= sessionTimeoutMillis())) {
+            transitionTo(new StateDescription(State.TIMED_OUT, String.format("Session timeout of %d ms expired", sessionTimeoutMillis())));
             if (visitingCompleted()) {
                 markSessionCompleted();
             }
@@ -963,7 +977,7 @@ public class MessageBusVisitorSession implements VisitorSession {
         if (!mayScheduleCreateVisitorsTask()) {
             return;
         }
-        final long messageTimeoutMillis = timeoutMillis - elapsedMillis;
+        final long messageTimeoutMillis = computeBoundedMessageTimeoutMillis(elapsedMillis);
         taskExecutor.scheduleTask(new SendCreateVisitorsTask(messageTimeoutMillis), delay, unit);
         scheduledSendCreateVisitors = true;
     }


### PR DESCRIPTION
@dybis Please review.

This augments today's per-visitor timeout, which should not be used
implicitly for setting the session timeout.