### PR TITLE
Balder/avoid partial old and new stringfieldvalue after deserialization

### DIFF
--- a/document/src/vespa/document/fieldvalue/stringfieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/stringfieldvalue.cpp
@@ -80,6 +80,11 @@ StringFieldValue::SpanTrees StringFieldValue::getSpanTrees() const {
     return trees;
 }
 
+void
+StringFieldValue::doClearSpanTrees() {
+    _annotationData.reset();
+}
+
 const SpanTree * StringFieldValue::findTree(const SpanTrees & trees, const stringref & name)
 {
     for(const auto & tree : trees) {

--- a/document/src/vespa/document/fieldvalue/stringfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/stringfieldvalue.h
@@ -47,10 +47,16 @@ public:
     }
     bool hasSpanTrees() const { return _annotationData ? _annotationData->hasSpanTrees() : false; }
     static const SpanTree *findTree(const SpanTrees &trees, const vespalib::stringref &name);
+    void clearSpanTrees() {
+        if (_annotationData) {
+            doClearSpanTrees();
+        }
+    }
 
     using LiteralFieldValueB::operator=;
     DECLARE_IDENTIFIABLE(StringFieldValue);
 private:
+    void doClearSpanTrees();
 
     class AnnotationData {
     public:

--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -278,6 +278,8 @@ void VespaDocumentDeserializer::read(StringFieldValue &value) {
         value.setSpanTrees(vespalib::ConstBufferRef(_stream.peek(), serializedAnnotationsSize),
                            _repo, _version, _stream.isLongLivedBuffer());
         _stream.adjustReadPos(serializedAnnotationsSize);
+    } else {
+        value.clearSpanTrees();
     }
 }
 


### PR DESCRIPTION
@havardpe PR
I finally found the error. It was the annotation from the previous document that was not cleared away during deserialisation into the same field...
The problem only occurs when the previous document was so alrge that its uncompressed content was above 2M as it will then be mmapped directly. Once unmapped any copy from here will fail.
But deserialization must of of course leave the object in the same state independent of its old state.

I will merge to get factoryy<s point of view,