### PR TITLE
Revert "Use Jetty 9.3.16"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.3.16.v20170120</jetty.version>
+        <jetty.version>9.3.15.v20161220</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>


### PR DESCRIPTION
Reverts yahoo/vespa#1580

vespaclient-container-plugin unit tests started failing after this was merged, consider reverting