### PR TITLE
Use Jetty 9.3.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.3.15.v20161220</jetty.version>
+        <jetty.version>9.3.16.v20170120</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
@@ -286,7 +286,7 @@ public class RestApiTest {
     private String doRest(HttpRequestBase request) throws IOException {
         HttpClient client = HttpClientBuilder.create().build();
         HttpResponse response = client.execute(request);
-        assertThat(response.getEntity().getContentType().getValue().toString(), is("application/json; charset=UTF-8"));
+        assertThat(response.getEntity().getContentType().getValue().toString(), is("application/json;charset=utf-8"));
         HttpEntity entity = response.getEntity();
         return EntityUtils.toString(entity);
     }


### PR DESCRIPTION
Includes fix for failing unit test in `vespaclient-container-plugin`