### PR TITLE
Ensure reference document ID mutations also check for correct document type

### DIFF
--- a/document/src/main/java/com/yahoo/document/datatypes/ReferenceFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/ReferenceFieldValue.java
@@ -79,6 +79,7 @@ public class ReferenceFieldValue extends FieldValue {
     }
 
     public void setDocumentId(DocumentId documentId) {
+        requireIdOfMatchingType(referenceType, documentId);
         this.documentId = Optional.of(documentId);
     }
 
@@ -97,7 +98,7 @@ public class ReferenceFieldValue extends FieldValue {
         if (o == null) {
             clear();
         } else if (o instanceof DocumentId) {
-            this.documentId = Optional.of((DocumentId)o);
+            setDocumentId((DocumentId) o);
         } else {
             throw new IllegalArgumentException(String.format(
                     "Can't assign value of type '%s' to field of type '%s'. Expected value of type '%s'",

--- a/document/src/test/java/com/yahoo/document/datatypes/ReferenceFieldValueTestCase.java
+++ b/document/src/test/java/com/yahoo/document/datatypes/ReferenceFieldValueTestCase.java
@@ -144,4 +144,17 @@ public class ReferenceFieldValueTestCase {
         new ReferenceFieldValue(referenceTypeFoo(), docId("id:ns:bar::mismatch"));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void reference_doc_id_setter_requires_that_id_has_same_document_type_as_data_type() {
+        ReferenceFieldValue value = new ReferenceFieldValue(referenceTypeFoo());
+        value.setDocumentId(docId("id:ns:bar::mismatch"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void assigning_new_id_for_existing_reference_requires_that_id_has_same_document_type_as_data_type() {
+        ReferenceFieldValue value = new ReferenceFieldValue(referenceTypeFoo());
+        DocumentId newId = docId("id:ns:bar::mama-mia");
+        value.assign(newId);
+    }
+
 }


### PR DESCRIPTION
@geirst @bjorncs Plugging some API holes where ID was not checked for document type correctness.