### PR TITLE
Add reference type and field value to C++

### DIFF
--- a/document/src/tests/datatype/CMakeLists.txt
+++ b/document/src/tests/datatype/CMakeLists.txt
@@ -8,3 +8,13 @@ vespa_add_executable(document_datatype_test_app TEST
     document_documentconfig
 )
 vespa_add_test(NAME document_datatype_test_app COMMAND document_datatype_test_app)
+
+vespa_add_executable(document_referencedatatype_test_app TEST
+    SOURCES
+    referencedatatype_test.cpp
+    DEPENDS
+    document
+    AFTER
+    document_documentconfig
+)
+vespa_add_test(NAME document_referencedatatype_test_app COMMAND document_referencedatatype_test_app)

--- a/document/src/tests/datatype/referencedatatype_test.cpp
+++ b/document/src/tests/datatype/referencedatatype_test.cpp
@@ -1,0 +1,71 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/document/base/field.h>
+#include <vespa/document/datatype/referencedatatype.h>
+#include <vespa/document/fieldvalue/referencefieldvalue.h>
+#include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/exceptions.h>
+#include <ostream>
+#include <sstream>
+
+using namespace document;
+
+struct Fixture {
+    DocumentType docType{"foo"};
+    ReferenceDataType refType{docType, 12345};
+};
+
+TEST_F("Constructor generates type-parameterized name and sets type ID", Fixture) {
+    EXPECT_EQUAL("Reference<foo>", f.refType.getName());
+    EXPECT_EQUAL(12345, f.refType.getId());
+}
+
+TEST_F("Target document type is accessible via data type", Fixture) {
+    EXPECT_EQUAL(f.docType, f.refType.getTargetType());
+}
+
+TEST_F("Empty ReferenceFieldValue instances can be created from type", Fixture) {
+    auto fv = f.refType.createFieldValue();
+    ASSERT_TRUE(fv.get() != nullptr);
+    ASSERT_TRUE(dynamic_cast<ReferenceFieldValue*>(fv.get()) != nullptr);
+    EXPECT_EQUAL(&f.refType, fv->getDataType());
+}
+
+TEST_F("operator== checks document type and type ID", Fixture) {
+    EXPECT_NOT_EQUAL(f.refType, *DataType::STRING);
+    EXPECT_EQUAL(f.refType, f.refType);
+
+    DocumentType otherDocType("bar");
+    ReferenceDataType refWithDifferentType(otherDocType, 12345);
+    ReferenceDataType refWithSameTypeDifferentId(f.docType, 56789);
+
+    EXPECT_NOT_EQUAL(f.refType, refWithDifferentType);
+    EXPECT_NOT_EQUAL(f.refType, refWithSameTypeDifferentId);
+}
+
+TEST_F("clone() creates new type instance equal to old instance", Fixture) {
+    std::unique_ptr<ReferenceDataType> cloned(f.refType.clone());
+    ASSERT_TRUE(cloned.get() != nullptr);
+    EXPECT_EQUAL(f.refType, *cloned);
+}
+
+TEST_F("print() emits type name and id", Fixture) {
+    std::ostringstream ss;
+    f.refType.print(ss, true, "");
+    EXPECT_EQUAL("ReferenceDataType(foo, id 12345)", ss.str());
+}
+
+TEST_F("buildFieldPath returns empty path for empty input", Fixture) {
+    auto fp = f.refType.buildFieldPath("");
+    ASSERT_TRUE(fp.get() != nullptr);
+    EXPECT_TRUE(fp->empty());
+}
+
+TEST_F("buildFieldPath throws IllegalArgumentException for non-empty input", Fixture) {
+    EXPECT_EXCEPTION(f.refType.buildFieldPath("herebedragons"),
+                     vespalib::IllegalArgumentException,
+                     "Reference data type does not support further field "
+                     "recursion: 'herebedragons'");
+}
+
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/document/src/tests/fieldvalue/CMakeLists.txt
+++ b/document/src/tests/fieldvalue/CMakeLists.txt
@@ -26,3 +26,13 @@ vespa_add_executable(document_predicatefieldvalue_test_app TEST
     document_documentconfig
 )
 vespa_add_test(NAME document_predicatefieldvalue_test_app COMMAND document_predicatefieldvalue_test_app)
+
+vespa_add_executable(document_referencefieldvalue_test_app TEST
+    SOURCES
+    referencefieldvalue_test.cpp
+    DEPENDS
+    document
+    AFTER
+    document_documentconfig
+)
+vespa_add_test(NAME document_referencefieldvalue_test_app COMMAND document_referencefieldvalue_test_app)

--- a/document/src/tests/fieldvalue/referencefieldvalue_test.cpp
+++ b/document/src/tests/fieldvalue/referencefieldvalue_test.cpp
@@ -165,5 +165,13 @@ TEST_F("print() includes reference type and document ID", Fixture) {
                  "DocumentId(id:ns:foo::yoshi))", ss.str());
 }
 
+TEST_F("print() only indents start of output line", Fixture) {
+    ReferenceFieldValue src(f.refType, DocumentId("id:ns:foo::yoshi"));
+    std::ostringstream ss;
+    src.print(ss, false, "    ");
+    EXPECT_EQUAL("    ReferenceFieldValue(ReferenceDataType(foo, id 12345), "
+                 "DocumentId(id:ns:foo::yoshi))", ss.str());
+}
+
 TEST_MAIN() { TEST_RUN_ALL(); }
 

--- a/document/src/tests/fieldvalue/referencefieldvalue_test.cpp
+++ b/document/src/tests/fieldvalue/referencefieldvalue_test.cpp
@@ -130,7 +130,18 @@ TEST_F("clone()ing creates new instance with same ID and type", Fixture) {
 
     std::unique_ptr<ReferenceFieldValue> cloned(src.clone());
     ASSERT_TRUE(cloned.get() != nullptr);
+    ASSERT_TRUE(cloned->hasValidDocumentId());
     EXPECT_EQUAL(src.getDocumentId(), cloned->getDocumentId());
+    EXPECT_EQUAL(src.getDataType(), cloned->getDataType());
+    EXPECT_TRUE(cloned->hasChanged());
+}
+
+TEST_F("Can clone() value without document ID", Fixture) {
+    ReferenceFieldValue src(f.refType);
+
+    std::unique_ptr<ReferenceFieldValue> cloned(src.clone());
+    ASSERT_TRUE(cloned.get() != nullptr);
+    EXPECT_FALSE(cloned->hasValidDocumentId());
     EXPECT_EQUAL(src.getDataType(), cloned->getDataType());
     EXPECT_TRUE(cloned->hasChanged());
 }

--- a/document/src/tests/fieldvalue/referencefieldvalue_test.cpp
+++ b/document/src/tests/fieldvalue/referencefieldvalue_test.cpp
@@ -161,6 +161,11 @@ TEST_F("compare() orders first on type ID, then on document ID", Fixture) {
     // Same types, different IDs
     EXPECT_TRUE(fvType1Id1.compare(fvType1Id2) < 0);
     EXPECT_TRUE(fvType1Id2.compare(fvType1Id1) > 0);
+    EXPECT_TRUE(fvType2Id1.compare(fvType2Id2) < 0);
+
+    // Different types and IDs
+    EXPECT_TRUE(fvType1Id1.compare(fvType2Id2) < 0);
+    EXPECT_TRUE(fvType2Id2.compare(fvType1Id1) > 0);
 
     // Equal types and ID 
     EXPECT_EQUAL(0, fvType1Id1.compare(fvType1Id1));

--- a/document/src/tests/serialization/vespadocumentserializer_test.cpp
+++ b/document/src/tests/serialization/vespadocumentserializer_test.cpp
@@ -886,7 +886,7 @@ struct RefFixture {
         return dynamic_cast<const ReferenceDataType&>(*raw_type);
     }
 
-    void roundtripSerialize(const ReferenceFieldValue& src, ReferenceFieldValue& dest) {
+    void roundtrip_serialize(const ReferenceFieldValue& src, ReferenceFieldValue& dest) {
         nbostream stream;
         VespaDocumentSerializer serializer(stream);
         serializer.write(src);
@@ -912,7 +912,7 @@ TEST_F("ReferenceFieldValue with ID can be roundtrip serialized", RefFixture) {
 TEST_F("Empty ReferenceFieldValue has changed-flag cleared after deserialization", RefFixture) {
     ReferenceFieldValue src(f.ref_type());
     ReferenceFieldValue dest(f.ref_type());
-    f.roundtripSerialize(src, dest);
+    f.roundtrip_serialize(src, dest);
 
     EXPECT_FALSE(dest.hasChanged());
 }
@@ -921,7 +921,7 @@ TEST_F("ReferenceFieldValue with ID has changed-flag cleared after deserializati
     ReferenceFieldValue src(
             f.ref_type(), DocumentId("id:ns:" + doc_name + "::foo"));
     ReferenceFieldValue dest(f.ref_type());
-    f.roundtripSerialize(src, dest);
+    f.roundtrip_serialize(src, dest);
 
     EXPECT_FALSE(dest.hasChanged());
 }

--- a/document/src/vespa/document/config/documenttypes.def
+++ b/document/src/vespa/document/config/documenttypes.def
@@ -101,6 +101,10 @@ documenttype[].annotationtype[].inherits[].id int
 ## Field sets
 documenttype[].fieldsets{}.fields[] string
 
+## ID of reference type. This is a regular data type, but is kept in its own
+## array to avoid polluting the existing datatype array with a new default
+## field value.
 documenttype[].referencetype[].id int
 
+## Numeric ID of the document type instances of the reference point to.
 documenttype[].referencetype[].target_type_id int

--- a/document/src/vespa/document/config/documenttypes.def
+++ b/document/src/vespa/document/config/documenttypes.def
@@ -100,3 +100,7 @@ documenttype[].annotationtype[].inherits[].id int
 
 ## Field sets
 documenttype[].fieldsets{}.fields[] string
+
+documenttype[].referencetype[].id int
+
+documenttype[].referencetype[].target_type_id int

--- a/document/src/vespa/document/datatype/CMakeLists.txt
+++ b/document/src/vespa/document/datatype/CMakeLists.txt
@@ -15,6 +15,7 @@ vespa_add_library(document_datatypes OBJECT
     structureddatatype.cpp
     urldatatype.cpp
     weightedsetdatatype.cpp
+    referencedatatype.cpp
     DEPENDS
     AFTER
     document_documentconfig

--- a/document/src/vespa/document/datatype/referencedatatype.cpp
+++ b/document/src/vespa/document/datatype/referencedatatype.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "referencedatatype.h"
-#include "../fieldvalue/referencefieldvalue.h"
+#include <vespa/document/fieldvalue/referencefieldvalue.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <ostream>

--- a/document/src/vespa/document/datatype/referencedatatype.cpp
+++ b/document/src/vespa/document/datatype/referencedatatype.cpp
@@ -1,0 +1,46 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "referencedatatype.h"
+#include "../fieldvalue/referencefieldvalue.h"
+#include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/stringfmt.h>
+#include <ostream>
+
+namespace document {
+
+ReferenceDataType::ReferenceDataType(const DocumentType& targetDocType, int id)
+    : DataType(vespalib::make_string("Reference<%s>", targetDocType.getName().c_str()), id),
+      _targetDocType(targetDocType)
+{
+}
+
+ReferenceDataType::~ReferenceDataType() {
+}
+
+std::unique_ptr<FieldValue> ReferenceDataType::createFieldValue() const {
+    return std::make_unique<ReferenceFieldValue>(*this);
+}
+
+void ReferenceDataType::print(std::ostream& os, bool verbose, const std::string& indent) const {
+    (void) verbose;
+    (void) indent;
+    os << "ReferenceDataType(" << _targetDocType.getName()
+       << ", id " << getId() << ')';
+}
+
+ReferenceDataType* ReferenceDataType::clone() const {
+    return new ReferenceDataType(_targetDocType, getId());
+}
+
+std::unique_ptr<FieldPath> ReferenceDataType::onBuildFieldPath(
+        const vespalib::stringref& remainingFieldName) const {
+    if (!remainingFieldName.empty()) {
+        throw vespalib::IllegalArgumentException(
+                vespalib::make_string("Reference data type does not support "
+                                      "further field recursion: '%s'",
+                                      remainingFieldName.c_str()), VESPA_STRLOC);
+    }
+    return std::make_unique<FieldPath>();
+}
+
+} // document

--- a/document/src/vespa/document/datatype/referencedatatype.h
+++ b/document/src/vespa/document/datatype/referencedatatype.h
@@ -6,6 +6,10 @@
 
 namespace document {
 
+/**
+ * A ReferenceDataType specifies a particular concrete document type that a
+ * ReferenceFieldValue instance binds to.
+ */
 class ReferenceDataType : public DataType {
     const DocumentType& _targetDocType;
 public:

--- a/document/src/vespa/document/datatype/referencedatatype.h
+++ b/document/src/vespa/document/datatype/referencedatatype.h
@@ -1,0 +1,26 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "documenttype.h"
+
+namespace document {
+
+class ReferenceDataType : public DataType {
+    const DocumentType& _targetDocType;
+public:
+    ReferenceDataType(const DocumentType& targetDocType, int id);
+    ~ReferenceDataType();
+
+    const DocumentType& getTargetType() const noexcept {
+        return _targetDocType;
+    }
+
+    std::unique_ptr<FieldValue> createFieldValue() const override;
+    void print(std::ostream&, bool verbose, const std::string& indent) const override;
+    ReferenceDataType* clone() const override;
+    std::unique_ptr<FieldPath> onBuildFieldPath(
+            const vespalib::stringref& remainingFieldName) const override;
+};
+
+} // document

--- a/document/src/vespa/document/fieldvalue/CMakeLists.txt
+++ b/document/src/vespa/document/fieldvalue/CMakeLists.txt
@@ -23,6 +23,7 @@ vespa_add_library(document_fieldvalues OBJECT
     structuredfieldvalue.cpp
     tensorfieldvalue.cpp
     weightedsetfieldvalue.cpp
+    referencefieldvalue.cpp
     DEPENDS
     AFTER
     document_documentconfig

--- a/document/src/vespa/document/fieldvalue/document.h
+++ b/document/src/vespa/document/fieldvalue/document.h
@@ -36,7 +36,7 @@ public:
     typedef std::unique_ptr<Document> UP;
     typedef std::shared_ptr<Document> SP;
 
-    static uint16_t getNewestSerializationVersion() { return 8; };
+    static constexpr uint16_t getNewestSerializationVersion() { return 8; }
 
     Document();
     Document(const Document&);

--- a/document/src/vespa/document/fieldvalue/fieldvaluevisitor.h
+++ b/document/src/vespa/document/fieldvalue/fieldvaluevisitor.h
@@ -19,6 +19,7 @@ class StringFieldValue;
 class StructFieldValue;
 class WeightedSetFieldValue;
 class TensorFieldValue;
+class ReferenceFieldValue;
 
 struct FieldValueVisitor {
     virtual ~FieldValueVisitor() {}
@@ -39,6 +40,7 @@ struct FieldValueVisitor {
     virtual void visit(StructFieldValue &value) = 0;
     virtual void visit(WeightedSetFieldValue &value) = 0;
     virtual void visit(TensorFieldValue &value) = 0;
+    virtual void visit(ReferenceFieldValue& value) = 0;
 };
 
 struct ConstFieldValueVisitor {
@@ -60,6 +62,7 @@ struct ConstFieldValueVisitor {
     virtual void visit(const StructFieldValue &value) = 0;
     virtual void visit(const WeightedSetFieldValue &value) = 0;
     virtual void visit(const TensorFieldValue &value) = 0;
+    virtual void visit(const ReferenceFieldValue& value) = 0;
 };
 
 }  // namespace document

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
@@ -80,7 +80,11 @@ void ReferenceFieldValue::setDeserializedDocumentId(const DocumentId& id) {
 
 ReferenceFieldValue* ReferenceFieldValue::clone() const {
     assert(_dataType != nullptr);
-    return new ReferenceFieldValue(*_dataType, _documentId);
+    if (hasValidDocumentId()) {
+        return new ReferenceFieldValue(*_dataType, _documentId);
+    } else {
+        return new ReferenceFieldValue(*_dataType);
+    }
 }
 
 int ReferenceFieldValue::compare(const FieldValue& rhs) const {

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
@@ -55,20 +55,19 @@ void ReferenceFieldValue::requireIdOfMatchingType(
 
 FieldValue& ReferenceFieldValue::assign(const FieldValue& rhs) {
     const auto* refValueRhs(dynamic_cast<const ReferenceFieldValue*>(&rhs));
-    if (refValueRhs != nullptr) {
-        if (refValueRhs == this) {
-            return *this;
-        }
-        _documentId = refValueRhs->_documentId;
-        _dataType = refValueRhs->_dataType;
-        _altered = true;
-    } else {
+    if (refValueRhs == nullptr) {
         throw IllegalArgumentException(
                 make_string("Can't assign field value of type %s to "
                             "a ReferenceFieldValue",
                             rhs.getDataType()->getName().c_str()),
                 VESPA_STRLOC);
     }
+    if (refValueRhs == this) {
+        return *this;
+    }
+    _documentId = refValueRhs->_documentId;
+    _dataType = refValueRhs->_dataType;
+    _altered = true;
     return *this;
 }
 

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
@@ -99,9 +99,8 @@ int ReferenceFieldValue::compare(const FieldValue& rhs) const {
 
 void ReferenceFieldValue::print(std::ostream& os, bool verbose, const std::string& indent) const {
     (void) verbose;
-    (void) indent;
     assert(_dataType != nullptr);
-    os << "ReferenceFieldValue(" << *_dataType << ", DocumentId(";
+    os << indent << "ReferenceFieldValue(" << *_dataType << ", DocumentId(";
     _documentId.print(os, false, "");
     os << "))";
 }

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.h
@@ -11,6 +11,7 @@ namespace document {
 class ReferenceFieldValue : public FieldValue {
     const ReferenceDataType* _dataType;
     DocumentId _documentId;
+    bool _altered;
 public:
     // Empty constructor required for Identifiable.
     ReferenceFieldValue();
@@ -32,6 +33,13 @@ public:
     // Returned value is only well-defined if hasValidDocumentId() == true.
     const DocumentId& getDocumentId() const noexcept {
         return _documentId;
+    }
+
+    // Should only be called by deserializer code, as it will clear hasChanged.
+    // `id` must be a valid document ID and cannot be empty.
+    void setDeserializedDocumentId(const DocumentId& id);
+    void clearChanged() {
+        _altered = false;
     }
 
     const DataType* getDataType() const override { return _dataType; }

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.h
@@ -10,6 +10,7 @@ namespace document {
 
 class ReferenceFieldValue : public FieldValue {
     const ReferenceDataType* _dataType;
+    // TODO wrap in std::optional once available.
     DocumentId _documentId;
     bool _altered;
 public:

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.h
@@ -1,0 +1,55 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "fieldvalue.h"
+#include "../datatype/referencedatatype.h"
+#include "../base/documentid.h"
+
+namespace document {
+
+class ReferenceFieldValue : public FieldValue {
+    const ReferenceDataType* _dataType;
+    DocumentId _documentId;
+public:
+    // Empty constructor required for Identifiable.
+    ReferenceFieldValue();
+
+    explicit ReferenceFieldValue(const ReferenceDataType& dataType);
+
+    ReferenceFieldValue(const ReferenceDataType& dataType,
+                        const DocumentId& documentId);
+
+    ~ReferenceFieldValue();
+
+    ReferenceFieldValue(const ReferenceFieldValue&) = default;
+    ReferenceFieldValue& operator=(const ReferenceFieldValue&) = default;
+
+    bool hasValidDocumentId() const noexcept {
+        return _documentId.hasDocType();
+    }
+
+    // Returned value is only well-defined if hasValidDocumentId() == true.
+    const DocumentId& getDocumentId() const noexcept {
+        return _documentId;
+    }
+
+    const DataType* getDataType() const override { return _dataType; }
+    FieldValue& assign(const FieldValue&) override;
+    ReferenceFieldValue* clone() const override;
+    int compare(const FieldValue&) const override;
+    void printXml(XmlOutputStream&) const override { /* Not implemented */ }
+    void print(std::ostream&, bool, const std::string&) const override;
+    bool hasChanged() const override;
+    void accept(FieldValueVisitor&) override;
+    void accept(ConstFieldValueVisitor&) const override;
+
+    DECLARE_IDENTIFIABLE(ReferenceFieldValue);
+private:
+    // Throws vespalib::IllegalArgumentException if  doc type of `id` does not
+    // match the name of `type`.
+    static void requireIdOfMatchingType(
+            const DocumentId& id, const DocumentType& type);
+};
+
+} // document

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "fieldvalue.h"
-#include "../datatype/referencedatatype.h"
-#include "../base/documentid.h"
+#include <vespa/document/datatype/referencedatatype.h>
+#include <vespa/document/base/documentid.h>
 
 namespace document {
 

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.h
@@ -8,6 +8,20 @@
 
 namespace document {
 
+/**
+ * A reference field value allows search queries to access fields in other
+ * document instances as if they were fields natively stored within the
+ * searched document. This allows modelling one-to-many relations such as a
+ * parent document with many children containing references back to the parent.
+ *
+ * Each ReferenceFieldValue may contain a single document ID which specifies the
+ * instance the field should refer to. This document ID must have a type
+ * matching that of the reference data type of the field itself.
+ *
+ * Note that references are not polymorphic. This means that if you have a
+ * document type "foo" inheriting "bar", you cannot have a reference<bar> field
+ * containing a document ID for a "foo" document.
+ */
 class ReferenceFieldValue : public FieldValue {
     const ReferenceDataType* _dataType;
     // TODO wrap in std::optional once available.

--- a/document/src/vespa/document/repo/configbuilder.h
+++ b/document/src/vespa/document/repo/configbuilder.h
@@ -137,6 +137,12 @@ struct DocTypeRep {
         addType(type, doc_type);
         return annotationType(id, name, type.id);
     }
+    DocTypeRep& referenceType(int32_t id, int32_t target_type_id) {
+        doc_type.referencetype.resize(doc_type.referencetype.size() + 1);
+        doc_type.referencetype.back().id = id;
+        doc_type.referencetype.back().targetTypeId = target_type_id;
+        return *this;
+    }
 };
 
 class DocumenttypesConfigBuilderHelper {

--- a/document/src/vespa/document/repo/documenttyperepo.cpp
+++ b/document/src/vespa/document/repo/documenttyperepo.cpp
@@ -199,7 +199,7 @@ struct DataTypeRepo {
     Repo repo;
     AnnotationTypeRepo annotations;
 
-    DataTypeRepo() : doc_type(0) {}
+    DataTypeRepo() : doc_type(nullptr) {}
     ~DataTypeRepo() { delete doc_type; }
 };
 
@@ -534,7 +534,7 @@ DocumentTypeRepo::~DocumentTypeRepo() {
 
 const DocumentType *DocumentTypeRepo::getDocumentType(int32_t type_id) const {
     const DataTypeRepo *repo = FindPtr(_doc_types, type_id);
-    return repo ? repo->doc_type : 0;
+    return repo ? repo->doc_type : nullptr;
 }
 
 const DocumentType *DocumentTypeRepo::getDocumentType(const stringref &name) const {
@@ -549,26 +549,26 @@ const DocumentType *DocumentTypeRepo::getDocumentType(const stringref &name) con
             return it->second->doc_type;
         }
     }
-    return 0;
+    return nullptr;
 }
 
 const DataType *
 DocumentTypeRepo::getDataType(const DocumentType &doc_type, int32_t id) const {
     const DataTypeRepo *dt_repo = FindPtr(_doc_types, doc_type.getId());
-    return dt_repo ? dt_repo->repo.lookup(id) : 0;
+    return dt_repo ? dt_repo->repo.lookup(id) : nullptr;
 }
 
 const DataType *
 DocumentTypeRepo::getDataType(
         const DocumentType &doc_type, const stringref &name) const {
     const DataTypeRepo *dt_repo = FindPtr(_doc_types, doc_type.getId());
-    return dt_repo ? dt_repo->repo.lookup(name) : 0;
+    return dt_repo ? dt_repo->repo.lookup(name) : nullptr;
 }
 
 const AnnotationType *DocumentTypeRepo::getAnnotationType(
         const DocumentType &doc_type, int32_t id) const {
     const DataTypeRepo *dt_repo = FindPtr(_doc_types, doc_type.getId());
-    return dt_repo ? dt_repo->annotations.lookup(id) : 0;
+    return dt_repo ? dt_repo->annotations.lookup(id) : nullptr;
 }
 
 void DocumentTypeRepo::forEachDocumentType(

--- a/document/src/vespa/document/repo/documenttyperepo.cpp
+++ b/document/src/vespa/document/repo/documenttyperepo.cpp
@@ -10,6 +10,7 @@
 #include <vespa/document/datatype/positiondatatype.h>
 #include <vespa/document/datatype/urldatatype.h>
 #include <vespa/document/datatype/weightedsetdatatype.h>
+#include <vespa/document/datatype/referencedatatype.h>
 #include <vespa/vespalib/objects/identifiable.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/util/closure.h>
@@ -444,6 +445,16 @@ void addFieldSet(const DocumenttypesConfig::Documenttype::FieldsetsMap & fsv, Do
     }
 }
 
+void addReferenceTypes(
+        const vector<DocumenttypesConfig::Documenttype::Referencetype> &ref_types,
+        Repo& data_type_repo,
+        const DocumentTypeMap& doc_type_map) {
+    for (const auto& ref_type : ref_types) {
+        const auto* target_doc_type = lookupRepo(ref_type.targetTypeId, doc_type_map).doc_type;
+        data_type_repo.addDataType(std::make_unique<ReferenceDataType>(*target_doc_type, ref_type.id));
+    }
+}
+
 void configureDataTypeRepo(
         const DocumenttypesConfig::Documenttype &doc_type,
         DocumentTypeMap &type_map) {
@@ -452,6 +463,7 @@ void configureDataTypeRepo(
             doc_type.inherits, type_map, data_types->annotations);
     addAnnotationTypes(doc_type.annotationtype, data_types->annotations);
     inheritDataTypes(doc_type.inherits, type_map, data_types->repo);
+    addReferenceTypes(doc_type.referencetype, data_types->repo, type_map);
     addDataTypes(doc_type.datatype, data_types->repo, data_types->annotations);
     setAnnotationDataTypes(doc_type.annotationtype, data_types->annotations,
                            data_types->repo);

--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -17,6 +17,7 @@
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/document/fieldvalue/weightedsetfieldvalue.h>
 #include <vespa/document/fieldvalue/tensorfieldvalue.h>
+#include <vespa/document/fieldvalue/referencefieldvalue.h>
 #include <vespa/vespalib/data/slime/binary_format.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/stllike/asciistream.h>
@@ -387,6 +388,17 @@ VespaDocumentDeserializer::read(TensorFieldValue &value)
     }
     value.assignDeserialized(std::move(tensor));
     _stream.adjustReadPos(length);
+}
+
+void VespaDocumentDeserializer::read(ReferenceFieldValue& value) {
+    const bool hasId(readValue<uint8_t>(_stream) == 1);
+    if (hasId) {
+        DocumentId id;
+        read(id);
+        value.setDeserializedDocumentId(id);
+    } else {
+        value.clearChanged();
+    }
 }
 
 }  // document

--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.h
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.h
@@ -19,22 +19,23 @@ class VespaDocumentDeserializer : private FieldValueVisitor {
     FixedTypeRepo _repo;
     uint16_t _version;
 
-    virtual void visit(AnnotationReferenceFieldValue &value) { read(value); }
-    virtual void visit(ArrayFieldValue &value) { read(value); }
-    virtual void visit(ByteFieldValue &value) { read(value); }
-    virtual void visit(Document &value) { read(value); }
-    virtual void visit(DoubleFieldValue &value) { read(value); }
-    virtual void visit(FloatFieldValue &value) { read(value); }
-    virtual void visit(IntFieldValue &value) { read(value); }
-    virtual void visit(LongFieldValue &value) { read(value); }
-    virtual void visit(MapFieldValue &value) { read(value); }
-    virtual void visit(PredicateFieldValue &value) { read(value); }
-    virtual void visit(RawFieldValue &value) { read(value); }
-    virtual void visit(ShortFieldValue &value) { read(value); }
-    virtual void visit(StringFieldValue &value) { read(value); }
-    virtual void visit(StructFieldValue &value) { read(value); }
-    virtual void visit(WeightedSetFieldValue &value) { read(value); }
-    virtual void visit(TensorFieldValue &value) { read(value); }
+    void visit(AnnotationReferenceFieldValue &value) override { read(value); }
+    void visit(ArrayFieldValue &value) override { read(value); }
+    void visit(ByteFieldValue &value) override { read(value); }
+    void visit(Document &value) override { read(value); }
+    void visit(DoubleFieldValue &value) override { read(value); }
+    void visit(FloatFieldValue &value) override { read(value); }
+    void visit(IntFieldValue &value) override { read(value); }
+    void visit(LongFieldValue &value) override { read(value); }
+    void visit(MapFieldValue &value) override { read(value); }
+    void visit(PredicateFieldValue &value) override { read(value); }
+    void visit(RawFieldValue &value) override { read(value); }
+    void visit(ShortFieldValue &value) override { read(value); }
+    void visit(StringFieldValue &value) override { read(value); }
+    void visit(StructFieldValue &value) override { read(value); }
+    void visit(WeightedSetFieldValue &value) override { read(value); }
+    void visit(TensorFieldValue &value) override { read(value); }
+    void visit(ReferenceFieldValue &value) override { read(value); }
 
     void readDocument(Document &value);
 
@@ -75,6 +76,7 @@ public:
     void readStructNoReset(StructFieldValue &value);
     void read(WeightedSetFieldValue &value);
     void read(TensorFieldValue &value);
+    void read(ReferenceFieldValue& value);
 };
 }  // namespace document
 

--- a/document/src/vespa/document/serialization/vespadocumentserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentserializer.cpp
@@ -19,6 +19,7 @@
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/document/fieldvalue/weightedsetfieldvalue.h>
 #include <vespa/document/fieldvalue/tensorfieldvalue.h>
+#include <vespa/document/fieldvalue/referencefieldvalue.h>
 #include <vespa/document/update/updates.h>
 #include <vespa/document/update/fieldpathupdates.h>
 #include <vespa/vespalib/data/slime/binary_format.h>
@@ -396,6 +397,13 @@ VespaDocumentSerializer::write(const TensorFieldValue &value) {
         _stream.write(tmpStream.peek(), tmpStream.size());
     } else {
         _stream.putInt1_4Bytes(0);
+    }
+}
+
+void VespaDocumentSerializer::write(const ReferenceFieldValue& value) {
+    _stream << static_cast<uint8_t>(value.hasValidDocumentId() ? 1 : 0);
+    if (value.hasValidDocumentId()) {
+       write(value.getDocumentId());
     }
 }
 

--- a/document/src/vespa/document/serialization/vespadocumentserializer.h
+++ b/document/src/vespa/document/serialization/vespadocumentserializer.h
@@ -52,6 +52,7 @@ public:
     void write(const StructFieldValue &val, const FieldSet& fieldSet);
     void write(const WeightedSetFieldValue &value);
     void write(const TensorFieldValue &value);
+    void write(const ReferenceFieldValue& value);
 
     void write42(const DocumentUpdate &value);
     void writeHEAD(const DocumentUpdate &value);
@@ -102,7 +103,8 @@ private:
     void visit(const StringFieldValue &value)              override { write(value); }
     void visit(const StructFieldValue &value)              override { write(value, AllFields()); }
     void visit(const WeightedSetFieldValue &value)         override { write(value); }
-    void visit(const TensorFieldValue &value) override { write(value); }
+    void visit(const TensorFieldValue &value)              override { write(value); }
+    void visit(const ReferenceFieldValue& value)           override { write(value); }
 
     vespalib::nbostream &_stream;
 };

--- a/document/src/vespa/document/util/identifiableid.h
+++ b/document/src/vespa/document/util/identifiableid.h
@@ -40,6 +40,7 @@
 #define CID_MapFieldValue          DOCUMENT_CID(36)
 #define CID_PredicateFieldValue    DOCUMENT_CID(37)
 #define CID_TensorFieldValue       DOCUMENT_CID(38)
+#define CID_ReferenceFieldValue    DOCUMENT_CID(39)
 
 #define CID_DataType               DOCUMENT_CID(50)
 #define CID_PrimitiveDataType      DOCUMENT_CID(51)
@@ -58,6 +59,7 @@
 #define CID_MapDataType            DOCUMENT_CID(65)
 #define CID_AnnotationReferenceDataType DOCUMENT_CID(66)
 #define CID_TensorDataType         DOCUMENT_CID(67)
+#define CID_ReferenceDataType      DOCUMENT_CID(68)
 
 #define CID_document_FieldPathEntry DOCUMENT_CID(80)
 

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summaryfieldconverter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summaryfieldconverter.cpp
@@ -488,7 +488,7 @@ class SummaryFieldValueConverter : protected ConstFieldValueVisitor
     void visit(const ReferenceFieldValue& value) override {
         if (value.hasValidDocumentId()) {
             _str << value.getDocumentId().toString();
-        } // else:: implicit empty string
+        } // else: implicit empty string
     }
 
 public:

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summaryfieldconverter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summaryfieldconverter.cpp
@@ -29,6 +29,7 @@
 #include <vespa/document/fieldvalue/weightedsetfieldvalue.h>
 #include <vespa/document/fieldvalue/annotationreferencefieldvalue.h>
 #include <vespa/document/fieldvalue/tensorfieldvalue.h>
+#include <vespa/document/fieldvalue/referencefieldvalue.h>
 #include <vespa/searchcommon/common/schema.h>
 #include <vespa/searchlib/util/url.h>
 #include <vespa/vespalib/encoding/base64.h>
@@ -79,6 +80,7 @@ using document::StructFieldValue;
 using document::WeightedSetDataType;
 using document::WeightedSetFieldValue;
 using document::TensorFieldValue;
+using document::ReferenceFieldValue;
 using search::index::Schema;
 using search::util::URL;
 using std::make_pair;
@@ -377,6 +379,12 @@ class JsonFiller : public ConstFieldValueVisitor {
         }
     }
 
+    void visit(const ReferenceFieldValue& value) override {
+        _json.appendString(value.hasValidDocumentId()
+                ? value.getDocumentId().toString()
+                : string());
+    }
+
 public:
     JsonFiller(bool markup, JSONWriter &json)
         : _json(json), _tokenize(markup) {}
@@ -475,6 +483,12 @@ class SummaryFieldValueConverter : protected ConstFieldValueVisitor
 
     virtual void visit(const TensorFieldValue &value) override {
         visitPrimitive(value);
+    }
+
+    void visit(const ReferenceFieldValue& value) override {
+        if (value.hasValidDocumentId()) {
+            _str << value.getDocumentId().toString();
+        } // else:: implicit empty string
     }
 
 public:
@@ -639,6 +653,12 @@ class SlimeFiller : public ConstFieldValueVisitor {
             vespalib::tensor::TypedBinaryFormat::serialize(s, *tensor);
         }
         _inserter.insertData(vespalib::slime::Memory(s.peek(), s.size()));
+    }
+
+    void visit(const ReferenceFieldValue& value) override {
+        _inserter.insertString(Memory(value.hasValidDocumentId()
+                ? value.getDocumentId().toString()
+                : string()));
     }
 
 public:


### PR DESCRIPTION
@geirst @bjorncs Please review.

Note that this does not include cross-language serialization tests. Will add those after we've glued the pieces together.