### PR TITLE
assume node down until proven otherwise

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterMonitor.java
@@ -67,6 +67,7 @@ public class ClusterMonitor implements Runnable, Freezable {
         if (isFrozen())
             throw new IllegalStateException("Can not add new nodes after ClusterMonitor has been frozen.");
         nodeMonitors.put(node, new NodeMonitor(node));
+        updateVipStatus();
     }
 
     /** Called from ClusterSearcher/NodeManager when a node failed */


### PR DESCRIPTION
* change initializer values in NodeMonitor to assume
  the node is down and has no search nodes online
  until we see some data from it.  Also, update vip
  status as soon as we have some nodes attached.
  This is to avoid the container believing it should be in
  service at startup and then changing its mind when it
  discovers that underlying services are down.

@bratseth please review and merge
@hmusum FYI (we discussed this a while ago)