### PR TITLE
Prepare for wiring in reference attribute:

### DIFF
--- a/configdefinitions/src/vespa/attributes.def
+++ b/configdefinitions/src/vespa/attributes.def
@@ -2,7 +2,7 @@
 namespace=vespa.config.search
 
 attribute[].name                string
-attribute[].datatype            enum { STRING, UINT1, UINT2, UINT4, INT8, INT16, INT32, INT64, FLOAT, DOUBLE, PREDICATE, TENSOR, NONE } default=NONE
+attribute[].datatype            enum { STRING, UINT1, UINT2, UINT4, INT8, INT16, INT32, INT64, FLOAT, DOUBLE, PREDICATE, TENSOR, REFERENCE, NONE } default=NONE
 attribute[].collectiontype      enum { SINGLE, ARRAY, WEIGHTEDSET } default=SINGLE
 attribute[].removeifzero        bool default=false
 attribute[].createifnonexistent bool default=false

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.h
@@ -93,9 +93,11 @@ public:
             return false;
         }
         search::attribute::BasicType::Type attrType = attribute->getBasicType();
-        // Partial update to tensor or predicate attribute must update document
+        // Partial update to tensor, predicate or reference attribute
+        // must update document
         return ((attrType != search::attribute::BasicType::Type::PREDICATE) &&
-                (attrType != search::attribute::BasicType::Type::TENSOR));
+                (attrType != search::attribute::BasicType::Type::TENSOR) &&
+                (attrType != search::attribute::BasicType::Type::REFERENCE));
     }
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -34,6 +34,7 @@ getDataTypeMap()
     map[AttributesConfig::Attribute::DOUBLE] = BasicType::DOUBLE;
     map[AttributesConfig::Attribute::PREDICATE] = BasicType::PREDICATE;
     map[AttributesConfig::Attribute::TENSOR] = BasicType::TENSOR;
+    map[AttributesConfig::Attribute::REFERENCE] = BasicType::REFERENCE;
     map[AttributesConfig::Attribute::NONE] = BasicType::NONE;
     return map;
 }

--- a/searchlib/src/vespa/searchlib/attribute/createsinglestd.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/createsinglestd.cpp
@@ -8,6 +8,7 @@ LOG_SETUP(".createsinglestd");
 
 #include "predicate_attribute.h"
 #include "singlesmallnumericattribute.h"
+#include "reference_attribute.h"
 #include <vespa/searchlib/attribute/attributevector.hpp>
 #include <vespa/searchlib/attribute/singlenumericattribute.hpp>
 #include <vespa/searchlib/attribute/singlestringattribute.h>
@@ -64,6 +65,9 @@ AttributeFactory::createSingleStd(const vespalib::string & baseFileName, const C
         } else {
             ret.reset(new tensor::GenericTensorAttribute(baseFileName, info));
         }
+        break;
+    case BasicType::REFERENCE:
+        ret = std::make_shared<attribute::ReferenceAttribute>(baseFileName, info);
         break;
     default:
         break;


### PR DESCRIPTION
  - Add data type to attributes.def
  - Update attribute config conversion
  - Update attribute factory
  - Specify that reference attribute doesn't support fast update,
    docstore must be updated.

@geirst, please review