### PR TITLE
Use same IDs for Identifiable across languages

### DIFF
--- a/document/src/main/java/com/yahoo/document/ReferenceDataType.java
+++ b/document/src/main/java/com/yahoo/document/ReferenceDataType.java
@@ -3,6 +3,7 @@ package com.yahoo.document;
 
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.ReferenceFieldValue;
+import com.yahoo.vespa.objects.Ids;
 
 /**
  * A <code>ReferenceDataType</code> specifies a particular concrete document type that a
@@ -12,6 +13,9 @@ import com.yahoo.document.datatypes.ReferenceFieldValue;
  * @since 6.65
  */
 public class ReferenceDataType extends DataType {
+
+    // Magic number for Identifiable, see document/util/identifiable.h
+    public static final int classId = registerClass(Ids.document + 68, ReferenceDataType.class);
 
     private StructuredDataType targetType;
 

--- a/document/src/main/java/com/yahoo/document/datatypes/ReferenceFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/ReferenceFieldValue.java
@@ -8,6 +8,7 @@ import com.yahoo.document.ReferenceDataType;
 import com.yahoo.document.serialization.FieldReader;
 import com.yahoo.document.serialization.FieldWriter;
 import com.yahoo.document.serialization.XmlStream;
+import com.yahoo.vespa.objects.Ids;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -30,6 +31,9 @@ import java.util.Optional;
  * @since 6.65
  */
 public class ReferenceFieldValue extends FieldValue {
+
+    // Magic number for Identifiable, see document/util/identifiable.h
+    public static final int classId = registerClass(Ids.document + 39, ReferenceFieldValue.class);
 
     private final ReferenceDataType referenceType;
     private Optional<DocumentId> documentId;


### PR DESCRIPTION
@geirst Please review. Note that I have no idea if this stuff (vespalib Identifiable) is even used anymore, but since it's used for the other document types/values, let's at least have parity between languages.
@bjorncs FYI