### PR TITLE
Balder/implement get hits for attribute postinglist iterators

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -20,7 +20,7 @@ set(AUTORUN_UNIT_TESTS FALSE CACHE BOOL "If TRUE, tests will be run immediately 
 set(WARN_OPTS "-Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wcomment -Wformat -Wparentheses -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings")
 
 # C and C++ compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -march=westmere -mtune=intel")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Og ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -march=westmere -mtune=intel")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} -Wnon-virtual-dtor -fvisibility-inlines-hidden -fdiagnostics-color=auto")
 

--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -20,7 +20,7 @@ set(AUTORUN_UNIT_TESTS FALSE CACHE BOOL "If TRUE, tests will be run immediately 
 set(WARN_OPTS "-Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wcomment -Wformat -Wparentheses -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings")
 
 # C and C++ compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Og ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -march=westmere -mtune=intel")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 ${WARN_OPTS} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -DBOOST_DISABLE_ASSERTS -march=westmere -mtune=intel")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} -Wnon-virtual-dtor -fvisibility-inlines-hidden -fdiagnostics-color=auto")
 

--- a/config/src/apps/configproxy-cmd/main.cpp
+++ b/config/src/apps/configproxy-cmd/main.cpp
@@ -1,11 +1,10 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <iostream>
-#include <vespa/vespalib/stllike/string.h>
 #include "flags.h"
 #include "proxycmd.h"
 #include "methods.h"
+#include <vespa/fastos/app.h>
+#include <iostream>
 
 class Application : public FastOS_Application
 {

--- a/config/src/apps/configproxy-cmd/methods.cpp
+++ b/config/src/apps/configproxy-cmd/methods.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "methods.h"
 #include <iostream>
 

--- a/config/src/apps/configproxy-cmd/proxycmd.cpp
+++ b/config/src/apps/configproxy-cmd/proxycmd.cpp
@@ -1,8 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "proxycmd.h"
 #include <iostream>
-#include <vespa/vespalib/util/vstringfmt.h>
+#include <vespa/vespalib/util/stringfmt.h>
 
 ProxyCmd::ProxyCmd(const Flags& flags)
     : _supervisor(NULL),
@@ -46,7 +46,7 @@ void ProxyCmd::printArray(FRT_Values *rvals) {
 }
 
 vespalib::string ProxyCmd::makeSpec() {
-    return vespalib::make_vespa_string("tcp/%s:%d", _flags.hostname.c_str(), _flags.portnumber);
+    return vespalib::make_string("tcp/%s:%d", _flags.hostname.c_str(), _flags.portnumber);
 }
 
 void ProxyCmd::autoPrint() {

--- a/config/src/apps/getvespaconfig/getconfig.cpp
+++ b/config/src/apps/getvespaconfig/getconfig.cpp
@@ -1,20 +1,19 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-
-#include <vespa/log/log.h>
-LOG_SETUP("getconfig");
 
 #include <vespa/fnet/frt/frt.h>
 #include <vespa/config/config.h>
-#include <vespa/config/frt/protocol.h>
 #include <vespa/config/frt/frtconfigrequestfactory.h>
 #include <vespa/config/frt/frtconnection.h>
 #include <vespa/config/common/payload_converter.h>
-#include <vespa/config/common/vespa_version.h>
+#include <vespa/fastos/app.h>
+
 
 #include <string>
 #include <sstream>
 #include <fstream>
+
+#include <vespa/log/log.h>
+LOG_SETUP("getconfig");
 
 using namespace config;
 

--- a/config/src/apps/pingproxy/pingproxy.cpp
+++ b/config/src/apps/pingproxy/pingproxy.cpp
@@ -1,13 +1,12 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
+#include <vespa/fnet/frt/frt.h>
+#include <vespa/fastos/app.h>
+
+#include <sstream>
 
 #include <vespa/log/log.h>
 LOG_SETUP("pingproxy");
-
-#include <vespa/fnet/frt/frt.h>
-
-#include <string>
-#include <sstream>
 
 
 class PingProxy : public FastOS_Application

--- a/configd/src/apps/sentinel/metrics.cpp
+++ b/configd/src/apps/sentinel/metrics.cpp
@@ -1,9 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".metrics");
 
 #include "metrics.h"
+#include <vespa/log/log.h>
+LOG_SETUP(".metrics");
 
 namespace config {
 namespace sentinel {

--- a/configd/src/apps/sentinel/state-api.cpp
+++ b/configd/src/apps/sentinel/state-api.cpp
@@ -1,6 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include "state-api.h"
 #include <vespa/vespalib/util/host_name.h>
 #include <vespa/vespalib/util/stringfmt.h>

--- a/configutil/src/apps/configstatus/main.cpp
+++ b/configutil/src/apps/configstatus/main.cpp
@@ -1,13 +1,13 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include <vespa/defaults.h>
-#include <vespa/log/log.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
-LOG_SETUP("vespa-config-status");
 #include <iostream>
 #include <lib/configstatus.h>
-#include <lib/hostfilter.h>
+#include <vespa/fastos/app.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("vespa-config-status");
 
 class Application : public FastOS_Application {
     ConfigStatus::Flags _flags;

--- a/configutil/src/apps/modelinspect/main.cpp
+++ b/configutil/src/apps/modelinspect/main.cpp
@@ -1,13 +1,14 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include <vespa/defaults.h>
-#include <vespa/log/log.h>
-LOG_SETUP("vespa-model-inspect");
 #include <iostream>
 #include <lib/modelinspect.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/fastos/app.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("vespa-model-inspect");
 
 class Application : public FastOS_Application
 {

--- a/configutil/src/lib/configstatus.cpp
+++ b/configutil/src/lib/configstatus.cpp
@@ -1,19 +1,16 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP("vespa-config-status");
-#include <iostream>
-
+#include "configstatus.h"
+#include "tags.h"
 #include <vespa/fnet/frt/frt.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vbench/http/http_result_handler.h>
 #include <vbench/http/server_spec.h>
 #include <vbench/http/http_client.h>
+#include <iostream>
 
-#include <lib/tags.h>
-
-#include "configstatus.h"
+#include <vespa/log/log.h>
+LOG_SETUP("vespa-config-status");
 
 using configdefinitions::tagsContain;
 

--- a/configutil/src/lib/tags.cpp
+++ b/configutil/src/lib/tags.cpp
@@ -1,10 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-
-#include <vespa/vespalib/stllike/string.h>
-
 #include "tags.h"
+#include <vespa/vespalib/stllike/string.h>
 
 namespace configdefinitions {
 

--- a/fastos/src/vespa/fastos/app.h
+++ b/fastos/src/vespa/fastos/app.h
@@ -34,7 +34,7 @@ class FastOS_ProcessInterface;
  *
  * Example:
  * @code
- *    #include <vespa/fastos/fastos.h>
+ *    #include <vespa/fastos/app.h>
  *
  *    class MyApplication : public FastOS_Application
  *    {
@@ -59,7 +59,7 @@ class FastOS_ProcessInterface;
  * @ref Cleanup(). Most applications do not need to do this, but
  * an example of how to do it is included anyway:
  * @code
- *    #include <vespa/fastos/fastos.h>
+ *    #include <vespa/fastos/app.h>
  *
  *    class MyApplication : public FastOS_Application
  *    {

--- a/fnet/src/vespa/fnet/connect_thread.cpp
+++ b/fnet/src/vespa/fnet/connect_thread.cpp
@@ -1,7 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-
-#include <vespa/fastos/fastos.h>
 #include "connect_thread.h"
 
 namespace fnet {

--- a/frtstream/src/example/simple.cpp
+++ b/frtstream/src/example/simple.cpp
@@ -1,13 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <iostream>
-#include <csignal>
-#include <vector>
-#include <string>
-#include <set>
+#include <vespa/fastos/app.h>
 
 #include <vespa/frtstream/frtclientstream.h>
-
 
 using namespace std;
 using frtstream::FrtClientStream;

--- a/frtstream/src/vespa/frtstream/frtclientstream.cpp
+++ b/frtstream/src/vespa/frtstream/frtclientstream.cpp
@@ -1,10 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/frtstream/frtclientstream.h>
 
+#include "frtclientstream.h"
 
 using namespace fnet;
-
 
 namespace frtstream {
 

--- a/frtstream/src/vespa/frtstream/frtstream.cpp
+++ b/frtstream/src/vespa/frtstream/frtstream.cpp
@@ -1,10 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
+#include "frtstream.h"
 #include <algorithm>
 #include <ostream>
-
-
-#include <vespa/frtstream/frtstream.h>
 
 using namespace fnet;
 

--- a/logd/src/logd/watch.cpp
+++ b/logd/src/logd/watch.cpp
@@ -1,18 +1,4 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <unistd.h>
-#include <time.h>
-#include <glob.h>
-#include <sys/stat.h>
-
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP("");
-LOG_RCSID("$Id$");
 
 #include "errhandle.h"
 #include "sigterm.h"
@@ -22,6 +8,10 @@ LOG_RCSID("$Id$");
 #include "watch.h"
 #include "perform.h"
 #include "cmdbuf.h"
+#include <glob.h>
+
+LOG_SETUP("");
+LOG_RCSID("$Id$");
 
 namespace logdemon {
 namespace {

--- a/persistence/src/vespa/persistence/proxy/buildid.cpp
+++ b/persistence/src/vespa/persistence/proxy/buildid.cpp
@@ -1,8 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/vespalib/component/vtag.h>
 #include "buildid.h"
+#include <vespa/vespalib/component/vtag.h>
 
 const char *storage::spi::getBuildId() {
     return vespalib::VersionTagComponent;

--- a/persistence/src/vespa/persistence/proxy/providerproxy.cpp
+++ b/persistence/src/vespa/persistence/proxy/providerproxy.cpp
@@ -1,6 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include "providerproxy.h"
 #include "buildid.h"
 #include <vespa/document/repo/documenttyperepo.h>

--- a/persistence/src/vespa/persistence/proxy/providerstub.cpp
+++ b/persistence/src/vespa/persistence/proxy/providerstub.cpp
@@ -1,6 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include "buildid.h"
 #include "providerstub.h"
 #include <vespa/document/serialization/vespadocumentdeserializer.h>
@@ -13,18 +12,13 @@
 #include <persistence/spi/types.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/closuretask.h>
-#include <sstream>
 #include <vespa/document/fieldset/fieldsetrepo.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".providerstub");
 
 using document::BucketId;
 using document::ByteBuffer;
 using document::DocumentTypeRepo;
 using document::VespaDocumentDeserializer;
 using document::VespaDocumentSerializer;
-using std::map;
-using std::ostringstream;
 using std::vector;
 using vespalib::Closure;
 using vespalib::makeClosure;

--- a/persistence/src/vespa/persistence/spi/abstractpersistenceprovider.cpp
+++ b/persistence/src/vespa/persistence/spi/abstractpersistenceprovider.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "abstractpersistenceprovider.h"
 #include <vespa/document/update/documentupdate.h>
 #include <vespa/document/fieldset/fieldsets.h>

--- a/persistence/src/vespa/persistence/spi/partitionstate.cpp
+++ b/persistence/src/vespa/persistence/spi/partitionstate.cpp
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/persistence/spi/partitionstate.h>
+#include "partitionstate.h"
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 

--- a/persistence/src/vespa/persistence/spi/persistenceprovider.cpp
+++ b/persistence/src/vespa/persistence/spi/persistenceprovider.cpp
@@ -1,14 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/persistence/spi/persistenceprovider.h>
+#include "persistenceprovider.h"
 
 namespace storage {
 namespace spi {
 
-PersistenceProvider::~PersistenceProvider()
-{
-}
+PersistenceProvider::~PersistenceProvider() { }
 
 } // spi
 } // storage

--- a/persistencetypes/src/persistence/spi/types.cpp
+++ b/persistencetypes/src/persistence/spi/types.cpp
@@ -1,13 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
 #include "types.h"
+
 #include <vespa/vespalib/objects/nbostream.h>
 
-namespace storage
-{
+namespace storage {
 
-namespace spi
-{
+namespace spi {
 
 DEFINE_PRIMITIVE_WRAPPER_NBOSTREAM(NodeIndex);
 DEFINE_PRIMITIVE_WRAPPER_NBOSTREAM(PartitionId);

--- a/searchcommon/src/vespa/searchcommon/common/schemaconfigurer.cpp
+++ b/searchcommon/src/vespa/searchcommon/common/schemaconfigurer.cpp
@@ -1,10 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
+#include "schemaconfigurer.h"
 #include <vespa/searchcommon/config/subscriptionproxyng.h>
-#include <vespa/searchcommon/common/schemaconfigurer.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".index.schemaconfigurer");
 
 using namespace config;

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -16,6 +16,7 @@
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/searchcore/proton/server/itlssyncer.h>
 #include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/searchlib/query/queryterm.h>
 #include <vespa/log/log.h>
 LOG_SETUP("documentmetastore_test");
 

--- a/searchcore/src/vespa/searchcore/fdispatch/common/stdincl.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/common/stdincl.h
@@ -1,8 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
+
+#include <cstdint>
 
 /**
  * This method defines the illegal/undefined value for unsigned 32-bit

--- a/searchcore/src/vespa/searchcore/fdispatch/search/configdesc.cpp
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/configdesc.cpp
@@ -1,12 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
+#include "configdesc.h"
 #include <vespa/searchcore/util/log.h>
-#include <vespa/searchcore/fdispatch/search/configdesc.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".search.configdesc");
 
 //----------------------------------------------------------------------

--- a/searchcore/src/vespa/searchcore/fdispatch/search/configdesc.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/configdesc.h
@@ -1,12 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 
 #include <vespa/searchlib/common/fslimits.h>
 #include <vespa/searchcore/fdispatch/common/stdincl.h>
 #include <vespa/searchcore/config/config-partitions.h>
+#include <cassert>
 
 using vespa::config::search::core::PartitionsConfig;
 
@@ -35,8 +34,7 @@ public:
           _unitrefcost(1),
           _isBad(false),
           _confPartIDOverrides(false)
-    {
-    }
+    { }
 
     void SetNext(FastS_EngineDesc *next) { _next = next; }
     void SetConfPartID(int32_t value) { assert(value >= 0); _confPartID = value; }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -16,6 +16,7 @@
 #include <vespa/searchcore/proton/bucketdb/splitbucketsession.h>
 #include <vespa/searchlib/util/bufferwriter.h>
 #include <vespa/searchlib/common/rcuvector.hpp>
+#include <vespa/searchlib/query/queryterm.h>
 #include <vespa/fastos/file.h>
 
 
@@ -622,8 +623,7 @@ DocumentMetaStore::move(DocId fromLid, DocId toLid)
 }
 
 void
-DocumentMetaStore::removeBatch(const std::vector<search::DocumentIdT> &lidsToRemove,
-                               const uint32_t docIdLimit)
+DocumentMetaStore::removeBatch(const std::vector<DocId> &lidsToRemove, const uint32_t docIdLimit)
 {
     for (const auto &lid : lidsToRemove) {
         assert(lid > 0 && lid < docIdLimit);
@@ -750,7 +750,7 @@ DocumentMetaStore::createBlackListBlueprint() const
 }
 
 AttributeVector::SearchContext::UP
-DocumentMetaStore::getSearch(search::QueryTermSimple::UP qTerm, const AttributeVector::SearchContext::Params &) const
+DocumentMetaStore::getSearch(std::unique_ptr<search::QueryTermSimple> qTerm, const AttributeVector::SearchContext::Params &) const
 {
     return AttributeVector::SearchContext::UP
             (new documentmetastore::SearchContext(std::move(qTerm), *this));

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -212,7 +212,7 @@ public:
      * Implements search::AttributeVector
      */
     SearchContext::UP
-    getSearch(search::QueryTermSimple::UP qTerm,
+    getSearch(std::unique_ptr<search::QueryTermSimple> qTerm,
               const search::AttributeVector::SearchContext::Params & params)
         const override;
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "lid_allocator.h"
-
+#include <vespa/searchlib/query/queryterm.h>
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.documentmetastore.lid_allocator");
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/search_context.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/search_context.cpp
@@ -1,11 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".proton.documentmetastore.search_context");
-
 #include "search_context.h"
 #include <vespa/searchlib/attribute/attributeiterators.h>
+#include <vespa/searchlib/query/queryterm.h>
 #include <vespa/vespalib/util/exceptions.h>
 
 using document::GlobalId;

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/search_context.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/search_context.h
@@ -20,18 +20,17 @@ private:
     bool _isWord;
     document::GlobalId _gid;
 
-    virtual unsigned int approximateHits() const;
-    virtual bool onCmp(DocId docId, int32_t &weight) const;
-    virtual bool onCmp(DocId docId) const;
+    unsigned int approximateHits() const override;
+    bool onCmp(DocId docId, int32_t &weight) const override;
+    bool onCmp(DocId docId) const override;
 
-    virtual search::queryeval::SearchIterator::UP
-    createIterator(search::fef::TermFieldMatchData *matchData,
-                   bool strict);
+    search::queryeval::SearchIterator::UP
+    createIterator(search::fef::TermFieldMatchData *matchData, bool strict) override;
 
     const DocumentMetaStore &getStore() const;
 
 public:
-    SearchContext(search::QueryTermSimple::UP qTerm,
+    SearchContext(std::unique_ptr<search::QueryTermSimple> qTerm,
                   const DocumentMetaStore &toBeSearched);
 };
 

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
@@ -9,8 +9,9 @@
 #include <vespa/vespalib/util/closure.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 #include <vespa/searchcore/grouping/groupingmanager.h>
-#include <vespa/log/log.h>
+#include <vespa/searchlib/common/bitvector.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".proton.matching.match_thread");
 
 namespace proton {
@@ -18,7 +19,6 @@ namespace matching {
 
 using search::queryeval::OptimizedAndNotForBlackListing;
 using search::queryeval::SearchIterator;
-using search::fef::TermFieldHandle;
 using search::fef::MatchData;
 using search::fef::RankProgram;
 using search::fef::FeatureResolver;

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
@@ -2,11 +2,6 @@
 
 #pragma once
 
-#include <vespa/vespalib/util/runnable.h>
-#include <vespa/vespalib/util/dual_merge_director.h>
-#include <vespa/searchlib/common/resultset.h>
-#include <vespa/searchlib/common/sortresults.h>
-#include <vespa/searchlib/queryeval/hitcollector.h>
 #include "match_tools.h"
 #include "i_match_loop_communicator.h"
 #include "match_params.h"
@@ -14,6 +9,11 @@
 #include "partial_result.h"
 #include "result_processor.h"
 #include "docid_range_scheduler.h"
+#include <vespa/vespalib/util/runnable.h>
+#include <vespa/vespalib/util/dual_merge_director.h>
+#include <vespa/searchlib/common/resultset.h>
+#include <vespa/searchlib/common/sortresults.h>
+#include <vespa/searchlib/queryeval/hitcollector.h>
 
 namespace proton {
 namespace matching {

--- a/searchlib/src/tests/attribute/attributesearcher.h
+++ b/searchlib/src/tests/attribute/attributesearcher.h
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/queryeval/hitcollector.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/compress.h>
+#include <vespa/searchlib/parsequery/parse.h>
 
 namespace search {
 

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -19,6 +19,8 @@
 #include <vespa/searchlib/util/randomgenerator.h>
 #include <vespa/searchlib/util/bufferwriter.h>
 #include <vespa/searchlib/attribute/attributememoryfilebufferwriter.h>
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
+#include <vespa/searchlib/parsequery/parse.h>
 
 #include <vespa/searchlib/attribute/attributevector.hpp>
 

--- a/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
+++ b/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
@@ -14,6 +14,7 @@
 #include <vespa/searchlib/attribute/enumstore.hpp>
 #include <vespa/searchlib/attribute/attributevector.hpp>
 #include <vespa/vespalib/util/compress.h>
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
 #include <vespa/fastos/file.h>
 #include <iostream>
 #include <vespa/log/log.h>

--- a/searchlib/src/tests/attribute/searchcontext/searchcontext.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext.cpp
@@ -10,10 +10,12 @@
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>
 #include <vespa/searchlib/queryeval/hitcollector.h>
+#include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/compress.h>
 #include <vespa/searchlib/test/searchiteratorverifier.h>
-
+#include <vespa/searchlib/query/queryterm.h>
+#include <vespa/searchlib/parsequery/parse.h>
 #include <vespa/searchlib/attribute/attributevector.hpp>
 
 #include <vespa/log/log.h>

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -290,6 +290,7 @@ public:
           _terms(),
           _attr(attr)
     {
+        set_allow_termwise_eval(true);
         _weights.reserve(size_hint);
         _terms.reserve(size_hint);
     }

--- a/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
@@ -123,6 +123,7 @@ AttributeWeightedSetBlueprint::AttributeWeightedSetBlueprint(const queryeval::Fi
       _attr(attr),
       _contexts()
 {
+    set_allow_termwise_eval(true);
 }
 
 AttributeWeightedSetBlueprint::~AttributeWeightedSetBlueprint()

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
@@ -25,6 +25,13 @@ AttributeIteratorBase::visitMembers(vespalib::ObjectVisitor &visitor) const
     visit(visitor, "tfmd.docId", _matchData->getDocId());
 }
 
+FilterAttributeIterator::FilterAttributeIterator(fef::TermFieldMatchData * matchData, uint32_t docIdLimit)
+    : AttributeIteratorBase(matchData),
+      _docIdLimit(docIdLimit)
+{
+    _matchPosition->setElementWeight(1);
+}
+
 void
 FilterAttributeIterator::visitMembers(vespalib::ObjectVisitor &visitor) const
 {

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -21,6 +21,8 @@ namespace fef {
 class AttributeIteratorBase : public queryeval::SearchIterator
 {
 protected:
+    template <typename SC>
+    void and_hits_into(const SC & sc, BitVector & result, uint32_t begin_id) const;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     fef::TermFieldMatchData * _matchData;
     fef::TermFieldMatchDataPosition * _matchPosition;
@@ -71,6 +73,7 @@ class AttributeIteratorT : public AttributeIterator
 private:
     void doSeek(uint32_t docId) override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
+    void and_hits_into(BitVector & result, uint32_t begin_id) override;
 
 protected:
     const SC & _searchContext;
@@ -87,6 +90,7 @@ class FilterAttributeIteratorT : public FilterAttributeIterator
 private:
     void doSeek(uint32_t docId) override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
+    void and_hits_into(BitVector & result, uint32_t begin_id) override;
 
 protected:
     const SC & _searchContext;

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -46,8 +46,7 @@ public:
         : AttributeIteratorBase(matchData),
           _docIdLimit(docIdLimit),
           _weight(1)
-    {
-    }
+    { }
 protected:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void doUnpack(uint32_t docId) override;
@@ -201,6 +200,7 @@ private:
     }
 
     void initRange(uint32_t begin, uint32_t end) override;
+    std::unique_ptr<BitVector> get_hits(uint32_t begin_id) override;
 
 public:
     // Note: iterator constructor argument is destroyed

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "dociditerator.h"
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/searchlib/btree/btreenode.h>
 #include <vespa/searchlib/btree/btreeiterator.h>
@@ -249,6 +250,53 @@ getWeight()
 {
     return 1;	// default weight 1 for single value attributes
 }
+
+    template <>
+    void
+    AttributePostingListIteratorT<btree::BTreeConstIterator<uint32_t, btree::BTreeNoLeafData, btree::NoAggregated,
+                                  std::less<uint32_t>, btree::BTreeDefaultTraits> >::
+    doUnpack(uint32_t docId);
+
+
+    template <>
+    void
+    AttributePostingListIteratorT<btree::BTreeConstIterator<uint32_t, int32_t, btree::MinMaxAggregated,
+                                  std::less<uint32_t>, btree::BTreeDefaultTraits> >::
+    doUnpack(uint32_t docId);
+
+
+    template <>
+    void
+    AttributePostingListIteratorT<InnerAttributePostingListIterator>::setupPostingInfo();
+
+
+    template <>
+    void
+    AttributePostingListIteratorT<WeightedInnerAttributePostingListIterator>::setupPostingInfo();
+
+
+    template <>
+    void
+    AttributePostingListIteratorT<DocIdMinMaxIterator<AttributePosting> >::setupPostingInfo();
+
+
+    template <>
+    void
+    AttributePostingListIteratorT<DocIdMinMaxIterator<AttributeWeightPosting> >::setupPostingInfo();
+
+    template <>
+    void
+    FilterAttributePostingListIteratorT<InnerAttributePostingListIterator>::setupPostingInfo();
+
+
+    template <>
+    void
+    FilterAttributePostingListIteratorT<WeightedInnerAttributePostingListIterator>::setupPostingInfo();
+
+
+    template <>
+    void
+    FilterAttributePostingListIteratorT<DocIdMinMaxIterator<AttributePosting> >::setupPostingInfo();
 
 /**
  * This class acts as an iterator over a flag attribute.

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -277,6 +277,10 @@ class FilterAttributePostingListIteratorT
 {
 private:
     PL                                     _iterator;
+public:
+    std::unique_ptr<BitVector> get_hits(uint32_t begin_id) override;
+
+private:
     queryeval::MinMaxPostingInfo           _postingInfo;
     bool                                   _postingInfoValid;
 
@@ -300,8 +304,7 @@ private:
 
 public:
     // Note: iterator constructor argument is destroyed
-    FilterAttributePostingListIteratorT(PL &iterator,
-                                        fef::TermFieldMatchData *matchData);
+    FilterAttributePostingListIteratorT(PL &iterator, fef::TermFieldMatchData *matchData);
 };
 
 
@@ -405,8 +408,7 @@ AttributePostingListIteratorT(PL &iterator,
 
 template <typename PL>
 FilterAttributePostingListIteratorT<PL>::
-FilterAttributePostingListIteratorT(PL &iterator,
-                              fef::TermFieldMatchData *matchData)
+FilterAttributePostingListIteratorT(PL &iterator, fef::TermFieldMatchData *matchData)
     : FilterAttributePostingListIterator(matchData),
       _iterator(),
       _postingInfo(1, 1),
@@ -416,6 +418,7 @@ FilterAttributePostingListIteratorT(PL &iterator,
     setupPostingInfo();
     _matchPosition->setElementWeight(1);
 }
+
 
 /**
  * This class acts as an iterator over a flag attribute.

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
@@ -23,6 +23,16 @@ AttributePostingListIteratorT<PL>::doSeek(uint32_t docId)
 }
 
 template <typename PL>
+std::unique_ptr<BitVector>
+FilterAttributePostingListIteratorT<PL>::get_hits(uint32_t begin_id) {
+    BitVector::UP result(BitVector::create(begin_id, getEndId()));
+    for (; _iterator.getKey() < getEndId(); ++_iterator) {
+        result->setBit(_iterator.getKey());
+    }
+    return result;
+}
+
+template <typename PL>
 void
 FilterAttributePostingListIteratorT<PL>::doSeek(uint32_t docId)
 {

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
@@ -13,10 +13,15 @@
 
 namespace search {
 
+template <typename SC>
+void
+AttributeIteratorBase::and_hits_into(const SC & sc, BitVector & result, uint32_t begin_id) const {
+    result.foreach_truebit([&](uint32_t key) { if ( ! sc.cmp(key)) { result.clearBit(key); }}, begin_id);
+}
+
 template <typename PL>
 AttributePostingListIteratorT<PL>::
-AttributePostingListIteratorT(PL &iterator, bool hasWeight,
-                              fef::TermFieldMatchData *matchData)
+AttributePostingListIteratorT(PL &iterator, bool hasWeight, fef::TermFieldMatchData *matchData)
     : AttributePostingListIterator(hasWeight, matchData),
       _iterator(),
       _postingInfo(1, 1),
@@ -252,6 +257,19 @@ FilterAttributeIteratorStrict<SC>::doSeek(uint32_t docId)
         }
     }
     setAtEnd();
+}
+
+template <typename SC>
+void
+AttributeIteratorT<SC>::and_hits_into(BitVector & result, uint32_t begin_id) {
+    AttributeIteratorBase::and_hits_into(_searchContext, result, begin_id);
+}
+
+
+template <typename SC>
+void
+FilterAttributeIteratorT<SC>::and_hits_into(BitVector & result, uint32_t begin_id) {
+    AttributeIteratorBase::and_hits_into(_searchContext, result, begin_id);
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
@@ -15,8 +15,7 @@ namespace search {
 
 template <typename PL>
 AttributePostingListIteratorT<PL>::
-AttributePostingListIteratorT(PL &iterator,
-                              bool hasWeight,
+AttributePostingListIteratorT(PL &iterator, bool hasWeight,
                               fef::TermFieldMatchData *matchData)
     : AttributePostingListIterator(hasWeight, matchData),
       _iterator(),
@@ -77,9 +76,19 @@ AttributePostingListIteratorT<PL>::doSeek(uint32_t docId)
 
 template <typename PL>
 std::unique_ptr<BitVector>
+AttributePostingListIteratorT<PL>::get_hits(uint32_t begin_id) {
+    BitVector::UP result(BitVector::create(begin_id, getEndId()));
+    for (; _iterator.valid() && _iterator.getKey() < getEndId(); ++_iterator) {
+        result->setBit(_iterator.getKey());
+    }
+    return result;
+}
+
+template <typename PL>
+std::unique_ptr<BitVector>
 FilterAttributePostingListIteratorT<PL>::get_hits(uint32_t begin_id) {
     BitVector::UP result(BitVector::create(begin_id, getEndId()));
-    for (; _iterator.getKey() < getEndId(); ++_iterator) {
+    for (; _iterator.valid() && _iterator.getKey() < getEndId(); ++_iterator) {
         result->setBit(_iterator.getKey());
     }
     return result;

--- a/searchlib/src/vespa/searchlib/attribute/dociditerator.h
+++ b/searchlib/src/vespa/searchlib/attribute/dociditerator.h
@@ -32,8 +32,8 @@ public:
         }
     }
 
-    uint32_t getKey(void) const { return _cur->_key; }
-    inline int32_t getData(void) const { return _cur->getData(); }
+    uint32_t getKey() const { return _cur->_key; }
+    inline int32_t getData() const { return _cur->getData(); }
 
     void set(const P *begin, const P *end) {
         _cur = begin;
@@ -83,7 +83,7 @@ public:
     { }
     
     inline btree::MinMaxAggregated
-    getAggregated(void) const {
+    getAggregated() const {
         return btree::MinMaxAggregated(1, 1);
     }
 };

--- a/searchlib/src/vespa/searchlib/attribute/flagattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/flagattribute.h
@@ -2,8 +2,6 @@
 #pragma once
 
 #include "multinumericattribute.h"
-#include <vespa/searchlib/queryeval/searchiterator.h>
-#include <vespa/searchlib/common/rcuvector.h>
 
 namespace search {
 
@@ -20,7 +18,7 @@ private:
     class SearchContext : public BaseSC {
     public:
         typedef FlagAttributeT<B> Attribute;
-        SearchContext(QueryTermSimple::UP qTerm, const FlagAttributeT<B> & toBeSearched);
+        SearchContext(std::unique_ptr<QueryTermSimple> qTerm, const FlagAttributeT<B> & toBeSearched);
 
         std::unique_ptr<queryeval::SearchIterator>
         createIterator(fef::TermFieldMatchData * matchData, bool strict) override;
@@ -34,7 +32,7 @@ private:
     bool onLoad() override;
     bool onLoadEnumerated(ReaderBase &attrReader) override;
     AttributeVector::SearchContext::UP
-    getSearch(QueryTermSimple::UP term, const AttributeVector::SearchContext::Params & params) const override;
+    getSearch(std::unique_ptr<QueryTermSimple> term, const AttributeVector::SearchContext::Params & params) const override;
     void clearOldValues(DocId doc) override;
     void setNewValues(DocId doc, const std::vector<typename B::WType> & values) override;
 

--- a/searchlib/src/vespa/searchlib/attribute/iterator_pack.h
+++ b/searchlib/src/vespa/searchlib/attribute/iterator_pack.h
@@ -42,6 +42,11 @@ public:
         return _children[ref].getData();
     }
 
+    uint32_t next(uint16_t ref) {
+        ++_children[ref];
+        return get_docid(ref);
+    }
+
     size_t size() const { return _children.size(); }
     void initRange(uint32_t begin, uint32_t end) {
         (void) end;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
@@ -2,14 +2,10 @@
 
 #pragma once
 
-#include <vespa/searchlib/attribute/integerbase.h>
-#include <vespa/searchlib/attribute/floatbase.h>
-#include <vespa/searchlib/attribute/multivalueattribute.h>
-#include <vespa/searchlib/attribute/attributeiterators.h>
-#include <vespa/searchlib/query/query.h>
-#include <vespa/searchlib/queryeval/emptysearch.h>
+#include "integerbase.h"
+#include "floatbase.h"
+#include "multivalueattribute.h"
 #include <limits>
-#include <string>
 
 namespace search {
 
@@ -84,7 +80,7 @@ public:
         bool valid() const override;
 
     public:
-        SetSearchContext(QueryTermSimple::UP qTerm, const NumericAttribute & toBeSearched);
+        SetSearchContext(std::unique_ptr<QueryTermSimple> qTerm, const NumericAttribute & toBeSearched);
 
         Int64Range getAsIntegerTerm() const override;
 
@@ -133,7 +129,7 @@ public:
         bool valid() const override;
 
     public:
-        ArraySearchContext(QueryTermSimple::UP qTerm, const NumericAttribute & toBeSearched);
+        ArraySearchContext(std::unique_ptr<QueryTermSimple> qTerm, const NumericAttribute & toBeSearched);
         bool cmp(DocId doc, int32_t & weight) const {
             uint32_t hitCount = 0;
             MultiValueArrayRef values(_toBeSearched._mvMapping.get(doc));
@@ -176,7 +172,7 @@ public:
     virtual bool onLoadEnumerated(ReaderBase &attrReader);
 
     AttributeVector::SearchContext::UP
-    getSearch(QueryTermSimple::UP term, const AttributeVector::SearchContext::Params & params) const override;
+    getSearch(std::unique_ptr<QueryTermSimple> term, const AttributeVector::SearchContext::Params & params) const override;
 
     virtual void clearOldValues(DocId doc);
     virtual void setNewValues(DocId doc, const std::vector<WType> & values);

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
@@ -5,11 +5,12 @@
 #include "multivalueattribute.hpp"
 #include "attributevector.hpp"
 #include "attributeiterators.hpp"
-#include <vespa/searchlib/util/fileutil.h>
-#include <vespa/fastlib/io/bufferedfile.h>
 #include "multinumericattributesaver.h"
 #include "load_utils.h"
 #include "primitivereader.h"
+#include <vespa/searchlib/queryeval/emptysearch.h>
+#include <vespa/searchlib/util/fileutil.h>
+#include <vespa/fastlib/io/bufferedfile.h>
 
 namespace search {
 
@@ -211,8 +212,7 @@ std::unique_ptr<queryeval::SearchIterator>
 MultiValueNumericAttribute<B, M>::SetSearchContext::createFilterIterator(fef::TermFieldMatchData * matchData, bool strict)
 {
     if (!valid()) {
-        return queryeval::SearchIterator::UP(
-                new queryeval::EmptySearch());
+        return queryeval::SearchIterator::UP(new queryeval::EmptySearch());
     }
     if (getIsFilter()) {
         return queryeval::SearchIterator::UP

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
@@ -3,8 +3,6 @@
 #pragma once
 
 #include "multienumattribute.h"
-#include "attributeiterators.h"
-#include <vespa/searchlib/queryeval/emptysearch.h>
 #include "numericbase.h"
 #include "primitivereader.h"
 

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.hpp
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/util/fileutil.hpp>
 #include <vespa/fastlib/io/bufferedfile.h>
 #include <vespa/searchlib/query/queryterm.h>
+#include <vespa/searchlib/queryeval/emptysearch.h>
 
 namespace search {
 
@@ -161,8 +162,7 @@ std::unique_ptr<queryeval::SearchIterator>
 MultiValueNumericEnumAttribute<B, M>::SetSearchContext::createFilterIterator(fef::TermFieldMatchData * matchData, bool strict)
 {
     if (!valid()) {
-        return queryeval::SearchIterator::UP(
-                new queryeval::EmptySearch());
+        return queryeval::SearchIterator::UP(new queryeval::EmptySearch());
     }
     if (getIsFilter()) {
         return queryeval::SearchIterator::UP

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.h
@@ -4,10 +4,7 @@
 
 #include "integerbase.h"
 #include "floatbase.h"
-#include "attributeiterators.h"
 #include <vespa/searchlib/common/rcuvector.h>
-#include <vespa/searchlib/query/query.h>
-#include <vespa/searchlib/queryeval/emptysearch.h>
 #include <limits>
 
 namespace search {
@@ -55,7 +52,7 @@ private:
         bool valid() const override;
 
     public:
-        SingleSearchContext(QueryTermSimple::UP qTerm, const NumericAttribute & toBeSearched);
+    SingleSearchContext(std::unique_ptr<QueryTermSimple> qTerm, const NumericAttribute & toBeSearched);
         bool cmp(DocId docId, int32_t & weight) const {
             const T v = _data[docId];
             weight = 1;
@@ -107,7 +104,7 @@ public:
     bool onLoadEnumerated(ReaderBase &attrReader);
 
     AttributeVector::SearchContext::UP
-    getSearch(QueryTermSimple::UP term, const AttributeVector::SearchContext::Params & params) const override;
+    getSearch(std::unique_ptr<QueryTermSimple> term, const AttributeVector::SearchContext::Params & params) const override;
 
     void set(DocId doc, T v) {
         _data[doc] = v;

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
@@ -7,6 +7,7 @@
 #include "load_utils.h"
 #include "primitivereader.h"
 #include "attributeiterators.hpp"
+#include <vespa/searchlib/queryeval/emptysearch.h>
 
 namespace search {
 
@@ -223,8 +224,8 @@ SingleValueNumericAttribute<B>::SingleSearchContext<M>::getAsIntegerTerm() const
 template <typename B>
 template <typename M>
 std::unique_ptr<queryeval::SearchIterator>
-SingleValueNumericAttribute<B>::SingleSearchContext<M>::createFilterIterator(fef::TermFieldMatchData * matchData,
-                                                                             bool strict)
+SingleValueNumericAttribute<B>::SingleSearchContext<M>::
+createFilterIterator(fef::TermFieldMatchData * matchData, bool strict)
 {
     if (!valid()) {
         return queryeval::SearchIterator::UP(new queryeval::EmptySearch());

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.h
@@ -4,8 +4,6 @@
 
 #include "singleenumattribute.h"
 #include "numericbase.h"
-#include "attributeiterators.h"
-#include <vespa/searchlib/queryeval/emptysearch.h>
 #include <map>
 
 namespace search {

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
@@ -8,6 +8,7 @@
 #include "loadednumericvalue.h"
 #include "primitivereader.h"
 #include "attributeiterators.hpp"
+#include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/searchlib/query/queryterm.h>
 
 namespace search {

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
@@ -3,6 +3,8 @@
 #include "singlesmallnumericattribute.h"
 #include "attributevector.hpp"
 #include "primitivereader.h"
+#include "attributeiterators.hpp"
+#include <vespa/searchlib/queryeval/emptysearch.h>
 
 namespace search {
 
@@ -165,7 +167,7 @@ SingleValueSmallNumericAttribute::onSave(IAttributeSaveTarget &saveTarget)
 
 
 AttributeVector::SearchContext::UP
-SingleValueSmallNumericAttribute::getSearch(QueryTermSimple::UP qTerm,
+SingleValueSmallNumericAttribute::getSearch(std::unique_ptr<QueryTermSimple> qTerm,
                                             const SearchContext::Params & params) const
 {
     (void) params;
@@ -211,7 +213,7 @@ SingleValueSmallNumericAttribute::getEstimatedSaveByteSize() const
 bool SingleValueSmallNumericAttribute::SingleSearchContext::valid() const { return this->isValid(); }
 
 
-SingleValueSmallNumericAttribute::SingleSearchContext::SingleSearchContext(QueryTermSimple::UP qTerm,
+SingleValueSmallNumericAttribute::SingleSearchContext::SingleSearchContext(std::unique_ptr<QueryTermSimple> qTerm,
                                                                            const NumericAttribute & toBeSearched)
     : NumericAttribute::Range<T>(*qTerm),
       SearchContext(toBeSearched), _wordData(&static_cast<const SingleValueSmallNumericAttribute &>(toBeSearched)._wordData[0]),

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.h
@@ -4,10 +4,7 @@
 
 #include "integerbase.h"
 #include "floatbase.h"
-#include "attributeiterators.hpp"
 #include <vespa/searchlib/common/rcuvector.h>
-#include <vespa/searchlib/query/query.h>
-#include <vespa/searchlib/queryeval/emptysearch.h>
 #include <limits>
 
 namespace search {
@@ -81,7 +78,7 @@ public:
         bool valid() const override;
 
     public:
-        SingleSearchContext(QueryTermSimple::UP qTerm, const NumericAttribute & toBeSearched);
+        SingleSearchContext(std::unique_ptr<QueryTermSimple> qTerm, const NumericAttribute & toBeSearched);
 
         bool cmp(DocId docId, int32_t & weight) const {
             const Word &word = _wordData[docId >> _wordShift];
@@ -128,7 +125,7 @@ public:
     bool onLoad() override;
     void onSave(IAttributeSaveTarget &saveTarget) override;
 
-    SearchContext::UP getSearch(QueryTermSimple::UP term, const SearchContext::Params & params) const override;
+    SearchContext::UP getSearch(std::unique_ptr<QueryTermSimple> term, const SearchContext::Params & params) const override;
 
     T getFast(DocId doc) const {
         const Word &word = _wordData[doc >> _wordShift];

--- a/searchlib/src/vespa/searchlib/btree/btreeiterator.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreeiterator.hpp
@@ -4,6 +4,7 @@
 
 #include "btreeiterator.h"
 #include "btreeaggregator.h"
+#include "btreenode.hpp"
 #include <vespa/vespalib/stllike/asciistream.h>
 
 namespace search {

--- a/searchlib/src/vespa/searchlib/features/attributefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/attributefeature.cpp
@@ -1,8 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".features.attributefeature");
 #include "attributefeature.h"
 #include "utils.h"
 #include "valuefeature.h"
@@ -10,15 +7,15 @@ LOG_SETUP(".features.attributefeature");
 #include <vespa/searchcommon/common/undefinedvalues.h>
 #include <vespa/searchcommon/attribute/attributecontent.h>
 #include <vespa/searchlib/tensor/dense_tensor_attribute.h>
-#include <vespa/searchlib/tensor/tensor_attribute.h>
 #include <vespa/searchlib/features/constant_tensor_executor.h>
 #include <vespa/searchlib/features/dense_tensor_attribute_executor.h>
 #include <vespa/searchlib/features/tensor_attribute_executor.h>
-#include <vespa/searchlib/fef/fieldinfo.h>
 #include <vespa/searchlib/fef/indexproperties.h>
 #include <vespa/searchlib/attribute/singlenumericattribute.h>
-#include <vespa/eval/eval/value_type.h>
-#include <vespa/searchlib/fef/feature_type.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".features.attributefeature");
+
 
 using search::attribute::IAttributeVector;
 using search::attribute::BasicType;

--- a/searchlib/src/vespa/searchlib/features/matchcountfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/matchcountfeature.cpp
@@ -1,13 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/searchlib/fef/fieldinfo.h>
 #include "matchcountfeature.h"
 #include "utils.h"
 #include "valuefeature.h"
-
-#include <vespa/log/log.h>
-LOG_SETUP(".features.matchcountfeature");
 
 using namespace search::fef;
 

--- a/searchlib/src/vespa/searchlib/features/valuefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/valuefeature.cpp
@@ -1,11 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".features.value");
 #include "valuefeature.h"
-
-#include <sstream>
+#include <vespa/vespalib/stllike/asciistream.h>
 
 namespace search {
 namespace features {
@@ -51,9 +47,9 @@ ValueBlueprint::setup(const search::fef::IIndexEnvironment &,
 {
     for (uint32_t i = 0; i < params.size(); ++i) {
         _values.push_back(params[i].asDouble());
-        std::ostringstream name;
+        vespalib::asciistream name;
         name << i;
-        std::ostringstream desc;
+        vespalib::asciistream desc;
         desc << "value " << i;
         describeOutput(name.str(), desc.str());
         // we have no inputs

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -1,16 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Creation date: 2000-05-15
- *
- * Declaration of ParseItem class.
- *
- *   Copyright (C) 1997-2003 Fast Search & Transfer ASA
- *   Copyright (C) 2003 Overture Services Norway AS
- *               ALL RIGHTS RESERVED
- */
+
 #pragma once
 
-#include <vespa/searchlib/query/tree/predicate_query_term.h>
 #include <vespa/searchlib/query/weight.h>
 #include <vespa/searchlib/util/rawbuf.h>
 #include <vespa/vespalib/stllike/string.h>

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.h
@@ -17,6 +17,7 @@
 #include <vespa/vespalib/util/generationholder.h>
 #include <experimental/optional>
 
+
 namespace search {
 namespace predicate {
 

--- a/searchlib/src/vespa/searchlib/query/weight.h
+++ b/searchlib/src/vespa/searchlib/query/weight.h
@@ -1,6 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <cstdint>
+
 namespace search {
 namespace query {
 

--- a/searchlib/src/vespa/searchlib/queryeval/andnotsearch.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/andnotsearch.cpp
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include "andnotsearch.h"
+#include <vespa/searchlib/common/bitvector.h>
 
 namespace search {
 namespace queryeval {

--- a/searchlib/src/vespa/searchlib/queryeval/andnotsearch.h
+++ b/searchlib/src/vespa/searchlib/queryeval/andnotsearch.h
@@ -32,7 +32,7 @@ public:
     // Caller takes ownership of the returned SearchIterator.
     static SearchIterator *create(const Children &children, bool strict);
 
-    BitVector::UP get_hits(uint32_t begin_id) override;
+    std::unique_ptr<BitVector> get_hits(uint32_t begin_id) override;
 
 private:
     bool isAndNot() const override { return true; }

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -1,20 +1,14 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
 #include "blueprint.h"
 #include <vespa/vespalib/objects/visit.hpp>
 #include <vespa/vespalib/objects/objectdumper.h>
-#include <vespa/vespalib/util/stringfmt.h>
 #include "leaf_blueprints.h"
 #include "intermediate_blueprints.h"
 #include "equiv_blueprint.h"
 #include <vespa/vespalib/util/classname.h>
 
-#include <vector>
-#include <set>
-#include <map>
-
+#include <vespa/log/log.h>
 LOG_SETUP(".queryeval.blueprint");
 
 namespace search {

--- a/searchlib/src/vespa/searchlib/queryeval/iterator_pack.h
+++ b/searchlib/src/vespa/searchlib/queryeval/iterator_pack.h
@@ -54,6 +54,10 @@ public:
         return _children[ref]->getDocId();
     }
 
+    uint32_t next(uint32_t ref) {
+        return seek(ref, _children[ref]->getDocId()+1);
+    }
+
     uint32_t seek(uint32_t ref, uint32_t docid) {
         _children[ref]->seek(docid);
         return _children[ref]->getDocId();

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
@@ -1,12 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include "weighted_set_term_blueprint.h"
 #include "weighted_set_term_search.h"
-#include <vespa/searchlib/fef/termfieldmatchdata.h>
-#include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/vespalib/objects/visit.hpp>
-#include <algorithm>
 
 namespace search {
 namespace queryeval {
@@ -17,6 +13,7 @@ WeightedSetTermBlueprint::WeightedSetTermBlueprint(const FieldSpec &field)
       _weights(),
       _terms()
 {
+    set_allow_termwise_eval(true);
 }
 
 WeightedSetTermBlueprint::~WeightedSetTermBlueprint()
@@ -45,8 +42,7 @@ WeightedSetTermBlueprint::addTerm(Blueprint::UP term, int32_t weight)
 }
 
 SearchIterator::UP
-WeightedSetTermBlueprint::createSearch(search::fef::MatchData &md,
-                                       bool) const
+WeightedSetTermBlueprint::createSearch(search::fef::MatchData &md, bool) const
 {
     const State &state = getState();
     assert(state.numFields() == 1);

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
@@ -121,7 +121,11 @@ public:
         BitVector::UP result(BitVector::create(begin_id, getEndId()));
 
         for (size_t i = 0; i < _children.size(); ++i) {
-            for (uint32_t docId = _children.get_docid(i); ! isAtEnd(docId); docId = _children.next(i)) {
+            uint32_t docId = _children.get_docid(i);
+            if (begin_id > docId) {
+                _children.seek(i, begin_id);
+            }
+            for (docId = _children.get_docid(i); ! isAtEnd(docId); docId = _children.next(i)) {
                 result->setBit(docId);
             }
         }

--- a/searchsummary/src/vespa/searchsummary/docsummary/attributedfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/attributedfw.cpp
@@ -1,12 +1,12 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "docsumwriter.h"
+#include "attributedfw.h"
+#include "docsumstate.h"
 #include <vespa/searchlib/attribute/stringbase.h>
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/floatbase.h>
 #include <vespa/searchlib/tensor/tensor_attribute.h>
-#include "docsumwriter.h"
-#include "attributedfw.h"
-#include "docsumstate.h"
 #include <vespa/eval/tensor/tensor.h>
 #include <vespa/eval/tensor/serialization/typed_binary_format.h>
 #include <vespa/vespalib/objects/nbostream.h>

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumconfig.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumconfig.cpp
@@ -1,16 +1,14 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/searchsummary/docsummary/docsumconfig.h>
-#include <vespa/searchsummary/docsummary/docsumwriter.h>
-#include <vespa/searchsummary/docsummary/idocsumenvironment.h>
-#include <vespa/searchsummary/docsummary/rankfeaturesdfw.h>
-#include <vespa/searchsummary/docsummary/textextractordfw.h>
-#include <vespa/searchsummary/docsummary/geoposdfw.h>
-#include <vespa/searchsummary/docsummary/positionsdfw.h>
-#include <vespa/searchsummary/docsummary/juniperdfw.h>
-#include <vespa/vespalib/util/vstringfmt.h>
+#include "docsumconfig.h"
+#include "docsumwriter.h"
+#include "idocsumenvironment.h"
+#include "rankfeaturesdfw.h"
+#include "textextractordfw.h"
+#include "geoposdfw.h"
+#include "positionsdfw.h"
+#include "juniperdfw.h"
+#include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/exceptions.h>
 
 namespace search {

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumfieldwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumfieldwriter.cpp
@@ -1,18 +1,15 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-#include <vespa/searchlib/attribute/iattributemanager.h>
-#include <vespa/searchlib/common/documentlocations.h>
-#include <vespa/searchlib/common/location.h>
 #include "docsumfieldwriter.h"
 #include "idocsumenvironment.h"
 #include "docsumformat.h"
 #include "docsumstate.h"
+#include <vespa/searchlib/attribute/iattributemanager.h>
+#include <vespa/searchlib/common/documentlocations.h>
+#include <vespa/searchlib/common/location.h>
 #include <vespa/searchlib/parsequery/stackdumpiterator.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docsummary.docsumfieldwriter");
 
 namespace search {
@@ -29,14 +26,10 @@ const vespalib::string IDocsumFieldWriter::_empty("");
 
 //--------------------------------------------------------------------------
 
-EmptyDFW::EmptyDFW()
-{
-}
+EmptyDFW::EmptyDFW() { }
 
 
-EmptyDFW::~EmptyDFW()
-{
-}
+EmptyDFW::~EmptyDFW() { }
 
 void
 EmptyDFW::insertField(uint32_t /*docid*/,

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumformat.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumformat.cpp
@@ -1,16 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-#include <vespa/searchsummary/docsummary/docsumformat.h>
+#include "docsumformat.h"
 
 namespace search {
 namespace docsummary {
-
-LOG_SETUP(".searchlib.docsummary.docsumformat");
-
 
 size_t
 DocsumFormat::addByte(search::RawBuf &target, uint8_t value)
@@ -101,7 +94,7 @@ DocsumFormat::addEmpty(ResType type, search::RawBuf &target)
     case RES_FEATUREDATA:
         return addLongData(target, "", 0);
     }
-    LOG_ASSERT(type <= RES_FEATUREDATA);
+    assert(type <= RES_FEATUREDATA);
     return 0;
 }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.cpp
@@ -1,8 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
 #include "docsumstate.h"
 #include <vespa/juniper/rpinterface.h>
 #include <vespa/searchcommon/attribute/iattributecontext.h>

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
@@ -1,8 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastlib/text/normwordfolder.h>
 #include "docsumwriter.h"
 #include "docsumformat.h"
 #include "docsumstate.h"
@@ -10,6 +7,7 @@
 #include <vespa/searchlib/util/slime_output_raw_buf_adapter.h>
 #include <vespa/searchlib/attribute/iattributemanager.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/fastlib/text/normwordfolder.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docsummary.docsumwriter");

--- a/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
@@ -1,24 +1,20 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
-#include <cstdio>
-#include <vespa/log/log.h>
 #include "juniperdfw.h"
+#include "docsumwriter.h"
+#include "docsumfieldwriter.h"
+#include "docsumstate.h"
+#include "keywordextractor.h"
+#include "docsumformat.h"
 #include <vespa/searchlib/parsequery/stackdumpiterator.h>
 #include <vespa/searchlib/util/rawbuf.h>
 #include <vespa/searchlib/queryeval/split_float.h>
 
 #include <vespa/searchlib/fef/properties.h>
-#include <vespa/searchsummary/docsummary/docsumwriter.h>
-#include <vespa/searchsummary/docsummary/docsumfieldwriter.h>
-#include <vespa/searchsummary/docsummary/docsumstate.h>
-#include <vespa/searchsummary/docsummary/keywordextractor.h>
-#include <vespa/searchsummary/docsummary/docsumformat.h>
 #include <vespa/vespalib/objects/hexdump.h>
 #include <vespa/juniper/config.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docsummary.dynamicteaserdfw");
 
 namespace juniper {
@@ -317,9 +313,7 @@ JuniperDFW::JuniperDFW(juniper::Juniper * juniper)
 }
 
 
-JuniperDFW::~JuniperDFW()
-{
-}
+JuniperDFW::~JuniperDFW() { }
 
 bool
 JuniperDFW::Init(

--- a/searchsummary/src/vespa/searchsummary/docsummary/juniperproperties.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/juniperproperties.cpp
@@ -1,10 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/searchcommon/config/subscriptionproxyng.h>
-#include <vespa/vespalib/util/vstringfmt.h>
+
 #include "juniperproperties.h"
+#include <vespa/searchcommon/config/subscriptionproxyng.h>
+#include <vespa/vespalib/util/stringfmt.h>
 
 using vespa::config::search::summary::JuniperrcConfig;
+using vespalib::make_string;
 
 namespace search {
 namespace docsummary {
@@ -56,34 +57,34 @@ JuniperProperties::configure(const JuniperrcConfig &cfg)
 {
     reset();
     _properties["juniper.dynsum.fallback"]      = cfg.prefix ? "prefix" : "none";
-    _properties["juniper.dynsum.length"]        = vespalib::make_vespa_string("%d", cfg.length);
-    _properties["juniper.dynsum.max_matches"]   = vespalib::make_vespa_string("%d", cfg.maxMatches);
-    _properties["juniper.dynsum.min_length"]    = vespalib::make_vespa_string("%d", cfg.minLength);
-    _properties["juniper.dynsum.surround_max"]  = vespalib::make_vespa_string("%d", cfg.surroundMax);
-    _properties["juniper.matcher.winsize"]  = vespalib::make_vespa_string("%d", cfg.winsize);
-    _properties["juniper.matcher.winsize_fallback_multiplier"]  = vespalib::make_vespa_string("%f", cfg.winsizeFallbackMultiplier);
-    _properties["juniper.matcher.max_match_candidates"]  = vespalib::make_vespa_string("%d", cfg.maxMatchCandidates);
-    _properties["juniper.stem.min_length"]  = vespalib::make_vespa_string("%d", cfg.stemMinLength);
-    _properties["juniper.stem.max_extend"]  = vespalib::make_vespa_string("%d", cfg.stemMaxExtend);
+    _properties["juniper.dynsum.length"]        = make_string("%d", cfg.length);
+    _properties["juniper.dynsum.max_matches"]   = make_string("%d", cfg.maxMatches);
+    _properties["juniper.dynsum.min_length"]    = make_string("%d", cfg.minLength);
+    _properties["juniper.dynsum.surround_max"]  = make_string("%d", cfg.surroundMax);
+    _properties["juniper.matcher.winsize"]  = make_string("%d", cfg.winsize);
+    _properties["juniper.matcher.winsize_fallback_multiplier"]  = make_string("%f", cfg.winsizeFallbackMultiplier);
+    _properties["juniper.matcher.max_match_candidates"]  = make_string("%d", cfg.maxMatchCandidates);
+    _properties["juniper.stem.min_length"]  = make_string("%d", cfg.stemMinLength);
+    _properties["juniper.stem.max_extend"]  = make_string("%d", cfg.stemMaxExtend);
 
     for (uint32_t i = 0; i < cfg.override.size(); ++i) {
         const JuniperrcConfig::Override &override = cfg.override[i];
-        const vespalib::string keyDynsum = vespalib::make_vespa_string("%s.dynsum.", override.fieldname.c_str());
-        const vespalib::string keyMatcher = vespalib::make_vespa_string("%s.matcher.", override.fieldname.c_str());
-        const vespalib::string keyStem = vespalib::make_vespa_string("%s.stem.", override.fieldname.c_str());
+        const vespalib::string keyDynsum = make_string("%s.dynsum.", override.fieldname.c_str());
+        const vespalib::string keyMatcher = make_string("%s.matcher.", override.fieldname.c_str());
+        const vespalib::string keyStem = make_string("%s.stem.", override.fieldname.c_str());
 
         _properties[keyDynsum + "fallback"]           = override.prefix ? "prefix" : "none";
-        _properties[keyDynsum + "length"]             = vespalib::make_vespa_string("%d", override.length);
-        _properties[keyDynsum + "max_matches"]        = vespalib::make_vespa_string("%d", override.maxMatches);
-        _properties[keyDynsum + "min_length"]         = vespalib::make_vespa_string("%d", override.minLength);
-        _properties[keyDynsum + "surround_max"]       = vespalib::make_vespa_string("%d", override.surroundMax);
+        _properties[keyDynsum + "length"]             = make_string("%d", override.length);
+        _properties[keyDynsum + "max_matches"]        = make_string("%d", override.maxMatches);
+        _properties[keyDynsum + "min_length"]         = make_string("%d", override.minLength);
+        _properties[keyDynsum + "surround_max"]       = make_string("%d", override.surroundMax);
 
-        _properties[keyMatcher + "winsize"]                     = vespalib::make_vespa_string("%d", override.winsize);
-        _properties[keyMatcher + "winsize_fallback_multiplier"] = vespalib::make_vespa_string("%f", override.winsizeFallbackMultiplier);
-        _properties[keyMatcher + "max_match_candidates"] = vespalib::make_vespa_string("%d", override.maxMatchCandidates);
+        _properties[keyMatcher + "winsize"]                     = make_string("%d", override.winsize);
+        _properties[keyMatcher + "winsize_fallback_multiplier"] = make_string("%f", override.winsizeFallbackMultiplier);
+        _properties[keyMatcher + "max_match_candidates"] = make_string("%d", override.maxMatchCandidates);
 
-        _properties[keyStem + "min_length"] = vespalib::make_vespa_string("%d", override.stemMinLength);
-        _properties[keyStem + "max_extend"] = vespalib::make_vespa_string("%d", override.stemMaxExtend);
+        _properties[keyStem + "min_length"] = make_string("%d", override.stemMinLength);
+        _properties[keyStem + "max_extend"] = make_string("%d", override.stemMaxExtend);
     }
 }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.cpp
@@ -1,13 +1,10 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/searchlib/parsequery/stackdumpiterator.h>
-#include <vespa/searchlib/util/rawbuf.h>
 #include "docsumstate.h"
 #include "keywordextractor.h"
 #include "idocsumenvironment.h"
+#include <vespa/searchlib/parsequery/stackdumpiterator.h>
+#include <vespa/searchlib/util/rawbuf.h>
 
 /** Tell us what parts of the query we are interested in */
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/rankfeaturesdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/rankfeaturesdfw.cpp
@@ -1,11 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchlib/common/featureset.h>
-#include <vespa/searchlib/common/packets.h>
 #include "rankfeaturesdfw.h"
-#include <vespa/searchlib/common/feature.h>
 #include "docsumformat.h"
 #include "docsumstate.h"
+#include <vespa/searchlib/common/feature.h>
+#include <vespa/searchlib/common/featureset.h>
+#include <vespa/searchlib/common/packets.h>
 #include <vespa/vespalib/data/slime/cursor.h>
 
 namespace search {

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultclass.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultclass.cpp
@@ -1,6 +1,4 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 
 #include "resultclass.h"

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.cpp
@@ -1,11 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
+
+#include "resultpacker.h"
+#include <vespa/searchcommon/common/undefinedvalues.h>
 
 #include <vespa/log/log.h>
-#include <vespa/searchcommon/common/undefinedvalues.h>
-#include <vespa/searchsummary/docsummary/resultpacker.h>
-
 LOG_SETUP(".searchlib.docsummary.resultpacker");
 
 namespace search {

--- a/searchsummary/src/vespa/searchsummary/docsummary/summaryfeaturesdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/summaryfeaturesdfw.cpp
@@ -1,10 +1,10 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchlib/common/featureset.h>
-#include <vespa/searchlib/common/packets.h>
 #include "docsumformat.h"
 #include "summaryfeaturesdfw.h"
 #include "docsumstate.h"
+#include <vespa/searchlib/common/featureset.h>
+#include <vespa/searchlib/common/packets.h>
 #include <vespa/vespalib/data/slime/cursor.h>
 #include <cmath>
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/textextractordfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/textextractordfw.cpp
@@ -1,9 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include "tokenizer.h"
 #include "textextractordfw.h"
 #include "docsumstate.h"
+
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docsummary.textextractordfw");
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/tokenizer.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/tokenizer.cpp
@@ -1,9 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".summary.tokenizer");
 #include "tokenizer.h"
+#include <cassert>
 
 namespace search {
 namespace docsummary {
@@ -103,7 +101,7 @@ Tokenizer::getNextToken()
 
         _pos = next;
     }
-    LOG_ASSERT(_pos == _end);
+    assert(_pos == _end);
     _hasMoreTokens = false;
     return Token(textBegin, _pos, _type); // return the last token
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/urlresult.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/urlresult.cpp
@@ -1,13 +1,10 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-#include <vespa/searchsummary/docsummary/urlresult.h>
-#include <vespa/searchsummary/docsummary/resultconfig.h>
+#include "urlresult.h"
+#include "resultconfig.h"
 #include <zlib.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docsummary.urlresult");
 
 namespace search {
@@ -17,12 +14,10 @@ urlresult::urlresult(uint32_t partition, uint32_t docid, HitRank metric)
     : _partition(partition),
       _docid(docid),
       _metric(metric)
-{}
+{ }
 
 
-urlresult::~urlresult()
-{
-}
+urlresult::~urlresult() { }
 
 
 /*===============================================================*/
@@ -30,16 +25,15 @@ urlresult::~urlresult()
 
 badurlresult::badurlresult()
     : urlresult(0, 0, 0)
-{}
+{ }
 
 
 badurlresult::badurlresult(uint32_t partition, uint32_t docid, HitRank metric)
     : urlresult(partition, docid, metric)
-{}
+{ }
 
 
-badurlresult::~badurlresult()
-{}
+badurlresult::~badurlresult() { }
 
 
 int

--- a/storageserver/src/apps/storaged/forcelink.cpp
+++ b/storageserver/src/apps/storaged/forcelink.cpp
@@ -1,6 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include <vespa/document/base/forcelink.h>
 #include <vespa/documentapi/documentapi.h>
 #include <vespa/searchlib/aggregation/forcelink.hpp>

--- a/storageserver/src/vespa/storageserver/app/dummyservicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/dummyservicelayerprocess.cpp
@@ -1,11 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/storageserver/app/dummyservicelayerprocess.h>
-
-#include <vespa/log/log.h>
-
-LOG_SETUP(".process.servicelayer");
+#include "dummyservicelayerprocess.h"
 
 namespace storage {
 

--- a/storageserver/src/vespa/storageserver/app/memfileservicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/memfileservicelayerprocess.cpp
@@ -1,10 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/storageserver/app/memfileservicelayerprocess.h>
+#include "memfileservicelayerprocess.h"
 
 #include <vespa/log/log.h>
-
 LOG_SETUP(".process.servicelayer");
 
 namespace storage {

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
@@ -1,17 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
-#include <vespa/storageserver/app/servicelayerprocess.h>
+#include "servicelayerprocess.h"
 
-#include <vespa/log/log.h>
 #include <vespa/searchvisitor/searchvisitor.h>
 #include <vespa/storage/storageutil/utils.h>
 
-LOG_SETUP(".process.servicelayer");
-
 namespace storage {
-
-// ServiceLayerProcess implementation
 
 ServiceLayerProcess::ServiceLayerProcess(const config::ConfigUri & configUri)
     : Process(configUri)
@@ -30,8 +24,7 @@ ServiceLayerProcess::createNode()
 {
     _externalVisitors["searchvisitor"].reset(new SearchVisitorFactory(_configUri));
     setupProvider();
-    _node.reset(new ServiceLayerNode(
-            _configUri, _context, *this, getProvider(), _externalVisitors));
+    _node.reset(new ServiceLayerNode(_configUri, _context, *this, getProvider(), _externalVisitors));
     _node->init();
 }
 

--- a/vdslib/src/vespa/vdslib/bucketdistribution.cpp
+++ b/vdslib/src/vespa/vdslib/bucketdistribution.cpp
@@ -1,9 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+#include "bucketdistribution.h"
+
 #include <vespa/log/log.h>
 LOG_SETUP(".bucketdistribution");
-
-#include "bucketdistribution.h"
 
 namespace vdslib {
 

--- a/vdslib/src/vespa/vdslib/container/documentsummary.cpp
+++ b/vdslib/src/vespa/vdslib/container/documentsummary.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "documentsummary.h"
 
 namespace vdslib {

--- a/vdslib/src/vespa/vdslib/container/searchresult.cpp
+++ b/vdslib/src/vespa/vdslib/container/searchresult.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "searchresult.h"
 
 namespace vdslib {

--- a/vdslib/src/vespa/vdslib/container/visitorordering.cpp
+++ b/vdslib/src/vespa/vdslib/container/visitorordering.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "visitorordering.h"
 #include <sstream>
 

--- a/vdslib/src/vespa/vdslib/container/visitorstatistics.cpp
+++ b/vdslib/src/vespa/vdslib/container/visitorstatistics.cpp
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/vdslib/container/visitorstatistics.h>
-#include <iostream>
+
+#include "visitorstatistics.h"
+#include <ostream>
 
 namespace vdslib {
 

--- a/vdslib/src/vespa/vdslib/state/idealgroup.cpp
+++ b/vdslib/src/vespa/vdslib/state/idealgroup.cpp
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/vdslib/state/idealgroup.h>
 
+#include <vespa/vdslib/state/idealgroup.h>
 
 namespace storage {
 namespace lib {

--- a/vdslib/src/vespa/vdslib/state/state.cpp
+++ b/vdslib/src/vespa/vdslib/state/state.cpp
@@ -1,6 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/fastos/fastos.h>
 #include <vespa/vdslib/state/state.h>
 
 #include <vespa/vespalib/util/exceptions.h>

--- a/vdslib/src/vespa/vdslib/thread/taskscheduler.cpp
+++ b/vdslib/src/vespa/vdslib/thread/taskscheduler.cpp
@@ -1,6 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/vdslib/thread/taskscheduler.h>
+
+#include "taskscheduler.h"
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 

--- a/vespaclient/src/vespa/vespaclient/spoolmaster/application.cpp
+++ b/vespaclient/src/vespa/vespaclient/spoolmaster/application.cpp
@@ -1,12 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
 #include <vespa/defaults.h>
 #include <vector>
 #include <string>
 #include <iostream>
 #include <algorithm>
+#include <cstdio>
 #include <dirent.h>
-#include <stdio.h>
 #include <unistd.h>
 
 #include "application.h"

--- a/vespaclient/src/vespa/vespaclient/spoolmaster/application.h
+++ b/vespaclient/src/vespa/vespaclient/spoolmaster/application.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <vespa/fastos/app.h>
 
 namespace spoolmaster {
 /**

--- a/vespaclient/src/vespa/vespaclient/spoolmaster/main.cpp
+++ b/vespaclient/src/vespa/vespaclient/spoolmaster/main.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "application.h"
 
 int

--- a/vespaclient/src/vespa/vespaclient/vespadoclocator/main.cpp
+++ b/vespaclient/src/vespa/vespaclient/vespadoclocator/main.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "application.h"
 
 int

--- a/vespaclient/src/vespa/vespaclient/vesparoute/main.cpp
+++ b/vespaclient/src/vespa/vespaclient/vesparoute/main.cpp
@@ -1,7 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/vespalib/util/signalhandler.h>
+
 #include "application.h"
+#include <vespa/vespalib/util/signalhandler.h>
 
 int
 main(int argc, char** argv)

--- a/vespaclient/src/vespa/vespaclient/vesparoute/mynetwork.cpp
+++ b/vespaclient/src/vespa/vespaclient/vesparoute/mynetwork.cpp
@@ -1,11 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP(".testframe");
 
+#include "mynetwork.h"
 #include <vespa/messagebus/emptyreply.h>
 #include <vespa/messagebus/sendproxy.h>
-#include "mynetwork.h"
 
 class MyServiceAddress : public mbus::IServiceAddress {
 private:

--- a/vespaclient/src/vespa/vespaclient/vesparoute/params.cpp
+++ b/vespaclient/src/vespa/vespaclient/vesparoute/params.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
+
 #include "params.h"
 
 namespace vesparoute {

--- a/vespalog/src/vespa/log/log-assert.cpp
+++ b/vespalog/src/vespa/log/log-assert.cpp
@@ -1,10 +1,4 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <sys/types.h>
-#include <cstring>
-#include <cstdlib>
-#include <cstdio>
-#include <unistd.h>
 
 #include "log.h"
 LOG_SETUP("");

--- a/vespalog/src/vespa/log/log.cpp
+++ b/vespalog/src/vespa/log/log.cpp
@@ -1,19 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <sys/types.h>
-#include <cstring>
-#include <cstdlib>
-#include <stdarg.h>
-#include <cstdio>
-#include <sys/time.h>
-#include <unistd.h>
-#include <errno.h>
-#include <memory>
-
-#include <algorithm>
 
 #include "log.h"
 LOG_SETUP_INDIRECT(".log", "$Id$");
+
 #undef LOG
 #define LOG LOG_INDIRECT
 
@@ -21,6 +10,8 @@ LOG_SETUP_INDIRECT(".log", "$Id$");
 #include "log-target.h"
 #include "internal.h"
 #include "control-file.h"
+
+#include <vespa/fastos/thread.h>
 
 namespace ns_log {
 
@@ -384,7 +375,7 @@ Logger::doEventProgress(const char *name, double value, double total)
 void
 Logger::doEventCount(const char *name, uint64_t value)
 {
-    doLog(event, "", 0, "count/1 name=\"%s\" value=%" PRIu64, name, value);
+    doLog(event, "", 0, "count/1 name=\"%s\" value=%lu", name, value);
 }
 
 void
@@ -396,7 +387,7 @@ Logger::doEventValue(const char *name, double value)
 void
 Logger::doEventCollection(uint64_t collectionId, const char* name, const char* params)
 {
-  doLog(event, "", 0, "collection/1 collectionId=%" PRIu64 " name=\"%s\" %s",
+  doLog(event, "", 0, "collection/1 collectionId=%lu name=\"%s\" %s",
         collectionId, name, params);
 }
 


### PR DESCRIPTION
@havardpe PR
This reduced the matching time by a factor of 2.5x for gemini native.
Together with more aggressive macro inlining and removal of fast-search for rank/grouping increased overall QPS with a factor of 2.1. 