### PR TITLE
Allow 200 response without content

### DIFF
--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceTest.java
@@ -312,8 +312,9 @@ public class HttpServerConformanceTest extends ServerProviderConformanceTest {
     @Override
     @Test
     public void testRequestContentWriteNondeterministicExceptionWithAsyncCompletion() throws Throwable {
-        new TestRunner().expect(anyOf(success(), serverError()))
-                        .execute();
+        new TestRunner()
+                .expect(anyOf(success(), successNoContent(), serverError()))
+                .execute();
     }
 
     @Override


### PR DESCRIPTION
There is a window between the response is committed (headers including
response code is set) and the response body is written, where the exception
from the request handler can be catched. If that happens, the output
stream will be closed before response body is written.