### PR TITLE
Mount every directory under logs/ inside the container

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -57,7 +57,19 @@ public class DockerOperationsImpl implements DockerOperations {
     private static final Map<String, Boolean> DIRECTORIES_TO_MOUNT = new HashMap<>();
     static {
         DIRECTORIES_TO_MOUNT.put("/etc/yamas-agent", true);
-        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/daemontools_y"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/jdisc_core"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/langdetect/"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/vespa"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/yca"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/yck"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/yell"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/ykeykey"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/ykeykeyd"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/yms_agent"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/ysar"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/ystatus"), false);
+        DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/zpe_policy_updater"), false);
         DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("var/cache"), false);
         DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("var/crash"), false);
         DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("var/db/jdisc"), false);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/LocalZoneUtils.java
@@ -98,24 +98,36 @@ public class LocalZoneUtils {
         }
 
         Arrays.asList(
-                    "/home/y/logs",
-                    "/home/y/var/cache",
-                    "/home/y/var/crash",
-                    "/home/y/var/db/jdisc",
-                    "/home/y/var/db/vespa",
-                    "/home/y/var/jdisc_container",
-                    "/home/y/var/jdisc_core",
-                    "/home/y/var/maven",
-                    "/home/y/var/run",
-                    "/home/y/var/scoreboards",
-                    "/home/y/var/service",
-                    "/home/y/var/share",
-                    "/home/y/var/spool",
-                    "/home/y/var/vespa",
-                    "/home/y/var/yca",
-                    "/home/y/var/ycore++",
-                    "/home/y/var/zookeeper")
-                .forEach(path -> createCmd.withVolume(pathToContainerStorage.resolve("node-admin" + path).toString(), path));
+                "/home/y/logs/daemontools_y",
+                "/home/y/logs/jdisc_core",
+                "/home/y/logs/langdetect/",
+                "/home/y/logs/vespa",
+                "/home/y/logs/yca",
+                "/home/y/logs/yck",
+                "/home/y/logs/yell",
+                "/home/y/logs/ykeykey",
+                "/home/y/logs/ykeykeyd",
+                "/home/y/logs/yms_agent",
+                "/home/y/logs/ysar",
+                "/home/y/logs/ystatus",
+                "/home/y/logs/zpe_policy_updater",
+                "/home/y/var/cache",
+                "/home/y/var/crash",
+                "/home/y/var/db/jdisc",
+                "/home/y/var/db/vespa",
+                "/home/y/var/jdisc_container",
+                "/home/y/var/jdisc_core",
+                "/home/y/var/maven",
+                "/home/y/var/run",
+                "/home/y/var/scoreboards",
+                "/home/y/var/service",
+                "/home/y/var/share",
+                "/home/y/var/spool",
+                "/home/y/var/vespa",
+                "/home/y/var/yca",
+                "/home/y/var/ycore++",
+                "/home/y/var/zookeeper")
+              .forEach(path -> createCmd.withVolume(pathToContainerStorage.resolve("node-admin" + path).toString(), path));
 
         createCmd.create();
         docker.startContainer(NODE_ADMIN_CONTAINER_NAME);


### PR DESCRIPTION
* Since we mount directories in ../logs/ on the host inside the container
  we will not preserve any data in the image, so we need to explicitly
  specify any directories under logs/ to make them usable inside the container