### PR TITLE
Reintroduce redundancy requirement for production

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -61,9 +61,9 @@ public class CapacityPolicies {
      * @throws IllegalArgumentException if only one node is requested
      */
     private int ensureRedundancy(int nodeCount) {
-        // TODO: Reactivate this check when we have sufficient capacity in ap-northeast
-        // if (nodeCount == 1)
-        //    throw new IllegalArgumentException("Deployments to prod require at least 2 nodes per cluster for redundancy");
+        if (nodeCount == 1) {
+            throw new IllegalArgumentException("Deployments to prod require at least 2 nodes per cluster for redundancy");
+        }
         return nodeCount;
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -77,18 +77,18 @@ public class InactiveAndFailedExpirerTest {
     @Test
     public void reboot_generation_is_increased_when_node_moves_to_dirty() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")));
-        List<Node> nodes = tester.makeReadyNodes(1, "default");
+        List<Node> nodes = tester.makeReadyNodes(2, "default");
 
         // Allocate and deallocate a single node
-        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, 
+        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content,
                                                   ClusterSpec.Id.from("test"), 
                                                   Version.fromString("6.42"));
-        tester.prepare(applicationId, cluster, Capacity.fromNodeCount(1), 1);
+        tester.prepare(applicationId, cluster, Capacity.fromNodeCount(2), 1);
         tester.activate(applicationId, ProvisioningTester.toHostSpecs(nodes));
-        assertEquals(1, tester.getNodes(applicationId, Node.State.active).size());
+        assertEquals(2, tester.getNodes(applicationId, Node.State.active).size());
         tester.deactivate(applicationId);
         List<Node> inactiveNodes = tester.getNodes(applicationId, Node.State.inactive).asList();
-        assertEquals(1, inactiveNodes.size());
+        assertEquals(2, inactiveNodes.size());
 
         // Check reboot generation before node is moved. New nodes transition from provisioned to dirty, so their
         // wanted reboot generation will always be 1.
@@ -99,7 +99,7 @@ public class InactiveAndFailedExpirerTest {
         tester.advanceTime(Duration.ofMinutes(14));
         new InactiveExpirer(tester.nodeRepository(), tester.clock(), Duration.ofMinutes(10), new JobControl(tester.nodeRepository().database())).run();
         List<Node> dirty = tester.nodeRepository().getNodes(Node.State.dirty);
-        assertEquals(1, dirty.size());
+        assertEquals(2, dirty.size());
 
         // Reboot generation is increased
         assertEquals(wantedRebootGeneration + 1, dirty.get(0).status().reboot().wanted());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -105,7 +105,7 @@ public class RetiredExpirerTest {
 
         ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test"), Version.fromString("6.42"));
         activate(applicationId, cluster, 8, 8, provisioner);
-        activate(applicationId, cluster, 1, 1, provisioner);
+        activate(applicationId, cluster, 2, 2, provisioner);
         assertEquals(8, nodeRepository.getNodes(applicationId, Node.State.active).size());
         assertEquals(0, nodeRepository.getNodes(applicationId, Node.State.inactive).size());
 
@@ -113,10 +113,10 @@ public class RetiredExpirerTest {
         clock.advance(Duration.ofHours(30)); // Retire period spent
         MockDeployer deployer =
             new MockDeployer(provisioner,
-                             Collections.singletonMap(applicationId, new MockDeployer.ApplicationContext(applicationId, cluster, Capacity.fromNodeCount(1, Optional.of("default")), 1)));
+                             Collections.singletonMap(applicationId, new MockDeployer.ApplicationContext(applicationId, cluster, Capacity.fromNodeCount(2, Optional.of("default")), 1)));
         new RetiredExpirer(nodeRepository, deployer, clock, Duration.ofHours(12), new JobControl(nodeRepository.database())).run();
-        assertEquals(1, nodeRepository.getNodes(applicationId, Node.State.active).size());
-        assertEquals(7, nodeRepository.getNodes(applicationId, Node.State.inactive).size());
+        assertEquals(2, nodeRepository.getNodes(applicationId, Node.State.active).size());
+        assertEquals(6, nodeRepository.getNodes(applicationId, Node.State.inactive).size());
         assertEquals(1, deployer.redeployments);
 
         // inactivated nodes are not retired

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -28,7 +28,6 @@ import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -357,7 +356,6 @@ public class ProvisioningTest {
         tester.activate(application, state.allHosts);
     }
 
-    @Ignore // TODO: Re-activate when the check is reactivate in CapacityPolicies
     @Test(expected = IllegalArgumentException.class)
     public void prod_deployment_requires_redundancy() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")));
@@ -516,25 +514,27 @@ public class ProvisioningTest {
 
         ApplicationId application1 = tester.makeApplicationId();
 
-        tester.makeReadyNodes(10, "default");
+        tester.makeReadyNodes(14, "default");
 
         // deploy
-        SystemState state1 = prepare(application1, 2, 2, 3, 3, "default", tester);
+        SystemState state1 = prepare(application1, 3, 3, 4, 4, "default", tester);
         tester.activate(application1, state1.allHosts);
 
         // decrease cluster sizes
-        SystemState state2 = prepare(application1, 1, 1, 1, 1, "default", tester);
+        SystemState state2 = prepare(application1, 2, 2, 2, 2, "default", tester);
         tester.activate(application1, state2.allHosts);
 
         // content0
         assertFalse(state2.hostByMembership("content0", 0, 0).membership().get().retired());
-        assertTrue( state2.hostByMembership("content0", 0, 1).membership().get().retired());
+        assertFalse( state2.hostByMembership("content0", 0, 1).membership().get().retired());
         assertTrue( state2.hostByMembership("content0", 0, 2).membership().get().retired());
+        assertTrue( state2.hostByMembership("content0", 0, 3).membership().get().retired());
 
         // content1
         assertFalse(state2.hostByMembership("content1", 0, 0).membership().get().retired());
-        assertTrue( state2.hostByMembership("content1", 0, 1).membership().get().retired());
+        assertFalse(state2.hostByMembership("content1", 0, 1).membership().get().retired());
         assertTrue( state2.hostByMembership("content1", 0, 2).membership().get().retired());
+        assertTrue( state2.hostByMembership("content1", 0, 3).membership().get().retired());
     }
 
     @Test


### PR DESCRIPTION
I assume we can fix this TODO now? Last commit that touched this code was the initial import for open sourcing.