### PR TITLE
Clean up interface

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ConfigDefinitionRepo.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ConfigDefinitionRepo.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.api;
 
-import com.yahoo.config.codegen.InnerCNode;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import com.yahoo.vespa.config.buildergen.ConfigDefinition;
 
@@ -16,7 +15,7 @@ import java.util.Map;
 public interface ConfigDefinitionRepo {
 
     /**
-     * Retrieve a map with all configdefinitions in this repo.
+     * Retrieve a map with all config definitions in this repo.
      */
     Map<ConfigDefinitionKey, ConfigDefinition> getConfigDefinitions();
 

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/Model.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/Model.java
@@ -1,13 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.api;
 
-import com.yahoo.config.codegen.InnerCNode;
 import com.yahoo.config.provision.ProvisionInfo;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.buildergen.ConfigDefinition;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Collection;
@@ -28,20 +26,16 @@ public interface Model {
      * @param targetDef The config definition to use for applying defaults.
      * @return override The global override to apply to the generated config.
      */
-    // TODO: Remove 'throws IOException' when 6.67 is deployed everywhere
-    ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef, ConfigPayload override) throws IOException;
+    // TODO: Remove when 6.70 is deployed everywhere
+    ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef, ConfigPayload override);
 
     /**
-     * TODO: Remove this method once no fat bundles implementing it anymore.
-     * Use {@link Model#getConfig(ConfigKey, ConfigDefinition, ConfigPayload)} instead.
-     *
      * Resolves a config using a given def file, apply overrides and returns it.
      *
      * @param configKey The key of the config to retrieve.
      * @param targetDef The config definition to use for applying defaults.
-     * @return override The global override to apply to the generated config.
      */
-    ConfigPayload getConfig(ConfigKey<?> configKey, InnerCNode targetDef, ConfigPayload override) throws IOException;
+    ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef);
 
     /**
      * Produces a set of the valid config keys for this model.

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
@@ -313,9 +313,16 @@ public final class VespaModel extends AbstractConfigProducerRoot implements Seri
         }
     }
 
-    /** TODO: Remove once configserver has switched to using {@link VespaModel#getConfig(ConfigKey, ConfigDefinition, ConfigPayload)} instead. **/
-    public ConfigPayload getConfig(ConfigKey configKey, InnerCNode targetDef, ConfigPayload userOverride) {
-        return getConfig(configKey, targetDef == null ? null : new ConfigDefinition(targetDef), userOverride);
+    /**
+     * Resolve config for a given key and a def. Apply an override if given.
+     *
+     * @param configKey    The key to resolve.
+     * @param targetDef    The def file to use for the schema.
+     * @return The payload as a list of strings
+     */
+    @Override
+    public ConfigPayload getConfig(ConfigKey configKey, com.yahoo.vespa.config.buildergen.ConfigDefinition targetDef) {
+        return getConfig(configKey, targetDef, null);
     }
 
     /**

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/Application.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/Application.java
@@ -123,19 +123,13 @@ public class Application implements ModelResult {
             throw new UnknownConfigDefinitionException("Unable to find config definition for '" + configKey.getNamespace() + "." + configKey.getName());
         }
         configKey = new ConfigKey<>(configDefinitionWrapper.getDefKey().getName(), configKey.getConfigId(), configDefinitionWrapper.getDefKey().getNamespace());
-        ConfigPayload payload;
-        try {
-            if (logDebug()) {
-                debug("Resolving " + configKey + " with targetDef=" + def);
-            }
-
-            payload = model.getConfig(
-                    configKey,
-                    def,
-                    null); // TODO Remove this argument when possible
-        } catch (IOException e) {
+        if (logDebug()) {
+            debug("Resolving " + configKey + " with targetDef=" + def);
+        }
+        ConfigPayload payload = model.getConfig(configKey,def,null); // TODO Remove last argument when possible
+        if (payload == null) {
             metricUpdater.incrementFailedRequests();
-            throw new ConfigurationRuntimeException("Unable to resolve config", e);
+            throw new ConfigurationRuntimeException("Unable to resolve config " + configKey);
         }
 
         ConfigResponse configResponse = responseFactory.createResponse(payload, def.getCNode(), appGeneration);
@@ -183,6 +177,7 @@ public class Application implements ModelResult {
         return resolveConfig(req, new UncompressedConfigResponseFactory());
     }
 
+    // TODO: Remove 'throws IOException'
     public <CONFIGTYPE extends ConfigInstance> CONFIGTYPE getConfig(Class<CONFIGTYPE> configClass, String configId) throws IOException {
         ConfigKey<CONFIGTYPE> key = new ConfigKey<>(configClass, configId);
         ConfigPayload payload = model.getConfig(key, (ConfigDefinition)null, null);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/LogServerLogGrabber.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/LogServerLogGrabber.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.config.server.application;
 
 import com.yahoo.cloud.config.ModelConfig;
 import com.yahoo.component.AbstractComponent;
-import com.google.inject.Inject;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.server.http.InternalServerException;
 import com.yahoo.yolean.Exceptions;
@@ -39,6 +38,7 @@ public class LogServerLogGrabber extends AbstractComponent {
 
     public String grabLog(Application application) {
 
+        // TODO: Use model to get values (see how it's done in ApplicationConvergenceChecker)
         final ModelConfig config;
         try {
             config = application.getConfig(ModelConfig.class, "");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ModelStub.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ModelStub.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server;
 
-import com.yahoo.config.codegen.InnerCNode;
 import com.yahoo.config.model.api.FileDistribution;
 import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.Model;
@@ -20,12 +19,12 @@ import java.util.Set;
 public class ModelStub implements Model {
 
     @Override
-    public ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef, ConfigPayload override) {
+    public ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef) {
         return null;
     }
 
     @Override
-    public ConfigPayload getConfig(ConfigKey<?> configKey, InnerCNode targetDef, ConfigPayload override) {
+    public ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef, ConfigPayload override) {
         return null;
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/MockModel.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/MockModel.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.application;
 
-import com.yahoo.config.codegen.InnerCNode;
 import com.yahoo.config.model.api.FileDistribution;
 import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.Model;
@@ -69,12 +68,12 @@ class MockModel implements Model {
     }
 
     @Override
-    public ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef, ConfigPayload override) {
+    public ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public ConfigPayload getConfig(ConfigKey<?> configKey, InnerCNode targetDef, ConfigPayload override) {
+    public ConfigPayload getConfig(ConfigKey<?> configKey, ConfigDefinition targetDef, ConfigPayload override) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
* Remove 'throws IOException now that no implementors use it and handle
  getConfig now returning null instead of exception when no config found
* Remove getConfig method with InnerCNode as 2nd argument
* Prepare for removing 3-argument getConfig()