### PR TITLE
Freva/set created on init

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Container.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Container.java
@@ -1,16 +1,17 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.dockerapi;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 /**
  * @author stiankri
  */
 public class Container {
-    private static final SimpleDateFormat DOCKER_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
+    private static final DateTimeFormatter DOCKER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
     public final String hostname;
     public final DockerImage image;
     public final ContainerName name;
@@ -43,8 +44,8 @@ public class Container {
         this(hostname, image, containerName, state, pid, "2017-02-13T13:45:12.133713371Z");
     }
 
-    public Instant getCreatedAsInstant() throws ParseException {
-        return DOCKER_DATE_FORMAT.parse(created).toInstant();
+    public Instant getCreatedAsInstant() {
+        return LocalDateTime.parse(created, DOCKER_DATE_FORMAT).toInstant(ZoneOffset.UTC);
     }
 
     @Override

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Container.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Container.java
@@ -1,29 +1,50 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.dockerapi;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Objects;
 
 /**
  * @author stiankri
  */
 public class Container {
+    private static final SimpleDateFormat DOCKER_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
     public final String hostname;
     public final DockerImage image;
     public final ContainerName name;
     public final State state;
     public final int pid;
+    public final String created;
 
     public Container(
             final String hostname,
             final DockerImage image,
             final ContainerName containerName,
             final State state,
-            final int pid) {
+            final int pid,
+            final String created) {
         this.hostname = hostname;
         this.image = image;
         this.name = containerName;
         this.state = state;
         this.pid = pid;
+        this.created = created;
+    }
+
+    // For testing only
+    public Container(
+            final String hostname,
+            final DockerImage image,
+            final ContainerName containerName,
+            final State state,
+            final int pid) {
+        this(hostname, image, containerName, state, pid, "2017-02-13T13:45:12.133713371Z");
+    }
+
+    public Instant getCreatedAsInstant() throws ParseException {
+        return DOCKER_DATE_FORMAT.parse(created).toInstant();
     }
 
     @Override
@@ -35,7 +56,8 @@ public class Container {
         return Objects.equals(hostname, other.hostname)
                 && Objects.equals(image, other.image)
                 && Objects.equals(name, other.name)
-                && Objects.equals(pid, other.pid);
+                && Objects.equals(pid, other.pid)
+                && Objects.equals(created, other.created);
     }
 
     @Override
@@ -51,6 +73,7 @@ public class Container {
                 + " name=" + name
                 + " state=" + state
                 + " pid=" + pid
+                + " created=" + created
                 + "}";
     }
 

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -364,7 +364,8 @@ public class DockerImpl implements Docker {
                                 new DockerImage(response.getConfig().getImage()),
                                 new ContainerName(decode(response.getName())),
                                 Container.State.valueOf(response.getState().getStatus().toUpperCase()),
-                                response.getState().getPid()
+                                response.getState().getPid(),
+                                response.getCreated()
                         ))
                 .map(Stream::of)
                 .orElse(Stream.empty());

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -266,11 +266,11 @@ public class DockerOperationsImpl implements DockerOperations {
         PrefixLogger logger = PrefixLogger.getNodeAgentLogger(DockerOperationsImpl.class, nodeSpec.containerName);
         final ContainerName containerName = existingContainer.name;
         if (existingContainer.state.isRunning()) {
-            logger.info("Stopping container " + containerName);
+            logger.info("Stopping container " + containerName.asString());
             docker.stopContainer(containerName);
         }
 
-        logger.info("Deleting container " + containerName);
+        logger.info("Deleting container " + containerName.asString());
         docker.deleteContainer(containerName);
         numberOfRunningContainersGauge.sample(getAllManagedContainers().size());
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -22,7 +22,6 @@ import com.yahoo.vespa.hosted.provision.Node;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -104,16 +103,7 @@ public class NodeAgentImpl implements NodeAgent {
         this.metricReceiver = metricReceiver;
         this.environment = environment;
 
-        if (container.isPresent()) {
-            Instant createdAt = Instant.now();
-            try {
-                createdAt = container.get().getCreatedAsInstant();
-            } catch (ParseException e) {
-                logger.warning("Failed to parse created time stamp: " + container.get().created, e);
-                numberOfUnhandledException++;
-            }
-            lastCpuMetric = new CpuUsageReporter(createdAt);
-        }
+        container.map(Container::getCreatedAsInstant).ifPresent(created -> lastCpuMetric = new CpuUsageReporter(created));
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -65,7 +65,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
 
         Function<String, NodeAgent> nodeAgentFactory =
                 (hostName) -> new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
-                        storageMaintainer, metricReceiver, environment);
+                        storageMaintainer, metricReceiver, environment, dockerOperations.getContainer(hostName));
         NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer,
                 NODE_AGENT_SCAN_INTERVAL_MILLIS, metricReceiver, aclMaintainer);
         nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepository, nodeAdmin, INITIAL_SCHEDULER_DELAY_MILLIS,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
@@ -2,6 +2,9 @@
 package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
 import com.yahoo.metrics.simple.MetricReceiver;
+import com.yahoo.vespa.hosted.dockerapi.Container;
+import com.yahoo.vespa.hosted.dockerapi.ContainerName;
+import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdmin;
@@ -31,9 +34,11 @@ public class ComponentsProviderWithMocks implements ComponentsProvider {
     private final Environment environment = new Environment.Builder().build();
     private final MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
     private final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, mr);
+    private final Container container = new Container("host123.name.yahoo.com", new DockerImage("image-123"),
+            new ContainerName("host123"), Container.State.RUNNING, 1);
     private final Function<String, NodeAgent> nodeAgentFactory =
             (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock, orchestratorMock,
-                    dockerOperations, Optional.empty(), mr, environment);
+                    dockerOperations, Optional.empty(), mr, environment, Optional.of(container));
     private NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, Optional.empty(), 100, mr, Optional.empty());
 
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -1,8 +1,10 @@
 package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
 import com.yahoo.metrics.simple.MetricReceiver;
+import com.yahoo.vespa.hosted.dockerapi.Container;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
+import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
@@ -57,8 +59,10 @@ public class DockerTester implements AutoCloseable {
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
         final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, mr);
+        Container container = new Container("host123.name.yahoo.com", new DockerImage("image-123"),
+                new ContainerName("host123"), Container.State.RUNNING, 1);
         Function<String, NodeAgent> nodeAgentFactory = (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock,
-                orchestratorMock, dockerOperations, Optional.of(storageMaintainer), mr, environment);
+                orchestratorMock, dockerOperations, Optional.of(storageMaintainer), mr, environment, Optional.of(container));
         nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, Optional.of(storageMaintainer), 100, mr, Optional.empty());
         updater = new NodeAdminStateUpdater(nodeRepositoryMock, nodeAdmin, 1, 1, orchestratorMock, "basehostname");
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -66,8 +66,10 @@ public class NodeAgentImplTest {
             .inetAddressResolver(new InetAddressResolver())
             .pathResolver(pathResolver).build();
 
+    private final Container container = new Container("host123.name.yahoo.com", new DockerImage("image-123"),
+            new ContainerName("host123"), Container.State.RUNNING, 1);
     private final NodeAgentImpl nodeAgent = new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
-            Optional.of(storageMaintainer), metricReceiver, environment);
+            Optional.of(storageMaintainer), metricReceiver, environment, Optional.of(container));
 
     @Test
     public void upToDateContainerIsUntouched() throws Exception {


### PR DESCRIPTION
* Set container `Instant created` when creating `NodeAgent` instance (In case we restart `node-admin` while already running some containers)
* Create new `CpuUsageReporter` when starting new container