### PR TITLE
make it possible to patch ip addresses in node repo

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -204,6 +204,12 @@ public final class Node {
         return new Node(openStackId, ipAddresses, hostname, parentHostname, flavor, status, state, allocation, history, type);
     }
 
+    /** Returns a copy of this node with the IP addresses set to the given value. */
+    public Node withIpAddresses(Set<String> ipAddresses) {
+        return new Node(openStackId, ipAddresses, hostname, parentHostname, flavor, status, state,
+                allocation, history, type);
+    }
+
     /** Returns a copy of this node with the parent hostname assigned to the given value. */
     public Node withParentHostname(String parentHostname) {
         return new Node(openStackId, ipAddresses, hostname, Optional.of(parentHostname), flavor, status, state,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -154,6 +154,9 @@ public class RestApiTest {
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
                                    Utf8.toBytes("{\"parentHostname\": \"parent.yahoo.com\"}"), Request.Method.PATCH),
                        "{\"message\":\"Updated host4.yahoo.com\"}");
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+                        Utf8.toBytes("{\"ipAddresses\": [\"127.0.0.1\",\"::1\"]}"), Request.Method.PATCH),
+                "{\"message\":\"Updated host4.yahoo.com\"}");
 
         assertFile(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "node4-after-changes.json");
     }


### PR DESCRIPTION
@bratseth 

We'll temporarily be adding IPv6 addresses to existing nodes to be able to migrate data to IPv6-only docker containers. These IP addresses won't be in DNS, but will work for outgoing connections. This should be good enough, as docker containers can use IPv4 for outgoing connections (through NAT on the Docker host).