### PR TITLE
Validate that searchable copies matches redundancy

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/GlobalDistributionValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/GlobalDistributionValidator.java
@@ -25,6 +25,7 @@ public class GlobalDistributionValidator {
                          Redundancy redundancy) {
 
         verifyGlobalDocumentsHaveRequiredRedundancy(globallyDistributedDocuments, redundancy);
+        verifySearchableCopiesIsSameAsRedundancy(globallyDistributedDocuments, redundancy);
         verifyReferredDocumentsArePresent(documentDefinitions);
         verifyReferredDocumentsAreGlobal(documentDefinitions, globallyDistributedDocuments);
     }
@@ -40,6 +41,20 @@ public class GlobalDistributionValidator {
                             asPrintableString(toDocumentNameStream(globallyDistributedDocuments)),
                             redundancy.effectiveFinalRedundancy(),
                             redundancy.totalNodes()));
+        }
+    }
+
+    private static void verifySearchableCopiesIsSameAsRedundancy(Set<NewDocumentType> globallyDistributedDocuments,
+                                                                 Redundancy redundancy) {
+        if (!globallyDistributedDocuments.isEmpty() &&
+                redundancy.effectiveReadyCopies() != redundancy.effectiveFinalRedundancy()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "The following document types have the number of searchable copies less than redundancy: %s. " +
+                                    "Searchable copies is %d, while redundancy is %d.",
+                            asPrintableString(toDocumentNameStream(globallyDistributedDocuments)),
+                            redundancy.effectiveReadyCopies(),
+                            redundancy.effectiveFinalRedundancy()));
         }
     }
 

--- a/config-model/src/test/cfg/application/validation/global_distribution_validation/hosts.xml
+++ b/config-model/src/test/cfg/application/validation/global_distribution_validation/hosts.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<hosts>
+    <host name="localhost">
+        <alias>node1</alias>
+    </host>
+</hosts>

--- a/config-model/src/test/cfg/application/validation/global_distribution_validation/searchdefinitions/parent.sd
+++ b/config-model/src/test/cfg/application/validation/global_distribution_validation/searchdefinitions/parent.sd
@@ -1,0 +1,5 @@
+# Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+search parent {
+  document parent {
+  }
+}

--- a/config-model/src/test/cfg/application/validation/global_distribution_validation/searchdefinitions/simple.sd
+++ b/config-model/src/test/cfg/application/validation/global_distribution_validation/searchdefinitions/simple.sd
@@ -1,0 +1,6 @@
+# Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+search simple {
+    document simple {
+        field my_reference type reference<parent> { indexing: summary }
+    }
+}

--- a/config-model/src/test/cfg/application/validation/global_distribution_validation/services.xml
+++ b/config-model/src/test/cfg/application/validation/global_distribution_validation/services.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services>
+    <admin version="2.0">
+        <adminserver hostalias="node1" />
+        <logserver hostalias="node1" />
+    </admin>
+    <content version="1.0">
+        <redundancy>1</redundancy>
+        <documents>
+            <document type='simple' mode="index"/>
+            <document type='parent' mode="index"/>
+        </documents>
+        <nodes>
+            <node hostalias='node1' distribution-key='0'/>
+        </nodes>
+    </content>
+</services>


### PR DESCRIPTION
Verify that the number of searchable copies is the same as effective
redundancy. Rewrite GlobalDistributionValidatorTest to not use Mockito.
Add end-to-end test to verify that the GlobalDistributionValidator is wired
into the overall model validation.

New PR with content of #1780 (the two commits squashed to one). Please merge :)