### PR TITLE
Use specific error-code in response when unable to acquire applicatio…

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ApplicationLockException.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ApplicationLockException.java
@@ -1,0 +1,16 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+/**
+ *
+ * Exception thrown when we are unable to get the Zookeeper application lock.
+ * @author hmusum
+ *
+ */
+public class ApplicationLockException extends RuntimeException {
+
+    public ApplicationLockException(Exception e) {
+        super(e);
+    }
+
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpErrorResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpErrorResponse.java
@@ -18,7 +18,7 @@ import static com.yahoo.jdisc.Response.Status.*;
  * @since 5.1
  */
 public class HttpErrorResponse extends HttpResponse {
-    Logger log = Logger.getLogger(HttpErrorResponse.class.getName());
+    private static final Logger log = Logger.getLogger(HttpErrorResponse.class.getName());
     private final Slime slime = new Slime();
 
     public HttpErrorResponse(int code, final String errorType, final String msg) {
@@ -32,14 +32,15 @@ public class HttpErrorResponse extends HttpResponse {
     }
 
     public enum errorCodes {
-        NOT_FOUND,
+        APPLICATION_LOCK_FAILURE,
         BAD_REQUEST,
-        METHOD_NOT_ALLOWED,
         INTERNAL_SERVER_ERROR,
         INVALID_APPLICATION_PACKAGE,
-        UNKNOWN_VESPA_VERSION,
+        METHOD_NOT_ALLOWED,
+        NOT_FOUND,
         OUT_OF_CAPACITY,
-        REQUEST_TIMEOUT
+        REQUEST_TIMEOUT,
+        UNKNOWN_VESPA_VERSION
     }
 
     public static HttpErrorResponse notFoundError(String msg) {
@@ -72,6 +73,10 @@ public class HttpErrorResponse extends HttpResponse {
 
     public static HttpResponse requestTimeout(String message) {
         return new HttpErrorResponse(REQUEST_TIMEOUT, errorCodes.REQUEST_TIMEOUT.name(), message);
+    }
+
+    public static HttpErrorResponse applicationLockFailure(String msg) {
+        return new HttpErrorResponse(INTERNAL_SERVER_ERROR, errorCodes.APPLICATION_LOCK_FAILURE.name(), msg);
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -1,6 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http;
 
+import com.yahoo.config.provision.ApplicationLockException;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.LoggingRequestHandler;
@@ -46,9 +47,7 @@ public class HttpHandler extends LoggingRequestHandler {
             }
         } catch (NotFoundException | com.yahoo.vespa.config.server.NotFoundException e) {
             return HttpErrorResponse.notFoundError(getMessage(e, request));
-        } catch (BadRequestException e) {
-            return HttpErrorResponse.badRequest(getMessage(e, request));
-        } catch (IllegalArgumentException | IllegalStateException e) {
+        } catch (BadRequestException | IllegalArgumentException | IllegalStateException e) {
             return HttpErrorResponse.badRequest(getMessage(e, request));
         } catch (InvalidApplicationException e) {
             return HttpErrorResponse.invalidApplicationPackage(getMessage(e, request));
@@ -60,6 +59,8 @@ public class HttpHandler extends LoggingRequestHandler {
             return HttpErrorResponse.unknownVespaVersion(getMessage(e, request));
         } catch (RequestTimeoutException e) {
             return HttpErrorResponse.requestTimeout(getMessage(e, request));
+        } catch (ApplicationLockException e) {
+            return HttpErrorResponse.applicationLockFailure(getMessage(e, request));
         } catch (Exception e) {
             e.printStackTrace();
             return HttpErrorResponse.internalServerError(getMessage(e, request));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -313,7 +313,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
 
     @Test
     public void test_application_lock_failure() throws InterruptedException, IOException {
-        String message = "Exception acquiring lock '/provision/v1/locks/foo/bar/default': Timed out after waiting PT1M";
+        String message = "Timed out after waiting PT1M to acquire lock '/provision/v1/locks/foo/bar/default'";
         SessionThrowingException session = new SessionThrowingException(new ApplicationLockException(new UncheckedTimeoutException(message)));
         localRepo.addSession(session);
         HttpResponse response = createHandler(addTestTenant())

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabase.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabase.java
@@ -62,7 +62,6 @@ public class CuratorDatabase {
         CuratorMutex lock = locks.computeIfAbsent(path, (pathArg) -> new CuratorMutex(pathArg.getAbsolute(), curator.framework()));
         lock.acquire(timeout);
         return lock;
-
     }
 
     // --------- Write operations ------------------------------------------------------------------------------


### PR DESCRIPTION
…n lock

* Throw ApplicationLockException if acquiring lock fails (due to timeout)
  and use response with with new error-code for that case
VESPA-6501

I chose to create a new exception so that other (future) code cannot create a response which does not make sense.