### PR TITLE
Revert "Temporarily downgrade Jetty to evaluate performance degradation"

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -185,7 +185,7 @@ public class ConnectorFactory {
             factory.setTrustStorePassword(password.orElseThrow(passwordRequiredForJKSKeyStore("trust")));
         }
 
-        factory.setSslKeyManagerFactoryAlgorithm(sslConfig.sslKeyManagerFactoryAlgorithm());
+        factory.setKeyManagerFactoryAlgorithm(sslConfig.sslKeyManagerFactoryAlgorithm());
         factory.setProtocol(sslConfig.protocol());
         return new SslConnectionFactory(factory, HttpVersion.HTTP_1_1.asString());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.3.12.v20160915</jetty.version>
+        <jetty.version>9.3.16.v20170120</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>


### PR DESCRIPTION
Reverts yahoo/vespa#1805
@bjorncs PR, Back to 9.3.16.
I guess we should try to get a run with 9.4.2 too. before tomorrow meeting with webtide.