### PR TITLE
remove caching of mirror lookup

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/LoadBalancerPolicy.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/LoadBalancerPolicy.java
@@ -36,8 +36,6 @@ public class LoadBalancerPolicy extends ExternalSlobrokPolicy {
     String cluster = null;
     String session = null;
     private String pattern = null;
-    private AtomicLong count = new AtomicLong(0);
-    volatile Mirror.Entry [] lastLookup;
 
     LoadBalancer.Metrics metrics;
     LoadBalancer loadBalancer;
@@ -89,10 +87,7 @@ public class LoadBalancerPolicy extends ExternalSlobrokPolicy {
        @return Returns a hop representing the TCP address of the target, or null if none could be found.
     */
     LoadBalancer.Node getRecipient(RoutingContext context) {
-        long c = count.getAndIncrement();
-        if ((c%1024 == 0) || (lastLookup == null) || (lastLookup.length == 0)) {
-            lastLookup = lookup(context, pattern);
-        }
+        Mirror.Entry [] lastLookup = lookup(context, pattern);
         return loadBalancer.getRecipient(lastLookup);
     }
 


### PR DESCRIPTION
* the lastLookup value could be indefinitely old and would cause the
  LoadBalancer policy to send to machines that had gone down (or even been
  removed from the cluster if the message rate was low), since it would
  only be updated every 1024 messages.

@dybis please review and merge
@bjormel FYI