### PR TITLE
reuse the same termfieldmatchdata instead of pointing into the wild.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
@@ -10,12 +10,8 @@ using fef::TermFieldMatchData;
 
 AttributeIteratorBase::AttributeIteratorBase(TermFieldMatchData * matchData) :
     _matchData(matchData),
-    _matchPosition(NULL)
-{
-    fef::TermFieldMatchDataPosition pos;
-    _matchData->appendPosition(pos);
-    _matchPosition = _matchData->getPositions();
-}
+    _matchPosition(_matchData->populate_fixed())
+{ }
 
 void
 AttributeIteratorBase::visitMembers(vespalib::ObjectVisitor &visitor) const
@@ -54,9 +50,7 @@ FlagAttributeIterator::doUnpack(uint32_t docId)
     _matchData->resetOnlyDocId(docId);
 }
 
-AttributePostingListIterator::
-    AttributePostingListIterator(bool hasWeight,
-                             TermFieldMatchData *matchData)
+AttributePostingListIterator:: AttributePostingListIterator(bool hasWeight, TermFieldMatchData *matchData)
     : AttributeIteratorBase(matchData),
       _hasWeight(hasWeight)
       // _hasWeight(_searchContext.attribute().hasWeightedSetType())

--- a/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.cpp
+++ b/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.cpp
@@ -84,21 +84,21 @@ constexpr size_t MAX_ELEMS =  std::numeric_limits<uint16_t>::max();
 void
 TermFieldMatchData::resizePositionVector(size_t sz)
 {
-    size_t newSize(std::min(MAX_ELEMS, std::max(1ul, sz*2)));
+    size_t newSize(std::min(MAX_ELEMS, std::max(1ul, sz)));
     TermFieldMatchDataPosition * n = new TermFieldMatchDataPosition[newSize];
-    if (sz > 0) {
+    if (_sz > 0) {
         if (isMultiPos()) {
             for (size_t i(0); i < _data._positions._allocated; i++) {
                 n[i] = _data._positions._positions[i];
             }
             delete [] _data._positions._positions;
         } else {
-            assert(sz == 1);
-            _fieldId = _fieldId | 0x4000;
+            assert(_sz == 1);
             n[0] = *getFixed();
             _data._positions._maxElementLength = getFixed()->getElementLen();
         }
     }
+    _fieldId = _fieldId | 0x4000;
     _data._positions._allocated = newSize;
     _data._positions._positions = n;
 }
@@ -107,7 +107,7 @@ void
 TermFieldMatchData::appendPositionToAllocatedVector(const TermFieldMatchDataPosition &pos)
 {
     if (__builtin_expect(_sz >= _data._positions._allocated, false)) {
-        resizePositionVector(_sz);
+        resizePositionVector(_sz*2);
     }
     if (__builtin_expect(pos.getElementLen() > _data._positions._maxElementLength, false)) {
         _data._positions._maxElementLength = pos.getElementLen();

--- a/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.h
+++ b/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.h
@@ -70,6 +70,11 @@ public:
     PositionsIterator end() const { return allocated() ? getMultiple() + _sz : empty() ? getFixed() : getFixed()+1; }
     size_t size() const { return _sz; }
     size_t capacity() const { return allocated() ? _data._positions._allocated : 1; }
+    void reservePositions(size_t sz) {
+        if (sz > capacity()) {
+            resizePositionVector(sz);
+        }
+    }
 
     /**
      * Create empty object. To complete object setup, field id must be
@@ -89,6 +94,15 @@ public:
      * @param rhs The object to swap with.
      **/
     void swap(TermFieldMatchData &rhs);
+
+    MutablePositionsIterator populate_fixed() {
+        assert(!allocated());
+        if (_sz == 0) {
+            new (_data._position) TermFieldMatchDataPosition();
+            _sz = 1;
+        }
+        return getFixed();
+    }
 
     /**
      * Set which field this object has match information for.

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
@@ -73,6 +73,7 @@ public:
         }
         _data_begin = &_data_space[0];
         _data_end = _data_begin + _data_space.size();
+        _tmd.reservePositions(_children.size());
     }
 
     void doSeek(uint32_t docId) override {


### PR DESCRIPTION
@havardpe PR approximately as discussed.