### PR TITLE
fix precision loss

### DIFF
--- a/vsm/src/vespa/vsm/vsm/slimefieldwriter.cpp
+++ b/vsm/src/vespa/vsm/vsm/slimefieldwriter.cpp
@@ -112,8 +112,10 @@ SlimeFieldWriter::traverseRecursive(const document::FieldValue & fv,
             case document::DataType::T_LONG:
                 inserter.insertLong(fv.getAsLong());
                 break;
-            case document::DataType::T_FLOAT:
             case document::DataType::T_DOUBLE:
+                inserter.insertDouble(fv.getAsDouble());
+                break;
+            case document::DataType::T_FLOAT:
                 inserter.insertDouble(fv.getAsFloat());
                 break;
             default:


### PR DESCRIPTION
* code inherited from jsondocsumwriter would use "float"
  for handling doubles, losing some precision. Handle
  doubles separately.

@geirst please review and merge
@baldersheim FYI