### PR TITLE
Make ComponentGuard::get() return a pointer, not a reference

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -618,11 +618,11 @@ TEST_F("require that attributes can be initialized and loaded in sequence", Base
         SequentialAttributeManager newMgr(amf._m, AttrMgrSpec(newSpec, 10, createSerialNum + 5));
 
         AttributeGuard::UP a1 = newMgr.mgr.getAttribute("a1");
-        TEST_DO(validateAttribute(a1->get()));
+        TEST_DO(validateAttribute(*a1->get()));
         AttributeGuard::UP a2 = newMgr.mgr.getAttribute("a2");
-        TEST_DO(validateAttribute(a2->get()));
+        TEST_DO(validateAttribute(*a2->get()));
         AttributeGuard::UP a3 = newMgr.mgr.getAttribute("a3");
-        TEST_DO(validateAttribute(a3->get()));
+        TEST_DO(validateAttribute(*a3->get()));
     }
 }
 
@@ -653,11 +653,11 @@ TEST_F("require that attributes can be initialized and loaded in parallel", Base
         ParallelAttributeManager newMgr(createSerialNum + 5, amf._msp, attrCfg, 10);
 
         AttributeGuard::UP a1 = newMgr.mgr->get()->getAttribute("a1");
-        TEST_DO(validateAttribute(a1->get()));
+        TEST_DO(validateAttribute(*a1->get()));
         AttributeGuard::UP a2 = newMgr.mgr->get()->getAttribute("a2");
-        TEST_DO(validateAttribute(a2->get()));
+        TEST_DO(validateAttribute(*a2->get()));
         AttributeGuard::UP a3 = newMgr.mgr->get()->getAttribute("a3");
-        TEST_DO(validateAttribute(a3->get()));
+        TEST_DO(validateAttribute(*a3->get()));
     }
 }
 

--- a/searchcore/src/tests/proton/attribute/attribute_populator/attribute_populator_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_populator/attribute_populator_test.cpp
@@ -82,17 +82,17 @@ struct Fixture
 TEST_F("require that reprocess with document populates attribute", Fixture)
 {
     AttributeGuard::UP attr = f.getAttr();
-    EXPECT_EQUAL(1u, attr->get().getNumDocs());
+    EXPECT_EQUAL(1u, attr->get()->getNumDocs());
 
     f._pop.handleExisting(5, *f._ctx.create(0, 33));
-    EXPECT_EQUAL(6u, attr->get().getNumDocs());
-    EXPECT_EQUAL(33, attr->get().getInt(5));
-    EXPECT_EQUAL(1u, attr->get().getStatus().getLastSyncToken());
+    EXPECT_EQUAL(6u, attr->get()->getNumDocs());
+    EXPECT_EQUAL(33, attr->get()->getInt(5));
+    EXPECT_EQUAL(1u, attr->get()->getStatus().getLastSyncToken());
 
     f._pop.handleExisting(6, *f._ctx.create(1, 44));
-    EXPECT_EQUAL(7u, attr->get().getNumDocs());
-    EXPECT_EQUAL(44, attr->get().getInt(6));
-    EXPECT_EQUAL(2u, attr->get().getStatus().getLastSyncToken());
+    EXPECT_EQUAL(7u, attr->get()->getNumDocs());
+    EXPECT_EQUAL(44, attr->get()->getInt(6));
+    EXPECT_EQUAL(2u, attr->get()->getStatus().getLastSyncToken());
 }
 
 TEST_MAIN()

--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -551,7 +551,7 @@ TEST_F("require that filter attribute manager can filter attributes", FilterFixt
     std::vector<AttributeGuard> attrs;
     f._filterMgr.getAttributeList(attrs);
     EXPECT_EQUAL(1u, attrs.size());
-    EXPECT_EQUAL("a2", attrs[0].get().getName());
+    EXPECT_EQUAL("a2", attrs[0]->getName());
 }
 
 TEST_F("require that filter attribute manager can return flushed serial number", FilterFixture)

--- a/searchcore/src/tests/proton/common/cachedselect_test.cpp
+++ b/searchcore/src/tests/proton/common/cachedselect_test.cpp
@@ -272,7 +272,7 @@ MyDB::addDoc(uint32_t lid,
     _docIdToLid[docId] = lid;
     _lidToDocSP[lid] = Document::SP(doc.release());
     AttributeGuard::UP guard = _amgr.getAttribute("aa");
-    AttributeVector &av = guard->get();
+    AttributeVector &av = *guard->get();
     if (lid >= av.getNumDocs()) {
         AttributeVector::DocId checkDocId(0u);
         ASSERT_TRUE(av.addDoc(checkDocId));

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -453,7 +453,7 @@ void
 assertAttributes1(const AttributeGuardList &attributes)
 {
 	EXPECT_EQUAL(1u, attributes.size());
-	EXPECT_EQUAL("attr1", attributes[0].get().getName());
+	EXPECT_EQUAL("attr1", attributes[0]->getName());
 }
 
 void
@@ -467,8 +467,8 @@ void
 assertAttributes2(const AttributeGuardList &attributes)
 {
 	EXPECT_EQUAL(2u, attributes.size());
-	EXPECT_EQUAL("attr1", attributes[0].get().getName());
-	EXPECT_EQUAL("attr2", attributes[1].get().getName());
+	EXPECT_EQUAL("attr1", attributes[0]->getName());
+	EXPECT_EQUAL("attr2", attributes[1]->getName());
 }
 
 void
@@ -716,7 +716,7 @@ TEST_F("require that only fast-access attributes are instantiated", FastAccessOn
 	std::vector<AttributeGuard> attrs;
 	f.getAttributeManager()->getAttributeList(attrs);
 	EXPECT_EQUAL(1u, attrs.size());
-	EXPECT_EQUAL("attr1", attrs[0].get().getName());
+	EXPECT_EQUAL("attr1", attrs[0]->getName());
 }
 
 template <typename FixtureType>
@@ -803,12 +803,12 @@ assertAttribute(const AttributeGuard &attr,
                 SerialNum createSerialNum,
                 SerialNum lastSerialNum)
 {
-	EXPECT_EQUAL(name, attr.get().getName());
-	EXPECT_EQUAL(numDocs, attr.get().getNumDocs());
-	EXPECT_EQUAL(doc1Value, attr.get().getInt(1));
-	EXPECT_EQUAL(doc2Value, attr.get().getInt(2));
-	EXPECT_EQUAL(createSerialNum, attr.get().getCreateSerialNum());
-	EXPECT_EQUAL(lastSerialNum, attr.get().getStatus().getLastSyncToken());
+	EXPECT_EQUAL(name, attr->getName());
+	EXPECT_EQUAL(numDocs, attr->getNumDocs());
+	EXPECT_EQUAL(doc1Value, attr->getInt(1));
+	EXPECT_EQUAL(doc2Value, attr->getInt(2));
+	EXPECT_EQUAL(createSerialNum, attr->getCreateSerialNum());
+	EXPECT_EQUAL(lastSerialNum, attr->getStatus().getLastSyncToken());
 }
 
 void

--- a/searchcore/src/tests/proton/reference/document_db_reference_resolver/document_db_reference_resolver_test.cpp
+++ b/searchcore/src/tests/proton/reference/document_db_reference_resolver/document_db_reference_resolver_test.cpp
@@ -114,7 +114,7 @@ struct MyAttributeManager : public MockAttributeManager {
     }
     const ReferenceAttribute *getReferenceAttribute(const vespalib::string &name) const {
         AttributeGuard::UP guard = getAttribute(name);
-        const ReferenceAttribute *result = dynamic_cast<const ReferenceAttribute *>(&guard->get());
+        const ReferenceAttribute *result = dynamic_cast<const ReferenceAttribute *>(guard->get());
         ASSERT_TRUE(result != nullptr);
         return result;
     }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_explorer.cpp
@@ -32,7 +32,7 @@ AttributeManagerExplorer::get_children_names() const
     _mgr->getAttributeListAll(attributes);
     std::vector<vespalib::string> names;
     for (const auto &attr : attributes) {
-        names.push_back(attr.get().getName());
+        names.push_back(attr->getName());
     }
     return names;
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_populator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_populator.cpp
@@ -25,7 +25,7 @@ AttributePopulator::getNames() const
     _writer.getAttributeManager()->getAttributeList(attrs);
     std::vector<vespalib::string> names;
     for (const search::AttributeGuard &attr : attrs) {
-        names.push_back(_subDbName + ".attribute." + attr.get().getName());
+        names.push_back(_subDbName + ".attribute." + attr->getName());
     }
     return names;
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastorecontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastorecontext.cpp
@@ -9,7 +9,7 @@ namespace proton {
 
 DocumentMetaStoreContext::ReadGuard::ReadGuard(const search::AttributeVector::SP &metaStoreAttr) :
     _guard(metaStoreAttr),
-    _store(static_cast<const DocumentMetaStore &>(_guard.get())),
+    _store(static_cast<const DocumentMetaStore &>(*_guard)),
     _activeLidsGuard(_store.getActiveLidsGuard())
 {
 }

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.cpp
@@ -49,7 +49,7 @@ getReferenceAttribute(const vespalib::string &name, const IAttributeManager &att
 {
     AttributeGuard::UP guard = attrMgr.getAttribute(name);
     assert(guard.get());
-    assert(guard->get().getBasicType() == BasicType::REFERENCE);
+    assert(guard->get()->getBasicType() == BasicType::REFERENCE);
     return std::dynamic_pointer_cast<ReferenceAttribute>(guard->getSP());
 }
 
@@ -61,7 +61,7 @@ getReferenceAttributes(const IAttributeManager &attrMgr)
     std::vector<AttributeGuard> attributeList;
     attrMgr.getAttributeList(attributeList);
     for (auto &guard : attributeList) {
-        AttributeVector &attr = guard.get();
+        AttributeVector &attr = *guard;
         if (attr.getBasicType() == BasicType::REFERENCE) {
             auto refAttr = std::dynamic_pointer_cast<ReferenceAttribute>(guard.getSP());
             assert(refAttr);

--- a/searchlib/src/vespa/searchlib/attribute/attributecontext.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributecontext.cpp
@@ -14,7 +14,7 @@ AttributeContext::getAttribute(AttributeMap & map, const string & name, bool sta
 {
     AttributeMap::const_iterator itr = map.find(name);
     if (itr != map.end()) {
-        return itr->second->operator->();
+        return itr->second->get();
     } else {
         AttributeGuard::UP ret;
         if (stableEnum) {
@@ -25,7 +25,7 @@ AttributeContext::getAttribute(AttributeMap & map, const string & name, bool sta
         if (ret) {
             const AttributeGuard & guard = *ret;
             map[name] = std::move(ret);
-            return guard.operator->();
+            return guard.get();
         }
         return nullptr;
     }

--- a/searchlib/src/vespa/searchlib/attribute/attributeguard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeguard.cpp
@@ -32,7 +32,7 @@ AttributeEnumGuard::AttributeEnumGuard(const AttributeGuard & attr) :
 
 void AttributeEnumGuard::takeLock() {
     if (valid()) {
-        std::shared_lock<std::shared_timed_mutex> take(get().getEnumLock(),
+        std::shared_lock<std::shared_timed_mutex> take(get()->getEnumLock(),
                                                        std::defer_lock);
         _lock = std::move(take);
         _lock.lock();

--- a/searchlib/src/vespa/searchlib/attribute/componentguard.h
+++ b/searchlib/src/vespa/searchlib/attribute/componentguard.h
@@ -28,12 +28,12 @@ public:
      * Creates a guard for the shared pointer of the given component.
      **/
     ComponentGuard(const Component & component);
-    const T & get()          const { return *_component; }
+    const T * get()          const { return _component.get(); }
 
     const Component & getSP(void) const { return _component; }
     const T * operator -> () const { return _component.get(); }
     const T & operator * ()  const { return *_component.get(); }
-    T & get()                      { return *_component; }
+    T * get()                      { return _component.get(); }
     T * operator -> ()             { return _component.get(); }
     T & operator * ()              { return *_component.get(); }
     bool valid()             const { return _component.get() != NULL; }

--- a/searchlib/src/vespa/searchlib/common/documentlocations.cpp
+++ b/searchlib/src/vespa/searchlib/common/documentlocations.cpp
@@ -18,7 +18,7 @@ DocumentLocations::~DocumentLocations() { }
 void
 DocumentLocations::setVecGuard(std::unique_ptr<search::AttributeGuard> guard) {
     _vec_guard = std::move(guard);
-    setVec(_vec_guard.get()->get());
+    setVec(*_vec_guard.get()->get());
 }
 
 }  // namespace common


### PR DESCRIPTION
@geirst Please review. A lot of remaining `get()` calls could be removed with an extra de-ref, but `*`-chains often look uglier than the alternative.

With this change, `ComponentGuard` behaves like other smart handles.

Now shiny and rebased.