### PR TITLE
Add attribute guards for imported attribute vectors

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "imported_attribute_vector.h"
+#include "attributeguard.h"
 #include <vespa/vespalib/util/exceptions.h>
 
 namespace search {
@@ -119,6 +120,48 @@ long ImportedAttributeVector::onSerializeForDescendingSort(DocId doc,
                                                            long available,
                                                            const common::BlobConverter *bc) const {
     return _target_attribute->serializeForDescendingSort(doc, serTo, available, bc);
+}
+
+namespace {
+
+class ImportedAttributeGuard : public AttributeGuard {
+public:
+    ImportedAttributeGuard(const AttributeVectorSP& target_attr,
+                           const AttributeVectorSP& reference_attr)
+        : AttributeGuard(),
+          _target_attr_guard(target_attr),
+          _reference_attr_guard(reference_attr)
+    {
+    }
+    
+private:
+    AttributeGuard _target_attr_guard;
+    AttributeGuard _reference_attr_guard;
+};
+
+class ImportedAttributeEnumGuard : public AttributeEnumGuard {
+public:
+    ImportedAttributeEnumGuard(const AttributeVectorSP& target_attr,
+                               const AttributeVectorSP& reference_attr)
+        : AttributeEnumGuard(AttributeVectorSP()),
+          _target_attr_enum_guard(target_attr),
+          _reference_attr_guard(reference_attr)
+    {
+    }
+    
+private:
+    AttributeEnumGuard _target_attr_enum_guard;
+    AttributeGuard _reference_attr_guard;
+};
+
+}
+
+std::unique_ptr<AttributeGuard> ImportedAttributeVector::acquireGuard() const {
+    return std::make_unique<ImportedAttributeGuard>(_target_attribute, _reference_attribute);
+}
+
+std::unique_ptr<AttributeEnumGuard> ImportedAttributeVector::acquireEnumGuard() const {
+    return std::make_unique<ImportedAttributeEnumGuard>(_target_attribute, _reference_attribute);
 }
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
@@ -8,6 +8,10 @@
 #include <memory>
 
 namespace search {
+
+class AttributeGuard;
+class AttributeEnumGuard;
+
 namespace attribute {
 
 /**
@@ -56,6 +60,21 @@ public:
     const std::shared_ptr<AttributeVector>& getTargetAttribute() const noexcept {
         return _target_attribute;
     }
+
+    /**
+     * Acquire an opaque composite guard that covers both the target attribute and
+     * the reference attribute. Note that these are not directly accessible via the
+     * returned guard object itself; it does not expose a valid pointer (i.e. get() will
+     * return nullptr).
+     */
+    std::unique_ptr<AttributeGuard> acquireGuard() const;
+    /**
+     * Acquires a composite guard similar to acquireGuard(), but the target attribute is
+     * covered by an AttributeEnumGuard instead of a regular AttributeGuard.
+     *
+     * The reference attribute is _not_ covered by an enum guard.
+     */
+    std::unique_ptr<AttributeEnumGuard> acquireEnumGuard() const;
 
 private:
     long onSerializeForAscendingSort(DocId doc, void * serTo, long available,


### PR DESCRIPTION
@geirst Please review. Did not find a neat way to test enum locks explicitly, as I didn't feel entirely comfortable adding yet another friend class to `AttributeVector` to poke at its private parts (which `getEnumLock()` is part of).