### PR TITLE
revert qrserver part of docsum protocol changes

### DIFF
--- a/container-search/src/main/java/com/yahoo/fs4/GetDocSumsPacket.java
+++ b/container-search/src/main/java/com/yahoo/fs4/GetDocSumsPacket.java
@@ -69,9 +69,7 @@ public class GetDocSumsPacket extends Packet {
      * definition of enum getdocsums_flags
      */
     public static final int GDFLAG_IGNORE_ROW  = 0x00000001;
-
-    // TODO: now always assumed true; remove in Vespa 7
-    public static final int GDFLAG_ALLOW_SLIME_NOTUSED = 0x00000002;
+    public static final int GDFLAG_ALLOW_SLIME = 0x00000002;
 
     public void encodeBody(ByteBuffer buffer) {
         setFieldsFromHits();
@@ -81,6 +79,9 @@ public class GetDocSumsPacket extends Packet {
         if (useQueryCache) { // TODO: Move this decision (and the key) to ranking
             query.getRanking().getProperties().put(sessionIdKey, query.getSessionId(false).asUtf8String().toString());
         }
+
+        // always allow slime docsums
+        flags |= GDFLAG_ALLOW_SLIME;
 
         // set the default features
         long features = GDF_MLD;

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -181,6 +181,7 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         }
         params.setLibraryParameter("summarycount", String.valueOf(query.getOffset() + query.getHits()));
         params.setLibraryParameter("rankprofile", query.getRanking().getProfile());
+        params.setLibraryParameter("allowslimedocsums", "true");
         params.setLibraryParameter("queryflags", String.valueOf(getQueryFlags(query)));
 
         ByteBuffer buf = ByteBuffer.allocate(1024);

--- a/container-search/src/test/java/com/yahoo/fs4/test/GetDocSumsPacketTestCase.java
+++ b/container-search/src/test/java/com/yahoo/fs4/test/GetDocSumsPacketTestCase.java
@@ -37,13 +37,13 @@ public class GetDocSumsPacketTestCase {
         hit.setIgnoreRowBits(true);
         assertPacket(true, hit, new byte[] { 0, 0, 0, 57, 0, 0, 0, -37, 0, 0, 40, 21, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
                 IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x01, 0, 0, 0, 7,
-                100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1, 0, 0, 0, 6, 4, 0, 3, 102, 111, 111, 0, 0, 0, 1 });
+                100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1, 0, 0, 0, 6, 4, 0, 3, 102, 111, 111, 0, 0, 0, 3 });
 
         hit = new FastHit();
         hit.setIgnoreRowBits(false);
-        assertPacket(true, hit, new byte[] {0, 0, 0, 53, 0, 0, 0, -37, 0, 0, 8, 21, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
+        assertPacket(true, hit, new byte[] {0, 0, 0, 57, 0, 0, 0, -37, 0, 0, 40, 21, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
                 IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x01, 0, 0, 0, 7,
-                100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1, 0, 0, 0, 6, 4, 0, 3, 102, 111, 111});
+                100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1, 0, 0, 0, 6, 4, 0, 3, 102, 111, 111, 0, 0, 0, 2});
     }
 
     @Test
@@ -52,13 +52,13 @@ public class GetDocSumsPacketTestCase {
         hit.setIgnoreRowBits(true);
         assertPacket(false, hit, new byte[] { 0, 0, 0, 43, 0, 0, 0, -37, 0, 0, 40, 17, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
                      IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x01, 0, 0, 0, 7,
-                     100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1
+                     100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 3
         });
 
         hit = new FastHit();
         hit.setIgnoreRowBits(false);
-        assertPacket(false, hit, new byte[] { 0, 0, 0, 39, 0, 0, 0, -37, 0, 0, 8, 17, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
-                IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x01, 0, 0, 0, 7, 100, 101, 102, 97, 117, 108, 116
+        assertPacket(false, hit, new byte[] { 0, 0, 0, 43, 0, 0, 0, -37, 0, 0, 40, 17, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
+                IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x01, 0, 0, 0, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 2
         });
     }
 
@@ -68,7 +68,6 @@ public class GetDocSumsPacketTestCase {
         result.getQuery().getSessionId(true);  // create session id.
         result.getQuery().getRanking().setQueryCache(true);
         FastHit hit = new FastHit();
-        hit.setIgnoreRowBits(true);
         result.hits().add(hit);
         assertPacket(false, result, new byte[] { 0, 0, 0, -123, 0, 0, 0, -37, 0, 0, 56, 17, 0, 0, 0, 0,
                 // query timeout
@@ -85,7 +84,7 @@ public class GetDocSumsPacketTestCase {
                 // caches: features => true
                 0, 0, 0, 6, 'c', 'a', 'c', 'h', 'e', 's', 0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e',
                 // flags
-                0, 0, 0, 1
+                0, 0, 0, 2
         });
     }
 

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
@@ -262,7 +262,7 @@ public class FastSearcherTestCase {
         buf.get(actual);
 
         byte IGNORE = 69;
-        byte[] expected = new byte[] { 0, 0, 0, -89, 0, 0, 0, -37, 0, 0, 16, 17, 0, 0, 0, 0,
+        byte[] expected = new byte[] { 0, 0, 0, -85, 0, 0, 0, -37, 0, 0, 48, 17, 0, 0, 0, 0,
                 // query timeout
                 IGNORE, IGNORE, IGNORE, IGNORE,
                 // "default" - rank profile
@@ -275,8 +275,9 @@ public class FastSearcherTestCase {
                 // match: documentdb.searchdoctype => test
                 0, 0, 0, 5, 'm', 'a', 't', 'c', 'h', 0, 0, 0, 1, 0, 0, 0, 24, 'd', 'o', 'c', 'u', 'm', 'e', 'n', 't', 'd', 'b', '.', 's', 'e', 'a', 'r', 'c', 'h', 'd', 'o', 'c', 't', 'y', 'p', 'e', 0, 0, 0, 4, 't', 'e', 's', 't',
                 // sessionId => qrserver.0.XXXXXXXXXXXXX.0
-                0, 0, 0, 6, 'c', 'a', 'c', 'h', 'e', 's', 0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e'
-                // no flags
+                0, 0, 0, 6, 'c', 'a', 'c', 'h', 'e', 's', 0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e',
+                // flags
+                0, 0, 0, 2
         };
         assertEquals(expected.length, actual.length);
         for (int i = 0; i < expected.length; ++i) {


### PR DESCRIPTION
* when the qrserver was upgraded first, it would expect
  the backend to send schemaless docsums without asking
  for it, leading to lots of warnings and performance problems.
  We'll need to do this protocol change in two steps.

@geirst please review and merge
@baldersheim FYI
@kkraune FYI