### PR TITLE
Call tear_down_references() on sub dbs from document db close method

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.cpp
@@ -172,6 +172,10 @@ DocumentDBReferenceResolver::DocumentDBReferenceResolver(const IDocumentDBRefere
 {
 }
 
+DocumentDBReferenceResolver::~DocumentDBReferenceResolver()
+{
+}
+
 ImportedAttributesRepo::UP
 DocumentDBReferenceResolver::resolve(const IAttributeManager &newAttrMgr, const IAttributeManager &oldAttrMgr)
 {

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.h
@@ -47,6 +47,7 @@ public:
                                 const document::DocumentType &prevThisDocType,
                                 MonitoredRefCount &refCount,
                                 search::ISequencedTaskExecutor &attributeFieldWriter);
+    ~DocumentDBReferenceResolver();
 
     virtual std::unique_ptr<ImportedAttributesRepo> resolve(const search::IAttributeManager &newAttrMgr, const search::IAttributeManager &oldAttrMgr) override;
     virtual void teardown(const search::IAttributeManager &oldAttrMgr) override;

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -561,7 +561,7 @@ DocumentDB::performDropFeedView2(IFeedView::SP feedView)
 
 
 void
-DocumentDB::tear_down_references()
+DocumentDB::tearDownReferences()
 {
     // Called by master executor thread
     auto registry = _owner.getDocumentDBReferentRegistry();
@@ -575,7 +575,7 @@ DocumentDB::tear_down_references()
                                          *docType,
                                          _refCount,
                                          _writeService.attributeFieldWriter());
-    _subDBs.tear_down_references(resolver);
+    _subDBs.tearDownReferences(resolver);
 }
 
 void
@@ -586,7 +586,7 @@ DocumentDB::close()
         _state.enterShutdownState();
     }
     _writeService.master().sync(); // Complete all tasks that didn't observe shutdown
-    masterExecute([this]() { tear_down_references(); });
+    masterExecute([this]() { tearDownReferences(); });
     _writeService.master().sync();
     // Wait until inflight feed operations to this document db has left.
     // Caller should have removed document DB from feed router.

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -19,6 +19,7 @@
 #include <vespa/searchcore/proton/initializer/task_runner.h>
 #include <vespa/searchcore/proton/reference/i_document_db_reference_resolver.h>
 #include <vespa/searchcore/proton/reference/i_document_db_referent_registry.h>
+#include <vespa/searchcore/proton/reference/document_db_reference_resolver.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/configconverter.h>
 #include <vespa/searchlib/engine/docsumreply.h>
@@ -69,6 +70,12 @@ uint32_t semiUnboundTaskLimit(uint32_t semiUnboundExecutorTaskLimit,
     return taskLimit;
 }
 
+}
+
+template <typename FunctionType>
+void
+DocumentDB::masterExecute(FunctionType &&function) {
+    _writeService.master().execute(makeLambdaTask(std::forward<FunctionType>(function)));
 }
 
 DocumentDB::DocumentDB(const vespalib::string &baseDir,
@@ -554,6 +561,24 @@ DocumentDB::performDropFeedView2(IFeedView::SP feedView)
 
 
 void
+DocumentDB::tear_down_references()
+{
+    // Called by master executor thread
+    auto registry = _owner.getDocumentDBReferentRegistry();
+    auto activeConfig = getActiveConfig();
+    auto repo = activeConfig->getDocumentTypeRepoSP();
+    auto docType = repo->getDocumentType(_docTypeName.getName());
+    assert(docType != nullptr);
+    DocumentDBReferenceResolver resolver(*registry,
+                                         *docType,
+                                         activeConfig->getImportedFieldsConfig(),
+                                         *docType,
+                                         _refCount,
+                                         _writeService.attributeFieldWriter());
+    _subDBs.tear_down_references(resolver);
+}
+
+void
 DocumentDB::close()
 {
     {
@@ -561,6 +586,8 @@ DocumentDB::close()
         _state.enterShutdownState();
     }
     _writeService.master().sync(); // Complete all tasks that didn't observe shutdown
+    masterExecute([this]() { tear_down_references(); });
+    _writeService.master().sync();
     // Wait until inflight feed operations to this document db has left.
     // Caller should have removed document DB from feed router.
     _refCount.waitForZeroRefCount();

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -245,7 +245,7 @@ private:
      * Tear down references to this document db (e.g. listeners for
      * gid to lid changes) from other document dbs.
      */
-    void tear_down_references();
+    void tearDownReferences();
 
     template <typename FunctionType>
     inline void masterExecute(FunctionType &&function);

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -241,6 +241,15 @@ private:
     void updateMetrics(DocumentDBTaggedMetrics &metrics);
     void updateMetrics(DocumentDBTaggedMetrics::AttributeMetrics &metrics);
 
+    /*
+     * Tear down references to this document db (e.g. listeners for
+     * gid to lid changes) from other document dbs.
+     */
+    void tear_down_references();
+
+    template <typename FunctionType>
+    inline void masterExecute(FunctionType &&function);
+
 public:
     typedef std::unique_ptr<DocumentDB> UP;
     typedef std::shared_ptr<DocumentDB> SP;

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
@@ -318,4 +318,12 @@ DocumentSubDBCollection::close()
     }
 }
 
+void
+DocumentSubDBCollection::tear_down_references(IDocumentDBReferenceResolver &resolver)
+{
+    for (auto subDb : _subDBs) {
+        subDb->tear_down_references(resolver);
+    }
+}
+
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
@@ -319,10 +319,10 @@ DocumentSubDBCollection::close()
 }
 
 void
-DocumentSubDBCollection::tear_down_references(IDocumentDBReferenceResolver &resolver)
+DocumentSubDBCollection::tearDownReferences(IDocumentDBReferenceResolver &resolver)
 {
     for (auto subDb : _subDBs) {
-        subDb->tear_down_references(resolver);
+        subDb->tearDownReferences(resolver);
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
@@ -126,7 +126,7 @@ public:
     ReprocessingRunner &getReprocessingRunner() { return _reprocessingRunner; }
     double getReprocessingProgress() const;
     void close();
-    void tear_down_references(IDocumentDBReferenceResolver &resolver);
+    void tearDownReferences(IDocumentDBReferenceResolver &resolver);
 };
 
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
@@ -126,6 +126,7 @@ public:
     ReprocessingRunner &getReprocessingRunner() { return _reprocessingRunner; }
     double getReprocessingProgress() const;
     void close();
+    void tear_down_references(IDocumentDBReferenceResolver &resolver);
 };
 
 

--- a/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
@@ -130,6 +130,7 @@ public:
     virtual matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const = 0;
     virtual void close() = 0;
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() = 0;
+    virtual void tear_down_references(IDocumentDBReferenceResolver &resolver) = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
@@ -130,7 +130,7 @@ public:
     virtual matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const = 0;
     virtual void close() = 0;
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() = 0;
-    virtual void tear_down_references(IDocumentDBReferenceResolver &resolver) = 0;
+    virtual void tearDownReferences(IDocumentDBReferenceResolver &resolver) = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -380,7 +380,7 @@ SearchableDocSubDB::getDocumentDBReferent()
 }
 
 void
-SearchableDocSubDB::tear_down_references(IDocumentDBReferenceResolver &resolver)
+SearchableDocSubDB::tearDownReferences(IDocumentDBReferenceResolver &resolver)
 {
     auto attrMgr = getAttributeManager();
     resolver.teardown(*attrMgr);

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -174,7 +174,6 @@ SearchableDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot,
                                 const ReconfigParams &params,
                                 IDocumentDBReferenceResolver &resolver)
 {
-    (void) resolver;
     IReprocessingTask::List tasks;
     updateLidReuseDelayer(&newConfigSnapshot);
     if (params.shouldMatchersChange() && _addMetrics) {
@@ -378,6 +377,13 @@ std::shared_ptr<IDocumentDBReferent>
 SearchableDocSubDB::getDocumentDBReferent()
 {
     return std::make_shared<DocumentDBReferent>(getAttributeManager(), _dms, _gidToLidChangeHandler);
+}
+
+void
+SearchableDocSubDB::tear_down_references(IDocumentDBReferenceResolver &resolver)
+{
+    auto attrMgr = getAttributeManager();
+    resolver.teardown(*attrMgr);
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
@@ -164,6 +164,7 @@ public:
     matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const override;
     virtual void close() override;
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() override;
+    virtual void tear_down_references(IDocumentDBReferenceResolver &resolver) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
@@ -164,7 +164,7 @@ public:
     matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const override;
     virtual void close() override;
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() override;
-    virtual void tear_down_references(IDocumentDBReferenceResolver &resolver) override;
+    virtual void tearDownReferences(IDocumentDBReferenceResolver &resolver) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -471,6 +471,12 @@ StoreOnlyDocSubDB::getDocumentDBReferent()
 }
 
 void
+StoreOnlyDocSubDB::tear_down_references(IDocumentDBReferenceResolver &resolver)
+{
+    (void) resolver;
+}
+
+void
 StoreOnlySubDBFileHeaderContext::
 addTags(vespalib::GenericHeader &header,
         const vespalib::string &name) const

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -471,7 +471,7 @@ StoreOnlyDocSubDB::getDocumentDBReferent()
 }
 
 void
-StoreOnlyDocSubDB::tear_down_references(IDocumentDBReferenceResolver &resolver)
+StoreOnlyDocSubDB::tearDownReferences(IDocumentDBReferenceResolver &resolver)
 {
     (void) resolver;
 }

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -285,6 +285,7 @@ public:
     matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const override;
     void close() override;
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() override;
+    virtual void tear_down_references(IDocumentDBReferenceResolver &resolver) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -285,7 +285,7 @@ public:
     matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const override;
     void close() override;
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() override;
-    virtual void tear_down_references(IDocumentDBReferenceResolver &resolver) override;
+    virtual void tearDownReferences(IDocumentDBReferenceResolver &resolver) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
@@ -96,6 +96,7 @@ struct DummyDocumentSubDb : public IDocumentSubDB
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() override {
         return std::shared_ptr<IDocumentDBReferent>();
     }
+    virtual void tear_down_references(IDocumentDBReferenceResolver &) override { }
 };
 
 } // namespace test

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
@@ -96,7 +96,7 @@ struct DummyDocumentSubDb : public IDocumentSubDB
     virtual std::shared_ptr<IDocumentDBReferent> getDocumentDBReferent() override {
         return std::shared_ptr<IDocumentDBReferent>();
     }
-    virtual void tear_down_references(IDocumentDBReferenceResolver &) override { }
+    virtual void tearDownReferences(IDocumentDBReferenceResolver &) override { }
 };
 
 } // namespace test


### PR DESCRIPTION
to tear down gid to lid change listeners (which updated reference attributes).

@geirst, please review