### PR TITLE
Use primary cluster membership instead of the first one.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
@@ -180,8 +180,7 @@ public class HostSystem extends AbstractConfigProducer<Host> {
         LinkedHashSet<HostSpec> hostSpecs = new LinkedHashSet<>();
         for (HostResource host: hostname2host.values()) {
             if (! host.getHost().isMultitenant()) {
-                // TODO: always using the first cluster membership seems fishy.
-                hostSpecs.add(new HostSpec(host.getHostName(), host.clusterMemberships().stream().findFirst()));
+                hostSpecs.add(new HostSpec(host.getHostName(), host.primaryClusterMembership()));
             }
         }
         return hostSpecs;


### PR DESCRIPTION
@bratseth I forgot this in the previous PR.