### PR TITLE
Nodes rest api fail/park host children

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -315,12 +315,12 @@ public class NodeRepository extends AbstractComponent {
      * @throws IllegalArgumentException if the node has hardware failure
      */
     public Node setDirty(String hostname) {
-        Optional<Node> nodeToDirty = getNode(hostname, Node.State.provisioned, Node.State.failed, Node.State.parked);
-        if ( ! nodeToDirty.isPresent())
-            throw new IllegalArgumentException("Could not deallocate " + hostname + ": No such node in the provisioned, failed or parked state");
-        if (nodeToDirty.get().status().hardwareFailure().isPresent())
+        Node nodeToDirty = getNode(hostname, Node.State.provisioned, Node.State.failed, Node.State.parked).orElseThrow(() ->
+                new IllegalArgumentException("Could not deallocate " + hostname + ": No such node in the provisioned, failed or parked state"));
+
+        if (nodeToDirty.status().hardwareFailure().isPresent())
             throw new IllegalArgumentException("Could not deallocate " + hostname + ": It has a hardware failure");
-        return setDirty(Collections.singletonList(nodeToDirty.get())).get(0);
+        return setDirty(Collections.singletonList(nodeToDirty)).get(0);
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -342,6 +342,15 @@ public class NodeRepository extends AbstractComponent {
     }
 
     /**
+     * Fails all the nodes that are children of hostname before finally failing the hostname itself.
+     *
+     * @return List of all the failed nodes in their new state
+     */
+    public List<Node> failRecursively(String hostname) {
+        return moveRecursively(hostname, Node.State.failed);
+    }
+
+    /**
      * Parks this node and returns it in its new state.
      *
      * @return the node in its new state
@@ -349,6 +358,15 @@ public class NodeRepository extends AbstractComponent {
      */
     public Node park(String hostname) {
         return move(hostname, Node.State.parked);
+    }
+
+    /**
+     * Parks all the nodes that are children of hostname before finally parking the hostname itself.
+     *
+     * @return List of all the parked nodes in their new state
+     */
+    public List<Node> parkRecursively(String hostname) {
+        return moveRecursively(hostname, Node.State.parked);
     }
 
     /**
@@ -361,6 +379,14 @@ public class NodeRepository extends AbstractComponent {
         return move(hostname, Node.State.active);
     }
 
+    private List<Node> moveRecursively(String hostname, Node.State toState) {
+        List<Node> moved = getChildNodes(hostname).stream()
+                .map(child -> move(child, toState))
+                .collect(Collectors.toList());
+
+        moved.add(move(hostname, toState));
+        return moved;
+    }
 
     private Node move(String hostname, Node.State toState) {
         Node node = getNode(hostname).orElseThrow(() ->

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -224,7 +224,7 @@ public class NodeFailer extends Maintainer {
             // If the active node that we are trying to fail is of type host, we need to successfully fail all
             // the children nodes running on it before we fail the host
             boolean allTenantNodesFailedOutSuccessfully = true;
-            for (Node failingTenantNode : nodeRepository().getNodes(node)) {
+            for (Node failingTenantNode : nodeRepository().getChildNodes(node.hostname())) {
                 if (failingTenantNode.state() == Node.State.active) {
                     allTenantNodesFailedOutSuccessfully &= failActive(failingTenantNode);
                 } else {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/MessageResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/MessageResponse.java
@@ -2,17 +2,11 @@
 package com.yahoo.vespa.hosted.provision.restapi.v2;
 
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.slime.Cursor;
 import com.yahoo.slime.JsonFormat;
 import com.yahoo.slime.Slime;
 
 import java.io.IOException;
 import java.io.OutputStream;
-
-import static com.yahoo.jdisc.Response.Status.BAD_REQUEST;
-import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
-import static com.yahoo.jdisc.Response.Status.METHOD_NOT_ALLOWED;
-import static com.yahoo.jdisc.Response.Status.NOT_FOUND;
 
 /**
  * A 200 ok response with a message in JSON

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -166,9 +166,8 @@ public class NodesApiHandler extends LoggingRequestHandler {
         if (endIndex < 0) endIndex = path.length(); // path ends by ip
         String hostname = path.substring(beginIndex, endIndex);
 
-        Optional<Node> node = nodeRepository.getNode(hostname);
-        if ( ! node.isPresent()) throw new NotFoundException("No node found with hostname " + hostname);
-        return node.get();
+        return nodeRepository.getNode(hostname).orElseThrow(() ->
+                new NotFoundException("No node found with hostname " + hostname));
     }
 
     public int addNodes(InputStream jsonStream) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -89,7 +89,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
         if (path.startsWith("/nodes/v2/state/")) return new NodesResponse(ResponseType.nodesInStateList, request, nodeRepository);
         if (path.startsWith("/nodes/v2/acl/")) return new NodeAclResponse(request, nodeRepository);
         if (path.equals(    "/nodes/v2/command/")) return ResourcesResponse.fromStrings(request.getUri(), "restart", "reboot");
-        return ErrorResponse.notFoundError("Nothing at path '" + path + "'");
+        throw new NotFoundException("Nothing at path '" + path + "'");
     }
 
     private HttpResponse handlePUT(HttpRequest request) {
@@ -114,14 +114,13 @@ public class NodesApiHandler extends LoggingRequestHandler {
             nodeRepository.reactivate(lastElement(path));
             return new MessageResponse("Moved " + lastElement(path) + " to active");
         }
-        else {
-            return ErrorResponse.notFoundError("Cannot put to path '" + path + "'");
-        }
+
+        throw new NotFoundException("Cannot put to path '" + path + "'");
     }
 
     private HttpResponse handlePATCH(HttpRequest request) {
         String path = request.getUri().getPath();
-        if ( ! path.startsWith("/nodes/v2/node/")) return ErrorResponse.notFoundError("Nothing at '" + path + "'");
+        if ( ! path.startsWith("/nodes/v2/node/")) throw new NotFoundException("Nothing at '" + path + "'");
         Node node = nodeFromRequest(request);
         nodeRepository.write(new NodePatcher(nodeFlavors, request.getData(), node, nodeRepository.clock()).apply());
         return new MessageResponse("Updated " + node.hostname());
@@ -139,7 +138,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
                 int addedNodes = addNodes(request.getData());
                 return new MessageResponse("Added " + addedNodes + " nodes to the provisioned state");
             default:
-                return ErrorResponse.notFoundError("Nothing at path '" + request.getUri().getPath() + "'");
+                throw new NotFoundException("Nothing at path '" + request.getUri().getPath() + "'");
         }
     }
 
@@ -150,11 +149,10 @@ public class NodesApiHandler extends LoggingRequestHandler {
             if (nodeRepository.remove(hostname))
                 return new MessageResponse("Removed " + hostname);
             else
-                return ErrorResponse.notFoundError("No node in the failed state with hostname " + hostname);
+                throw new NotFoundException("No node in the failed state with hostname " + hostname);
         }
-        else {
-            return ErrorResponse.notFoundError("Nothing at path '" + request.getUri().getPath() + "'");
-        }
+
+        throw new NotFoundException("Nothing at path '" + request.getUri().getPath() + "'");
     }
 
     private Node nodeFromRequest(HttpRequest request) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import static com.yahoo.vespa.config.SlimeUtils.optionalString;
 
@@ -99,12 +100,14 @@ public class NodesApiHandler extends LoggingRequestHandler {
             return new MessageResponse("Moved " + lastElement(path) + " to ready");
         }
         else if (path.startsWith("/nodes/v2/state/failed/")) {
-            nodeRepository.fail(lastElement(path));
-            return new MessageResponse("Moved " + lastElement(path) + " to failed");
+            List<Node> failedNodes = nodeRepository.failRecursively(lastElement(path));
+            String failedHostnames = failedNodes.stream().map(Node::hostname).sorted().collect(Collectors.joining(", "));
+            return new MessageResponse("Moved " + failedHostnames + " to failed");
         }
         else if (path.startsWith("/nodes/v2/state/parked/")) {
-            nodeRepository.park(lastElement(path));
-            return new MessageResponse("Moved " + lastElement(path) + " to parked");
+            List<Node> parkedNodes = nodeRepository.parkRecursively(lastElement(path));
+            String parkedHostnames = parkedNodes.stream().map(Node::hostname).sorted().collect(Collectors.joining(", "));
+            return new MessageResponse("Moved " + parkedHostnames + " to parked");
         }
         else if (path.startsWith("/nodes/v2/state/dirty/")) {
             nodeRepository.setDirty(lastElement(path));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -123,10 +123,9 @@ class NodesResponse extends HttpResponse {
     }
 
     private void nodeToSlime(String hostname, Cursor object) {
-        Optional<Node> node = nodeRepository.getNode(hostname);
-        if (! node.isPresent())
-            throw new NotFoundException("No node with hostname '" + hostname + "'");
-        toSlime(node.get(), true, object);
+        Node node = nodeRepository.getNode(hostname).orElseThrow(() ->
+                new NotFoundException("No node with hostname '" + hostname + "'"));
+        toSlime(node, true, object);
     }
 
     private void toSlime(Node node, boolean allFields, Cursor object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -85,10 +85,11 @@ public class MockNodeRepository extends NodeRepository {
 
         nodes = addNodes(nodes);
         nodes.remove(6);
+        nodes.remove(7);
         nodes = setDirty(nodes);
         setReady(nodes);
         fail("host5.yahoo.com");
-        move("host55.yahoo.com", Node.State.dirty);
+        setDirty("host55.yahoo.com");
 
         ApplicationId app1 = ApplicationId.from(TenantName.from("tenant1"), ApplicationName.from("application1"), InstanceName.from("instance1"));
         ClusterSpec cluster1 = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("id1"), Optional.of("image-123"));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -65,13 +65,13 @@ public class MockNodeRepository extends NodeRepository {
         node4 = node4.with(node4.status().withDockerImage("image-12"));
         nodes.add(node4);
 
-        Node node5 = createNode("node5", "host5.yahoo.com", Optional.of("dockerhost"), flavors.getFlavorOrThrow("default"), NodeType.tenant);
+        Node node5 = createNode("node5", "host5.yahoo.com", Optional.of("parent1.yahoo.com"), flavors.getFlavorOrThrow("default"), NodeType.tenant);
         nodes.add(node5.with(node5.status().withDockerImage("image-123").withVespaVersion(new Version("1.2.3"))));
 
         nodes.add(createNode("node6", "host6.yahoo.com", Optional.empty(), flavors.getFlavorOrThrow("default"), NodeType.tenant));
         nodes.add(createNode("node7", "host7.yahoo.com", Optional.empty(), flavors.getFlavorOrThrow("default"), NodeType.tenant));
         // 8 and 9 are added by web service calls
-        Node node10 = createNode("node10", "host10.yahoo.com", Optional.of("parent.yahoo.com"), flavors.getFlavorOrThrow("default"), NodeType.tenant);
+        Node node10 = createNode("node10", "host10.yahoo.com", Optional.of("parent1.yahoo.com"), flavors.getFlavorOrThrow("default"), NodeType.tenant);
         Status node10newStatus = node10.status();
         node10newStatus = node10newStatus
                 .withVespaVersion(Version.fromString("5.104.142"))

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -24,7 +24,7 @@ public class NodeRepositoryTest {
 
         assertEquals(3, tester.getNodes(NodeType.tenant).size());
         
-        tester.nodeRepository().move("host2", Node.State.parked);
+        tester.nodeRepository().park("host2");
         assertTrue(tester.nodeRepository().remove("host2"));
 
         assertEquals(2, tester.getNodes(NodeType.tenant).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -46,7 +46,7 @@ public class ZooKeeperAccessMaintainerTest {
         assertEquals(2, tester.getNodes(NodeType.proxy).size());
         assertEquals(asSet("host1,host2,host3,host4,host5,server1,server2"), ZooKeeperServer.getAllowedClientHostnames());
 
-        tester.nodeRepository().move("host2", Node.State.parked);
+        tester.nodeRepository().park("host2");
         assertTrue(tester.nodeRepository().remove("host2"));
         maintainer.maintain();
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -94,7 +94,7 @@ public class RestApiTest {
         // calling ready again is a noop:
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/host8.yahoo.com",
                                   new byte[0], Request.Method.PUT),
-                       "{\"message\":\"Nothing done; host8.yahoo.com is already ready\"}");
+                       "{\"message\":\"Moved host8.yahoo.com to ready\"}");
 
         // PUT a node in failed ...
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/failed/host3.yahoo.com",
@@ -312,7 +312,7 @@ public class RestApiTest {
                        "{\"message\":\"Moved host1.yahoo.com to failed\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/host1.yahoo.com",
                                    new byte[0], Request.Method.PUT),
-                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Could not set host1.yahoo.com ready: Node is allocated and must be moved to dirty instead\"}");
+                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Can not set failed node host1.yahoo.com allocated to tenant 'tenant2', application 'application2', instance 'instance2' as 'content/id2/0/0' ready. It is not dirty.\"}");
         // (... while dirty then ready works (the ready move will be initiated by node maintenance))
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/dirty/host1.yahoo.com",
                                    new byte[0], Request.Method.PUT),
@@ -327,7 +327,7 @@ public class RestApiTest {
                        "{\"message\":\"Moved host2.yahoo.com to parked\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/host2.yahoo.com",
                                    new byte[0], Request.Method.PUT),
-                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Could not set host2.yahoo.com ready: Node is allocated and must be moved to dirty instead\"}");
+                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Can not set parked node host2.yahoo.com allocated to tenant 'tenant2', application 'application2', instance 'instance2' as 'content/id2/0/1' ready. It is not dirty.\"}");
         // (... while dirty then ready works (the ready move will be initiated by node maintenance))
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/dirty/host2.yahoo.com",
                                    new byte[0], Request.Method.PUT),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -46,7 +46,7 @@ public class RestApiTest {
         assertFile(new Request("http://localhost:8080/nodes/v2/node/?recursive=true&clusterType=content"), "active-nodes.json");
         assertFile(new Request("http://localhost:8080/nodes/v2/node/?recursive=true&clusterId=id2"), "application2-nodes.json");
         assertFile(new Request("http://localhost:8080/nodes/v2/node/?recursive=true&application=tenant2.application2.instance2"), "application2-nodes.json");
-        assertFile(new Request("http://localhost:8080/nodes/v2/node/?recursive=true&parentHost=parent.yahoo.com,parent.host.yahoo.com"), "parent-nodes.json");
+        assertFile(new Request("http://localhost:8080/nodes/v2/node/?recursive=true&parentHost=parent1.yahoo.com,parent.host.yahoo.com"), "parent-nodes.json");
 
         // POST restart command
         assertRestart(1, new Request("http://localhost:8080/nodes/v2/command/restart?hostname=host2.yahoo.com",
@@ -128,6 +128,16 @@ public class RestApiTest {
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/dirty/host6.yahoo.com",
                                    new byte[0], Request.Method.PUT),
                        "{\"message\":\"Moved host6.yahoo.com to dirty\"}");
+
+        // Put a host in failed and make sure it's children are also failed
+        assertResponse(new Request("http://localhost:8080/nodes/v2/state/failed/parent1.yahoo.com", new byte[0], Request.Method.PUT),
+                "{\"message\":\"Moved host10.yahoo.com, host5.yahoo.com, parent1.yahoo.com to failed\"}");
+
+        assertResponse(new Request("http://localhost:8080/nodes/v2/state/failed"), "{\"nodes\":[" +
+                "{\"url\":\"http://localhost:8080/nodes/v2/node/parent1.yahoo.com\"}," +
+                "{\"url\":\"http://localhost:8080/nodes/v2/node/host5.yahoo.com\"}," +
+                "{\"url\":\"http://localhost:8080/nodes/v2/node/host10.yahoo.com\"}]}");
+
 
         // Update (PATCH) a node (multiple fields can also be sent in one request body)
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -4,7 +4,7 @@
   "state": "reserved",
   "type": "tenant",
   "hostname": "host10.yahoo.com",
-  "parentHostname": "parent.yahoo.com",
+  "parentHostname": "parent1.yahoo.com",
   "openStackId": "node10",
   "flavor": "default",
   "canonicalFlavor": "default",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
@@ -4,7 +4,7 @@
   "state": "failed",
   "type": "tenant",
   "hostname": "host5.yahoo.com",
-  "parentHostname":"dockerhost",
+  "parentHostname":"parent1.yahoo.com",
   "openStackId": "node5",
   "flavor": "default",
   "canonicalFlavor": "default",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
@@ -4,7 +4,7 @@
   "state": "failed",
   "type": "tenant",
   "hostname": "host5.yahoo.com",
-  "parentHostname":"dockerhost",
+  "parentHostname":"parent1.yahoo.com",
   "openStackId": "node5",
   "flavor": "default",
   "canonicalFlavor": "default",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -12,9 +12,9 @@
   "description":"Flavor-name-is-default",
   "minCpuCores":2.0,
   "environment":"BARE_METAL",
-  "rebootGeneration": 2,
+  "rebootGeneration": 1,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "hardwareFailure" : false,
-  "history":[{"event":"readied","at":123},{"event":"deallocated","at":123}]
+  "history":[{"event":"deallocated","at":123}]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent-nodes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent-nodes.json
@@ -1,5 +1,6 @@
 {
   "nodes": [
-    @include(node10.json)
+    @include(node10.json),
+    @include(node5.json)
   ]
 }


### PR DESCRIPTION
Split up in several commits, most have no functional changes. The commits are:
1. Made `NodeRepository.move()` private and fixed the test as one of them did a move from ready to dirty.
2. Simplified a common pattern of throwing an exception if an `Optional` not `isPresent()` to use `Optional.orElseThrow`
3. Changed `return ErrorResponse.notFoundError` to `throw new NotFoundException`
4. Added a `setReady` method that takes in a `String` hostname instead of `Node`
5. Added `recusiveFail` and `recursivePark` along with test