### PR TITLE
Store streaming stats in query instead of query context

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/MetricsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/MetricsSearcher.java
@@ -2,13 +2,12 @@
 package com.yahoo.vespa.streamingvisitors;
 
 import com.yahoo.log.event.Event;
-import com.yahoo.search.query.context.QueryContext;
-import com.yahoo.search.result.ErrorMessage;
-import com.yahoo.search.searchchain.Execution;
+import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
-import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.searchchain.Execution;
 import com.yahoo.vdslib.VisitorStatistics;
 
 import java.util.Map;
@@ -77,11 +76,7 @@ public class MetricsSearcher extends Searcher {
                 stats.ok++;
             }
 
-            VisitorStatistics visitorstats = null;
-            final QueryContext queryContext = query.getContext(false);
-            if (queryContext != null) {
-                visitorstats = (VisitorStatistics)queryContext.getProperty(STREAMING_STATISTICS);
-            }
+            VisitorStatistics visitorstats = (VisitorStatistics) query.properties().get(STREAMING_STATISTICS);
             if (visitorstats != null) {
                 stats.dataStreamed += visitorstats.getBytesVisited();
                 stats.documentsStreamed += visitorstats.getDocumentsVisited();

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -26,6 +26,7 @@ import com.yahoo.search.searchchain.Execution;
 import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
+import com.yahoo.vdslib.VisitorStatistics;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -153,9 +154,9 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
 
         result.setTotalHitCount(visitor.getTotalHitCount());
 
-        Execution.Trace traceChild = query.getContext(true).getTrace().createChild();
-        traceChild.setTraceLevel(2);
-        traceChild.setProperty(STREAMING_STATISTICS, visitor.getStatistics());
+        VisitorStatistics statistics = visitor.getStatistics();
+        query.trace(statistics.toString(), false, 2);
+        query.properties().set(STREAMING_STATISTICS, statistics);
 
         Packet[] summaryPackets = new Packet [hits.size()];
 

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/MetricsSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/MetricsSearcherTestCase.java
@@ -132,9 +132,9 @@ public class MetricsSearcherTestCase {
 
         private void assignContextProperties(Query query, String loadType) {
             if (loadType != null && loadType.equals(LOADTYPE1)) {
-                query.getContext(true).setProperty(VdsStreamingSearcher.STREAMING_STATISTICS, visitorStats);
+                query.properties().set(VdsStreamingSearcher.STREAMING_STATISTICS, visitorStats);
             } else {
-                query.getContext(true).setProperty(VdsStreamingSearcher.STREAMING_STATISTICS, null);
+                query.properties().set(VdsStreamingSearcher.STREAMING_STATISTICS, null);
             }
         }
     }


### PR DESCRIPTION
All properties in the query context are modelled as trace nodes and will
be part of the query trace regardless of level. The streaming statistics
should only be visible in trace for levels >=2.