### PR TITLE
Revert "Store streaming stats in query instead of query context"

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/MetricsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/MetricsSearcher.java
@@ -2,12 +2,13 @@
 package com.yahoo.vespa.streamingvisitors;
 
 import com.yahoo.log.event.Event;
-import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.query.context.QueryContext;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
-import com.yahoo.search.result.ErrorMessage;
-import com.yahoo.search.searchchain.Execution;
+import com.yahoo.processing.request.CompoundName;
 import com.yahoo.vdslib.VisitorStatistics;
 
 import java.util.Map;
@@ -76,7 +77,11 @@ public class MetricsSearcher extends Searcher {
                 stats.ok++;
             }
 
-            VisitorStatistics visitorstats = (VisitorStatistics) query.properties().get(STREAMING_STATISTICS);
+            VisitorStatistics visitorstats = null;
+            final QueryContext queryContext = query.getContext(false);
+            if (queryContext != null) {
+                visitorstats = (VisitorStatistics)queryContext.getProperty(STREAMING_STATISTICS);
+            }
             if (visitorstats != null) {
                 stats.dataStreamed += visitorstats.getBytesVisited();
                 stats.documentsStreamed += visitorstats.getDocumentsVisited();

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -26,7 +26,6 @@ import com.yahoo.search.searchchain.Execution;
 import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
-import com.yahoo.vdslib.VisitorStatistics;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -154,9 +153,9 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
 
         result.setTotalHitCount(visitor.getTotalHitCount());
 
-        VisitorStatistics statistics = visitor.getStatistics();
-        query.trace(statistics.toString(), false, 2);
-        query.properties().set(STREAMING_STATISTICS, statistics);
+        Execution.Trace traceChild = query.getContext(true).getTrace().createChild();
+        traceChild.setTraceLevel(2);
+        traceChild.setProperty(STREAMING_STATISTICS, visitor.getStatistics());
 
         Packet[] summaryPackets = new Packet [hits.size()];
 

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/MetricsSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/MetricsSearcherTestCase.java
@@ -132,9 +132,9 @@ public class MetricsSearcherTestCase {
 
         private void assignContextProperties(Query query, String loadType) {
             if (loadType != null && loadType.equals(LOADTYPE1)) {
-                query.properties().set(VdsStreamingSearcher.STREAMING_STATISTICS, visitorStats);
+                query.getContext(true).setProperty(VdsStreamingSearcher.STREAMING_STATISTICS, visitorStats);
             } else {
-                query.properties().set(VdsStreamingSearcher.STREAMING_STATISTICS, null);
+                query.getContext(true).setProperty(VdsStreamingSearcher.STREAMING_STATISTICS, null);
             }
         }
     }


### PR DESCRIPTION
Reverts yahoo/vespa#1898

@vekterli @bjorncs 
Broke the system tests. I see that tracelevel=9 set, but the log message is not outputtet. Don't have time to look further into this, so reverting.

Please do an after the fact review on this one.