### PR TITLE
Store streaming stats in query instead of query context

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/MetricsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/MetricsSearcher.java
@@ -2,20 +2,17 @@
 package com.yahoo.vespa.streamingvisitors;
 
 import com.yahoo.log.event.Event;
-import com.yahoo.search.query.context.QueryContext;
-import com.yahoo.search.result.ErrorMessage;
-import com.yahoo.search.searchchain.Execution;
+import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
-import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.searchchain.Execution;
 import com.yahoo.vdslib.VisitorStatistics;
 
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Logger;
-
-import static com.yahoo.vespa.streamingvisitors.VdsStreamingSearcher.STREAMING_STATISTICS;
 
 /**
  * Generates mail-specific query metrics.
@@ -77,11 +74,7 @@ public class MetricsSearcher extends Searcher {
                 stats.ok++;
             }
 
-            VisitorStatistics visitorstats = null;
-            final QueryContext queryContext = query.getContext(false);
-            if (queryContext != null) {
-                visitorstats = (VisitorStatistics)queryContext.getProperty(STREAMING_STATISTICS);
-            }
+            VisitorStatistics visitorstats = (VisitorStatistics) query.properties().get(VdsStreamingSearcher.STREAMING_STATISTICS);
             if (visitorstats != null) {
                 stats.dataStreamed += visitorstats.getBytesVisited();
                 stats.documentsStreamed += visitorstats.getDocumentsVisited();

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -26,6 +26,7 @@ import com.yahoo.search.searchchain.Execution;
 import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
+import com.yahoo.vdslib.VisitorStatistics;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -48,7 +49,7 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
     private static final CompoundName streamingGroupname=new CompoundName("streaming.groupname");
     private static final CompoundName streamingSelection=new CompoundName("streaming.selection");
 
-    public static final String STREAMING_STATISTICS = "streaming.statistics";
+    public static final CompoundName STREAMING_STATISTICS = new CompoundName("streaming.statistics");
     private VisitorFactory visitorFactory;
     private static final Logger log = Logger.getLogger(VdsStreamingSearcher.class.getName());
     private Route route;
@@ -153,9 +154,9 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
 
         result.setTotalHitCount(visitor.getTotalHitCount());
 
-        Execution.Trace traceChild = query.getContext(true).getTrace().createChild();
-        traceChild.setTraceLevel(2);
-        traceChild.setProperty(STREAMING_STATISTICS, visitor.getStatistics());
+        VisitorStatistics statistics = visitor.getStatistics();
+        query.trace(statistics.toString(), false, 2);
+        query.properties().set(STREAMING_STATISTICS, statistics);
 
         Packet[] summaryPackets = new Packet [hits.size()];
 

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/MetricsSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/MetricsSearcherTestCase.java
@@ -132,9 +132,9 @@ public class MetricsSearcherTestCase {
 
         private void assignContextProperties(Query query, String loadType) {
             if (loadType != null && loadType.equals(LOADTYPE1)) {
-                query.getContext(true).setProperty(VdsStreamingSearcher.STREAMING_STATISTICS, visitorStats);
+                query.properties().set(VdsStreamingSearcher.STREAMING_STATISTICS, visitorStats);
             } else {
-                query.getContext(true).setProperty(VdsStreamingSearcher.STREAMING_STATISTICS, null);
+                query.properties().set(VdsStreamingSearcher.STREAMING_STATISTICS, null);
             }
         }
     }


### PR DESCRIPTION
All properties in the query context are modelled as trace nodes and will
be part of the query trace regardless of level. The streaming statistics
should only be visible in trace for levels >=2.

UPDATE: `STREAMING_STATISTICS` is now a `CompoundName` instead of `String`. I noticed that some implementations of `Properties` have different semantics when key is a `CompoundName` instead of `String`. Also, the other use of `query.properties()` in `MetricsSearcher` is with `CompoundName`.