### PR TITLE
Added disk.limit and updated memory.usage metric

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -510,6 +510,7 @@ public class NodeAgentImplTest {
                 .nodeFlavor("docker")
                 .owner(owner)
                 .membership(membership)
+                .minDiskAvailableGb(250)
                 .build();
 
         long totalContainerCpuTime = (long) ((Map) cpu_stats.get("cpu_usage")).get("total_usage");

--- a/node-admin/src/test/resources/docker.stats.metrics.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.expected.json
@@ -78,8 +78,9 @@
     "metrics":{
       "node.cpu.busy.pct": 45.6789123,
       "node.cpu.throttled_time": 4523.0,
-      "node.memory.usage":1.752707072E9,
-      "node.memory.limit":4.294967296E9
+      "node.memory.usage":1.326026752E9,
+      "node.memory.limit":4.294967296E9,
+      "node.disk.limit":2.68435456E11
     },
     "routing":{
       "yamas":{


### PR DESCRIPTION
* Added `node.disk.limit` metric
* Updated `node.memory.usage` metric to be more inline with what secret-agent reports on regular nodes (See https://git.corp.yahoo.com/Secret-Agent/health_check/blob/668c1c5a153ff32346eaae286e3b114737b244ed/src/main/gather_memory.cpp#L53)

FYI: @yngveaasheim @ldalves 