### PR TITLE
Freva/simplify get container

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -97,7 +97,7 @@ public class NodeRepositoryImpl implements NodeRepository {
         }
     }
 
-    private static ContainerNodeSpec createContainerNodeSpec(GetNodesResponse.Node node)
+    public static ContainerNodeSpec createContainerNodeSpec(GetNodesResponse.Node node)
             throws IllegalArgumentException, NullPointerException {
         Objects.requireNonNull(node.nodeState, "Unknown node state");
         Node.State nodeState = Node.State.valueOf(node.nodeState);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertTrue;
 
@@ -79,7 +80,13 @@ public class RunVespaLocal {
 
         logger.info("Provisioning nodes");
         Set<String> hostnames = LocalZoneUtils.provisionNodes(LocalZoneUtils.NODE_ADMIN_HOSTNAME, numNodesToProvision);
-        hostnames.forEach(hostname -> LocalZoneUtils.setState(Node.State.ready, hostname));
+        hostnames.stream()
+                .map(LocalZoneUtils::getContainerNodeSpec)
+                .flatMap(optional -> optional.isPresent() ? Stream.of(optional.get()) : Stream.empty()) // Remove with JDK 9
+                .forEach(nodeSpec -> {
+                    if (nodeSpec.nodeState == Node.State.provisioned) LocalZoneUtils.setState(Node.State.dirty, nodeSpec.hostname);
+                    if (nodeSpec.nodeState == Node.State.dirty) LocalZoneUtils.setState(Node.State.ready, nodeSpec.hostname);
+                });
     }
 
     /**
@@ -110,8 +117,11 @@ public class RunVespaLocal {
         LocalZoneUtils.startNodeAdminIfNeeded(docker, environmentBuilder.build(), pathToContainerStorage);
 
         logger.info("Provisioning host at " + parentHostHostname);
-        LocalZoneUtils.provisionHost(parentHostHostname);
-        LocalZoneUtils.setState(Node.State.ready, parentHostHostname);
+        LocalZoneUtils.getContainerNodeSpec(parentHostHostname)
+                .ifPresent(nodeSpec -> {
+                    if (nodeSpec.nodeState == Node.State.provisioned) LocalZoneUtils.setState(Node.State.dirty, nodeSpec.hostname);
+                    if (nodeSpec.nodeState == Node.State.dirty) LocalZoneUtils.setState(Node.State.ready, nodeSpec.hostname);
+                });
 
         logger.info("Deploying node-admin app");
         LocalZoneUtils.deployApp(docker, pathToNodeAdminApp, "vespa", "node-admin");

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/RunVespaLocal.java
@@ -117,6 +117,7 @@ public class RunVespaLocal {
         LocalZoneUtils.startNodeAdminIfNeeded(docker, environmentBuilder.build(), pathToContainerStorage);
 
         logger.info("Provisioning host at " + parentHostHostname);
+        LocalZoneUtils.provisionHost(parentHostHostname);
         LocalZoneUtils.getContainerNodeSpec(parentHostHostname)
                 .ifPresent(nodeSpec -> {
                     if (nodeSpec.nodeState == Node.State.provisioned) LocalZoneUtils.setState(Node.State.dirty, nodeSpec.hostname);


### PR DESCRIPTION
* Simplify `getContainer` - no need to iterate over all containers when we already know the name of the container we want.
* Fix local zone state transition - must go to dirty first, then ready. 