### PR TITLE
Implement destroy so that when the reference count reaches 0 destroy …

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -555,4 +555,9 @@ public class SearchHandler extends LoggingRequestHandler {
         return searchChainRegistry;
     }
 
+    @Override
+    protected void destroy() {
+        super.destroy();
+        rendererRegistry.allComponents().forEach(Renderer::deconstruct);
+    }
 }


### PR DESCRIPTION
…will actualyy be handled, and not ignored.

So far only deconstructing the components in the RendererRegistry.
This should stop the ThreadPoolExecutor leaks by properly shutting them down.
@bjorncs and @gjoranv PR Keep in mind there might be more the SearchHandler should deconstruct.
@bratseth FYI