### PR TITLE
Expect fieldpath remove value to be 0 to match the existing field format

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
+++ b/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
@@ -137,8 +137,7 @@ public class DocumentUpdateJsonSerializer
                 } else if (update instanceof AddFieldPathUpdate) {
                     ((AddFieldPathUpdate) update).getNewValues().serialize(null, this);
                 } else if (update instanceof RemoveFieldPathUpdate) {
-                    generator.writeStartObject();
-                    generator.writeEndObject();
+                    generator.writeNumber(0);
                 } else {
                     throw new RuntimeException("Unsupported fieldpath operation: " + update.getClass().getName());
                 }

--- a/document/src/main/java/com/yahoo/document/json/readers/JsonParserHelpers.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/JsonParserHelpers.java
@@ -24,4 +24,8 @@ public class JsonParserHelpers {
     public static void expectCompositeEnd(JsonToken token) {
         Preconditions.checkState(token.isStructEnd(), "Expected end of composite, got %s", token);
     }
+
+    public static void expectScalarValue(JsonToken token) {
+        Preconditions.checkState(token.isScalarValue(), "Expected to be scalar value, got %s", token);
+    }
 }

--- a/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
@@ -2,7 +2,6 @@ package com.yahoo.document.json.readers;
 
 import com.fasterxml.jackson.core.JsonToken;
 import com.google.common.base.Preconditions;
-import com.yahoo.document.DataType;
 import com.yahoo.document.Document;
 import com.yahoo.document.DocumentOperation;
 import com.yahoo.document.DocumentPut;
@@ -25,6 +24,7 @@ import static com.yahoo.document.json.readers.AddRemoveCreator.createRemoves;
 import static com.yahoo.document.json.readers.CompositeReader.populateComposite;
 import static com.yahoo.document.json.readers.JsonParserHelpers.expectObjectEnd;
 import static com.yahoo.document.json.readers.JsonParserHelpers.expectObjectStart;
+import static com.yahoo.document.json.readers.JsonParserHelpers.expectScalarValue;
 import static com.yahoo.document.json.readers.MapReader.UPDATE_MATCH;
 import static com.yahoo.document.json.readers.MapReader.createMapUpdate;
 import static com.yahoo.document.json.readers.SingleValueReader.UPDATE_ASSIGN;
@@ -170,8 +170,7 @@ public class VespaJsonDocumentReader {
     }
 
     private RemoveFieldPathUpdate readRemoveFieldPathUpdate(DocumentType documentType, String fieldPath, TokenBuffer buffer) {
-        expectObjectStart(buffer.currentToken());
-        expectObjectEnd(buffer.next());
+        expectScalarValue(buffer.currentToken());
         return new RemoveFieldPathUpdate(documentType, fieldPath);
     }
 

--- a/document/src/test/java/com/yahoo/document/json/DocumentUpdateJsonSerializerTest.java
+++ b/document/src/test/java/com/yahoo/document/json/DocumentUpdateJsonSerializerTest.java
@@ -392,7 +392,7 @@ public class DocumentUpdateJsonSerializerTest {
                 "   'update': 'DOCUMENT_ID',",
                 "   'fields': {",
                 "       'int_array[5]': {",
-                "           'remove': {}",
+                "           'remove': 0",
                 "       }",
                 "   }",
                 "}"
@@ -440,7 +440,7 @@ public class DocumentUpdateJsonSerializerTest {
                 "           'assign': {",
                 "               'my_string_field': 'Some string'",
                 "           },",
-                "           'remove': {}",
+                "           'remove': 0",
                 "       }",
                 "   }",
                 "}"


### PR DESCRIPTION
In the existing `field` format we expect the "value" for the `remove` operation to be `0` (See [document-json-update-format.html](https://git.corp.yahoo.com/pages/vespa/documentation/documentation/reference/document-json-update-format.html#removecomposite)) whereas the current `fieldpath` `remove` expects an empty object. This PR changes it to be consistent with the existing `field` format.