### PR TITLE
Run ACL maintainer just before starting the container

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -14,8 +14,9 @@ import java.util.Optional;
 public interface DockerOperations {
     Optional<String> getVespaVersion(ContainerName containerName);
 
-    // Returns true if started
-    boolean startContainerIfNeeded(ContainerName containerName, ContainerNodeSpec nodeSpec);
+    void startContainer(ContainerName containerName, ContainerNodeSpec nodeSpec);
+
+    void removeContainer(Container existingContainer);
 
     // Returns false if image is already downloaded
     boolean shouldScheduleDownloadOfImage(DockerImage dockerImage);
@@ -23,8 +24,6 @@ public interface DockerOperations {
     Optional<Container> getContainer(ContainerName containerName);
 
     void scheduleDownloadOfImage(ContainerName containerName, ContainerNodeSpec nodeSpec, Runnable callback);
-
-    void removeContainer(ContainerNodeSpec nodeSpec, Container existingContainer);
 
     ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, String[] command);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -69,7 +69,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
 
         Function<String, NodeAgent> nodeAgentFactory =
                 (hostName) -> new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
-                        storageMaintainer, metricReceiver, environment);
+                        storageMaintainer, metricReceiver, environment, aclMaintainer);
         NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer,
                 NODE_AGENT_SCAN_INTERVAL_MILLIS, metricReceiver, aclMaintainer);
         nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepository, nodeAdmin, INITIAL_SCHEDULER_DELAY_MILLIS,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
@@ -33,7 +33,7 @@ public class ComponentsProviderWithMocks implements ComponentsProvider {
     private final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, mr);
     private final Function<String, NodeAgent> nodeAgentFactory =
             (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock, orchestratorMock,
-                    dockerOperations, Optional.empty(), mr, environment);
+                    dockerOperations, Optional.empty(), mr, environment, Optional.empty());
     private NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, Optional.empty(), 100, mr, Optional.empty());
 
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -62,7 +62,7 @@ public class DockerTester implements AutoCloseable {
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
         final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, mr);
         Function<String, NodeAgent> nodeAgentFactory = (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock,
-                orchestratorMock, dockerOperations, Optional.of(storageMaintainer), mr, environment);
+                orchestratorMock, dockerOperations, Optional.of(storageMaintainer), mr, environment, Optional.empty());
         nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, Optional.of(storageMaintainer), 100, mr, Optional.empty());
         updater = new NodeAdminStateUpdater(nodeRepositoryMock, nodeAdmin, 1, 1, orchestratorMock, "basehostname");
     }


### PR DESCRIPTION
* Removes unused argument from `DockerOperatons.removeContainer()`
* Replaces `DockerOperations.startContainerIfNeeded()` with `DockerOperations.startContainer()`
* Run `AclMaintainer.run()` before starting a container