### PR TITLE
Set the logger at creation, to reuse the class logger

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -272,6 +272,7 @@ public class JettyHttpServer extends AbstractServerProvider {
     private ServletContextHandler createServletContextHandler() {
         ServletContextHandler servletContextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
         servletContextHandler.setContextPath("/");
+        servletContextHandler.setLogger(Log.getLogger(ServletContextHandler.class));
         return servletContextHandler;
     }
 


### PR DESCRIPTION
@bjorncs 

This will stop the doStart method from creating a new logger of name ContextHandler.#classLoaderHash, which happens only when the _logger is null (which it is initially).