### PR TITLE
Avoid race when getting config

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ClientUpdater.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ClientUpdater.java
@@ -104,4 +104,9 @@ class ClientUpdater {
             log.log(LogLevel.DEBUG, "Finished updating config for " + config.getKey() + "," + config.getGeneration());
         }
     }
+
+    // TODO: Remove, temporary until MapBackedConfigSource has been refactored
+    public MemoryCache getMemoryCache() {
+        return memoryCache;
+    }
 }

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/MapBackedConfigSource.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/MapBackedConfigSource.java
@@ -17,6 +17,7 @@ import java.util.List;
  * @author hmusum
  * @since 5.1.10
  */
+// TODO Move to src/test/
 public class MapBackedConfigSource implements ConfigSource, ConfigSourceClient {
     private final HashMap<ConfigKey<?>, RawConfig> backing = new HashMap<>();
     private final ClientUpdater clientUpdater;
@@ -33,7 +34,9 @@ public class MapBackedConfigSource implements ConfigSource, ConfigSourceClient {
 
     @Override
     public RawConfig getConfig(RawConfig input, JRTServerConfigRequest request) {
-        return getConfig(input.getKey());
+        final RawConfig config = getConfig(input.getKey());
+        clientUpdater.getMemoryCache().put(config);
+        return config;
     }
 
     RawConfig getConfig(ConfigKey<?> configKey) {

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ProxyServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ProxyServer.java
@@ -85,19 +85,21 @@ public class ProxyServer implements Runnable {
     }
 
     static ProxyServer createTestServer(ConfigSourceSet source) {
-        return createTestServer(source, null);
+        return createTestServer(source, null, new MemoryCache());
     }
 
-    static ProxyServer createTestServer(MapBackedConfigSource source) {
-        return createTestServer(source, source);
+    static ProxyServer createTestServer(MapBackedConfigSource source, MemoryCache memoryCache) {
+        return createTestServer(source, source, memoryCache);
     }
 
-    private static ProxyServer createTestServer(ConfigSource source, ConfigSourceClient configSourceClient) {
+    private static ProxyServer createTestServer(ConfigSource source,
+                                                ConfigSourceClient configSourceClient,
+                                                MemoryCache memoryCache) {
         final ConfigProxyStatistics statistics = new ConfigProxyStatistics();
         final boolean delayedResponseHandling = false;
         return new ProxyServer(null, new DelayedResponses(statistics),
                                source, statistics, defaultTimingValues(), delayedResponseHandling,
-                               new MemoryCache(), configSourceClient);
+                               memoryCache, configSourceClient);
     }
 
     public void run() {
@@ -123,11 +125,7 @@ public class ProxyServer implements Runnable {
         // create a background thread that retrieves config from the server and
         // calls updateSubscribers when new config is returned from the config source.
         // In the last case the method below will return null.
-        RawConfig config = configClient.getConfig(RawConfig.createFromServerRequest(req), req);
-        if (configOrGenerationHasChanged(config, req)) {
-            memoryCache.put(config);
-        }
-        return config;
+        return configClient.getConfig(RawConfig.createFromServerRequest(req), req);
     }
 
     static boolean configOrGenerationHasChanged(RawConfig config, JRTServerConfigRequest request) {

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/UpstreamConfigSubscriber.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/UpstreamConfigSubscriber.java
@@ -68,6 +68,7 @@ public class UpstreamConfigSubscriber implements Subscriber {
                     "', generation=" + newConfig.getGeneration() +
                     ", payload=" + newConfig.getPayload());
         }
+        // memoryCache.put(); TODO: Add here later and remove in ClientUpdater
         clientUpdater.updateSubscribers(newConfig);
     }
 

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/DelayedResponseHandlerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/DelayedResponseHandlerTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
  */
 public class DelayedResponseHandlerTest {
 
-    private final MapBackedConfigSource source = new MapBackedConfigSource(UpstreamConfigSubscriberTest.MockClientUpdater.create());
+    private final MapBackedConfigSource source = new MapBackedConfigSource(UpstreamConfigSubscriberTest.MockClientUpdater.create(new MemoryCache()));
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/UpstreamConfigSubscriberTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/UpstreamConfigSubscriberTest.java
@@ -43,7 +43,7 @@ public class UpstreamConfigSubscriberTest {
 
     @Before
     public void setup() {
-        clientUpdater = MockClientUpdater.create();
+        clientUpdater = MockClientUpdater.create(new MemoryCache());
         sourceResponses = new MapBackedConfigSource(clientUpdater);
 
         ConfigPayload payload = getConfigPayload("bar", "value");
@@ -147,14 +147,14 @@ public class UpstreamConfigSubscriberTest {
     static class MockClientUpdater extends ClientUpdater {
         private RawConfig lastConfig;
 
-        private MockClientUpdater(ConfigProxyStatistics statistics, Mode mode) {
-            super(new MemoryCache(), new MockRpcServer(), statistics, new DelayedResponses(statistics), mode);
+        private MockClientUpdater(ConfigProxyStatistics statistics, Mode mode, MemoryCache memoryCache) {
+            super(memoryCache, new MockRpcServer(), statistics, new DelayedResponses(statistics), mode);
         }
 
-        public static MockClientUpdater create() {
+        static MockClientUpdater create(MemoryCache memoryCache) {
             Mode mode = new Mode();
             ConfigProxyStatistics statistics = new ConfigProxyStatistics();
-            return new MockClientUpdater(statistics, mode);
+            return new MockClientUpdater(statistics, mode, memoryCache);
         }
 
         @Override


### PR DESCRIPTION
* Always add to delayed responses (we remove instead if we find config in cache)
  This is to avoid a race where we might end up not adding to delayed responses
  nor subscribing to config if another request for the same config
  happens at the same time
* Add to cache only in one place
* Remove meaningless test