### PR TITLE
Test library depends on searchcore_fconfig library.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/test/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/test/CMakeLists.txt
@@ -6,4 +6,5 @@ vespa_add_library(searchcore_test STATIC
     documentdb_config_builder.cpp
     userdocumentsbuilder.cpp
     DEPENDS
+    searchcore_fconfig
 )


### PR DESCRIPTION
@geirst, please review