### PR TITLE
Don't return stringref to temporary buffer

### DIFF
--- a/storage/src/vespa/storage/visiting/visitorthread.cpp
+++ b/storage/src/vespa/storage/visiting/visitorthread.cpp
@@ -65,7 +65,7 @@ VisitorThread::Event::Event(
 }
 
 namespace {
-    vespalib::stringref getThreadName(uint32_t i) {
+    vespalib::string getThreadName(uint32_t i) {
         vespalib::asciistream name;
         name << "Visitor thread " << i;
         return name.str();


### PR DESCRIPTION
@baldersheim please review. `-Og` makes some things fall out when you shake Vespa hard enough.

This line was last changed in 2011 so, uh, it's been buggy for a while.
Presumably this has been aggressively inlined, so going via the stringref
hasn't actually happened during normal compilation.