### PR TITLE
Update CPU usage metric

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -74,7 +74,7 @@ public class NodeAdminImpl implements NodeAdmin {
 
         scheduler.scheduleWithFixedDelay(() -> {
             try {
-                nodeAgents.values().forEach(NodeAgent::updateContainerNodeMetrics);
+                nodeAgents.values().forEach(nodeAgent -> nodeAgent.updateContainerNodeMetrics(nodeAgents.size()));
             } catch (Throwable e) {
                 logger.warning("Metric fetcher scheduler failed", e);
             }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
@@ -64,7 +64,7 @@ public interface NodeAgent {
     /**
      * Updates metric receiver with the latest node-agent stats
      */
-    void updateContainerNodeMetrics();
+    void updateContainerNodeMetrics(int numAllocatedContainersOnHost);
 
     ContainerName getContainerName();
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -497,10 +497,14 @@ public class NodeAgentImplTest {
 
         long totalContainerCpuTime = (long) ((Map) cpu_stats.get("cpu_usage")).get("total_usage");
         long totalSystemCpuTime = (long) cpu_stats.get("system_cpu_usage");
-        nodeAgent.lastCpuMetric.getCpuUsagePercentage(totalContainerCpuTime - 456_789_123, (long) (totalSystemCpuTime - 1e9));
-        // During the last 10^9 total cpu ns, 456,789,123ns were spent on running the container. That means the expected
-        // cpu usage percentage is 100 * (456,789,123 / 10^9) = 45.6789123%
-        nodeAgent.updateContainerNodeMetrics();
+        nodeAgent.lastCpuMetric.getCpuUsagePercentage(totalContainerCpuTime - 123_456_789, (long) (totalSystemCpuTime - 1e9));
+        int numAllocatedContainersOnHost = 4;
+        // During the last 10^9 total CPU ns, 123,456,789ns were spent on running the container. That means the container
+        // used 100 * (123,456,789 / 10^9) = 12.3456789% of total system CPU time.
+        // There are a total of 4 allocated nodes on this host, which means that the container only has 100 / 4 = 25%
+        // of total system CPU time at its disposal. Therefore, the expected CPU usage by this container is:
+        // 12.3456789% / 25% = 49.3827156%
+        nodeAgent.updateContainerNodeMetrics(4);
 
         Set<Map<String, Object>> actualMetrics = new HashSet<>();
         for (MetricReceiverWrapper.DimensionMetrics dimensionMetrics : metricReceiver.getMetrics(MetricReceiverWrapper.APPLICATION_DOCKER)) {

--- a/node-admin/src/test/resources/docker.stats.metrics.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.expected.json
@@ -76,7 +76,7 @@
       "zone":"dev.us-east-1"
     },
     "metrics":{
-      "node.cpu.busy.pct": 45.6789123,
+      "node.cpu.busy.pct": 49.3827156,
       "node.cpu.throttled_time": 4523.0,
       "node.memory.usage":1.326026752E9,
       "node.memory.limit":4.294967296E9,


### PR DESCRIPTION
The current value reported by the `docker.node.cpu.busy.pct` metric is a percentage of CPU time spent by the container of total system CPU time. Therefore, for large hosts with 32 containers, the usage will never be more than 100/32 = 3.125% as each container has equal amount of CPU shares. Whereas a host with only 3 containers could report up to 33.33% CPU usage. As such this number is not very useful.

This PR updates the `docker.node.cpu.busy.pct` metric to be the previous value multiplied by number of allocated containers to this host. 

FYI: @yngveaasheim @ldalves 