### PR TITLE
Avoid expensive pooling of json fieldnames. Works very bad with maps.…

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
@@ -25,7 +25,7 @@ import com.yahoo.vespaxmlparser.VespaXMLFeedReader.Operation;
 public class JsonFeedReader implements FeedReader {
     private final JsonReader reader;
     private InputStream stream;
-    private static final JsonFactory jsonFactory = new JsonFactory();
+    private static final JsonFactory jsonFactory = new JsonFactory().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
 
     public JsonFeedReader(InputStream stream, DocumentTypeManager docMan) {
         reader = new JsonReader(docMan, stream, jsonFactory);

--- a/document/src/main/java/com/yahoo/document/json/SingleDocumentParser.java
+++ b/document/src/main/java/com/yahoo/document/json/SingleDocumentParser.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
  * @author dybis
  */
 public class SingleDocumentParser {
-    private static final JsonFactory jsonFactory = new JsonFactory();
+    private static final JsonFactory jsonFactory = new JsonFactory().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
     private DocumentTypeManager docMan;
 
     public SingleDocumentParser(DocumentTypeManager docMan) {

--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaSimpleJsonInputFormat.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaSimpleJsonInputFormat.java
@@ -54,7 +54,7 @@ public class VespaSimpleJsonInputFormat extends FileInputFormat<Text, NullWritab
 
             remaining = fileSplit.getLength();
 
-            JsonFactory factory = new JsonFactory();
+            JsonFactory factory = new JsonFactory().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
             parser = factory.createParser(new BufferedInputStream(stream));
             parser.setCodec(new ObjectMapper());
             parser.nextToken();

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/JsonReader.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/JsonReader.java
@@ -35,7 +35,7 @@ public class JsonReader {
     public static void read(InputStream inputStream, FeedClient feedClient, AtomicInteger numSent) {
         try {
             final InputStreamJsonElementBuffer jsonElementBuffer = new InputStreamJsonElementBuffer(inputStream);
-            final JsonFactory jfactory = new JsonFactory();
+            final JsonFactory jfactory = new JsonFactory().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
             final JsonParser jParser = jfactory.createParser(jsonElementBuffer);
             while (true) {
                 String docId = parseOneDocument(jParser);


### PR DESCRIPTION
…....
@bratseth PR
@dybis FYI
Here is background https://github.com/FasterXML/jackson-core/wiki/JsonFactory-Features
It could be that it would be enough to just turn off INTERN_FIELD_NAMES, but I will just go for the whole shebang at once.
This is especially expensive when we are using maps. Since the key will be considered a field name and is candidate for the above. This will most likely add cost to normal json parsing.
It might also indicate that our map format is not very good. Perhaps we should consider {"key" : "keyValue", "value" : "valueValue"} instead of the elegant { "keyValue" : "valueValue" }
I guess we will have the same issue if we used slime. A huge symbol table.