### PR TITLE
Reject packets not matching any other rules

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
@@ -116,7 +116,7 @@ public class AclMaintainerTest {
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-P", "INPUT", "REJECT"})
+                aryEq(new String[]{"ip6tables", "-P", "INPUT", "DROP"})
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
@@ -143,6 +143,10 @@ public class AclMaintainerTest {
                 eq(containerName),
                 aryEq(new String[]{"ip6tables", "-A", "INPUT", "-s", aclSpec.ipAddress() + "/128", "-j", "ACCEPT"})
         ));
+        verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
+                eq(containerName),
+                aryEq(new String[]{"ip6tables", "-A", "INPUT", "-j", "REJECT"})
+        );
     }
 
     private Container makeContainer(String hostname) {


### PR DESCRIPTION
Only valid chain policies are ACCEPT and DROP, so the previous configuration
failed.

FYI @andreer 