### PR TITLE
Revert "Revert "Toregge/reduce wipe history arguments to index maintainer""

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
@@ -14,6 +14,45 @@ using search::AttributeVector;
 namespace proton
 {
 
+vespalib::string
+AttributeDiskLayout::getSnapshotDir(uint64_t syncToken)
+{
+    return vespalib::make_string("snapshot-%" PRIu64, syncToken);
+}
+
+vespalib::string
+AttributeDiskLayout::getSnapshotRemoveDir(const vespalib::string &baseDir,
+                                          const vespalib::string &snapDir)
+{
+    if (baseDir.empty()) {
+        return snapDir;
+    }
+    return vespalib::make_string("%s/%s",
+                                 baseDir.c_str(),
+                                 snapDir.c_str());
+}
+
+vespalib::string
+AttributeDiskLayout::getAttributeBaseDir(const vespalib::string &baseDir,
+                                         const vespalib::string &attrName)
+{
+    if (baseDir.empty()) {
+        return attrName;
+    }
+    return vespalib::make_string("%s/%s",
+                                 baseDir.c_str(),
+                                 attrName.c_str());
+}
+
+AttributeVector::BaseName
+AttributeDiskLayout::getAttributeFileName(const vespalib::string &baseDir,
+                                          const vespalib::string &attrName,
+                                          uint64_t syncToken)
+{
+    return AttributeVector::BaseName(getAttributeBaseDir(baseDir, attrName),
+                                     getSnapshotDir(syncToken),
+                                     attrName);
+}
 
 bool
 AttributeDiskLayout::removeOldSnapshots(IndexMetaInfo &snapInfo,

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
@@ -15,54 +15,14 @@ namespace proton {
 class AttributeDiskLayout
 {
 private:
-    static vespalib::string
-    getSnapshotDir(uint64_t syncToken)
-    {
-        return vespalib::make_string("snapshot-%" PRIu64, syncToken);
-    }
+    static vespalib::string getSnapshotDir(uint64_t syncToken);
+    static vespalib::string getSnapshotRemoveDir(const vespalib::string &baseDir, const vespalib::string &snapDir);
 
-    static vespalib::string
-    getSnapshotRemoveDir(const vespalib::string &baseDir,
-                         const vespalib::string &snapDir)
-    {
-        if (baseDir.empty()) {
-            return snapDir;
-        }
-        return vespalib::make_string("%s/%s",
-                                     baseDir.c_str(),
-                                     snapDir.c_str());
-    }
 public:
-    static vespalib::string
-    getAttributeBaseDir(const vespalib::string &baseDir,
-                        const vespalib::string &attrName)
-    {
-        if (baseDir.empty()) {
-            return attrName;
-        }
-        return vespalib::make_string("%s/%s",
-                                     baseDir.c_str(),
-                                     attrName.c_str());
-    }
-
-    static search::AttributeVector::BaseName
-    getAttributeFileName(const vespalib::string &baseDir,
-                         const vespalib::string &attrName,
-                         uint64_t syncToken)
-    {
-        return search::AttributeVector::BaseName(getAttributeBaseDir(baseDir,
-                                                         attrName),
-                getSnapshotDir(syncToken),
-                attrName);
-    }
-
-    static bool
-    removeOldSnapshots(search::IndexMetaInfo &snapInfo,
-                       vespalib::Lock &snapInfoLock);
-
-    static bool
-    removeAttribute(const vespalib::string &baseDir,
-                    const vespalib::string &attrName);
+    static vespalib::string  getAttributeBaseDir(const vespalib::string &baseDir, const vespalib::string &attrName);
+    static search::AttributeVector::BaseName getAttributeFileName(const vespalib::string &baseDir, const vespalib::string &attrName, uint64_t syncToken);
+    static bool removeOldSnapshots(search::IndexMetaInfo &snapInfo, vespalib::Lock &snapInfoLock);
+    static bool removeAttribute(const vespalib::string &baseDir, const vespalib::string &attrName);
 
 };
 

--- a/searchcore/src/vespa/searchcore/proton/index/indexmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/index/indexmanager.h
@@ -114,12 +114,12 @@ public:
         return _maintainer.getFlushTargets();
     }
 
-    virtual void setSchema(const Schema &schema) {
-        _maintainer.setSchema(schema);
+    virtual void setSchema(const Schema &schema, SerialNum serialNum) {
+        _maintainer.setSchema(schema, serialNum);
     }
 
-    virtual void wipeHistory(SerialNum wipeSerial, const Schema &historyFields) {
-        _maintainer.wipeHistory(wipeSerial, historyFields);
+    virtual void wipeHistory(SerialNum wipeSerial) {
+        _maintainer.wipeHistory(wipeSerial);
     }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -531,7 +531,7 @@ DocumentDB::applyConfig(DocumentDBConfig::SP configSnapshot,
         }
     }
     if (params.shouldIndexManagerChange()) {
-        setIndexSchema(*configSnapshot);
+        setIndexSchema(*configSnapshot, serialNum);
     }
     if (!fallbackConfig) { 
         if (_state.getRejectedConfig()) {
@@ -873,10 +873,10 @@ DocumentDB::flushDone(SerialNum flushedSerial)
 }
 
 void
-DocumentDB::setIndexSchema(const DocumentDBConfig &configSnapshot)
+DocumentDB::setIndexSchema(const DocumentDBConfig &configSnapshot, SerialNum serialNum)
 {
     // Called by executor thread
-    _subDBs.getReadySubDB()->setIndexSchema(configSnapshot.getSchemaSP());
+    _subDBs.getReadySubDB()->setIndexSchema(configSnapshot.getSchemaSP(), serialNum);
 
     // TODO: Adjust tune.
 }
@@ -1017,7 +1017,7 @@ DocumentDB::internalWipeHistory(SerialNum wipeSerial,
                                 const Schema &wipeSchema)
 {
     // Called by executor thread
-    _subDBs.wipeHistory(wipeSerial, *newHistorySchema, wipeSchema);
+    _subDBs.wipeHistory(wipeSerial, wipeSchema);
     _historySchema.reset(newHistorySchema.release());
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -186,7 +186,7 @@ private:
     reconfigureSchema(const DocumentDBConfig &configSnapshot,
                       const DocumentDBConfig &oldConfigSnapshot);
 
-    void setIndexSchema(const DocumentDBConfig &configSnapshot);
+    void setIndexSchema(const DocumentDBConfig &configSnapshot, SerialNum serialNum);
 
     /**
      * Redo interrupted reprocessing if last entry in transaction log

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
@@ -247,11 +247,10 @@ DocumentSubDBCollection::getNewestFlushedSerial()
 
 void
 DocumentSubDBCollection::wipeHistory(SerialNum wipeSerial,
-                                     const Schema &newHistorySchema,
                                      const Schema &wipeSchema)
 {
     for (auto subDb : _subDBs) {
-        subDb->wipeHistory(wipeSerial, newHistorySchema, wipeSchema);
+        subDb->wipeHistory(wipeSerial, wipeSchema);
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
@@ -111,7 +111,6 @@ public:
 
     void
     wipeHistory(SerialNum wipeSerial,
-                const search::index::Schema &newHistorySchema,
                 const search::index::Schema &wipeSchema);
 
     void

--- a/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
@@ -122,8 +122,8 @@ public:
      * last part of transaction log.
      */
     virtual SerialNum getNewestFlushedSerial()  = 0;
-    virtual void wipeHistory(SerialNum wipeSerial, const Schema &newHistorySchema, const Schema &wipeSchema) = 0;
-    virtual void setIndexSchema(const SchemaSP &schema) = 0;
+    virtual void wipeHistory(SerialNum wipeSerial, const Schema &wipeSchema) = 0;
+    virtual void setIndexSchema(const SchemaSP &schema, SerialNum serialNum) = 0;
     virtual search::SearchableStats getSearchableStats() const = 0;
     virtual std::unique_ptr<IDocumentRetriever> getDocumentRetriever() = 0;
 

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -298,26 +298,25 @@ SearchableDocSubDB::getFlushTargetsInternal()
 
 void
 SearchableDocSubDB::wipeHistory(SerialNum wipeSerial,
-                                const Schema &newHistorySchema,
                                 const Schema &wipeSchema)
 {
     assert(_writeService.master().isCurrentThread());
     SearchView::SP oldSearchView = _rSearchView.get();
     IFeedView::SP oldFeedView = _iFeedView.get();
-    _indexMgr->wipeHistory(wipeSerial, newHistorySchema);
+    _indexMgr->wipeHistory(wipeSerial);
     reconfigureIndexSearchable();
     getAttributeManager()->wipeHistory(wipeSchema);
 }
 
 void
-SearchableDocSubDB::setIndexSchema(const Schema::SP &schema)
+SearchableDocSubDB::setIndexSchema(const Schema::SP &schema, SerialNum serialNum)
 {
     assert(_writeService.master().isCurrentThread());
 
     SearchView::SP oldSearchView = _rSearchView.get();
     IFeedView::SP oldFeedView = _iFeedView.get();
 
-    _indexMgr->setSchema(*schema);
+    _indexMgr->setSchema(*schema, serialNum);
     reconfigureIndexSearchable();
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
@@ -154,8 +154,8 @@ public:
 
     SerialNum getOldestFlushedSerial() override;
     SerialNum getNewestFlushedSerial() override;
-    void wipeHistory(SerialNum wipeSerial, const Schema &newHistorySchema, const Schema &wipeSchema) override;
-    void setIndexSchema(const Schema::SP &schema) override;
+    void wipeHistory(SerialNum wipeSerial, const Schema &wipeSchema) override;
+    void setIndexSchema(const Schema::SP &schema, SerialNum serialNum) override;
     size_t getNumActiveDocs() const override;
     search::SearchableStats getSearchableStats() const override ;
     IDocumentRetriever::UP getDocumentRetriever() override;

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -458,15 +458,16 @@ StoreOnlyDocSubDB::getIndexWriter() const
 }
 
 void
-StoreOnlyDocSubDB::wipeHistory(SerialNum, const Schema &, const Schema &)
+StoreOnlyDocSubDB::wipeHistory(SerialNum, const Schema &)
 {
 }
 
 void
-StoreOnlyDocSubDB::setIndexSchema(const Schema::SP &schema)
+StoreOnlyDocSubDB::setIndexSchema(const Schema::SP &schema, SerialNum serialNum)
 {
     assert(_writeService.master().isCurrentThread());
     (void) schema;
+    (void) serialNum;
 }
 
 search::SearchableStats

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -249,8 +249,8 @@ public:
     SerialNum getOldestFlushedSerial() override;
     SerialNum getNewestFlushedSerial() override;
 
-    void wipeHistory(SerialNum wipeSerial, const Schema &newHistorySchema, const Schema &wipeSchema) override;
-    void setIndexSchema(const Schema::SP &schema) override;
+    void wipeHistory(SerialNum wipeSerial, const Schema &wipeSchema) override;
+    void setIndexSchema(const Schema::SP &schema, SerialNum serialNum) override;
     search::SearchableStats getSearchableStats() const override;
     IDocumentRetriever::UP getDocumentRetriever() override;
     matching::MatchingStats getMatcherStats(const vespalib::string &rankProfile) const override;

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
@@ -81,8 +81,8 @@ struct DummyDocumentSubDb : public IDocumentSubDB
     void onReprocessDone(SerialNum) override { }
     SerialNum getOldestFlushedSerial() override { return 0; }
     SerialNum getNewestFlushedSerial() override { return 0; }
-    void wipeHistory(SerialNum, const Schema &, const Schema &) override { }
-    void setIndexSchema(const Schema::SP &) override { }
+    void wipeHistory(SerialNum, const Schema &) override { }
+    void setIndexSchema(const Schema::SP &, SerialNum) override { }
     search::SearchableStats getSearchableStats() const override {
         return search::SearchableStats();
     }

--- a/searchcore/src/vespa/searchcore/proton/test/mock_index_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_index_manager.h
@@ -26,8 +26,8 @@ struct MockIndexManager : public IIndexManager
     virtual searchcorespi::IFlushTarget::List getFlushTargets() override {
         return searchcorespi::IFlushTarget::List();
     }
-    virtual void setSchema(const Schema &) override {}
-    virtual void wipeHistory(SerialNum, const Schema &) override {}
+    virtual void setSchema(const Schema &, SerialNum) override {}
+    virtual void wipeHistory(SerialNum) override {}
     virtual void heartBeat(SerialNum) override {}
 };
 

--- a/searchcorespi/src/tests/plugin/plugin.cpp
+++ b/searchcorespi/src/tests/plugin/plugin.cpp
@@ -34,8 +34,8 @@ public:
         searchcorespi::IFlushTarget::List l;
         return l;
     }
-    virtual void setSchema(const Schema &) { }
-    virtual void wipeHistory(SerialNum , const Schema &) { }
+    virtual void setSchema(const Schema &, SerialNum) override { }
+    virtual void wipeHistory(SerialNum) override { }
 };
 
 class IndexManagerFactory : public searchcorespi::IIndexManagerFactory

--- a/searchcorespi/src/vespa/searchcorespi/index/iindexmanager.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/iindexmanager.cpp
@@ -4,10 +4,9 @@
 namespace searchcorespi {
 
 void
-IIndexManager::wipeHistory(SerialNum wipeSerial, const Schema &historyFields)
+IIndexManager::wipeHistory(SerialNum wipeSerial)
 {
     (void) wipeSerial;
-    (void) historyFields;
 }
 
 IIndexManager::Reconfigurer::~Reconfigurer()

--- a/searchcorespi/src/vespa/searchcorespi/index/iindexmanager.h
+++ b/searchcorespi/src/vespa/searchcorespi/index/iindexmanager.h
@@ -156,17 +156,14 @@ public:
      *
      * @param schema The new schema to start using.
      **/
-    virtual void setSchema(const Schema &schema) = 0;
+    virtual void setSchema(const Schema &schema, SerialNum serialNum) = 0;
 
     /**
-     * Wipes remains of removed fields from this index manager as specified in the history schema.
-     * This can for instance be removing these fields from disk indexes.
-     * The default implementation does nothing.
+     * Wipes remains of removed fields from this index manager.
      *
      * @param wipeSerial The serial number of this wipe operation.
-     * @param historyFields The schema specifying which fields we should wipe away.
      **/
-    virtual void wipeHistory(SerialNum wipeSerial, const Schema &historyFields);
+    virtual void wipeHistory(SerialNum wipeSerial);
 };
 
 } // namespace searchcorespi

--- a/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.cpp
@@ -173,11 +173,11 @@ IndexMaintainer::reopenDiskIndexes(ISearchableIndexCollection &coll)
         }
         const string indexDir = d->getIndexDir();
         vespalib::string schemaName = IndexDiskLayout::getSchemaFileName(indexDir);
-        Schema oldSchema;
-        if (!oldSchema.loadFromFile(schemaName)) {
+        Schema trimmedSchema;
+        if (!trimmedSchema.loadFromFile(schemaName)) {
             LOG(error, "Could not open schema '%s'", schemaName.c_str());
         }
-        if (oldSchema != d->getSchema()) {
+        if (trimmedSchema != d->getSchema()) {
             IDiskIndex::SP newIndex(reloadDiskIndex(*d));
             coll.replace(coll.getSourceId(i), newIndex);
             hasReopenedAnything = true;
@@ -434,16 +434,6 @@ IndexMaintainer::FlushArgs::FlushArgs()
 IndexMaintainer::FlushArgs::~FlushArgs() { }
 IndexMaintainer::FlushArgs::FlushArgs(FlushArgs &&) = default;
 IndexMaintainer::FlushArgs & IndexMaintainer::FlushArgs::operator=(FlushArgs &&) = default;
-
-IndexMaintainer::WipeHistoryArgs::WipeHistoryArgs()
-        : _old_source_list(),
-          _new_source_list()
-{ }
-
-IndexMaintainer::WipeHistoryArgs::WipeHistoryArgs(WipeHistoryArgs &&) = default;
-IndexMaintainer::WipeHistoryArgs & IndexMaintainer::WipeHistoryArgs::operator=(WipeHistoryArgs &&) = default;
-
-IndexMaintainer::WipeHistoryArgs::~WipeHistoryArgs() { }
 
 bool
 IndexMaintainer::doneInitFlush(FlushArgs *args, IMemoryIndex::SP *new_index)
@@ -768,20 +758,6 @@ IndexMaintainer::doneSetSchema(SetSchemaArgs &args, IMemoryIndex::SP &newIndex)
 }
 
 
-bool
-IndexMaintainer::doneWipeHistory(WipeHistoryArgs &args)
-{
-    assert(_ctx.getThreadingService().master().isCurrentThread()); // with idle index executor
-    LockGuard state_lock(_state_lock);
-    LockGuard lock(_new_search_lock);
-    if (args._old_source_list.get() != _source_list.get()) {
-        return false;    // Flush or fusion had started/completed, must retry
-    }
-    _source_list = args._new_source_list;
-    return true;
-}
-
-
 Schema
 IndexMaintainer::getSchema(void) const
 {
@@ -891,7 +867,7 @@ IndexMaintainer::IndexMaintainer(const IndexMaintainerConfig &config,
     LOG(debug, "Index manager created with flushed serial num %" PRIu64, _flush_serial_num);
     sourceList->append(_current_index_id, _current_index);
     sourceList->setCurrentIndex(_current_index_id);
-    _source_list.reset(sourceList.release());
+    _source_list = std::move(sourceList);
     _fusion_spec = spec;
 }
 
@@ -1204,9 +1180,10 @@ IndexMaintainer::getFlushTargets(void)
 }
 
 void
-IndexMaintainer::setSchema(const Schema & schema)
+IndexMaintainer::setSchema(const Schema & schema, SerialNum serialNum)
 {
     assert(_ctx.getThreadingService().master().isCurrentThread());
+    internalWipeHistory(schema, serialNum);
     IMemoryIndex::SP new_index(_operations.createMemoryIndex(schema, _current_serial_num));
     SetSchemaArgs args;
 
@@ -1221,45 +1198,36 @@ IndexMaintainer::setSchema(const Schema & schema)
 }
 
 void
-IndexMaintainer::wipeHistory(SerialNum wipeSerial, const Schema &historyFields)
+IndexMaintainer::internalWipeHistory(const Schema &schema, SerialNum wipeSerial)
 {
     assert(_ctx.getThreadingService().master().isCurrentThread());
-    for (;;) {
-        const Schema before_schema = getSchema();
-        IIndexCollection::SP before_coll = getSourceCollection();
-
-        Schema::UP schema = Schema::make_union(before_schema, historyFields);
-        updateIndexSchemas(*before_coll, *schema, wipeSerial);
-        updateActiveFusionWipeTimeSchema(*schema);
-
-        const Schema after_schema(getSchema());
-        IIndexCollection::SP after_coll = getSourceCollection();
-        if (before_schema == after_schema &&
-            before_coll.get() == after_coll.get())
-        {
-            break;
-        }
-    }
+    ISearchableIndexCollection::SP new_source_list;
+    IIndexCollection::SP coll = getSourceCollection();
+    updateIndexSchemas(*coll, schema, wipeSerial);
+    updateActiveFusionWipeTimeSchema(schema);
     {
         LockGuard state_lock(_state_lock);
         LockGuard lock(_index_update_lock);
         _changeGens.bumpWipeGen();
     }
-    for (bool success(false); !success;) {
-        WipeHistoryArgs args;
-        {
-            LockGuard state_lock(_state_lock);
-            args._old_source_list = _source_list;
-            args._new_source_list.reset(new IndexCollection(_selector, *args._old_source_list));
-        }
-        if (reopenDiskIndexes(*args._new_source_list)) {
-            _ctx.getThreadingService().sync();
-            // Everything should be quiet now.
-            success = doneWipeHistory(args);
-        } else {
-            success = true;
-        }
+    {
+        LockGuard state_lock(_state_lock);
+        new_source_list = std::make_shared<IndexCollection>(_selector, *_source_list);
     }
+    if (reopenDiskIndexes(*new_source_list)) {
+        scheduleCommit();
+        _ctx.getThreadingService().sync();
+        // Everything should be quiet now.
+        LockGuard state_lock(_state_lock);
+        LockGuard lock(_new_search_lock);
+        _source_list = new_source_list;
+    }
+}
+
+void
+IndexMaintainer::wipeHistory(SerialNum wipeSerial)
+{
+    internalWipeHistory(getSchema(), wipeSerial);
 }
 
 }  // namespace index


### PR DESCRIPTION
Reverts yahoo/vespa#2040

I've marked two system tests RELEASE_OK WIP, they depend on data being resurrected when field is resurrected (which is no longer supposed to be supported) and will be removed or rewritten.

@geirst, please review
@aressem, @frodelu FYI