### PR TITLE
Change reference attribute to update the lid-2-lid mapping during upd…

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
@@ -14,8 +14,13 @@ class IGidToLidMapperFactory;
 namespace attribute {
 
 /*
- * Attribute vector mapping from local document ids to global ids
- * referencing external documents.
+ * Attribute vector which maintains a lid-2-lid mapping from local document ids to global ids (referencing external documents)
+ * and their local document ids counterpart.
+ *
+ * The lid-2-lid mapping is updated as follows:
+ * 1) In populateReferencedLids() all referenced lids are set by using the gid-2-lid mapper.
+ * 1) In update() a new lid-gid pair is set and the referenced lid is set by using gid-2-lid mapper.
+ * 2) In notifyGidToLidChange() a gid-reference-lid pair is set explicitly.
  */
 class ReferenceAttribute : public NotImplementedAttribute
 {

--- a/searchlib/src/vespa/searchlib/test/imported_attribute_fixture.h
+++ b/searchlib/src/vespa/searchlib/test/imported_attribute_fixture.h
@@ -87,9 +87,9 @@ struct ImportedAttributeFixture {
 
     void map_reference(DocId from_lid, GlobalId via_gid, DocId to_lid) {
         assert(from_lid < reference_attr->getNumDocs());
+        mapper_factory->_map[via_gid] = to_lid;
         reference_attr->update(from_lid, via_gid);
         reference_attr->commit();
-        mapper_factory->_map[via_gid] = to_lid;
     }
 
     static vespalib::stringref default_imported_attr_name() {


### PR DESCRIPTION
…ate() to avoid using gid mapper per lookup.

@toregge please review
@vekterli FYI