### PR TITLE
Freva/Fix docker metrics

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -508,21 +508,14 @@ public class NodeAgentImpl implements NodeAgent {
 
     @SuppressWarnings("unchecked")
     public void updateContainerNodeMetrics(int numAllocatedContainersOnHost) {
-        logger.debug("Gathering metrics");
         ContainerNodeSpec nodeSpec;
         synchronized (monitor) {
             nodeSpec = lastNodeSpec;
         }
 
-        if (nodeSpec == null || !vespaVersion.isPresent()) {
-            logger.debug("Not updating container metrics, nodeSpec=" + nodeSpec + ", vespaVersion=" + vespaVersion);
-            return;
-        }
+        if (nodeSpec == null || !vespaVersion.isPresent()) return;
         Optional<Docker.ContainerStats> containerStats = dockerOperations.getContainerStats(containerName);
-        if ( ! containerStats.isPresent()) {
-            logger.debug("Failed to get docker stats from daemon");
-            return;
-        }
+        if ( ! containerStats.isPresent()) return;
 
         Docker.ContainerStats stats = containerStats.get();
         Dimensions.Builder dimensionsBuilder = new Dimensions.Builder()
@@ -558,7 +551,6 @@ public class NodeAgentImpl implements NodeAgent {
         double cpuPercentageOfHost = lastCpuMetric.getCpuUsagePercentage(currentCpuContainerTotalTime, currentCpuSystemTotalTime);
         double cpuPercentageOfAllocated = numAllocatedContainersOnHost * cpuPercentageOfHost;
         metricReceiver.declareGauge(MetricReceiverWrapper.APPLICATION_DOCKER, dimensions, "node.cpu.busy.pct").sample(cpuPercentageOfAllocated);
-        logger.debug("Updated CPU busy metric with: " + cpuPercentageOfAllocated);
 
         addIfNotNull(dimensions, "node.cpu.throttled_time", stats.getCpuStats().get("throttling_data"), "throttled_time");
         addIfNotNull(dimensions, "node.memory.limit", stats.getMemoryStats(), "limit");


### PR DESCRIPTION
* ACL and metrics now each have their own scheduler
* Adds a work around getting docker stats via `docker-java` without waiting the entire `awaitCompletion` timeout
* Removes debug logging added in #2038