### PR TITLE
Get node candidates once when generating ACLs

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -2,15 +2,22 @@
 package com.yahoo.vespa.hosted.provision;
 
 import com.google.common.collect.ImmutableList;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.NodeType;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.collectingAndThen;
 
 /**
  * A filterable node list
  *
  * @author bratseth
+ * @author mpolden
  */
 public class NodeList {
 
@@ -43,6 +50,39 @@ public class NodeList {
     /** Returns the subset of nodes assigned to the given cluster type */
     public NodeList type(ClusterSpec.Type type) {
         return new NodeList(nodes.stream().filter(node -> node.allocation().get().membership().cluster().type().equals(type)).collect(Collectors.toList()));
+    }
+
+    /** Returns the subset of nodes owned by the given application */
+    public NodeList owner(ApplicationId application) {
+        return nodes.stream()
+                .filter(node -> node.allocation().map(a -> a.owner().equals(application)).orElse(false))
+                .collect(collectingAndThen(Collectors.toList(), NodeList::new));
+    }
+
+    /** Returns the subset of nodes matching the given node type */
+    public NodeList nodeType(NodeType nodeType) {
+        return nodes.stream()
+                .filter(node -> node.type() == nodeType)
+                .collect(collectingAndThen(Collectors.toList(), NodeList::new));
+    }
+
+    /** Returns the parent nodes of the given child nodes */
+    public NodeList parentNodes(Collection<Node> childNodes) {
+        return childNodes.stream()
+                .map(Node::parentHostname)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(hostName -> nodes.stream().filter(node -> node.hostname().equals(hostName)).findFirst())
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(collectingAndThen(Collectors.toList(), NodeList::new));
+    }
+
+    /** Returns the child nodes of the given parent node */
+    public NodeList childNodes(Node parentNode) {
+        return nodes.stream()
+                .filter(n -> n.parentHostname().map(hostName -> hostName.equals(parentNode.hostname())).orElse(false))
+                .collect(collectingAndThen(Collectors.toList(), NodeList::new));
     }
 
     public int size() { return nodes.size(); }


### PR DESCRIPTION
@andreer or @hakonhall or @hmusum 

Different take on #2049 by extending the existing `NodeList` class.