### PR TITLE
Feeding from grid to Vespa default settings 

### DIFF
--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaRecordWriter.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaRecordWriter.java
@@ -126,11 +126,14 @@ public class VespaRecordWriter extends RecordWriter {
         feedParamsBuilder.setRoute(configuration.route());
         feedParamsBuilder.setMaxSleepTimeMs(configuration.maxSleepTimeMs());
         feedParamsBuilder.setMaxInFlightRequests(configuration.maxInFlightRequests());
+        feedParamsBuilder.setLocalQueueTimeOut(3600*1000); //1 hour queue timeout
 
         SessionParams.Builder sessionParams = new SessionParams.Builder();
         sessionParams.setThrottlerMinSize(configuration.throttlerMinSize());
         sessionParams.setConnectionParams(connParamsBuilder.build());
         sessionParams.setFeedParams(feedParamsBuilder.build());
+        sessionParams.setClientQueueSize(configuration.maxInFlightRequests()*2);
+
 
         String endpoints = configuration.endpoint();
         StringTokenizer tokenizer = new StringTokenizer(endpoints, ",");

--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaRecordWriter.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaRecordWriter.java
@@ -149,6 +149,7 @@ public class VespaRecordWriter extends RecordWriter {
 
         initialized = true;
         log.info("VespaStorage configuration:\n" + configuration.toString());
+        log.info(feedClient.getStatsAsJson());
     }
 
     private String findDocIdFromXml(String xml) {

--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/util/VespaConfiguration.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/util/VespaConfiguration.java
@@ -71,7 +71,7 @@ public class VespaConfiguration {
 
 
     public int numConnections() {
-        return getInt(CONNECTIONS, 2);
+        return getInt(CONNECTIONS, 1);
     }
 
 
@@ -96,7 +96,7 @@ public class VespaConfiguration {
 
 
     public int maxInFlightRequests() {
-        return getInt(MAX_IN_FLIGHT_REQUESTS, 1000);
+        return getInt(MAX_IN_FLIGHT_REQUESTS, 500);
     }
 
 


### PR DESCRIPTION
Parts of last weeks discussion & testing 

- reduce client queues avoids mappers running with large heaps (OutOfMemoryExceptions etc) 
- Increase client queue timeout, avoids failed requests due to not reaching Vespa with large set of tasks where the total input is much higher then endpoint can handle
- Reduce default number of connections, the api is asynchronous and even with super large documents using 1 connection is enough to saturate most endpoints. Large jobs will by default be splitted to far many tasks with one feeding client per task 
 