### PR TITLE
Bump Curator version to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -721,12 +721,6 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
-                <!-- WARNING: If you change this version, you also need to update
-                         zkfacade/src/main/java/org/apache/curator/**/package-info.java
-                     using something like
-                         find zkfacade/src/main/java/org/apache/curator -name package-info.java | \
-                             xargs perl -pi -e 's/major = [0-9]+, minor = [0-9]+, micro = [0-9]+/major = 2, minor = 9, micro = 1/g'
-                -->
                 <version>${curator.version}</version>
             </dependency>
             <dependency>
@@ -1070,7 +1064,13 @@
         <aries.spifly.version>1.0.8</aries.spifly.version>
         <aries.util.version>1.0.0</aries.util.version>
         <asm-debug-all.version>5.0.3</asm-debug-all.version>
-        <curator.version>2.9.1</curator.version>
+        <!-- WARNING: If you change curator version, you also need to update
+                 zkfacade/src/main/java/org/apache/curator/**/package-info.java
+             using something like
+                 find zkfacade/src/main/java/org/apache/curator -name package-info.java | \
+                     xargs perl -pi -e 's/major = [0-9]+, minor = [0-9]+, micro = [0-9]+/major = 2, minor = 9, micro = 1/g'
+        -->
+        <curator.version>2.12.0</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
         <jetty.version>9.4.3.v20170317</jetty.version>

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCurator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCurator.java
@@ -12,6 +12,7 @@ import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ACLBackgroundPathAndBytesable;
 import org.apache.curator.framework.api.ACLCreateModeBackgroundPathAndBytesable;
+import org.apache.curator.framework.api.ACLCreateModePathAndBytesable;
 import org.apache.curator.framework.api.ACLPathAndBytesable;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.BackgroundPathAndBytesable;
@@ -23,6 +24,8 @@ import org.apache.curator.framework.api.CreateBuilder;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.ErrorListenerPathAndBytesable;
+import org.apache.curator.framework.api.ErrorListenerPathable;
 import org.apache.curator.framework.api.ExistsBuilder;
 import org.apache.curator.framework.api.ExistsBuilderMain;
 import org.apache.curator.framework.api.GetACLBuilder;
@@ -37,6 +40,7 @@ import org.apache.curator.framework.api.SetDataBackgroundVersionable;
 import org.apache.curator.framework.api.SetDataBuilder;
 import org.apache.curator.framework.api.SyncBuilder;
 import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.api.VersionPathAndBytesable;
 import org.apache.curator.framework.api.WatchPathable;
 import org.apache.curator.framework.api.Watchable;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
@@ -89,7 +93,7 @@ import java.util.concurrent.TimeUnit;
  * Due to the "fluent API" style of Curator managing to break JavaDoc at a fundamental level, there is no
  * documentation on the contract of each method. The behavior here is deduced by observing what using code exists
  * and peeking at the Curator code. It may be incorrect in some corner cases.</p>
- * 
+ *
  * <p>Contains some code from PathUtils in ZooKeeper, licensed under the Apache 2.0 license.</p>
  *
  * @author bratseth
@@ -144,8 +148,10 @@ public class MockCurator extends Curator {
     public Optional<DistributedAtomicLong> counter(String path) {
         return Optional.ofNullable(atomicCounters.get(path));
     }
-    
-    /** Assigns the connection string, which must be on the form host1:port,host2:port ... */
+
+    /**
+     * Assigns the connection string, which must be on the form host1:port,host2:port ...
+     */
     public void setConnectionSpec(String connectionSpec) { this.connectionSpec = connectionSpec; }
 
     @Override
@@ -591,30 +597,6 @@ public class MockCurator extends Curator {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
-        public PathAndBytesable<T> inBackground() {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        public PathAndBytesable<T> inBackground(Object o) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback, Object o) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
         public ACLBackgroundPathAndBytesable<T> withMode(CreateMode createMode) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
@@ -682,37 +664,71 @@ public class MockCurator extends Curator {
             return createNode(s, bytes, createParents, createMode, fileSystem.root(), listeners);
         }
 
+        @Override
+        public ErrorListenerPathAndBytesable<String> inBackground() {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<String> inBackground(Object o) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback, Object o) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
     }
 
     private class MockBackgroundPathableBuilder<T> implements BackgroundPathable<T>, Watchable<BackgroundPathable<T>> {
 
         @Override
-        public Pathable<T> inBackground() {
+        public ErrorListenerPathable<T> inBackground() {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public Pathable<T> inBackground(Object o) {
+        public ErrorListenerPathable<T> inBackground(Object o) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public Pathable<T> inBackground(BackgroundCallback backgroundCallback) {
+        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public Pathable<T> inBackground(BackgroundCallback backgroundCallback, Object o) {
+        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback, Object o) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public Pathable<T> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
+        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public Pathable<T> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
+        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public T forPath(String s) throws Exception {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
@@ -730,11 +746,6 @@ public class MockCurator extends Curator {
         public BackgroundPathable<T> usingWatcher(CuratorWatcher curatorWatcher) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
-
-        public T forPath(String path) throws Exception {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
     }
 
     private class MockGetChildrenBuilder extends MockBackgroundPathableBuilder<List<String>> implements GetChildrenBuilder {
@@ -830,6 +841,35 @@ public class MockCurator extends Curator {
             return null;
         }
 
+        @Override
+        public ErrorListenerPathAndBytesable<Stat> inBackground() {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<Stat> inBackground(Object o) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback, Object o) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        @Override
+        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
     }
 
     /** Allows addition of directoryListeners which are never called */
@@ -908,7 +948,7 @@ public class MockCurator extends Curator {
             }
 
             @Override
-            public ACLPathAndBytesable<CuratorTransactionBridge> compressed() {
+            public ACLCreateModePathAndBytesable<CuratorTransactionBridge> compressed() {
                 throw new UnsupportedOperationException("Not implemented in MockCurator");
             }
 
@@ -950,7 +990,7 @@ public class MockCurator extends Curator {
         private class MockTransactionSetDataBuilder implements TransactionSetDataBuilder {
 
             @Override
-            public PathAndBytesable<CuratorTransactionBridge> compressed() {
+            public VersionPathAndBytesable<CuratorTransactionBridge> compressed() {
                 throw new UnsupportedOperationException("Not implemented in MockCurator");
             }
 

--- a/zkfacade/src/main/java/org/apache/curator/framework/api/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/api/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.api;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/api/transaction/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/api/transaction/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.api.transaction;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/listen/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/listen/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.listen;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/atomic/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/atomic/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.recipes.atomic;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/barriers/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/barriers/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.recipes.barriers;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/cache/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/cache/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.recipes.cache;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/locks/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/locks/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.recipes.locks;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/state/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/state/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.framework.state;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/retry/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/retry/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
+@ExportPackage(version = @Version(major = 2, minor = 12, micro = 0))
 package org.apache.curator.retry;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;


### PR DESCRIPTION
When trying to upgrade to 2.10 system tests broke, so prepare for this breaking too. Want to try it on one system test run and revert it immediately.