### PR TITLE
Use new AttributeDirectory in flush targets.

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_directory/attribute_directory_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_directory/attribute_directory_test.cpp
@@ -142,7 +142,10 @@ struct Fixture : public test::DirectoryHandler
         auto dir = createFooAttrDir();
         auto writer = dir->getWriter();
         writer->invalidateOldSnapshots(10);
-        writer->removeInvalidSnapshots(removeDir);
+        writer->removeInvalidSnapshots();
+        if (removeDir) {
+            writer->removeDiskDir();
+        }
         TEST_DO(assertGetAttributeDir("foo", dir));
     }
 
@@ -210,7 +213,7 @@ TEST_F("Test that we can prune attribute snapshots", Fixture)
     TEST_DO(f.assertSnapshots("foo", "v2,v4"));
     dir->getWriter()->invalidateOldSnapshots();
     TEST_DO(f.assertSnapshots("foo", "i2,v4"));
-    dir->getWriter()->removeInvalidSnapshots(false);
+    dir->getWriter()->removeInvalidSnapshots();
     TEST_DO(f.assertSnapshots("foo", "v4"));
 }
 

--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -271,10 +271,8 @@ TEST_F("require that attributes are flushed and loaded", BaseFixture)
         EXPECT_EQUAL(1u, a2->getNumDocs());	// Not resized to size of attributemanager
         fillAttribute(a2, 1, 5, 4, 10);
         EXPECT_EQUAL(5u, a2->getNumDocs());	// Increased
-        EXPECT_TRUE(ia1.load());
-        EXPECT_TRUE(!ia1.getBestSnapshot().valid);
-        EXPECT_TRUE(ia2.load());
-        EXPECT_TRUE(!ia2.getBestSnapshot().valid);
+        EXPECT_TRUE(!ia1.load());
+        EXPECT_TRUE(!ia2.load());
         EXPECT_TRUE(!ia3.load());
         am.flushAll(0);
         EXPECT_TRUE(ia1.load());
@@ -308,8 +306,7 @@ TEST_F("require that attributes are flushed and loaded", BaseFixture)
         EXPECT_EQUAL(10u, ia1.getBestSnapshot().syncToken);
         EXPECT_TRUE(ia2.load());
         EXPECT_EQUAL(10u, ia2.getBestSnapshot().syncToken);
-        EXPECT_TRUE(ia3.load());
-        EXPECT_TRUE(!ia3.getBestSnapshot().valid);
+        EXPECT_TRUE(!ia3.load());
         am.flushAll(0);
         EXPECT_TRUE(ia1.load());
         EXPECT_EQUAL(20u, ia1.getBestSnapshot().syncToken);
@@ -357,8 +354,7 @@ TEST_F("require that predicate attributes are flushed and loaded", BaseFixture)
 
         EXPECT_EQUAL(2u, a1->getNumDocs());
 
-        EXPECT_TRUE(ia1.load());
-        EXPECT_TRUE(!ia1.getBestSnapshot().valid);
+        EXPECT_TRUE(!ia1.load());
         am.flushAll(0);
         EXPECT_TRUE(ia1.load());
         EXPECT_EQUAL(10u, ia1.getBestSnapshot().syncToken);

--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -409,7 +409,7 @@ TEST_F("require that reconfig can add attributes", Fixture)
     newSpec.push_back(AttrSpec("a2", INT32_SINGLE));
     newSpec.push_back(AttrSpec("a3", INT32_SINGLE));
 
-    SequentialAttributeManager sam(f._m, AttrMgrSpec(newSpec, f._m.getNumDocs(), 0));
+    SequentialAttributeManager sam(f._m, AttrMgrSpec(newSpec, f._m.getNumDocs(), 10));
     std::vector<AttributeGuard> list;
     sam.mgr.getAttributeList(list);
     std::sort(list.begin(), list.end(), [](const AttributeGuard & a, const AttributeGuard & b) {
@@ -432,7 +432,7 @@ TEST_F("require that reconfig can remove attributes", Fixture)
     AttrSpecList newSpec;
     newSpec.push_back(AttrSpec("a2", INT32_SINGLE));
 
-    SequentialAttributeManager sam(f._m, AttrMgrSpec(newSpec, 1, 0));
+    SequentialAttributeManager sam(f._m, AttrMgrSpec(newSpec, 1, 10));
     std::vector<AttributeGuard> list;
     sam.mgr.getAttributeList(list);
     EXPECT_EQUAL(1u, list.size());
@@ -471,7 +471,7 @@ TEST_F("require that new attributes after reconfig are initialized", Fixture)
     EXPECT_EQUAL(0u, a3->getStatus().getLastSyncToken());
 }
 
-TEST_F("require that removed attributes can resurrect", BaseFixture)
+TEST_F("require that removed attributes cannot resurrect", BaseFixture)
 {
     proton::AttributeManager::SP am1(
             new proton::AttributeManager(test_dir, "test.subdb",
@@ -499,11 +499,11 @@ TEST_F("require that removed attributes can resurrect", BaseFixture)
     AttributeGuard &ag1(*ag1ap);
     ASSERT_TRUE(ag1.valid());
     EXPECT_EQUAL(5u, ag1->getNumDocs());
-    EXPECT_EQUAL(10, ag1->getInt(1));
-    EXPECT_EQUAL(10, ag1->getInt(2));
+    EXPECT_TRUE(search::attribute::isUndefined<int32_t>(ag1->getInt(1)));
+    EXPECT_TRUE(search::attribute::isUndefined<int32_t>(ag1->getInt(2)));
     EXPECT_TRUE(search::attribute::isUndefined<int32_t>(ag1->getInt(3)));
     EXPECT_TRUE(search::attribute::isUndefined<int32_t>(ag1->getInt(4)));
-    EXPECT_EQUAL(16u, ag1->getStatus().getLastSyncToken());
+    EXPECT_EQUAL(0u, ag1->getStatus().getLastSyncToken());
 }
 
 TEST_F("require that extra attribute is not treated as removed", Fixture)

--- a/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
@@ -359,8 +359,7 @@ Test::requireThatFlushableAttributeManagesSyncTokenInfo()
     IndexMetaInfo info("flush/a3");
     EXPECT_EQUAL(0u, fa->getFlushedSerialNum());
     EXPECT_TRUE(fa->initFlush(0).get() == NULL);
-    EXPECT_TRUE(info.load());
-    EXPECT_EQUAL(0u, info.snapshots().size());
+    EXPECT_TRUE(!info.load());
 
     av->commit(10, 10); // last sync token = 10
     EXPECT_EQUAL(0u, fa->getFlushedSerialNum());
@@ -406,8 +405,10 @@ Test::requireThatCleanUpIsPerformedAfterFlush(void)
     av->commit(30, 30);
 
     // fake up some snapshots
+    std::string base = "flush/a6";
     std::string snap10 = "flush/a6/snapshot-10";
     std::string snap20 = "flush/a6/snapshot-20";
+    vespalib::mkdir(base, false);
     vespalib::mkdir(snap10, false);
     vespalib::mkdir(snap20, false);
     IndexMetaInfo info("flush/a6");

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.cpp
@@ -63,7 +63,7 @@ AttributeDirectory::getDirName() const
     if (_name.empty()) {
         return diskLayout->getBaseDir();
     }
-    return AttributeDiskLayout::getAttributeBaseDir(diskLayout->getBaseDir(), _name);
+    return diskLayout->getBaseDir() + "/" + _name;
 }
 
 SerialNum
@@ -234,6 +234,12 @@ AttributeDirectory::empty() const
 {
     std::unique_lock<std::mutex> guard(_mutex);
     return _snapInfo.snapshots().empty();
+}
+
+vespalib::string
+AttributeDirectory::getAttributeFileName(SerialNum serialNum)
+{
+    return getSnapshotDir(serialNum) + "/" + _name;
 }
 
 AttributeDirectory::Writer::Writer(AttributeDirectory &dir)

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.cpp
@@ -60,6 +60,9 @@ AttributeDirectory::getDirName() const
         diskLayout = _diskLayout.lock();
     }
     assert(diskLayout);
+    if (_name.empty()) {
+        return diskLayout->getBaseDir();
+    }
     return AttributeDiskLayout::getAttributeBaseDir(diskLayout->getBaseDir(), _name);
 }
 
@@ -98,10 +101,8 @@ AttributeDirectory::saveSnapInfo()
 vespalib::string
 AttributeDirectory::getSnapshotDir(search::SerialNum serialNum)
 {
-    auto snap = _snapInfo.getSnapshot(serialNum);
-    assert(snap.syncToken == serialNum);
     vespalib::string dirName(getDirName());
-    return dirName + "/" + snap.dirName;
+    return dirName + "/" + getSnapshotDirComponent(serialNum);
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.cpp
@@ -163,8 +163,8 @@ AttributeDirectory::invalidateOldSnapshots()
     }
 }
 
-bool
-AttributeDirectory::removeInvalidSnapshots(bool removeDir)
+void
+AttributeDirectory::removeInvalidSnapshots()
 {
     std::vector<SerialNum> toRemove;
     auto &list = _snapInfo.snapshots();
@@ -186,7 +186,12 @@ AttributeDirectory::removeInvalidSnapshots(bool removeDir)
         }
         saveSnapInfo();
     }
-    if (empty() && removeDir) {
+}
+
+bool
+AttributeDirectory::removeDiskDir()
+{
+    if (empty()) {
         vespalib::string dirName(getDirName());
         vespalib::rmdir(dirName, true);
         return true;

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.h
@@ -42,7 +42,6 @@ private:
     bool removeInvalidSnapshots(bool removeDir);
     void detach();
     vespalib::string getDirName() const;
-    bool empty() const;
 
 public:
     AttributeDirectory(const std::shared_ptr<AttributeDiskLayout> &diskLayout,
@@ -78,6 +77,8 @@ public:
     std::unique_ptr<Writer> tryGetWriter();
     SerialNum getFlushedSerialNum() const;
     fastos::TimeStamp getLastFlushTime() const;
+    bool empty() const;
+    vespalib::string getAttributeFileName(SerialNum serialNum);
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_directory.h
@@ -39,7 +39,8 @@ private:
     void markValidSnapshot(SerialNum serialNum);
     void invalidateOldSnapshots(SerialNum serialNum);
     void invalidateOldSnapshots();
-    bool removeInvalidSnapshots(bool removeDir);
+    void removeInvalidSnapshots();
+    bool removeDiskDir();
     void detach();
     vespalib::string getDirName() const;
 
@@ -69,7 +70,8 @@ public:
         // methods called while pruning old snapshots or removing attribute
         void invalidateOldSnapshots(SerialNum serialNum) { _dir.invalidateOldSnapshots(serialNum); }
         void invalidateOldSnapshots() { _dir.invalidateOldSnapshots(); }
-        bool removeInvalidSnapshots(bool removeDir) { return _dir.removeInvalidSnapshots(removeDir); }
+        void removeInvalidSnapshots() { _dir.removeInvalidSnapshots(); }
+        bool removeDiskDir() { return _dir.removeDiskDir(); }
         void detach() { _dir.detach(); }
     };
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_initializer.h
@@ -4,10 +4,12 @@
 
 #include "i_attribute_factory.h"
 #include <vespa/searchlib/attribute/attributevector.h>
-#include <vespa/searchlib/common/indexmetainfo.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/searchlib/common/serialnum.h>
 
 namespace proton {
+
+class AttributeDirectory;
 
 /**
  * Class used by an attribute manager to initialize and load attribute vectors from disk.
@@ -28,28 +30,26 @@ public:
     };
 
 private:
-    const vespalib::string          _baseDir;
+    std::shared_ptr<AttributeDirectory> _attrDir;
     const vespalib::string          _documentSubDbName;
-    const vespalib::string          _attrName;
     const search::attribute::Config _cfg;
     const uint64_t                  _currentSerialNum;
     const IAttributeFactory        &_factory;
 
-    search::AttributeVector::SP tryLoadAttribute(const search::IndexMetaInfo &info) const;
+    search::AttributeVector::SP tryLoadAttribute() const;
 
     bool loadAttribute(const search::AttributeVector::SP &attr,
-                       const search::IndexMetaInfo::Snapshot &snap) const;
+                       search::SerialNum serialNum) const;
 
     void setupEmptyAttribute(search::AttributeVector::SP &attr,
-                             const search::IndexMetaInfo::Snapshot &snap,
+                             search::SerialNum serialNum,
                              const AttributeHeader &header) const;
 
-    search::AttributeVector::SP createAndSetupEmptyAttribute(search::IndexMetaInfo &info) const;
+    search::AttributeVector::SP createAndSetupEmptyAttribute() const;
 
 public:
-    AttributeInitializer(const vespalib::string &baseDir,
+    AttributeInitializer(const std::shared_ptr<AttributeDirectory> &attrDir,
                          const vespalib::string &documentSubDbName,
-                         const vespalib::string &attrName,
                          const search::attribute::Config &cfg,
                          uint64_t currentSerialNum,
                          const IAttributeFactory &factory);

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
@@ -4,14 +4,8 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.attribute.attributedisklayout");
 #include "attributedisklayout.h"
-#include <vespa/searchcommon/common/schemaconfigurer.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include "attribute_directory.h"
-
-using search::IndexMetaInfo;
-using search::index::SchemaBuilder;
-using search::index::Schema;
-using search::AttributeVector;
 
 namespace proton
 {

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
@@ -16,6 +16,16 @@ using search::AttributeVector;
 namespace proton
 {
 
+namespace {
+
+vespalib::string
+getSnapshotDir(uint64_t syncToken)
+{
+    return vespalib::make_string("snapshot-%" PRIu64, syncToken);
+}
+
+}
+
 AttributeDiskLayout::AttributeDiskLayout(const vespalib::string &baseDir, PrivateConstructorTag)
     : _baseDir(baseDir),
       _mutex(),
@@ -31,24 +41,6 @@ void
 AttributeDiskLayout::createBaseDir()
 {
     vespalib::mkdir(_baseDir, false);
-}
-
-vespalib::string
-AttributeDiskLayout::getSnapshotDir(uint64_t syncToken)
-{
-    return vespalib::make_string("snapshot-%" PRIu64, syncToken);
-}
-
-vespalib::string
-AttributeDiskLayout::getSnapshotRemoveDir(const vespalib::string &baseDir,
-                                          const vespalib::string &snapDir)
-{
-    if (baseDir.empty()) {
-        return snapDir;
-    }
-    return vespalib::make_string("%s/%s",
-                                 baseDir.c_str(),
-                                 snapDir.c_str());
 }
 
 vespalib::string
@@ -73,139 +65,13 @@ AttributeDiskLayout::getAttributeFileName(const vespalib::string &baseDir,
                                      attrName);
 }
 
-bool
-AttributeDiskLayout::removeOldSnapshots(IndexMetaInfo &snapInfo,
-                                        vespalib::Lock &snapInfoLock)
-{
-    IndexMetaInfo::Snapshot best = snapInfo.getBestSnapshot();
-    if (!best.valid) {
-        return true;
-    }
-    std::vector<IndexMetaInfo::Snapshot> toRemove;
-    const IndexMetaInfo::SnapshotList & list = snapInfo.snapshots();
-    for (const auto &snap : list) {
-        if (!(snap == best)) {
-            toRemove.push_back(snap);
-        }
-    }
-    LOG(debug,
-        "About to remove %zu old snapshots. "
-        "Will keep best snapshot with sync token %" PRIu64,
-        toRemove.size(),
-        best.syncToken);
-    for (const auto &snap : toRemove) {
-        if (snap.valid) {
-            {
-                vespalib::LockGuard guard(snapInfoLock);
-                snapInfo.invalidateSnapshot(snap.syncToken);
-            }
-            if (!snapInfo.save()) {
-                LOG(warning,
-                    "Could not save meta info file in directory '%s' after "
-                    "invalidating snapshot with sync token %" PRIu64,
-                    snapInfo.getPath().c_str(),
-                    snap.syncToken);
-                return false;
-            }
-        }
-        vespalib::string rmDir =
-            getSnapshotRemoveDir(snapInfo.getPath(), snap.dirName);
-        FastOS_StatInfo statInfo;
-        if (!FastOS_File::Stat(rmDir.c_str(), &statInfo) &&
-            statInfo._error == FastOS_StatInfo::FileNotFound)
-        {
-            // Directory already removed
-        } else {
-            FastOS_FileInterface:: EmptyAndRemoveDirectory(rmDir.c_str());
-#if 0
-            LOG(warning,
-                "Could not remove snapshot directory '%s'",
-                rmDir.c_str());
-            return false;
-#endif
-        }
-        {
-            vespalib::LockGuard guard(snapInfoLock);
-            snapInfo.removeSnapshot(snap.syncToken);
-        }
-        if (!snapInfo.save()) {
-            LOG(warning,
-                "Could not save meta info file in directory '%s' after "
-                "removing snapshot with sync token %" PRIu64,
-                snapInfo.getPath().c_str(), snap.syncToken);
-            return false;
-        }
-        LOG(debug, "Removed snapshot directory '%s'", rmDir.c_str());
-    }
-    return true;
-}
-
-bool
-AttributeDiskLayout::removeAttribute(const vespalib::string &baseDir,
-                                     const vespalib::string &attrName,
-                                     uint64_t wipeSerial)
-{
-    const vespalib::string currDir = getAttributeBaseDir(baseDir, attrName);
-    search::IndexMetaInfo snapInfo(currDir);
-    IndexMetaInfo::Snapshot best = snapInfo.getBestSnapshot();
-    if (best.valid && best.syncToken >= wipeSerial) {
-        return true; // Attribute has been resurrected and flushed later on
-    }
-    const vespalib::string rmDir =
-        getAttributeBaseDir(baseDir,
-                            vespalib::make_string("remove.%s",
-                                    attrName.c_str()));
-
-    FastOS_StatInfo statInfo;
-    if (FastOS_File::Stat(rmDir.c_str(), &statInfo) && statInfo._isDirectory) {
-        FastOS_FileInterface::EmptyAndRemoveDirectory(rmDir.c_str());
-#if 0
-        if (!FastOS_FileInterface::EmptyAndRemoveDirectory(rmDir.c_str())) {
-            LOG(warning,
-                "Could not remove attribute directory '%s'",
-                rmDir.c_str());
-            return false;
-        }
-#endif
-    }
-    if (!FastOS_File::Stat(currDir.c_str(), &statInfo) &&
-        statInfo._error == FastOS_StatInfo::FileNotFound)
-    {
-        // Directory already removed
-        return true;
-    }
-    if (!FastOS_FileInterface::MoveFile(currDir.c_str(), rmDir.c_str())) {
-        LOG(warning,
-            "Could not move attribute directory '%s' to '%s'",
-            currDir.c_str(),
-            rmDir.c_str());
-        return false;
-    }
-    FastOS_FileInterface::EmptyAndRemoveDirectory(rmDir.c_str());
-#if 0
-    if (!FastOS_FileInterface::EmptyAndRemoveDirectory(rmDir.c_str())) {
-        LOG(warning,
-            "Could not remove attribute directory '%s'",
-            rmDir.c_str());
-        return false;
-    }
-#endif
-    return true;
-}
-
 std::vector<vespalib::string>
-AttributeDiskLayout::listAttributes(const vespalib::string &baseDir)
+AttributeDiskLayout::listAttributes()
 {
     std::vector<vespalib::string> attributes;
-    FastOS_DirectoryScan dir(baseDir.c_str());
-    while (dir.ReadNext()) {
-        if (strcmp(dir.GetName(), "..") != 0 &&
-            strcmp(dir.GetName(), ".") != 0)
-        {
-            if (dir.IsDirectory()) {
-                attributes.emplace_back(dir.GetName());
-            }
-        }
+    std::shared_lock<std::shared_timed_mutex> guard(_mutex);
+    for (const auto &dir : _dirs)  {
+        attributes.emplace_back(dir.first);
     }
     return attributes;
 }
@@ -281,6 +147,13 @@ AttributeDiskLayout::create(const vespalib::string &baseDir)
 {
     auto diskLayout = std::make_shared<AttributeDiskLayout>(baseDir, PrivateConstructorTag());
     diskLayout->scanDir();
+    return diskLayout;
+}
+
+std::shared_ptr<AttributeDiskLayout>
+AttributeDiskLayout::createSimple(const vespalib::string &baseDir)
+{
+    auto diskLayout = std::make_shared<AttributeDiskLayout>(baseDir, PrivateConstructorTag());
     return diskLayout;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
@@ -81,7 +81,8 @@ AttributeDiskLayout::removeAttributeDir(const vespalib::string &name, search::Se
         auto writer = dir->getWriter();
         if (writer) {
             writer->invalidateOldSnapshots(serialNum);
-            if (writer->removeInvalidSnapshots(true)) {
+            writer->removeInvalidSnapshots();
+            if (writer->removeDiskDir()) {
                 std::unique_lock<std::shared_timed_mutex> guard(_mutex);
                 auto itr = _dirs.find(name);
                 assert(itr != _dirs.end());

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
@@ -15,16 +15,11 @@ AttributeDiskLayout::AttributeDiskLayout(const vespalib::string &baseDir, Privat
       _mutex(),
       _dirs()
 {
+    vespalib::mkdir(_baseDir, false);
 }
 
 AttributeDiskLayout::~AttributeDiskLayout()
 {
-}
-
-void
-AttributeDiskLayout::createBaseDir()
-{
-    vespalib::mkdir(_baseDir, false);
 }
 
 std::vector<vespalib::string>

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.cpp
@@ -16,16 +16,6 @@ using search::AttributeVector;
 namespace proton
 {
 
-namespace {
-
-vespalib::string
-getSnapshotDir(uint64_t syncToken)
-{
-    return vespalib::make_string("snapshot-%" PRIu64, syncToken);
-}
-
-}
-
 AttributeDiskLayout::AttributeDiskLayout(const vespalib::string &baseDir, PrivateConstructorTag)
     : _baseDir(baseDir),
       _mutex(),
@@ -41,28 +31,6 @@ void
 AttributeDiskLayout::createBaseDir()
 {
     vespalib::mkdir(_baseDir, false);
-}
-
-vespalib::string
-AttributeDiskLayout::getAttributeBaseDir(const vespalib::string &baseDir,
-                                         const vespalib::string &attrName)
-{
-    if (baseDir.empty()) {
-        return attrName;
-    }
-    return vespalib::make_string("%s/%s",
-                                 baseDir.c_str(),
-                                 attrName.c_str());
-}
-
-AttributeVector::BaseName
-AttributeDiskLayout::getAttributeFileName(const vespalib::string &baseDir,
-                                          const vespalib::string &attrName,
-                                          uint64_t syncToken)
-{
-    return AttributeVector::BaseName(getAttributeBaseDir(baseDir, attrName),
-                                     getSnapshotDir(syncToken),
-                                     attrName);
 }
 
 std::vector<vespalib::string>

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
@@ -29,8 +29,6 @@ private:
 public:
     explicit AttributeDiskLayout(const vespalib::string &baseDir, PrivateConstructorTag tag);
     ~AttributeDiskLayout();
-    static vespalib::string  getAttributeBaseDir(const vespalib::string &baseDir, const vespalib::string &attrName);
-    static search::AttributeVector::BaseName getAttributeFileName(const vespalib::string &baseDir, const vespalib::string &attrName, uint64_t syncToken);
     std::vector<vespalib::string> listAttributes();
     const vespalib::string &getBaseDir() const { return _baseDir; }
     void createBaseDir();

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
@@ -24,9 +24,6 @@ private:
     mutable std::shared_timed_mutex _mutex;
     std::map<vespalib::string, std::shared_ptr<AttributeDirectory>> _dirs;
 
-    static vespalib::string getSnapshotDir(uint64_t syncToken);
-    static vespalib::string getSnapshotRemoveDir(const vespalib::string &baseDir, const vespalib::string &snapDir);
-
     void scanDir();
     struct PrivateConstructorTag { };
 public:
@@ -34,15 +31,14 @@ public:
     ~AttributeDiskLayout();
     static vespalib::string  getAttributeBaseDir(const vespalib::string &baseDir, const vespalib::string &attrName);
     static search::AttributeVector::BaseName getAttributeFileName(const vespalib::string &baseDir, const vespalib::string &attrName, uint64_t syncToken);
-    static bool removeOldSnapshots(search::IndexMetaInfo &snapInfo, vespalib::Lock &snapInfoLock);
-    static bool removeAttribute(const vespalib::string &baseDir, const vespalib::string &attrName, uint64_t wipeSerial);
-    static std::vector<vespalib::string> listAttributes(const vespalib::string &baseDir);
+    std::vector<vespalib::string> listAttributes();
     const vespalib::string &getBaseDir() const { return _baseDir; }
     void createBaseDir();
     std::shared_ptr<AttributeDirectory> getAttributeDir(const vespalib::string &name);
     std::shared_ptr<AttributeDirectory> createAttributeDir(const vespalib::string &name);
     void removeAttributeDir(const vespalib::string &name, search::SerialNum serialNum);
     static std::shared_ptr<AttributeDiskLayout> create(const vespalib::string &baseDir);
+    static std::shared_ptr<AttributeDiskLayout> createSimple(const vespalib::string &baseDir);
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
@@ -2,14 +2,12 @@
 
 #pragma once
 
-#include <vespa/searchlib/attribute/attributevector.h>
 #include <vespa/searchlib/common/serialnum.h>
-#include <vespa/searchlib/common/indexmetainfo.h>
-#include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/searchcommon/common/schema.h>
+#include <vespa/vespalib/stllike/string.h>
 #include <mutex>
 #include <shared_mutex>
 #include <map>
+#include <vector>
 
 namespace proton {
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributedisklayout.h
@@ -29,7 +29,6 @@ public:
     ~AttributeDiskLayout();
     std::vector<vespalib::string> listAttributes();
     const vespalib::string &getBaseDir() const { return _baseDir; }
-    void createBaseDir();
     std::shared_ptr<AttributeDirectory> getAttributeDir(const vespalib::string &name);
     std::shared_ptr<AttributeDirectory> createAttributeDir(const vespalib::string &name);
     void removeAttributeDir(const vespalib::string &name, search::SerialNum serialNum);

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -97,28 +97,6 @@ AttributeManager::transferExistingAttributes(const AttributeManager &currMgr,
 }
 
 void
-AttributeManager::flushRemovedAttributes(const AttributeManager &currMgr,
-                                         const Spec &newSpec)
-{
-    for (const auto &kv : currMgr._attributes) {
-        if (!newSpec.hasAttribute(kv.first) &&
-            !kv.second.isExtra() &&
-            kv.second->getStatus().getLastSyncToken() <
-            newSpec.getCurrentSerialNum() - 1) {
-            FlushableAttribute::SP flushable =
-                currMgr.findFlushable(kv.first);
-            vespalib::Executor::Task::UP flushTask =
-                flushable->initFlush(newSpec.getCurrentSerialNum() - 1);
-            if (flushTask.get() != NULL) {
-                LOG(debug, "Flushing removed attribute vector '%s' with %u docs and serial number %lu",
-                           kv.first.c_str(), kv.second->getNumDocs(), kv.second->getStatus().getLastSyncToken());
-                flushTask->run();
-            }
-        }
-    }
-}
-
-void
 AttributeManager::addNewAttributes(const Spec &newSpec,
                                    const Spec::AttributeList &toBeAdded,
                                    IAttributeInitializerRegistry &initializerRegistry)
@@ -223,7 +201,6 @@ AttributeManager::AttributeManager(const AttributeManager &currMgr,
 {
     Spec::AttributeList toBeAdded;
     transferExistingAttributes(currMgr, newSpec, toBeAdded);
-    flushRemovedAttributes(currMgr, newSpec);
     addNewAttributes(newSpec, toBeAdded, initializerRegistry);
     transferExtraAttributes(currMgr);
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -177,7 +177,6 @@ AttributeManager::AttributeManager(const vespalib::string &baseDir,
       _hwInfo(hwInfo),
       _importedAttributes()
 {
-    _diskLayout->createBaseDir();
 }
 
 
@@ -203,7 +202,6 @@ AttributeManager::AttributeManager(const vespalib::string &baseDir,
       _hwInfo(hwInfo),
       _importedAttributes()
 {
-    _diskLayout->createBaseDir();
 }
 
 AttributeManager::AttributeManager(const AttributeManager &currMgr,

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -36,7 +36,7 @@ AttributeManager::internalAddAttribute(const vespalib::string &name,
                                        uint64_t serialNum,
                                        const IAttributeFactory &factory)
 {
-    AttributeInitializer initializer(_diskLayout->getBaseDir(), _documentSubDbName, name, cfg, serialNum, factory);
+    AttributeInitializer initializer(_diskLayout->createAttributeDir(name), _documentSubDbName, cfg, serialNum, factory);
     AttributeVector::SP attr = initializer.init();
     if (attr.get() != NULL) {
         attr->setInterlock(_interlock);
@@ -128,7 +128,7 @@ AttributeManager::addNewAttributes(const Spec &newSpec,
                    aspec.getName().c_str(), newSpec.getDocIdLimit(), newSpec.getCurrentSerialNum());
 
         AttributeInitializer::UP initializer =
-                std::make_unique<AttributeInitializer>(_diskLayout->getBaseDir(), _documentSubDbName, aspec.getName(),
+            std::make_unique<AttributeInitializer>(_diskLayout->createAttributeDir(aspec.getName()), _documentSubDbName,
                         aspec.getConfig(), newSpec.getCurrentSerialNum(), *_factory);
         initializerRegistry.add(std::move(initializer));
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
@@ -84,9 +84,6 @@ private:
                                     const Spec &newSpec,
                                     Spec::AttributeList &toBeAdded);
 
-    void flushRemovedAttributes(const AttributeManager &currMgr,
-                                const Spec &newSpec);
-
     void addNewAttributes(const Spec &newSpec,
                           const Spec::AttributeList &toBeAdded,
                           IAttributeInitializerRegistry &initializerRegistry);

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -135,7 +135,7 @@ FlushableAttribute::Flusher::cleanUp(AttributeDirectory::Writer &writer)
 {
     if (_fattr._cleanUpAfterFlush) {
         writer.invalidateOldSnapshots();
-        writer.removeInvalidSnapshots(false);
+        writer.removeInvalidSnapshots();
     }
     return true;
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -143,7 +143,7 @@ FlushableAttribute::Flusher::cleanUp(AttributeDirectory::Writer &writer)
 void
 FlushableAttribute::Flusher::run()
 {
-    auto writer = _fattr._attrDir->getWriter();
+    auto writer = _fattr._attrDir->tryGetWriter();
     if (!writer || _syncToken <= _fattr.getFlushedSerialNum()) {
         // another flusher has created an equal or better snapshot
         // after this flusher was created

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -12,6 +12,7 @@
 #include <vespa/searchlib/common/serialnumfileheadercontext.h>
 #include <vespa/searchlib/common/isequencedtaskexecutor.h>
 #include <future>
+#include "attribute_directory.h"
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.attribute.flushableattribute");
@@ -25,7 +26,37 @@ using vespalib::makeClosure;
 
 namespace proton {
 
-FlushableAttribute::Flusher::Flusher(FlushableAttribute & fattr, SerialNum syncToken)
+/**
+ * Task performing the actual flushing to disk.
+ **/
+class FlushableAttribute::Flusher : public Task {
+private:
+    FlushableAttribute              & _fattr;
+    search::AttributeMemorySaveTarget      _saveTarget;
+    std::unique_ptr<search::AttributeSaver> _saver;
+    uint64_t                          _syncToken;
+    search::AttributeVector::BaseName _flushFile;
+
+    bool saveAttribute(); // not updating snap info.
+public:
+    Flusher(FlushableAttribute & fattr, uint64_t syncToken, AttributeDirectory::Writer &writer);
+    ~Flusher();
+    uint64_t getSyncToken() const { return _syncToken; }
+    bool flush(AttributeDirectory::Writer &writer);
+    void updateStats();
+    bool cleanUp(AttributeDirectory::Writer &writer);
+    // Implements vespalib::Executor::Task
+    virtual void run();
+
+    virtual SerialNum
+    getFlushSerial(void) const
+    {
+        return _syncToken;
+    }
+};
+
+
+FlushableAttribute::Flusher::Flusher(FlushableAttribute & fattr, SerialNum syncToken, AttributeDirectory::Writer &writer)
     : _fattr(fattr),
       _saveTarget(),
       _saver(),
@@ -38,9 +69,7 @@ FlushableAttribute::Flusher::Flusher(FlushableAttribute & fattr, SerialNum syncT
     if (attr.canShrinkLidSpace()) {
         attr.shrinkLidSpace();
     }
-    _flushFile = AttributeDiskLayout::getAttributeFileName(_fattr._baseDir,
-                                                           attr.getName(),
-                                                           _syncToken);
+    _flushFile = writer.getSnapshotDir(_syncToken) + "/" + attr.getName();
     attr.setBaseFileName(_flushFile);
     _saver = attr.initSave();
     if (!_saver) {
@@ -52,18 +81,6 @@ FlushableAttribute::Flusher::Flusher(FlushableAttribute & fattr, SerialNum syncT
 FlushableAttribute::Flusher::~Flusher()
 {
     // empty
-}
-
-bool
-FlushableAttribute::Flusher::saveSnapInfo()
-{
-    if (!_fattr._snapInfo.save()) {
-        LOG(warning,
-            "Could not save meta-info file for attribute vector '%s' to disk",
-            _fattr._attr->getBaseFileName().c_str());
-        return false;
-    }
-    return true;
 }
 
 bool
@@ -93,31 +110,16 @@ FlushableAttribute::Flusher::saveAttribute()
 }
 
 bool
-FlushableAttribute::Flusher::flush()
+FlushableAttribute::Flusher::flush(AttributeDirectory::Writer &writer)
 {
-    IndexMetaInfo::Snapshot newSnap(false, _syncToken,
-                                    _flushFile.getSnapshotName());
-    {
-        vespalib::LockGuard guard(_fattr._snapInfoLock);
-        _fattr._snapInfo.addSnapshot(newSnap);
-    }
-    if (!saveSnapInfo()) {
-        return false;
-    }
+    writer.createInvalidSnapshot(_syncToken);
     if (!saveAttribute()) {
         LOG(warning, "Could not write attribute vector '%s' to disk",
             _flushFile.c_str());
         return false;
     }
-    {
-        vespalib::LockGuard guard(_fattr._snapInfoLock);
-        _fattr._snapInfo.validateSnapshot(_syncToken);
-    }
-    if (!saveSnapInfo()) {
-        return false;
-    }
-    _fattr._lastFlushTime =
-        search::FileKit::getModificationTime(_flushFile.getDirName());
+    writer.markValidSnapshot(_syncToken);
+    writer.setLastFlushTime(search::FileKit::getModificationTime(_flushFile.getDirName()));
     return true;
 }
 
@@ -128,17 +130,11 @@ FlushableAttribute::Flusher::updateStats()
 }
 
 bool
-FlushableAttribute::Flusher::cleanUp()
+FlushableAttribute::Flusher::cleanUp(AttributeDirectory::Writer &writer)
 {
     if (_fattr._cleanUpAfterFlush) {
-        if (!AttributeDiskLayout::removeOldSnapshots(_fattr._snapInfo,
-                    _fattr._snapInfoLock)) {
-            LOG(warning,
-                "Encountered problems when removing old snapshot directories"
-                "after flushing attribute vector '%s' to disk",
-                _fattr._attr->getBaseFileName().c_str());
-            return false;
-        }
+        writer.invalidateOldSnapshots();
+        writer.removeInvalidSnapshots(false);
     }
     return true;
 }
@@ -146,23 +142,23 @@ FlushableAttribute::Flusher::cleanUp()
 void
 FlushableAttribute::Flusher::run()
 {
-    vespalib::LockGuard guard(_fattr._flusherLock);
-    if (_syncToken <= _fattr.getFlushedSerialNum()) {
+    auto writer = _fattr._attrDir->getWriter();
+    if (!writer || _syncToken <= _fattr.getFlushedSerialNum()) {
         // another flusher has created an equal or better snapshot
         // after this flusher was created
         return;
     }
-    if (!flush()) {
+    if (!flush(*writer)) {
         // TODO (geirst): throw exception ?
     }
     updateStats();
-    if (!cleanUp()) {
+    if (!cleanUp(*writer)) {
         // TODO (geirst): throw exception ?
     }
 }
 
 FlushableAttribute::FlushableAttribute(const AttributeVector::SP attr,
-                                       const vespalib::string & baseDir,
+                                       const std::shared_ptr<AttributeDirectory> &attrDir,
                                        const TuneFileAttributes &
                                        tuneFileAttributes,
                                        const FileHeaderContext &
@@ -175,28 +171,14 @@ FlushableAttribute::FlushableAttribute(const AttributeVector::SP attr,
                            attr->getName().c_str()),
             Type::SYNC, Component::ATTRIBUTE),
       _attr(attr),
-      _baseDir(baseDir),
-      _snapInfo(AttributeDiskLayout::getAttributeBaseDir(baseDir,
-                        attr->getName())),
-      _snapInfoLock(),
-      _flusherLock(),
       _cleanUpAfterFlush(true),
       _lastStats(),
       _tuneFileAttributes(tuneFileAttributes),
       _fileHeaderContext(fileHeaderContext),
-      _lastFlushTime(),
       _attributeFieldWriter(attributeFieldWriter),
-      _hwInfo(hwInfo)
+      _hwInfo(hwInfo),
+      _attrDir(attrDir)
 {
-    if (!_snapInfo.load()) {
-        _snapInfo.save();
-    } else {
-        vespalib::string dirName =
-            AttributeDiskLayout::getAttributeFileName(_baseDir,
-                    _attr->getName(),
-                    getFlushedSerialNum()).getDirName();
-        _lastFlushTime = search::FileKit::getModificationTime(dirName);
-    }
     _lastStats.setPathElementsToLog(8);
 }
 
@@ -209,9 +191,7 @@ FlushableAttribute::~FlushableAttribute()
 IFlushTarget::SerialNum
 FlushableAttribute::getFlushedSerialNum() const
 {
-    vespalib::LockGuard guard(_snapInfoLock);
-    IndexMetaInfo::Snapshot bestSnap = _snapInfo.getBestSnapshot();
-    return bestSnap.valid ? bestSnap.syncToken : 0;
+    return _attrDir->getFlushedSerialNum();
 }
 
 IFlushTarget::MemoryGain
@@ -253,34 +233,36 @@ FlushableAttribute::getApproxDiskGain() const
 IFlushTarget::Time
 FlushableAttribute::getLastFlushTime() const
 {
-    return _lastFlushTime;
+    return _attrDir->getLastFlushTime();
 }
 
 IFlushTarget::Task::UP
 FlushableAttribute::internalInitFlush(SerialNum currentSerial)
 {
-    // Called by document db executor
-    (void)currentSerial;
+    // Called by attribute field writer thread while document db executor waits
     _attr->removeAllOldGenerations();
-    SerialNum syncToken = currentSerial;
-    syncToken = std::max(currentSerial,
-                         _attr->getStatus().getLastSyncToken());
+    SerialNum syncToken = std::max(currentSerial,
+                                   _attr->getStatus().getLastSyncToken());
+    auto writer = _attrDir->tryGetWriter();
+    if (!writer) {
+        return Task::UP();
+    }
     if (syncToken <= getFlushedSerialNum()) {
-        vespalib::LockGuard guard(_flusherLock);
-        _lastFlushTime = fastos::ClockSystem::now();
+        writer->setLastFlushTime(fastos::ClockSystem::now());
         LOG(debug,
             "No attribute vector to flush."
             " Update flush time to current: lastFlushTime(%f)",
-            _lastFlushTime.sec());
+            getLastFlushTime().sec());
         return Task::UP();
     }
-    return Task::UP(new Flusher(*this, syncToken));
+    return Task::UP(new Flusher(*this, syncToken, *writer));
 }
 
 
 IFlushTarget::Task::UP
 FlushableAttribute::initFlush(SerialNum currentSerial)
 {
+    // Called by document db executor
     std::promise<IFlushTarget::Task::UP> promise;
     std::future<IFlushTarget::Task::UP> future = promise.get_future();
     _attributeFieldWriter.execute(_attr->getName(),

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -13,6 +13,7 @@
 #include <vespa/searchlib/common/isequencedtaskexecutor.h>
 #include <future>
 #include "attribute_directory.h"
+#include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.attribute.flushableattribute");

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
@@ -151,7 +151,7 @@ DocumentMetaStoreFlushTarget::Flusher::cleanUp(AttributeDirectory::Writer &write
 void
 DocumentMetaStoreFlushTarget::Flusher::run()
 {
-    auto writer = _dmsft._dmsDir->getWriter();
+    auto writer = _dmsft._dmsDir->tryGetWriter();
     if (!writer || _syncToken <= _dmsft.getFlushedSerialNum()) {
         // another flusher has created an equal or better snapshot
         // after this flusher was created

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
@@ -143,7 +143,7 @@ DocumentMetaStoreFlushTarget::Flusher::cleanUp(AttributeDirectory::Writer &write
 {
     if (_dmsft._cleanUpAfterFlush) {
         writer.invalidateOldSnapshots();
-        writer.removeInvalidSnapshots(false);
+        writer.removeInvalidSnapshots();
     }
     return true;
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.h
@@ -25,6 +25,8 @@ namespace proton
 {
 
 class ITlsSyncer;
+class AttributeDiskLayout;
+class AttributeDirectory;
 
 using searchcorespi::FlushStats;
 using searchcorespi::IFlushTarget;
@@ -38,50 +40,18 @@ private:
     /**
      * Task performing the actual flushing to disk.
      **/
-    class Flusher : public Task {
-    private:
-        DocumentMetaStoreFlushTarget     &_dmsft;
-        std::unique_ptr<search::AttributeSaver> _saver;
-        uint64_t                          _syncToken;
-        vespalib::string                  _flushDir;
-
-        bool saveDocumentMetaStore(); // not updating snap info.
-    public:
-        Flusher(DocumentMetaStoreFlushTarget &dmsft, uint64_t syncToken);
-        ~Flusher();
-        uint64_t getSyncToken() const { return _syncToken; }
-        bool saveSnapInfo();
-        bool flush();
-        void updateStats();
-        bool cleanUp();
-        // Implements vespalib::Executor::Task
-        virtual void run();
-
-        virtual SerialNum
-        getFlushSerial(void) const
-        {
-            return _syncToken;
-        }
-    };
+    class Flusher;
 
     DocumentMetaStore::SP       _dms;
     ITlsSyncer                 &_tlsSyncer;
     vespalib::string            _baseDir;
-    search::IndexMetaInfo       _snapInfo;
-    vespalib::Lock		_snapInfoLock;
-    vespalib::Lock              _flusherLock;
     bool                        _cleanUpAfterFlush;
     FlushStats                  _lastStats;
     const search::TuneFileAttributes _tuneFileAttributes;
     const search::common::FileHeaderContext &_fileHeaderContext;
-    fastos::TimeStamp           _lastFlushTime;
     HwInfo                      _hwInfo;
-    
-    static vespalib::string
-    getSnapshotName(uint64_t syncToken);
-
-    vespalib::string
-    getSnapshotDir(uint64_t syncToken);
+    std::shared_ptr<AttributeDiskLayout> _diskLayout;
+    std::shared_ptr<AttributeDirectory> _dmsDir;
 
 public:
     typedef std::shared_ptr<DocumentMetaStoreFlushTarget> SP;


### PR DESCRIPTION
Remove old methods for pruning old snapshots/removing attributes.

@geirst, please review
