### PR TITLE
Use list of all managed containers in ACL maintainer

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -66,7 +66,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
         Optional<StorageMaintainer> storageMaintainer = isRunningLocally ?
                 Optional.empty() : Optional.of(new StorageMaintainer(docker, metricReceiver, environment));
         Optional<AclMaintainer> aclMaintainer = isRunningLocally ?
-                Optional.empty() : Optional.of(new AclMaintainer(dockerOperations, nodeRepository));
+                Optional.empty() : Optional.of(new AclMaintainer(dockerOperations, nodeRepository, baseHostName));
 
         Function<String, NodeAgent> nodeAgentFactory =
                 (hostName) -> new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,


### PR DESCRIPTION
Join list of all running containers with the list of all `ContainerAclSpec`s instead of asking docker daemon for every container in `ContainerAclSpec` list.