### PR TITLE
Made OrcherstratorException unchecked

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorException.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorException.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.orchestrator;
 
 @SuppressWarnings("serial")
-public class OrchestratorException extends Exception {
+public class OrchestratorException extends RuntimeException {
     public OrchestratorException(String message) {
         super(message);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/Environment.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/Environment.java
@@ -231,7 +231,7 @@ public class Environment {
             return this;
         }
 
-        public Builder athensDomain(String region) {
+        public Builder athensDomain(String athensDomain) {
             this.athensDomain = athensDomain;
             return this;
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -301,7 +301,7 @@ public class NodeAgentImplTest {
                         .withVespaVersion(vespaVersion));
     }
 
-    private void nodeRunningContainerIsTakenDownAndCleanedAndRecycled(Node.State nodeState, Optional<Long> wantedRestartGeneration) throws Exception {
+    private void nodeRunningContainerIsTakenDownAndCleanedAndRecycled(Node.State nodeState, Optional<Long> wantedRestartGeneration) {
         wantedRestartGeneration.ifPresent(restartGeneration -> nodeSpecBuilder
                 .wantedRestartGeneration(restartGeneration)
                 .currentRestartGeneration(restartGeneration));
@@ -336,12 +336,12 @@ public class NodeAgentImplTest {
     }
 
     @Test
-    public void dirtyNodeRunningContainerIsTakenDownAndCleanedAndRecycled() throws Exception {
+    public void dirtyNodeRunningContainerIsTakenDownAndCleanedAndRecycled() {
         nodeRunningContainerIsTakenDownAndCleanedAndRecycled(Node.State.dirty, Optional.of(1L));
     }
 
     @Test
-    public void dirtyNodeRunningContainerIsTakenDownAndCleanedAndRecycledNoRestartGeneration() throws Exception {
+    public void dirtyNodeRunningContainerIsTakenDownAndCleanedAndRecycledNoRestartGeneration() {
         nodeRunningContainerIsTakenDownAndCleanedAndRecycled(Node.State.dirty, Optional.empty());
     }
 
@@ -473,7 +473,7 @@ public class NodeAgentImplTest {
     }
 
 
-    private NodeAgentImpl makeNodeAgent(DockerImage dockerImage, boolean isRunning) throws Exception {
+    private NodeAgentImpl makeNodeAgent(DockerImage dockerImage, boolean isRunning) {
         Optional<Container> container = dockerImage != null ?
                 Optional.of(new Container(
                         hostName,


### PR DESCRIPTION
Minor refactoring, no functional changes
* Adds helper method `getContainer` in `NodeAgent` to the container managed by this `NodeAgent` with quick return if `ContainerState` is `ABSENT`
* Makes `OrchestratorException` unchecked. It is only used in `NodeAgent` and makes harder to use the `Optional`s
* Fixes a bug in `Environment.Builder` where athens domain was no set