### PR TITLE
Revert "Set domain name"

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
@@ -145,7 +145,6 @@ class CreateContainerCommandImpl implements Docker.CreateContainerCommand {
                 .createContainerCmd(dockerImage.asString())
                 .withName(containerName.asString())
                 .withHostName(hostName)
-                .withDomainName(findDomainName(hostName))
                 .withLabels(labels)
                 .withEnv(environmentAssignments)
                 .withBinds(volumeBinds)
@@ -219,9 +218,5 @@ class CreateContainerCommandImpl implements Docker.CreateContainerCommand {
         }
 
         return sb.substring(1);
-    }
-
-    private String findDomainName(String hostName) {
-        return hostName.substring(hostName.indexOf(".") + 1);
     }
 }


### PR DESCRIPTION
Reverts yahoo/vespa#2093

Now Vespa doesn't start due to:
The hostname (oxy-oxygen-2001-4998-44-5084--2096.ne1.yahoo.com.ne1.yahoo.com) must match with gethostbyname (was )