### PR TITLE
Ensure closing the flushengine includes stopping the shutdting down a…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/docsummary/summarymanager.h
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summarymanager.h
@@ -1,8 +1,8 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespa/document/fieldvalue/document.h>
-#include <vespa/document/repo/documenttyperepo.h>
+#include "isummarymanager.h"
+#include "fieldcacherepo.h"
 #include <vespa/searchcore/config/config-proton.h>
 #include <vespa/searchcore/proton/attribute/attributemanager.h>
 #include <vespa/searchcore/proton/common/doctypename.h>
@@ -10,9 +10,9 @@
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/searchlib/docstore/idatastore.h>
 #include <vespa/searchlib/transactionlog/syncproxy.h>
+#include <vespa/document/fieldvalue/document.h>
+#include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
-#include "fieldcacherepo.h"
-#include "isummarymanager.h"
 
 namespace search {
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -1,6 +1,5 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
+
 #include "cachedflushtarget.h"
 #include "flush_all_strategy.h"
 #include "flushengine.h"
@@ -9,8 +8,8 @@
 #include "tls_stats_factory.h"
 #include <vespa/searchcore/proton/common/eventlogger.h>
 #include <vespa/vespalib/util/jsonwriter.h>
-#include <vespa/vespalib/util/exceptions.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".proton.flushengine.flushengine");
 
 using vespalib::MonitorGuard;
@@ -84,7 +83,6 @@ FlushEngine::FlushEngine(std::shared_ptr<flushengine::ITlsStatsFactory>
 FlushEngine::~FlushEngine()
 {
     close();
-    _executor.sync();
 }
 
 FlushEngine &
@@ -106,6 +104,8 @@ FlushEngine::close()
         guard.broadcast();
     }
     _threadPool.Close();
+    _executor.shutdown();
+    _executor.sync();
     return *this;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
@@ -1,13 +1,13 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "flushcontext.h"
+#include "iflushstrategy.h"
 #include <vespa/searchcore/proton/common/handlermap.hpp>
-#include <vespa/searchcore/proton/flushengine/flushcontext.h>
-#include <vespa/searchcore/proton/flushengine/iflushstrategy.h>
-#include <set>
+#include <vespa/searchcore/proton/common/doctypename.h>
 #include <vespa/vespalib/util/sync.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
-#include <vespa/searchcore/proton/common/doctypename.h>
+#include <set>
 
 namespace proton {
 
@@ -129,8 +129,7 @@ public:
      */
     void triggerFlush();
 
-    void
-    kick(void);
+    void kick(void);
 
     /**
      * Registers a new flush handler for the given document type. If another

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -480,17 +480,17 @@ Proton::~Proton()
     _customComponentRootToken.reset();
     _customComponentBindToken.reset();
     _stateServer.reset();
-    if (_metricsEngine.get() != NULL) {
+    if (_metricsEngine) {
         _metricsEngine->removeMetricsHook(_metricsHook);
         _metricsEngine->stop();
     }
-    if (_matchEngine.get() != NULL) {
+    if (_matchEngine) {
         _matchEngine->close();
     }
-    if (_summaryEngine.get() != NULL) {
+    if (_summaryEngine) {
         _summaryEngine->close();
     }
-    if (_rpcHooks.get() != NULL) {
+    if (_rpcHooks) {
         _rpcHooks->close();
     }
     if (_memoryFlushConfigUpdater) {
@@ -499,20 +499,20 @@ Proton::~Proton()
     _executor.shutdown();
     _executor.sync();
     _rpcHooks.reset();
-    if (_flushEngine.get() != NULL) {
+    if (_flushEngine) {
         _flushEngine->close();
     }
-    if (_warmupExecutor.get() != NULL) {
+    if (_warmupExecutor) {
         _warmupExecutor->sync();
     }
-    if (_summaryExecutor.get() != NULL) {
+    if (_summaryExecutor) {
         _summaryExecutor->sync();
     }
     LOG(debug, "Shutting down fs4 interface");
-    if (_metricsEngine.get() != NULL) {
+    if (_metricsEngine) {
         _metricsEngine->removeExternalMetrics(_fs4Server->getMetrics());
     }
-    if (_fs4Server.get() != NULL) {
+    if (_fs4Server) {
         _fs4Server->shutDown();
     }
     _persistenceProxy.reset();

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <vespa/searchlib/docstore/filechunk.h>
+#include "filechunk.h"
 #include <vespa/vespalib/util/threadexecutor.h>
 #include <vespa/searchlib/transactionlog/syncproxy.h>
 #include <vespa/fastos/file.h>


### PR DESCRIPTION
…nd syncing the flush executor.

This is done to avoid tasks refering to destructed objects.
@geirst PR