### PR TITLE
Remove LP from ExpressionTree by using deep copy.

### DIFF
--- a/searchcore/src/tests/grouping/grouping.cpp
+++ b/searchcore/src/tests/grouping/grouping.cpp
@@ -328,7 +328,7 @@ TEST_F("testGroupingSession", DoomFixture()) {
     for (const auto & g : initContext.getGroupingList()) {
         g->select(attrCheck2, attrCheck2);
     }
-    EXPECT_EQUAL(10u, attrCheck2._numrefs);
+    EXPECT_EQUAL(8u, attrCheck2._numrefs);
     RankedHit hit;
     hit._docId = 0;
     GroupingManager &manager(session.getGroupingManager());

--- a/searchlib/src/vespa/searchlib/expression/expressiontree.h
+++ b/searchlib/src/vespa/searchlib/expression/expressiontree.h
@@ -71,7 +71,7 @@ private:
     typedef std::vector<InterpolatedLookup *> InterpolatedLookupList;
     typedef std::vector<ArrayAtLookup *> ArrayAtLookupList;
 
-    vespalib::IdentifiableLinkedPtr<ExpressionNode>        _root;
+    ExpressionNode::CP        _root;
     AttributeNodeList         _attributeNodes;
     DocumentAccessorNodeList  _documentAccessorNodes;
     RelevanceNodeList         _relevanceNodes;


### PR DESCRIPTION
@havardpe PR
Here is a minor one to actually remove the second last usage of LinkedPtr...