### PR TITLE
Handle NoNodeException for notifyInternal

### DIFF
--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/CuratorCompletionWaiter.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/CuratorCompletionWaiter.java
@@ -75,18 +75,7 @@ class CuratorCompletionWaiter implements Curator.CompletionWaiter {
     }
 
     private void notifyInternal() throws Exception {
-        try {
-            curator.create().forPath(myId);
-        } catch (RuntimeException e) {
-            // Throw only if we get something else than NoNodeException -- NoNodeException might happen when
-            // an application have been deleted and this method has not been called yet for the previous deployment
-            // on a minority of the config servers (see awaitInternal() method in this class)
-            if (e.getCause().getClass() != KeeperException.NoNodeException.class) {
-                throw e;
-            } else {
-                log.log(LogLevel.INFO, "Not able to notify completion at path: " + myId +", node has been deleted");
-            }
-        }
+        curator.create().forPath(myId);
     }
 
     @Override


### PR DESCRIPTION
* This might happen if deploy prepare is returned successfully to client
  (majority of config servers have done prepare) and then client deletes
  application. The one config server that did not prepare will try to notify
  that it is finished but the path to the node it creates has gone when
  the application was deleted.