### PR TITLE
Bratseth/fast deploy on manual changes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -120,7 +120,7 @@ public final class Node {
     /** Returns a history of the last events happening to this node */
     public History history() { return history; }
 
-    /** 
+    /**
      * Returns a copy of this node which is retired.
      * If the node was already retired it is returned as-is.
      */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -6,6 +6,7 @@ import com.google.common.net.InetAddresses;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.vespa.hosted.provision.node.Generation;
@@ -119,29 +120,22 @@ public final class Node {
     /** Returns a history of the last events happening to this node */
     public History history() { return history; }
 
-    /**
-     * Returns a copy of this node which is retired by the application owning it.
+    /** 
+     * Returns a copy of this node which is retired.
      * If the node was already retired it is returned as-is.
      */
-    public Node retireByApplication(Instant retiredAt) {
+    public Node retire(Agent agent, Instant retiredAt) {
         if (allocation().get().membership().retired()) return this;
         return with(allocation.get().retire())
-               .with(history.with(new History.Event(History.Event.Type.retired, retiredAt, History.Event.Agent.application)));
-    }
-
-    /** Returns a copy of this node which is retired by the system */
-    public Node retireBySystem(Instant retiredAt) {
-        if (allocation().get().membership().retired()) return this;
-        return with(allocation.get().retire())
-               .with(history.with(new History.Event(History.Event.Type.retired, retiredAt, History.Event.Agent.system)));
+               .with(history.with(new History.Event(History.Event.Type.retired, agent, retiredAt)));
     }
 
     /** Returns a copy of this node which is retired */
     public Node retire(Instant retiredAt) {
-        if (flavor.isRetired() || status.wantToRetire()) {
-            return retireBySystem(retiredAt);
-        }
-        return retireByApplication(retiredAt);
+        if (flavor.isRetired() || status.wantToRetire())
+            return retire(Agent.system, retiredAt);
+        else
+            return retire(Agent.application, retiredAt);
     }
 
     /** Returns a copy of this node which is not retired */
@@ -181,7 +175,7 @@ public final class Node {
 
     /** Returns a copy of this with a history record saying it was detected to be down at this instant */
     public Node downAt(Instant instant) {
-        return with(history.with(new History.Event(History.Event.Type.down, instant)));
+        return with(history.with(new History.Event(History.Event.Type.down, Agent.system, instant)));
     }
 
     /** Returns a copy of this with any history record saying it has been detected down removed */
@@ -192,7 +186,7 @@ public final class Node {
     /** Returns a copy of this with allocation set as specified. <code>node.state</code> is *not* changed. */
     public Node allocate(ApplicationId owner, ClusterMembership membership, Instant at) {
         return this.with(new Allocation(owner, membership, new Generation(0, 0), false))
-                   .with(history.with(new History.Event(History.Event.Type.reserved, at)));
+                   .with(history.with(new History.Event(History.Event.Type.reserved, Agent.application, at)));
     }
 
     /**
@@ -220,7 +214,7 @@ public final class Node {
         Status newStatus = status().withReboot(status().reboot().withCurrent(generation));
         History newHistory = history();
         if (generation > status().reboot().current())
-            newHistory = history.with(new History.Event(History.Event.Type.rebooted, instant));
+            newHistory = history.with(new History.Event(History.Event.Type.rebooted, Agent.system, instant));
         return this.with(newStatus).with(newHistory);
     }
     

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -126,14 +126,14 @@ public final class Node {
     public Node retireByApplication(Instant retiredAt) {
         if (allocation().get().membership().retired()) return this;
         return with(allocation.get().retire())
-               .with(history.with(new History.RetiredEvent(retiredAt, History.RetiredEvent.Agent.application)));
+               .with(history.with(new History.Event(History.Event.Type.retired, retiredAt, History.Event.Agent.application)));
     }
 
     /** Returns a copy of this node which is retired by the system */
     public Node retireBySystem(Instant retiredAt) {
         if (allocation().get().membership().retired()) return this;
         return with(allocation.get().retire())
-               .with(history.with(new History.RetiredEvent(retiredAt, History.RetiredEvent.Agent.system)));
+               .with(history.with(new History.Event(History.Event.Type.retired, retiredAt, History.Event.Agent.system)));
     }
 
     /** Returns a copy of this node which is retired */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DirtyExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DirtyExpirer.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.History;
 
 import java.time.Clock;
@@ -33,7 +34,7 @@ public class DirtyExpirer extends Expirer {
     @Override
     protected void expire(List<Node> expired) {
         for (Node expiredNode : expired.stream().collect(Collectors.toList()))
-            nodeRepository.fail(expiredNode.hostname(), "Node is stuck in dirty");
+            nodeRepository.fail(expiredNode.hostname(), Agent.system, "Node is stuck in dirty");
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveExpirer.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.History;
 
 import java.time.Clock;
@@ -39,7 +40,7 @@ public class InactiveExpirer extends Expirer {
     protected void expire(List<Node> expired) {
         expired.forEach(node -> {
             if (node.status().wantToRetire()) {
-                nodeRepository.park(node.hostname());
+                nodeRepository.park(node.hostname(), Agent.system);
             } else {
                 nodeRepository.setDirty(node);
             }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
@@ -1,0 +1,10 @@
+package com.yahoo.vespa.hosted.provision.node;
+
+/**
+ * The enum of kinds of actions making changes to the system.
+ * 
+ * @author bratseth
+ */
+public enum Agent {
+    system, application, operator
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -62,15 +62,15 @@ public class History {
     }
 
     /** Returns a copy of this history with a record of this state transition added, if applicable */
-    public History recordStateTransition(Node.State from, Node.State to, Instant at) {
+    public History recordStateTransition(Node.State from, Node.State to, Agent agent, Instant at) {
         if (from == to) return this;
         switch (to) {
-            case ready:    return this.withoutApplicationEvents().with(new Event(Event.Type.readied, at));
-            case active:   return this.with(new Event(Event.Type.activated, at));
-            case inactive: return this.with(new Event(Event.Type.deactivated, at));
-            case reserved: return this.with(new Event(Event.Type.reserved, at));
-            case failed:   return this.with(new Event(Event.Type.failed, at));
-            case dirty:    return this.with(new Event(Event.Type.deallocated, at));
+            case ready:    return this.withoutApplicationEvents().with(new Event(Event.Type.readied, agent, at));
+            case active:   return this.with(new Event(Event.Type.activated, agent, at));
+            case inactive: return this.with(new Event(Event.Type.deactivated, agent, at));
+            case reserved: return this.with(new Event(Event.Type.reserved, agent, at));
+            case failed:   return this.with(new Event(Event.Type.failed, agent, at));
+            case dirty:    return this.with(new Event(Event.Type.deallocated, agent, at));
             default:       return this;
         }
     }
@@ -95,35 +95,19 @@ public class History {
          b.setLength(b.length() -2); // remove last comma
         return b.toString();
     }
-    
+
     /** An event which may happen to a node */
     public static class Event {
 
         private final Instant at;
-        private final Type type;
         private final Agent agent;
+        private final Type type;
 
-        public enum Agent { system, application, operator }
-
-        /** Creates an event caused by the system */
-        public Event(Event.Type type, Instant at) {
-            this(type, at, Agent.system);
-        }
-
-        public Event(Event.Type type, Instant at, Agent agent) {
+        public Event(Event.Type type, Agent agent, Instant at) {
             this.type = type;
-            this.at = at;
             this.agent = agent;
+            this.at = at;
         }
-
-        /** Returns the type of event */
-        public Event.Type type() { return type; }
-
-        /** Returns the instant this even took place */
-        public Instant at() { return at; }
-        
-        /** Returns the agent causing this event */
-        public Agent agent() { return agent; }
 
         public enum Type { 
             // State move events
@@ -153,6 +137,15 @@ public class History {
             /** Returns true if this is an application level event and false it it is a node level event */
             public boolean isApplicationLevel() { return applicationLevel; }
         }
+
+        /** Returns the type of event */
+        public Event.Type type() { return type; }
+
+        /** Returns the agent causing this event */
+        public Agent agent() { return agent; }
+
+        /** Returns the instant this even took place */
+        public Instant at() { return at; }
 
         @Override
         public String toString() { return "'" + type + "' event at " + at; }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -100,11 +100,20 @@ public class History {
     public static class Event {
 
         private final Instant at;
-        private final Event.Type type;
+        private final Type type;
+        private final Agent agent;
 
+        public enum Agent { system, application, operator }
+
+        /** Creates an event caused by the system */
         public Event(Event.Type type, Instant at) {
+            this(type, at, Agent.system);
+        }
+
+        public Event(Event.Type type, Instant at, Agent agent) {
             this.type = type;
             this.at = at;
+            this.agent = agent;
         }
 
         /** Returns the type of event */
@@ -112,6 +121,9 @@ public class History {
 
         /** Returns the instant this even took place */
         public Instant at() { return at; }
+        
+        /** Returns the agent causing this event */
+        public Agent agent() { return agent; }
 
         public enum Type { 
             // State move events
@@ -144,23 +156,6 @@ public class History {
 
         @Override
         public String toString() { return "'" + type + "' event at " + at; }
-
-    }
-
-    /** A retired event includes additional information about the causing agent. */
-    public static class RetiredEvent extends Event {
-
-        private final RetiredEvent.Agent agent;
-
-        public RetiredEvent(Instant at, RetiredEvent.Agent agent) {
-            super(Type.retired, at);
-            this.agent = agent;
-        }
-
-        /** Returns the agent which caused retirement */
-        public RetiredEvent.Agent agent() { return agent; }
-
-        public enum Agent { system, application }
 
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -15,6 +15,7 @@ import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
 import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.vespa.hosted.provision.node.Generation;
@@ -205,8 +206,8 @@ public class NodeSerializer {
         History.Event.Type type = eventTypeFromString(object.field(historyEventTypeKey).asString());
         if (type == null) return null;
         Instant at = Instant.ofEpochMilli(object.field(atKey).asLong());
-        History.Event.Agent agent = eventAgentFromSlime(object.field(agentKey));
-        return new History.Event(type, at, agent);
+        Agent agent = eventAgentFromSlime(object.field(agentKey));
+        return new History.Event(type, agent, at);
     }
 
     private Generation generationFromSlime(Inspector object, String wantedField, String currentField) {
@@ -271,17 +272,17 @@ public class NodeSerializer {
         throw new IllegalArgumentException("Serialized form of '" + nodeEventType + "' not defined");
     }
 
-    private History.Event.Agent eventAgentFromSlime(Inspector eventAgentField) {
-        if ( ! eventAgentField.valid()) return History.Event.Agent.system; // TODO: Remove after April 2017
+    private Agent eventAgentFromSlime(Inspector eventAgentField) {
+        if ( ! eventAgentField.valid()) return Agent.system; // TODO: Remove after April 2017
 
         switch (eventAgentField.asString()) {
-            case "application" : return History.Event.Agent.application;
-            case "system" : return History.Event.Agent.system;
-            case "operator" : return History.Event.Agent.operator;
+            case "application" : return Agent.application;
+            case "system" : return Agent.system;
+            case "operator" : return Agent.operator;
         }
         throw new IllegalArgumentException("Unknown node event agent '" + eventAgentField.asString() + "'");
     }
-    private String toString(History.Event.Agent agent) {
+    private String toString(Agent agent) {
         switch (agent) {
             case application : return "application";
             case system : return "system";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -10,6 +10,7 @@ import com.yahoo.lang.MutableInteger;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -358,7 +359,7 @@ class GroupPreparer {
             if (surplus > 0) { // retire until surplus is 0, prefer to retire higher indexes to minimize redistribution
                 for (Node node : byDecreasingIndex(nodes)) {
                     if ( ! node.allocation().get().membership().retired() && node.state().equals(Node.State.active)) {
-                        changedNodes.add(node.retireByApplication(clock.instant()));
+                        changedNodes.add(node.retire(Agent.application, clock.instant()));
                         surplusNodes.add(node); // offer this node to other groups
                         if (--surplus == 0) break;
                     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -17,6 +17,7 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.node.filter.ApplicationFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.lang.MutableInteger;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -113,7 +114,7 @@ class Preparer {
         List<Node> retired = new ArrayList<>(nodes.size());
         for (Node node : nodes) {
             if ( ! node.allocation().get().isRemovable())
-                retired.add(node.retireByApplication(clock.instant()));
+                retired.add(node.retire(Agent.application, clock.instant()));
         }
         return retired;
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -16,6 +16,7 @@ import com.yahoo.vespa.hosted.provision.NoSuchNodeException;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.filter.ApplicationFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
@@ -101,12 +102,12 @@ public class NodesApiHandler extends LoggingRequestHandler {
             return new MessageResponse("Moved " + lastElement(path) + " to ready");
         }
         else if (path.startsWith("/nodes/v2/state/failed/")) {
-            List<Node> failedNodes = nodeRepository.failRecursively(lastElement(path), "Failed through the nodes/v2 API");
+            List<Node> failedNodes = nodeRepository.failRecursively(lastElement(path), Agent.operator, "Failed through the nodes/v2 API");
             String failedHostnames = failedNodes.stream().map(Node::hostname).sorted().collect(Collectors.joining(", "));
             return new MessageResponse("Moved " + failedHostnames + " to failed");
         }
         else if (path.startsWith("/nodes/v2/state/parked/")) {
-            List<Node> parkedNodes = nodeRepository.parkRecursively(lastElement(path));
+            List<Node> parkedNodes = nodeRepository.parkRecursively(lastElement(path), Agent.operator);
             String parkedHostnames = parkedNodes.stream().map(Node::hostname).sorted().collect(Collectors.joining(", "));
             return new MessageResponse("Moved " + parkedHostnames + " to parked");
         }
@@ -115,7 +116,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
             return new MessageResponse("Moved " + lastElement(path) + " to dirty");
         }
         else if (path.startsWith("/nodes/v2/state/active/")) {
-            nodeRepository.reactivate(lastElement(path));
+            nodeRepository.reactivate(lastElement(path), Agent.operator);
             return new MessageResponse("Moved " + lastElement(path) + " to active");
         }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -202,6 +202,7 @@ class NodesResponse extends HttpResponse {
             Cursor object = array.addObject();
             object.setString("event", event.type().name());
             object.setLong("at", event.at().toEpochMilli());
+            object.setString("agent", event.agent().name());
         }
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -17,6 +17,7 @@ import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Status;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 
@@ -96,7 +97,7 @@ public class MockNodeRepository extends NodeRepository {
         nodes.remove(7);
         nodes = setDirty(nodes);
         setReady(nodes);
-        fail("host5.yahoo.com", "Failing to unit test");
+        fail("host5.yahoo.com", Agent.system, "Failing to unit test");
         setDirty("host55.yahoo.com");
 
         ApplicationId app1 = ApplicationId.from(TenantName.from("tenant1"), ApplicationName.from("application1"), InstanceName.from("instance1"));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -33,7 +34,7 @@ public class NodeRepositoryTest {
 
         assertEquals(3, tester.getNodes(NodeType.tenant).size());
         
-        tester.nodeRepository().park("host2");
+        tester.nodeRepository().park("host2", Agent.system);
         assertTrue(tester.nodeRepository().remove("host2"));
 
         assertEquals(2, tester.getNodes(NodeType.tenant).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainerTest.java
@@ -23,6 +23,7 @@ import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 import com.yahoo.vespa.hosted.provision.testutils.FlavorConfigBuilder;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
@@ -68,9 +69,9 @@ public class ApplicationMaintainerTest {
         fixture.activate();
 
         // Fail and park some nodes
-        nodeRepository.fail(nodeRepository.getNodes(fixture.app1).get(3).hostname(), "Failing to unit test");
-        nodeRepository.fail(nodeRepository.getNodes(fixture.app2).get(0).hostname(), "Failing to unit test");
-        nodeRepository.park(nodeRepository.getNodes(fixture.app2).get(4).hostname());
+        nodeRepository.fail(nodeRepository.getNodes(fixture.app1).get(3).hostname(), Agent.system, "Failing to unit test");
+        nodeRepository.fail(nodeRepository.getNodes(fixture.app2).get(0).hostname(), Agent.system, "Failing to unit test");
+        nodeRepository.park(nodeRepository.getNodes(fixture.app2).get(4).hostname(), Agent.system);
         int failedInApp1 = 1;
         int failedOrParkedInApp2 = 2;
         assertEquals(fixture.wantedNodesApp1 - failedInApp1, nodeRepository.getNodes(fixture.app1, Node.State.active).size());
@@ -86,9 +87,9 @@ public class ApplicationMaintainerTest {
         assertEquals(0, nodeRepository.getNodes(NodeType.tenant, Node.State.ready).size());
 
         // Reactivate the previously failed nodes
-        nodeRepository.reactivate(nodeRepository.getNodes(NodeType.tenant, Node.State.failed).get(0).hostname());
-        nodeRepository.reactivate(nodeRepository.getNodes(NodeType.tenant, Node.State.failed).get(0).hostname());
-        nodeRepository.reactivate(nodeRepository.getNodes(NodeType.tenant, Node.State.parked).get(0).hostname());
+        nodeRepository.reactivate(nodeRepository.getNodes(NodeType.tenant, Node.State.failed).get(0).hostname(), Agent.system);
+        nodeRepository.reactivate(nodeRepository.getNodes(NodeType.tenant, Node.State.failed).get(0).hostname(), Agent.system);
+        nodeRepository.reactivate(nodeRepository.getNodes(NodeType.tenant, Node.State.parked).get(0).hostname(), Agent.system);
         int reactivatedInApp1 = 1;
         int reactivatedInApp2 = 2;
         assertEquals(0, nodeRepository.getNodes(NodeType.tenant, Node.State.failed).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
@@ -20,6 +20,7 @@ import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Status;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
@@ -112,9 +113,9 @@ public class FailedExpirerTest {
         assertEquals(3, nodeRepository.getNodes(NodeType.tenant, Node.State.active).size());
 
         // Fail the nodes
-        nodeRepository.fail("node1", "Failing to unit test");
-        nodeRepository.fail("node2", "Failing to unit test");
-        nodeRepository.fail("node3", "Failing to unit test");
+        nodeRepository.fail("node1", Agent.system, "Failing to unit test");
+        nodeRepository.fail("node2", Agent.system, "Failing to unit test");
+        nodeRepository.fail("node3", Agent.system, "Failing to unit test");
         assertEquals(3, nodeRepository.getNodes(NodeType.tenant, Node.State.failed).size());
 
         // Failure times out

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Status;
 import com.yahoo.vespa.orchestrator.ApplicationIdNotFoundException;
 import com.yahoo.vespa.orchestrator.ApplicationStateChangeDeniedException;
@@ -363,7 +364,7 @@ public class NodeFailerTest {
             List<Node> deadNodes = readyNodes.subList(0, 4);
             // Fail 10 Docker containers, should not impact throttling policy
             readyDockerNodes.subList(0, 10)
-                    .forEach(node -> tester.nodeRepository.fail(node.hostname(), "Failed in test"));
+                    .forEach(node -> tester.nodeRepository.fail(node.hostname(), Agent.system, "Failed in test"));
 
             // 2 hours pass, 4 nodes die
             for (int minutes = 0, interval = 30; minutes < 2 * 60; minutes += interval) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepositoryTester;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.zookeeper.ZooKeeperServer;
 import org.junit.Test;
 
@@ -46,7 +47,7 @@ public class ZooKeeperAccessMaintainerTest {
         assertEquals(2, tester.getNodes(NodeType.proxy).size());
         assertEquals(asSet("host1,host2,host3,host4,host5,server1,server2"), ZooKeeperServer.getAllowedClientHostnames());
 
-        tester.nodeRepository().park("host2");
+        tester.nodeRepository().park("host2", Agent.system);
         assertTrue(tester.nodeRepository().remove("host2"));
         maintainer.maintain();
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -14,6 +14,7 @@ import com.yahoo.test.ManualClock;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.Node.State;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Generation;
 import com.yahoo.vespa.hosted.provision.node.History;
@@ -157,11 +158,11 @@ public class SerializationTest {
                              clock.instant());
         assertEquals(1, node.history().events().size());
         clock.advance(Duration.ofMinutes(2));
-        node = node.retireByApplication(clock.instant());
+        node = node.retire(Agent.application, clock.instant());
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
         assertEquals(2, copy.history().events().size());
         assertEquals(clock.instant(), copy.history().event(History.Event.Type.retired).get().at());
-        assertEquals(History.Event.Agent.application,
+        assertEquals(Agent.application,
                      (copy.history().event(History.Event.Type.retired).get()).agent());
         assertTrue(copy.allocation().get().membership().retired());
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -161,8 +161,8 @@ public class SerializationTest {
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
         assertEquals(2, copy.history().events().size());
         assertEquals(clock.instant(), copy.history().event(History.Event.Type.retired).get().at());
-        assertEquals(History.RetiredEvent.Agent.application,
-                     ((History.RetiredEvent) copy.history().event(History.Event.Type.retired).get()).agent());
+        assertEquals(History.Event.Agent.application,
+                     (copy.history().event(History.Event.Type.retired).get()).agent());
         assertTrue(copy.allocation().get().membership().retired());
 
         Node removable = copy.with(node.allocation().get().removable());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeTypeProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeTypeProvisioningTest.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -70,9 +71,9 @@ public class NodeTypeProvisioningTest {
 
         { // Remove 3 proxies then redeploy
             List<Node> nodes = tester.nodeRepository().getNodes(NodeType.proxy, Node.State.active);
-            tester.nodeRepository().fail(nodes.get(0).hostname(), "Failing to unit test");
-            tester.nodeRepository().fail(nodes.get(1).hostname(), "Failing to unit test");
-            tester.nodeRepository().fail(nodes.get(5).hostname(), "Failing to unit test");
+            tester.nodeRepository().fail(nodes.get(0).hostname(), Agent.system, "Failing to unit test");
+            tester.nodeRepository().fail(nodes.get(1).hostname(), Agent.system, "Failing to unit test");
+            tester.nodeRepository().fail(nodes.get(5).hostname(), Agent.system, "Failing to unit test");
             
             List<HostSpec> hosts = deployProxies(application, tester);
             assertEquals(10, hosts.size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -580,7 +580,7 @@ public class ProvisioningTest {
             // Nodes with retired flavor are retired
             NodeList retired = tester.getNodes(application).retired();
             assertEquals(4, retired.size());
-            assertTrue("Nodes are retired by system", retired.asList().stream().allMatch(retiredBy(History.RetiredEvent.Agent.system)));
+            assertTrue("Nodes are retired by system", retired.asList().stream().allMatch(retiredBy(History.Event.Agent.system)));
         }
     }
 
@@ -638,7 +638,7 @@ public class ProvisioningTest {
 
             List<Node> retiredNodes = tester.getNodes(application).retired().asList();
             assertEquals(2, retiredNodes.size());
-            assertTrue("Nodes are retired by system", retiredNodes.stream().allMatch(retiredBy(History.RetiredEvent.Agent.system)));
+            assertTrue("Nodes are retired by system", retiredNodes.stream().allMatch(retiredBy(History.Event.Agent.system)));
         }
     }
 
@@ -808,10 +808,9 @@ public class ProvisioningTest {
     }
 
     /** A predicate that returns whether a node has been retired by the given agent */
-    private static Predicate<Node> retiredBy(History.RetiredEvent.Agent agent) {
+    private static Predicate<Node> retiredBy(History.Event.Agent agent) {
         return (node) -> node.history().event(History.Event.Type.retired)
-                .filter(e -> e instanceof History.RetiredEvent)
-                .map(e -> (History.RetiredEvent) e)
+                .filter(e -> e.type() == History.Event.Type.retired)
                 .filter(e -> e.agent() == agent)
                 .isPresent();
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -22,6 +22,7 @@ import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 import com.yahoo.vespa.hosted.provision.testutils.FlavorConfigBuilder;
@@ -580,7 +581,7 @@ public class ProvisioningTest {
             // Nodes with retired flavor are retired
             NodeList retired = tester.getNodes(application).retired();
             assertEquals(4, retired.size());
-            assertTrue("Nodes are retired by system", retired.asList().stream().allMatch(retiredBy(History.Event.Agent.system)));
+            assertTrue("Nodes are retired by system", retired.asList().stream().allMatch(retiredBy(Agent.system)));
         }
     }
 
@@ -638,7 +639,7 @@ public class ProvisioningTest {
 
             List<Node> retiredNodes = tester.getNodes(application).retired().asList();
             assertEquals(2, retiredNodes.size());
-            assertTrue("Nodes are retired by system", retiredNodes.stream().allMatch(retiredBy(History.Event.Agent.system)));
+            assertTrue("Nodes are retired by system", retiredNodes.stream().allMatch(retiredBy(Agent.system)));
         }
     }
 
@@ -808,7 +809,7 @@ public class ProvisioningTest {
     }
 
     /** A predicate that returns whether a node has been retired by the given agent */
-    private static Predicate<Node> retiredBy(History.Event.Agent agent) {
+    private static Predicate<Node> retiredBy(Agent agent) {
         return (node) -> node.history().event(History.Event.Type.retired)
                 .filter(e -> e.type() == History.Event.Type.retired)
                 .filter(e -> e.agent() == agent)

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -21,6 +21,7 @@ import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.NodeFlavors;
@@ -173,7 +174,7 @@ public class ProvisioningTester implements AutoCloseable {
 
     public void fail(HostSpec host) {
         int beforeFailCount = nodeRepository.getNode(host.hostname(), Node.State.active).get().status().failCount();
-        Node failedNode = nodeRepository.fail(host.hostname(), "Failing to unit test");
+        Node failedNode = nodeRepository.fail(host.hostname(), Agent.system, "Failing to unit test");
         assertTrue(nodeRepository.getNodes(NodeType.tenant, Node.State.failed).contains(failedNode));
         assertEquals(beforeFailCount + 1, failedNode.status().failCount());
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
@@ -31,6 +31,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
@@ -31,6 +31,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"reserved","at":123},{"event":"activated","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -36,6 +36,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"reserved","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -36,6 +36,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
@@ -31,6 +31,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
@@ -31,6 +31,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"reserved","at":123},{"event":"activated","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
@@ -29,6 +29,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
@@ -29,6 +29,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"reserved","at":123},{"event":"activated","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -41,15 +41,18 @@
   "history": [
     {
       "event": "readied",
-      "at": 123
+      "at": 123,
+      "agent": "system"    
     },
     {
       "event": "reserved",
-      "at": 123
+      "at": 123,
+      "agent": "system"
     },
     {
       "event": "rebooted",
-      "at": 123
+      "at": 123,
+      "agent": "system"
     }
   ],
   "ipAddresses":["127.0.0.1", "::1"]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -47,7 +47,7 @@
     {
       "event": "reserved",
       "at": 123,
-      "agent": "system"
+      "agent": "application"
     },
     {
       "event": "rebooted",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
@@ -34,6 +34,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"reserved","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
@@ -34,6 +34,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
@@ -18,6 +18,6 @@
   "failCount": 1,
   "hardwareFailure": false,
   "wantToRetire": false,
-  "history":[{"event":"readied","at":123},{"event":"failed","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"failed","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
@@ -20,6 +20,6 @@
   "failCount": 1,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"failed","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"failed","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -17,6 +17,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"deallocated","at":123}],
+  "history":[{"event":"deallocated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
@@ -31,6 +31,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
@@ -31,6 +31,6 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "history":[{"event":"readied","at":123},{"event":"reserved","at":123},{"event":"activated","at":123}],
+  "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"system"},{"event":"activated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
@@ -20,7 +20,8 @@
   "history": [
     {
       "event": "readied",
-      "at": 123
+      "at": 123,
+      "agent": "system"
     }
   ],
   "ipAddresses":["::1", "127.0.0.1"]


### PR DESCRIPTION
@mpolden please review

This adds a causing agent to each node history event (instead of just retired events), in the first commit.
In the second commit I propagate causing agent in all calls.

I plan to use this to detect nodes which are moved by operators to a new state which requires an application redeployment asap, but I want to split it into two PR's - this one makes no functional changes.