### PR TITLE
Set log level to INFO to avoid massive debug output.

### DIFF
--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -147,6 +147,9 @@
         <configuration>
           <testNGArtifactName>org.testng:testng</testNGArtifactName>
           <redirectTestOutputToFile>${test.hide}</redirectTestOutputToFile>
+          <systemPropertyVariables>
+            <jdisc.logger.level>INFO</jdisc.logger.level>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
@bjorncs 

This should fix the log output. Right ?