### PR TITLE
Fix container restart after node-admin restart

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -82,7 +82,7 @@ public class NodeAgentImpl implements NodeAgent {
         RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN,
         RUNNING
     }
-    private ContainerState containerState = ABSENT;
+    private ContainerState containerState = RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN;
 
     // The attributes of the last successful node repo attribute update for this node. Used to avoid redundant calls.
     private NodeAttributes lastAttributesSet = null;
@@ -119,7 +119,6 @@ public class NodeAgentImpl implements NodeAgent {
                 .ifPresent(container -> {
                     vespaVersion = dockerOperations.getVespaVersion(container.name);
                     lastCpuMetric = new CpuUsageReporter(container.created);
-                    containerState = RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN;
                 });
     }
 


### PR DESCRIPTION
Fixes VESPA-7063 by always assuming the container is running, will set the correct state after first tick-loop.