### PR TITLE
Use Version toFullString()

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -104,8 +104,8 @@ public class NodeSerializer {
         object.setString(flavorKey, node.flavor().name());
         object.setLong(rebootGenerationKey, node.status().reboot().wanted());
         object.setLong(currentRebootGenerationKey, node.status().reboot().current());
-        node.status().vespaVersion().ifPresent(version -> object.setString(vespaVersionKey, version.toString()));
-        node.status().hostedVersion().ifPresent(version -> object.setString(hostedVersionKey, version.toString()));
+        node.status().vespaVersion().ifPresent(version -> object.setString(vespaVersionKey, version.toFullString()));
+        node.status().hostedVersion().ifPresent(version -> object.setString(hostedVersionKey, version.toFullString()));
         node.status().stateVersion().ifPresent(version -> object.setString(stateVersionKey, version));
         node.status().dockerImage().ifPresent(image -> object.setString(dockerImageKey, image));
         object.setLong(failCountKey, node.status().failCount());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -160,9 +160,9 @@ class NodesResponse extends HttpResponse {
         object.setLong("rebootGeneration", node.status().reboot().wanted());
         object.setLong("currentRebootGeneration", node.status().reboot().current());
         node.status().vespaVersion().ifPresent(version -> {
-            if (! version.toString().isEmpty()) object.setString("vespaVersion", version.toFullString());
+            if (! version.toFullString().isEmpty()) object.setString("vespaVersion", version.toFullString());
         });
-        node.status().hostedVersion().ifPresent(version -> object.setString("hostedVersion", version.toString()));
+        node.status().hostedVersion().ifPresent(version -> object.setString("hostedVersion", version.toFullString()));
         node.status().dockerImage().ifPresent(image -> object.setString("currentDockerImage", image));
         node.status().stateVersion().ifPresent(version -> object.setString("convergedStateVersion", version));
         object.setLong("failCount", node.status().failCount());


### PR DESCRIPTION
Missed a few cases of using `Version` `toString()` instead of `toFullString()`