### PR TITLE
Fix node-admin test

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
@@ -89,7 +89,7 @@ public class NodeRepositoryImplTest {
         assertThat(containersToRun.size(), is(1));
         final ContainerNodeSpec nodeSpec = containersToRun.get(0);
         assertThat(nodeSpec.hostname, is("host4.yahoo.com"));
-        assertThat(nodeSpec.wantedDockerImage.get(), is(new DockerImage("image-123")));
+        assertThat(nodeSpec.wantedDockerImage.get(), is(new DockerImage("docker-registry.ops.yahoo.com:4443/vespa/ci:6.42.0")));
         assertThat(nodeSpec.nodeState, is(Node.State.reserved));
         assertThat(nodeSpec.wantedRestartGeneration.get(), is(0L));
         assertThat(nodeSpec.currentRestartGeneration.get(), is(0L));


### PR DESCRIPTION
Fixes broken test in node-admin introduced in https://github.com/yahoo/vespa/pull/2131/files#diff-7caf3e71afe43207ef9b4bc8ea86034d

```
Running com.yahoo.vespa.hosted.node.admin.noderepository.NodeRepositoryImplTest
Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.686 sec <<< FAILURE! - in com.yahoo.vespa.hosted.node.admin.noderepository.NodeRepositoryImplTest
testGetContainersToRunAPi(com.yahoo.vespa.hosted.node.admin.noderepository.NodeRepositoryImplTest)  Time elapsed: 0.366 sec  <<< FAILURE!
java.lang.AssertionError: 
Expected: is <DockerImage { imageId=image-123 }>
     but: was <DockerImage { imageId=docker-registry.ops.yahoo.com:4443/vespa/ci:6.42.0 }>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:865)
        at org.junit.Assert.assertThat(Assert.java:832)
        at com.yahoo.vespa.hosted.node.admin.noderepository.NodeRepositoryImplTest.testGetContainersToRunAPi(NodeRepositoryImplTest.java:92)
```