### PR TITLE
Properly initialize ContainerState

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -80,7 +80,7 @@ public class NodeAgentImpl implements NodeAgent {
         RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN,
         RUNNING
     }
-    private ContainerState containerState = RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN;
+    private ContainerState containerState = ABSENT;
 
     // The attributes of the last successful node repo attribute update for this node. Used to avoid redundant calls.
     private NodeAttributes lastAttributesSet = null;
@@ -114,10 +114,12 @@ public class NodeAgentImpl implements NodeAgent {
         // If the container is already running, initialize vespaVersion and lastCpuMetric
         lastCpuMetric = new CpuUsageReporter(clock.instant());
         dockerOperations.getContainer(containerName)
-                .filter(container -> container.state.isRunning())
                 .ifPresent(container -> {
-                    vespaVersion = dockerOperations.getVespaVersion(container.name);
-                    lastCpuMetric = new CpuUsageReporter(container.created);
+                    if (container.state.isRunning()) {
+                        vespaVersion = dockerOperations.getVespaVersion(container.name);
+                        lastCpuMetric = new CpuUsageReporter(container.created);
+                    }
+                    containerState = RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN;
                 });
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -261,7 +261,11 @@ public class NodeAgentImplTest {
         when(nodeRepository.getContainerNodeSpec(hostName)).thenReturn(Optional.of(nodeSpec));
 
         nodeAgent.converge();
+        nodeAgent.converge();
+        nodeAgent.converge();
 
+        // Should only be called once, when we initialize
+        verify(dockerOperations, times(1)).getContainer(eq(containerName));
         verify(dockerOperations, never()).removeContainer(any());
         verify(dockerOperations, never()).startContainer(eq(containerName), eq(nodeSpec));
         verify(orchestrator, never()).resume(any(String.class));


### PR DESCRIPTION
`ContainerState` can only be set to `ABSENT` if node-admin itself removed it, therefore we need to properly set the `ContainerState` right in constructor.