### PR TITLE
Push node metrics to containers - take 1

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
@@ -72,13 +72,36 @@ public interface Docker {
     void deleteUnusedDockerImages();
 
     /**
-     * Execute a command in docker container as "yahoo" user
-     * TODO: Make this function interruptible
+     * Execute a command in docker container as "yahoo". Will block until the command is finished.
      *
-     * @param args          Program arguments. args[0] must be the program filename.
-     * @throws RuntimeException  (or some subclass thereof) on failure, including docker failure, command failure
+     * @param containerName The name of the container
+     * @param command The command with arguments to run.
+     *
+     * @return exitcodes, stdout and stderr in the ProcessResult
      */
-    ProcessResult executeInContainer(ContainerName containerName, String... args);
+    ProcessResult executeInContainer(ContainerName containerName, String... command);
 
-    ProcessResult executeInContainerAsRoot(ContainerName containerName, String... args);
+    /**
+     * Execute a command in docker container as "root". Will block until the command is finished.
+     *
+     * @param containerName The name of the container
+     * @param command The command with arguments to run.
+     *
+     * @return exitcodes, stdout and stderr in the ProcessResult
+     */
+    ProcessResult executeInContainerAsRoot(ContainerName containerName, String... command);
+
+    /**
+     * Execute a command in docker container as "root"
+     * The timeout will not kill the process spawned.
+     *
+     * @param containerName The name of the container
+     * @param timeoutSeconds Timeout for the process to finish in seconds or without timeout if empty
+     * @param command The command with arguments to run.
+     *
+     * @return exitcodes, stdout and stderr in the ProcessResult
+     */
+    ProcessResult executeInContainerAsRoot(ContainerName containerName, Long timeoutSeconds, String... command);
+
+
 }

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerExecTimeoutException.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerExecTimeoutException.java
@@ -1,0 +1,16 @@
+package com.yahoo.vespa.hosted.dockerapi;
+
+/**
+ * Runtime exception to be thrown when the exec commands did not finish in time.
+ *
+ * The underlying process has not been killed. If you need the process to be
+ * killed you need to wrap it into a commands that times out.
+ *
+ * @author smorgrav
+ */
+@SuppressWarnings("serial")
+public class DockerExecTimeoutException extends RuntimeException {
+    public DockerExecTimeoutException(String msg) {
+        super(msg);
+    }
+}

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -93,7 +93,7 @@ public class DockerImpl implements Docker {
                 true, /* fallback to 1.23 on errors */
                 metricReceiver);
 
-        if (! config.isRunningLocally()) {
+        if (!config.isRunningLocally()) {
             Duration minAgeToDelete = Duration.ofMinutes(config.imageGCMinTimeToLiveMinutes());
             dockerImageGC = Optional.of(new DockerImageGarbageCollector(minAgeToDelete));
 
@@ -121,7 +121,7 @@ public class DockerImpl implements Docker {
     }
 
     private void setupDockerNetworkIfNeeded() throws IOException {
-        if (! dockerClient.listNetworksCmd().withNameFilter(DOCKER_CUSTOM_MACVLAN_NETWORK_NAME).exec().isEmpty()) return;
+        if (!dockerClient.listNetworksCmd().withNameFilter(DOCKER_CUSTOM_MACVLAN_NETWORK_NAME).exec().isEmpty()) return;
 
         // Use IPv6 address if there is a mix of IP4 and IPv6 by taking the longest address.
         List<InetAddress> hostAddresses = Arrays.asList(InetAddress.getAllByName(com.yahoo.net.HostName.getLocalhost()));
@@ -426,7 +426,7 @@ public class DockerImpl implements Docker {
 
     @Override
     public void deleteUnusedDockerImages() {
-        if (! dockerImageGC.isPresent()) return;
+        if (!dockerImageGC.isPresent()) return;
 
         List<Image> images = listAllImages();
         List<com.github.dockerjava.api.model.Container> containers = listAllContainers();
@@ -494,7 +494,7 @@ public class DockerImpl implements Docker {
             remoteApiVersion = RemoteApiVersion.parseConfig(DockerClientImpl.getInstance(
                     buildDockerClientConfig(config).build())
                     .withDockerCmdExecFactory(dockerFactory).versionCmd().exec().getApiVersion());
-            logger.info("Found version of remote docker API: "+ remoteApiVersion);
+            logger.info("Found version of remote docker API: " + remoteApiVersion);
             // From version 1.24 a field was removed which causes trouble with the current docker java code.
             // When this is fixed, we can remove this and do not specify version.
             if (remoteApiVersion.isGreaterOrEqual(RemoteApiVersion.VERSION_1_24)) {
@@ -502,7 +502,7 @@ public class DockerImpl implements Docker {
                 logger.info("Found version 1.24 or newer of remote API, using 1.23.");
             }
         } catch (Exception e) {
-            if (! fallbackTo123orErrors) {
+            if (!fallbackTo123orErrors) {
                 throw e;
             }
             logger.log(LogLevel.ERROR, "Failed when trying to figure out remote API version of docker, using 1.23", e);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -25,9 +25,11 @@ public interface DockerOperations {
 
     void scheduleDownloadOfImage(ContainerName containerName, ContainerNodeSpec nodeSpec, Runnable callback);
 
-    ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, String[] command);
+    ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, String... command);
 
-    void executeCommandInNetworkNamespace(ContainerName containerName, String[] command);
+    ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, Long timeoutSeconds, String... command);
+
+    void executeCommandInNetworkNamespace(ContainerName containerName, String... command);
 
     void resumeNode(ContainerName containerName);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -274,10 +274,10 @@ public class DockerOperationsImpl implements DockerOperations {
         });
     }
 
-    ProcessResult executeCommandInContainer(ContainerName containerName, String[] command) {
+    ProcessResult executeCommandInContainer(ContainerName containerName, String... command) {
         ProcessResult result = docker.executeInContainerAsRoot(containerName, command);
 
-        if (! result.isSuccess()) {
+        if (!result.isSuccess()) {
             throw new RuntimeException("Container " + containerName.asString() +
                     ": command " + Arrays.toString(command) + " failed: " + result);
         }
@@ -285,12 +285,17 @@ public class DockerOperationsImpl implements DockerOperations {
     }
 
     @Override
-    public ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, String[] command) {
+    public ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, Long timeoutSeconds, String... command) {
+        return docker.executeInContainerAsRoot(containerName, timeoutSeconds, command);
+    }
+
+    @Override
+    public ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, String... command) {
         return docker.executeInContainerAsRoot(containerName, command);
     }
 
     @Override
-    public void executeCommandInNetworkNamespace(ContainerName containerName, String[] command) {
+    public void executeCommandInNetworkNamespace(ContainerName containerName, String... command) {
         final PrefixLogger logger = PrefixLogger.getNodeAgentLogger(DockerOperationsImpl.class, containerName);
         final Integer containerPid = docker.getContainer(containerName)
                 .filter(container -> container.state.isRunning())

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -38,16 +38,17 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
 /**
  * Class that wraps the Docker class and have some tools related to running programs in docker.
+ *
  * @author dybis
  */
 public class DockerOperationsImpl implements DockerOperations {
     public static final String NODE_PROGRAM = Defaults.getDefaults().underVespaHome("bin/vespa-nodectl");
     private static final String[] GET_VESPA_VERSION_COMMAND = new String[]{NODE_PROGRAM, "vespa-version"};
 
-    private static final String[] RESUME_NODE_COMMAND = new String[] {NODE_PROGRAM, "resume"};
-    private static final String[] SUSPEND_NODE_COMMAND = new String[] {NODE_PROGRAM, "suspend"};
-    private static final String[] RESTART_VESPA_ON_NODE_COMMAND = new String[] {NODE_PROGRAM, "restart-vespa"};
-    private static final String[] STOP_NODE_COMMAND = new String[] {NODE_PROGRAM, "stop"};
+    private static final String[] RESUME_NODE_COMMAND = new String[]{NODE_PROGRAM, "resume"};
+    private static final String[] SUSPEND_NODE_COMMAND = new String[]{NODE_PROGRAM, "suspend"};
+    private static final String[] RESTART_VESPA_ON_NODE_COMMAND = new String[]{NODE_PROGRAM, "restart-vespa"};
+    private static final String[] STOP_NODE_COMMAND = new String[]{NODE_PROGRAM, "stop"};
 
     private static final Pattern VESPA_VERSION_PATTERN = Pattern.compile("^(\\S*)$", Pattern.MULTILINE);
 
@@ -55,6 +56,7 @@ public class DockerOperationsImpl implements DockerOperations {
 
     // Map of directories to mount and whether they should be writable by everyone
     private static final Map<String, Boolean> DIRECTORIES_TO_MOUNT = new HashMap<>();
+
     static {
         DIRECTORIES_TO_MOUNT.put("/etc/yamas-agent", true);
         DIRECTORIES_TO_MOUNT.put("/etc/filebeat", true);
@@ -231,7 +233,7 @@ public class DockerOperationsImpl implements DockerOperations {
      * Try to suspend node. Suspending a node means the node should be taken offline,
      * such that maintenance can be done of the node (upgrading, rebooting, etc),
      * and such that we will start serving again as soon as possible afterwards.
-     *
+     * <p>
      * Any failures are logged and ignored.
      */
     @Override
@@ -244,7 +246,7 @@ public class DockerOperationsImpl implements DockerOperations {
             // It's bad to continue as-if nothing happened, but on the other hand if we do not proceed to
             // remove container, we will not be able to upgrade to fix any problems in the suspend logic!
             logger.warning("Failed trying to suspend container " + containerName.asString() + "  with "
-                   + Arrays.toString(SUSPEND_NODE_COMMAND), e);
+                    + Arrays.toString(SUSPEND_NODE_COMMAND), e);
         }
     }
 
@@ -371,7 +373,7 @@ public class DockerOperationsImpl implements DockerOperations {
             if (resultCode != 0) {
                 throw new RuntimeException("Command " + Joiner.on(' ').join(command) + " failed: " + output);
             }
-        } catch (IOException|InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainer.java
@@ -22,11 +22,11 @@ import java.util.stream.Collectors;
  * The responsibility of this class is to configure ACLs for all running containers. The ACLs are fetched from the Node
  * repository. Based on those ACLs, iptables commands are created and then executed in each of the containers network
  * namespace.
- *
+ * <p>
  * If an ACL cannot be configured (e.g. iptables process execution fails), a rollback is attempted by setting the
  * default policy to ACCEPT which will allow any traffic. The configuration will be retried the next time the
  * maintainer runs.
- *
+ * <p>
  * The ACL maintainer does not handle IPv4 addresses and is thus only intended to configure ACLs for IPv6-only
  * containers (e.g. any container, except node-admin).
  *
@@ -43,7 +43,7 @@ public class AclMaintainer implements Runnable {
     private final Map<ContainerName, Acl> containerAcls;
 
     public AclMaintainer(DockerOperations dockerOperations, NodeRepository nodeRepository,
-                  String nodeAdminHostname) {
+                         String nodeAdminHostname) {
         this.dockerOperations = dockerOperations;
         this.nodeRepository = nodeRepository;
         this.nodeAdminHostname = nodeAdminHostname;

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.node.admin.nodeagent;
 import com.yahoo.vespa.hosted.dockerapi.Container;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
+import com.yahoo.vespa.hosted.dockerapi.DockerExecTimeoutException;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.metrics.Dimensions;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -572,6 +572,15 @@ public class NodeAgentImpl implements NodeAgent {
 
         metricReceiver.declareGauge(MetricReceiverWrapper.APPLICATION_HOST_LIFE, dimensions, "uptime").sample(lastCpuMetric.getUptime());
         metricReceiver.declareGauge(MetricReceiverWrapper.APPLICATION_HOST_LIFE, dimensions, "alive").sample(1);
+
+        // Push metrics to the metrics proxy in each container - give it maximum 1 seconds to complete
+        try {
+            //TODO The command here is almost a dummy command until we have the proper RPC method in place
+            // Remember proper argument encoding
+            dockerOperations.executeCommandInContainerAsRoot(containerName, 1L, "sh", "-c", "'echo " + metricReceiver.toString() + "'");
+        } catch (DockerExecTimeoutException e) {
+            logger.warning("Unable to push metrics to container: " + containerName, e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -83,7 +83,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
     public ComponentsProviderImpl(final NodeAdminConfig config, final Docker docker, final MetricReceiverWrapper metricReceiver) {
         this(docker, metricReceiver, new Environment(), config.isRunningLocally());
 
-        if (! config.isRunningLocally()) {
+        if (!config.isRunningLocally()) {
             setCorePattern(docker);
             initializeNodeAgentSecretAgent(docker);
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
@@ -40,7 +40,7 @@ public class DockerOperationsImplTest {
         final ContainerName containerName = new ContainerName("container-name");
         final ProcessResult actualResult = new ProcessResult(0, "output", "errors");
         final String programPath = "/bin/command";
-        final String[] command = new String[] {programPath, "arg"};
+        final String[] command = new String[]{programPath, "arg"};
 
         when(docker.executeInContainerAsRoot(any(), anyVararg()))
                 .thenReturn(actualResult); // output from node program
@@ -56,12 +56,12 @@ public class DockerOperationsImplTest {
         assertThat(result, is(actualResult));
     }
 
-    @Test(expected=RuntimeException.class)
+    @Test(expected = RuntimeException.class)
     public void processResultFromNodeProgramWhenNonZeroExitCode() throws Exception {
         final ContainerName containerName = new ContainerName("container-name");
         final ProcessResult actualResult = new ProcessResult(3, "output", "errors");
         final String programPath = "/bin/command";
-        final String[] command = new String[] {programPath, "arg"};
+        final String[] command = new String[]{programPath, "arg"};
 
         when(docker.executeInContainerAsRoot(any(), anyVararg()))
                 .thenReturn(actualResult); // output from node program

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -220,10 +220,14 @@ public class DockerMock implements Docker {
         }
 
         @Override
-        public CreateContainerCommand withAddCapability(String capabilityName) {return this; }
+        public CreateContainerCommand withAddCapability(String capabilityName) {
+            return this;
+        }
 
         @Override
-        public CreateContainerCommand withDropCapability(String capabilityName) {return this; }
+        public CreateContainerCommand withDropCapability(String capabilityName) {
+            return this;
+        }
 
         @Override
         public void create() {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -159,6 +159,14 @@ public class DockerMock implements Docker {
         return new ProcessResult(0, null, "");
     }
 
+    @Override
+    public ProcessResult executeInContainerAsRoot(ContainerName containerName, Long timeoutSeconds, String... args) {
+        synchronized (monitor) {
+            callOrderVerifier.add("executeInContainerAsRoot with " + containerName + ", args: " + Arrays.toString(args));
+        }
+        return new ProcessResult(0, null, "");
+    }
+
 
     public static class StartContainerCommandMock implements CreateContainerCommand {
         @Override

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -102,7 +101,9 @@ public class AclMaintainerTest {
 
         verify(dockerOperations).executeCommandInNetworkNamespace(
                 eq(container.name),
-                aryEq(new String[]{"ip6tables", "-P", "INPUT", "ACCEPT"})
+                eq("ip6tables"),
+                eq("-F"),
+                eq("INPUT")
         );
     }
 
@@ -114,40 +115,80 @@ public class AclMaintainerTest {
                                    VerificationMode verificationMode) {
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-F", "INPUT"})
+                eq("ip6tables"),
+                eq("-F"),
+                eq("INPUT")
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-P", "INPUT", "DROP"})
+                eq("ip6tables"),
+                eq("-P"),
+                eq("INPUT"),
+                eq("DROP")
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-P", "FORWARD", "DROP"})
+                eq("ip6tables"),
+                eq("-P"),
+                eq("FORWARD"),
+                eq("DROP")
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-P", "OUTPUT", "ACCEPT"})
+                eq("ip6tables"),
+                eq("-P"),
+                eq("OUTPUT"),
+                eq("ACCEPT")
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-A", "INPUT", "-m", "state", "--state", "RELATED,ESTABLISHED", "-j",
-                        "ACCEPT"})
+                eq("ip6tables"),
+                eq("-A"),
+                eq("INPUT"),
+                eq("-m"),
+                eq("state"),
+                eq("--state"),
+                eq("RELATED,ESTABLISHED"),
+                eq("-j"),
+                eq("ACCEPT")
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-A", "INPUT", "-i", "lo", "-j", "ACCEPT"})
+                eq("ip6tables"),
+                eq("-A"),
+                eq("INPUT"),
+                eq("-i"),
+                eq("lo"),
+                eq("-j"),
+                eq("ACCEPT")
         );
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-A", "INPUT", "-p", "ipv6-icmp", "-j", "ACCEPT"})
+                eq("ip6tables"),
+                eq("-A"),
+                eq("INPUT"),
+                eq("-p"),
+                eq("ipv6-icmp"),
+                eq("-j"),
+                eq("ACCEPT")
         );
         containerAclSpecs.forEach(aclSpec -> verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-A", "INPUT", "-s", aclSpec.ipAddress() + "/128", "-j", "ACCEPT"})
+                eq("ip6tables"),
+                eq("-A"),
+                eq("INPUT"),
+                eq("-s"),
+                eq(aclSpec.ipAddress() + "/128"),
+                eq("-j"),
+                eq("ACCEPT")
         ));
         verify(dockerOperations, verificationMode).executeCommandInNetworkNamespace(
                 eq(containerName),
-                aryEq(new String[]{"ip6tables", "-A", "INPUT", "-j", "REJECT"})
+                eq("ip6tables"),
+                eq("-A"),
+                eq("INPUT"),
+                eq("-j"),
+                eq("REJECT")
         );
     }
 


### PR DESCRIPTION
@freva @hakonhall 

This is WIP and I want your feedback about the idea of introducing an optional timeout to the execute commands and then how to handle timeouts (throw or exit code or something else). 

Introducing a uncheck throw on timeout is not something the rest of the code is prepared to handle gracefully but a concept of exit codes seems to be handeled - So I lean towards the latter. 

If we instead of introducing an optinal in the signature we could double the methods - one with time out and one without - but I think it is good to make the caller of these commands aware of the timeout handling (now it is just implicit) - thus the current suggestion with changing the signatures.

