### PR TITLE
Do not erroneously mark replicas as trusted when merging bucket info

### DIFF
--- a/storage/src/vespa/storage/bucketdb/bucketinfo.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketinfo.cpp
@@ -165,7 +165,8 @@ BucketInfo::updateNode(const BucketCopy& newCopy)
 
 void
 BucketInfo::addNodes(const std::vector<BucketCopy>& newCopies,
-                     const std::vector<uint16_t>& recommendedOrder)
+                     const std::vector<uint16_t>& recommendedOrder,
+                     TrustedUpdate update)
 {
     for (uint32_t i = 0; i < newCopies.size(); ++i) {
         BucketCopy* found = getNodeInternal(newCopies[i].getNode());
@@ -182,7 +183,9 @@ BucketInfo::addNodes(const std::vector<BucketCopy>& newCopies,
 
     std::sort(_nodes.begin(), _nodes.end(), Sorter(recommendedOrder));
 
-    updateTrusted();
+    if (update == TrustedUpdate::UPDATE) {
+        updateTrusted();
+    }
 }
 
 void
@@ -194,14 +197,16 @@ BucketInfo::addNode(const BucketCopy& newCopy,
 }
 
 bool
-BucketInfo::removeNode(unsigned short node)
+BucketInfo::removeNode(unsigned short node, TrustedUpdate update)
 {
     for (std::vector<BucketCopy>::iterator iter = _nodes.begin();
          iter != _nodes.end();
          iter++) {
         if (iter->getNode() == node) {
             _nodes.erase(iter);
-            updateTrusted();
+            if (update == TrustedUpdate::UPDATE) {
+                updateTrusted();
+            }
             return true;
         }
     }

--- a/storage/src/vespa/storage/bucketdb/bucketinfo.h
+++ b/storage/src/vespa/storage/bucketdb/bucketinfo.h
@@ -9,6 +9,11 @@ namespace distributor {
     class DistributorTestUtil;
 }
 
+enum class TrustedUpdate {
+    UPDATE,
+    DEFER
+};
+
 class BucketInfo
 {
 private:
@@ -84,9 +89,11 @@ public:
 
        listed. Any nodes not in this list will be order numerically afterward.
        @param replace If replace is true, replaces old ones that may exist.
+       @param update If true, will invoke updateTrusted() after replicas are added
     */
     void addNodes(const std::vector<BucketCopy>& newCopies,
-                  const std::vector<uint16_t>& recommendedOrder);
+                  const std::vector<uint16_t>& recommendedOrder,
+                  TrustedUpdate update = TrustedUpdate::UPDATE);
 
     /**
        Simplified API for the common case of inserting one node. See addNodes().
@@ -103,7 +110,7 @@ public:
     /**
         Returns true if the node existed and was removed.
     */
-    bool removeNode(uint16_t node);
+    bool removeNode(uint16_t node, TrustedUpdate update = TrustedUpdate::UPDATE);
 
     /**
      * Returns the bucket copy struct for the given node, null if nonexisting
@@ -113,7 +120,7 @@ public:
     /**
      * Returns the number of nodes this entry has.
      */
-    uint32_t getNodeCount() const { return _nodes.size(); }
+    uint32_t getNodeCount() const noexcept { return static_cast<uint32_t>(_nodes.size()); }
 
     /**
      * Returns a list of the nodes this entry has.

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -238,6 +238,9 @@ private:
 
     std::string requestNodesToString();
 
+    // Returns whether at least one replica was removed from the entry.
+    // Does NOT implicitly update trusted status on remaining replicas; caller must do
+    // this explicitly.
     bool removeCopiesFromNodesThatWereRequested(
             BucketDatabase::Entry& e,
             const document::BucketId& bucketId);


### PR DESCRIPTION
@hakonhall Please review

Addresses two long-standing distributor bugs:
1) Fix removal loop of bucket replica information removal for nodes
   whose information has been fetched (i.e. "outdated" nodes). Could
   previously prematurely terminate loop.
2) Defer update of trusted flag on replicas until _after_ all
   replicas have been removed for outdated nodes AND new replica
   information has been merged in. Fixes edge case where e.g. transiently
   removing 1 of 2 mutually out of sync replicas before merging its info
   back in again would mark the remaining replica as trusted due to being
   the only remaining replica in this transient period.