### PR TITLE
Revert "Balder/fast access fields are also in memory for streaming search"

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
@@ -26,8 +26,6 @@ import java.util.Map;
  */
 public class AttributeFields extends Derived implements AttributesConfig.Producer {
 
-    public enum FieldSet {ALL, FAST_ACCESS}
-
     private Map<String, Attribute> attributes = new java.util.LinkedHashMap<>();
 
     /**
@@ -67,30 +65,28 @@ public class AttributeFields extends Derived implements AttributesConfig.Produce
         return getAttribute(attributeName) != null;
     }
 
-    private void deriveAttribute(ImmutableSDField field, Attribute fieldAttribute) {
-        Attribute attribute = getAttribute(fieldAttribute.getName());
-        if (attribute == null) {
-            attributes.put(fieldAttribute.getName(), fieldAttribute);
-            attribute = getAttribute(fieldAttribute.getName());
-        }
-        Ranking ranking = field.getRanking();
-        if (ranking != null && ranking.isFilter()) {
-            attribute.setEnableBitVectors(true);
-            attribute.setEnableOnlyBitVector(true);
-        }
-    }
     /**
      * Derives one attribute. TODO: Support non-default named attributes
      */
     private void deriveAttributes(ImmutableSDField field) {
         for (Attribute fieldAttribute : field.getAttributes().values()) {
-            deriveAttribute(field, fieldAttribute);
+            Attribute attribute = getAttribute(fieldAttribute.getName());
+            if (attribute == null) {
+                attributes.put(fieldAttribute.getName(), fieldAttribute);
+                attribute = getAttribute(fieldAttribute.getName());
+            }
+            Ranking ranking = field.getRanking();
+            if (ranking != null && ranking.isFilter()) {
+                attribute.setEnableBitVectors(true);
+                attribute.setEnableOnlyBitVector(true);
+            }
         }
 
         if (field.containsExpression(ToPositionExpression.class)) {
             // TODO: Move this check to processing and remove this
             if (hasPosition) {
-                throw new IllegalArgumentException("Can not specify more than one set of position attributes per field: " + field.getName());
+                throw new IllegalArgumentException("Can not specify more than one " +
+                                                   "set of position attributes per " + "field: " + field.getName());
             }
             hasPosition = true;
         }
@@ -126,62 +122,48 @@ public class AttributeFields extends Derived implements AttributesConfig.Produce
 
     @Override
     public void getConfig(AttributesConfig.Builder builder) {
-        getConfig(builder, FieldSet.ALL);
-    }
-
-    private boolean isAttributeInFieldSet(Attribute attribute, FieldSet fs) {
-        return (fs == FieldSet.ALL) || ((fs == FieldSet.FAST_ACCESS) && attribute.isFastAccess());
-    }
-
-    private AttributesConfig.Attribute.Builder getConfig(Attribute attribute) {
-        AttributesConfig.Attribute.Builder aaB = new AttributesConfig.Attribute.Builder()
+        for (Attribute attribute : attributes.values()) {
+            AttributesConfig.Attribute.Builder aaB = new AttributesConfig.Attribute.Builder()
                 .name(attribute.getName())
                 .datatype(AttributesConfig.Attribute.Datatype.Enum.valueOf(attribute.getType().getExportAttributeTypeName()))
                 .collectiontype(AttributesConfig.Attribute.Collectiontype.Enum.valueOf(attribute.getCollectionType().getName()));
-        if (attribute.isRemoveIfZero()) {
-            aaB.removeifzero(true);
-        }
-        if (attribute.isCreateIfNonExistent()) {
-            aaB.createifnonexistent(true);
-        }
-        aaB.enablebitvectors(attribute.isEnabledBitVectors());
-        aaB.enableonlybitvector(attribute.isEnabledOnlyBitVector());
-        if (attribute.isFastSearch()) {
-            aaB.fastsearch(true);
-        }
-        if (attribute.isFastAccess()) {
-            aaB.fastaccess(true);
-        }
-        if (attribute.isHuge()) {
-            aaB.huge(true);
-        }
-        if (attribute.getSorting().isDescending()) {
-            aaB.sortascending(false);
-        }
-        if (attribute.getSorting().getFunction() != Sorting.Function.UCA) {
-            aaB.sortfunction(AttributesConfig.Attribute.Sortfunction.Enum.valueOf(attribute.getSorting().getFunction().toString()));
-        }
-        if (attribute.getSorting().getStrength() != Sorting.Strength.PRIMARY) {
-            aaB.sortstrength(AttributesConfig.Attribute.Sortstrength.Enum.valueOf(attribute.getSorting().getStrength().toString()));
-        }
-        if (!attribute.getSorting().getLocale().isEmpty()) {
-            aaB.sortlocale(attribute.getSorting().getLocale());
-        }
-        aaB.arity(attribute.arity());
-        aaB.lowerbound(attribute.lowerBound());
-        aaB.upperbound(attribute.upperBound());
-        aaB.densepostinglistthreshold(attribute.densePostingListThreshold());
-        if (attribute.tensorType().isPresent()) {
-            aaB.tensortype(attribute.tensorType().get().toString());
-        }
-        return aaB;
-    }
-
-    public void getConfig(AttributesConfig.Builder builder, FieldSet fs) {
-        for (Attribute attribute : attributes.values()) {
-            if (isAttributeInFieldSet(attribute, fs)) {
-                builder.attribute(getConfig(attribute));
+            if (attribute.isRemoveIfZero()) {
+                aaB.removeifzero(true);
             }
+            if (attribute.isCreateIfNonExistent()) {
+                aaB.createifnonexistent(true);
+            }
+            aaB.enablebitvectors(attribute.isEnabledBitVectors());
+            aaB.enableonlybitvector(attribute.isEnabledOnlyBitVector());
+            if (attribute.isFastSearch()) {
+                aaB.fastsearch(true);
+            }
+            if (attribute.isFastAccess()) {
+                aaB.fastaccess(true);
+            }
+            if (attribute.isHuge()) {
+                aaB.huge(true);
+            }
+            if (attribute.getSorting().isDescending()) {
+                aaB.sortascending(false);
+            }
+            if (attribute.getSorting().getFunction() != Sorting.Function.UCA) {
+                aaB.sortfunction(AttributesConfig.Attribute.Sortfunction.Enum.valueOf(attribute.getSorting().getFunction().toString()));
+            }
+            if (attribute.getSorting().getStrength() != Sorting.Strength.PRIMARY) {
+                aaB.sortstrength(AttributesConfig.Attribute.Sortstrength.Enum.valueOf(attribute.getSorting().getStrength().toString()));
+            }
+            if (!attribute.getSorting().getLocale().isEmpty()) {
+                aaB.sortlocale(attribute.getSorting().getLocale());
+            }
+            aaB.arity(attribute.arity());
+            aaB.lowerbound(attribute.lowerBound());
+            aaB.upperbound(attribute.upperBound());
+            aaB.densepostinglistthreshold(attribute.densePostingListThreshold());
+            if (attribute.tensorType().isPresent()) {
+                aaB.tensortype(attribute.tensorType().get().toString());
+            }
+            builder.attribute(aaB);
         }
     }
 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/DerivedConfiguration.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/DerivedConfiguration.java
@@ -78,11 +78,11 @@ public class DerivedConfiguration {
                 }
             }
         }
-        if ( ! search.isDocumentsOnly()) {
-            attributeFields = new AttributeFields(search);
+        if (!search.isDocumentsOnly()) {
             summaries = new Summaries(search, deployLogger);
             summaryMap = new SummaryMap(search, summaries);
             juniperrc = new Juniperrc(search);
+            attributeFields = new AttributeFields(search);
             rankProfileList = new RankProfileList(search, attributeFields, rankProfileRegistry);
             indexingScript = new IndexingScript(search);
             indexInfo = new IndexInfo(search);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -106,9 +106,11 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
         }
 
         private void buildStreamingSearchCluster(ModelElement clusterElem, String clusterName, ContentSearchCluster search, ModelElement docType) {
-            String docTypeName = docType.getStringAttribute("type");
-            StreamingSearchCluster cluster = new StreamingSearchCluster(search, clusterName + "." + docTypeName, 0, docTypeName, clusterName);
-            search.addSearchCluster(cluster, getQueryTimeout(clusterElem), Arrays.asList(docType));
+            StreamingSearchCluster cluster = new StreamingSearchCluster(search, clusterName + "." + docType.getStringAttribute("type"), 0, clusterName, clusterName);
+
+            List<ModelElement> def = new ArrayList<>();
+            def.add(docType);
+            search.addSearchCluster(cluster, getQueryTimeout(clusterElem), def);
         }
 
         private void buildIndexedSearchCluster(ModelElement clusterElem,
@@ -264,14 +266,6 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
         this.redundancy = redundancy;
     }
 
-    private Optional<StreamingSearchCluster> findStreamingCluster(String docType) {
-        return getClusters().values().stream()
-                .filter(StreamingSearchCluster.class::isInstance)
-                .map(StreamingSearchCluster.class::cast)
-                .filter(ssc -> ssc.getSdConfig().getSearch().getName().equals(docType))
-                .findFirst();
-    }
-
     @Override
     public void getConfig(ProtonConfig.Builder builder) {
         double visibilityDelay = hasIndexedCluster() ? getIndexed().getVisibilityDelay() : 0.0;
@@ -282,15 +276,19 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
                 .configid(getConfigId())
                 .visibilitydelay(visibilityDelay)
                 .global(isGloballyDistributed(type));
-            Optional<StreamingSearchCluster> ssc = findStreamingCluster(docTypeName);
-            if (ssc.isPresent()) {
-                ddbB.inputdoctypename(type.getFullName().getName()).configid(ssc.get().getDocumentDBConfigId());
-            } else if (hasIndexedCluster()) {
+            if (hasIndexedCluster()) {
                 getIndexed().fillDocumentDBConfig(type.getFullName().getName(), ddbB);
             }
             builder.documentdb(ddbB);
         }
-
+        for (AbstractSearchCluster sc : getClusters().values()) {
+            if (sc instanceof StreamingSearchCluster) {
+                NewDocumentType type = repo.getDocumentType(((StreamingSearchCluster)sc).getSdConfig().getSearch().getName());
+                ProtonConfig.Documentdb.Builder ddbB = new ProtonConfig.Documentdb.Builder();
+                ddbB.inputdoctypename(type.getFullName().getName()).configid(getConfigId());
+                builder.documentdb(ddbB);
+            }
+        }
         int numDocumentDbs = builder.documentdb.size();
         builder.initialize(new ProtonConfig.Initialize.Builder().threads(numDocumentDbs + 1));
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/StreamingSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/StreamingSearchCluster.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.model.search;
 
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
-import com.yahoo.searchdefinition.derived.AttributeFields;
 import com.yahoo.searchdefinition.derived.DerivedConfiguration;
 import com.yahoo.vespa.config.search.AttributesConfig;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
@@ -30,36 +29,17 @@ public class StreamingSearchCluster extends SearchCluster implements
         SummaryConfig.Producer
 {
 
-    private class AttributesProducer extends AbstractConfigProducer implements AttributesConfig.Producer {
-        AttributesProducer(AbstractConfigProducer parent, String docType) {
-            super(parent, docType);
-        }
-
-        @Override
-        public void getConfig(AttributesConfig.Builder builder) {
-            if (getSdConfig() != null) {
-                getSdConfig().getAttributeFields().getConfig(builder, AttributeFields.FieldSet.FAST_ACCESS);
-            }
-        }
-    }
-
     private final String storageRouteSpec;
-    private final AttributesProducer attributesConfig;
     private DerivedConfiguration sdConfig = null;
 
-    public StreamingSearchCluster(AbstractConfigProducer parent, String clusterName, int index, String docTypeName, String storageRouteSpec) {
+    public StreamingSearchCluster(AbstractConfigProducer parent, String clusterName, int index, String storageClusterName, String storageRouteSpec) {
         super(parent, clusterName, index);
-        attributesConfig = new AttributesProducer(this, docTypeName);
         this.storageRouteSpec = storageRouteSpec;
     }
 
-    public final String getDocumentDBConfigId() {
-        return attributesConfig.getConfigId();
-    }
     @Override
     protected IndexingMode getIndexingMode() { return IndexingMode.STREAMING; }
     public final String getStorageRouteSpec()       { return storageRouteSpec; }
-    @Override
     public int getRowBits() { return 0; }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/DocumentDatabaseTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/DocumentDatabaseTestCase.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.search.test;
 
-import com.google.common.collect.ImmutableMap;
 import com.yahoo.vespa.config.search.IndexschemaConfig;
 import com.yahoo.vespa.config.search.core.ProtonConfig;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
@@ -15,20 +14,16 @@ import com.yahoo.vespa.model.content.ContentSearchCluster;
 import com.yahoo.vespa.model.search.IndexedSearchCluster;
 import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * @author geirst
- */
+// TODO: Author!
 public class DocumentDatabaseTestCase {
 
     private String vespaHosts = "<?xml version='1.0' encoding='utf-8' ?>" +
@@ -38,7 +33,7 @@ public class DocumentDatabaseTestCase {
             "  </host>" +
             "</hosts>";
 
-    private String createVespaServices(List<String> sdNames, String mode) {
+    private String createVespaServices(List<String> sdNames, String selection, String mode) {
         StringBuilder retval = new StringBuilder();
         retval.append("" +
                       "<?xml version='1.0' encoding='utf-8' ?>\n" +
@@ -56,7 +51,9 @@ public class DocumentDatabaseTestCase {
                       "   <redundancy>1</redundancy>\n");
         retval.append("   <documents>\n");
         for (String sdName : sdNames) {
-            retval.append("").append("      <document type='").append(sdName).append("' mode='").append(mode).append("'");
+            retval.append("").append("      <document type='").append(sdName).append("' mode='" + mode + "'");
+            if (selection != null)
+                retval.append(" selection='").append(selection).append("'");
             retval.append("/>\n");
         }
         retval.append("   </documents>\n");
@@ -75,10 +72,10 @@ public class DocumentDatabaseTestCase {
         return new ProtonConfig(pb);
     }
 
-    private void assertSingleSD(String mode) {
+    @Test
+    public void requireThatWeCanHaveOneSearchDefinition() throws IOException, SAXException, ParseException {
         final List<String> sds = Arrays.asList("type1");
-        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, createVespaServices(sds, mode),
-                ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
+        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, createVespaServices(sds, null, "index"), ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
         IndexedSearchCluster indexedSearchCluster = (IndexedSearchCluster)model.getSearchClusters().get(0);
         ContentSearchCluster contentSearchCluster = model.getContentClusters().get("test").getSearch();
         assertEquals(1, indexedSearchCluster.getDocumentDbs().size());
@@ -87,10 +84,10 @@ public class DocumentDatabaseTestCase {
         assertEquals(1, proton.documentdb().size());
         assertEquals("type1", proton.documentdb(0).inputdoctypename());
         assertEquals(type1Id, proton.documentdb(0).configid());
-    }
-    @Test
-    public void requireThatWeCanHaveOneSDForIndexedMode() throws IOException, SAXException, ParseException {
-        assertSingleSD("index");
+        ProtonConfig nodeCfg = getProtonCfg(contentSearchCluster);
+        assertEquals(1, nodeCfg.documentdb().size());
+        assertEquals("type1", nodeCfg.documentdb(0).inputdoctypename());
+        assertEquals(type1Id, nodeCfg.documentdb(0).configid());
     }
 
     private void assertDocTypeConfig(VespaModel model, String configId, String indexField, String attributeField) {
@@ -98,9 +95,8 @@ public class DocumentDatabaseTestCase {
         assertEquals(1, icfg.indexfield().size());
         assertEquals(indexField, icfg.indexfield(0).name());
         AttributesConfig acfg = model.getConfig(AttributesConfig.class, configId);
-        assertEquals(2, acfg.attribute().size());
+        assertEquals(1, acfg.attribute().size());
         assertEquals(attributeField, acfg.attribute(0).name());
-        assertEquals(attributeField+"_nfa", acfg.attribute(1).name());
         RankProfilesConfig rcfg = model.getConfig(RankProfilesConfig.class, configId);
         assertEquals(6, rcfg.rankprofile().size());
     }
@@ -108,8 +104,7 @@ public class DocumentDatabaseTestCase {
     @Test
     public void requireThatWeCanHaveMultipleSearchDefinitions() throws IOException, SAXException, ParseException {
         final List<String> sds = Arrays.asList("type1", "type2", "type3");
-        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, createVespaServices(sds, "index"),
-                ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
+        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, createVespaServices(sds, null, "index"), ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
         IndexedSearchCluster indexedSearchCluster = (IndexedSearchCluster)model.getSearchClusters().get(0);
         ContentSearchCluster contentSearchCluster = model.getContentClusters().get("test").getSearch();
         String type1Id = "test/search/cluster.test/type1";
@@ -137,14 +132,12 @@ public class DocumentDatabaseTestCase {
             assertEquals("type3", iicfg.indexinfo().get(2).name());
         }
         {
-            AttributesConfig rac1 = model.getConfig(AttributesConfig.class, type1Id);
-            assertEquals(2, rac1.attribute().size());
+            AttributesConfig rac1 = model.getConfig(AttributesConfig.class, "test/search/cluster.test/type1");
+            assertEquals(1, rac1.attribute().size());
             assertEquals("f2", rac1.attribute(0).name());
-            assertEquals("f2_nfa", rac1.attribute(1).name());
-            AttributesConfig rac2 = model.getConfig(AttributesConfig.class, type2Id);
-            assertEquals(2, rac2.attribute().size());
+            AttributesConfig rac2 = model.getConfig(AttributesConfig.class, "test/search/cluster.test/type2");
+            assertEquals(1, rac2.attribute().size());
             assertEquals("f4", rac2.attribute(0).name());
-            assertEquals("f4_nfa", rac2.attribute(1).name());
         }
         {
             IlscriptsConfig icfg = model.getConfig(IlscriptsConfig.class, "test/search/cluster.test");
@@ -158,8 +151,7 @@ public class DocumentDatabaseTestCase {
     @Test
     public void requireThatRelevantConfigIsAvailableForClusterSearcher() throws ParseException, IOException, SAXException {
         final List<String> sds = Arrays.asList("type1", "type2");
-        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, createVespaServices(sds, "index"),
-                ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
+        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, createVespaServices(sds, null, "index"), ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
         String searcherId = "container/searchchains/chain/test/component/com.yahoo.prelude.cluster.ClusterSearcher";
 
         { // documentdb-info config
@@ -192,12 +184,10 @@ public class DocumentDatabaseTestCase {
         }
         { // attributes config
             AttributesConfig acfg = model.getConfig(AttributesConfig.class, searcherId);
-            assertEquals(4, acfg.attribute().size());
+            assertEquals(2, acfg.attribute().size());
             assertEquals("f2", acfg.attribute(0).name());
-            assertEquals("f2_nfa", acfg.attribute(1).name());
-            assertEquals("f4", acfg.attribute(2).name());
-            assertEquals("f4_nfa", acfg.attribute(3).name());
-
+            assertEquals("f4", acfg.attribute(1).name());
+            assertEquals("f4", acfg.attribute(1).name());
         }
     }
 
@@ -217,62 +207,16 @@ public class DocumentDatabaseTestCase {
         assertEquals(dynamic, field.dynamic());
     }
 
-    private void assertDocumentDBConfigAvailableForStreaming(String mode) {
+
+    @Test
+    public void requireThatConfigIsAvailableForStreaming() throws ParseException, IOException, SAXException {
         final List<String> sds = Arrays.asList("type");
-        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts,  createVespaServices(sds, mode),
-                ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
+        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts,  createVespaServices(sds, null, "streaming"), ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
 
         DocumentdbInfoConfig dcfg = model.getConfig(DocumentdbInfoConfig.class, "test/search/cluster.test.type");
         assertEquals(1, dcfg.documentdb().size());
         DocumentdbInfoConfig.Documentdb db = dcfg.documentdb(0);
         assertEquals("type", db.name());
-    }
-
-    @Test
-    public void requireThatDocumentDBConfigIsAvailableForStreaming() throws ParseException, IOException, SAXException {
-        assertDocumentDBConfigAvailableForStreaming("streaming");
-    }
-
-
-    private void assertAttributesConfigIndependentOfMode(String mode, List<String> sds,
-                                                         List<String> documentDBConfigIds,
-                                                         Map<String, List<String>> expectedAttributesMap) {
-        VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts,  createVespaServices(sds, mode),
-                ApplicationPackageUtils.generateSearchDefinitions(sds)).create();
-        ContentSearchCluster contentSearchCluster = model.getContentClusters().get("test").getSearch();
-
-        ProtonConfig proton = getProtonCfg(contentSearchCluster);
-        assertEquals(sds.size(), proton.documentdb().size());
-        for (int i = 0; i < sds.size(); i++) {
-            assertEquals(sds.get(i), proton.documentdb(i).inputdoctypename());
-            assertEquals(documentDBConfigIds.get(i), proton.documentdb(i).configid());
-            List<String> expectedAttributes = expectedAttributesMap.get(sds.get(i));
-            if (expectedAttributes != null) {
-                AttributesConfig rac1 = model.getConfig(AttributesConfig.class, proton.documentdb(i).configid());
-                assertEquals(expectedAttributes.size(), rac1.attribute().size());
-                for (int j = 0; j < expectedAttributes.size(); j++) {
-                    assertEquals(expectedAttributes.get(j), rac1.attribute(j).name());
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testThatAttributesConfigIsProducedForIndexed() {
-        assertAttributesConfigIndependentOfMode("index", Arrays.asList("type1"),
-                Arrays.asList("test/search/cluster.test/type1"),
-                ImmutableMap.of("type1", Arrays.asList("f2", "f2_nfa")));
-    }
-    @Test
-    public void testThatAttributesConfigIsProducedForStreamingForFastAccessFields() {
-        assertAttributesConfigIndependentOfMode("streaming", Arrays.asList("type1"),
-                Arrays.asList("test/search/cluster.test.type1/type1"),
-                ImmutableMap.of("type1", Arrays.asList("f2")));
-    }
-    @Test
-    public void testThatAttributesConfigIsNotProducedForStoreOnlyEvenForFastAccessFields() {
-        assertAttributesConfigIndependentOfMode("store-only", Arrays.asList("type1"),
-                Arrays.asList("test/search"), Collections.emptyMap());
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/utils/ApplicationPackageUtils.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/utils/ApplicationPackageUtils.java
@@ -27,11 +27,7 @@ public class ApplicationPackageUtils {
                 "    }\n" +
                 "    field " + field2 + " type int {\n" +
                 "      indexing: attribute | summary\n" +
-                "      attribute: fast-access\n" +
                 "      header\n" +
-                "    }\n" +
-                "    field " + field2 + "_nfa type int {\n" +
-                "      indexing: attribute \n" +
                 "    }\n" +
                 "  }\n" +
                 "  rank-profile staticrank inherits default {" +


### PR DESCRIPTION
Reverts yahoo/vespa#2202
Due to broken system tests. Revert and debug.
http://factory-web.vespa.corp.gq1.yahoo.com/versions/1/builds/20577/products/1/tests
@geirst PR