### PR TITLE
Arnej/more warnings in application

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -110,6 +110,7 @@
           <compilerArgs>
             <arg>-Xlint:all</arg>
             <arg>-Xlint:-serial</arg>
+            <arg>-Werror</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -108,9 +108,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>
-            <arg>-Xlint:rawtypes</arg>
-            <arg>-Xlint:unchecked</arg>
-            <arg>-Xlint:deprecation</arg>
+            <arg>-Xlint:all</arg>
+            <arg>-Xlint:-serial</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/application/src/main/java/com/yahoo/application/container/Search.java
+++ b/application/src/main/java/com/yahoo/application/container/Search.java
@@ -41,6 +41,7 @@ public final class Search extends ProcessingBase<Query, Result, Searcher> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected ListenableFuture<Boolean> doProcessAndRender(ComponentSpecification chainSpec,
                                                            Query request,
                                                            Renderer<Result> renderer,
@@ -51,6 +52,7 @@ public final class Search extends ProcessingBase<Query, Result, Searcher> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Renderer<Result> doGetRenderer(ComponentSpecification spec) {
         return handler.getRendererCopy(spec);
     }

--- a/application/src/test/java/com/yahoo/application/ApplicationFacade.java
+++ b/application/src/test/java/com/yahoo/application/ApplicationFacade.java
@@ -155,7 +155,7 @@ public class ApplicationFacade implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         application.close();
     }
 }

--- a/application/src/test/java/com/yahoo/application/ApplicationTest.java
+++ b/application/src/test/java/com/yahoo/application/ApplicationTest.java
@@ -54,6 +54,7 @@ public class ApplicationTest {
     @Test
     public void minimal_application_can_be_constructed() throws Exception {
         try (Application application = Application.fromServicesXml("<jdisc version=\"1.0\"/>", Networking.disable)) {
+                Application unused = application;
         }
     }
 
@@ -296,6 +297,7 @@ public class ApplicationTest {
     public void file_distribution() throws Exception {
         try (Application application = Application.fromApplicationPackage(new File("src/test/app-packages/filedistribution/"), Networking.disable)) {
             // Deployment succeeded
+            Application unused = application;
         }
     }
 
@@ -324,6 +326,7 @@ public class ApplicationTest {
                 .container("default", new Application.Builder.Container()
                 .search(true)
                 ))) {
+            Application unused = app;
         }
     }
 
@@ -334,6 +337,7 @@ public class ApplicationTest {
             HttpClient client = new org.apache.http.impl.client.DefaultHttpClient();
             int statusCode = client.execute(new HttpGet("http://localhost:" + httpPort)).getStatusLine().getStatusCode();
             fail("Networking.disable is specified, but the network interface is enabled! Got status code: " + statusCode);
+            Application unused = application;
         }
     }
 
@@ -351,6 +355,7 @@ public class ApplicationTest {
                 sb.append(line).append("\n");
             }
             assertTrue(sb.toString().contains("Handler"));
+            Application unused = application;
         }
     }
 


### PR DESCRIPTION
@bratseth please review

i did not turn on -Werror here because there are two deprecation warnings that need to be dealt with first:

[WARNING] src/main/java/com/yahoo/application/container/Search.java:[49,31] setRenderer(com.yahoo.processing.rendering.Renderer<com.yahoo.search.Result>) in com.yahoo.search.result.Templating has been deprecated
[WARNING] src/main/java/com/yahoo/application/container/Search.java:[55,23] getRendererCopy(com.yahoo.component.ComponentSpecification) in com.yahoo.search.handler.SearchHandler has been deprecated

i didn't find a non-deprecated way to deal with rendering, do you know how?