### PR TITLE
Allow nodes in state provisioned to be deleted

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -425,12 +425,12 @@ public class NodeRepository extends AbstractComponent {
     }
 
     /**
-     * Removes a node. A node must be in the failed or parked state before it can be removed.
+     * Removes a node. A node must be in the provisioned, failed or parked state before it can be removed.
      *
      * @return true if the node was removed, false if it was not found in one of these states
      */
     public boolean remove(String hostname) {
-        Optional<Node> nodeToRemove = getNode(hostname, Node.State.failed, Node.State.parked);
+        Optional<Node> nodeToRemove = getNode(hostname, Node.State.provisioned, Node.State.failed, Node.State.parked);
         if ( ! nodeToRemove.isPresent()) return false;
 
         try (Mutex lock = lock(nodeToRemove.get())) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -154,7 +154,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
             if (nodeRepository.remove(hostname))
                 return new MessageResponse("Removed " + hostname);
             else
-                throw new NotFoundException("No node in the failed state with hostname " + hostname);
+                throw new NotFoundException("No node in the provisioned, parked or failed state with hostname " + hostname);
         }
 
         throw new NotFoundException("Nothing at path '" + request.getUri().getPath() + "'");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -82,6 +82,11 @@ public class RestApiTest {
         assertFile(new Request("http://localhost:8080/nodes/v2/node/host11.yahoo.com"), "node11.json");
         assertFile(new Request("http://localhost:8080/nodes/v2/node/parent2.yahoo.com"), "parent2.json");
 
+        // DELETE a provisioned node
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host11.yahoo.com",
+                                   new byte[0], Request.Method.DELETE),
+                       "{\"message\":\"Removed host11.yahoo.com\"}");
+
         // PUT nodes ready
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/dirty/host8.yahoo.com",
                         new byte[0], Request.Method.PUT),
@@ -352,10 +357,10 @@ public class RestApiTest {
                                    new byte[0], Request.Method.PUT),
                        "{\"message\":\"Moved host2.yahoo.com to ready\"}");
 
-        // Attempt to DELETE a node which is not put in failed first
-        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host8.yahoo.com",
+        // Attempt to DELETE a node which is not put in a deletable state first
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host2.yahoo.com",
                                    new byte[0], Request.Method.DELETE),
-                       404, "{\"error-code\":\"NOT_FOUND\",\"message\":\"No node in the failed state with hostname host8.yahoo.com\"}");
+                       404, "{\"error-code\":\"NOT_FOUND\",\"message\":\"No node in the provisioned, parked or failed state with hostname host2.yahoo.com\"}");
 
         // PUT current restart generation with string instead of long
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",


### PR DESCRIPTION
When node fails during provisioning, we usually just delete them. Make this process easier by not requiring it to be moved to failed first.