### PR TITLE
Add state/v1/version path returning the Vespa version

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/StateResource.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/StateResource.java
@@ -32,10 +32,11 @@ import org.glassfish.jersey.client.proxy.WebResourceFactory;
 /**
  * A web service to discover and proxy Vespa service state info.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 @Path("/")
 public class StateResource implements StateClient {
+
     private static final String SINGLE_API_LINK = "url";
     private final int restApiPort;
     private final String host;

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/StateHandlerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/StateHandlerTest.java
@@ -4,6 +4,7 @@ package com.yahoo.container.jdisc.state;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
+import com.yahoo.component.Vtag;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.jdisc.Metric;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen Hult</a>
+ * @author Simon Thoresen Hult
  */
 public class StateHandlerTest {
 
@@ -383,6 +384,14 @@ public class StateHandlerTest {
         JsonNode config = root.get("config");
         JsonNode container = config.get("container");
         assertEquals(META_GENERATION, container.get("generation").asLong());
+    }
+
+    @Test
+    public void testStateVersion() throws Exception {
+        JsonNode root = requestAsJson("http://localhost/state/v1/version");
+
+        JsonNode version = root.get("version");
+        assertEquals(Vtag.currentVersion.toString(), version.asText());
     }
 
     private void incrementCurrentTime(long val) {

--- a/container-search-and-docproc/src/main/java/com/yahoo/container/handler/observability/ApplicationStatusHandler.java
+++ b/container-search-and-docproc/src/main/java/com/yahoo/container/handler/observability/ApplicationStatusHandler.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * Handler that outputs meta-info about the deployed Vespa application, and status of components and chains.
  *
  * @author gjoranv
- * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
+ * @author Einar M R Rosenvinge
  */
 public class ApplicationStatusHandler extends AbstractRequestHandler {
 


### PR DESCRIPTION
@gjoranv please review

This add the path /state/v1/version
which returns
{"version": "vespa-version-number"}
which I need to check convergence of config servers from the controller.

I know this is included in the /ApplicationStatus api as well, but I think it's messy to depend on that.