### PR TITLE
Bjorncs/upgrade netty

### DIFF
--- a/application/src/main/java/com/yahoo/application/Application.java
+++ b/application/src/main/java/com/yahoo/application/Application.java
@@ -20,7 +20,6 @@ import com.yahoo.search.rendering.Renderer;
 import com.yahoo.text.StringUtilities;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.model.VespaModel;
-import org.jboss.netty.channel.ChannelException;
 import org.xml.sax.SAXException;
 
 import java.io.File;
@@ -316,7 +315,7 @@ public final class Application implements AutoCloseable {
                     break;
                 } catch (Error e) { // the container thinks this is really serious, in this case is it not in the cause is a BindException
                     // catch bind error and reset container
-                    if (e.getCause() != null && e.getCause() instanceof ChannelException && e.getCause().getCause() != null && e.getCause().getCause() instanceof BindException) {
+                    if (e.getCause() != null && e.getCause().getCause() != null && e.getCause().getCause() instanceof BindException) {
                         exception = (Exception) e.getCause().getCause();
                         com.yahoo.container.Container.resetInstance(); // this is needed to be able to recreate the container from config again
                     } else {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/Cookie.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/Cookie.java
@@ -1,10 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http;
 
-import org.jboss.netty.handler.codec.http.CookieDecoder;
-import org.jboss.netty.handler.codec.http.CookieEncoder;
-import org.jboss.netty.handler.codec.http.DefaultCookie;
-
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -14,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  */
+@SuppressWarnings("deprecation")
 public class Cookie {
 
     private final Set<Integer> ports = new HashSet<>();
@@ -240,10 +237,11 @@ public class Cookie {
     }
 
     private static String encodeCookies(Iterable<? extends Cookie> cookies, boolean server) {
-        CookieEncoder encoder = new org.jboss.netty.handler.codec.http.CookieEncoder(server);
+        org.jboss.netty.handler.codec.http.CookieEncoder encoder =
+                new org.jboss.netty.handler.codec.http.CookieEncoder(server);
         for (Cookie cookie : cookies) {
             org.jboss.netty.handler.codec.http.Cookie nettyCookie =
-                    new DefaultCookie(String.valueOf(cookie.getName()), String.valueOf(cookie.getValue()));
+                    new org.jboss.netty.handler.codec.http.DefaultCookie(String.valueOf(cookie.getName()), String.valueOf(cookie.getValue()));
             nettyCookie.setComment(cookie.getComment());
             nettyCookie.setCommentUrl(cookie.getCommentUrl());
             nettyCookie.setDiscard(cookie.isDiscard());
@@ -260,7 +258,8 @@ public class Cookie {
     }
 
     private static List<Cookie> decodeCookies(String str) {
-        CookieDecoder decoder = new CookieDecoder();
+        org.jboss.netty.handler.codec.http.CookieDecoder decoder =
+                new org.jboss.netty.handler.codec.http.CookieDecoder();
         List<Cookie> ret = new LinkedList<>();
         for (org.jboss.netty.handler.codec.http.Cookie nettyCookie : decoder.decode(str)) {
             Cookie cookie = new Cookie();

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -70,7 +70,6 @@ public class JettyHttpServer extends AbstractServerProvider {
         String NAME_DIMENSION = "serverName";
         String PORT_DIMENSION = "serverPort";
 
-        String NUM_ACTIVE_REQUESTS = "serverNumActiveRequests";
         String NUM_OPEN_CONNECTIONS = "serverNumOpenConnections";
         String NUM_CONNECTIONS_OPEN_MAX = "serverConnectionsOpenMax";
         String CONNECTION_DURATION_MAX = "serverConnectionDurationMax";
@@ -83,8 +82,6 @@ public class JettyHttpServer extends AbstractServerProvider {
         String MANHATTAN_NUM_BYTES_SENT     = "http.out.bytes";
 
         String NUM_CONNECTIONS = "serverNumConnections";
-        String NUM_CONNECTIONS_IDLE = "serverNumConnectionsIdle";
-        String NUM_UNEXPECTED_DISCONNECTS = "serverNumUnexpectedDisconnects";
 
         /* For historical reasons, these are all aliases for the same metric. 'jdisc.http' should ideally be the only one. */
         String JDISC_HTTP_REQUESTS = "jdisc.http.requests";
@@ -96,7 +93,6 @@ public class JettyHttpServer extends AbstractServerProvider {
         String NUM_SUCCESSFUL_WRITES = "serverNumSuccessfulResponseWrites";
         String NUM_FAILED_WRITES = "serverNumFailedResponseWrites";
 
-        String NETWORK_LATENCY = "serverNetworkLatency";
         String TOTAL_SUCCESSFUL_LATENCY = "serverTotalSuccessfulResponseLatency";
         String MANHATTAN_TOTAL_SUCCESSFUL_LATENCY = "http.latency";
         String TOTAL_FAILED_LATENCY = "serverTotalFailedResponseLatency";

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/CookieTestCase.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/CookieTestCase.java
@@ -1,8 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http;
 
-import org.jboss.netty.handler.codec.http.CookieDecoder;
-import org.jboss.netty.handler.codec.http.DefaultCookie;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -23,12 +21,13 @@ import static org.testng.AssertJUnit.fail;
 /**
  * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen Hult</a>
  */
+@SuppressWarnings("deprecation")
 public class CookieTestCase {
 
     @Test
     public void requireThatDefaultValuesAreSane() {
-        assertCookie(new DefaultCookie("foo", "bar"), new Cookie().setName("foo").setValue("bar"));
-        assertCookie(new DefaultCookie("foo", "bar"), new Cookie("foo", "bar"));
+        assertCookie(new org.jboss.netty.handler.codec.http.DefaultCookie("foo", "bar"), new Cookie().setName("foo").setValue("bar"));
+        assertCookie(new org.jboss.netty.handler.codec.http.DefaultCookie("foo", "bar"), new Cookie("foo", "bar"));
     }
 
     @Test
@@ -134,20 +133,17 @@ public class CookieTestCase {
     @Test
     public void requireThatCookieCanBeEncoded() {
         assertEncodeCookie(
-                Collections.singletonList("$Version=1; foo.name=foo.value; $Path=path; $Domain=domain; $Port=\"69\""),
+                Collections.singletonList("foo.name=foo.value"),
                 Collections.singletonList(newCookie("foo")));
         assertEncodeCookie(
-                Arrays.asList("$Version=1; bar.name=bar.value; $Path=path; $Domain=domain; $Port=\"69\"",
-                              "$Version=1; foo.name=foo.value; $Path=path; $Domain=domain; $Port=\"69\""),
+                Collections.singletonList("bar.name=bar.value; foo.name=foo.value"),
                 Arrays.asList(newCookie("foo"), newCookie("bar")));
     }
 
     @Test
     public void requireThatSetCookieCanBeEncoded() {
         assertEncodeSetCookie(
-                Collections.singletonList("foo.name=foo.value; Max-Age=0; Path=path; Domain=domain; Secure; " +
-                                          "HTTPOnly; Comment=comment; Version=1; CommentURL=\"commentUrl\"; " +
-                                          "Port=\"69\"; Discard"),
+                Collections.singletonList("foo.name=foo.value; Path=path; Domain=domain; Secure; HTTPOnly"),
                 Collections.singletonList(newCookie("foo")));
     }
 
@@ -214,7 +210,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForGenericValidCookies() {
-        new CookieDecoder().decode("Y=v=1&n=8es5opih9ljtk&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
+        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=8es5opih9ljtk&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
                                    "us&np=1; T=z=h.nzPBhSP4PBVd5JqacVnIbNjU1NAY2TjYzNzVOTjYzNzM0Mj&a=YAE&sk=DAALShmNQ" +
                                    "vhoZV&ks=EAABsibvMK6ejwn0uUoS4rC9w--~E&d=c2wBTVRJeU13RXhPVEUwTURJNU9URTBNRFF6TlRJ" +
                                    "NU5nLS0BYQFZQUUBZwE1VkNHT0w3VUVDTklJVEdRR1FXT0pOSkhEQQFzY2lkAWNOUnZIbEc3ZHZoVHlWZ" +
@@ -223,7 +219,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForYInvalidCookies() {
-        new CookieDecoder().decode("Y=v=1&n=77nkr5t7o4nqn&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
+        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=77nkr5t7o4nqn&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
                                    "us&np=1; T=z=05nzPB0NP4PBN/n0gwc1AWGNjU1NAY2TjYzNzVOTjYzNzM0Mj&a=QAE&sk=DAA4R2svo" +
                                    "osjIa&ks=EAAj3nBQFkN4ZmuhqFxJdNoaQ--~E&d=c2wBTVRJeU13RXhPVEUwTURJNU9URTBNRFF6TlRJ" +
                                    "NU5nLS0BYQFRQUUBZwE1VkNHT0w3VUVDTklJVEdRR1FXT0pOSkhEQQFzY2lkAUpPalRXOEVsUDZrR3RHT" +
@@ -232,7 +228,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForYValidCookies() {
-        new CookieDecoder().decode("Y=v=1&n=3767k6te5aj2s&l=1v4u3001uw2ys00q0rw0qrw34q0x5s3u/o&p=030vvit012000000&iz=" +
+        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=3767k6te5aj2s&l=1v4u3001uw2ys00q0rw0qrw34q0x5s3u/o&p=030vvit012000000&iz=" +
                                    "&r=pu&lg=en-US,it-IT,it&intl=it&np=1; T=z=m38yPBmLk3PBWvehTPBhBHYNU5OBjQ3NE5ONU5P" +
                                    "NDY0NzU0M0&a=IAE&sk=DAAAx5URYgbhQ6&ks=EAA4rTgdlAGeMQmdYeM_VehGg--~E&d=c2wBTWprNUF" +
                                    "UTXdNems1TWprNE16RXpNREl6TkRneAFhAUlBRQFnAUVJSlNMSzVRM1pWNVNLQVBNRkszQTRaWDZBAXNj" +
@@ -242,7 +238,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForGenericInvalidCookies() {
-        new CookieDecoder().decode("Y=v=1&n=e92s5cq8qbs6h&l=3kdb0f.3@i126be10b.d4j/o&p=m1f2qgmb13000107&r=g5&lg=en-US" +
+        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=e92s5cq8qbs6h&l=3kdb0f.3@i126be10b.d4j/o&p=m1f2qgmb13000107&r=g5&lg=en-US" +
                                    "&intl=us; T=z=TXp3OBTrQ8OBFMcj3GBpFSyNk83TgY2MjMwN04zMDMw&a=YAE&sk=DAAVfaNwLeISrX" +
                                    "&ks=EAAOeNNgY8c5hV8YzPYmnrW7w--~E&d=c2wBTVRnd09RRXhOVFEzTURrME56UTMBYQFZQUUBZwFMQ" +
                                    "U5NT0Q2UjY2Q0I1STY0R0tKSUdVQVlRRQFvawFaVzAtAXRpcAFMTlRUdkMBenoBVFhwM09CQTdF&af=QU" +
@@ -282,7 +278,7 @@ public class CookieTestCase {
         }
     }
 
-    private static void assertCookie(final DefaultCookie expected, final Cookie actual) {
+    private static void assertCookie(final org.jboss.netty.handler.codec.http.DefaultCookie expected, final Cookie actual) {
         assertEquals(expected.getName(), actual.getName());
         assertEquals(expected.getValue(), actual.getValue());
         assertEquals(expected.getDomain(), actual.getDomain());
@@ -304,7 +300,6 @@ public class CookieTestCase {
         cookie.setPath("path");
         cookie.setComment("comment");
         cookie.setCommentUrl("commentUrl");
-        cookie.setMaxAge(69, TimeUnit.MILLISECONDS);
         cookie.setVersion(2);
         cookie.setSecure(true);
         cookie.setHttpOnly(true);

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/HttpRequestTestCase.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/HttpRequestTestCase.java
@@ -4,9 +4,6 @@ package com.yahoo.jdisc.http;
 import com.yahoo.jdisc.Container;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.service.CurrentContainer;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
@@ -28,27 +25,6 @@ import static org.testng.AssertJUnit.assertTrue;
  * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
  */
 public class HttpRequestTestCase {
-
-    @Test
-    public void requireThatMethodIsCompatibleWithNetty() {
-        assertMethod(HttpRequest.Method.OPTIONS, HttpMethod.OPTIONS);
-        assertMethod(HttpRequest.Method.GET, HttpMethod.GET);
-        assertMethod(HttpRequest.Method.HEAD, HttpMethod.HEAD);
-        assertMethod(HttpRequest.Method.POST, HttpMethod.POST);
-        assertMethod(HttpRequest.Method.PUT, HttpMethod.PUT);
-        assertMethod(HttpRequest.Method.PATCH, HttpMethod.PATCH);
-        assertMethod(HttpRequest.Method.DELETE, HttpMethod.DELETE);
-        assertMethod(HttpRequest.Method.TRACE, HttpMethod.TRACE);
-        assertMethod(HttpRequest.Method.CONNECT, HttpMethod.CONNECT);
-        assertEquals(9, HttpRequest.Method.values().length);
-    }
-
-    @Test
-    public void requireThatVersionIsCompatibleWithNetty() {
-        assertVersion(HttpRequest.Version.HTTP_1_0, HttpVersion.HTTP_1_0);
-        assertVersion(HttpRequest.Version.HTTP_1_1, HttpVersion.HTTP_1_1);
-        assertEquals(2, HttpRequest.Version.values().length);
-    }
 
     @Test
     public void requireThatSimpleServerConstructorsUseReasonableDefaults() {
@@ -212,18 +188,6 @@ public class HttpRequestTestCase {
         final List<Cookie> cookies = Collections.singletonList(new Cookie("foo", "bar"));
         request.encodeCookieHeader(cookies);
         assertEquals(cookies, request.decodeCookieHeader());
-    }
-
-    private static void assertMethod(final HttpRequest.Method discMethod, final HttpMethod nettyMethod) {
-        assertEquals(discMethod, HttpRequest.Method.valueOf(nettyMethod.getName()));
-        assertEquals(discMethod, HttpRequest.Method.valueOf(nettyMethod.toString()));
-        assertEquals(nettyMethod, HttpMethod.valueOf(discMethod.toString()));
-    }
-
-    private static void assertVersion(final HttpRequest.Version discVersion, final HttpVersion nettyVersion) {
-        assertEquals(discVersion, HttpRequest.Version.fromString(nettyVersion.getText()));
-        assertEquals(discVersion, HttpRequest.Version.fromString(nettyVersion.toString()));
-        assertEquals(nettyVersion, HttpVersion.valueOf(discVersion.toString()));
     }
 
     private static HttpRequest newRequest(final HttpRequest.Version version) throws Exception {

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -353,21 +353,13 @@ public class HttpServerTest {
                                             .setDiscard(true)
                                             .setDomain(".localhost")
                                             .setHttpOnly(true)
-                                            .setMaxAge(5000, TimeUnit.SECONDS)
                                             .setPath("/foopath")
                                             .setSecure(true)
                                             .setVersion(2)));
         driver.client().get("/status.html")
               .expectStatusCode(is(OK))
-              .expectHeader("Set-Cookie", is("foo=bar; " +
-                                             "Max-Age=5000; " +
-                                             "Path=\"/foopath\"; " +
-                                             "Domain=.localhost; " +
-                                             "Secure; HTTPOnly; " +
-                                             "Comment=\"comment yeah\"; " +
-                                             "Version=1; " +
-                                             "CommentURL=\"http://comment.yes/\"; " +
-                                             "Discard"));
+              .expectHeader("Set-Cookie",
+                      is("foo=bar; Path=/foopath; Domain=.localhost; Secure; HTTPOnly"));
         assertThat(driver.close(), is(true));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.6.10.Final</version>
+                <version>3.10.6.Final</version>
             </dependency>
             <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Upgrade to Netty 3.10.6 and remove some other minor usage of Netty. The cookie behaviour has changed due to Netty now abiding RFC 6265, the newest cookie spec. 