### PR TITLE
disallow some warnings

### DIFF
--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -272,6 +272,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Xlint:-rawtypes</arg>
+            <arg>-Xlint:-unchecked</arg>
+            <arg>-Xlint:-serial</arg>
+            <arg>-Xlint:-try</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
     </plugins>
     <outputDirectory>${buildOutputDirectory}</outputDirectory>


### PR DESCRIPTION
* note that "rawtypes" and "unchecked" warnings are
  not enabled, since some design choices (especially
  the type parametrization of DataList and Renderer)
  means we would have to suppress those warnings a lot.

@gjoranv please review and merge
@bratseth FYI