### PR TITLE
Remove use of deprecated cookie API of Netty

### DIFF
--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -22,10 +22,6 @@
       <classifier>no_aop</classifier>
     </dependency>
     <dependency>
-      <groupId>commons-pool</groupId>
-      <artifactId>commons-pool</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/HttpResponse.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/HttpResponse.java
@@ -8,7 +8,6 @@ import com.yahoo.jdisc.handler.CompletionHandler;
 import com.yahoo.jdisc.handler.ContentChannel;
 import com.yahoo.jdisc.handler.ResponseHandler;
 import com.yahoo.jdisc.http.servlet.ServletOrJdiscHttpResponse;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -78,7 +77,7 @@ public class HttpResponse extends Response implements ServletOrJdiscHttpResponse
     public void encodeSetCookieHeader(List<Cookie> cookies) {
         headers().remove(HttpHeaders.Names.SET_COOKIE);
         for (Cookie cookie : cookies) {
-            headers().add(HttpHeaders.Names.SET_COOKIE, Cookie.toSetCookieHeader(Arrays.asList(cookie)));
+            headers().add(HttpHeaders.Names.SET_COOKIE, Cookie.toSetCookieHeaderAll(Arrays.asList(cookie)));
         }
     }
 

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/JDiscCookieWrapper.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/JDiscCookieWrapper.java
@@ -1,9 +1,9 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.filter;
 
-import java.util.concurrent.TimeUnit;
-
 import com.yahoo.jdisc.http.Cookie;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Wrapper of Cookie.
@@ -23,6 +23,7 @@ public class JDiscCookieWrapper {
         return new JDiscCookieWrapper(cookie);
     }
 
+    @Deprecated
     public String getComment() {
         return cookie.getComment();
     }
@@ -51,10 +52,12 @@ public class JDiscCookieWrapper {
         return cookie.getValue();
     }
 
+    @Deprecated
     public int getVersion() {
         return cookie.getVersion();
     }
 
+    @Deprecated
     public void setComment(String purpose) {
         cookie.setComment(purpose);
     }
@@ -79,6 +82,7 @@ public class JDiscCookieWrapper {
        cookie.setValue(newValue);
     }
 
+    @Deprecated
     public void setVersion(int version) {
        cookie.setVersion(version);
     }

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/ServletFilterResponse.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/ServletFilterResponse.java
@@ -7,7 +7,6 @@ import com.yahoo.jdisc.http.HttpHeaders;
 import com.yahoo.jdisc.http.servlet.ServletResponse;
 
 import javax.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -78,8 +77,7 @@ class ServletFilterResponse extends DiscFilterResponse {
     @Override
     public void setCookies(List<Cookie> cookies) {
         removeHeaders(HttpHeaders.Names.SET_COOKIE);
-        for (Cookie cookie : cookies) {
-            addHeader(HttpHeaders.Names.SET_COOKIE, Cookie.toSetCookieHeader(Arrays.asList(cookie)));
-        }
+        List<String> setCookieHeaders = Cookie.toSetCookieHeaderAll(cookies);
+        setCookieHeaders.forEach(cookie -> addHeader(HttpHeaders.Names.SET_COOKIE, cookie));
     }
 }

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/CookieTestCase.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/CookieTestCase.java
@@ -5,29 +5,32 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertNotSame;
-import static org.testng.AssertJUnit.assertSame;
 import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
 
 /**
  * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen Hult</a>
+ * @author bjorncs
  */
-@SuppressWarnings("deprecation")
 public class CookieTestCase {
 
     @Test
     public void requireThatDefaultValuesAreSane() {
-        assertCookie(new org.jboss.netty.handler.codec.http.DefaultCookie("foo", "bar"), new Cookie().setName("foo").setValue("bar"));
-        assertCookie(new org.jboss.netty.handler.codec.http.DefaultCookie("foo", "bar"), new Cookie("foo", "bar"));
+        Cookie cookie = new Cookie("foo", "bar");
+        assertEquals("foo", cookie.getName());
+        assertEquals("bar", cookie.getValue());
+        assertEquals(null, cookie.getDomain());
+        assertEquals(Integer.MIN_VALUE, cookie.getMaxAge(TimeUnit.SECONDS));
+        assertEquals(null, cookie.getPath());
+        assertEquals(false, cookie.isHttpOnly());
+        assertEquals(false, cookie.isSecure());
     }
 
     @Test
@@ -53,23 +56,9 @@ public class CookieTestCase {
         cookie.setPath("bar");
         assertEquals("bar", cookie.getPath());
 
-        cookie.setComment("foo");
-        assertEquals("foo", cookie.getComment());
-        cookie.setComment("bar");
-        assertEquals("bar", cookie.getComment());
-
-        cookie.setCommentUrl("foo");
-        assertEquals("foo", cookie.getCommentUrl());
-        assertSame(cookie.getCommentUrl(), cookie.getCommentURL());
-        cookie.setCommentUrl("bar");
-        assertEquals("bar", cookie.getCommentUrl());
-        assertSame(cookie.getCommentUrl(), cookie.getCommentURL());
-
         cookie.setMaxAge(69, TimeUnit.DAYS);
         assertEquals(69, cookie.getMaxAge(TimeUnit.DAYS));
         assertEquals(TimeUnit.DAYS.toHours(69), cookie.getMaxAge(TimeUnit.HOURS));
-        cookie.setVersion(69);
-        assertEquals(69, cookie.getVersion());
 
         cookie.setSecure(true);
         assertTrue(cookie.isSecure());
@@ -80,38 +69,19 @@ public class CookieTestCase {
         assertTrue(cookie.isHttpOnly());
         cookie.setHttpOnly(false);
         assertFalse(cookie.isHttpOnly());
-
-        cookie.setDiscard(true);
-        assertTrue(cookie.isDiscard());
-        cookie.setDiscard(false);
-        assertFalse(cookie.isDiscard());
-
-        cookie.ports().add(6);
-        assertEquals(1, cookie.ports().size());
-        assertTrue(cookie.ports().contains(6));
-        cookie.ports().add(9);
-        assertEquals(2, cookie.ports().size());
-        assertTrue(cookie.ports().contains(6));
-        assertTrue(cookie.ports().contains(9));
     }
 
     @Test
     public void requireThatCopyConstructorWorks() {
-        final Cookie lhs = newCookie("foo");
+        final Cookie lhs = newSetCookie("foo");
         final Cookie rhs = new Cookie(lhs);
         assertEquals(rhs.getName(), rhs.getName());
         assertEquals(rhs.getValue(), rhs.getValue());
         assertEquals(rhs.getDomain(), rhs.getDomain());
         assertEquals(rhs.getPath(), rhs.getPath());
-        assertEquals(rhs.getComment(), rhs.getComment());
-        assertEquals(rhs.getCommentUrl(), rhs.getCommentUrl());
         assertEquals(rhs.getMaxAge(TimeUnit.MILLISECONDS), rhs.getMaxAge(TimeUnit.MILLISECONDS));
-        assertEquals(rhs.getVersion(), rhs.getVersion());
         assertEquals(rhs.isSecure(), rhs.isSecure());
         assertEquals(rhs.isHttpOnly(), rhs.isHttpOnly());
-        assertEquals(rhs.isDiscard(), rhs.isDiscard());
-        assertEquals(rhs.ports(), lhs.ports());
-        assertNotSame(rhs.ports(), lhs.ports());
     }
 
     @Test
@@ -133,10 +103,10 @@ public class CookieTestCase {
     @Test
     public void requireThatCookieCanBeEncoded() {
         assertEncodeCookie(
-                Collections.singletonList("foo.name=foo.value"),
+                "foo.name=foo.value",
                 Collections.singletonList(newCookie("foo")));
         assertEncodeCookie(
-                Collections.singletonList("bar.name=bar.value; foo.name=foo.value"),
+                "foo.name=foo.value; bar.name=bar.value",
                 Arrays.asList(newCookie("foo"), newCookie("bar")));
     }
 
@@ -144,17 +114,7 @@ public class CookieTestCase {
     public void requireThatSetCookieCanBeEncoded() {
         assertEncodeSetCookie(
                 Collections.singletonList("foo.name=foo.value; Path=path; Domain=domain; Secure; HTTPOnly"),
-                Collections.singletonList(newCookie("foo")));
-    }
-
-    @Test
-    public void requireThatOnlyOneSetCookieCanBeEncoded() {
-        try {
-            Cookie.toSetCookieHeader(Arrays.asList(newCookie("foo"), newCookie("bar")));
-            fail();
-        } catch (final IllegalStateException ignored) {
-
-        }
+                Collections.singletonList(newSetCookie("foo")));
     }
 
     @Test
@@ -162,23 +122,12 @@ public class CookieTestCase {
         final Cookie foo = new Cookie();
         foo.setName("foo.name");
         foo.setValue("foo.value");
-        foo.setVersion(1);
-        foo.setPath("path");
-        foo.setDomain("domain");
-        foo.setMaxAge(-1, TimeUnit.SECONDS);
-        assertDecodeSetCookie(Collections.singletonList(foo),
-                              "$Version=1;foo.name=foo.value;$Path=path;$Domain=domain;$Port=\"69\"");
+        assertDecodeCookie(Collections.singletonList(newCookie("foo")), "foo.name=foo.value");
 
         final Cookie bar = new Cookie();
         bar.setName("bar.name");
         bar.setValue("bar.value");
-        bar.setVersion(1);
-        bar.setPath("path");
-        bar.setDomain("domain");
-        bar.setMaxAge(-1, TimeUnit.SECONDS);
-        assertDecodeCookie(Arrays.asList(foo, bar),
-                           "$Version=1;foo.name=foo.value;$Path=path;$Domain=domain;$Port=\"69\";" +
-                           "$Version=1;bar.name=bar.value;$Path=path;$Domain=domain;$Port=\"69\";");
+        assertDecodeCookie(Arrays.asList(foo, bar),"foo.name=foo.value; bar.name=bar.value");
     }
 
     @Test
@@ -186,31 +135,25 @@ public class CookieTestCase {
         final Cookie foo = new Cookie();
         foo.setName("foo.name");
         foo.setValue("foo.value");
-        foo.setVersion(1);
         foo.setPath("path");
         foo.setDomain("domain");
-        foo.setMaxAge(-1, TimeUnit.SECONDS);
-        assertDecodeSetCookie(Collections.singletonList(foo),
-                              "foo.name=foo.value;Max-Age=0;Path=path;Domain=domain;Secure;HTTPOnly;Comment=comment;" +
-                              "Version=2;CommentURL=\"commentUrl\";Port=\"69\";Discard");
+        foo.setMaxAge(0, TimeUnit.SECONDS);
+        foo.setSecure(true);
+        foo.setHttpOnly(true);
+        assertDecodeSetCookie(foo, "foo.name=foo.value;Max-Age=0;Path=path;Domain=domain;Secure;HTTPOnly;");
 
         final Cookie bar = new Cookie();
         bar.setName("bar.name");
         bar.setValue("bar.value");
-        bar.setVersion(1);
         bar.setPath("path");
         bar.setDomain("domain");
-        bar.setMaxAge(-1, TimeUnit.SECONDS);
-        assertDecodeSetCookie(Arrays.asList(foo, bar),
-                              "bar.name=bar.value;Max-Age=0;Path=path;Domain=domain;Secure;HTTPOnly;Comment=comment;" +
-                              "Version=2;CommentURL=\"commentUrl\";Port=\"69\";Discard;" +
-                              "foo.name=foo.value;Max-Age=0;Path=path;Domain=domain;Secure;HTTPOnly;Comment=comment;" +
-                              "Version=2;CommentURL=\"commentUrl\";Port=\"69\";Discard");
+        bar.setMaxAge(0, TimeUnit.SECONDS);
+        assertDecodeSetCookie(bar, "bar.name=bar.value;Max-Age=0;Path=path;Domain=domain;");
     }
 
     @Test
     public void requireThatCookieDecoderWorksForGenericValidCookies() {
-        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=8es5opih9ljtk&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
+        Cookie.fromCookieHeader("Y=v=1&n=8es5opih9ljtk&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
                                    "us&np=1; T=z=h.nzPBhSP4PBVd5JqacVnIbNjU1NAY2TjYzNzVOTjYzNzM0Mj&a=YAE&sk=DAALShmNQ" +
                                    "vhoZV&ks=EAABsibvMK6ejwn0uUoS4rC9w--~E&d=c2wBTVRJeU13RXhPVEUwTURJNU9URTBNRFF6TlRJ" +
                                    "NU5nLS0BYQFZQUUBZwE1VkNHT0w3VUVDTklJVEdRR1FXT0pOSkhEQQFzY2lkAWNOUnZIbEc3ZHZoVHlWZ" +
@@ -219,7 +162,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForYInvalidCookies() {
-        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=77nkr5t7o4nqn&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
+        Cookie.fromCookieHeader("Y=v=1&n=77nkr5t7o4nqn&l=og0_iedeh0qqvqqr/o&p=m2g2rs6012000000&r=pv&lg=en-US&intl=" +
                                    "us&np=1; T=z=05nzPB0NP4PBN/n0gwc1AWGNjU1NAY2TjYzNzVOTjYzNzM0Mj&a=QAE&sk=DAA4R2svo" +
                                    "osjIa&ks=EAAj3nBQFkN4ZmuhqFxJdNoaQ--~E&d=c2wBTVRJeU13RXhPVEUwTURJNU9URTBNRFF6TlRJ" +
                                    "NU5nLS0BYQFRQUUBZwE1VkNHT0w3VUVDTklJVEdRR1FXT0pOSkhEQQFzY2lkAUpPalRXOEVsUDZrR3RHT" +
@@ -228,7 +171,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForYValidCookies() {
-        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=3767k6te5aj2s&l=1v4u3001uw2ys00q0rw0qrw34q0x5s3u/o&p=030vvit012000000&iz=" +
+        Cookie.fromCookieHeader("Y=v=1&n=3767k6te5aj2s&l=1v4u3001uw2ys00q0rw0qrw34q0x5s3u/o&p=030vvit012000000&iz=" +
                                    "&r=pu&lg=en-US,it-IT,it&intl=it&np=1; T=z=m38yPBmLk3PBWvehTPBhBHYNU5OBjQ3NE5ONU5P" +
                                    "NDY0NzU0M0&a=IAE&sk=DAAAx5URYgbhQ6&ks=EAA4rTgdlAGeMQmdYeM_VehGg--~E&d=c2wBTWprNUF" +
                                    "UTXdNems1TWprNE16RXpNREl6TkRneAFhAUlBRQFnAUVJSlNMSzVRM1pWNVNLQVBNRkszQTRaWDZBAXNj" +
@@ -238,7 +181,7 @@ public class CookieTestCase {
 
     @Test
     public void requireThatCookieDecoderWorksForGenericInvalidCookies() {
-        new org.jboss.netty.handler.codec.http.CookieDecoder().decode("Y=v=1&n=e92s5cq8qbs6h&l=3kdb0f.3@i126be10b.d4j/o&p=m1f2qgmb13000107&r=g5&lg=en-US" +
+        Cookie.fromCookieHeader("Y=v=1&n=e92s5cq8qbs6h&l=3kdb0f.3@i126be10b.d4j/o&p=m1f2qgmb13000107&r=g5&lg=en-US" +
                                    "&intl=us; T=z=TXp3OBTrQ8OBFMcj3GBpFSyNk83TgY2MjMwN04zMDMw&a=YAE&sk=DAAVfaNwLeISrX" +
                                    "&ks=EAAOeNNgY8c5hV8YzPYmnrW7w--~E&d=c2wBTVRnd09RRXhOVFEzTURrME56UTMBYQFZQUUBZwFMQ" +
                                    "U5NT0Q2UjY2Q0I1STY0R0tKSUdVQVlRRQFvawFaVzAtAXRpcAFMTlRUdkMBenoBVFhwM09CQTdF&af=QU" +
@@ -246,65 +189,37 @@ public class CookieTestCase {
                                    "2UDMuUGZ6WkdTT2ctLQ--");
     }
 
-    private static void assertDecodeCookie(final List<Cookie> expected, final String toDecode) {
-        assertCookies(expected, Cookie.fromCookieHeader(toDecode));
+    private static void assertEncodeCookie(String expectedResult, List<Cookie> cookies) {
+        assertThat(Cookie.toCookieHeader(cookies), equalTo(expectedResult));
     }
 
-    private static void assertDecodeSetCookie(final List<Cookie> expected, final String toDecode) {
-        assertCookies(expected, Cookie.fromSetCookieHeader(toDecode));
+    private static void assertEncodeSetCookie(List<String> expectedResult, List<Cookie> cookies) {
+        assertThat(Cookie.toSetCookieHeaderAll(cookies), containsInAnyOrder(expectedResult.toArray()));
     }
 
-    private static void assertCookies(final List<Cookie> expected, final List<Cookie> actual) {
-        assertEquals(expected.size(), actual.size());
-        for (final Cookie cookie : expected) {
-            assertNotNull(actual.remove(cookie));
-        }
+    private static void assertDecodeCookie(List<Cookie> expected, String toDecode) {
+        assertThat(Cookie.fromCookieHeader(toDecode), containsInAnyOrder(expected.toArray()));
     }
 
-    private static void assertEncodeCookie(final List<String> expected, final List<Cookie> toEncode) {
-        assertCookies(expected, Cookie.toCookieHeader(toEncode));
-    }
-
-    private static void assertEncodeSetCookie(final List<String> expected, final List<Cookie> toEncode) {
-        assertCookies(expected, Cookie.toSetCookieHeader(toEncode));
-    }
-
-    private static void assertCookies(final List<String> expected, final String actual) {
-        final Set<Integer> seen = new HashSet<>();
-        for (final String str : expected) {
-            final int pos = actual.indexOf(str);
-            assertTrue(pos >= 0);
-            assertTrue(seen.add(pos));
-        }
-    }
-
-    private static void assertCookie(final org.jboss.netty.handler.codec.http.DefaultCookie expected, final Cookie actual) {
-        assertEquals(expected.getName(), actual.getName());
-        assertEquals(expected.getValue(), actual.getValue());
-        assertEquals(expected.getDomain(), actual.getDomain());
-        assertEquals(expected.getPath(), actual.getPath());
-        assertEquals(expected.getComment(), actual.getComment());
-        assertEquals(expected.getCommentUrl(), actual.getCommentUrl());
-        assertEquals(expected.getMaxAge(), actual.getMaxAge(TimeUnit.SECONDS));
-        assertEquals(expected.getVersion(), actual.getVersion());
-        assertEquals(expected.isSecure(), actual.isSecure());
-        assertEquals(expected.isHttpOnly(), actual.isHttpOnly());
-        assertEquals(expected.isDiscard(), actual.isDiscard());
+    private static void assertDecodeSetCookie(final Cookie expected, String toDecode) {
+        assertThat(Cookie.fromSetCookieHeader(toDecode), containsInAnyOrder(expected));
     }
 
     private static Cookie newCookie(final String name) {
         final Cookie cookie = new Cookie();
         cookie.setName(name + ".name");
         cookie.setValue(name + ".value");
+        return cookie;
+    }
+
+    private static Cookie newSetCookie(String name) {
+        final Cookie cookie = new Cookie();
+        cookie.setName(name + ".name");
+        cookie.setValue(name + ".value");
         cookie.setDomain("domain");
         cookie.setPath("path");
-        cookie.setComment("comment");
-        cookie.setCommentUrl("commentUrl");
-        cookie.setVersion(2);
         cookie.setSecure(true);
         cookie.setHttpOnly(true);
-        cookie.setDiscard(true);
-        cookie.ports().add(69);
         return cookie;
     }
 }

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/HttpResponseTestCase.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/HttpResponseTestCase.java
@@ -92,8 +92,7 @@ public class HttpResponseTestCase {
         response.encodeSetCookieHeader(cookies);
         final List<String> headers = response.headers().get(HttpHeaders.Names.SET_COOKIE);
         assertEquals(1, headers.size());
-        assertEquals(Cookie.toSetCookieHeader(cookies),
-                     headers.get(0));
+        assertEquals(Cookie.toSetCookieHeaderAll(cookies), headers);
     }
 
     @Test
@@ -103,10 +102,8 @@ public class HttpResponseTestCase {
         response.encodeSetCookieHeader(cookies);
         final List<String> headers = response.headers().get(HttpHeaders.Names.SET_COOKIE);
         assertEquals(2, headers.size());
-        assertEquals(Cookie.toSetCookieHeader(Collections.singletonList(new Cookie("foo", "bar"))),
-                     headers.get(0));
-        assertEquals(Cookie.toSetCookieHeader(Collections.singletonList(new Cookie("baz", "cox"))),
-                     headers.get(1));
+        assertEquals(Cookie.toSetCookieHeaderAll(Arrays.asList(new Cookie("foo", "bar"), new Cookie("baz", "cox"))),
+                     headers);
     }
 
     @Test

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/filter/JDiscCookieWrapperTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/filter/JDiscCookieWrapperTest.java
@@ -1,14 +1,13 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.filter;
 
-import java.util.concurrent.TimeUnit;
-
-import com.yahoo.jdisc.http.filter.JDiscCookieWrapper;
+import com.yahoo.jdisc.http.Cookie;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.yahoo.jdisc.http.Cookie;
+import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("deprecation")
 public class JDiscCookieWrapperTest {
 
     @Test

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceTest.java
@@ -717,7 +717,6 @@ public class HttpServerConformanceTest extends ServerProviderConformanceTest {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private class TestRunner implements Adapter<JettyHttpServer, ClientProxy, Future<HttpResponse>> {
 
         private Matcher<ResponseGist> expectedResponse = null;

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -348,14 +348,11 @@ public class HttpServerTest {
     @Test
     public void requireThatSetCookieHeaderIsCorrect() throws Exception {
         final TestDriver driver = TestDrivers.newInstance(new CookieSetterRequestHandler(
-                new Cookie("foo", "bar").setComment("comment yeah")
-                                            .setCommentURL("http://comment.yes/")
-                                            .setDiscard(true)
-                                            .setDomain(".localhost")
-                                            .setHttpOnly(true)
-                                            .setPath("/foopath")
-                                            .setSecure(true)
-                                            .setVersion(2)));
+                new Cookie("foo", "bar")
+                        .setDomain(".localhost")
+                        .setHttpOnly(true)
+                        .setPath("/foopath")
+                        .setSecure(true)));
         driver.client().get("/status.html")
               .expectStatusCode(is(OK))
               .expectHeader("Set-Cookie",


### PR DESCRIPTION
Note: This change alters the Cookie class, which is public API.

FYI @bratseth