### PR TITLE
Catch exception thrown from AbstractComponent.deconstruct.

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -6,6 +6,7 @@ import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.container.di.ComponentDeconstructor;
 import com.yahoo.container.di.componentgraph.Provider;
 import com.yahoo.jdisc.SharedResource;
+import com.yahoo.yolean.Exceptions;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,8 +55,13 @@ public class Deconstructor implements ComponentDeconstructor {
 
         public void run() {
             log.info("Starting deconstruction of " + component);
-            component.deconstruct();
-            log.info("Finished deconstructing " + component);
+            try {
+                component.deconstruct();
+                log.info("Finished deconstructing " + component);
+            } catch (Exception e) {
+                log.warning("Exception thrown when deconstructing " + component + ": " + e.getClass().getName()
+                                    + ": " + Exceptions.toMessageString(e));
+            }
         }
     }
 }

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -6,12 +6,13 @@ import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.container.di.ComponentDeconstructor;
 import com.yahoo.container.di.componentgraph.Provider;
 import com.yahoo.jdisc.SharedResource;
-import com.yahoo.yolean.Exceptions;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
 
 /**
 * @author tonyv
@@ -59,9 +60,11 @@ public class Deconstructor implements ComponentDeconstructor {
                 component.deconstruct();
                 log.info("Finished deconstructing " + component);
             } catch (Exception e) {
-                log.warning("Exception thrown when deconstructing " + component + ": " + e.getClass().getName()
-                                    + ": " + Exceptions.toMessageString(e));
+                log.log(WARNING, "Exception thrown when deconstructing " + component, e);
+            } catch (Throwable t) {
+                com.yahoo.protect.Process.logAndDie("Error when deconstructing " + component, t);
             }
         }
+
     }
 }


### PR DESCRIPTION
@jobergum This will log the error messages from the exception and its cause(s), but not the stack trace.

@baldersheim, shouldn't we see a stacktrace in the log if an exception is thrown in the thread running the deconstruct task?