### PR TITLE
Return empty cookie list on 'null'

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/Cookie.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/Cookie.java
@@ -1,6 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -225,6 +226,7 @@ public class Cookie {
     }
 
     public static List<Cookie> fromCookieHeader(String headerVal) {
+        if (headerVal == null) return Collections.emptyList();
         return decodeCookies(headerVal);
     }
 
@@ -233,6 +235,7 @@ public class Cookie {
     }
 
     public static List<Cookie> fromSetCookieHeader(String headerVal) {
+        if (headerVal == null) return Collections.emptyList();
         return decodeCookies(headerVal);
     }
 


### PR DESCRIPTION
This should fix the NPEs. There is a security filters that adds an "Cookie" header with null value if the request does not contain any cookies.

FYI @baldersheim 