### PR TITLE
Save empty history schema, to allow for limited vespa version downgrade.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
@@ -325,6 +325,11 @@ FileConfigManager::saveConfig(const DocumentDBConfig &snapshot,
     assert(saveSchemaRes);
     (void) saveSchemaRes;
 
+    search::index::Schema historySchema;
+    bool saveHistorySchemaRes = historySchema.saveToFile(snapDir + "/historyschema.txt");
+    assert(saveHistorySchemaRes);
+    (void) saveHistorySchemaRes;
+
     writeExtraConfigs(snapDir, snapshot);
     _info.validateSnapshot(serialNum);
 


### PR DESCRIPTION
@geirst, please review
@baldersheim FYI