### PR TITLE
Revert and fix changes to dependencies

### DIFF
--- a/node-admin/pom.xml
+++ b/node-admin/pom.xml
@@ -30,12 +30,6 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
-            <artifactId>service-monitor</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.yahoo.vespa</groupId>
             <artifactId>defaults</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -44,7 +38,7 @@
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>orchestrator</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
Revert parts of change in https://github.com/yahoo/vespa/commit/cd2df6cb62fbfe847dacddfbb539434c7fafd385

node-admin fails to start with bundle issues regarding orchestrator and servicemonitor packages, this change makes node-admin start