### PR TITLE
Add configuration for minimum number of slobroks per container cluster

### DIFF
--- a/config-model/src/main/resources/schema/admin.rnc
+++ b/config-model/src/main/resources/schema/admin.rnc
@@ -5,6 +5,7 @@ AdminV2 =
  element admin {
    attribute version { "2.0" } &
    element adminserver { service.attlist } &
+   element minSlobroksPerCluster { xsd:positiveInteger }? &
    GenericConfig* &
    LogServer? &
    (ConfigServer | ConfigServers)? &

--- a/config-model/src/test/schema-test-files/services.xml
+++ b/config-model/src/test/schema-test-files/services.xml
@@ -7,6 +7,7 @@
   </config>
 
   <admin version="2.0">
+    <minSlobroksPerCluster>1</minSlobroksPerCluster>
     <adminserver hostalias="adminserver" />
     <logserver hostalias="logserver" />
     <slobroks>


### PR DESCRIPTION
* By default, we use between 1 and 3/(number of container clusters) nodes per
  container cluster for slobroks. If a customer has 3 or more container clusters
  we end up with just one slobrok per cluster. These might end up on the same
  Docker host when running on Docker.
* Make minimum number of slobroks per container cluster configurable (default 1 as before)
  so that we can migrate apps that have more than 3 container clusters in a controlled manner

The plan is to change the default to 2 and remove the configuration as soon as the one customer we know about has set this setting to 2 and upgraded.