### PR TITLE
Change scope of Netty from 'compile' to 'provided'

### DIFF
--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -24,6 +24,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/provided-dependencies/pom.xml
+++ b/provided-dependencies/pom.xml
@@ -33,6 +33,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>${jetty.version}</version>


### PR DESCRIPTION
FYI @baldersheim 

This concludes on the cleanup of `jdisc_http_service` for now.

Wait with merge until we got a release.