### PR TITLE
Make struct builders public.

### DIFF
--- a/configgen/src/main/scala/com/yahoo/config/codegen/BuilderGenerator.scala
+++ b/configgen/src/main/scala/com/yahoo/config/codegen/BuilderGenerator.scala
@@ -85,7 +85,7 @@ object BuilderGenerator {
       case map if node.isMap =>
         "public Map<String, %s> %s = new LinkedHashMap<>()".format(builderType(map), map.getName)
       case struct: InnerCNode =>
-        "private %s %s = new %s()".format(builderType(struct), struct.getName, builderType(struct))
+        "public %s %s = new %s()".format(builderType(struct), struct.getName, builderType(struct))
       case scalar : LeafCNode =>
         "private " + boxedBuilderType(scalar) + " " + scalar.getName + " = null"
     }) + ";"


### PR DESCRIPTION
Before this change, a new struct builder had to be created to set values
on the builder. Then this builder was set on the toplevel config builder,
replacing the previous struct builder and any changes already done.
Now however, it is possible to set only a subset of values on a default constructed
struct builder without affecting any previous changes.

@gjoranv please review