### PR TITLE
Makes the Orchestrator policy use the new model classes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/OrchestratorMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/OrchestratorMock.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.orchestrator.BatchHostNameNotFoundException;
 import com.yahoo.vespa.orchestrator.BatchInternalErrorException;
 import com.yahoo.vespa.orchestrator.HostNameNotFoundException;
 import com.yahoo.vespa.orchestrator.Orchestrator;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
 import com.yahoo.vespa.orchestrator.policy.BatchHostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.status.ApplicationInstanceStatus;
@@ -37,6 +38,9 @@ public class OrchestratorMock implements Orchestrator {
     public void suspend(HostName hostName) throws HostStateChangeDeniedException, HostNameNotFoundException {}
 
     @Override
+    public void suspendGroup(NodeGroup nodeGroup) throws HostStateChangeDeniedException, HostNameNotFoundException {}
+
+    @Override
     public ApplicationInstanceStatus getApplicationInstanceStatus(ApplicationId appId) throws ApplicationIdNotFoundException {
         return suspendedApplications.contains(appId)
                ? ApplicationInstanceStatus.ALLOWED_TO_BE_DOWN : ApplicationInstanceStatus.NO_REMARKS;
@@ -61,5 +65,4 @@ public class OrchestratorMock implements Orchestrator {
     public void suspendAll(HostName parentHostname, List<HostName> hostNames) throws BatchInternalErrorException, BatchHostStateChangeDeniedException, BatchHostNameNotFoundException {
         throw new UnsupportedOperationException("Not implemented");
     }
-
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/BatchInternalErrorException.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/BatchInternalErrorException.java
@@ -2,15 +2,14 @@
 package com.yahoo.vespa.orchestrator;
 
 import com.yahoo.vespa.applicationmodel.HostName;
-
-import java.util.List;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
 
 public class BatchInternalErrorException extends OrchestrationException {
 
     public BatchInternalErrorException(HostName parentHostname,
-                                       List<HostName> orderedHostNames,
+                                       NodeGroup nodeGroup,
                                        RuntimeException e) {
-        super("Failed to suspend " + orderedHostNames + " with parent host "
+        super("Failed to suspend " + nodeGroup + " with parent host "
                 + parentHostname + ": " + e.getMessage(), e);
     }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/Orchestrator.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/Orchestrator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.orchestrator;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
 import com.yahoo.vespa.orchestrator.policy.BatchHostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.status.ApplicationInstanceStatus;
@@ -59,6 +60,21 @@ public interface Orchestrator {
     void suspend(HostName hostName) throws HostStateChangeDeniedException, HostNameNotFoundException;
 
     /**
+     * Suspend normal operations for a group of nodes in the same application.
+     *
+     * @param nodeGroup The group of nodes in an application.
+     * @throws HostStateChangeDeniedException if the request cannot be meet due to policy constraints.
+     * @throws HostNameNotFoundException if any hostnames in the node group is not recognized
+     */
+    void suspendGroup(NodeGroup nodeGroup) throws HostStateChangeDeniedException, HostNameNotFoundException;
+
+    /**
+     * Suspend several hosts. On failure, all hosts are resumed before exiting the method with an exception.
+     */
+    void suspendAll(HostName parentHostname, List<HostName> hostNames)
+            throws BatchInternalErrorException, BatchHostStateChangeDeniedException, BatchHostNameNotFoundException;
+
+    /**
      * Get the orchestrator status of the application instance.
      *
      * @param appId Identifier of the application to check
@@ -83,16 +99,10 @@ public interface Orchestrator {
 
 
     /**
-     * Suspend orchestration for hosts belonging to this application.
-     * I.e all suspend requests for its hosts will succeed.
+     * Suspend an application:  All hosts will allow suspension in parallel.
+     * CAUTION:  Only use this if the application is not in service.
      *
      * @param appId Identifier of the application to resume
      */
     void suspend(ApplicationId appId) throws ApplicationStateChangeDeniedException, ApplicationIdNotFoundException;
-
-    /**
-     * Suspend all hosts. On failure, all hosts are resumed before exiting the method with an exception.
-     */
-    void suspendAll(HostName parentHostname, List<HostName> hostNames)
-            throws BatchInternalErrorException, BatchHostStateChangeDeniedException, BatchHostNameNotFoundException;
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/BatchHostStateChangeDeniedException.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/BatchHostStateChangeDeniedException.java
@@ -2,16 +2,15 @@
 package com.yahoo.vespa.orchestrator.policy;
 
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
 import com.yahoo.vespa.orchestrator.OrchestrationException;
-
-import java.util.List;
 
 public class BatchHostStateChangeDeniedException extends OrchestrationException {
 
     public BatchHostStateChangeDeniedException(HostName parentHostname,
-                                               List<HostName> orderedHostNames,
+                                               NodeGroup group,
                                                HostStateChangeDeniedException e) {
-        super("Failed to suspend " + orderedHostNames + " with parent host "
+        super("Failed to suspend " + group + " with parent host "
                 + parentHostname + ": " + e.getMessage(), e);
 
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/ClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/ClusterPolicy.java
@@ -1,0 +1,14 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.policy;
+
+import com.yahoo.vespa.orchestrator.model.ClusterApi;
+
+public interface ClusterPolicy {
+    /**
+     * There's an implicit group of nodes known to clusterApi.  This method answers whether
+     * it would be fine, just looking at this cluster (and disregarding Cluster Controller/storage
+     * which is handled separately), whether it would be fine to allow all services on all the nodes
+     * in the group to go down.
+     */
+    void verifyGroupGoingDownIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException;
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/ConcurrentSuspensionLimitForCluster.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/ConcurrentSuspensionLimitForCluster.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.policy;
+
+/**
+ * How many nodes can suspend concurrently, at most.
+ */
+public enum ConcurrentSuspensionLimitForCluster {
+    ONE_NODE(0),
+    TEN_PERCENT(10),
+    ALL_NODES(100);
+
+    int percentage;
+
+    ConcurrentSuspensionLimitForCluster(int percentage) {
+        this.percentage = percentage;
+    }
+
+    public int asPercentage() {
+        return percentage;
+    }
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostStateChangeDeniedException.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostStateChangeDeniedException.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.orchestrator.policy;
 
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.applicationmodel.ServiceType;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
 import com.yahoo.vespa.orchestrator.OrchestrationException;
 
 /**
@@ -15,21 +16,36 @@ public class HostStateChangeDeniedException extends OrchestrationException {
 
     public HostStateChangeDeniedException(HostName hostName, String constraintName, 
                                           ServiceType serviceType, String message) {
-        super(createMessage(hostName, constraintName, serviceType, message));
-        this.constraintName = constraintName;
-        this.serviceType = serviceType;
+        this(hostName, constraintName, serviceType, message, null);
     }
 
     public HostStateChangeDeniedException(HostName hostName, String constraintName, 
                                           ServiceType serviceType, String message, Throwable cause) {
-        super(createMessage(hostName, constraintName, serviceType, message), cause);
+        this(hostName.toString(), constraintName, serviceType, message, cause);
+    }
+
+    public HostStateChangeDeniedException(NodeGroup nodeGroup,
+                                          String constraintName,
+                                          ServiceType serviceType,
+                                          String message) {
+        this(nodeGroup.toCommaSeparatedString(), constraintName, serviceType, message, null);
+    }
+
+    private HostStateChangeDeniedException(String nodes,
+                                           String constraintName,
+                                           ServiceType serviceType,
+                                           String message,
+                                           Throwable cause) {
+        super(createMessage(nodes, constraintName, serviceType, message), cause);
         this.constraintName = constraintName;
         this.serviceType = serviceType;
     }
 
-    private static String createMessage(HostName hostName, String constraintName, 
-                                        ServiceType serviceType, String message) {
-        return "Changing the state of host " + hostName + " would violate " + constraintName
+    private static String createMessage(String nodes,
+                                        String constraintName,
+                                        ServiceType serviceType,
+                                        String message) {
+        return "Changing the state of " + nodes + " would violate " + constraintName
                 + " for service type " + serviceType + ": " + message;
     }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -1,0 +1,52 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.policy;
+
+import com.yahoo.vespa.orchestrator.model.VespaModelUtil;
+import com.yahoo.vespa.orchestrator.model.ClusterApi;
+
+import static com.yahoo.vespa.orchestrator.policy.HostedVespaPolicy.ENOUGH_SERVICES_UP_CONSTRAINT;
+
+public class HostedVespaClusterPolicy implements ClusterPolicy {
+    public void verifyGroupGoingDownIsFine(ClusterApi clusterApi)
+            throws HostStateChangeDeniedException {
+        if (clusterApi.noServicesOutsideGroupIsDown()) {
+            return;
+        }
+
+        if (clusterApi.noServicesInGroupIsUp()) {
+            return;
+        }
+
+        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi).asPercentage();
+        if (clusterApi.percentageOfServicesDownIfGroupIsAllowedToBeDown() <= percentageOfServicesAllowedToBeDown) {
+            return;
+        }
+
+        throw new HostStateChangeDeniedException(
+                clusterApi.getNodeGroup(),
+                ENOUGH_SERVICES_UP_CONSTRAINT,
+                clusterApi.serviceType(),
+                "Suspension percentage would increase from " + clusterApi.percentageOfServicesDown()
+                        + "% to " + clusterApi.percentageOfServicesDownIfGroupIsAllowedToBeDown()
+                        + "%, over the limit of " + percentageOfServicesAllowedToBeDown + "%."
+                        + " These instances may be down: " + clusterApi.servicesDownAndNotInGroupDescription()
+                        + " and these hosts are allowed to be down: "
+                        + clusterApi.nodesAllowedToBeDownNotInGroupDescription());
+    }
+
+    static ConcurrentSuspensionLimitForCluster getConcurrentSuspensionLimit(ClusterApi clusterApi) {
+        if (VespaModelUtil.ADMIN_CLUSTER_ID.equals(clusterApi.clusterId())) {
+            if (VespaModelUtil.SLOBROK_SERVICE_TYPE.equals(clusterApi.serviceType())) {
+                return ConcurrentSuspensionLimitForCluster.ONE_NODE;
+            }
+
+            return ConcurrentSuspensionLimitForCluster.ALL_NODES;
+        }
+
+        if (clusterApi.isStorageCluster()) {
+            return ConcurrentSuspensionLimitForCluster.ONE_NODE;
+        }
+
+        return ConcurrentSuspensionLimitForCluster.TEN_PERCENT;
+    }
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicy.java
@@ -3,31 +3,19 @@ package com.yahoo.vespa.orchestrator.policy;
 
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.applicationmodel.ApplicationInstance;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.HostName;
-import com.yahoo.vespa.applicationmodel.ServiceCluster;
-import com.yahoo.vespa.applicationmodel.ServiceInstance;
-import com.yahoo.vespa.orchestrator.controller.ClusterControllerClient;
 import com.yahoo.vespa.orchestrator.controller.ClusterControllerClientFactory;
 import com.yahoo.vespa.orchestrator.controller.ClusterControllerState;
-import com.yahoo.vespa.orchestrator.controller.ClusterControllerStateResponse;
-import com.yahoo.vespa.orchestrator.model.VespaModelUtil;
+import com.yahoo.vespa.orchestrator.model.ApplicationApi;
+import com.yahoo.vespa.orchestrator.model.ApplicationApiImpl;
+import com.yahoo.vespa.orchestrator.model.ClusterApi;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
+import com.yahoo.vespa.orchestrator.model.StorageNode;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 import com.yahoo.vespa.orchestrator.status.MutableStatusRegistry;
 import com.yahoo.vespa.service.monitor.ServiceMonitorStatus;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-
-import static com.yahoo.vespa.orchestrator.OrchestratorUtil.getHostStatusMap;
-import static com.yahoo.vespa.orchestrator.OrchestratorUtil.getHostsUsedByApplicationInstance;
-import static com.yahoo.vespa.orchestrator.OrchestratorUtil.getServiceClustersUsingHost;
 
 /**
  * @author oyving
@@ -41,191 +29,69 @@ public class HostedVespaPolicy implements Policy {
 
     private static final Logger log = Logger.getLogger(HostedVespaPolicy.class.getName());
 
+    private final HostedVespaClusterPolicy clusterPolicy;
     private final ClusterControllerClientFactory clusterControllerClientFactory;
 
-    public HostedVespaPolicy(ClusterControllerClientFactory clusterControllerClientFactory) {
+    public HostedVespaPolicy(HostedVespaClusterPolicy clusterPolicy, ClusterControllerClientFactory clusterControllerClientFactory) {
+        this.clusterPolicy = clusterPolicy;
         this.clusterControllerClientFactory = clusterControllerClientFactory;
     }
 
-    private static long numContentServiceClusters(Set<? extends ServiceCluster<?>> serviceClustersOnHost) {
-        return serviceClustersOnHost.stream().filter(VespaModelUtil::isContent).count();
+    @Override
+    public void grantSuspensionRequest(ApplicationApi application)
+            throws HostStateChangeDeniedException {
+        // Apply per-cluster policy
+        for (ClusterApi cluster : application.getClusters()) {
+            clusterPolicy.verifyGroupGoingDownIsFine(cluster);
+        }
+
+        // Ask Cluster Controller to set UP storage nodes in maintenance.
+        // These storage nodes are guaranteed to be NO_REMARKS
+        for (StorageNode storageNode : application.getUpStorageNodesInGroupInClusterOrder()) {
+            storageNode.setNodeState(ClusterControllerState.MAINTENANCE);
+            log.log(LogLevel.INFO, "The storage node on " + storageNode.hostName() + " has been set to MAINTENANCE");
+        }
+
+        // Ensure all nodes in the group are marked as allowed to be down
+        for (HostName hostName : application.getNodesInGroupWithStatus(HostStatus.NO_REMARKS)) {
+            application.setHostState(hostName, HostStatus.ALLOWED_TO_BE_DOWN);
+            log.log(LogLevel.INFO, hostName + " is now allowed to be down (suspended)");
+        }
     }
 
+    @Override
+    public void releaseSuspensionGrant(ApplicationApi application) throws HostStateChangeDeniedException {
+        // Always defer to Cluster Controller whether it's OK to resume storage node
+        for (StorageNode storageNode : application.getStorageNodesAllowedToBeDownInGroupInReverseClusterOrder()) {
+            storageNode.setNodeState(ClusterControllerState.UP);
+            log.log(LogLevel.INFO, "The storage node on " + storageNode.hostName() + " has been set to UP");
+        }
 
+        for (HostName hostName : application.getNodesInGroupWithStatus(HostStatus.ALLOWED_TO_BE_DOWN)) {
+            application.setHostState(hostName, HostStatus.NO_REMARKS);
+            log.log(LogLevel.INFO, hostName + " is no longer allowed to be down (resumed)");
+        }
+    }
+
+    // TODO: Remove later - currently used for backward compatibility testing
     @Override
     public void grantSuspensionRequest(ApplicationInstance<ServiceMonitorStatus> applicationInstance,
                                        HostName hostName,
                                        MutableStatusRegistry hostStatusService) throws HostStateChangeDeniedException {
-
-        Set<ServiceCluster<ServiceMonitorStatus>> serviceClustersOnHost =
-                getServiceClustersUsingHost(applicationInstance.serviceClusters(), hostName);
-
-        Map<HostName, HostStatus> hostStatusMap = getHostStatusMap(
-                getHostsUsedByApplicationInstance(applicationInstance),
-                hostStatusService);
-
-        boolean hasUpStorageInstance = false;
-        for (ServiceCluster<ServiceMonitorStatus> serviceCluster : serviceClustersOnHost) {
-            Set<ServiceInstance<ServiceMonitorStatus>> instancesOnThisHost;
-            Set<ServiceInstance<ServiceMonitorStatus>> instancesOnOtherHosts;
-            {
-                Map<Boolean, Set<ServiceInstance<ServiceMonitorStatus>>> serviceInstancesByLocality =
-                        serviceCluster.serviceInstances().stream()
-                                .collect(
-                                        Collectors.groupingBy(
-                                                instance -> instance.hostName().equals(hostName),
-                                                Collectors.toSet()));
-                instancesOnThisHost = serviceInstancesByLocality.getOrDefault(true, Collections.emptySet());
-                instancesOnOtherHosts = serviceInstancesByLocality.getOrDefault(false, Collections.emptySet());
-            }
-
-            if (VespaModelUtil.isStorage(serviceCluster)) {
-                boolean thisHostHasSomeUpInstances = instancesOnThisHost.stream()
-                        .map(ServiceInstance::serviceStatus)
-                        .anyMatch(status -> status == ServiceMonitorStatus.UP);
-                if (thisHostHasSomeUpInstances) {
-                    hasUpStorageInstance = true;
-                }
-            }
-
-            boolean thisHostHasOnlyDownInstances = instancesOnThisHost.stream()
-                    .map(ServiceInstance::serviceStatus)
-                    .allMatch(status -> status == ServiceMonitorStatus.DOWN);
-            if (thisHostHasOnlyDownInstances) {
-                // Suspending this host will not make a difference for this cluster, so no need to investigate further.
-                continue;
-            }
-
-            Set<ServiceInstance<ServiceMonitorStatus>> possiblyDownInstancesOnOtherHosts =
-                    instancesOnOtherHosts.stream()
-                            .filter(instance -> effectivelyDown(instance, hostStatusMap))
-                            .collect(Collectors.toSet());
-            if (possiblyDownInstancesOnOtherHosts.isEmpty()) {
-                // This short-circuits the percentage calculation below and ensures that we can always upgrade
-                // any cluster by allowing one host at the time to be suspended, no matter what percentage of
-                // the cluster that host amounts to.
-                continue;
-            }
-
-            // Now calculate what the service suspension percentage will be if we suspend this host.
-            int numServiceInstancesTotal = serviceCluster.serviceInstances().size();
-            int numInstancesThatWillBeSuspended = union(possiblyDownInstancesOnOtherHosts, instancesOnThisHost).size();
-            int percentThatWillBeSuspended = numInstancesThatWillBeSuspended * 100 / numServiceInstancesTotal;
-            int suspendPercentageAllowed = ServiceClusterSuspendPolicy.getSuspendPercentageAllowed(serviceCluster);
-            if (percentThatWillBeSuspended > suspendPercentageAllowed) {
-                // It may seem like this may in some cases prevent upgrading, especially for small clusters (where the
-                // percentage of service instances affected by suspending a single host may easily exceed the allowed
-                // suspension percentage). Note that we always allow progress by allowing a single host to suspend.
-                // See previous section.
-                int currentSuspensionPercentage
-                        = possiblyDownInstancesOnOtherHosts.size() * 100 / numServiceInstancesTotal;
-                Set<HostName> otherHostsWithThisServiceCluster = instancesOnOtherHosts.stream()
-                        .map(ServiceInstance::hostName)
-                        .collect(Collectors.toSet());
-                Set<HostName> hostsAllowedToBeDown = hostStatusMap.entrySet().stream()
-                        .filter(entry -> entry.getValue() == HostStatus.ALLOWED_TO_BE_DOWN)
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.toSet());
-                Set<HostName> otherHostsAllowedToBeDown
-                        = intersection(otherHostsWithThisServiceCluster, hostsAllowedToBeDown);
-                throw new HostStateChangeDeniedException(
-                        hostName,
-                        ENOUGH_SERVICES_UP_CONSTRAINT,
-                        serviceCluster.serviceType(),
-                        "Suspension percentage would increase from " + currentSuspensionPercentage
-                                + "% to " + percentThatWillBeSuspended
-                                + "%, over the limit of " + suspendPercentageAllowed + "%."
-                                + " These instances may be down: " + possiblyDownInstancesOnOtherHosts
-                                + " and these hosts are allowed to be down: " + otherHostsAllowedToBeDown
-                );
-            }
-        }
-
-        if (hasUpStorageInstance) {
-            // If there is an UP storage service on the host, we need to make sure
-            // there's sufficient redundancy before allowing the suspension. This will
-            // also avoid redistribution (which is unavoidable if the storage instance
-            // is already down).
-            setNodeStateInController(applicationInstance, hostName, ClusterControllerState.MAINTENANCE);
-        }
-
-
-        // We have "go" for suspending the services on the host,store decision.
-        hostStatusService.setHostState(hostName, HostStatus.ALLOWED_TO_BE_DOWN);
-        log.log(LogLevel.INFO, hostName + " is now allowed to be down (suspended)");
+        NodeGroup nodeGroup = new NodeGroup(applicationInstance);
+        nodeGroup.addNode(hostName);
+        ApplicationApi applicationApi = new ApplicationApiImpl(nodeGroup, hostStatusService, clusterControllerClientFactory);
+        grantSuspensionRequest(applicationApi);
     }
 
-    private static <T> Set<T> union(Set<T> setA, Set<T> setB) {
-        Set<T> union = new HashSet<>(setA);
-        union.addAll(setB);
-        return union;
-    }
-
-    private static <T> Set<T> intersection(Set<T> setA, Set<T> setB) {
-        Set<T> intersection = new HashSet<>(setA);
-        intersection.retainAll(setB);
-        return intersection;
-    }
-
+    // TODO: Remove later - currently used for backward compatibility testing
     @Override
     public void releaseSuspensionGrant(
             ApplicationInstance<ServiceMonitorStatus> applicationInstance,
             HostName hostName,
             MutableStatusRegistry hostStatusService) throws HostStateChangeDeniedException {
-        Set<ServiceCluster<ServiceMonitorStatus>> serviceClustersOnHost =
-                getServiceClustersUsingHost(applicationInstance.serviceClusters(), hostName);
-
-        // TODO: Always defer to Cluster Controller whether it's OK to resume host (if content node).
-        if (numContentServiceClusters(serviceClustersOnHost) > 0) {
-            setNodeStateInController(applicationInstance, hostName, ClusterControllerState.UP);
-        }
-        hostStatusService.setHostState(hostName, HostStatus.NO_REMARKS);
-        log.log(LogLevel.INFO, hostName + " is no longer allowed to be down (resumed)");
+        NodeGroup nodeGroup = new NodeGroup(applicationInstance, hostName);
+        ApplicationApi applicationApi = new ApplicationApiImpl(nodeGroup, hostStatusService, clusterControllerClientFactory);
+        releaseSuspensionGrant(applicationApi);
     }
-
-    private static boolean effectivelyDown(ServiceInstance<ServiceMonitorStatus> serviceInstance,
-                                           Map<HostName, HostStatus> hostStatusMap) {
-        ServiceMonitorStatus instanceStatus = serviceInstance.serviceStatus();
-        HostStatus hostStatus = hostStatusMap.get(serviceInstance.hostName());
-        return hostStatus == HostStatus.ALLOWED_TO_BE_DOWN || instanceStatus == ServiceMonitorStatus.DOWN;
-    }
-
-    private void setNodeStateInController(ApplicationInstance<?> application,
-                                          HostName hostName,
-                                          ClusterControllerState nodeState) throws HostStateChangeDeniedException {
-        ClusterId contentClusterId = VespaModelUtil.getContentClusterName(application, hostName);
-        List<HostName> clusterControllers = VespaModelUtil.getClusterControllerInstancesInOrder(application, contentClusterId);
-        ClusterControllerClient client = clusterControllerClientFactory.createClient(
-                clusterControllers,
-                contentClusterId.s());
-        int nodeIndex = VespaModelUtil.getStorageNodeIndex(application, hostName);
-
-        log.log(LogLevel.DEBUG,
-                "application " + application.applicationInstanceId() +
-                ", host " + hostName +
-                ", cluster name " + contentClusterId +
-                ", node index " + nodeIndex +
-                ", node state " + nodeState);
-
-        ClusterControllerStateResponse response;
-        try {
-            response = client.setNodeState(nodeIndex, nodeState);
-        } catch (IOException e) {
-            throw new HostStateChangeDeniedException(
-                    hostName,
-                    CLUSTER_CONTROLLER_AVAILABLE_CONSTRAINT,
-                    VespaModelUtil.CLUSTER_CONTROLLER_SERVICE_TYPE,
-                    "Failed to communicate with cluster controllers " + clusterControllers + ": " + e,
-                    e);
-        }
-
-        if ( ! response.wasModified) {
-            throw new HostStateChangeDeniedException(
-                    hostName,
-                    SET_NODE_STATE_CONSTRAINT,
-                    VespaModelUtil.CLUSTER_CONTROLLER_SERVICE_TYPE,
-                    "Failed to set state to " + nodeState + " in controller: " + response.reason);
-        }
-    }
-
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/Policy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/Policy.java
@@ -1,9 +1,10 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.policy;
 
-import com.yahoo.vespa.orchestrator.status.MutableStatusRegistry;
 import com.yahoo.vespa.applicationmodel.ApplicationInstance;
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.orchestrator.model.ApplicationApi;
+import com.yahoo.vespa.orchestrator.status.MutableStatusRegistry;
 import com.yahoo.vespa.service.monitor.ServiceMonitorStatus;
 
 /**
@@ -22,6 +23,13 @@ public interface Policy {
             MutableStatusRegistry hostStatusService) throws HostStateChangeDeniedException;
 
     /**
+     * Decide whether to grant a request for temporarily suspending the services on all hosts in the group.
+     */
+    void grantSuspensionRequest(ApplicationApi applicationApi) throws HostStateChangeDeniedException;
+
+    void releaseSuspensionGrant(ApplicationApi application) throws HostStateChangeDeniedException;
+
+    /**
      * Release an earlier grant for suspension.
      *
      * @throws HostStateChangeDeniedException if the release failed.
@@ -30,5 +38,4 @@ public interface Policy {
             ApplicationInstance<ServiceMonitorStatus> applicationInstance,
             HostName hostName,
             MutableStatusRegistry hostStatusService) throws HostStateChangeDeniedException;
-
 }

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyInstanceLookupService.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyInstanceLookupService.java
@@ -12,6 +12,7 @@ import com.yahoo.vespa.applicationmodel.ServiceCluster;
 import com.yahoo.vespa.applicationmodel.ServiceInstance;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.applicationmodel.TenantId;
+import com.yahoo.vespa.orchestrator.model.NodeGroup;
 import com.yahoo.vespa.orchestrator.model.VespaModelUtil;
 import com.yahoo.vespa.service.monitor.ServiceMonitorStatus;
 
@@ -33,7 +34,6 @@ public class DummyInstanceLookupService implements InstanceLookupService {
     public static final HostName TEST6_HOST_NAME = new HostName("test6.prod.us-east-1.vespahosted.ne1.yahoo.com");
 
     private static final Set<ApplicationInstance<ServiceMonitorStatus>> apps = new HashSet<>();
-
 
     static {
         apps.add(new ApplicationInstance<>(
@@ -119,6 +119,11 @@ public class DummyInstanceLookupService implements InstanceLookupService {
                 )
         ));
     }
+
+    // A node group is tied to an application, so we need to define them after we have populated the above applications.
+    public final static NodeGroup TEST1_NODE_GROUP = new NodeGroup(new DummyInstanceLookupService().findInstanceByHost(TEST1_HOST_NAME).get(), TEST1_HOST_NAME);
+    public final static NodeGroup TEST3_NODE_GROUP = new NodeGroup(new DummyInstanceLookupService().findInstanceByHost(TEST3_HOST_NAME).get(), TEST3_HOST_NAME);
+    public final static NodeGroup TEST6_NODE_GROUP = new NodeGroup(new DummyInstanceLookupService().findInstanceByHost(TEST6_HOST_NAME).get(), TEST6_HOST_NAME);
 
 
     @Override

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
@@ -10,6 +10,7 @@ import com.yahoo.vespa.applicationmodel.TenantId;
 import com.yahoo.vespa.orchestrator.InstanceLookupService;
 import com.yahoo.vespa.orchestrator.OrchestratorImpl;
 import com.yahoo.vespa.orchestrator.controller.ClusterControllerClientFactoryMock;
+import com.yahoo.vespa.orchestrator.model.ApplicationApi;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.Policy;
 import com.yahoo.vespa.orchestrator.restapi.wire.BatchHostSuspendRequest;
@@ -90,8 +91,18 @@ public class HostResourceTest {
         public void grantSuspensionRequest(
                 ApplicationInstance<ServiceMonitorStatus> applicationInstance,
                 HostName hostName,
-                MutableStatusRegistry hostStatusRegistry) {
+                MutableStatusRegistry hostStatusService) throws HostStateChangeDeniedException {
+
         }
+
+        @Override
+        public void grantSuspensionRequest(ApplicationApi applicationApi) throws HostStateChangeDeniedException {
+        }
+
+        @Override
+        public void releaseSuspensionGrant(ApplicationApi application) throws HostStateChangeDeniedException {
+        }
+
         @Override
         public void releaseSuspensionGrant(
                 ApplicationInstance<ServiceMonitorStatus> applicationInstance,
@@ -180,6 +191,17 @@ public class HostResourceTest {
                 MutableStatusRegistry hostStatusRegistry) throws HostStateChangeDeniedException {
             doThrow();
         }
+
+        @Override
+        public void grantSuspensionRequest(ApplicationApi applicationApi) throws HostStateChangeDeniedException {
+            doThrow();
+        }
+
+        @Override
+        public void releaseSuspensionGrant(ApplicationApi application) throws HostStateChangeDeniedException {
+            doThrow();
+        }
+
         @Override
         public void releaseSuspensionGrant(
                 ApplicationInstance<ServiceMonitorStatus> applicationInstance,


### PR DESCRIPTION
Functionally, the new code should be identical to the old one, EXCEPT if an
application has 2 or more nodes on a Docker host:
- In this case the new code puts these nodes into a NodeGroup, and will try to
  suspend them all at the same time.

This PR could have been functionally identical to the old code by by putting
each HostName into its own NodeGroup in OrchestratorImpl::nodeGroupsOrderedForSuspend.