### PR TITLE
Fix getting cluster controller index for standalone clusters

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/VespaModelUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/VespaModelUtil.java
@@ -197,7 +197,7 @@ public class VespaModelUtil {
     }
 
     // See getClusterControllerIndex()
-    private static final Pattern CONTROLLER_INDEX_PATTERN = Pattern.compile("admin/cluster-controllers/(\\d+)");
+    private static final Pattern CONTROLLER_INDEX_PATTERN = Pattern.compile(".*/cluster-controllers/(\\d+)");
 
     /**
      * @param configId  Must be of the form admin/cluster-controllers/2

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/TestUtil.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/TestUtil.java
@@ -27,11 +27,11 @@ public class TestUtil {
         return new HashSet<>(Arrays.asList(serviceClusters));
     }
 
-    public static ConfigId storageNodeConfigId(int index) {
-        return new ConfigId("storage/storage/" + index);
+    public static ConfigId storageNodeConfigId(String contentClusterName, int index) {
+        return new ConfigId(contentClusterName + "/storage/" + index);
     }
 
-    public static ConfigId clusterControllerConfigId(int index) {
-        return new ConfigId("admin/cluster-controllers/" + index);
+    public static ConfigId clusterControllerConfigId(String contentClusterName, int index) {
+        return new ConfigId(contentClusterName + "/cluster-controllers/" + index);
     }
 }

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/VespaModelUtilTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/VespaModelUtilTest.java
@@ -36,11 +36,11 @@ public class VespaModelUtilTest {
     public static final HostName controller0Host = new HostName("controller-0");
 
     private static final ServiceInstance<ServiceMonitorStatus> controller0 = new ServiceInstance<>(
-            TestUtil.clusterControllerConfigId(0),
+            TestUtil.clusterControllerConfigId(CONTENT_CLUSTER_ID.toString(), 0),
             controller0Host,
             ServiceMonitorStatus.UP);
     private static final ServiceInstance<ServiceMonitorStatus> controller1 = new ServiceInstance<>(
-            TestUtil.clusterControllerConfigId(1),
+            TestUtil.clusterControllerConfigId(CONTENT_CLUSTER_ID.toString(), 1),
             new HostName("controller-1"),
             ServiceMonitorStatus.UP);
 
@@ -216,8 +216,20 @@ public class VespaModelUtilTest {
     }
 
     @Test
+    public void testGetClusterControllerIndexWithNonStandardClusterName() {
+        ConfigId configId = new ConfigId("foo/cluster-controllers/2");
+        assertThat(VespaModelUtil.getClusterControllerIndex(configId)).isEqualTo(2);
+    }
+
+    @Test
+    public void testGetClusterControllerIndexWithStandaloneClusterController() {
+        ConfigId configId = new ConfigId("foo/standalone/cluster-controllers/2");
+        assertThat(VespaModelUtil.getClusterControllerIndex(configId)).isEqualTo(2);
+    }
+
+    @Test
     public void testGetStorageNodeIndex() {
-        ConfigId configId = TestUtil.storageNodeConfigId(3);
+        ConfigId configId = TestUtil.storageNodeConfigId(CONTENT_CLUSTER_ID.toString(), 3);
         assertThat(VespaModelUtil.getStorageNodeIndex(configId)).isEqualTo(3);
     }
 }

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/VespaModelUtilTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/VespaModelUtilTest.java
@@ -216,12 +216,6 @@ public class VespaModelUtilTest {
     }
 
     @Test
-    public void testGetClusterControllerIndexWithNonStandardClusterName() {
-        ConfigId configId = new ConfigId("foo/cluster-controllers/2");
-        assertThat(VespaModelUtil.getClusterControllerIndex(configId)).isEqualTo(2);
-    }
-
-    @Test
     public void testGetClusterControllerIndexWithStandaloneClusterController() {
         ConfigId configId = new ConfigId("foo/standalone/cluster-controllers/2");
         assertThat(VespaModelUtil.getClusterControllerIndex(configId)).isEqualTo(2);

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicyTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicyTest.java
@@ -344,7 +344,7 @@ public class HostedVespaPolicyTest {
             VespaModelUtil.CLUSTER_CONTROLLER_SERVICE_TYPE,
             makeServiceInstanceSet(
                     new ServiceInstance<>(
-                            TestUtil.clusterControllerConfigId(0),
+                            TestUtil.clusterControllerConfigId(CONTENT_CLUSTER_NAME, 0),
                             CLUSTER_CONTROLLER_HOST,
                             UP)));
 
@@ -362,7 +362,7 @@ public class HostedVespaPolicyTest {
             VespaModelUtil.STORAGENODE_SERVICE_TYPE,
             makeServiceInstanceSet(
                     new ServiceInstance<>(
-                            TestUtil.storageNodeConfigId(STORAGE_NODE_INDEX),
+                            TestUtil.storageNodeConfigId(CONTENT_CLUSTER_NAME, STORAGE_NODE_INDEX),
                             STORAGE_NODE_HOST,
                             UP)));
 
@@ -731,7 +731,7 @@ public class HostedVespaPolicyTest {
         private final Set<ServiceInstance<ServiceMonitorStatus>> instances = new HashSet<>();
 
         public StorageClusterBuilder instance(final HostName hostName, final ServiceMonitorStatus status, int index) {
-            instances.add(new ServiceInstance<>(TestUtil.storageNodeConfigId(index), hostName, status));
+            instances.add(new ServiceInstance<>(TestUtil.storageNodeConfigId("content", index), hostName, status));
             return this;
         }
 


### PR DESCRIPTION
* Cluster controller cluster can either be using zookeeper on config
  server and be part of admin cluster (config id 'admin/cluster-controllers/[n]')
  or standalone (running zookeeper in cluster controller and be in its own
  cluster, config id '[content cluster id]/standalone/[n]')
VESPA-7356