### PR TITLE
Balder/gcc7 linkage issues

### DIFF
--- a/document/src/vespa/document/repo/documenttyperepo.cpp
+++ b/document/src/vespa/document/repo/documenttyperepo.cpp
@@ -384,7 +384,8 @@ void addDefaultDocument(DocumentTypeMap &type_map) {
                 AnnotationType::UP(new AnnotationType(*annotation_types[i])));
     }
 
-    type_map[data_types->doc_type->getId()] = data_types.release();
+    uint32_t typeId = data_types->doc_type->getId();
+    type_map[typeId] = data_types.release();
 }
 
 const DataTypeRepo &lookupRepo(int32_t id, const DocumentTypeMap &type_map) {

--- a/fastos/src/vespa/fastos/unix_process.h
+++ b/fastos/src/vespa/fastos/unix_process.h
@@ -56,6 +56,7 @@ public:
               _writeBuffer()
         {
         }
+        ~DescriptorHandle() { }
         void CloseHandle(void)
         {
             _wantRead = false;

--- a/searchcore/src/tests/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/tests/proton/flushengine/flushengine.cpp
@@ -1,7 +1,4 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
-#include <vespa/log/log.h>
-LOG_SETUP("flushengine_test");
 
 #include <vespa/searchcore/proton/flushengine/cachedflushtarget.h>
 #include <vespa/searchcore/proton/flushengine/flush_engine_explorer.h>
@@ -16,7 +13,9 @@ LOG_SETUP("flushengine_test");
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/util/sync.h>
 #include <vespa/vespalib/test/insertion_operators.h>
-#include <memory>
+
+#include <vespa/log/log.h>
+LOG_SETUP("flushengine_test");
 
 // --------------------------------------------------------------------------------
 //
@@ -263,7 +262,7 @@ public:
     {
     }
 
-    SimpleTarget(const std::string &name = "anon", search::SerialNum flushedSerial = 0, bool proceedImmediately = true) :
+    SimpleTarget(const std::string &name, search::SerialNum flushedSerial = 0, bool proceedImmediately = true) :
         test::DummyFlushTarget(name),
         _flushedSerial(flushedSerial),
         _proceed(),
@@ -277,6 +276,9 @@ public:
             _proceed.countDown();
         }
     }
+    SimpleTarget(search::SerialNum flushedSerial = 0, bool proceedImmediately = true)
+        : SimpleTarget("anon", flushedSerial, proceedImmediately)
+    { }
 
     virtual Time
     getLastFlushTime() const override { return fastos::ClockSystem::now(); }
@@ -309,12 +311,11 @@ public:
 public:
     typedef std::shared_ptr<AssertedTarget> SP;
 
-    AssertedTarget(const std::string &name = "anon")
-        : SimpleTarget(name),
+    AssertedTarget()
+        : SimpleTarget("anon"),
           _mgain(false),
           _serial(false)
     {
-        // empty
     }
 
     virtual MemoryGain

--- a/searchcore/src/tests/proton/matchengine/matchengine.cpp
+++ b/searchcore/src/tests/proton/matchengine/matchengine.cpp
@@ -1,5 +1,4 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/fastos/fastos.h>
 #include <vespa/searchcore/proton/matchengine/matchengine.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/searchlib/engine/docsumreply.h>

--- a/searchcore/src/tests/proton/matchengine/matchengine.cpp
+++ b/searchcore/src/tests/proton/matchengine/matchengine.cpp
@@ -15,10 +15,8 @@ class MySearchHandler : public ISearchHandler {
     std::string _name;
     std::string _reply;
 public:
-    MySearchHandler(size_t numHits = 0,
-                    const std::string & name = "my",
-                    const std::string & reply = "myreply") :
-        _numHits(numHits), _name(name), _reply(reply) {}
+    MySearchHandler(size_t numHits = 0) :
+        _numHits(numHits), _name("my"), _reply("myreply") {}
     virtual DocsumReply::UP getDocsums(const DocsumRequest &) override {
         return DocsumReply::UP(new DocsumReply);
     }

--- a/storage/src/tests/bucketdb/judymultimaptest.cpp
+++ b/storage/src/tests/bucketdb/judymultimaptest.cpp
@@ -34,7 +34,7 @@ namespace {
         int _val2;
         int _val3;
 
-        A() {}
+        A() = default;
         A(const B &);
         A(const C &);
         A(int val1, int val2, int val3)
@@ -51,7 +51,7 @@ namespace {
         int _val1;
         int _val2;
 
-        B() {}
+        B() = default;
         B(const A& a) : _val1(a._val1), _val2(a._val2) {}
         B(int val1, int val2) : _val1(val1), _val2(val2) {}
 
@@ -61,7 +61,7 @@ namespace {
     struct C {
         int _val1;
 
-        C() {}
+        C() = default;
         C(const A& a) : _val1(a._val1) {}
         C(int val1) : _val1(val1) {}
 

--- a/vdslib/src/vespa/vdslib/distribution/group.cpp
+++ b/vdslib/src/vespa/vdslib/distribution/group.cpp
@@ -116,7 +116,8 @@ Group::addSubGroup(Group::UP group)
                 "Another subgroup with same index is already added.",
                 VESPA_STRLOC);
     }
-    _subGroups[group->getIndex()] = group.release();
+    auto index = group->getIndex();
+    _subGroups[index] = group.release();
 }
 
 void

--- a/vdslib/src/vespa/vdslib/state/clusterstate.cpp
+++ b/vdslib/src/vespa/vdslib/state/clusterstate.cpp
@@ -3,13 +3,15 @@
 
 #include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/document/util/stringutil.h>
-#include <sstream>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/stllike/asciistream.h>
-#include <vespa/log/log.h>
+#include <sstream>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".vdslib.state.cluster");
+
+using vespalib::IllegalArgumentException;
 
 namespace storage {
 namespace lib {
@@ -22,51 +24,36 @@ ClusterState::ClusterState()
       _nodeCount(2),
       _description(),
       _distributionBits(16)
-{
-}
+{ }
 
-ClusterState::ClusterState(const ClusterState& other)
-    : Printable(other),
-      _version(other._version),
-      _clusterState(other._clusterState),
-      _nodeStates(other._nodeStates),
-      _nodeCount(other._nodeCount),
-      _description(other._description),
-      _distributionBits(other._distributionBits)
-{
-}
+ClusterState::ClusterState(const ClusterState& other) = default;
+ClusterState::~ClusterState() { }
 
-ClusterState::~ClusterState()
-{
-}
+struct NodeData {
+    bool empty;
+    Node node;
+    vespalib::asciistream ost;
 
-namespace {
-    struct NodeData {
-        bool empty;
-        Node node;
-        vespalib::asciistream ost;
+    NodeData() : empty(true), node(NodeType::STORAGE, 0), ost() {}
 
-        NodeData() : empty(true), node(NodeType::STORAGE, 0), ost() {}
-
-        void addTo(std::map<Node, NodeState>& nodeStates,
-                   std::vector<uint16_t>& nodeCount)
-        {
-            if (!empty) {
-                NodeState state(ost.str(), &node.getType());
-                if (state != NodeState(node.getType(), State::UP)
-                    || state.getDescription().size() > 0)
-                {
-                    nodeStates.insert(std::make_pair(node, state));
-                }
-                if (nodeCount[node.getType()] <= node.getIndex()) {
-                    nodeCount[node.getType()] = node.getIndex() + 1;
-                }
-                empty = true;
-                ost.clear();
+    void addTo(std::map<Node, NodeState>& nodeStates,
+               std::vector<uint16_t>& nodeCount)
+    {
+        if (!empty) {
+            NodeState state(ost.str(), &node.getType());
+            if (state != NodeState(node.getType(), State::UP)
+                || state.getDescription().size() > 0)
+            {
+                nodeStates.insert(std::make_pair(node, state));
             }
+            if (nodeCount[node.getType()] <= node.getIndex()) {
+                nodeCount[node.getType()] = node.getIndex() + 1;
+            }
+            empty = true;
+            ost.clear();
         }
-    };
-}
+    }
+};
 
 ClusterState::ClusterState(const vespalib::stringref & serialized)
     : Printable(),
@@ -82,108 +69,113 @@ ClusterState::ClusterState(const vespalib::stringref & serialized)
     NodeData nodeData;
     vespalib::string lastAbsolutePath;
 
-    for (vespalib::StringTokenizer::Iterator it = st.begin();
-         it != st.end(); ++it)
-    {
+    for (vespalib::StringTokenizer::Iterator it = st.begin(); it != st.end(); ++it) {
         vespalib::string::size_type index = it->find(':');
         if (index == vespalib::string::npos) {
-            throw vespalib::IllegalArgumentException(
-                    "Token " + *it + " does not contain ':': " + serialized,
-                    VESPA_STRLOC);
+            throw IllegalArgumentException("Token " + *it + " does not contain ':': " + serialized, VESPA_STRLOC);
         }
         vespalib::stringref key = it->substr(0, index);
         vespalib::stringref value = it->substr(index + 1);
         if (key.size() > 0 && key[0] == '.') {
             if (lastAbsolutePath == "") {
-                throw vespalib::IllegalArgumentException(
-                        "The first path in system state string needs to be "
-                        "absolute", VESPA_STRLOC);
+                throw IllegalArgumentException("The first path in system state string needs to be absolute", VESPA_STRLOC);
             }
             key = lastAbsolutePath + key;
         } else {
             lastAbsolutePath = key;
         }
-        if (key.size() > 0) switch (key[0]) {
-        case 'c':
-            if (key == "cluster") {
-                setClusterState(State::get(value));
-                continue;
-            }
-            break;
-        case 'b':
-            if (key == "bits") {
-                _distributionBits = atoi(value.c_str());
-                continue;
-            }
-            break;
-        case 'v':
-            if (key == "version") {
-                _version = atoi(value.c_str());
-                continue;
-            }
-            break;
-        case 'm':
-            if (key.size() > 1) break;
-            _description = document::StringUtil::unescape(value);
-            continue;
-        case 'd':
-        case 's':
-        {
-            const NodeType* nodeType(0);
-            vespalib::string::size_type dot = key.find('.');
-            vespalib::stringref type(dot == vespalib::string::npos
-                             ? key : key.substr(0, dot));
-            if (type == "storage") {
-                nodeType = &NodeType::STORAGE;
-            } else if (type == "distributor") {
-                nodeType = &NodeType::DISTRIBUTOR;
-            }
-            if (nodeType == 0) break;
-            if (dot == vespalib::string::npos) { // Entry that set node counts
-                uint16_t nodeCount = 0;
-                nodeCount = atoi(value.c_str());
-
-                if (nodeCount > _nodeCount[*nodeType] ) {
-                    _nodeCount[*nodeType] = nodeCount;
-                }
-                continue;
-            }
-            vespalib::string::size_type dot2 = key.find('.', dot + 1);
-            Node node;
-            if (dot2 == vespalib::string::npos) {
-                node = Node(*nodeType, atoi(key.substr(dot + 1).c_str()));
-            } else {
-                node = Node(*nodeType, atoi(key.substr(dot + 1, dot2 - dot - 1).c_str()));
-            }
-
-            if (node.getIndex() >= _nodeCount[*nodeType]) {
-                vespalib::asciistream ost;
-                ost << "Cannot index " << *nodeType << " node "
-                    << node.getIndex() << " of " << _nodeCount[*nodeType];
-                throw vespalib::IllegalArgumentException(
-                        ost.str(), VESPA_STRLOC);
-            }
-            if (nodeData.node != node) {
-                nodeData.addTo(_nodeStates, _nodeCount);
-            }
-            if (dot2 == vespalib::string::npos) {
-                break; // No default key for nodes.
-            } else {
-                nodeData.ost << " " << key.substr(dot2 + 1) << ':' << value;
-            }
-            nodeData.node = node;
-            nodeData.empty = false;
-            continue;
+        
+        if (key.empty() || parse(key, value, nodeData) ) {
+            LOG(debug, "Unknown key %s in systemstate. Ignoring it, assuming it's "
+                       "a new feature from a newer version than ourself: %s",
+                       key.c_str(), serialized.c_str());
         }
-        default:
-            break;
-        }
-        LOG(debug, "Unknown key %s in systemstate. Ignoring it, assuming it's "
-            "a new feature from a newer version than ourself: %s",
-            key.c_str(), serialized.c_str());
     }
     nodeData.addTo(_nodeStates, _nodeCount);
     removeExtraElements();
+}
+
+bool
+ClusterState::parse(vespalib::stringref key, vespalib::stringref value, NodeData & nodeData) {
+    switch (key[0]) {
+    case 'c':
+        if (key == "cluster") {
+            setClusterState(State::get(value));
+            return true;
+        }
+        break;
+    case 'b':
+        if (key == "bits") {
+            _distributionBits = atoi(value.c_str());
+            return true;
+        }
+        break;
+    case 'v':
+        if (key == "version") {
+            _version = atoi(value.c_str());
+            return true;
+        }
+        break;
+    case 'm':
+        if (key.size() == 1) {
+            _description = document::StringUtil::unescape(value);
+            return true;
+        }
+        break;
+    case 'd':
+    case 's':
+        return parseSorD(key, value, nodeData);
+    default:
+        break;
+    }
+    return false;
+}
+
+bool
+ClusterState::parseSorD(vespalib::stringref key, vespalib::stringref value, NodeData & nodeData) {
+    const NodeType* nodeType(0);
+    vespalib::string::size_type dot = key.find('.');
+    vespalib::stringref type(dot == vespalib::string::npos
+                             ? key : key.substr(0, dot));
+    if (type == "storage") {
+        nodeType = &NodeType::STORAGE;
+    } else if (type == "distributor") {
+        nodeType = &NodeType::DISTRIBUTOR;
+    }
+    if (nodeType == 0) return false;
+    if (dot == vespalib::string::npos) { // Entry that set node counts
+        uint16_t nodeCount = 0;
+        nodeCount = atoi(value.c_str());
+
+        if (nodeCount > _nodeCount[*nodeType] ) {
+            _nodeCount[*nodeType] = nodeCount;
+        }
+        return true;
+    }
+    vespalib::string::size_type dot2 = key.find('.', dot + 1);
+    Node node;
+    if (dot2 == vespalib::string::npos) {
+        node = Node(*nodeType, atoi(key.substr(dot + 1).c_str()));
+    } else {
+        node = Node(*nodeType, atoi(key.substr(dot + 1, dot2 - dot - 1).c_str()));
+    }
+
+    if (node.getIndex() >= _nodeCount[*nodeType]) {
+        vespalib::asciistream ost;
+        ost << "Cannot index " << *nodeType << " node " << node.getIndex() << " of " << _nodeCount[*nodeType];
+        throw IllegalArgumentException( ost.str(), VESPA_STRLOC);
+    }
+    if (nodeData.node != node) {
+        nodeData.addTo(_nodeStates, _nodeCount);
+    }
+    if (dot2 == vespalib::string::npos) {
+        return false; // No default key for nodes.
+    } else {
+        nodeData.ost << " " << key.substr(dot2 + 1) << ':' << value;
+    }
+    nodeData.node = node;
+    nodeData.empty = false;
+    return true;
 }
 
 namespace {

--- a/vdslib/src/vespa/vdslib/state/clusterstate.h
+++ b/vdslib/src/vespa/vdslib/state/clusterstate.h
@@ -17,6 +17,7 @@ namespace lib {
 
 class Distribution;
 class Group;
+class NodeData;
 
 class ClusterState : public document::Printable {
     uint32_t _version;
@@ -70,6 +71,8 @@ public:
                              const std::string& indent = "") const;
 
 private:
+    bool parse(vespalib::stringref key, vespalib::stringref value, NodeData & nodeData);
+    bool parseSorD(vespalib::stringref key, vespalib::stringref value, NodeData & nodeData);
     void removeExtraElements();
     void printStateGroupwise(std::ostream& out, const Group&, bool verbose,
                              const std::string& indent, bool rootGroup) const;

--- a/vespalib/src/tests/stllike/asciistream_test.cpp
+++ b/vespalib/src/tests/stllike/asciistream_test.cpp
@@ -103,7 +103,8 @@ AsciistreamTest::testIllegalNumbers()
         float f(0);
         EXPECT_EXCEPTION(is >> f, IllegalArgumentException, "float value is outside of range '7777777777777777777777777777777777777777'");
         EXPECT_EQUAL(40u, is.size());
-        is << "e" << is.str();
+        vespalib::string tmp = is.str();
+        is << "e" << tmp;
         EXPECT_EQUAL(81u, is.size());
         double d(0);
         EXPECT_EXCEPTION(is >> d, IllegalArgumentException, "double value is outside of range '7777777777777777777777777777777777777777e7777777777777777777777777777777777777777'");

--- a/vespamalloc/src/tests/allocfree/CMakeLists.txt
+++ b/vespamalloc/src/tests/allocfree/CMakeLists.txt
@@ -21,6 +21,7 @@ vespa_add_executable(vespamalloc_linklist_test_app
     $<TARGET_OBJECTS:vespamalloc_util>
     DEPENDS
     dl
+    atomic
 )
 vespa_add_test(NAME vespamalloc_allocfree_shared_test_app NO_VALGRIND COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/allocfree_test.sh BENCHMARK
                DEPENDS vespamalloc_realloc_test_app vespamalloc_allocfree_shared_test_app vespamalloc_linklist_test_app


### PR DESCRIPTION
@havardpe and @vekterli PR
This contains all that was need to bring to gcc from compiles vespa to compiles and correctly runs all unit tests.

Now there is the [[fallthrough]] that must pend gcc 7 usage, and one issue with std::atomic<vespamalloc::TaggedPtr> not being lockfree in gcc 7.

Code has become better and bugs has been found, but gcc 7.1 does not feel mature enough for usage. So we we need at least 7.2 or 7.3 befor eit can be considered for usage.