### PR TITLE
Fetch containers to run from tick loop

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import static com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.State.RESUMED;
 import static com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.State.SUSPENDED;
 import static com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.State.SUSPENDED_NODE_ADMIN;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Pulls information from node repository and forwards containers to run to node admin.
@@ -128,6 +127,8 @@ public class NodeAdminStateUpdater extends AbstractComponent {
                 logger.error("Failed to converge NodeAdminStateUpdater", e);
             }
         }
+
+        fetchContainersToRunFromNodeRepository();
     }
 
     /**
@@ -212,7 +213,11 @@ public class NodeAdminStateUpdater extends AbstractComponent {
                              .collect(Collectors.toList());
     }
 
-    public void start(long stateConvergeInterval, long fetchContainersInterval) {
+    public void start(long stateConvergeInterval, long foo) {
+        start(stateConvergeInterval);
+    }
+
+    public void start(long stateConvergeInterval) {
         delaysBetweenEachTickMillis = stateConvergeInterval;
         if (loopThread != null) {
             throw new RuntimeException("Can not restart NodeAdminStateUpdater");
@@ -223,12 +228,6 @@ public class NodeAdminStateUpdater extends AbstractComponent {
         });
         loopThread.setName("tick-NodeAdminStateUpdater");
         loopThread.start();
-
-        scheduler.scheduleWithFixedDelay(
-                this::fetchContainersToRunFromNodeRepository,
-                0,
-                fetchContainersInterval,
-                MILLISECONDS);
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -213,10 +213,6 @@ public class NodeAdminStateUpdater extends AbstractComponent {
                              .collect(Collectors.toList());
     }
 
-    public void start(long stateConvergeInterval, long foo) {
-        start(stateConvergeInterval);
-    }
-
     public void start(long stateConvergeInterval) {
         delaysBetweenEachTickMillis = stateConvergeInterval;
         if (loopThread != null) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -47,12 +47,8 @@ public class ComponentsProviderImpl implements ComponentsProvider {
     private static final int NODE_AGENT_SCAN_INTERVAL_MILLIS = 30000;
     private static final int WEB_SERVICE_PORT = Defaults.getDefaults().vespaWebServicePort();
 
-    // We only scan for new nodes within a host every 5 minutes. This is only if new nodes are added or removed
-    // which happens rarely. Changes of apps running etc. is detected by the NodeAgent.
-    private static final int NODE_ADMIN_CONTAINERS_TO_RUN_INTERVAL_MILLIS = 5 * 60000;
-
     // Converge towards desired node admin state every 30 seconds
-    private static final int NODE_ADMIN_CONVER_STATE_INTERVAL_MILLIS = 30000;
+    private static final int NODE_ADMIN_CONVERGE_STATE_INTERVAL_MILLIS = 30000;
 
     public ComponentsProviderImpl(Docker docker, MetricReceiverWrapper metricReceiver, Environment environment,
                                   boolean isRunningLocally) {
@@ -78,8 +74,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
         NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer,
                 NODE_AGENT_SCAN_INTERVAL_MILLIS, metricReceiver, aclMaintainer);
         nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepository, nodeAdmin, Clock.systemUTC(), orchestrator, baseHostName);
-        nodeAdminStateUpdater.start(NODE_ADMIN_CONVER_STATE_INTERVAL_MILLIS,
-                NODE_ADMIN_CONTAINERS_TO_RUN_INTERVAL_MILLIS);
+        nodeAdminStateUpdater.start(NODE_ADMIN_CONVERGE_STATE_INTERVAL_MILLIS);
 
         metricReceiverWrapper = metricReceiver;
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
@@ -39,7 +39,7 @@ public class ComponentsProviderWithMocks implements ComponentsProvider {
     private final NodeAdminStateUpdater nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepositoryMock, nodeAdmin, Clock.systemUTC(), orchestratorMock, "localhost.test.yahoo.com");
 
     public ComponentsProviderWithMocks() {
-        nodeAdminStateUpdater.start(10, 1000);
+        nodeAdminStateUpdater.start(10);
     }
 
     @Override

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -66,7 +66,7 @@ public class DockerTester implements AutoCloseable {
                 orchestratorMock, dockerOperations, Optional.of(storageMaintainer), mr, environment, Clock.systemUTC(), Optional.empty());
         nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, Optional.of(storageMaintainer), 100, mr, Optional.empty());
         updater = new NodeAdminStateUpdater(nodeRepositoryMock, nodeAdmin, Clock.systemUTC(), orchestratorMock, "basehostname");
-        updater.start(5, 5);
+        updater.start(5);
     }
 
     public void addContainerNodeSpec(ContainerNodeSpec containerNodeSpec) {


### PR DESCRIPTION
* Avoid first time fetching not being run due to not being
  in resumed state and the not fetching for 5 minutes by fetching
  from tick loop instead. Also makes code simpler.