### PR TITLE
Deprecate and ignore reply-after attribute

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -260,7 +260,7 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
 
     public void handleRedundancy(Redundancy redundancy) {
         if (usesHierarchicDistribution()) {
-            indexedCluster.setMaxNodesDownPerFixedRow((redundancy.effectiveFinalRedundancy() / groupToSpecMap.size()) - 1);
+            indexedCluster.setMaxNodesDownPerFixedRow((redundancy.effectiveRedundancy() / groupToSpecMap.size()) - 1);
         }
         this.redundancy = redundancy;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/GlobalDistributionValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/GlobalDistributionValidator.java
@@ -39,7 +39,7 @@ public class GlobalDistributionValidator {
                                     "but do not have high enough redundancy to make the documents globally distributed: %s. " +
                                     "Redundancy is %d, expected %d.",
                             asPrintableString(toDocumentNameStream(globallyDistributedDocuments)),
-                            redundancy.effectiveFinalRedundancy(),
+                            redundancy.effectiveRedundancy(),
                             redundancy.totalNodes()));
         }
     }
@@ -47,14 +47,14 @@ public class GlobalDistributionValidator {
     private static void verifySearchableCopiesIsSameAsRedundancy(Set<NewDocumentType> globallyDistributedDocuments,
                                                                  Redundancy redundancy) {
         if (!globallyDistributedDocuments.isEmpty() &&
-                redundancy.effectiveReadyCopies() != redundancy.effectiveFinalRedundancy()) {
+                redundancy.effectiveReadyCopies() != redundancy.effectiveRedundancy()) {
             throw new IllegalArgumentException(
                     String.format(
                             "The following document types have the number of searchable copies less than redundancy: %s. " +
                                     "Searchable copies is %d, while redundancy is %d.",
                             asPrintableString(toDocumentNameStream(globallyDistributedDocuments)),
                             redundancy.effectiveReadyCopies(),
-                            redundancy.effectiveFinalRedundancy()));
+                            redundancy.effectiveRedundancy()));
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/IndexedHierarchicDistributionValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/IndexedHierarchicDistributionValidator.java
@@ -67,15 +67,15 @@ public class IndexedHierarchicDistributionValidator {
     }
 
     private void validateThatLeafGroupsCountIsAFactorOfRedundancy() {
-        if (redundancy.effectiveFinalRedundancy() % rootGroup.getSubgroups().size() != 0) {
+        if (redundancy.effectiveRedundancy() % rootGroup.getSubgroups().size() != 0) {
             throw new IllegalArgumentException(getErrorMsgPrefix() + "Expected number of leaf groups (" +
                                                rootGroup.getSubgroups().size() + ") to be a factor of redundancy (" +
-                                               redundancy.effectiveFinalRedundancy() + "), but it is not.");
+                                               redundancy.effectiveRedundancy() + "), but it is not.");
         }
     }
 
     private void validateThatRedundancyPerGroupIsEqual() {
-        int redundancyPerGroup = redundancy.effectiveFinalRedundancy() / rootGroup.getSubgroups().size();
+        int redundancyPerGroup = redundancy.effectiveRedundancy() / rootGroup.getSubgroups().size();
         String expPartitions = createDistributionPartitions(redundancyPerGroup, rootGroup.getSubgroups().size());
         if (!rootGroup.getPartitions().get().equals(expPartitions)) {
             throw new IllegalArgumentException(getErrorMsgPrefix() + "Expected redundancy per leaf group to be " +
@@ -99,7 +99,7 @@ public class IndexedHierarchicDistributionValidator {
     }
 
     private void validateThatReadyCopiesIsCompatibleWithRedundancy(int groupCount) throws Exception {
-        if (redundancy.effectiveFinalRedundancy() % groupCount != 0) {
+        if (redundancy.effectiveRedundancy() % groupCount != 0) {
             throw new Exception(getErrorMsgPrefix() + "Expected equal redundancy per group.");
         }
         if (redundancy.effectiveReadyCopies() % groupCount != 0) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/StorageGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/StorageGroup.java
@@ -302,7 +302,7 @@ public class StorageGroup {
                     owner.redundancy().setImplicitGroups(hostGroups.size());
 
                     // Compute partitions expression
-                    int redundancyPerGroup = (int)Math.floor(owner.redundancy().effectiveFinalRedundancy() / hostGroups.size());
+                    int redundancyPerGroup = (int)Math.floor(owner.redundancy().effectiveRedundancy() / hostGroups.size());
                     storageGroup.partitions = Optional.of(computePartitions(redundancyPerGroup, hostGroups.size()));
 
                     // create subgroups as returned from allocation

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -10,6 +10,7 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.content.MessagetyperouteselectorpolicyConfig;
 import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import com.yahoo.vespa.config.content.StorDistributionConfig;
@@ -104,6 +105,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
                     new SearchDefinitionBuilder().build(context.getParentProducer().getRoot().getDeployState().getDocumentModel().getDocumentManager(), documentsElement);
 
             String routingSelection = new DocumentSelectionBuilder().build(documentsElement);
+            warnIfDeprecatedReplyAfterAttributeIsPresent(contentElement);
             Redundancy redundancy = new RedundancyBuilder().build(contentElement);
             Set<NewDocumentType> globallyDistributedDocuments = new GlobalDistributionBuilder(documentDefinitions).build(documentsElement);
 
@@ -454,6 +456,13 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
             return false;
         }
 
+        private void warnIfDeprecatedReplyAfterAttributeIsPresent(ModelElement contentElement) {
+            final ModelElement redundancyElement = contentElement.getChild("redundancy");
+            if (redundancyElement != null) {
+                this.admin.deployLogger().log(LogLevel.WARNING, "The 'reply-after' attribute on content cluster 'redundancy' element is deprecated and ignored");
+            }
+        }
+
     }
 
     private ContentCluster(AbstractConfigProducer parent,
@@ -680,4 +689,5 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
         }
 
     }
+
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
@@ -9,32 +9,22 @@ import com.yahoo.vespa.model.content.Redundancy;
  */
 public class RedundancyBuilder {
     Redundancy build(ModelElement clusterXml) {
-        Integer initialRedundancy = 2;
-        Integer finalRedundancy = 3;
+        Integer redundancy = 3;
         Integer readyCopies = 2;
 
         ModelElement redundancyElement = clusterXml.getChild("redundancy");
         if (redundancyElement != null) {
-            initialRedundancy = redundancyElement.getIntegerAttribute("reply-after");
-            finalRedundancy = (int)redundancyElement.asLong();
-
-            if (initialRedundancy == null) {
-                initialRedundancy = finalRedundancy;
-            } else {
-                if (finalRedundancy < initialRedundancy) {
-                    throw new IllegalArgumentException("Final redundancy must be higher than or equal to initial redundancy");
-                }
-            }
+            redundancy = (int)redundancyElement.asLong();
 
             readyCopies = clusterXml.childAsInteger("engine.proton.searchable-copies");
             if (readyCopies == null) {
-                readyCopies = Math.min(finalRedundancy, 2);
+                readyCopies = Math.min(redundancy, 2);
             }
-            if (readyCopies > finalRedundancy) {
+            if (readyCopies > redundancy) {
                 throw new IllegalArgumentException("Number of searchable copies can not be higher than final redundancy");
             }
         }
 
-        return new Redundancy(initialRedundancy, finalRedundancy, readyCopies);
+        return new Redundancy(redundancy, readyCopies);
     }
 }

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -859,8 +859,7 @@ public class ModelProvisioningTest {
         assertThat(model.getRoot().getHostSystem().getHosts().size(), is(numberOfHosts));
 
         ContentCluster cluster = model.getContentClusters().get("bar");
-        assertEquals(2*3, cluster.redundancy().effectiveInitialRedundancy()); // Reduced from 3*3
-        assertEquals(2*3, cluster.redundancy().effectiveFinalRedundancy()); // Reduced from 3*4
+        assertEquals(2*3, cluster.redundancy().effectiveRedundancy()); // Reduced from 3*4
         assertEquals(2*3, cluster.redundancy().effectiveReadyCopies()); // Reduced from 3*3
         assertEquals("2|2|*", cluster.getRootGroup().getPartitions().get()); // Reduced from 4|4|*
         assertEquals(0, cluster.getRootGroup().getNodes().size());
@@ -911,8 +910,7 @@ public class ModelProvisioningTest {
         assertThat(model.getRoot().getHostSystem().getHosts().size(), is(numberOfHosts));
 
         ContentCluster cluster = model.getContentClusters().get("bar");
-        assertEquals(4, cluster.redundancy().effectiveInitialRedundancy());
-        assertEquals(4, cluster.redundancy().effectiveFinalRedundancy());
+        assertEquals(4, cluster.redundancy().effectiveRedundancy());
         assertEquals(4, cluster.redundancy().effectiveReadyCopies());
         assertEquals(4, cluster.getSearch().getIndexed().getDispatchSpec().getGroups().size());
         assertFalse(cluster.getRootGroup().getPartitions().isPresent());
@@ -958,8 +956,7 @@ public class ModelProvisioningTest {
         assertEquals(1, clusterControllers.getContainers().size());
         assertEquals("bar-controllers", clusterControllers.getName());
         assertEquals("default0", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals(1, cluster.redundancy().effectiveInitialRedundancy()); // Reduced from 3*3
-        assertEquals(1, cluster.redundancy().effectiveFinalRedundancy()); // Reduced from 3*4
+        assertEquals(1, cluster.redundancy().effectiveRedundancy()); // Reduced from 3*4
         assertEquals(1, cluster.redundancy().effectiveReadyCopies()); // Reduced from 3*3
         assertFalse(cluster.getRootGroup().getPartitions().isPresent()); // 1 group - > flattened -> no distribution
         assertEquals(1, cluster.getRootGroup().getNodes().size());
@@ -1015,8 +1012,7 @@ public class ModelProvisioningTest {
         assertThat(model.getRoot().getHostSystem().getHosts().size(), is(numberOfHosts));
 
         ContentCluster cluster = model.getContentClusters().get("bar");
-        assertEquals(1, cluster.redundancy().effectiveInitialRedundancy());
-        assertEquals(1, cluster.redundancy().effectiveFinalRedundancy());
+        assertEquals(1, cluster.redundancy().effectiveRedundancy());
         assertEquals(1, cluster.redundancy().effectiveReadyCopies());
 
         assertEquals(1, cluster.getSearch().getIndexed().getDispatchSpec().getGroups().size());

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterTest.java
@@ -107,7 +107,8 @@ public class ClusterTest extends ContentBaseTest {
         StorDistributionConfig.Builder storBuilder = new StorDistributionConfig.Builder();
         cc.getConfig(storBuilder);
         StorDistributionConfig storConfig = new StorDistributionConfig(storBuilder);
-        assertEquals(4, storConfig.initial_redundancy());
+        // TODO remove initial_redundancy from config. For now, it should always be equal to (final) redundancy.
+        assertEquals(5, storConfig.initial_redundancy());
         assertEquals(5, storConfig.redundancy());
         assertEquals(3, storConfig.ready_copies());
         ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
@@ -148,7 +149,8 @@ public class ClusterTest extends ContentBaseTest {
         ).getConfig(builder);
 
         StorDistributionConfig config = new StorDistributionConfig(builder);
-        assertEquals(2, config.initial_redundancy());
+        // TODO remove initial_redundancy from config. For now, it should always be equal to (final) redundancy.
+        assertEquals(3, config.initial_redundancy());
         assertEquals(3, config.redundancy());
         assertEquals(2, config.ready_copies());
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/GlobalDistributionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/GlobalDistributionValidatorTest.java
@@ -127,19 +127,19 @@ public class GlobalDistributionValidatorTest {
     }
 
     private static Redundancy createRedundancyWithGlobalDistribution() {
-        Redundancy redundancy = new Redundancy(2, 2, 2);
+        Redundancy redundancy = new Redundancy(2, 2);
         redundancy.setTotalNodes(2);
         return redundancy;
     }
 
     private static Redundancy createRedundancyWithoutGlobalDistribution() {
-        Redundancy redundancy = new Redundancy(2, 2, 2);
+        Redundancy redundancy = new Redundancy(2, 2);
         redundancy.setTotalNodes(3);
         return redundancy;
     }
 
     private static Redundancy createRedundancyWithTooFewSearchableCopies() {
-        Redundancy redundancy = new Redundancy(2, 2, 1);
+        Redundancy redundancy = new Redundancy(2, 1);
         redundancy.setTotalNodes(2);
         return redundancy;
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/RedundancyTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/RedundancyTest.java
@@ -21,7 +21,7 @@ public class RedundancyTest {
     }
 
     private static Redundancy createRedundancy(int redundancy, int implicitGroups, int totalNodes) {
-        Redundancy r = new Redundancy(1, redundancy, 1);
+        Redundancy r = new Redundancy(redundancy, 1);
         r.setImplicitGroups(implicitGroups);
         r.setTotalNodes(totalNodes);
         return r;


### PR DESCRIPTION
@bratseth Please review

"n-of-m" redundancy has too many unfortunate edge cases for consistency
and distributor memory usage to keep this feature around.
Field still remains in config, but is always set equal to final redundancy.

If reply-after attribute is present, a deployment deprecation warning is issued.

If we move to consensus-based consistency, bringing back this feature will
effectively be a no-op.