### PR TITLE
Fix coredump reporting

### DIFF
--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/maintainer/CoredumpHandler.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/maintainer/CoredumpHandler.java
@@ -117,9 +117,11 @@ public class CoredumpHandler {
         return Files.move(coredumpPath, folder.resolve(coredumpPath.getFileName()));
     }
 
-    String collectMetadata(Path coredumpPath, Map<String, Object> nodeAttributes) throws IOException {
-        Path metadataPath = coredumpPath.resolve(METADATA_FILE_NAME);
+    String collectMetadata(Path coredumpDirectory, Map<String, Object> nodeAttributes) throws IOException {
+        Path metadataPath = coredumpDirectory.resolve(METADATA_FILE_NAME);
         if (!Files.exists(metadataPath)) {
+            Path coredumpPath = Files.list(coredumpDirectory).findFirst()
+                    .orElseThrow(() -> new RuntimeException("No coredump file found in processing directory " + coredumpDirectory));
             Map<String, Object> metadata = coreCollector.collect(coredumpPath, yinstStatePath);
             metadata.putAll(nodeAttributes);
 

--- a/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/maintainer/CoredumpHandlerTest.java
+++ b/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/maintainer/CoredumpHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -109,11 +110,11 @@ public class CoredumpHandlerTest {
 
     @Test
     public void coredumpMetadataCollectAndWriteTest() throws IOException, InterruptedException {
-        when(coreCollector.collect(any(), any())).thenReturn(metadata);
         createCoredump("core.dump");
         Path processingPath = coredumpHandler.processCoredumps();
         Path processingCoredumpPath = Files.list(processingPath).findFirst().orElseThrow(() ->
                 new RuntimeException("Expected to find directory with coredump in processing dir"));
+        when(coreCollector.collect(eq(processingCoredumpPath.resolve("core.dump")), any())).thenReturn(metadata);
 
         // Inside 'processing' directory, there should be a new directory containing 'core.dump' file
         String returnedMetadata = coredumpHandler.collectMetadata(processingCoredumpPath, attributes);


### PR DESCRIPTION
`CoreCollector` expects the path to the coredump file, not the directory in which the coredump file is.

FYI: @tokle This fixes all the coredump reports without bin path and backtrace info.