### PR TITLE
Freva/feed metrics

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -19,7 +19,7 @@ public class VespaMetricSet extends MetricSet {
     }
 
     private static Set<Metric> getVespaMetrics() {
-        Set<Metric> metrics =new LinkedHashSet<>();
+        Set<Metric> metrics = new LinkedHashSet<>();
 
         metrics.addAll(getSearchNodeMetrics());
         metrics.addAll(getStorageMetrics());
@@ -48,7 +48,7 @@ public class VespaMetricSet extends MetricSet {
     }
 
     private static Set<Metric> getContainerMetrics() {
-        Set<Metric> metrics =new LinkedHashSet<>();
+        Set<Metric> metrics = new LinkedHashSet<>();
 
         metrics.add(new Metric("serverRejectedRequests.rate"));
         metrics.add(new Metric("serverRejectedRequests.count"));
@@ -105,7 +105,7 @@ public class VespaMetricSet extends MetricSet {
     }
 
     private static Set<Metric> getDocprocMetrics() {
-        Set<Metric> metrics =new LinkedHashSet<>();
+        Set<Metric> metrics = new LinkedHashSet<>();
 
         // per chain
         metrics.add(new Metric("documents_processed.rate", "documents_processed"));
@@ -119,6 +119,8 @@ public class VespaMetricSet extends MetricSet {
         metrics.add(new Metric("peak_qps.average", "peak_qps"));
         metrics.add(new Metric("search_connections.average", "search_connections"));
         metrics.add(new Metric("active_queries.average", "active_queries"));
+        metrics.add(new Metric("feed.operations.rate"));
+        metrics.add(new Metric("feed.latency.average"));
         metrics.add(new Metric("queries.rate", "queries"));
         metrics.add(new Metric("query_latency.average", "mean_query_latency"));
         metrics.add(new Metric("query_latency.max", "max_query_latency"));
@@ -154,7 +156,7 @@ public class VespaMetricSet extends MetricSet {
     }
 
     private static Set<Metric> getSearchNodeMetrics() {
-        Set<Metric> metrics =new LinkedHashSet<>();
+        Set<Metric> metrics = new LinkedHashSet<>();
 
         metrics.add(new Metric("proton.numstoreddocs.last", "documents_total"));
         metrics.add(new Metric("proton.numindexeddocs.last", "documents_ready"));
@@ -245,7 +247,7 @@ public class VespaMetricSet extends MetricSet {
     }
 
     private static Set<Metric> getStorageMetrics() {
-        Set<Metric> metrics =new LinkedHashSet<>();
+        Set<Metric> metrics = new LinkedHashSet<>();
 
         metrics.add(new Metric("vds.datastored.alldisks.docs.average","docs"));
         metrics.add(new Metric("vds.datastored.alldisks.bytes.average","bytes"));

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
@@ -198,14 +198,6 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
         return errors.toString();
     }
 
-    public static Set<Integer> getErrorCodes(Reply reply) {
-        Set<Integer> errorCodes = new HashSet<>();
-        for (int i = 0; i < reply.getNumErrors(); ++i) {
-            errorCodes.add(reply.getError(i).getCode());
-        }
-        return errorCodes;
-    }
-
     private static Result.ResultType messageBusErrorToResultType(int messageBusError) {
         switch (messageBusError) {
             case ErrorCode.SEND_QUEUE_FULL: return Result.ResultType.TRANSIENT_ERROR;

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
@@ -198,8 +198,7 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
         return errors.toString();
     }
 
-    static Set<Integer>
-    getErrorCodes(Reply reply) {
+    public static Set<Integer> getErrorCodes(Reply reply) {
         Set<Integer> errorCodes = new HashSet<>();
         for (int i = 0; i < reply.getNumErrors(); ++i) {
             errorCodes.add(reply.getError(i).getCode());

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
@@ -167,8 +167,7 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
         msg.setPriority(pri);
         Reply reply = syncSend(msg);
         if (reply.hasErrors()) {
-            throw new DocumentAccessException(MessageBusAsyncSession.getErrorMessage(reply),
-                    MessageBusAsyncSession.getErrorCodes(reply));
+            throw new DocumentAccessException(MessageBusAsyncSession.getErrorMessage(reply), reply.getErrorCodes());
         }
         if (reply.getType() != DocumentProtocol.REPLY_UPDATEDOCUMENT) {
             throw new DocumentAccessException("Received unknown response: " + reply);
@@ -218,8 +217,7 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
     private void syncSendPutDocumentMessage(PutDocumentMessage putDocumentMessage) {
         Reply reply = syncSend(putDocumentMessage);
         if (reply.hasErrors()) {
-            throw new DocumentAccessException(MessageBusAsyncSession.getErrorMessage(reply),
-                    MessageBusAsyncSession.getErrorCodes(reply));
+            throw new DocumentAccessException(MessageBusAsyncSession.getErrorMessage(reply), reply.getErrorCodes());
         }
     }
 }

--- a/messagebus/src/main/java/com/yahoo/messagebus/Reply.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/Reply.java
@@ -2,7 +2,9 @@
 package com.yahoo.messagebus;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -138,4 +140,16 @@ public abstract class Reply extends Routable {
     public Stream<Error> getErrors() {
         return errors.stream();
     }
+
+    /**
+     * Retrieves a set of integer error codes
+     */
+    public Set<Integer> getErrorCodes() {
+        Set<Integer> errorCodes = new HashSet<>();
+        for (Error error : errors) {
+            errorCodes.add(error.getCode());
+        }
+        return errorCodes;
+    }
+
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandlerImpl.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandlerImpl.java
@@ -73,7 +73,7 @@ public class OperationHandlerImpl implements OperationHandler {
         this.documentAccess = documentAccess;
         this.clusterEnumerator = clusterEnumerator;
         syncSessions = new ConcurrentResourcePool<>(new SyncSessionFactory(documentAccess));
-        metricsHelper = new DocumentApiMetricsHelper(metricReceiver, "/document/v1");
+        metricsHelper = new DocumentApiMetricsHelper(metricReceiver, "documentV1");
     }
 
     @Override

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
@@ -24,6 +24,7 @@ import com.yahoo.document.restapi.RestUri;
 import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
 import com.yahoo.documentapi.messagebus.MessageBusParams;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.config.content.LoadTypeConfig;
 import com.yahoo.vespaxmlparser.VespaXMLFeedReader;
 
@@ -58,12 +59,12 @@ public class RestApi extends LoggingRequestHandler {
     private final AtomicInteger threadsAvailableForApi;
 
     @Inject
-    public RestApi(Executor executor, AccessLog accessLog, DocumentmanagerConfig documentManagerConfig, 
-                   LoadTypeConfig loadTypeConfig, ThreadpoolConfig threadpoolConfig) {
+    public RestApi(Executor executor, AccessLog accessLog, DocumentmanagerConfig documentManagerConfig,
+                   LoadTypeConfig loadTypeConfig, ThreadpoolConfig threadpoolConfig, MetricReceiver metricReceiver) {
         super(executor, accessLog);
         MessageBusParams params = new MessageBusParams(new LoadTypeSet(loadTypeConfig));
         params.setDocumentmanagerConfig(documentManagerConfig);
-        this.operationHandler = new OperationHandlerImpl(new MessageBusDocumentAccess(params));
+        this.operationHandler = new OperationHandlerImpl(new MessageBusDocumentAccess(params), metricReceiver);
         this.singleDocumentParser = new SingleDocumentParser(new DocumentTypeManager(documentManagerConfig));
         // 40% of the threads can be blocked before we deny requests.
         if (threadpoolConfig != null) {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentApiMetricsHelper.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentApiMetricsHelper.java
@@ -1,0 +1,53 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.documentapi.metrics;
+
+import com.yahoo.metrics.simple.Counter;
+import com.yahoo.metrics.simple.Gauge;
+import com.yahoo.metrics.simple.MetricReceiver;
+import com.yahoo.metrics.simple.Point;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * @author freva
+ */
+public class DocumentApiMetricsHelper {
+    private final Counter feeds;
+    private final Gauge feedLatency;
+    private final Map<DocumentOperationStatus, Map<DocumentOperationType, Point>> points = new HashMap<>();
+
+    public DocumentApiMetricsHelper(MetricReceiver metricReceiver, String apiName) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put("api", apiName);
+        for (DocumentOperationStatus status : DocumentOperationStatus.values()) {
+            points.put(status, new HashMap<>());
+            dimensions.put("status", status.name());
+            for (DocumentOperationType operation : DocumentOperationType.values()) {
+                dimensions.put("operation", operation.name());
+                points.get(status).put(operation, new Point(dimensions));
+            }
+        }
+
+        feeds = metricReceiver.declareCounter("feed_operations");
+        feedLatency = metricReceiver.declareGauge("feed_latency");
+    }
+
+    public void reportSuccessful(DocumentOperationType documentOperationType, double latency) {
+        Point point = points.get(DocumentOperationStatus.OK).get(documentOperationType);
+
+        feedLatency.sample(latency, point);
+        feeds.add(point);
+    }
+
+    public void reportSuccessful(DocumentOperationType documentOperationType, long startTime) {
+        final double latency = (System.currentTimeMillis() - startTime) / 1000.0d;
+        reportSuccessful(documentOperationType, latency);
+    }
+
+    public void reportFailure(DocumentOperationType documentOperationType, DocumentOperationStatus documentOperationStatus) {
+        Point point = points.get(documentOperationStatus).get(documentOperationType);
+        feeds.add(point);
+    }
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentApiMetricsHelper.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentApiMetricsHelper.java
@@ -30,8 +30,8 @@ public class DocumentApiMetricsHelper {
             }
         }
 
-        feeds = metricReceiver.declareCounter("feed_operations");
-        feedLatency = metricReceiver.declareGauge("feed_latency");
+        feeds = metricReceiver.declareCounter("feed.operations");
+        feedLatency = metricReceiver.declareGauge("feed.latency");
     }
 
     public void reportSuccessful(DocumentOperationType documentOperationType, double latency) {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationStatus.java
@@ -9,7 +9,7 @@ import java.util.Set;
  * @author freva
  */
 public enum  DocumentOperationStatus {
-    OK, CLIENT_ERROR, SERVER_ERROR;
+    OK, REQUEST_ERROR, SERVER_ERROR;
 
     public static DocumentOperationStatus fromHttpStatusCode(int httpStatus) {
         switch (httpStatus / 100) {
@@ -17,7 +17,7 @@ public enum  DocumentOperationStatus {
                 return OK;
 
             case 4:
-                return CLIENT_ERROR;
+                return REQUEST_ERROR;
 
             case 5:
                 return SERVER_ERROR;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationStatus.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.documentapi.metrics;
+
+import com.yahoo.document.restapi.OperationHandlerImpl;
+
+import java.util.Set;
+
+/**
+ * @author freva
+ */
+public enum  DocumentOperationStatus {
+    OK, CLIENT_ERROR, SERVER_ERROR;
+
+    public static DocumentOperationStatus fromHttpStatusCode(int httpStatus) {
+        switch (httpStatus / 100) {
+            case 2:
+                return OK;
+
+            case 4:
+                return CLIENT_ERROR;
+
+            case 5:
+                return SERVER_ERROR;
+
+            default:
+                return null;
+        }
+    }
+
+    public static DocumentOperationStatus fromMessageBusErrorCodes(Set<Integer> errorCodes) {
+        return fromHttpStatusCode(OperationHandlerImpl.getHTTPStatusCode(errorCodes));
+    }
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationStatus.java
@@ -6,24 +6,24 @@ import com.yahoo.document.restapi.OperationHandlerImpl;
 import java.util.Set;
 
 /**
+ * Enum with possible outcomes of a single document feeding operation:
+ * <ul>
+ * <li>OK: Document was successfully added/updated/removed</li>
+ * <li>REQUEST_ERROR: User-made error, for example invalid document format</li>
+ * <li>SERVER_ERROR: Server-made error, for example insufficient disk space</li>
+ * </ul>
+ *
  * @author freva
  */
-public enum  DocumentOperationStatus {
+public enum DocumentOperationStatus {
     OK, REQUEST_ERROR, SERVER_ERROR;
 
     public static DocumentOperationStatus fromHttpStatusCode(int httpStatus) {
         switch (httpStatus / 100) {
-            case 2:
-                return OK;
-
-            case 4:
-                return REQUEST_ERROR;
-
-            case 5:
-                return SERVER_ERROR;
-
-            default:
-                return null;
+            case 2: return OK;
+            case 4: return REQUEST_ERROR;
+            case 5: return SERVER_ERROR;
+            default: return null;
         }
     }
 

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationType.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationType.java
@@ -1,25 +1,26 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.documentapi.metrics;
 
-import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
+import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
+import com.yahoo.documentapi.messagebus.protocol.RemoveDocumentMessage;
+import com.yahoo.documentapi.messagebus.protocol.UpdateDocumentMessage;
 import com.yahoo.messagebus.Message;
 
 /**
  * @author freva
  */
 public enum DocumentOperationType {
-    PUT, REMOVE, UPDATE;
+    PUT, REMOVE, UPDATE, ERROR;
 
     public static DocumentOperationType fromMessage(Message msg) {
-        switch (msg.getType()) {
-            case DocumentProtocol.MESSAGE_PUTDOCUMENT:
-                return PUT;
-            case DocumentProtocol.MESSAGE_UPDATEDOCUMENT:
-                return UPDATE;
-            case DocumentProtocol.MESSAGE_REMOVEDOCUMENT:
-                return REMOVE;
-            default:
-                return null;
+        if (msg instanceof PutDocumentMessage) {
+            return PUT;
+        } else if (msg instanceof RemoveDocumentMessage) {
+            return REMOVE;
+        } else if (msg instanceof UpdateDocumentMessage) {
+            return UPDATE;
+        } else {
+            return ERROR;
         }
     }
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationType.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/documentapi/metrics/DocumentOperationType.java
@@ -1,0 +1,26 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.documentapi.metrics;
+
+import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
+import com.yahoo.messagebus.Message;
+
+/**
+ * @author freva
+ */
+public enum DocumentOperationType {
+    PUT, REMOVE, UPDATE;
+
+    public static DocumentOperationType fromMessage(Message msg) {
+        switch (msg.getType()) {
+            case DocumentProtocol.MESSAGE_PUTDOCUMENT:
+                return PUT;
+            case DocumentProtocol.MESSAGE_UPDATEDOCUMENT:
+                return UPDATE;
+            case DocumentProtocol.MESSAGE_REMOVEDOCUMENT:
+                return REMOVE;
+            default:
+                return null;
+        }
+    }
+}
+

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/ClientFeederV3.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/ClientFeederV3.java
@@ -6,6 +6,7 @@ import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.documentapi.messagebus.protocol.DocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
+import com.yahoo.documentapi.metrics.DocumentOperationType;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.log.LogLevel;
@@ -301,7 +302,7 @@ class ClientFeederV3 {
     }
 
     private void setMessageParameters(DocumentOperationMessageV3 msg, FeederSettings settings) {
-        msg.getMessage().setContext(new ReplyContext(msg.getOperationId(), feedReplies));
+        msg.getMessage().setContext(new ReplyContext(msg.getOperationId(), feedReplies, DocumentOperationType.fromMessage(msg.getMessage())));
         if (settings.traceLevel != null) {
             msg.getMessage().getTrace().setLevel(settings.traceLevel);
         }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandler.java
@@ -11,7 +11,7 @@ import com.yahoo.container.jdisc.messagebus.SessionCache;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.config.DocumentmanagerConfig;
-import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
+import com.yahoo.documentapi.metrics.DocumentApiMetrics;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.http.HttpResponse.Status;
 import com.yahoo.log.LogLevel;
@@ -69,7 +69,7 @@ public class FeedHandler extends LoggingRequestHandler {
             ThreadpoolConfig threadpoolConfig,
             MetricReceiver metricReceiver) throws Exception {
         super(executor, accessLog);
-        DocumentApiMetricsHelper metricsHelper = new DocumentApiMetricsHelper(metricReceiver, "vespa.http.server");
+        DocumentApiMetrics metricsHelper = new DocumentApiMetrics(metricReceiver, "vespa.http.server");
         feedHandlerV3 = new FeedHandlerV3(executor, documentManagerConfig, sessionCache, metric, accessLog, threadpoolConfig, metricsHelper);
         docTypeManager = createDocumentManager(documentManagerConfig);
         clients = new HashMap<>();

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
@@ -10,6 +10,7 @@ import com.yahoo.container.jdisc.messagebus.SessionCache;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.config.DocumentmanagerConfig;
+import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.log.LogLevel;
@@ -53,11 +54,12 @@ public class FeedHandlerV3 extends LoggingRequestHandler {
             SessionCache sessionCache,
             Metric metric,
             AccessLog accessLog,
-            ThreadpoolConfig threadpoolConfig) throws Exception {
+            ThreadpoolConfig threadpoolConfig,
+            DocumentApiMetricsHelper metricsHelper) throws Exception {
         super(executor, accessLog);
         docTypeManager = new DocumentTypeManager(documentManagerConfig);
         this.sessionCache = sessionCache;
-        feedReplyHandler = new FeedReplyReader(metric);
+        feedReplyHandler = new FeedReplyReader(metric, metricsHelper);
         cron = new ScheduledThreadPoolExecutor(1, ThreadFactoryFactory.getThreadFactory("feedhandlerv3.cron"));
         cron.scheduleWithFixedDelay(this::removeOldClients, 16, 11, TimeUnit.MINUTES);
         this.metric = metric;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
@@ -10,7 +10,7 @@ import com.yahoo.container.jdisc.messagebus.SessionCache;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.config.DocumentmanagerConfig;
-import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
+import com.yahoo.documentapi.metrics.DocumentApiMetrics;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.log.LogLevel;
@@ -55,7 +55,7 @@ public class FeedHandlerV3 extends LoggingRequestHandler {
             Metric metric,
             AccessLog accessLog,
             ThreadpoolConfig threadpoolConfig,
-            DocumentApiMetricsHelper metricsHelper) throws Exception {
+            DocumentApiMetrics metricsHelper) throws Exception {
         super(executor, accessLog);
         docTypeManager = new DocumentTypeManager(documentManagerConfig);
         this.sessionCache = sessionCache;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedReplyReader.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedReplyReader.java
@@ -1,9 +1,14 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.http.server;
 
+import java.util.Set;
 import java.util.logging.Logger;
 
+import com.yahoo.documentapi.messagebus.MessageBusAsyncSession;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
+import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
+import com.yahoo.documentapi.metrics.DocumentOperationStatus;
+import com.yahoo.documentapi.metrics.DocumentOperationType;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.log.LogLevel;
 import com.yahoo.messagebus.Reply;
@@ -21,9 +26,11 @@ public class FeedReplyReader implements ReplyHandler {
 
     private static final Logger log = Logger.getLogger(FeedReplyReader.class.getName());
     private final Metric metric;
+    private final DocumentApiMetricsHelper metricsHelper;
 
-    public FeedReplyReader(Metric metric) {
+    public FeedReplyReader(Metric metric, DocumentApiMetricsHelper metricsHelper) {
         this.metric = metric;
+        this.metricsHelper = metricsHelper;
     }
 
     @Override
@@ -33,15 +40,18 @@ public class FeedReplyReader implements ReplyHandler {
             return;
         }
         ReplyContext context = (ReplyContext) o;
-        metric.set(
-                MetricNames.LATENCY,
-                Double.valueOf((System.currentTimeMillis() - context.creationTime) / 1000.0d),
-                null);
+        final double latency = (System.currentTimeMillis() - context.creationTime) / 1000.0d;
+        metric.set(MetricNames.LATENCY, latency, null);
+
         if (reply.hasErrors()) {
+            //Set<Integer> errorCodes = MessageBusAsyncSession.getErrorCodes(reply);
+            //metricsHelper.reportFailure(DocumentOperationType.fromMessage(reply.getMessage()),
+            //        DocumentOperationStatus.fromMessageBusErrorCodes(errorCodes));
             metric.add(MetricNames.FAILED, 1, null);
             enqueue(context, reply.getError(0).getMessage(), ErrorCode.ERROR,
                     reply.getError(0).getCode() == DocumentProtocol.ERROR_TEST_AND_SET_CONDITION_FAILED, reply.getTrace());
         } else {
+            metricsHelper.reportSuccessful(DocumentOperationType.fromMessage(reply.getMessage()), latency);
             metric.add(MetricNames.SUCCEEDED, 1, null);
             enqueue(context, "Document processed.", ErrorCode.OK, false, reply.getTrace());
         }
@@ -58,5 +68,4 @@ public class FeedReplyReader implements ReplyHandler {
             Thread.currentThread().interrupt();
         }
     }
-
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedReplyReader.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedReplyReader.java
@@ -44,9 +44,9 @@ public class FeedReplyReader implements ReplyHandler {
         metric.set(MetricNames.LATENCY, latency, null);
 
         if (reply.hasErrors()) {
-            //Set<Integer> errorCodes = MessageBusAsyncSession.getErrorCodes(reply);
-            //metricsHelper.reportFailure(DocumentOperationType.fromMessage(reply.getMessage()),
-            //        DocumentOperationStatus.fromMessageBusErrorCodes(errorCodes));
+            Set<Integer> errorCodes = MessageBusAsyncSession.getErrorCodes(reply);
+            metricsHelper.reportFailure(DocumentOperationType.fromMessage(reply.getMessage()),
+                    DocumentOperationStatus.fromMessageBusErrorCodes(errorCodes));
             metric.add(MetricNames.FAILED, 1, null);
             enqueue(context, reply.getError(0).getMessage(), ErrorCode.ERROR,
                     reply.getError(0).getCode() == DocumentProtocol.ERROR_TEST_AND_SET_CONDITION_FAILED, reply.getTrace());

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/Feeder.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/Feeder.java
@@ -13,6 +13,7 @@ import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.RemoveDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.UpdateDocumentMessage;
+import com.yahoo.documentapi.metrics.DocumentOperationType;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.log.LogLevel;
@@ -350,7 +351,7 @@ public class Feeder implements Runnable {
     }
 
     private void setMessageParameters(Tuple2<String, Message> msg) {
-        msg.second.setContext(new ReplyContext(msg.first, feedReplies));
+        msg.second.setContext(new ReplyContext(msg.first, feedReplies, DocumentOperationType.fromMessage(msg.second)));
         if (settings.traceLevel != null) {
             msg.second.getTrace().setLevel(settings.traceLevel);
         }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/ReplyContext.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/ReplyContext.java
@@ -1,6 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.http.server;
 
+import com.yahoo.documentapi.metrics.DocumentOperationType;
 import com.yahoo.vespa.http.client.core.OperationStatus;
 
 import java.util.concurrent.BlockingQueue;
@@ -8,15 +9,16 @@ import java.util.concurrent.BlockingQueue;
 /**
  * Mapping between document ID and client session.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 public class ReplyContext {
 
     public final String docId;
+    public DocumentOperationType documentOperationType;
     public final BlockingQueue<OperationStatus> feedReplies;
     public final long creationTime;
 
-    public ReplyContext(String docId, BlockingQueue<OperationStatus> feedReplies) {
+    public ReplyContext(String docId, BlockingQueue<OperationStatus> feedReplies, DocumentOperationType documentOperationType) {
         this.docId = docId;
         this.feedReplies = feedReplies;
         this.creationTime = System.currentTimeMillis();

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/OperationHandlerImplTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/OperationHandlerImplTest.java
@@ -6,6 +6,7 @@ import com.yahoo.documentapi.ProgressToken;
 import com.yahoo.documentapi.VisitorControlHandler;
 import com.yahoo.documentapi.VisitorParameters;
 import com.yahoo.documentapi.VisitorSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vdslib.VisitorStatistics;
 import com.yahoo.vespaclient.ClusterDef;
 import org.junit.Test;
@@ -114,7 +115,7 @@ public class OperationHandlerImplTest {
                 return visitorSession;
             });
             OperationHandlerImpl.ClusterEnumerator clusterEnumerator = () -> Arrays.asList(new ClusterDef("foo", "configId"));
-            return new OperationHandlerImpl(documentAccess, clusterEnumerator);
+            return new OperationHandlerImpl(documentAccess, clusterEnumerator, MetricReceiver.nullImplementation);
         }
     }
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/FeedHandlerTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/FeedHandlerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.jdisc.HeaderFields;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.container.logging.AccessLog;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.http.client.core.Headers;
 import com.yahoo.vespa.http.client.core.OperationStatus;
 import com.yahoo.vespa.http.server.FeedHandler;
@@ -38,7 +39,7 @@ public class FeedHandlerTest {
         private final CountDownLatch countDownLatch = new CountDownLatch(1);
 
         public TestFeedHandler() throws Exception {
-            super(Executors.newCachedThreadPool(), null, null, mock(Metric.class), mock(AccessLog.class), null);
+            super(Executors.newCachedThreadPool(), null, null, mock(Metric.class), mock(AccessLog.class), null, MetricReceiver.nullImplementation);
         }
 
         /**

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/v3/FeedTesterV3.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/v3/FeedTesterV3.java
@@ -10,10 +10,12 @@ import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
+import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
 import com.yahoo.feedhandler.NullFeedMetric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.messagebus.SourceSessionParams;
 import com.yahoo.messagebus.shared.SharedSourceSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.http.client.config.FeedParams;
 import com.yahoo.vespa.http.client.core.ErrorCode;
@@ -100,7 +102,7 @@ public class FeedTesterV3 {
         Executor threadPool = Executors.newCachedThreadPool();
         DocumentmanagerConfig docMan = new DocumentmanagerConfig(new DocumentmanagerConfig.Builder().enablecompression(true));
         FeedHandlerV3 feedHandlerV3 = new FeedHandlerV3(
-                threadPool, docMan, null /* session cache */ , new NullFeedMetric(), AccessLog.voidAccessLog(), null) {
+                threadPool, docMan, null /* session cache */ , new NullFeedMetric(), AccessLog.voidAccessLog(), null, new DocumentApiMetricsHelper(MetricReceiver.nullImplementation, "test")) {
             @Override
             protected ReferencedResource<SharedSourceSession> retainSource(
                     SessionCache sessionCache, SourceSessionParams sessionParams)  {

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/v3/FeedTesterV3.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/v3/FeedTesterV3.java
@@ -10,7 +10,7 @@ import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
-import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
+import com.yahoo.documentapi.metrics.DocumentApiMetrics;
 import com.yahoo.feedhandler.NullFeedMetric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.messagebus.SourceSessionParams;
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.yahoo.messagebus.Result;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class FeedTesterV3 {
@@ -102,7 +101,7 @@ public class FeedTesterV3 {
         Executor threadPool = Executors.newCachedThreadPool();
         DocumentmanagerConfig docMan = new DocumentmanagerConfig(new DocumentmanagerConfig.Builder().enablecompression(true));
         FeedHandlerV3 feedHandlerV3 = new FeedHandlerV3(
-                threadPool, docMan, null /* session cache */ , new NullFeedMetric(), AccessLog.voidAccessLog(), null, new DocumentApiMetricsHelper(MetricReceiver.nullImplementation, "test")) {
+                threadPool, docMan, null /* session cache */ , new NullFeedMetric(), AccessLog.voidAccessLog(), null, new DocumentApiMetrics(MetricReceiver.nullImplementation, "test")) {
             @Override
             protected ReferencedResource<SharedSourceSession> retainSource(
                     SessionCache sessionCache, SourceSessionParams sessionParams)  {

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2ErrorsInResultTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2ErrorsInResultTestCase.java
@@ -14,6 +14,7 @@ import com.yahoo.messagebus.*;
 import com.yahoo.messagebus.Error;
 import com.yahoo.messagebus.shared.SharedMessageBus;
 import com.yahoo.messagebus.shared.SharedSourceSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.text.Utf8;
 import com.yahoo.text.Utf8String;
 import com.yahoo.vespa.http.client.core.Headers;
@@ -59,7 +60,7 @@ public class V2ErrorsInResultTestCase {
     private static class LessConfiguredHandler extends FeedHandler {
 
         public LessConfiguredHandler(Executor executor) throws Exception {
-            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null);
+            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null, MetricReceiver.nullImplementation);
         }
 
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2ExternalFeedTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2ExternalFeedTestCase.java
@@ -20,6 +20,7 @@ import com.yahoo.messagebus.SourceSessionParams;
 import com.yahoo.messagebus.network.Network;
 import com.yahoo.messagebus.shared.SharedMessageBus;
 import com.yahoo.messagebus.shared.SharedSourceSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.http.client.config.FeedParams.DataFormat;
 import com.yahoo.vespa.http.client.core.Headers;
@@ -50,7 +51,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -115,7 +115,7 @@ public class V2ExternalFeedTestCase {
         volatile DataFormat lastFormatSeen;
 
         public LessConfiguredHandler(Executor executor) throws Exception {
-            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null);
+            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null, MetricReceiver.nullImplementation);
         }
 
         @Override

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2FailingMessagebusTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2FailingMessagebusTestCase.java
@@ -13,6 +13,7 @@ import com.yahoo.jdisc.http.HttpRequest.Method;
 import com.yahoo.messagebus.*;
 import com.yahoo.messagebus.shared.SharedMessageBus;
 import com.yahoo.messagebus.shared.SharedSourceSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.http.client.core.Headers;
 import com.yahoo.vespa.http.client.core.OperationStatus;
@@ -60,7 +61,7 @@ public class V2FailingMessagebusTestCase {
     private class LessConfiguredHandler extends FeedHandler {
 
         public LessConfiguredHandler(Executor executor) throws Exception {
-            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null);
+            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null, MetricReceiver.nullImplementation);
         }
 
         @Override

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2NoXmlReaderTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V2NoXmlReaderTestCase.java
@@ -14,6 +14,7 @@ import com.yahoo.messagebus.*;
 import com.yahoo.messagebus.Error;
 import com.yahoo.messagebus.shared.SharedMessageBus;
 import com.yahoo.messagebus.shared.SharedSourceSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.http.client.core.Headers;
 import com.yahoo.vespa.http.client.core.OperationStatus;
@@ -57,7 +58,7 @@ public class V2NoXmlReaderTestCase {
     private static class LessConfiguredHandler extends FeedHandler {
 
         public LessConfiguredHandler(Executor executor) throws Exception {
-            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null);
+            super(executor, null, null, new DummyMetric(), AccessLog.voidAccessLog(), null, MetricReceiver.nullImplementation);
         }
 
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V3CongestionTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V3CongestionTestCase.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.http.server;
 
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.document.DocumentTypeManager;
-import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
+import com.yahoo.documentapi.metrics.DocumentApiMetrics;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.jdisc.References;
@@ -88,7 +88,7 @@ public class V3CongestionTestCase {
                 null /*DocTypeManager*/,
                 "clientID",
                 null/*metric*/,
-                new FeedReplyReader(null/*metric*/, new DocumentApiMetricsHelper(MetricReceiver.nullImplementation, "tester")),
+                new FeedReplyReader(null/*metric*/, new DocumentApiMetrics(MetricReceiver.nullImplementation, "tester")),
                 threadsAvail);
     }
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V3CongestionTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/vespa/http/server/V3CongestionTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.http.server;
 
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.document.DocumentTypeManager;
+import com.yahoo.documentapi.metrics.DocumentApiMetricsHelper;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.jdisc.References;
@@ -15,6 +16,7 @@ import com.yahoo.messagebus.Result;
 import com.yahoo.messagebus.SourceSessionParams;
 import com.yahoo.messagebus.shared.SharedMessageBus;
 import com.yahoo.messagebus.shared.SharedSourceSession;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.http.client.core.Headers;
 import com.yahoo.vespaxmlparser.MockFeedReaderFactory;
 import com.yahoo.vespaxmlparser.VespaXMLFeedReader;
@@ -86,7 +88,7 @@ public class V3CongestionTestCase {
                 null /*DocTypeManager*/,
                 "clientID",
                 null/*metric*/,
-                new FeedReplyReader(null/*metric*/),
+                new FeedReplyReader(null/*metric*/, new DocumentApiMetricsHelper(MetricReceiver.nullImplementation, "tester")),
                 threadsAvail);
     }
 


### PR DESCRIPTION
Adds two metrics for `/document/v1` and `vespa.http.server`:
* Vespa.container.feed.operations
* Vespa.container.feed.latency

With dimensions:
api (`documentV1`, `vespa.http.server`)
operation (`PUT`, `UPDATE`, `REMOVE`) 
status (`OK`, `REQUEST-ERROR`, `SERVER-ERROR`) 
