### PR TITLE
Always write new cluster state versions to ZooKeeper

### DIFF
--- a/clustercontroller-core/pom.xml
+++ b/clustercontroller-core/pom.xml
@@ -27,6 +27,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
         </dependency>

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -113,7 +113,7 @@ public class SystemStateBroadcaster {
         // Store new version in ZooKeeper _before_ publishing to any nodes so that a
         // cluster controller crash after publishing but before a successful ZK store
         // will not risk reusing the same version number.
-        if (!recipients.isEmpty() && !systemState.isOfficial()) {
+        if (!systemState.isOfficial()) {
             database.saveLatestSystemStateVersion(dbContext, systemState.getVersion());
             systemState.setOfficial(true);
         }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseTest.java
@@ -12,7 +12,6 @@ import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vdslib.state.State;
-import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -27,17 +26,8 @@ public class DatabaseTest extends FleetControllerTest {
 
     private static Logger log = Logger.getLogger(DatabaseTest.class.getName());
 
-    protected Supervisor supervisor;
-
-    @After
-    public void tearDown() throws Exception {
-        if (supervisor != null) {
-            supervisor.transport().shutdown().join();
-        }
-        super.tearDown();
-    }
-
-    private void setWantedState(Node n, NodeState ns, Map<Node, NodeState> wantedStates) {
+    // Note: different semantics than FleetControllerTest.setWantedState
+    protected void setWantedState(Node n, NodeState ns, Map<Node, NodeState> wantedStates) {
         int rpcPort = fleetController.getRpcPort();
         if (supervisor == null) {
             supervisor = new Supervisor(new Transport());

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/WantedStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/WantedStateTest.java
@@ -1,49 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
-import com.yahoo.jrt.*;
-import com.yahoo.jrt.StringValue;
-import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.State;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class WantedStateTest extends FleetControllerTest {
-
-    private Supervisor supervisor;
-
-    @Before
-    public void setUp() {
-        supervisor = new Supervisor(new Transport());
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        if (supervisor != null) {
-            supervisor.transport().shutdown().join();
-            supervisor = null;
-        }
-        super.tearDown();
-    }
-
-    public void setWantedState(DummyVdsNode node, State state, String reason) {
-        NodeState ns = new NodeState(node.getType(), state);
-        if (reason != null) ns.setDescription(reason);
-        Target connection = supervisor.connect(new Spec("localhost", fleetController.getRpcPort()));
-        Request req = new Request("setNodeState");
-        req.parameters().add(new StringValue(node.getSlobrokName()));
-        req.parameters().add(new StringValue(ns.serialize()));
-        connection.invokeSync(req, timeoutS);
-        if (req.isError()) {
-            assertTrue("Failed to invoke setNodeState(): " + req.errorCode() + ": " + req.errorMessage(), false);
-        }
-        if (!req.checkReturnTypes("s")) {
-            assertTrue("Failed to invoke setNodeState(): Invalid return types.", false);
-        }
-    }
 
     @Test
     public void testSettingStorageNodeMaintenanceAndBack() throws Exception {


### PR DESCRIPTION
@hakonhall Please review

Previously, the controller would not write the version to ZK unless the
version was published to at least one node. This could lead to problems
due to un-written version numbers being visible via the controller's REST
APIs. External observers could see versions that were not present in ZK
and that would not be stable across reelections. As a consequence, invariants
for strictly increasing version numbers would be violated from the
perspective of these external observers (in particular, our system test
framework).