### PR TITLE
Freva/use node application for system metrics from docker

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/metrics/MetricReceiverWrapper.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/metrics/MetricReceiverWrapper.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 public class MetricReceiverWrapper {
     // Application names used
     public static final String APPLICATION_DOCKER = "docker";
+    public static final String APPLICATION_NODE = "node";
     public static final String APPLICATION_HOST_LIFE = "host_life";
 
     private final static ObjectMapper objectMapper = new ObjectMapper();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -61,7 +61,7 @@ public class ComponentsProviderImpl implements ComponentsProvider {
         ConfigServerHttpRequestExecutor requestExecutor = ConfigServerHttpRequestExecutor.create(configServerHosts);
         Orchestrator orchestrator = new OrchestratorImpl(requestExecutor);
         NodeRepository nodeRepository = new NodeRepositoryImpl(requestExecutor, WEB_SERVICE_PORT, baseHostName);
-        DockerOperations dockerOperations = new DockerOperationsImpl(docker, environment, metricReceiver);
+        DockerOperations dockerOperations = new DockerOperationsImpl(docker, environment);
 
         Optional<StorageMaintainer> storageMaintainer = isRunningLocally ?
                 Optional.empty() : Optional.of(new StorageMaintainer(docker, metricReceiver, environment));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
@@ -1,13 +1,11 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.docker;
 
-import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.hosted.dockerapi.Container;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.ProcessResult;
-import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
@@ -32,8 +30,7 @@ import static org.mockito.Mockito.when;
 public class DockerOperationsImplTest {
     private final Environment environment = new Environment.Builder().build();
     private final Docker docker = mock(Docker.class);
-    private final DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment,
-            new MetricReceiverWrapper(MetricReceiver.nullImplementation));
+    private final DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment);
 
     @Test
     public void processResultFromNodeProgramWhenSuccess() throws Exception {
@@ -108,8 +105,7 @@ public class DockerOperationsImplTest {
     public void runsCommandInNetworkNamespace() {
         Container container = makeContainer("container-42", Container.State.RUNNING, 42);
         List<String> capturedArgs = new ArrayList<>();
-        DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment,
-                new MetricReceiverWrapper(MetricReceiver.nullImplementation), capturedArgs::addAll);
+        DockerOperationsImpl dockerOperations = new DockerOperationsImpl(docker, environment, capturedArgs::addAll);
 
         dockerOperations.executeCommandInNetworkNamespace(container.name, new String[]{"iptables", "-nvL"});
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -61,7 +61,7 @@ public class DockerTester implements AutoCloseable {
 
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
-        final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, mr);
+        final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment);
         Function<String, NodeAgent> nodeAgentFactory = (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock,
                 orchestratorMock, dockerOperations, Optional.of(storageMaintainer), mr, environment, Clock.systemUTC(), Optional.empty());
         nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, Optional.of(storageMaintainer), 100, mr, Optional.empty());

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
@@ -9,8 +9,7 @@ import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.node.admin.maintenance.StorageMaintainer;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author freva
@@ -24,8 +23,8 @@ public class StorageMaintainerMock extends StorageMaintainer {
     }
 
     @Override
-    public Map<String, Number> updateIfNeededAndGetDiskMetricsFor(ContainerName containerName) {
-        return new HashMap<>();
+    public Optional<Long> updateIfNeededAndGetDiskMetricsFor(ContainerName containerName) {
+        return Optional.empty();
     }
 
     @Override

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -484,6 +484,7 @@ public class NodeAgentImplTest {
         NodeAgentImpl nodeAgent = makeNodeAgent(dockerImage, true);
 
         when(nodeRepository.getContainerNodeSpec(eq(hostName))).thenReturn(Optional.of(nodeSpec));
+        when(storageMaintainer.updateIfNeededAndGetDiskMetricsFor(eq(containerName))).thenReturn(Optional.of(42547019776L));
         when(dockerOperations.shouldScheduleDownloadOfImage(eq(dockerImage))).thenReturn(false);
         when(dockerOperations.getContainerStats(eq(containerName)))
                 .thenReturn(Optional.of(stats1))

--- a/node-admin/src/test/resources/docker.stats.json
+++ b/node-admin/src/test/resources/docker.stats.json
@@ -52,7 +52,7 @@
     "stats":{
       "active_anon":1326051328,
       "active_file":188919808,
-      "cache":426680320,
+      "cache":678965248,
       "hierarchical_memory_limit":4294967296,
       "hierarchical_memsw_limit":8589934592,
       "inactive_anon":0,

--- a/node-admin/src/test/resources/docker.stats.metrics.active.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.active.expected.json
@@ -30,6 +30,106 @@
         }
     },
     {
+        "application": "node",
+        "dimensions": {
+            "flavor": "docker",
+            "applicationName": "testapp",
+            "instanceName": "testinstance",
+            "applicationId": "tester.testapp.testinstance",
+            "app": "testapp.testinstance",
+            "clustertype": "clustType",
+            "role": "tenants",
+            "tenantName": "tester",
+            "host": "host1.test.yahoo.com",
+            "vespaVersion": "1.2.3",
+            "state": "active",
+            "clusterid": "clustId",
+            "parentHostname": "parent.host.name.yahoo.com",
+            "zone": "dev.us-east-1"
+        },
+        "metrics": {
+            "alive": 1.0,
+            "cpu.util": 6.75,
+            "mem.limit": 4.294967296E9,
+            "mem.used": 1.073741824E9,
+            "mem.util": 25.0,
+            "disk.limit": 2.68435456E11,
+            "disk.used": 4.2547019776E10,
+            "disk.util": 15.85
+        },
+        "routing": {
+            "yamas": {
+                "namespaces": ["Vespa"]
+            }
+        }
+    },
+    {
+        "application": "node",
+        "dimensions": {
+            "flavor": "docker",
+            "applicationName": "testapp",
+            "instanceName": "testinstance",
+            "applicationId": "tester.testapp.testinstance",
+            "app": "testapp.testinstance",
+            "clustertype": "clustType",
+            "role": "tenants",
+            "tenantName": "tester",
+            "host": "host1.test.yahoo.com",
+            "vespaVersion": "1.2.3",
+            "state": "active",
+            "clusterid": "clustId",
+            "parentHostname": "parent.host.name.yahoo.com",
+            "zone": "dev.us-east-1",
+            "interface": "eth1"
+        },
+        "metrics": {
+            "net.out.bytes": 5.4246745E7,
+            "net.out.errors": 0.0,
+            "net.out.dropped": 0.0,
+            "net.in.bytes": 3245766.0,
+            "net.in.errors": 0.0,
+            "net.in.dropped": 0.0
+        },
+        "routing": {
+            "yamas": {
+                "namespaces": ["Vespa"]
+            }
+        }
+    },
+    {
+        "application": "node",
+        "dimensions": {
+            "flavor": "docker",
+            "applicationName": "testapp",
+            "instanceName": "testinstance",
+            "applicationId": "tester.testapp.testinstance",
+            "app": "testapp.testinstance",
+            "clustertype": "clustType",
+            "role": "tenants",
+            "tenantName": "tester",
+            "host": "host1.test.yahoo.com",
+            "vespaVersion": "1.2.3",
+            "state": "active",
+            "clusterid": "clustId",
+            "parentHostname": "parent.host.name.yahoo.com",
+            "zone": "dev.us-east-1",
+            "interface": "eth0"
+        },
+        "metrics": {
+            "net.out.bytes": 2.0303455E7,
+            "net.out.errors": 3.0,
+            "net.out.dropped": 13.0,
+            "net.in.bytes": 1.949927E7,
+            "net.in.errors": 55.0,
+            "net.in.dropped": 4.0
+        },
+        "routing": {
+            "yamas": {
+                "namespaces": ["Vespa"]
+            }
+        }
+    },
+    {
         "application": "docker",
         "dimensions": {
             "flavor": "docker",
@@ -84,8 +184,9 @@
             "node.alive": 1.0,
             "node.cpu.busy.pct": 6.75,
             "node.cpu.throttled_time": 4523.0,
-            "node.memory.usage": 1.326026752E9,
+            "node.memory.usage": 1.073741824E9,
             "node.memory.limit": 4.294967296E9,
+            "node.disk.used": 4.2547019776E10,
             "node.disk.limit": 2.68435456E11
         },
         "routing": {

--- a/node-admin/src/test/resources/docker.stats.metrics.ready.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.ready.expected.json
@@ -1,5 +1,24 @@
 [
     {
+        "application": "node",
+        "dimensions": {
+            "flavor": "docker",
+            "role": "tenants",
+            "host": "host1.test.yahoo.com",
+            "state": "ready",
+            "parentHostname": "parent.host.name.yahoo.com",
+            "zone": "dev.us-east-1"
+        },
+        "metrics": {
+            "alive": 1.0
+        },
+        "routing": {
+            "yamas": {
+                "namespaces": ["Vespa"]
+            }
+        }
+    },
+    {
         "application": "docker",
         "dimensions": {
             "flavor": "docker",


### PR DESCRIPTION
* Removes `Vespa.docker.containers.running` metric: not used
* Adds following new metrics:
  * `Vespa.node.alive`
  * `Vespa.node.cpu.util`
  * `Vespa.node.mem.(limit|used|util)`
  * `Vespa.node.disk.(limit|used|util)`
  * Per network interface:
    * `Vespa.node.net.in.(bytes|errors|dropped)`
    * `Vespa.node.net.out.(bytes|errors|dropped)`

FYI: @ldalves 