### PR TITLE
Initialize mocks before calling anything

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RunInContainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RunInContainerTest.java
@@ -115,6 +115,8 @@ public class RunInContainerTest {
 
     @Test
     public void testGetContainersToRunAPi() throws IOException, InterruptedException {
+        doThrow(new OrchestratorException("Cannot suspend because...")).when(orchestrator).suspend(parentHostname);
+        when(ComponentsProviderWithMocks.nodeRepositoryMock.getContainersToRun()).thenReturn(Collections.emptyList());
         waitForJdiscContainerToServe();
 
         assertFalse(doPutCall("resume")); // Initial is false to force convergence
@@ -128,7 +130,6 @@ public class RunInContainerTest {
         assertFalse(doPutCall("suspend/node-admin"));
 
         // Orchestrator changes its mind, allows node-admin to suspend
-        when(ComponentsProviderWithMocks.nodeRepositoryMock.getContainersToRun()).thenReturn(Collections.emptyList());
         doNothing().when(orchestrator).suspend(parentHostname, Collections.singletonList(parentHostname));
         Thread.sleep(50);
         assertTrue(doPutCall("suspend/node-admin")); // Tick loop should've run several times by now, expect to be suspended


### PR DESCRIPTION
Fixes unstable test in `node-admin` by initializing mock methods before calling anything else. Most likely caused by #2415 

```
Error Message

Unfinished stubbing detected here:
-> at com.yahoo.vespa.hosted.node.admin.integrationTests.RunInContainerTest.testGetContainersToRunAPi(RunInContainerTest.java:132)

E.g. thenReturn() may be missing.
Examples of correct stubbing:
    when(mock.isOk()).thenReturn(true);
    when(mock.isOk()).thenThrow(exception);
    doThrow(exception).when(mock).someVoidMethod();
Hints:
 1. missing thenReturn()
 2. you are trying to stub a final method, you naughty developer!
Stacktrace

org.mockito.exceptions.misusing.UnfinishedStubbingException: 

Unfinished stubbing detected here:
-> at com.yahoo.vespa.hosted.node.admin.integrationTests.RunInContainerTest.testGetContainersToRunAPi(RunInContainerTest.java:132)

E.g. thenReturn() may be missing.
Examples of correct stubbing:
    when(mock.isOk()).thenReturn(true);
    when(mock.isOk()).thenThrow(exception);
    doThrow(exception).when(mock).someVoidMethod();
Hints:
 1. missing thenReturn()
 2. you are trying to stub a final method, you naughty developer!

	at com.yahoo.vespa.hosted.node.admin.integrationTests.RunInContainerTest.testGetContainersToRunAPi(RunInContainerTest.java:147)
```