### PR TITLE
Remove expired compatibility code

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -284,17 +284,11 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return currentActiveApplicationSet;
     }
 
-    public ConfigChangeActions prepare(Tenant tenant,
-                                       long sessionId,
-                                       DeployLogger logger,
-                                       PrepareParams params) {
+    public ConfigChangeActions prepare(Tenant tenant, long sessionId, DeployLogger logger, PrepareParams params) {
         LocalSession session = getLocalSession(tenant, sessionId);
         ApplicationId appId = params.getApplicationId();
         Optional<ApplicationSet> currentActiveApplicationSet = getCurrentActiveApplicationSet(tenant, appId);
-        return session.prepare(logger,
-                               params,
-                               currentActiveApplicationSet,
-                               tenant.getPath());
+        return session.prepare(logger, params, currentActiveApplicationSet, tenant.getPath());
     }
 
     private List<ApplicationId> listApplicationIds(Tenant tenant) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -98,7 +98,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
         if (prepared) return;
         TimeoutBudget timeoutBudget = new TimeoutBudget(clock, timeout);
         session.prepare(logger,
-                        /** Assumes that session has already set application id, see {@link com.yahoo.vespa.config.server.session.SessionFactoryImpl}. */
+                        /** Assumes that session has already set application id and version, see {@link com.yahoo.vespa.config.server.session.SessionFactoryImpl}. */
                         new PrepareParams.Builder().applicationId(session.getApplicationId())
                                                    .timeoutBudget(timeoutBudget)
                                                    .ignoreValidationErrors( ! validate)

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
@@ -48,6 +48,7 @@ public final class PrepareParams {
     }
 
     public static class Builder {
+
         private boolean ignoreValidationErrors = false;
         private boolean dryRun = false;
         private ApplicationId applicationId = ApplicationId.defaultId();

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -87,18 +87,18 @@ public class SessionPreparer {
      */
     public ConfigChangeActions prepare(SessionContext context, DeployLogger logger, PrepareParams params,
                                        Optional<ApplicationSet> currentActiveApplicationSet, Path tenantPath) {
-        Preparation prep = new Preparation(context, logger, params, currentActiveApplicationSet, tenantPath);
-        prep.preprocess();
+        Preparation preparation = new Preparation(context, logger, params, currentActiveApplicationSet, tenantPath);
+        preparation.preprocess();
         try {
-            prep.buildModels();
-            prep.makeResult();
-            if (!params.isDryRun()) {
-                prep.writeStateZK();
-                prep.writeRotZK();
-                prep.distribute();
-                prep.reloadDeployFileDistributor();
+            preparation.buildModels();
+            preparation.makeResult();
+            if ( ! params.isDryRun()) {
+                preparation.writeStateZK();
+                preparation.writeRotZK();
+                preparation.distribute();
+                preparation.reloadDeployFileDistributor();
             }
-            return prep.result();
+            return preparation.result();
         } catch (OutOfCapacityException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -265,6 +265,16 @@ public class EvaluationTestCase {
         tester.assertEvaluates("1.0", "sum(tensor0 * tensor1 + 0.5)", "{}",                  "{ {x:0}:1, {x:1}:1 }");
         tester.assertEvaluates("0.0", "sum(tensor0 * tensor1 + 0.5)", "tensor(x{}):{}",                  "{ {x:0}:1, {x:1}:1 }");
 
+        tester.assertEvaluates("1",
+                               "reduce(join(tensor0, tensor1, f(x,y) (if(x > y, 1.0, 0.0))), sum, tag) == reduce(tensor0, count, tag)",
+                               "tensor(tag{}):{{tag:tag1}:10, {tag:tag2}:20}", "{5}");
+        tester.assertEvaluates("0",
+                               "reduce(join(tensor0, tensor1, f(x,y) (if(x > y, 1.0, 0.0))), sum, tag) == reduce(tensor0, count, tag)",
+                               "tensor(tag{}):{{tag:tag1}:10, {tag:tag2}:20}", "{15}");
+        tester.assertEvaluates("0",
+                               "reduce(join(tensor0, tensor1, f(x,y) (if(x > y, 1.0, 0.0))), sum, tag) == reduce(tensor0, count, tag)",
+                               "tensor(tag{}):{{tag:tag1}:10, {tag:tag2}:20}", "{25}");
+
         // tensor result dimensions are given from argument dimensions, not the resulting values
         tester.assertEvaluates("tensor(x{}):{}", "tensor0 * tensor1", "{ {x:0}:1 }", "tensor(x{}):{ {x:1}:1 }");
         tester.assertEvaluates("tensor(x{},y{}):{}", "tensor0 * tensor1", "{ {x:0}:1 }", "tensor(x{},y{}):{ {x:1,y:0}:1, {x:2,y:1}:1 }");


### PR DESCRIPTION
@hmusum please review

With this + your earlier one there is just one usage of Vtag.currentVersion left which ends up as the wanted Vespa version: SessionPreparer.Preparation.new, when PrepareParams.vespaVersion is empty(). This in turn only happens on a HTTP prepare which is missing vespaVersion.

Hence it will not be possible for this to happen again, unless due to old config models.
After reviewing all the relevant code in detail I could not find any loopholse prior to these two PR's either, so I think what happened is that an older config model triggered the compatibility paths to transfer a Vtag.currentVersion to the nodes through the model - oldest model versions are created last.