### PR TITLE
Fix deleteDirectories in node-maintainer

### DIFF
--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/maintainer/FileHelper.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/maintainer/FileHelper.java
@@ -136,10 +136,8 @@ public class FileHelper {
         }
     }
 
-    private static Optional<Path> getMostRecentlyModifiedFileIn(Path basePath) {
-        return listContentsOfDirectory(basePath).stream()
-                .filter(Files::isRegularFile)
-                .max(Comparator.comparing(FileHelper::getLastModifiedTime));
+    private static Optional<Path> getMostRecentlyModifiedFileIn(Path basePath) throws IOException {
+        return Files.walk(basePath).max(Comparator.comparing(FileHelper::getLastModifiedTime));
     }
 
     private static boolean isTimeSinceLastModifiedMoreThan(Path path, Duration duration) {

--- a/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/maintainer/FileHelperTest.java
+++ b/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/maintainer/FileHelperTest.java
@@ -192,14 +192,27 @@ public class FileHelperTest {
     @Test
     public void testDeleteDirectoriesBasedOnAge() throws IOException {
         initSubDirectories();
+        // Create folder3 which is older than maxAge, inside have a single directory, subSubFolder3, inside it which is
+        // also older than maxAge inside the sub directory, create some files which are newer than maxAge.
+        // deleteDirectories() should NOT delete folder3
+        File subFolder3 = folder.newFolder("test_folder3");
+        File subSubFolder3 = folder.newFolder("test_folder3/subSubFolder3");
+
+        for (int j=0; j<11; j++) {
+            File.createTempFile("test_", ".json", subSubFolder3);
+        }
+
+        subFolder3.setLastModified(System.currentTimeMillis() - Duration.ofHours(1).toMillis());
+        subSubFolder3.setLastModified(System.currentTimeMillis() - Duration.ofHours(3).toMillis());
 
         FileHelper.deleteDirectories(folder.getRoot().toPath(), Duration.ofSeconds(50), Optional.of(".*folder.*"));
 
         //23 files in root
         // + 13 in test_folder2
         // + 13 in subSubFolder2
-        // + test_folder2 + subSubFolder2 itself
-        assertEquals(51, getNumberOfFilesAndDirectoriesIn(folder.getRoot()));
+        // + 11 in subSubFolder3
+        // + test_folder2 + subSubFolder2 + folder3 + subSubFolder3 itself
+        assertEquals(64, getNumberOfFilesAndDirectoriesIn(folder.getRoot()));
     }
 
     @Test


### PR DESCRIPTION
This fixes a bug where `node-maintainer` deleted archived app data too early. The previous version checked if the youngest file directly under `/` of old container was older than `maxAge`, the new version checks recursively to find the youngest file.