### PR TITLE
Don't swallow document policy creation exceptions

### DIFF
--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -43,6 +43,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config</artifactId>
       <version>${project.version}</version>

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutingPolicyRepository.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutingPolicyRepository.java
@@ -55,22 +55,18 @@ class RoutingPolicyRepository {
             log.log(LogLevel.ERROR, "No routing policy factory found for name '" + name + "'.");
             return null;
         }
-        DocumentProtocolRoutingPolicy ret;
-        try {
-            ret = factory.createPolicy(param);
-        } catch (Exception e) {
-            ret = new ErrorPolicy(e.getMessage());
+        final DocumentProtocolRoutingPolicy ret = factory.createPolicy(param);
+
+        if (ret == null) {
+            log.log(LogLevel.ERROR, "Routing policy factory " + factory.getClass().getName() + " failed to create a " +
+                    "routing policy for parameter '" + name + "'.");
+            return null;
         }
 
         if (ret.getMetrics() != null) {
             metrics.routingPolicyMetrics.addMetric(ret.getMetrics());
         }
 
-        if (ret == null) {
-            log.log(LogLevel.ERROR, "Routing policy factory " + factory.getClass().getName() + " failed to create a " +
-                                    "routing policy for parameter '" + name + "'.");
-            return null;
-        }
         return ret;
     }
 }

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/RoutingPolicyRepositoryTest.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/RoutingPolicyRepositoryTest.java
@@ -1,0 +1,33 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.documentapi.messagebus.protocol;
+
+import com.yahoo.documentapi.metrics.DocumentProtocolMetricSet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RoutingPolicyRepositoryTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void policy_creation_does_not_swallow_exception() {
+        final DocumentProtocolMetricSet metrics = new DocumentProtocolMetricSet();
+        final RoutingPolicyRepository repo = new RoutingPolicyRepository(metrics);
+        final RoutingPolicyFactory factory = mock(RoutingPolicyFactory.class);
+
+        when(factory.createPolicy(anyString())).thenThrow(new IllegalArgumentException("oh no!"));
+        repo.putFactory("foo", factory);
+
+        expectedException.expectMessage("oh no!");
+        expectedException.expect(IllegalArgumentException.class);
+
+        repo.createPolicy("foo", "bar");
+    }
+
+}


### PR DESCRIPTION
@baldersheim Please review

Prevents an ErrorPolicy from being cached for the policy when a policy
(likely transiently) cannot be created. Caching an ErrorPolicy will fail
all ops towards the policy until the process has been restarted.