### PR TITLE
wrapped simple tensor

### DIFF
--- a/eval/src/tests/tensor/tensor_conformance/tensor_conformance_test.cpp
+++ b/eval/src/tests/tensor/tensor_conformance/tensor_conformance_test.cpp
@@ -12,11 +12,11 @@ vespalib::string module_path(TEST_PATH("../../../../"));
 
 
 TEST("require that reference tensor implementation passes all conformance tests") {
-    TEST_DO(TensorConformance::run_tests(module_path, SimpleTensorEngine::ref(), true));
+    TEST_DO(TensorConformance::run_tests(module_path, SimpleTensorEngine::ref()));
 }
 
-IGNORE_TEST("require that production tensor implementation passes non-mixed conformance tests") {
-    TEST_DO(TensorConformance::run_tests(module_path, DefaultTensorEngine::ref(), false));
+TEST("require that production tensor implementation passes all conformance tests") {
+    TEST_DO(TensorConformance::run_tests(module_path, DefaultTensorEngine::ref()));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/eval/src/vespa/eval/eval/simple_tensor.cpp
+++ b/eval/src/vespa/eval/eval/simple_tensor.cpp
@@ -416,14 +416,14 @@ public:
 };
 
 struct Format {
-    bool    is_sparse;
-    bool    is_dense;
-    uint8_t tag;
+    bool     is_sparse;
+    bool     is_dense;
+    uint32_t tag;
     explicit Format(const TypeMeta &meta)
         : is_sparse(meta.mapped.size() > 0),
           is_dense((meta.indexed.size() > 0) || !is_sparse),
           tag((is_sparse ? 0x1 : 0) | (is_dense ? 0x2 : 0)) {}
-    explicit Format(uint8_t tag_in)
+    explicit Format(uint32_t tag_in)
         : is_sparse((tag_in & 0x1) != 0),
           is_dense((tag_in & 0x2) != 0),
           tag(tag_in) {}
@@ -689,7 +689,7 @@ SimpleTensor::encode(const SimpleTensor &tensor, nbostream &output)
 {
     TypeMeta meta(tensor.type());
     Format format(meta);
-    output << format.tag;
+    output.putInt1_4Bytes(format.tag);
     encode_type(output, format, tensor.type(), meta);
     maybe_encode_num_blocks(output, meta, tensor.cells().size() / meta.block_size);
     View view(tensor, meta.mapped);
@@ -705,7 +705,7 @@ SimpleTensor::encode(const SimpleTensor &tensor, nbostream &output)
 std::unique_ptr<SimpleTensor>
 SimpleTensor::decode(nbostream &input)
 {
-    Format format(input.readValue<uint8_t>());
+    Format format(input.getInt1_4Bytes());
     ValueType type = decode_type(input, format);
     TypeMeta meta(type);
     Builder builder(type);

--- a/eval/src/vespa/eval/eval/test/tensor_conformance.h
+++ b/eval/src/vespa/eval/eval/test/tensor_conformance.h
@@ -14,7 +14,7 @@ namespace test {
  * implementations of the TensorEngine interface.
  **/
 struct TensorConformance {
-    static void run_tests(const vespalib::string &module_path, const TensorEngine &engine, bool test_mixed_cases);
+    static void run_tests(const vespalib::string &module_path, const TensorEngine &engine);
 };
 
 } // namespace vespalib::eval::test

--- a/eval/src/vespa/eval/tensor/CMakeLists.txt
+++ b/eval/src/vespa/eval/tensor/CMakeLists.txt
@@ -7,4 +7,5 @@ vespa_add_library(eval_tensor OBJECT
     tensor_apply.cpp
     tensor_factory.cpp
     tensor_mapper.cpp
+    wrapped_simple_tensor.cpp
 )

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor.h
@@ -28,6 +28,7 @@ private:
 
 public:
     DenseTensor();
+    ~DenseTensor() {}
     DenseTensor(const eval::ValueType &type_in,
                 const Cells &cells_in);
     DenseTensor(const eval::ValueType &type_in,

--- a/eval/src/vespa/eval/tensor/serialization/format.txt
+++ b/eval/src/vespa/eval/tensor/serialization/format.txt
@@ -8,7 +8,7 @@ effortlessly as possible with both existing formats.
 
 //-----------------------------------------------------------------------------
 
-byte: type (1:sparse, 2:dense, 3:mixed)
+1_4_int: type (1:sparse, 2:dense, 3:mixed)
   bit 0 -> 'sparse'
   bit 1 -> 'dense'
   (mixed tensors are tagged as both 'sparse' and 'dense')

--- a/eval/src/vespa/eval/tensor/serialization/typed_binary_format.cpp
+++ b/eval/src/vespa/eval/tensor/serialization/typed_binary_format.cpp
@@ -8,6 +8,8 @@
 #include <vespa/eval/tensor/default_tensor.h>
 #include <vespa/eval/tensor/tensor.h>
 #include <vespa/eval/tensor/dense/dense_tensor.h>
+#include <vespa/eval/eval/simple_tensor.h>
+#include <vespa/eval/tensor/wrapped_simple_tensor.h>
 
 using vespalib::nbostream;
 
@@ -18,10 +20,11 @@ namespace tensor {
 void
 TypedBinaryFormat::serialize(nbostream &stream, const Tensor &tensor)
 {
-    const DenseTensor *denseTensor = dynamic_cast<const DenseTensor *>(&tensor);
-    if (denseTensor != nullptr) {
+    if (auto denseTensor = dynamic_cast<const DenseTensor *>(&tensor)) {
         stream.putInt1_4Bytes(DENSE_BINARY_FORMAT_TYPE);
         DenseBinaryFormat::serialize(stream, *denseTensor);
+    } else if (auto wrapped = dynamic_cast<const WrappedSimpleTensor *>(&tensor)) {
+        eval::SimpleTensor::encode(wrapped->get(), stream);
     } else {
         stream.putInt1_4Bytes(SPARSE_BINARY_FORMAT_TYPE);
         SparseBinaryFormat::serialize(stream, tensor);
@@ -32,6 +35,7 @@ TypedBinaryFormat::serialize(nbostream &stream, const Tensor &tensor)
 std::unique_ptr<Tensor>
 TypedBinaryFormat::deserialize(nbostream &stream)
 {
+    auto read_pos = stream.rp();
     auto formatId = stream.getInt1_4Bytes();
     if (formatId == SPARSE_BINARY_FORMAT_TYPE) {
         DefaultTensor::builder builder;
@@ -40,6 +44,10 @@ TypedBinaryFormat::deserialize(nbostream &stream)
     }
     if (formatId == DENSE_BINARY_FORMAT_TYPE) {
         return DenseBinaryFormat::deserialize(stream);
+    }
+    if (formatId == MIXED_BINARY_FORMAT_TYPE) {
+        stream.adjustReadPos(read_pos - stream.rp());
+        return std::make_unique<WrappedSimpleTensor>(eval::SimpleTensor::decode(stream));
     }
     abort();
 }

--- a/eval/src/vespa/eval/tensor/serialization/typed_binary_format.h
+++ b/eval/src/vespa/eval/tensor/serialization/typed_binary_format.h
@@ -18,6 +18,7 @@ class TypedBinaryFormat
 {
     static constexpr uint32_t SPARSE_BINARY_FORMAT_TYPE = 1u;
     static constexpr uint32_t DENSE_BINARY_FORMAT_TYPE = 2u;
+    static constexpr uint32_t MIXED_BINARY_FORMAT_TYPE = 3u;
 public:
     static void serialize(nbostream &stream, const Tensor &tensor);
     static std::unique_ptr<Tensor> deserialize(nbostream &stream);

--- a/eval/src/vespa/eval/tensor/tensor.cpp
+++ b/eval/src/vespa/eval/tensor/tensor.cpp
@@ -13,6 +13,21 @@ Tensor::Tensor()
 {
 }
 
+bool
+Tensor::supported(TypeList types)
+{
+    bool sparse = false;
+    bool dense = false;
+    for (const eval::ValueType &type: types) {
+        dense = (dense || type.is_double());
+        for (const auto &dim: type.dimensions()) {
+            dense = (dense || dim.is_indexed());
+            sparse = (sparse || dim.is_mapped());
+        }
+    }
+    return (dense != sparse);
+}
+
 std::ostream &
 operator<<(std::ostream &out, const Tensor &value)
 {

--- a/eval/src/vespa/eval/tensor/tensor.h
+++ b/eval/src/vespa/eval/tensor/tensor.h
@@ -50,6 +50,9 @@ struct Tensor : public eval::Tensor
     virtual Tensor::UP clone() const = 0;
     virtual eval::TensorSpec toSpec() const = 0;
     virtual void accept(TensorVisitor &visitor) const = 0;
+
+    using TypeList = std::initializer_list<std::reference_wrapper<const eval::ValueType>>;
+    static bool supported(TypeList types);
 };
 
 std::ostream &operator<<(std::ostream &out, const Tensor &value);

--- a/eval/src/vespa/eval/tensor/wrapped_simple_tensor.cpp
+++ b/eval/src/vespa/eval/tensor/wrapped_simple_tensor.cpp
@@ -1,0 +1,130 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "wrapped_simple_tensor.h"
+#include <vespa/eval/eval/simple_tensor_engine.h>
+
+namespace vespalib::tensor {
+
+bool
+WrappedSimpleTensor::equals(const Tensor &arg) const
+{
+    if (auto other = dynamic_cast<const WrappedSimpleTensor *>(&arg)) {
+        return eval::SimpleTensor::equal(_tensor, other->_tensor);
+    }
+    return false;
+}
+
+vespalib::string
+WrappedSimpleTensor::toString() const
+{
+    return eval::SimpleTensorEngine::ref().to_string(_tensor);
+}
+
+eval::TensorSpec
+WrappedSimpleTensor::toSpec() const
+{
+    return eval::SimpleTensorEngine::ref().to_spec(_tensor);
+}
+
+double
+WrappedSimpleTensor::sum() const
+{
+    double result = 0.0;
+    for (const auto &cell: _tensor.cells()) {
+        result += cell.value;
+    }
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+
+Tensor::UP
+WrappedSimpleTensor::add(const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::subtract(const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::multiply(const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::min(const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::max(const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::match(const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::apply(const CellFunction &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::sum(const vespalib::string &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::apply(const eval::BinaryOperation &, const Tensor &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+Tensor::UP
+WrappedSimpleTensor::reduce(const eval::BinaryOperation &, const std::vector<vespalib::string> &) const
+{
+    abort();
+    return Tensor::UP();
+}
+
+void
+WrappedSimpleTensor::print(std::ostream &) const
+{
+    abort();
+}
+
+Tensor::UP
+WrappedSimpleTensor::clone() const
+{
+    abort();
+    return Tensor::UP();
+}
+
+void
+WrappedSimpleTensor::accept(TensorVisitor &) const
+{
+    abort();
+}
+
+} // namespace vespalib::tensor

--- a/eval/src/vespa/eval/tensor/wrapped_simple_tensor.h
+++ b/eval/src/vespa/eval/tensor/wrapped_simple_tensor.h
@@ -1,0 +1,52 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "tensor.h"
+#include <vespa/eval/eval/simple_tensor.h>
+
+namespace vespalib::tensor {
+
+/**
+ * A thin wrapper around a SimpleTensor (tensor reference
+ * implementation) to be used as fallback for tensors with data
+ * layouts not supported by the default tensor implementation.
+ *
+ * Tensor implementation class is currently inferred from its value
+ * type. Consider adding explicit tagging to the tensor::Tensor
+ * default implementation top-level class in the future.
+ **/
+class WrappedSimpleTensor : public Tensor
+{
+private:
+    std::unique_ptr<eval::SimpleTensor> _space;
+    const eval::SimpleTensor &_tensor;
+public:
+    explicit WrappedSimpleTensor(const eval::SimpleTensor &tensor)
+        : _space(), _tensor(tensor) {}
+    explicit WrappedSimpleTensor(std::unique_ptr<eval::SimpleTensor> tensor)
+        : _space(std::move(tensor)), _tensor(*_space) {}
+    ~WrappedSimpleTensor() {}
+    const eval::SimpleTensor &get() const { return _tensor; }
+    const eval::ValueType &getType() const override { return _tensor.type(); }
+    bool equals(const Tensor &arg) const override;
+    vespalib::string toString() const override;
+    eval::TensorSpec toSpec() const override;
+    double sum() const override;
+    // functions below should not be used for this implementation
+    Tensor::UP add(const Tensor &) const override;
+    Tensor::UP subtract(const Tensor &) const override;
+    Tensor::UP multiply(const Tensor &) const override;
+    Tensor::UP min(const Tensor &) const override;
+    Tensor::UP max(const Tensor &) const override;
+    Tensor::UP match(const Tensor &) const override;
+    Tensor::UP apply(const CellFunction &) const override;
+    Tensor::UP sum(const vespalib::string &) const override;
+    Tensor::UP apply(const eval::BinaryOperation &, const Tensor &) const override;
+    Tensor::UP reduce(const eval::BinaryOperation &, const std::vector<vespalib::string> &) const override;
+    void print(std::ostream &out) const override;
+    Tensor::UP clone() const override;
+    void accept(TensorVisitor &visitor) const override;
+};
+
+} // namespace vespalib::tensor


### PR DESCRIPTION
fall back to wrapping SimpleTensors for cases where the default tensor
implementation does not support the data model (mixed dimensions).

remove special handling of mixed cases in tensor conformance tests.

require that the default tensor implementation passes all conformance
tests.

ironed out a small mismatch in the tensor binary format tag.

@geirst please review
@bratseth @lesters FYI