### PR TITLE
Shrink lid space on attribute vectors and document meta store when

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -119,6 +119,7 @@ applyReplayDone(uint32_t docIdLimit, AttributeVector &attr)
 {
     AttributeManager::padAttribute(attr, docIdLimit);
     attr.compactLidSpace(docIdLimit);
+    attr.shrinkLidSpace();
 }
 
 

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -176,7 +176,8 @@ StoreOnlyDocSubDB::hasDocument(const document::DocumentId &id)
 void
 StoreOnlyDocSubDB::onReplayDone()
 {
-    _metaStoreCtx->get().constructFreeList();
+    _dms->constructFreeList();
+    _dms->shrinkLidSpace();
 }
 
 


### PR DESCRIPTION
tls replay is done.

@geirst, please review