### PR TITLE
Set streaming session trace level if debug logging is enabled

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -39,7 +39,7 @@ import com.yahoo.vdslib.SearchResult;
  * visitors in storage and collecting and merging the results.
  *
  * @author  baldersheim
- * @author  <a href="mailto:ulf@yahoo-inc.com">Ulf Carlin</a>
+ * @author  Ulf Carlin
  */
 @SuppressWarnings("deprecation")
 public class VdsStreamingSearcher extends VespaBackEndSearcher {

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -117,6 +117,16 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         setVisitorParameters(searchCluster, route);
     }
 
+    private static int inferSessionTraceLevel(final Query query) {
+        int implicitLevel = 0;
+        if (log.isLoggable(LogLevel.SPAM)) {
+            implicitLevel = 9;
+        } else if (log.isLoggable(LogLevel.DEBUG)) {
+            implicitLevel = 7;
+        }
+        return Math.max(query.getTraceLevel(), implicitLevel);
+    }
+
     private void setVisitorParameters(String searchCluster, Route route) {
         if (query.properties().getString(streamingUserid) != null) {
             params.setDocumentSelection("id.user==" + query.properties().getString(streamingUserid));
@@ -154,7 +164,8 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
 
         params.setMaxPending(Integer.MAX_VALUE);
         params.setMaxBucketsPerVisitor(Integer.MAX_VALUE);
-        params.setTraceLevel(query.getTraceLevel());
+        params.setTraceLevel(inferSessionTraceLevel(query));
+
 
         String ordering = query.properties().getString(streamingOrdering);
         if (ordering != null) {
@@ -300,6 +311,9 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         }
 
         query.trace(session.getTrace().toString(), false, 9);
+        if (log.isLoggable(LogLevel.DEBUG)) {
+            log.log(LogLevel.DEBUG, session.getTrace().toString());
+        }
 
         if (params.getControlHandler().getResult().code == VisitorControlHandler.CompletionCode.SUCCESS) {
             if (log.isLoggable(LogLevel.DEBUG)) {

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -117,7 +117,7 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         setVisitorParameters(searchCluster, route);
     }
 
-    private static int inferSessionTraceLevel(final Query query) {
+    private static int inferSessionTraceLevel(Query query) {
         int implicitLevel = 0;
         if (log.isLoggable(LogLevel.SPAM)) {
             implicitLevel = 9;


### PR DESCRIPTION
@bratseth Please review. Presumably we do not already have any such auto-tracelevel functionality higher up in the query stack?

Makes it easier to debug streaming search issues without having to alter
the query input itself.