### PR TITLE
The threadpoolProvider does not use the container to get config. Only…

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerClusterVerifier.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerClusterVerifier.java
@@ -1,6 +1,7 @@
 package com.yahoo.vespa.model.admin.clustercontroller;
 
 import com.yahoo.component.ComponentSpecification;
+import com.yahoo.container.handler.ThreadpoolConfig;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerClusterVerifier;
@@ -24,5 +25,10 @@ public class ClusterControllerClusterVerifier implements ContainerClusterVerifie
     @Override
     public boolean acceptContainer(Container container) {
         return container instanceof ClusterControllerContainer;
+    }
+
+    @Override
+    public void getConfig(ThreadpoolConfig.Builder builder) {
+        builder.maxthreads(10);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -28,8 +28,7 @@ import java.util.TreeSet;
 public class ClusterControllerContainer extends Container implements
         BundlesConfig.Producer,
         ZookeeperServerConfig.Producer,
-        QrStartConfig.Producer,
-        ThreadpoolConfig.Producer
+        QrStartConfig.Producer
 {
     private static final ComponentSpecification CLUSTERCONTROLLER_BUNDLE = new ComponentSpecification("clustercontroller-apps");
     private static final ComponentSpecification ZKFACADE_BUNDLE = new ComponentSpecification("zkfacade");
@@ -114,10 +113,6 @@ public class ClusterControllerContainer extends Container implements
     @Override
     public void getConfig(QrStartConfig.Builder builder) {
         builder.jvm(new QrStartConfig.Jvm.Builder().heapsize(512));
-    }
-    @Override
-    public void getConfig(ThreadpoolConfig.Builder builder) {
-        builder.maxthreads(10);
     }
 
     int getIndex() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -24,6 +24,7 @@ import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.core.document.ContainerDocumentConfig;
 import com.yahoo.container.handler.ThreadPoolProvider;
+import com.yahoo.container.handler.ThreadpoolConfig;
 import com.yahoo.container.jdisc.ContainerMbusConfig;
 import com.yahoo.container.jdisc.JdiscBindingsConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
@@ -133,7 +134,9 @@ public final class ContainerCluster
         ClusterInfoConfig.Producer,
         ServletPathsConfig.Producer,
         RoutingProviderConfig.Producer,
-        ConfigserverConfig.Producer {
+        ConfigserverConfig.Producer,
+        ThreadpoolConfig.Producer
+{
 
     /**
      * URI prefix used for internal, usually programmatic, APIs. URIs using this
@@ -190,6 +193,11 @@ public final class ContainerCluster
 
         @Override
         public boolean acceptContainer(Container container) { return true; }
+
+        @Override
+        public void getConfig(ThreadpoolConfig.Builder builder) {
+
+        }
     }
 
     public ContainerCluster(AbstractConfigProducer<?> parent, String subId, String name) {
@@ -571,7 +579,12 @@ public final class ContainerCluster
         allJersey1Handlers().forEach(handler ->
                         builder.handlers.putAll(DiscBindingsConfigGenerator.generate(handler))
         );
-     }
+    }
+
+    @Override
+    public void getConfig(ThreadpoolConfig.Builder builder) {
+        clusterVerifier.getConfig(builder);
+    }
 
     private Stream<JerseyHandler> allJersey1Handlers() {
         return restApiGroup.getComponents().stream().flatMap(streamOf(RestApi::getJersey1Handler));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerClusterVerifier.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerClusterVerifier.java
@@ -1,5 +1,6 @@
 package com.yahoo.vespa.model.container;
 
+import com.yahoo.container.handler.ThreadpoolConfig;
 import com.yahoo.vespa.model.container.component.Component;
 
 /**
@@ -24,4 +25,9 @@ public interface ContainerClusterVerifier {
      * @return true if you accept it
      */
     boolean acceptContainer(Container container);
+
+    /**
+     * Produce threadpool config
+     */
+    void getConfig(ThreadpoolConfig.Builder builder);
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -172,6 +172,17 @@ public class ContainerClusterTest {
     }
 
     @Test
+    public void testContainerClusterMaxThreads() {
+        ContainerCluster cluster = createContainerCluster(false, false);
+        addContainer(cluster, "c1","host-c1");
+
+        ThreadpoolConfig.Builder tpBuilder = new ThreadpoolConfig.Builder();
+        cluster.getConfig(tpBuilder);
+        ThreadpoolConfig threadpoolConfig = new ThreadpoolConfig(tpBuilder);
+        assertEquals(500, threadpoolConfig.maxthreads());
+    }
+
+    @Test
     public void testClusterControllerResourceUsage() {
         ContainerCluster cluster = createClusterControllerCluster();
         addClusterController(cluster, "host-c1");
@@ -183,10 +194,9 @@ public class ContainerClusterTest {
         assertEquals(512, qrStartConfig.jvm().heapsize());
 
         ThreadpoolConfig.Builder tpBuilder = new ThreadpoolConfig.Builder();
-        container.getConfig(tpBuilder);
+        cluster.getConfig(tpBuilder);
         ThreadpoolConfig threadpoolConfig = new ThreadpoolConfig(tpBuilder);
         assertEquals(10, threadpoolConfig.maxthreads());
-
     }
 
     @Test


### PR DESCRIPTION
… the cluster.

So we need to produce it there to.
@bratseth PR