### PR TITLE
Rename system metrics application to "vespa.node"

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/metrics/MetricReceiverWrapper.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/metrics/MetricReceiverWrapper.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 public class MetricReceiverWrapper {
     // Application names used
     public static final String APPLICATION_DOCKER = "docker";
-    public static final String APPLICATION_NODE = "node";
+    public static final String APPLICATION_NODE = "vespa.node";
     public static final String APPLICATION_HOST_LIFE = "host_life";
 
     private final static ObjectMapper objectMapper = new ObjectMapper();

--- a/node-admin/src/test/resources/docker.stats.metrics.active.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.active.expected.json
@@ -30,7 +30,7 @@
         }
     },
     {
-        "application": "node",
+        "application": "vespa.node",
         "dimensions": {
             "flavor": "docker",
             "applicationName": "testapp",
@@ -64,7 +64,7 @@
         }
     },
     {
-        "application": "node",
+        "application": "vespa.node",
         "dimensions": {
             "flavor": "docker",
             "applicationName": "testapp",
@@ -97,7 +97,7 @@
         }
     },
     {
-        "application": "node",
+        "application": "vespa.node",
         "dimensions": {
             "flavor": "docker",
             "applicationName": "testapp",

--- a/node-admin/src/test/resources/docker.stats.metrics.ready.expected.json
+++ b/node-admin/src/test/resources/docker.stats.metrics.ready.expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "application": "node",
+        "application": "vespa.node",
         "dimensions": {
             "flavor": "docker",
             "role": "tenants",


### PR DESCRIPTION
Changes yamas application name for system metrics from `node` to `vespa.node`