### PR TITLE
Enable patching of additional IP addresses

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -83,6 +83,8 @@ public class NodePatcher {
                 return node.withParentHostname(asString(value));
             case "ipAddresses" :
                 return node.withIpAddresses(asStringSet(value));
+            case "additionalIpAddresses" :
+                return node.withAdditionalIpAddresses(asStringSet(value));
             case "wantToRetire" :
                 return node.with(node.status().withWantToRetire(asBoolean(value)));
             default :


### PR DESCRIPTION
This to enable HV tool to migrate existing docker hosts to the new node representation (where we have ip addresses available for docker containers as a static list on the host node object)