### PR TITLE
Revert "Change read timeout towards docker daemon"

### DIFF
--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -10,7 +10,7 @@ secondsToWaitBeforeKillingContainer int default = 10
 maxPerRouteConnections int default = 10
 maxTotalConnections int default = 100
 connectTimeoutMillis int default = 100000 # 100 sec
-readTimeoutMillis int default = 60000 # 1 min
+readTimeoutMillis int default = 1800000 # 30 min
 
 isRunningLocally bool default = false
 imageGCMinTimeToLiveMinutes int default = 45


### PR DESCRIPTION
Reverts yahoo/vespa#2503

I haven't seen this fail yet, but Im pretty sure it will: I did a quick test with readTimeout = 5 sec and executing `sleep 10` in container and it failed with timeout. Coredump reporting will almost certainly fail, possible docker pull as well.