### PR TITLE
Disable logAndDie upon failing to set up first component graph.

### DIFF
--- a/container-di/src/main/scala/com/yahoo/container/di/Container.scala
+++ b/container-di/src/main/scala/com/yahoo/container/di/Container.scala
@@ -104,7 +104,8 @@ class Container(
 
     val message = newGraphErrorMessage(generation, cause)
     generation match {
-      case 0 => logAndDie(message, cause)
+      // Disabled, as it breaks application based tests.
+      // case 0 => logAndDie(message, cause)
       case _ =>
         log.log(Level.WARNING, message, cause)
         leastGeneration = max(configurer.getComponentsGeneration, configurer.getBootstrapGeneration) + 1


### PR DESCRIPTION
@bjorncs 
FYI: @hmusum, @bratseth, @baldersheim 

- It breaks some tests using the 'application' framework.