### PR TITLE
Allow docker containers to be deleted in dirty - add temporary rest call

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -207,7 +207,7 @@ public class NodeAgentImpl implements NodeAgent {
                         .withRebootGeneration(nodeSpec.wantedRebootGeneration.orElse(0L))
                         .withDockerImage(new DockerImage(""))
                         .withVespaVersion(""));
-        nodeRepository.markAsReady(nodeSpec.hostname);
+        nodeRepository.markNodeAvailableForNewAllocation(nodeSpec.hostname);
     }
 
     private void updateNodeRepoWithCurrentAttributes(final ContainerNodeSpec nodeSpec) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepository.java
@@ -23,5 +23,5 @@ public interface NodeRepository {
 
     void markAsDirty(String hostName);
 
-    void markAsReady(String hostName);
+    void markNodeAvailableForNewAllocation(String hostName);
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -155,15 +155,17 @@ public class NodeRepositoryImpl implements NodeRepository {
 
     @Override
     public void markAsDirty(String hostName) {
-        markNodeToState(hostName, Node.State.dirty);
+        // This will never happen once the new allocation scheme is rolled out.
+        markNodeToState(hostName, Node.State.dirty.name());
     }
 
     @Override
-    public void markAsReady(final String hostName) {
-        markNodeToState(hostName, Node.State.ready);
+    public void markNodeAvailableForNewAllocation(final String hostName) {
+        // TODO replace with call to delete node when everything has been migrated to dynamic docker allocation
+        markNodeToState(hostName, "availablefornewallocations");
     }
 
-    private void markNodeToState(String hostName, Node.State state) {
+    private void markNodeToState(String hostName, String state) {
         NodeMessageResponse response = requestExecutor.put(
                 "/nodes/v2/state/" + state + "/" + hostName,
                 port,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -56,7 +56,7 @@ public class MultiDockerTest {
             callOrderVerifier.assertInOrder(
                     "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image1, vespaVersion=''}",
                     "updateNodeAttributes with HostName: host2.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image2, vespaVersion=''}",
-                    "markAsReady with HostName: host2.test.yahoo.com",
+                    "markNodeAvailableForNewAllocation with HostName: host2.test.yahoo.com",
                     "updateNodeAttributes with HostName: host3.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image1, vespaVersion=''}");
         }
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
@@ -79,7 +79,7 @@ public class NodeRepoMock implements NodeRepository {
     }
 
     @Override
-    public void markAsReady(String hostName) {
+    public void markNodeAvailableForNewAllocation(String hostName) {
         Optional<ContainerNodeSpec> cns = getContainerNodeSpec(hostName);
 
         synchronized (monitor) {
@@ -90,7 +90,7 @@ public class NodeRepoMock implements NodeRepository {
                         .nodeFlavor("docker")
                         .build());
             }
-            callOrderVerifier.add("markAsReady with HostName: " + hostName);
+            callOrderVerifier.add("markNodeAvailableForNewAllocation with HostName: " + hostName);
         }
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -334,7 +334,7 @@ public class NodeAgentImplTest {
         inOrder.verify(storageMaintainer, times(1)).removeOldFilesFromNode(eq(containerName));
         inOrder.verify(dockerOperations, times(1)).removeContainer(any());
         inOrder.verify(storageMaintainer, times(1)).archiveNodeData(eq(containerName));
-        inOrder.verify(nodeRepository, times(1)).markAsReady(eq(hostName));
+        inOrder.verify(nodeRepository, times(1)).markNodeAvailableForNewAllocation(eq(hostName));
 
         verify(dockerOperations, never()).startContainer(eq(containerName), any());
         verify(orchestrator, never()).resume(any(String.class));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
@@ -149,17 +149,17 @@ public class NodeRepositoryImplTest {
         NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost4");
         waitForJdiscContainerToServe();
 
-        nodeRepositoryApi.markAsReady("host55.yahoo.com");
+        nodeRepositoryApi.markNodeAvailableForNewAllocation("host55.yahoo.com");
 
         try {
-            nodeRepositoryApi.markAsReady("host1.yahoo.com");
+            nodeRepositoryApi.markNodeAvailableForNewAllocation("host1.yahoo.com");
             fail("Expected failure because host1 is not registered as provisioned, dirty, failed or parked");
         } catch (RuntimeException ignored) {
             // expected
         }
 
         try {
-            nodeRepositoryApi.markAsReady("host101.yahoo.com");
+            nodeRepositoryApi.markNodeAvailableForNewAllocation("host101.yahoo.com");
             fail("Expected failure because host101 does not exist");
         } catch (RuntimeException ignored) {
             // expected

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -451,13 +451,22 @@ public class NodeRepository extends AbstractComponent {
     }
 
     /**
-     * Removes a node. A node must be in the provisioned, failed or parked state before it can be removed.
+     * Removes a node. A node must be in a legal state before it can be removed.
      *
-     * @return true if the node was removed, false if it was not found in one of these states
+     * @return true if the node was removed, false if it was not found in one of the legal states
      */
     public boolean remove(String hostname) {
-        Optional<Node> nodeToRemove = getNode(hostname, Node.State.provisioned, Node.State.failed, Node.State.parked);
+
+        Node.State[] legalStates = {Node.State.provisioned, Node.State.failed, Node.State.parked};
+        Node.State[] legalDynamicStates = {Node.State.provisioned, Node.State.failed, Node.State.parked, Node.State.dirty};
+
+        Optional<Node> nodeToRemove = getNode(hostname, dynamicAllocationEnabled() ? legalDynamicStates : legalStates);
         if ( ! nodeToRemove.isPresent()) return false;
+
+        // Only docker nodes are allowed to be deleted in state dirty.
+        if ( nodeToRemove.get().state().equals(Node.State.dirty)) {
+            if (!(nodeToRemove.get().flavor().getType().equals(Flavor.Type.DOCKER_CONTAINER))) return false;
+        }
 
         try (Mutex lock = lock(nodeToRemove.get())) {
             return db.removeNode(nodeToRemove.get().state(), hostname);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -129,13 +129,17 @@ public class NodesApiHandler extends LoggingRequestHandler {
              * This is a temporary "state" or rest call that we use to enable a smooth rollout of
              * dynamic docker flavor allocations. Once we have switch everything we remove this
              * and change the code in the nodeadmin to delete directly.
+             *
+             * Should only be called by node-admin for docker containers (the docker constraint is
+             * enforced in the remove method)
              */
+            String hostname = lastElement(path);
             if (nodeRepository.dynamicAllocationEnabled()) {
-                nodeRepository.remove(lastElement(path));
-                return new MessageResponse("Removed " + lastElement(path));
+                nodeRepository.remove(hostname);
+                return new MessageResponse("Removed " + hostname);
             } else {
-                nodeRepository.setReady(lastElement(path));
-                return new MessageResponse("Moved " + lastElement(path) + " to ready");
+                nodeRepository.setReady(hostname);
+                return new MessageResponse("Moved " + hostname + " to ready");
             }
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -66,4 +66,21 @@ public class NodeRepositoryTest {
         tester.curator().set(Path.fromString("/provision/v1/dynamicDockerAllocation"), new byte[0]);
         assertTrue(tester.nodeRepository().dynamicAllocationEnabled());
     }
+
+    @Test
+    public void only_allow_to_delete_dirty_nodes_when_dynamic_allocation_feature_enabled() {
+        NodeRepositoryTester tester = new NodeRepositoryTester();
+        try {
+            tester.addNode("id1", "host1", "default", NodeType.host);
+            tester.addNode("id2", "host2", "docker", NodeType.tenant);
+            tester.nodeRepository().setDirty("host2");
+
+            assertFalse(tester.nodeRepository().remove("host2"));
+
+            tester.curator().set(Path.fromString("/provision/v1/dynamicDockerAllocation"), new byte[0]);
+            assertTrue(tester.nodeRepository().remove("host2"));
+        } finally {
+            tester.curator().delete(Path.fromString("/provision/v1/dynamicDockerAllocation"));
+        }
+    }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
@@ -52,6 +52,7 @@ public class NodeRepositoryTester {
         FlavorConfigBuilder b = new FlavorConfigBuilder();
         b.addFlavor("default", 2., 4., 100, Flavor.Type.BARE_METAL).cost(3);
         b.addFlavor("small", 1., 2., 50, Flavor.Type.BARE_METAL).cost(2);
+        b.addFlavor("docker", 1., 2., 50, Flavor.Type.DOCKER_CONTAINER).cost(1);
         return b.build();
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -149,6 +149,11 @@ public class RestApiTest {
                                    new byte[0], Request.Method.PUT),
                        "{\"message\":\"Moved host6.yahoo.com to dirty\"}");
 
+        // ... and set it back to ready as if this was from the node-admin with the temporary state rest api
+        assertResponse(new Request("http://localhost:8080/nodes/v2/state/availablefornewallocations/host6.yahoo.com",
+                        new byte[0], Request.Method.PUT),
+                "{\"message\":\"Moved host6.yahoo.com to ready\"}");
+
         // Put a host in failed and make sure it's children are also failed
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/failed/parent1.yahoo.com", new byte[0], Request.Method.PUT),
                 "{\"message\":\"Moved host10.yahoo.com, host5.yahoo.com, parent1.yahoo.com to failed\"}");


### PR DESCRIPTION
We are rolling out the dynamic docker allocation schema gradually. the Node admin does not know about this and thus must use a call to the node repository where the node repository decides if we do it the old way or the new way. After the rollout we can change the node admin to delete container nodes directly. 

This PR needs the feature flag code before it can be merged.