### PR TITLE
Set vespaVersion in node-repo to be the same as wantedVespaVersion

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/ContainerNodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/ContainerNodeSpec.java
@@ -17,6 +17,7 @@ public class ContainerNodeSpec {
     public final Node.State nodeState;
     public final String nodeType;
     public final String nodeFlavor;
+    public final Optional<String> wantedVespaVersion;
     public final Optional<String> vespaVersion;
     public final Optional<Owner> owner;
     public final Optional<Membership> membership;
@@ -34,6 +35,7 @@ public class ContainerNodeSpec {
             final Node.State nodeState,
             final String nodeType,
             final String nodeFlavor,
+            final Optional<String> wantedVespaVersion,
             final Optional<String> vespaVersion,
             final Optional<Owner> owner,
             final Optional<Membership> membership,
@@ -54,6 +56,7 @@ public class ContainerNodeSpec {
         this.nodeState = nodeState;
         this.nodeType = nodeType;
         this.nodeFlavor = nodeFlavor;
+        this.wantedVespaVersion = wantedVespaVersion;
         this.vespaVersion = vespaVersion;
         this.owner = owner;
         this.membership = membership;
@@ -78,6 +81,7 @@ public class ContainerNodeSpec {
                 Objects.equals(nodeState, that.nodeState) &&
                 Objects.equals(nodeType, that.nodeType) &&
                 Objects.equals(nodeFlavor, that.nodeFlavor) &&
+                Objects.equals(wantedVespaVersion, that.wantedVespaVersion) &&
                 Objects.equals(vespaVersion, that.vespaVersion) &&
                 Objects.equals(owner, that.owner) &&
                 Objects.equals(membership, that.membership) &&
@@ -98,6 +102,7 @@ public class ContainerNodeSpec {
                 nodeState,
                 nodeType,
                 nodeFlavor,
+                wantedVespaVersion,
                 vespaVersion,
                 owner,
                 membership,
@@ -118,6 +123,7 @@ public class ContainerNodeSpec {
                 + " nodeState=" + nodeState
                 + " nodeType = " + nodeType
                 + " nodeFlavor = " + nodeFlavor
+                + " wantedVespaVersion = " + wantedVespaVersion
                 + " vespaVersion = " + vespaVersion
                 + " owner = " + owner
                 + " membership = " + membership
@@ -230,6 +236,7 @@ public class ContainerNodeSpec {
         private Node.State nodeState;
         private String nodeType;
         private String nodeFlavor;
+        private Optional<String> wantedVespaVersion = Optional.empty();
         private Optional<String> vespaVersion = Optional.empty();
         private Optional<Owner> owner = Optional.empty();
         private Optional<Membership> membership = Optional.empty();
@@ -250,6 +257,7 @@ public class ContainerNodeSpec {
             nodeFlavor(nodeSpec.nodeFlavor);
 
             nodeSpec.wantedDockerImage.ifPresent(this::wantedDockerImage);
+            nodeSpec.wantedVespaVersion.ifPresent(this::wantedVespaVersion);
             nodeSpec.vespaVersion.ifPresent(this::vespaVersion);
             nodeSpec.owner.ifPresent(this::owner);
             nodeSpec.membership.ifPresent(this::membership);
@@ -283,6 +291,11 @@ public class ContainerNodeSpec {
 
         public Builder nodeFlavor(String nodeFlavor) {
             this.nodeFlavor = nodeFlavor;
+            return this;
+        }
+
+        public Builder wantedVespaVersion(String wantedVespaVersion) {
+            this.wantedVespaVersion = Optional.of(wantedVespaVersion);
             return this;
         }
 
@@ -338,7 +351,7 @@ public class ContainerNodeSpec {
 
         public ContainerNodeSpec build() {
             return new ContainerNodeSpec(hostname, wantedDockerImage, nodeState, nodeType, nodeFlavor,
-                                         vespaVersion, owner, membership,
+                                         wantedVespaVersion, vespaVersion, owner, membership,
                                          wantedRestartGeneration, currentRestartGeneration,
                                          wantedRebootGeneration, currentRebootGeneration,
                                          minCpuCores, minMainMemoryAvailableGb, minDiskAvailableGb);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DockerOperations {
-    Optional<String> getVespaVersion(ContainerName containerName);
 
     void startContainer(ContainerName containerName, ContainerNodeSpec nodeSpec);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -36,7 +36,6 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
  */
 public class DockerOperationsImpl implements DockerOperations {
     public static final String NODE_PROGRAM = Defaults.getDefaults().underVespaHome("bin/vespa-nodectl");
-    private static final String[] GET_VESPA_VERSION_COMMAND = new String[]{NODE_PROGRAM, "vespa-version"};
 
     private static final String[] RESUME_NODE_COMMAND = new String[]{NODE_PROGRAM, "resume"};
     private static final String[] SUSPEND_NODE_COMMAND = new String[]{NODE_PROGRAM, "suspend"};
@@ -90,26 +89,6 @@ public class DockerOperationsImpl implements DockerOperations {
     public DockerOperationsImpl(Docker docker, Environment environment) {
         this.docker = docker;
         this.environment = environment;
-    }
-
-    @Override
-    public Optional<String> getVespaVersion(ContainerName containerName) {
-        PrefixLogger logger = PrefixLogger.getNodeAgentLogger(DockerOperationsImpl.class, containerName);
-
-        ProcessResult result = docker.executeInContainer(containerName, DockerOperationsImpl.GET_VESPA_VERSION_COMMAND);
-        if (!result.isSuccess()) {
-            logger.warning("Container " + containerName.asString() + ": Command "
-                    + Arrays.toString(DockerOperationsImpl.GET_VESPA_VERSION_COMMAND) + " failed: " + result);
-            return Optional.empty();
-        }
-        Optional<String> vespaVersion = parseVespaVersion(result.getOutput());
-        if (vespaVersion.isPresent()) {
-            return vespaVersion;
-        } else {
-            logger.warning("Container " + containerName.asString() + ": Failed to parse vespa version from "
-                    + result.getOutput());
-            return Optional.empty();
-        }
     }
 
     // Returns empty if vespa version cannot be parsed.

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -101,6 +101,7 @@ public class NodeRepositoryImpl implements NodeRepository {
         Objects.requireNonNull(node.nodeState, "Unknown node state");
         Node.State nodeState = Node.State.valueOf(node.nodeState);
         if (nodeState == Node.State.active) {
+            Objects.requireNonNull(node.wantedVespaVersion, "Unknown vespa version for active node");
             Objects.requireNonNull(node.wantedDockerImage, "Unknown docker image for active node");
             Objects.requireNonNull(node.wantedRestartGeneration, "Unknown wantedRestartGeneration for active node");
             Objects.requireNonNull(node.currentRestartGeneration, "Unknown currentRestartGeneration for active node");
@@ -125,6 +126,7 @@ public class NodeRepositoryImpl implements NodeRepository {
                 nodeState,
                 node.nodeType,
                 node.nodeFlavor,
+                Optional.ofNullable(node.wantedVespaVersion),
                 Optional.ofNullable(node.vespaVersion),
                 Optional.ofNullable(owner),
                 Optional.ofNullable(membership),

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/bindings/GetNodesResponse.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/bindings/GetNodesResponse.java
@@ -31,6 +31,7 @@ public class GetNodesResponse {
         public final String nodeState;
         public final String nodeType;
         public final String nodeFlavor;
+        public final String wantedVespaVersion;
         public final String vespaVersion;
         public final Owner owner;
         public final Membership membership;
@@ -49,6 +50,7 @@ public class GetNodesResponse {
                     @JsonProperty("state") String nodeState,
                     @JsonProperty("type") String nodeType,
                     @JsonProperty("flavor") String nodeFlavor,
+                    @JsonProperty("wantedVespaVersion") String wantedVespaVersion,
                     @JsonProperty("vespaVersion") String vespaVersion,
                     @JsonProperty("owner") Owner owner,
                     @JsonProperty("membership") Membership membership,
@@ -65,6 +67,7 @@ public class GetNodesResponse {
             this.nodeState = nodeState;
             this.nodeType = nodeType;
             this.nodeFlavor = nodeFlavor;
+            this.wantedVespaVersion = wantedVespaVersion;
             this.vespaVersion = vespaVersion;
             this.owner = owner;
             this.membership = membership;
@@ -85,6 +88,7 @@ public class GetNodesResponse {
                     + " nodeState = " + nodeState
                     + " nodeType = " + nodeType
                     + " nodeFlavor = " + nodeFlavor
+                    + " wantedVespaVersion = " + wantedVespaVersion
                     + " vespaVersion = " + vespaVersion
                     + " owner = " + owner
                     + " membership = " + membership

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -94,6 +94,7 @@ public class NodeAgentImplTest {
         final ContainerNodeSpec nodeSpec = nodeSpecBuilder
                 .wantedDockerImage(dockerImage)
                 .nodeState(Node.State.active)
+                .wantedVespaVersion(vespaVersion)
                 .vespaVersion(vespaVersion)
                 .wantedRestartGeneration(restartGeneration)
                 .currentRestartGeneration(restartGeneration)
@@ -131,6 +132,7 @@ public class NodeAgentImplTest {
         final ContainerNodeSpec nodeSpec = nodeSpecBuilder
                 .wantedDockerImage(dockerImage)
                 .nodeState(Node.State.active)
+                .wantedVespaVersion(vespaVersion)
                 .vespaVersion(vespaVersion)
                 .wantedRestartGeneration(restartGeneration)
                 .currentRestartGeneration(restartGeneration)
@@ -224,6 +226,7 @@ public class NodeAgentImplTest {
         final ContainerNodeSpec nodeSpec = nodeSpecBuilder
                 .wantedDockerImage(dockerImage)
                 .nodeState(Node.State.failed)
+                .wantedVespaVersion(vespaVersion)
                 .vespaVersion(vespaVersion)
                 .wantedRestartGeneration(restartGeneration)
                 .currentRestartGeneration(restartGeneration)
@@ -285,6 +288,7 @@ public class NodeAgentImplTest {
         final ContainerNodeSpec nodeSpec = nodeSpecBuilder
                 .wantedDockerImage(dockerImage)
                 .nodeState(Node.State.inactive)
+                .wantedVespaVersion(vespaVersion)
                 .vespaVersion(vespaVersion)
                 .wantedRestartGeneration(restartGeneration)
                 .currentRestartGeneration(restartGeneration)
@@ -544,8 +548,9 @@ public class NodeAgentImplTest {
                 Optional.empty();
 
         when(dockerOperations.getContainerStats(any())).thenReturn(Optional.of(emptyContainerStats));
-        when(dockerOperations.getVespaVersion(eq(containerName))).thenReturn(Optional.of(vespaVersion));
         when(dockerOperations.getContainer(eq(containerName))).thenReturn(container);
+        doNothing().when(storageMaintainer).writeFilebeatConfig(any(), any());
+        doNothing().when(storageMaintainer).writeMetricsConfig(any(), any());
 
         return new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
                 Optional.of(storageMaintainer), metricReceiver, environment, clock, Optional.of(aclMaintainer));


### PR DESCRIPTION
Set `vespaVersion` field in node-repo the same way we set `currentDockerImage`, by setting it to be the same as its `wanted*` counterpart. 