### PR TITLE
Write to ZooKeeper must be timing invariant

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -348,6 +348,23 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         newStates.add(state);
         metricUpdater.updateClusterStateMetrics(cluster, state);
         systemStateBroadcaster.handleNewSystemState(state);
+        // Iff master, always store new version in ZooKeeper _before_ publishing to any
+        // nodes so that a cluster controller crash after publishing but before a successful
+        // ZK store will not risk reusing the same version number.
+        if (masterElectionHandler.isMaster()) {
+            storeClusterStateVersionToZooKeeper(state);
+        }
+    }
+
+    private void storeClusterStateVersionToZooKeeper(ClusterState state) {
+        try {
+            database.saveLatestSystemStateVersion(databaseContext, state.getVersion());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // Rethrow as RuntimeException to propagate exception up to main thread method.
+            // Don't want to hide failures to write cluster state version.
+            throw new RuntimeException("ZooKeeper write interrupted", e);
+        }
     }
 
     /**

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -360,7 +360,6 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         try {
             database.saveLatestSystemStateVersion(databaseContext, state.getVersion());
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             // Rethrow as RuntimeException to propagate exception up to main thread method.
             // Don't want to hide failures to write cluster state version.
             throw new RuntimeException("ZooKeeper write interrupted", e);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -110,11 +110,7 @@ public class SystemStateBroadcaster {
         if (systemState == null) return false;
 
         List<NodeInfo> recipients = resolveStateVersionSendSet(dbContext);
-        // Store new version in ZooKeeper _before_ publishing to any nodes so that a
-        // cluster controller crash after publishing but before a successful ZK store
-        // will not risk reusing the same version number.
         if (!systemState.isOfficial()) {
-            database.saveLatestSystemStateVersion(dbContext, systemState.getVersion());
             systemState.setOfficial(true);
         }
 


### PR DESCRIPTION
@hakonhall Please review. Previous fix was not sufficient for always writing new version.

Previously could risk that state transition grace period would elide
write to ZooKeeper if state changes happened within previous grace
period.