### PR TITLE
Reduce number of component configs reported by proton.

### DIFF
--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -114,6 +114,7 @@ public:
         // down component.
         _metricManager = &mm;
     }
+    virtual int64_t getGeneration() const override;
 };
 
 ProtonServiceLayerProcess::ProtonServiceLayerProcess(const config::ConfigUri &
@@ -149,6 +150,14 @@ storage::spi::PersistenceProvider &
 ProtonServiceLayerProcess::getProvider()
 {
     return _downPersistence ? *_downPersistence : _proton.getPersistence();
+}
+
+int64_t
+ProtonServiceLayerProcess::getGeneration() const
+{
+    int64_t slGen = storage::ServiceLayerProcess::getGeneration();
+    int64_t protonGen = _proton.getConfigGeneration();
+    return std::min(slGen, protonGen);
 }
 
 int

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -178,7 +178,6 @@ Proton::Proton(const config::ConfigUri & configUri,
       _flushEngine(),
       _rpcHooks(),
       _healthAdapter(*this),
-      _componentConfig(),
       _genericStateHandler(CUSTOM_COMPONENT_API_PATH, *this),
       _customComponentBindToken(),
       _customComponentRootToken(),
@@ -250,10 +249,6 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
     _diskMemUsageSampler = std::make_unique<DiskMemUsageSampler>
                            (protonConfig.basedir,
                             diskMemUsageSamplerConfig(protonConfig));
-
-    _componentConfig.addConfig(vespalib::ComponentConfigProducer::Config("proton",
-                                       configSnapshot->getGeneration(),
-                                       "config obtained at startup"));
 
     _metricsEngine.reset(new MetricsEngine());
     _metricsEngine->addMetricsHook(_metricsHook);
@@ -425,8 +420,6 @@ Proton::applyConfig(const BootstrapConfig::SP & configSnapshot)
     if (_persistenceProxy.get() != NULL) {
         _persistenceProxy->setRepo(*repo);
     }
-    _componentConfig.addConfig(vespalib::ComponentConfigProducer::Config("proton.documentdbs",
-                                       configSnapshot->getGeneration()));
     _diskMemUsageSampler->
         setConfig(diskMemUsageSamplerConfig(protonConfig));
     if (_memoryFlushConfigUpdater) {
@@ -883,7 +876,7 @@ Proton::waitForOnlineState()
 void
 Proton::getComponentConfig(Consumer &consumer)
 {
-    _componentConfig.getComponentConfig(consumer);
+    _protonConfigurer.getComponentConfig().getComponentConfig(consumer);
     std::vector<DocumentDB::SP> dbs;
     {
         std::shared_lock<std::shared_timed_mutex> guard(_mutex);
@@ -906,19 +899,7 @@ Proton::getComponentConfig(Consumer &consumer)
 int64_t
 Proton::getConfigGeneration(void)
 {
-    int64_t g = _protonConfigurer.getActiveConfigSnapshot()->getBootstrapConfig()->getGeneration();
-    std::vector<DocumentDB::SP> dbs;
-    {
-        std::shared_lock<std::shared_timed_mutex> guard(_mutex);
-        for (const auto &kv : _documentDBMap) {
-            dbs.push_back(kv.second);
-        }
-    }
-    for (const auto &docDb : dbs) {
-        int64_t ddbActiveGen = docDb->getActiveGeneration();
-        g = std::min(g, ddbActiveGen);
-    }
-    return g;
+    return _protonConfigurer.getActiveConfigSnapshot()->getBootstrapConfig()->getGeneration();
 }
 
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -32,7 +32,6 @@
 #include <vespa/vespalib/net/component_config_producer.h>
 #include <vespa/vespalib/net/generic_state_handler.h>
 #include <vespa/vespalib/net/json_get_handler.h>
-#include <vespa/vespalib/net/simple_component_config_producer.h>
 #include <vespa/vespalib/net/state_explorer.h>
 #include <vespa/vespalib/net/state_server.h>
 #include <vespa/vespalib/util/varholder.h>
@@ -118,7 +117,6 @@ private:
     FlushEngine::UP                 _flushEngine;
     RPCHooks::UP                    _rpcHooks;
     HealthAdapter                   _healthAdapter;
-    vespalib::SimpleComponentConfigProducer _componentConfig;
     vespalib::GenericStateHandler   _genericStateHandler;
     vespalib::JsonHandlerRepo::Token::UP _customComponentBindToken;
     vespalib::JsonHandlerRepo::Token::UP _customComponentRootToken;

--- a/searchcore/src/vespa/searchcore/proton/server/proton_configurer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_configurer.cpp
@@ -23,7 +23,8 @@ ProtonConfigurer::ProtonConfigurer(vespalib::ThreadStackExecutorBase &executor,
       _pendingConfigSnapshot(),
       _activeConfigSnapshot(),
       _mutex(),
-      _allowReconfig(false)
+      _allowReconfig(false),
+      _componentConfig()
 {
 }
 
@@ -116,6 +117,8 @@ ProtonConfigurer::applyConfig(std::shared_ptr<ProtonConfigSnapshot> configSnapsh
         configureDocumentDB(*configSnapshot, docTypeName, ddbConfig.configid, initializeThreads);
     }
     pruneDocumentDBs(*configSnapshot);
+    size_t gen = bootstrapConfig->getGeneration();
+    _componentConfig.addConfig({"proton", gen});
     std::lock_guard<std::mutex> guard(_mutex);
     _activeConfigSnapshot = configSnapshot;
 }

--- a/searchcore/src/vespa/searchcore/proton/server/proton_configurer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_configurer.h
@@ -4,6 +4,7 @@
 
 #include "i_proton_configurer.h"
 #include <vespa/searchcore/proton/common/doctypename.h>
+#include <vespa/vespalib/net/simple_component_config_producer.h>
 #include <map>
 #include <mutex>
 #include "executor_thread_service.h"
@@ -30,6 +31,7 @@ class ProtonConfigurer : public IProtonConfigurer
     std::shared_ptr<ProtonConfigSnapshot> _activeConfigSnapshot;
     mutable std::mutex _mutex;
     bool _allowReconfig;
+    vespalib::SimpleComponentConfigProducer _componentConfig;
 
     void performReconfigure();
     bool skipConfig(const ProtonConfigSnapshot *configSnapshot, bool initialConfig);
@@ -52,6 +54,7 @@ public:
     virtual void reconfigure(std::shared_ptr<ProtonConfigSnapshot> configSnapshot) override;
 
     void applyInitialConfig(InitializeThreads initializeThreads);
+    vespalib::SimpleComponentConfigProducer &getComponentConfig() { return _componentConfig; }
 };
 
 } // namespace proton


### PR DESCRIPTION
Move setting of "proton" component from proton to
proton configurer and delay it until document dbs have
been updated.

Report min of service layer config generation and proton config generation
when reporting component config in service layer state server.

@vekterli, please review 