### PR TITLE
C++ style fix: Use foo() instead of foo(void)

### DIFF
--- a/searchlib/src/apps/docstore/benchmarkdatastore.cpp
+++ b/searchlib/src/apps/docstore/benchmarkdatastore.cpp
@@ -16,23 +16,23 @@ using namespace search;
 
 class BenchmarkDataStoreApp : public FastOS_Application
 {
-    void usage(void);
+    void usage();
     int benchmark(const vespalib::string & directory, size_t numReads, size_t numThreads, size_t perChunk, const vespalib::string & readType);
-    int Main(void) override;
+    int Main() override;
     void read(size_t numReads, size_t perChunk, const IDataStore * dataStore);
 };
 
 
 
 void
-BenchmarkDataStoreApp::usage(void)
+BenchmarkDataStoreApp::usage()
 {
     printf("Usage: %s <direcory> <numreads> <numthreads> <objects per read> <normal,directio,mmap,mlock>\n", _argv[0]);
     fflush(stdout);
 }
 
 int
-BenchmarkDataStoreApp::Main(void)
+BenchmarkDataStoreApp::Main()
 {
     if (_argc >= 2) {
         size_t numThreads(16);

--- a/searchlib/src/apps/docstore/create-idx-from-dat.cpp
+++ b/searchlib/src/apps/docstore/create-idx-from-dat.cpp
@@ -11,13 +11,13 @@ using namespace search;
 
 class CreateIdxFileFromDatApp : public FastOS_Application
 {
-    void usage(void);
+    void usage();
     int createIdxFile(const vespalib::string & datFileName, const vespalib::string & idxFileName);
-    int Main(void) override;
+    int Main() override;
 };
 
 void
-CreateIdxFileFromDatApp::usage(void)
+CreateIdxFileFromDatApp::usage()
 {
     printf("Usage: %s <datfile> <idxfile>\n", _argv[0]);
     fflush(stdout);
@@ -149,7 +149,7 @@ int CreateIdxFileFromDatApp::createIdxFile(const vespalib::string & datFileName,
 }
 
 int
-CreateIdxFileFromDatApp::Main(void)
+CreateIdxFileFromDatApp::Main()
 {
     vespalib::string cmd;
     if (_argc == 3) {

--- a/searchlib/src/apps/docstore/documentstoreinspect.cpp
+++ b/searchlib/src/apps/docstore/documentstoreinspect.cpp
@@ -11,16 +11,16 @@ using namespace search;
 
 class DocumentStoreInspectApp : public FastOS_Application
 {
-    void usage(void);
+    void usage();
     int verify(const vespalib::string & directory);
     int dumpIdxFile(const vespalib::string & file);
-    int Main(void) override;
+    int Main() override;
 };
 
 
 
 void
-DocumentStoreInspectApp::usage(void)
+DocumentStoreInspectApp::usage()
 {
     printf("Usage: %s dumpidxfile [--idxfile idxFile]\n", _argv[0]);
     fflush(stdout);
@@ -62,7 +62,7 @@ int DocumentStoreInspectApp::dumpIdxFile(const vespalib::string & file)
 }
 
 int
-DocumentStoreInspectApp::Main(void)
+DocumentStoreInspectApp::Main()
 {
     vespalib::string cmd;
     if (_argc >= 2) {

--- a/searchlib/src/apps/docstore/verifylogdatastore.cpp
+++ b/searchlib/src/apps/docstore/verifylogdatastore.cpp
@@ -12,22 +12,22 @@ using namespace search;
 
 class VerifyLogDataStoreApp : public FastOS_Application
 {
-    void usage(void);
+    void usage();
     int verify(const vespalib::string & directory);
-    int Main(void) override;
+    int Main() override;
 };
 
 
 
 void
-VerifyLogDataStoreApp::usage(void)
+VerifyLogDataStoreApp::usage()
 {
     printf("Usage: %s <direcory>\n", _argv[0]);
     fflush(stdout);
 }
 
 int
-VerifyLogDataStoreApp::Main(void)
+VerifyLogDataStoreApp::Main()
 {
     if (_argc >= 2) {
         vespalib::string directory(_argv[1]);

--- a/searchlib/src/apps/expgolomb/expgolomb.cpp
+++ b/searchlib/src/apps/expgolomb/expgolomb.cpp
@@ -6,23 +6,16 @@
 
 class ExpGolombApp : public FastOS_Application
 {
-    void
-    usage(void);
-
-    int
-    testExpGolomb64(int kValue);
-
-    int
-    testExpGolomb64le(int kValue);
-
-    int
-    Main(void) override;
+    void usage();
+    int testExpGolomb64(int kValue);
+    int testExpGolomb64le(int kValue);
+    int Main() override;
 };
 
 
 
 void
-ExpGolombApp::usage(void)
+ExpGolombApp::usage()
 {
     printf("Usage: expgolomb testeg64 <kValue>]\n");
     fflush(stdout);
@@ -139,7 +132,7 @@ ExpGolombApp::testExpGolomb64le(int kValue)
 
 
 int
-ExpGolombApp::Main(void)
+ExpGolombApp::Main()
 {
     printf("Hello world\n");
     if (_argc >= 2) {

--- a/searchlib/src/apps/tests/memoryindexstress_test.cpp
+++ b/searchlib/src/apps/tests/memoryindexstress_test.cpp
@@ -70,7 +70,7 @@ makeSchema()
 }
 
 document::DocumenttypesConfig
-makeDocTypeRepoConfig(void)
+makeDocTypeRepoConfig()
 {
     const int32_t doc_type_id = 787121340;
     document::config_builder::DocumenttypesConfigBuilderHelper builder;

--- a/searchlib/src/apps/uniform/uniform.cpp
+++ b/searchlib/src/apps/uniform/uniform.cpp
@@ -23,25 +23,15 @@ class UniformApp : public FastOS_Application
     uint64_t _bits[MAXK + 1];
     uint64_t _next;
 
-    static uint32_t
-    encodeSpace(uint64_t x, uint32_t k)
-    {
-        return EC64::encodeExpGolombSpace(x, k);
-    }
-
-    void
-    clearBits(void);
-
-    void
-    reportBits(void);
-
-    int
-    Main(void) override;
+    static uint32_t encodeSpace(uint64_t x, uint32_t k) { return EC64::encodeExpGolombSpace(x, k); }
+    void clearBits();
+    void reportBits();
+    int Main() override;
 };
 
 
 void
-UniformApp::clearBits(void)
+UniformApp::clearBits()
 {
     for (unsigned int k = 0; k <= MAXK; ++k)
         _bits[k] = 0;
@@ -50,7 +40,7 @@ UniformApp::clearBits(void)
 
 
 void
-UniformApp::reportBits(void)
+UniformApp::reportBits()
 {
     printf("next=%" PRIu64 " ", _next);
     for (unsigned int k = 0; k <= MAXK; ++k)
@@ -64,7 +54,7 @@ UniformApp::reportBits(void)
 
 
 int
-UniformApp::Main(void)
+UniformApp::Main()
 {
     int k, l, m, bestmask, oldbestmask;
     printf("Hello world\n");

--- a/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
+++ b/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
@@ -118,7 +118,7 @@ unpackFeatures(std::vector<PosEntry> &entries,
 
 
 void
-usageHeader(void)
+usageHeader()
 {
     using std::cerr;
     cerr <<
@@ -140,20 +140,9 @@ public:
     {
     }
 
-    void
-    addField(const vespalib::string &field)
-    {
-        _fields.push_back(field);
-    }
-
-    bool
-    empty(void) const
-    {
-        return _ids.empty();
-    }
-
-    void
-    validateFields(const Schema &schema);
+    void addField(const vespalib::string &field) { _fields.push_back(field); }
+    bool empty() const { return _ids.empty(); }
+    void validateFields(const Schema &schema);
 };
 
 
@@ -188,19 +177,10 @@ public:
     {
     }
 
-    virtual
-    ~SubApp(void)
-    {
-    }
-
-    virtual void
-    usage(bool showHeader) = 0;
-
-    virtual bool
-    getOptions(void) = 0;
-
-    virtual int
-    run(void) = 0;
+    virtual ~SubApp() { }
+    virtual void  usage(bool showHeader) = 0;
+    virtual bool getOptions() = 0;
+    virtual int run() = 0;
 };
 
 
@@ -220,51 +200,20 @@ class ShowPostingListSubApp : public SubApp
     uint32_t _docIdLimit;
     uint32_t _minDocId;
 
-    static uint64_t
-    noWordNumHigh(void)
-    {
-        return std::numeric_limits<uint64_t>::max();
-    }
-
-    static uint64_t
-    noWordNum(void)
-    {
-        return 0u;
-    }
+    static uint64_t noWordNumHigh() { return std::numeric_limits<uint64_t>::max(); }
+    static uint64_t noWordNum() { return 0u; }
 public:
-
     ShowPostingListSubApp(FastOS_Application &app);
-
-    virtual
-    ~ShowPostingListSubApp(void);
-
-    virtual void
-    usage(bool showHeader) override;
-
-    virtual bool
-    getOptions(void) override;
-
-    virtual int
-    run(void) override;
-
-    void
-    showPostingList(void);
-
-    bool
-    readDocIdLimit(const Schema &schema);
-
-    bool
-    readWordList(const SchemaUtil::IndexIterator &index);
-
-    bool
-    readWordList(const Schema &schema);
-
-    void
-    readPostings(const SchemaUtil::IndexIterator &index,
-                 std::vector<PosEntry> &entries);
-
-    void
-    showTransposedPostingList();
+    virtual ~ShowPostingListSubApp();
+    virtual void usage(bool showHeader) override;
+    virtual bool getOptions() override;
+    virtual int run() override;
+    void showPostingList();
+    bool readDocIdLimit(const Schema &schema);
+    bool readWordList(const SchemaUtil::IndexIterator &index);
+    bool readWordList(const Schema &schema);
+    void readPostings(const SchemaUtil::IndexIterator &index, std::vector<PosEntry> &entries);
+    void showTransposedPostingList();
 };
 
 
@@ -287,7 +236,7 @@ ShowPostingListSubApp::ShowPostingListSubApp(FastOS_Application &app)
 }
 
 
-ShowPostingListSubApp::~ShowPostingListSubApp(void)
+ShowPostingListSubApp::~ShowPostingListSubApp()
 {
 }
 
@@ -312,7 +261,7 @@ ShowPostingListSubApp::usage(bool showHeader)
 
 
 bool
-ShowPostingListSubApp::getOptions(void)
+ShowPostingListSubApp::getOptions()
 {
     int c;
     const char *optArgument = NULL;
@@ -509,7 +458,7 @@ ShowPostingListSubApp::readPostings(const SchemaUtil::IndexIterator &index,
 
 
 void
-ShowPostingListSubApp::showTransposedPostingList(void)
+ShowPostingListSubApp::showTransposedPostingList()
 {
     Schema schema;
     std::string schemaName = _indexDir + "/schema.txt";
@@ -579,7 +528,7 @@ ShowPostingListSubApp::showTransposedPostingList(void)
 
 
 void
-ShowPostingListSubApp::showPostingList(void)
+ShowPostingListSubApp::showPostingList()
 {
     Schema schema;
     uint32_t numFields = 1;
@@ -715,7 +664,7 @@ ShowPostingListSubApp::showPostingList(void)
 
 
 int
-ShowPostingListSubApp::run(void)
+ShowPostingListSubApp::run()
 {
     if (_transpose)
         showTransposedPostingList();
@@ -736,21 +685,11 @@ class DumpWordsSubApp : public SubApp
 
 public:
     DumpWordsSubApp(FastOS_Application &app);
-
-    virtual
-    ~DumpWordsSubApp(void);
-
-    virtual void
-    usage(bool showHeader) override;
-
-    virtual bool
-    getOptions(void) override;
-
-    virtual int
-    run(void) override;
-
-    void
-    dumpWords(void);
+    virtual ~DumpWordsSubApp();
+    virtual void usage(bool showHeader) override;
+    virtual bool getOptions() override;
+    virtual int run() override;
+    void dumpWords();
 };
 
 
@@ -765,7 +704,7 @@ DumpWordsSubApp::DumpWordsSubApp(FastOS_Application &app)
 }
 
 
-DumpWordsSubApp::~DumpWordsSubApp(void)
+DumpWordsSubApp::~DumpWordsSubApp()
 {
 }
 
@@ -785,7 +724,7 @@ DumpWordsSubApp::usage(bool showHeader)
 
 
 bool
-DumpWordsSubApp::getOptions(void)
+DumpWordsSubApp::getOptions()
 {
     int c;
     const char *optArgument = NULL;
@@ -853,7 +792,7 @@ DumpWordsSubApp::getOptions(void)
 
 
 void
-DumpWordsSubApp::dumpWords(void)
+DumpWordsSubApp::dumpWords()
 {
     search::index::Schema schema;
     std::string schemaName = _indexDir + "/schema.txt";
@@ -907,7 +846,7 @@ DumpWordsSubApp::dumpWords(void)
 
 
 int
-DumpWordsSubApp::run(void)
+DumpWordsSubApp::run()
 {
     dumpWords();
     return 0;
@@ -917,24 +856,20 @@ DumpWordsSubApp::run(void)
 class VespaIndexInspectApp : public FastOS_Application
 {
 public:
-    VespaIndexInspectApp(void);
-
-    void
-    usage(void);
-
-    int
-    Main(void) override;
+    VespaIndexInspectApp();
+    void usage();
+    int Main() override;
 };
 
 
-VespaIndexInspectApp::VespaIndexInspectApp(void)
+VespaIndexInspectApp::VespaIndexInspectApp()
     : FastOS_Application()
 {
 }
 
 
 void
-VespaIndexInspectApp::usage(void)
+VespaIndexInspectApp::usage()
 {
     ShowPostingListSubApp(*this).usage(true);
     DumpWordsSubApp(*this).usage(false);
@@ -942,7 +877,7 @@ VespaIndexInspectApp::usage(void)
 
 
 int
-VespaIndexInspectApp::Main(void)
+VespaIndexInspectApp::Main()
 {
     if (_argc < 2) {
         usage();

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -214,8 +214,7 @@ private:
     void testGeneration(const AttributePtr & attr, bool exactStatus);
     void testGeneration();
 
-    void
-    testCreateSerialNum(void);
+    void testCreateSerialNum();
 
     void testPredicateHeaderTags();
 
@@ -232,8 +231,7 @@ private:
     void
     testCompactLidSpace(const Config &config);
 
-    void
-    testCompactLidSpace(void);
+    void testCompactLidSpace();
 
     template <typename AttributeType>
     void requireThatAddressSpaceUsageIsReported(const Config &config, bool fastSearch);

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -84,7 +84,7 @@ public:
     }
 
     void
-    updateFirstUsedGen(void)
+    updateFirstUsedGen()
     {
         updateFirstUsedGeneration();
     }

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -47,7 +47,7 @@ typedef std::unique_ptr<AttributeVector::SearchContext> SearchContextPtr;
 typedef std::unique_ptr<search::queryeval::SearchIterator> SearchBasePtr;
 
 bool
-FastOS_UNIX_File::Sync(void)
+FastOS_UNIX_File::Sync()
 {
     // LOG(info, "Skip sync");
     return true;

--- a/searchlib/src/tests/attribute/postinglist/postinglist.cpp
+++ b/searchlib/src/tests/attribute/postinglist/postinglist.cpp
@@ -36,7 +36,7 @@ private:
         int _value;
         uint32_t _order;
 
-        RandomValue(void)
+        RandomValue()
             : _docId(0),
               _value(0u),
               _order(0u)
@@ -146,7 +146,7 @@ private:
     uint32_t _generation;
 
     void
-    allocTree(void);
+    allocTree();
 
     void
     freeTree(bool verbose);
@@ -180,7 +180,7 @@ private:
                        RandomValuesVector &values);
 
     void
-    sortRandomValues(void);
+    sortRandomValues();
 
     void
     doCompactEnumStore(Tree &tree,
@@ -214,7 +214,7 @@ public:
     AttributePostingListTest();
     ~AttributePostingListTest();
 
-    int Main(void) override;
+    int Main() override;
 };
 
 AttributePostingListTest::AttributePostingListTest()

--- a/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
+++ b/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
@@ -165,8 +165,8 @@ private:
     template <typename VectorType>
     void testMinMax(AttributePtr &ptr1, AttributePtr &ptr2);
 
-    void testMinMax(void);
-    void testStringFold(void);
+    void testMinMax();
+    void testStringFold();
     void testDupValuesInIntArray();
     void testDupValuesInStringArray();
 public:
@@ -990,7 +990,7 @@ PostingListAttributeTest::testMinMax(AttributePtr &ptr1, AttributePtr &ptr2)
 }
 
 void
-PostingListAttributeTest::testMinMax(void)
+PostingListAttributeTest::testMinMax()
 {
     {
         Config cfg(Config(BasicType::INT32, CollectionType::SINGLE));
@@ -1026,7 +1026,7 @@ PostingListAttributeTest::testMinMax(void)
 
 
 void
-PostingListAttributeTest::testStringFold(void)
+PostingListAttributeTest::testStringFold()
 {
     Config cfg(Config(BasicType::STRING, CollectionType::SINGLE));
     cfg.setFastSearch(true);

--- a/searchlib/src/tests/btree/btreeaggregation_test.cpp
+++ b/searchlib/src/tests/btree/btreeaggregation_test.cpp
@@ -136,7 +136,7 @@ class WrapInt
 public:
     int _val;
     WrapInt(int val) : _val(val) {}
-    WrapInt(void) : _val(0) {}
+    WrapInt() : _val(0) {}
     bool operator==(const WrapInt & rhs) const { return _val == rhs._val; }
 };
 
@@ -1031,7 +1031,7 @@ Test::requireThatUpdateOfDataWorks()
 
 template <typename TreeStore>
 void
-Test::requireThatSmallNodesWorks(void)
+Test::requireThatSmallNodesWorks()
 {
     GenerationHandler g;
     TreeStore s;

--- a/searchlib/src/tests/btree/iteratespeed.cpp
+++ b/searchlib/src/tests/btree/iteratespeed.cpp
@@ -35,11 +35,8 @@ class IterateSpeed : public FastOS_Application
     void
     workLoop(int loops, bool enableForward, bool enableBackwards,
              bool enableLambda, int leafSlots);
-
     void usage();
-
-    int
-    Main(void) override;
+    int Main() override;
 };
 
 

--- a/searchlib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/searchlib/src/tests/datastore/datastore/datastore_test.cpp
@@ -50,7 +50,7 @@ public:
     }
 
     void
-    switchActiveBuffer(void)
+    switchActiveBuffer()
     {
         ParentType::switchActiveBuffer(0, 0u);
     }
@@ -140,7 +140,7 @@ private:
     void requireThatWeCanUseFreeLists();
     void requireThatMemoryStatsAreCalculated();
     void requireThatMemoryUsageIsCalculated();
-    void requireThatWecanDisableElemHoldList(void);
+    void requireThatWecanDisableElemHoldList();
     void requireThatBufferGrowthWorks();
 public:
     int Main() override;
@@ -442,7 +442,7 @@ Test::requireThatMemoryUsageIsCalculated()
 
 
 void
-Test::requireThatWecanDisableElemHoldList(void)
+Test::requireThatWecanDisableElemHoldList()
 {
     MyStore s;
     MyRef r1 = s.addEntry(10);

--- a/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
+++ b/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
@@ -62,22 +62,19 @@ uint32_t minChunkDocs = 262144;
 
 vespalib::string dirprefix = "index/";
 
-void
-disableSkip(void)
+void disableSkip()
 {
     minSkipDocs = 10000000;
     minChunkDocs = 1 << 30;
 }
 
-void
-enableSkip(void)
+void enableSkip()
 {
     minSkipDocs = 64;
     minChunkDocs = 1 << 30;
 }
 
-void
-enableSkipChunks(void)
+void enableSkipChunks()
 {
     minSkipDocs = 64;
     minChunkDocs = 9000;	// Unrealistic low for testing
@@ -110,17 +107,17 @@ public:
     search::Rand48 _rnd;
 
 private:
-    void Usage(void);
+    void Usage();
     void testFake(const std::string &postingType, FakeWord &fw);
 public:
-    FieldWriterTest(void);
-    ~FieldWriterTest(void);
-    int Main(void) override;
+    FieldWriterTest();
+    ~FieldWriterTest();
+    int Main() override;
 };
 
 
 void
-FieldWriterTest::Usage(void)
+FieldWriterTest::Usage()
 {
     printf("fieldwriter_test "
            "[-c <commonDocFreq>] "
@@ -130,7 +127,7 @@ FieldWriterTest::Usage(void)
 }
 
 
-FieldWriterTest::FieldWriterTest(void)
+FieldWriterTest::FieldWriterTest()
     : _verbose(false),
       _numDocs(3000000),
       _commonDocFreq(50000),
@@ -142,7 +139,7 @@ FieldWriterTest::FieldWriterTest(void)
 }
 
 
-FieldWriterTest::~FieldWriterTest(void)
+FieldWriterTest::~FieldWriterTest()
 {
 }
 
@@ -197,7 +194,7 @@ WrappedFieldWriter::WrappedFieldWriter(const vespalib::string &namepref,
 
 
 void
-WrappedFieldWriter::earlyOpen(void)
+WrappedFieldWriter::earlyOpen()
 {
     TuneFileSeqWrite tuneFileWrite;
     _fieldWriter.reset(new  FieldWriter(_docIdLimit, _numWordIds));
@@ -209,7 +206,7 @@ WrappedFieldWriter::earlyOpen(void)
 
 
 void
-WrappedFieldWriter::lateOpen(void)
+WrappedFieldWriter::lateOpen()
 {
     TuneFileSeqWrite tuneFileWrite;
     DummyFileHeaderContext fileHeaderContext;
@@ -219,7 +216,7 @@ WrappedFieldWriter::lateOpen(void)
 
 
 void
-WrappedFieldWriter::open(void)
+WrappedFieldWriter::open()
 {
     earlyOpen();
     lateOpen();
@@ -227,7 +224,7 @@ WrappedFieldWriter::open(void)
 
 
 void
-WrappedFieldWriter::close(void)
+WrappedFieldWriter::close()
 {
     _fieldWriter->close();
     _fieldWriter.reset();
@@ -235,7 +232,7 @@ WrappedFieldWriter::close(void)
 
 
 void
-WrappedFieldWriter::writeCheckPoint(void)
+WrappedFieldWriter::writeCheckPoint()
 {
     CheckPointFile chkptfile("chkpt");
     nbostream out;
@@ -260,7 +257,7 @@ WrappedFieldWriter::readCheckPoint(bool first)
 
 
 void
-WrappedFieldWriter::checkPoint(void)
+WrappedFieldWriter::checkPoint()
 {
     writeCheckPoint();
     _fieldWriter.reset();
@@ -288,28 +285,14 @@ public:
                       uint32_t numWordIds,
                       uint32_t docIdLimit);
 
-    ~WrappedFieldReader(void);
-
-    void
-    earlyOpen(void);
-
-    void
-    lateOpen(void);
-
-    void
-    open(void);
-
-    void
-    close(void);
-
-    void
-    writeCheckPoint(void);
-
-    void
-    readCheckPoint(bool first);
-
-    virtual void
-    checkPoint(void) override;
+    ~WrappedFieldReader();
+    void earlyOpen();
+    void lateOpen();
+    void open();
+    void close();
+    void writeCheckPoint();
+    void readCheckPoint(bool first);
+    virtual void checkPoint() override;
 };
 
 
@@ -336,13 +319,13 @@ WrappedFieldReader::WrappedFieldReader(const vespalib::string &namepref,
 }
 
 
-WrappedFieldReader::~WrappedFieldReader(void)
+WrappedFieldReader::~WrappedFieldReader()
 {
 }
 
 
 void
-WrappedFieldReader::earlyOpen(void)
+WrappedFieldReader::earlyOpen()
 {
     TuneFileSeqRead tuneFileRead;
     _fieldReader.reset(new FieldReader());
@@ -351,7 +334,7 @@ WrappedFieldReader::earlyOpen(void)
 
 
 void
-WrappedFieldReader::lateOpen(void)
+WrappedFieldReader::lateOpen()
 {
     TuneFileSeqRead tuneFileRead;
     _wmap.setup(_numWordIds);
@@ -362,7 +345,7 @@ WrappedFieldReader::lateOpen(void)
 
 
 void
-WrappedFieldReader::open(void)
+WrappedFieldReader::open()
 {
     earlyOpen();
     lateOpen();
@@ -370,7 +353,7 @@ WrappedFieldReader::open(void)
 
 
 void
-WrappedFieldReader::close(void)
+WrappedFieldReader::close()
 {
     _fieldReader->close();
     _fieldReader.reset();
@@ -378,7 +361,7 @@ WrappedFieldReader::close(void)
 
 
 void
-WrappedFieldReader::writeCheckPoint(void)
+WrappedFieldReader::writeCheckPoint()
 {
     CheckPointFile chkptfile("chkpt");
     nbostream out;
@@ -403,7 +386,7 @@ WrappedFieldReader::readCheckPoint(bool first)
 
 
 void
-WrappedFieldReader::checkPoint(void)
+WrappedFieldReader::checkPoint()
 {
     writeCheckPoint();
     _fieldReader.reset();
@@ -898,7 +881,7 @@ testFieldWriterVariantsWithHighLids(FakeWordSet &wordSet, uint32_t docIdLimit,
 }
 
 int
-FieldWriterTest::Main(void)
+FieldWriterTest::Main()
 {
     int argi;
     char c;

--- a/searchlib/src/tests/diskindex/pagedict4/pagedict4test.cpp
+++ b/searchlib/src/tests/diskindex/pagedict4/pagedict4test.cpp
@@ -65,15 +65,14 @@ public:
     {
     }
 
-    ~Writer(void)
+    ~Writer()
     {
         delete _ssw;
         delete _spw;
         delete _pw;
     }
 
-    void
-    allocWriters()
+    void allocWriters()
     {
         _ssw = new PageDict4SSWriter(_sse);
         _spw = new PageDict4SPWriter(*_ssw, _spe);
@@ -82,16 +81,14 @@ public:
         _pw->setup();
     }
 
-    void
-    flush(void)
+    void flush()
     {
         _pw->flush();
         ThreeLevelCountWriteBuffers::flush();
     }
 
-    void
-    addCounts(const std::string &word,
-              const PostingListCounts &counts)
+    void addCounts(const std::string &word,
+                   const PostingListCounts &counts)
     {
         _pw->addCounts(word, counts);
     }
@@ -119,10 +116,9 @@ public:
         _pr.setup();
     }
 
-    void
-    readCounts(vespalib::string &word,
-               uint64_t &wordNum,
-               PostingListCounts &counts)
+    void readCounts(vespalib::string &word,
+                    uint64_t &wordNum,
+                    PostingListCounts &counts)
     {
         _pr.readCounts(word, wordNum, counts);
     }
@@ -215,16 +211,10 @@ public:
     bool _firstWordForcedCommon;
     bool _lastWordForcedCommon;
 
-    void
-    usage(void);
-
-    int
-    Main(void) override;
-
-    void
-    testWords(void);
-
-    PageDict4TestApp(void)
+    void usage();
+    int Main() override;
+    void testWords();
+    PageDict4TestApp()
         : _rnd(),
           _stress(false),
           _emptyWord(false),
@@ -236,7 +226,7 @@ public:
 
 
 void
-PageDict4TestApp::usage(void)
+PageDict4TestApp::usage()
 {
     printf("Usage: wordnumbers\n");
     fflush(stdout);
@@ -244,7 +234,7 @@ PageDict4TestApp::usage(void)
 
 
 int
-PageDict4TestApp::Main(void)
+PageDict4TestApp::Main()
 {
     if (_argc > 0) {
         DummyFileHeaderContext::setCreator(_argv[0]);
@@ -836,7 +826,7 @@ testWords(const std::string &logname,
 
 
 void
-PageDict4TestApp::testWords(void)
+PageDict4TestApp::testWords()
 {
     ::testWords("smallchunkwordsempty", _rnd,
                 1000000, 0,

--- a/searchlib/src/tests/docstore/document_store_visitor/document_store_visitor_test.cpp
+++ b/searchlib/src/tests/docstore/document_store_visitor/document_store_visitor_test.cpp
@@ -35,7 +35,7 @@ const string header_name = doc_type_name + ".header";
 const string body_name = doc_type_name + ".body";
 
 document::DocumenttypesConfig
-makeDocTypeRepoConfig(void)
+makeDocTypeRepoConfig()
 {
     const int32_t doc_type_id = 787121340;
     document::config_builder::DocumenttypesConfigBuilderHelper builder;
@@ -79,7 +79,7 @@ class MyTlSyncer : public transactionlog::SyncProxy
     SerialNum _syncedTo;
     
 public:
-    MyTlSyncer(void)
+    MyTlSyncer()
         : _syncedTo(0)
     {
     }

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -25,7 +25,7 @@ using search::index::DummyFileHeaderContext;
 class MyTlSyncer : public transactionlog::SyncProxy {
     SerialNum _syncedTo;
 public:
-    MyTlSyncer(void) : _syncedTo(0) { }
+    MyTlSyncer() : _syncedTo(0) { }
 
     void sync(SerialNum syncTo) override {
         _syncedTo = syncTo;

--- a/searchlib/src/tests/memoryindex/btree/btree_test.cpp
+++ b/searchlib/src/tests/memoryindex/btree/btree_test.cpp
@@ -51,7 +51,7 @@ class WrapInt
 public:
     int _val;
     WrapInt(int val) : _val(val) {}
-    WrapInt(void) : _val(0) {}
+    WrapInt() : _val(0) {}
     bool operator==(const WrapInt & rhs) const { return _val == rhs._val; }
 };
 
@@ -944,7 +944,7 @@ Test::requireThatUpdateOfKeyWorks()
 
 
 void
-Test::requireThatSmallNodesWorks(void)
+Test::requireThatSmallNodesWorks()
 {
     typedef BTreeStore<MyKey, std::string, btree::NoAggregated, MyComp,
         BTreeDefaultTraits> TreeStore;
@@ -1018,7 +1018,7 @@ Test::requireThatSmallNodesWorks(void)
 
 
 void
-Test::requireThatApplyWorks(void)
+Test::requireThatApplyWorks()
 {
     typedef BTreeStore<MyKey, std::string, btree::NoAggregated, MyComp,
         BTreeDefaultTraits> TreeStore;
@@ -1154,11 +1154,7 @@ public:
     {
     }
 
-    int
-    getPathSize(void) const
-    {
-        return _pathSize;
-    }
+    int getPathSize() const { return _pathSize; }
 };
 
 

--- a/searchlib/src/tests/memoryindex/btree/frozenbtree_test.cpp
+++ b/searchlib/src/tests/memoryindex/btree/frozenbtree_test.cpp
@@ -49,7 +49,7 @@ private:
 
     Rand48 _randomGenerator;
 
-    void allocTree(void);
+    void allocTree();
     void freeTree(bool verbose);
     void fillRandomValues(unsigned int count);
     void insertRandomValues(Tree &tree, NodeAllocator &allocator, const std::vector<KeyType> &values);
@@ -282,7 +282,7 @@ lookupFrozenRandomValues(const Tree &tree,
 
 
 void
-FrozenBTreeTest::sortRandomValues(void)
+FrozenBTreeTest::sortRandomValues()
 {
     std::vector<KeyType>::iterator i;
     std::vector<KeyType>::iterator ie;

--- a/searchlib/src/tests/memoryindex/datastore/featurestore_test.cpp
+++ b/searchlib/src/tests/memoryindex/datastore/featurestore_test.cpp
@@ -25,29 +25,15 @@ class Test : public vespalib::TestApp
 private:
     Schema _schema;
 
-    const Schema &
-    getSchema(void) const
-    {
-        return _schema;
-    }
-
-    bool
-    assertFeatures(const DocIdAndFeatures &exp,
-                   const DocIdAndFeatures &act);
-
-    void
-    requireThatFeaturesCanBeAddedAndRetrieved(void);
-
-    void
-    requireThatNextWordsAreWorking(void);
-    void
-    requireThatAddFeaturesTriggersChangeOfBuffer(void);
+    const Schema & getSchema() const { return _schema; }
+    bool assertFeatures(const DocIdAndFeatures &exp, const DocIdAndFeatures &act);
+    void requireThatFeaturesCanBeAddedAndRetrieved();
+    void requireThatNextWordsAreWorking();
+    void requireThatAddFeaturesTriggersChangeOfBuffer();
 
 public:
-    Test(void);
-
-    int
-    Main(void) override;
+    Test();
+    int Main() override;
 };
 
 
@@ -101,7 +87,7 @@ getFeatures(uint32_t numOccs,
 
 
 void
-Test::requireThatFeaturesCanBeAddedAndRetrieved(void)
+Test::requireThatFeaturesCanBeAddedAndRetrieved()
 {
     FeatureStore fs(getSchema());
     DocIdAndFeatures act;
@@ -145,7 +131,7 @@ Test::requireThatFeaturesCanBeAddedAndRetrieved(void)
 
 
 void
-Test::requireThatNextWordsAreWorking(void)
+Test::requireThatNextWordsAreWorking()
 {
     FeatureStore fs(getSchema());
     DocIdAndFeatures act;
@@ -189,7 +175,7 @@ Test::requireThatNextWordsAreWorking(void)
 
 
 void
-Test::requireThatAddFeaturesTriggersChangeOfBuffer(void)
+Test::requireThatAddFeaturesTriggersChangeOfBuffer()
 {
     FeatureStore fs(getSchema());
     size_t cnt = 1;

--- a/searchlib/src/tests/memoryindex/dictionary/dictionary_test.cpp
+++ b/searchlib/src/tests/memoryindex/dictionary/dictionary_test.cpp
@@ -81,7 +81,7 @@ public:
     }
 
     virtual void
-    endWord(void) override
+    endWord() override
     {
         assert(_insideWord);
         assert(!_insideDoc);
@@ -122,7 +122,7 @@ public:
     }
 
     virtual void
-    endDocument(void) override
+    endDocument() override
     {
         assert(_insideDoc);
         assert(!_insideElem);
@@ -147,7 +147,7 @@ public:
     }
 
     virtual void
-    endElement(void) override
+    endElement() override
     {
         assert(_insideElem);
         _ss << "]";
@@ -165,7 +165,7 @@ public:
     }
 
     std::string
-    toStr(void) const
+    toStr() const
     {
         return _ss.str();
     }

--- a/searchlib/src/tests/postinglistbm/andstress.cpp
+++ b/searchlib/src/tests/postinglistbm/andstress.cpp
@@ -71,45 +71,19 @@ public:
                     uint32_t stride,
                     bool unpack);
 
-    ~AndStressMaster(void);
-
-    void
-    run(void);
-
-    void
-    makePostingsHelper(FPFactory *postingFactory,
-                       const std::string &postingFormat,
-                       bool validate, bool verbose);
-
-    void
-    dropPostings(void);
-
-    void
-    dropTasks(void);
-
-    void
-    resetTasks(void);	// Prepare for rerun
-
-    void
-    setupTasks(unsigned int numTasks);
-
-    Task *
-    getTask(void);
-
-    unsigned int
-    getNumDocs(void) const
-    {
-        return _numDocs;
-    }
-
-    bool
-    getUnpack(void) const
-    {
-        return _unpack;
-    }
-
-    double
-    runWorkers(const std::string &postingFormat);
+    ~AndStressMaster();
+    void run();
+    void makePostingsHelper(FPFactory *postingFactory,
+                            const std::string &postingFormat,
+                            bool validate, bool verbose);
+    void dropPostings();
+    void dropTasks();
+    void resetTasks();	// Prepare for rerun
+    void setupTasks(unsigned int numTasks);
+    Task *getTask();
+    unsigned int getNumDocs() const { return _numDocs; }
+    bool getUnpack() const { return _unpack; }
+    double runWorkers(const std::string &postingFormat);
 };
 
 
@@ -125,11 +99,8 @@ private:
     unsigned int _id;
 public:
     AndStressWorker(AndStressMaster &master, unsigned int id);
-
-    ~AndStressWorker(void);
-
-    virtual void
-    Run(FastOS_ThreadInterface *thisThread, void *arg) override;
+    ~AndStressWorker();
+    virtual void Run(FastOS_ThreadInterface *thisThread, void *arg) override;
 };
 
 
@@ -184,7 +155,7 @@ clearPtrVector(std::vector<C> &v)
 }
 
 
-AndStressMaster::~AndStressMaster(void)
+AndStressMaster::~AndStressMaster()
 {
     LOG(info, "AndStressMaster::~AndStressMaster");
 
@@ -197,7 +168,7 @@ AndStressMaster::~AndStressMaster(void)
 
 
 void
-AndStressMaster::dropPostings(void)
+AndStressMaster::dropPostings()
 {
     for (unsigned int i = 0; i < _postings.size(); ++i)
         _postings[i].clear();
@@ -206,7 +177,7 @@ AndStressMaster::dropPostings(void)
 
 
 void
-AndStressMaster::dropTasks(void)
+AndStressMaster::dropTasks()
 {
     _tasks.clear();
     _taskIdx = 0;
@@ -214,7 +185,7 @@ AndStressMaster::dropTasks(void)
 
 
 void
-AndStressMaster::resetTasks(void)
+AndStressMaster::resetTasks()
 {
     _taskIdx = 0;
 }
@@ -302,7 +273,7 @@ AndStressMaster::setupTasks(unsigned int numTasks)
 
 
 AndStressMaster::Task *
-AndStressMaster::getTask(void)
+AndStressMaster::getTask()
 {
     Task *result = NULL;
     _taskCond.Lock();
@@ -319,7 +290,7 @@ AndStressMaster::getTask(void)
 }
 
 void
-AndStressMaster::run(void)
+AndStressMaster::run()
 {
     LOG(info, "AndStressMaster::run");
 
@@ -381,7 +352,7 @@ AndStressWorker::AndStressWorker(AndStressMaster &master, unsigned int id)
     LOG(debug, "AndStressWorker::AndStressWorker, id=%u", id);
 }
 
-AndStressWorker::~AndStressWorker(void)
+AndStressWorker::~AndStressWorker()
 {
     LOG(debug, "AndStressWorker::~AndStressWorker, id=%u", _id);
 }
@@ -500,13 +471,13 @@ AndStressWorker::Run(FastOS_ThreadInterface *thisThread, void *arg)
 }
 
 
-AndStress::AndStress(void)
+AndStress::AndStress()
 {
     LOG(debug, "Andstress::AndStress");
 }
 
 
-AndStress::~AndStress(void)
+AndStress::~AndStress()
 {
     LOG(debug, "Andstress::~AndStress");
 }

--- a/searchlib/src/tests/postinglistbm/andstress.h
+++ b/searchlib/src/tests/postinglistbm/andstress.h
@@ -22,9 +22,9 @@ namespace postinglistbm
 class AndStress
 {
 public:
-    AndStress(void);
+    AndStress();
 
-    ~AndStress(void);
+    ~AndStress();
 
     void
     run(search::Rand48 &rnd,

--- a/searchlib/src/tests/postinglistbm/postinglistbm.cpp
+++ b/searchlib/src/tests/postinglistbm/postinglistbm.cpp
@@ -47,24 +47,20 @@ public:
     search::Rand48 _rnd;
 
 private:
-    void Usage(void);
-
-    void
-    badPostingType(const std::string &postingType);
-
-    void
-    testFake(const std::string &postingType,
-             const Schema &schema,
-             const FakeWord &fw);
+    void Usage();
+    void badPostingType(const std::string &postingType);
+    void testFake(const std::string &postingType,
+                  const Schema &schema,
+                  const FakeWord &fw);
 public:
-    PostingListBM(void);
-    ~PostingListBM(void);
-    int Main(void) override;
+    PostingListBM();
+    ~PostingListBM();
+    int Main() override;
 };
 
 
 void
-PostingListBM::Usage(void)
+PostingListBM::Usage()
 {
     printf("postinglistbm "
            "[-C <skipCommonPairsRate>] "
@@ -102,7 +98,7 @@ PostingListBM::badPostingType(const std::string &postingType)
 }
 
 
-PostingListBM::PostingListBM(void)
+PostingListBM::PostingListBM()
     : _verbose(false),
       _numDocs(10000000),
       _commonDocFreq(50000),
@@ -118,7 +114,7 @@ PostingListBM::PostingListBM(void)
 }
 
 
-PostingListBM::~PostingListBM(void)
+PostingListBM::~PostingListBM()
 {
 }
 
@@ -323,7 +319,7 @@ testFakePair(const std::string &postingType,
 
 
 int
-PostingListBM::Main(void)
+PostingListBM::Main()
 {
     int argi;
     char c;

--- a/searchlib/src/tests/queryeval/blueprint/blueprint_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/blueprint_test.cpp
@@ -34,7 +34,7 @@ public:
     }
 
     virtual bool inheritStrict(size_t i) const override {
-        (void)i;
+        (void) i;
         return true;
     }
 

--- a/searchlib/src/tests/stringenum/stringenum_test.cpp
+++ b/searchlib/src/tests/stringenum/stringenum_test.cpp
@@ -19,8 +19,7 @@ class MyApp : public vespalib::TestApp
 public:
     void CheckLookup( search::util::StringEnum *strEnum, const char *str, int value);
     int Main() override;
-
-    MyApp(void) {}
+    MyApp() {}
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/attribute_header.h
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_header.h
@@ -59,10 +59,10 @@ public:
     bool hasWeightedSetType() const;
     uint32_t getNumDocs() const { return _numDocs; }
     size_t getFixedWidth() const { return _fixedWidth; }
-    uint64_t getUniqueValueCount(void) const { return _uniqueValueCount; }
-    uint64_t getTotalValueCount(void) const { return _totalValueCount; }
-    bool getEnumerated(void) const { return _enumerated; }
-    uint64_t getCreateSerialNum(void) const { return _createSerialNum; }
+    uint64_t getUniqueValueCount() const { return _uniqueValueCount; }
+    uint64_t getTotalValueCount() const { return _totalValueCount; }
+    bool getEnumerated() const { return _enumerated; }
+    uint64_t getCreateSerialNum() const { return _createSerialNum; }
     uint32_t getVersion() const  { return _version; }
     const PersistentPredicateParams &getPredicateParams() const { return _predicateParams; }
     bool getPredicateParamsSet() const { return _predicateParamsSet; }

--- a/searchlib/src/vespa/searchlib/attribute/attributefile.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributefile.cpp
@@ -258,7 +258,7 @@ AttributeFile::AttributeFile(const vespalib::string &fileName,
 }
 
 
-AttributeFile::~AttributeFile(void)
+AttributeFile::~AttributeFile()
 {
     Close();
 }

--- a/searchlib/src/vespa/searchlib/attribute/attributefile.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributefile.h
@@ -63,7 +63,7 @@ protected:
     typedef attribute::Config Config;
 public:
     AttributeFile(const vespalib::string & fileName, const Config & config);
-    ~AttributeFile(void);
+    ~AttributeFile();
 
     std::unique_ptr<Record> getRecord();
     bool read(Record & record);
@@ -72,7 +72,7 @@ public:
 protected:
     void OpenReadOnly();
     void OpenWriteOnly(const search::common::FileHeaderContext &fileHeaderContext, uint32_t docIdLimit);
-    void Close(void);
+    void Close();
     bool seekIdxPos(size_t idxPos);
 private:
     uint32_t                          _currIdx;

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
@@ -138,7 +138,7 @@ doUnpack(uint32_t docId)
 template <>
 void
 AttributePostingListIteratorT<InnerAttributePostingListIterator>::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         _postingInfo = MinMaxPostingInfo(1, 1);
@@ -150,7 +150,7 @@ setupPostingInfo(void)
 template <>
 void
 AttributePostingListIteratorT<WeightedInnerAttributePostingListIterator>::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         const btree::MinMaxAggregated &a(_iterator.getAggregated());
@@ -163,7 +163,7 @@ setupPostingInfo(void)
 template <>
 void
 AttributePostingListIteratorT<DocIdMinMaxIterator<AttributePosting> >::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         _postingInfo = MinMaxPostingInfo(1, 1);
@@ -175,7 +175,7 @@ setupPostingInfo(void)
 template <>
 void
 AttributePostingListIteratorT<DocIdMinMaxIterator<AttributeWeightPosting> >::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         const btree::MinMaxAggregated a(_iterator.getAggregated());
@@ -187,7 +187,7 @@ setupPostingInfo(void)
 template <>
 void
 FilterAttributePostingListIteratorT<InnerAttributePostingListIterator>::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         _postingInfo = MinMaxPostingInfo(1, 1);
@@ -199,7 +199,7 @@ setupPostingInfo(void)
 template <>
 void
 FilterAttributePostingListIteratorT<WeightedInnerAttributePostingListIterator>::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         _postingInfo = MinMaxPostingInfo(1, 1);
@@ -211,7 +211,7 @@ setupPostingInfo(void)
 template <>
 void
 FilterAttributePostingListIteratorT<DocIdMinMaxIterator<AttributePosting> >::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         _postingInfo = MinMaxPostingInfo(1, 1);
@@ -223,7 +223,7 @@ setupPostingInfo(void)
 template <>
 void
 FilterAttributePostingListIteratorT<DocIdMinMaxIterator<AttributeWeightPosting> >::
-setupPostingInfo(void)
+setupPostingInfo()
 {
     if (_iterator.valid()) {
         _postingInfo = MinMaxPostingInfo(1, 1);

--- a/searchlib/src/vespa/searchlib/attribute/attributemanager.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributemanager.cpp
@@ -108,7 +108,7 @@ AttributeManager::setBaseDir(const string & base)
 }
 
 
-AttributeManager::~AttributeManager(void)
+AttributeManager::~AttributeManager()
 {
     _attributes.clear();
     LOG(debug,

--- a/searchlib/src/vespa/searchlib/attribute/attributemanager.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributemanager.h
@@ -51,7 +51,7 @@ public:
     const string & getBaseDir()       const { return _baseDir; }
     void setSnapshot(const Snapshot &snap)       { _snapShot = snap; }
     void setBaseDir(const string & base);
-    bool hasReaders(void) const;
+    bool hasReaders() const;
     uint64_t getMemoryFootprint() const;
 protected:
     typedef vespalib::hash_map<string, VectorHolder> AttributeMap;

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -198,7 +198,7 @@ size_t AttributeVector::getFixedWidth() const { return _config.basicType().fixed
 bool AttributeVector::hasEnum() const { return _hasEnum; }
 bool AttributeVector::hasEnum2Value() const { return false; }
 uint32_t AttributeVector::getMaxValueCount() const { return _highestValueCount; }
-uint32_t AttributeVector::getNumDocs(void) const { return _status.getNumDocs(); }
+uint32_t AttributeVector::getNumDocs() const { return _status.getNumDocs(); }
 
 bool
 AttributeVector::isEnumerated(const vespalib::GenericHeader &header)
@@ -511,7 +511,7 @@ AttributeVector::hasLoadData() const {
 
 
 bool
-AttributeVector::isEnumeratedSaveFormat(void) const
+AttributeVector::isEnumeratedSaveFormat() const
 {
     vespalib::string datName(vespalib::make_string("%s.dat", getBaseFileName().c_str()));
     Fast_BufferedFile   datFile;
@@ -663,7 +663,7 @@ AttributeVector::performCompactionWarning()
 
 
 void
-AttributeVector::addReservedDoc(void)
+AttributeVector::addReservedDoc()
 {
     uint32_t docId = 42;
     addDoc(docId);		// Reserved
@@ -701,7 +701,7 @@ bool AttributeVector::hasPostings() { return getIPostingListAttributeBase() != n
 uint64_t AttributeVector::getUniqueValueCount() const { return getTotalValueCount(); }
 uint64_t AttributeVector::getTotalValueCount() const { return getNumDocs(); }
 void AttributeVector::setCreateSerialNum(uint64_t createSerialNum) { _createSerialNum = createSerialNum; }
-uint64_t AttributeVector::getCreateSerialNum(void) const { return _createSerialNum; }
+uint64_t AttributeVector::getCreateSerialNum() const { return _createSerialNum; }
 uint32_t AttributeVector::getVersion() const { return 0; }
 
 void
@@ -719,14 +719,14 @@ AttributeVector::compactLidSpace(uint32_t wantedLidLimit) {
 
 
 bool
-AttributeVector::canShrinkLidSpace(void) const {
+AttributeVector::canShrinkLidSpace() const {
     return wantShrinkLidSpace() &&
         _compactLidSpaceGeneration < getFirstUsedGeneration();
 }
 
 
 void
-AttributeVector::shrinkLidSpace(void)
+AttributeVector::shrinkLidSpace()
 {
     commit();
     removeAllOldGenerations();
@@ -746,7 +746,7 @@ AttributeVector::shrinkLidSpace(void)
     updateStat(true);
 }
 
-void AttributeVector::onShrinkLidSpace(void) {}
+void AttributeVector::onShrinkLidSpace() {}
 
 void
 AttributeVector::clearDocs(DocId lidLow, DocId lidLimit)

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -454,12 +454,12 @@ public:
     /** Returns whether this attribute has load data files on disk **/
     bool hasLoadData() const;
 
-    bool isEnumeratedSaveFormat(void) const;
+    bool isEnumeratedSaveFormat() const;
     bool load();
     void commit(bool forceStatUpdate = false);
     void commit(uint64_t firstSyncToken, uint64_t lastSyncToken);
     void setCreateSerialNum(uint64_t createSerialNum);
-    uint64_t getCreateSerialNum(void) const;
+    uint64_t getCreateSerialNum() const;
     virtual uint32_t getVersion() const;
 
 ////// Interface to access single documents.
@@ -665,7 +665,7 @@ public:
     virtual uint64_t getTotalValueCount() const;
     virtual void compactLidSpace(uint32_t wantedLidLimit) override;
     virtual void clearDocs(DocId lidLow, DocId lidLimit);
-    bool wantShrinkLidSpace(void) const { return _committedDocIdLimit < getNumDocs(); }
+    bool wantShrinkLidSpace() const { return _committedDocIdLimit < getNumDocs(); }
     virtual bool canShrinkLidSpace() const override;
     virtual void shrinkLidSpace() override;
     virtual void onShrinkLidSpace();

--- a/searchlib/src/vespa/searchlib/attribute/componentguard.h
+++ b/searchlib/src/vespa/searchlib/attribute/componentguard.h
@@ -30,7 +30,7 @@ public:
     ComponentGuard(const Component & component);
     const T * get()          const { return _component.get(); }
 
-    const Component & getSP(void) const { return _component; }
+    const Component & getSP() const { return _component; }
     const T * operator -> () const { return _component.get(); }
     const T & operator * ()  const { return *_component.get(); }
     T * get()                      { return _component.get(); }

--- a/searchlib/src/vespa/searchlib/attribute/dociditerator.h
+++ b/searchlib/src/vespa/searchlib/attribute/dociditerator.h
@@ -63,7 +63,7 @@ protected:
 
 template <>
 inline int32_t
-DocIdIterator<AttributePosting>::getData(void) const
+DocIdIterator<AttributePosting>::getData() const
 {
     return 1;	// default weight 1 for single value attributes
 }
@@ -78,20 +78,16 @@ template <typename P>
 class DocIdMinMaxIterator : public DocIdIterator<P>
 {
 public:
-    DocIdMinMaxIterator(void)
+    DocIdMinMaxIterator()
         : DocIdIterator<P>()
     { }
-    
-    inline btree::MinMaxAggregated
-    getAggregated() const {
-        return btree::MinMaxAggregated(1, 1);
-    }
+    inline btree::MinMaxAggregated getAggregated() const { return btree::MinMaxAggregated(1, 1); }
 };
 
 
 template<>
 inline btree::MinMaxAggregated
-DocIdMinMaxIterator<AttributeWeightPosting>::getAggregated(void) const
+DocIdMinMaxIterator<AttributeWeightPosting>::getAggregated() const
 {
     btree::MinMaxAggregated a;
     for (const AttributeWeightPosting *cur = _cur, *end = _end; cur != end; ++cur) {

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.h
@@ -63,7 +63,7 @@ protected:
     void fillEnum(LoadedVector & loaded) override;
     void fillEnum0(const void *src, size_t srcLen, EnumIndexVector &eidxs) override;
     void fixupEnumRefCounts(const EnumVector &enumHist) override;
-    uint64_t getUniqueValueCount(void) const override;
+    uint64_t getUniqueValueCount() const override;
 
     static EnumType getDefaultEnumTypeValue() { return B::defaultValue(); }
 

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
@@ -75,7 +75,7 @@ EnumAttribute<B>::fixupEnumRefCounts(
 
 template <typename B>
 uint64_t
-EnumAttribute<B>::getUniqueValueCount(void) const
+EnumAttribute<B>::getUniqueValueCount() const
 {
     return _enumStore.getNumUniques();
 }

--- a/searchlib/src/vespa/searchlib/attribute/enumcomparator.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumcomparator.h
@@ -75,29 +75,14 @@ public:
      **/
     EnumStoreFoldedComparatorT(const EnumStoreType & enumStore,
                                EntryValue value, bool prefix = false);
-
-    inline bool
-    getUsePrefix(void) const
-    {
-        return false;
-    }
-
-    static int
-    compareFolded(EntryValue lhs, EntryValue rhs)
-    {
-        return ParentType::compare(lhs, rhs);
-    }
-
-    static int
-    compareFoldedPrefix(EntryValue lhs, EntryValue rhs, size_t prefixLen)
-    {
+    inline bool getUsePrefix() const { return false; }
+    static int compareFolded(EntryValue lhs, EntryValue rhs) { return ParentType::compare(lhs, rhs); }
+    static int compareFoldedPrefix(EntryValue lhs, EntryValue rhs, size_t prefixLen) {
         (void) prefixLen;
         return ParentType::compare(lhs, rhs);
     }
 
-    bool
-    operator() (const EnumIndex & lhs, const EnumIndex & rhs) const override
-    {
+    bool operator() (const EnumIndex & lhs, const EnumIndex & rhs) const override {
         if (getUsePrefix())
             return compareFoldedPrefix(getValue(lhs),
                                        getValue(rhs), _prefixLen) < 0;
@@ -170,7 +155,7 @@ compareFoldedPrefix(EntryValue lhs, EntryValue rhs, size_t prefixLen);
 
 template <>
 inline bool
-EnumStoreFoldedComparatorT<StringEntryType>::getUsePrefix(void) const
+EnumStoreFoldedComparatorT<StringEntryType>::getUsePrefix() const
 {
     return _prefix;
 }

--- a/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.cpp
@@ -28,7 +28,7 @@ EnumHintSearchContext(const EnumStoreDictBase &dictionary,
 }
 
 
-EnumHintSearchContext::~EnumHintSearchContext(void)
+EnumHintSearchContext::~EnumHintSearchContext()
 {
 }
 
@@ -67,7 +67,7 @@ EnumHintSearchContext::createPostingIterator(TermFieldMatchData *matchData,
 
 
 unsigned int
-EnumHintSearchContext::approximateHits(void) const
+EnumHintSearchContext::approximateHits() const
 {
     return (_uniqueValues == 0u)
         ? 0u

--- a/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.h
@@ -30,7 +30,7 @@ protected:
     EnumHintSearchContext(const EnumStoreDictBase &dictionary,
                           uint32_t docIdLimit,
                           uint64_t numValues);
-    ~EnumHintSearchContext(void);
+    ~EnumHintSearchContext();
 
     void lookupTerm(const EnumStoreComparator &comp);
     void lookupRange(const EnumStoreComparator &low, const EnumStoreComparator &high);
@@ -39,7 +39,7 @@ protected:
     createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) override;
 
     void fetchPostings(bool strict) override;
-    unsigned int approximateHits(void) const override;
+    unsigned int approximateHits() const override;
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/enumstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumstore.h
@@ -30,12 +30,7 @@ public:
     typedef T Type;
     static uint32_t size(Type)  { return fixedSize(); }
     static uint32_t fixedSize() { return sizeof(T); }
-
-    static bool
-    hasFold(void)
-    {
-        return false;
-    }
+    static bool hasFold() { return false; }
 };
 
 /**
@@ -47,12 +42,7 @@ public:
     typedef const char * Type;
     static uint32_t size(Type value) { return strlen(value) + fixedSize(); }
     static uint32_t fixedSize()      { return 1; }
-
-    static bool
-    hasFold(void)
-    {
-        return true;
-    }
+    static bool hasFold() { return true; }
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
@@ -319,7 +319,7 @@ EnumStoreDictBase::EnumStoreDictBase(EnumStoreBase &enumStore)
 }
 
 
-EnumStoreDictBase::~EnumStoreDictBase(void)
+EnumStoreDictBase::~EnumStoreDictBase()
 {
 }
 
@@ -332,14 +332,14 @@ EnumStoreDict<Dictionary>::EnumStoreDict(EnumStoreBase &enumStore)
 }
 
 template <typename Dictionary>
-EnumStoreDict<Dictionary>::~EnumStoreDict(void)
+EnumStoreDict<Dictionary>::~EnumStoreDict()
 {
 }
 
 
 template <typename Dictionary>
 void
-EnumStoreDict<Dictionary>::freezeTree(void)
+EnumStoreDict<Dictionary>::freezeTree()
 {
     _dict.getAllocator().freeze();
 }
@@ -361,7 +361,7 @@ EnumStoreDict<Dictionary>::getTreeMemoryUsage() const
 
 template <typename Dictionary>
 void
-EnumStoreDict<Dictionary>::reEnumerate(void)
+EnumStoreDict<Dictionary>::reEnumerate()
 {
     _enumStore.reEnumerate(_dict);
 }
@@ -505,7 +505,7 @@ EnumStoreDict<Dictionary>::findFrozenIndex(const EnumStoreComparator &cmp,
 
 template <typename Dictionary>
 void
-EnumStoreDict<Dictionary>::onReset(void)
+EnumStoreDict<Dictionary>::onReset()
 {
     _dict.clear();
 }
@@ -529,7 +529,7 @@ EnumStoreDict<Dictionary>::onTrimHoldLists(generation_t firstUsed)
 
 template <typename Dictionary>
 BTreeNode::Ref
-EnumStoreDict<Dictionary>::getFrozenRootRef(void) const
+EnumStoreDict<Dictionary>::getFrozenRootRef() const
 {
     return _dict.getFrozenView().getRoot();
 }
@@ -570,7 +570,7 @@ lookupFrozenRange(BTreeNode::Ref frozenRootRef,
 
 template <>
 EnumPostingTree &
-EnumStoreDict<EnumTree>::getPostingDictionary(void)
+EnumStoreDict<EnumTree>::getPostingDictionary()
 {
     abort();
 }
@@ -578,7 +578,7 @@ EnumStoreDict<EnumTree>::getPostingDictionary(void)
 
 template <>
 EnumPostingTree &
-EnumStoreDict<EnumPostingTree>::getPostingDictionary(void)
+EnumStoreDict<EnumPostingTree>::getPostingDictionary()
 {
     return _dict;
 }
@@ -586,7 +586,7 @@ EnumStoreDict<EnumPostingTree>::getPostingDictionary(void)
 
 template <>
 const EnumPostingTree &
-EnumStoreDict<EnumTree>::getPostingDictionary(void) const
+EnumStoreDict<EnumTree>::getPostingDictionary() const
 {
     abort();
 }
@@ -594,7 +594,7 @@ EnumStoreDict<EnumTree>::getPostingDictionary(void) const
 
 template <>
 const EnumPostingTree &
-EnumStoreDict<EnumPostingTree>::getPostingDictionary(void) const
+EnumStoreDict<EnumPostingTree>::getPostingDictionary() const
 {
     return _dict;
 }
@@ -602,7 +602,7 @@ EnumStoreDict<EnumPostingTree>::getPostingDictionary(void) const
 
 template <typename Dictionary>
 bool
-EnumStoreDict<Dictionary>::hasData(void) const
+EnumStoreDict<Dictionary>::hasData() const
 {
     return Dictionary::LeafNodeType::hasData();
 }

--- a/searchlib/src/vespa/searchlib/attribute/iattributesavetarget.h
+++ b/searchlib/src/vespa/searchlib/attribute/iattributesavetarget.h
@@ -22,7 +22,7 @@ public:
     IAttributeSaveTarget() : _header() {}
     void setHeader(const attribute::AttributeHeader & header) { _header = header; }
 
-    bool getEnumerated(void) const { return _header.getEnumerated(); }
+    bool getEnumerated() const { return _header.getEnumerated(); }
 
     /**
      * Setups this saveTarget before any data is written. Returns true

--- a/searchlib/src/vespa/searchlib/attribute/ipostinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/ipostinglistsearchcontext.h
@@ -34,25 +34,13 @@ namespace attribute
 class IPostingListSearchContext
 {
 protected:
-
-    IPostingListSearchContext(void)
-    {
-    }
-
-    virtual
-    ~IPostingListSearchContext(void)
-    {
-    }
+    IPostingListSearchContext() { }
+    virtual ~IPostingListSearchContext() { }
 
 public:
-    virtual void
-    fetchPostings(bool strict) = 0;
-
-    virtual std::unique_ptr<queryeval::SearchIterator>
-    createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) = 0;
-
-    virtual unsigned int
-    approximateHits(void) const = 0;
+    virtual void fetchPostings(bool strict) = 0;
+    virtual std::unique_ptr<queryeval::SearchIterator> createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) = 0;
+    virtual unsigned int approximateHits() const = 0;
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/loadedenumvalue.h
+++ b/searchlib/src/vespa/searchlib/attribute/loadedenumvalue.h
@@ -49,7 +49,7 @@ public:
         }
     };
 
-    LoadedEnumAttribute(void)
+    LoadedEnumAttribute()
         : _enum(0),
           _docId(0),
           _weight(1)
@@ -65,23 +65,9 @@ public:
     {
     }
         
-    uint32_t
-    getEnum(void) const
-    {
-        return _enum;
-    }
-
-    uint32_t
-    getDocId(void) const
-    {
-        return _docId;
-    }
-
-    int32_t
-    getWeight(void) const
-    {
-        return _weight;
-    }
+    uint32_t getEnum() const  { return _enum; }
+    uint32_t getDocId() const { return _docId; }
+    int32_t getWeight() const { return _weight; }
 };
     
 typedef vespalib::Array<LoadedEnumAttribute> LoadedEnumAttributeVector;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -45,8 +45,7 @@ MultiValueNumericPostingAttribute<B, M>::MultiValueNumericPostingAttribute(const
 }
 
 template <typename B, typename M>
-MultiValueNumericPostingAttribute<B, M>::
-~MultiValueNumericPostingAttribute(void)
+MultiValueNumericPostingAttribute<B, M>::~MultiValueNumericPostingAttribute()
 {
     this->disableFreeLists();
     this->disableElemHoldList();

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
@@ -30,7 +30,7 @@ MultiValueStringAttributeT<B, M>::~MultiValueStringAttributeT() { }
 
 template <typename B, typename M>
 void
-MultiValueStringAttributeT<B, M>::freezeEnumDictionary(void)
+MultiValueStringAttributeT<B, M>::freezeEnumDictionary()
 {
     this->getEnumStore().freezeTree();
 }

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -103,9 +103,7 @@ public:
         handleFillPostings(loaded);
     }
 
-    attribute::IPostingListAttributeBase * getIPostingListAttributeBase(void) override {
-        return this;
-    }
+    attribute::IPostingListAttributeBase * getIPostingListAttributeBase() override { return this; }
 
     void fillPostingsFixupEnum(const LoadedEnumAttributeVector &loaded) override {
         fillPostingsFixupEnumBase(loaded);

--- a/searchlib/src/vespa/searchlib/attribute/multivalue.h
+++ b/searchlib/src/vespa/searchlib/attribute/multivalue.h
@@ -27,7 +27,7 @@ public:
     bool operator ==(const Value<T> & rhs) const { return _v == rhs._v; }
     bool operator <(const Value<T> & rhs) const { return _v < rhs._v; }
     bool operator >(const Value<T> & rhs) const { return _v > rhs._v; }
-    static bool hasWeight(void) { return false; }
+    static bool hasWeight() { return false; }
 
     static const bool _hasWeight = false;
 private:
@@ -50,7 +50,7 @@ public:
     bool operator==(const WeightedValue<T> & rhs) const { return _v == rhs._v; }
     bool operator <(const WeightedValue<T> & rhs) const { return _v < rhs._v; }
     bool operator >(const WeightedValue<T> & rhs) const { return _v > rhs._v; }
-    static bool hasWeight(void) { return true; }
+    static bool hasWeight() { return true; }
 
     static const bool _hasWeight = true;
 private:

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
@@ -64,7 +64,7 @@ public:
 private:
     int32_t getWeight(DocId doc, uint32_t idx) const override;
 
-    uint64_t getTotalValueCount(void) const override;
+    uint64_t getTotalValueCount() const override;
 
 public:
     void clearDocs(DocId lidLow, DocId lidLimit) override;

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -176,7 +176,7 @@ MultiValueAttribute<B, M>::getValueCount(DocId doc) const
 
 template <typename B, typename M>
 uint64_t
-MultiValueAttribute<B, M>::getTotalValueCount(void) const
+MultiValueAttribute<B, M>::getTotalValueCount() const
 {
     return _mvMapping.getTotalValueCnt();
 }

--- a/searchlib/src/vespa/searchlib/attribute/postingchange.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postingchange.cpp
@@ -108,7 +108,7 @@ EnumIndexMapper::map(EnumStoreBase::Index original, const EnumStoreComparator & 
 
 template <>
 void
-PostingChange<AttributePosting>::removeDups(void)
+PostingChange<AttributePosting>::removeDups()
 {
     removeDupAdditions(_additions);
     removeDupRemovals(_removals);
@@ -117,7 +117,7 @@ PostingChange<AttributePosting>::removeDups(void)
 
 template <>
 void
-PostingChange<AttributeWeightPosting>::removeDups(void)
+PostingChange<AttributeWeightPosting>::removeDups()
 {
     removeDupAdditions(_additions);
     removeDupRemovals(_removals);

--- a/searchlib/src/vespa/searchlib/attribute/postingchange.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingchange.h
@@ -32,7 +32,7 @@ public:
         return *this;
     }
 
-    void clear(void) {
+    void clear() {
         _additions.clear();
         _removals.clear();
     }
@@ -41,7 +41,7 @@ public:
      * Remove duplicates in additions and removals vectors, since new
      * posting list tree doesn't support duplicate entries.
      */
-    void removeDups(void);
+    void removeDups();
     void apply(GrowableBitVector &bv);
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/postinglistattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistattribute.cpp
@@ -217,7 +217,7 @@ PostingListAttributeSubBase(AttributeVector &attr,
 template <typename P, typename LoadedVector, typename LoadedValueType,
           typename EnumStoreType>
 PostingListAttributeSubBase<P, LoadedVector, LoadedValueType, EnumStoreType>::
-~PostingListAttributeSubBase(void)
+~PostingListAttributeSubBase()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
@@ -55,7 +55,7 @@ protected:
     virtual void updatePostings(PostingMap & changePost) = 0;
 
     void updatePostings(PostingMap &changePost, EnumStoreComparator &cmp);
-    void clearAllPostings(void);
+    void clearAllPostings();
     void disableFreeLists() { _postingList.disableFreeLists(); }
     void disableElemHoldList() { _postingList.disableElemHoldList(); }
     void fillPostingsFixupEnumBase(const LoadedEnumAttributeVector &loaded);
@@ -101,7 +101,7 @@ private:
 
 public:
     PostingListAttributeSubBase(AttributeVector &attr, EnumStore &enumStore);
-    virtual ~PostingListAttributeSubBase(void);
+    virtual ~PostingListAttributeSubBase();
 
     void handleFillPostings(LoadedVector &loaded);
     void updatePostings(PostingMap &changePost) override;

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -53,17 +53,17 @@ protected:
                              uint32_t minBvDocFreq,
                              bool useBitVector);
 
-    ~PostingListSearchContext(void);
+    ~PostingListSearchContext();
 
     void lookupTerm(const EnumStoreComparator &comp);
     void lookupRange(const EnumStoreComparator &low, const EnumStoreComparator &high);
-    void lookupSingle(void);
+    void lookupSingle();
     virtual bool useThis(const DictionaryConstIterator & it) const {
         (void) it;
         return true;
     }
 
-    float calculateFilteringCost(void) const {
+    float calculateFilteringCost() const {
         // filtering search time (ms) ~ FSTC * numValues; (FSTC =
         // Filtering Search Time Constant)
         return _FSTC * _numValues;
@@ -75,13 +75,13 @@ protected:
         return _PLSTC * approxNumHits;
     }
 
-    uint32_t calculateApproxNumHits(void) const {
+    uint32_t calculateApproxNumHits() const {
         float docsPerUniqueValue = static_cast<float>(_docIdLimit) /
                                    static_cast<float>(_dictSize);
         return static_cast<uint32_t>(docsPerUniqueValue * _uniqueValues);
     }
 
-    virtual bool fallbackToFiltering(void) const {
+    virtual bool fallbackToFiltering() const {
         uint32_t numHits = calculateApproxNumHits();
         // numHits > 1000: make sure that posting lists are unit tested.
         return (numHits > 1000) &&
@@ -127,10 +127,10 @@ protected:
                               bool useBitVector);
     ~PostingListSearchContextT();
 
-    void lookupSingle(void);
-    size_t countHits(void) const;
+    void lookupSingle();
+    size_t countHits() const;
     void fillArray(size_t numDocs);
-    void fillBitVector(void);
+    void fillBitVector();
 
     PostingVector &
     merge(PostingVector &v, PostingVector &temp,
@@ -145,8 +145,8 @@ protected:
     queryeval::SearchIterator::UP
     createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) override;
 
-    unsigned int singleHits(void) const;
-    unsigned int approximateHits(void) const override;
+    unsigned int singleHits() const;
+    unsigned int approximateHits() const override;
     void applyRangeLimit(int rangeLimit);
 };
 
@@ -174,7 +174,7 @@ protected:
                                     uint32_t minBvCocFreq,
                                     bool useBitVector);
 
-    unsigned int approximateHits(void) const override;
+    unsigned int approximateHits() const override;
 };
 
 
@@ -241,12 +241,12 @@ private:
     void getIterators(bool shouldApplyRangeLimit);
     bool valid() const override { return this->isValid(); }
 
-    bool fallbackToFiltering(void) const override {
+    bool fallbackToFiltering() const override {
         return (this->getRangeLimit() != 0)
             ? false
             : Parent::fallbackToFiltering();
     }
-    unsigned int approximateHits(void) const override {
+    unsigned int approximateHits() const override {
         const unsigned int estimate = PostingListSearchContextT<DataT>::approximateHits();
         const unsigned int limit = std::abs(this->getRangeLimit());
         return ((limit > 0) && (limit < estimate))

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -41,7 +41,7 @@ PostingListSearchContextT<DataT>::~PostingListSearchContextT() {}
 
 template <typename DataT>
 void
-PostingListSearchContextT<DataT>::lookupSingle(void)
+PostingListSearchContextT<DataT>::lookupSingle()
 {
     PostingListSearchContext::lookupSingle();
     if (!_pidx.valid())
@@ -82,7 +82,7 @@ PostingListSearchContextT<DataT>::lookupSingle(void)
 
 template <typename DataT>
 size_t
-PostingListSearchContextT<DataT>::countHits(void) const
+PostingListSearchContextT<DataT>::countHits() const
 {
     size_t sum(0);
     for (auto it(_lowerDictItr); it != _upperDictItr; ++it) {
@@ -122,7 +122,7 @@ PostingListSearchContextT<DataT>::fillArray(size_t numDocs)
 
 template <typename DataT>
 void
-PostingListSearchContextT<DataT>::fillBitVector(void)
+PostingListSearchContextT<DataT>::fillBitVector()
 {
     _bitVector = BitVector::create(_docIdLimit);
     BitVector &bv(*_bitVector);
@@ -272,7 +272,7 @@ createPostingIterator(fef::TermFieldMatchData *matchData, bool strict)
 
 template <typename DataT>
 unsigned int
-PostingListSearchContextT<DataT>::singleHits(void) const
+PostingListSearchContextT<DataT>::singleHits() const
 {
     if (_gbv) {
         // Some inaccuracy is expected, data changes underfeet
@@ -290,7 +290,7 @@ PostingListSearchContextT<DataT>::singleHits(void) const
 
 template <typename DataT>
 unsigned int
-PostingListSearchContextT<DataT>::approximateHits(void) const
+PostingListSearchContextT<DataT>::approximateHits() const
 {
     unsigned int numHits = 0;
     if (_uniqueValues == 0u) {
@@ -362,7 +362,7 @@ PostingListFoldedSearchContextT(const Dictionary &dictionary,
 
 template <typename DataT>
 unsigned int
-PostingListFoldedSearchContextT<DataT>::approximateHits(void) const
+PostingListFoldedSearchContextT<DataT>::approximateHits() const
 {
     unsigned int numHits = 0;
     if (_uniqueValues == 0u) {

--- a/searchlib/src/vespa/searchlib/attribute/readerbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/readerbase.h
@@ -24,7 +24,7 @@ public:
         return (_idxFileSize - _idxHeaderLen) /sizeof(uint32_t);
     }
 
-    size_t getEnumCount(void) const {
+    size_t getEnumCount() const {
         size_t dataSize(_datFileSize - _datHeaderLen);
         assert((dataSize % sizeof(uint32_t)) == 0);
         return dataSize / sizeof(uint32_t);

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -282,7 +282,7 @@ SingleValueEnumAttribute<B>::clearDocs(DocId lidLow, DocId lidLimit)
 
 template <typename B>
 void
-SingleValueEnumAttribute<B>::onShrinkLidSpace(void)
+SingleValueEnumAttribute<B>::onShrinkLidSpace()
 {
     EnumHandle e;
     bool findDefaultEnumRes(this->findEnum(this->getDefaultEnumTypeValue(), e));

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
@@ -22,7 +22,7 @@ SingleValueNumericAttribute(const vespalib::string & baseFileName, const Attribu
 { }
 
 template <typename B>
-SingleValueNumericAttribute<B>::~SingleValueNumericAttribute(void)
+SingleValueNumericAttribute<B>::~SingleValueNumericAttribute()
 {
     getGenerationHolder().clearHoldLists();
 }

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
@@ -33,7 +33,7 @@ SingleValueSmallNumericAttribute(const vespalib::string & baseFileName,
 }
 
 
-SingleValueSmallNumericAttribute::~SingleValueSmallNumericAttribute(void)
+SingleValueSmallNumericAttribute::~SingleValueSmallNumericAttribute()
 {
     getGenerationHolder().clearHoldLists();
 }
@@ -253,11 +253,11 @@ namespace
 
 template <typename TT>
 uint32_t
-log2bits(void);
+log2bits();
 
 template <>
 uint32_t
-log2bits<uint32_t>(void)
+log2bits<uint32_t>()
 {
     return 0x05u;
 }

--- a/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
@@ -29,7 +29,7 @@ SingleValueStringAttributeT<B>::~SingleValueStringAttributeT() { }
 
 template <typename B>
 void
-SingleValueStringAttributeT<B>::freezeEnumDictionary(void) {
+SingleValueStringAttributeT<B>::freezeEnumDictionary() {
     this->getEnumStore().freezeTree();
 }
 

--- a/searchlib/src/vespa/searchlib/bitcompression/compression.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/compression.cpp
@@ -347,7 +347,7 @@ readHeader(const vespalib::GenericHeader &header,
 
 template <bool bigEndian>
 const vespalib::string &
-FeatureDecodeContext<bigEndian>::getIdentifier(void) const
+FeatureDecodeContext<bigEndian>::getIdentifier() const
 {
     return noFeatures;
 }
@@ -423,7 +423,7 @@ writeHeader(vespalib::GenericHeader &header,
 
 template <bool bigEndian>
 const vespalib::string &
-FeatureEncodeContext<bigEndian>::getIdentifier(void) const
+FeatureEncodeContext<bigEndian>::getIdentifier() const
 {
     return noFeatures;
 }

--- a/searchlib/src/vespa/searchlib/bitcompression/compression.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/compression.h
@@ -1136,7 +1136,7 @@ public:
     // minus sizeof uint64_t.  Then shifted left by 3 to represent bits.
     uint64_t _fileReadBias;
 
-    DecodeContext64Base(void)
+    DecodeContext64Base()
         : search::ComprFileDecodeContext(),
           _valI(NULL),
           _valE(NULL),
@@ -1167,7 +1167,7 @@ public:
     }
 
     virtual
-    ~DecodeContext64Base(void)
+    ~DecodeContext64Base()
     {
     }
 
@@ -1261,11 +1261,11 @@ public:
             _valE += END_BUFFER_SAFETY;
     }
 
-    const uint64_t *getCompr(void) const {
+    const uint64_t *getCompr() const {
         return (_preRead == 0) ? (_valI - 1) : (_valI - 2);
     }
 
-    int getBitOffset(void) const {
+    int getBitOffset() const {
         return (_preRead == 0) ? 0 : 64 - _preRead;
     }
 
@@ -1290,7 +1290,7 @@ private:
 public:
     typedef EncodeContext64<bigEndian> EC;
 
-    DecodeContext64(void)
+    DecodeContext64()
         : DecodeContext64Base()
     {
     }
@@ -1415,7 +1415,7 @@ public:
      * Used by iterators when switching from bitwise to bytewise decoding.
      */
     const uint8_t *
-    getByteCompr(void) const
+    getByteCompr() const
     {
         assert((_preRead & 7) == 0);
         return reinterpret_cast<const uint8_t *>(getCompr()) +
@@ -1501,7 +1501,7 @@ public:
     using ParentClass::readBits;
     using ParentClass::ReadBits;
 
-    FeatureDecodeContext(void)
+    FeatureDecodeContext()
         : ParentClass(),
           _readContext(NULL)
     {
@@ -1537,19 +1537,19 @@ public:
     }
 
     search::ComprFileReadContext *
-    getReadContext(void) const
+    getReadContext() const
     {
         return _readContext;
     }
 
     void
-    readComprBuffer(void)
+    readComprBuffer()
     {
         _readContext->readComprBuffer();
     }
 
     void
-    readComprBufferIfNeeded(void)
+    readComprBufferIfNeeded()
     {
         if (__builtin_expect(_valI >= _valE, false))
             readComprBuffer();
@@ -1566,7 +1566,7 @@ public:
                const vespalib::string &prefix);
 
     virtual const vespalib::string &
-    getIdentifier(void) const;
+    getIdentifier() const;
 
     virtual void
     readFeatures(DocIdAndFeatures &features);
@@ -1641,7 +1641,7 @@ public:
     using ParentClass::smallPadBits;
 
 public:
-    FeatureEncodeContext(void)
+    FeatureEncodeContext()
         : ParentClass(),
           _writeContext(NULL)
     {

--- a/searchlib/src/vespa/searchlib/bitcompression/countcompression.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/countcompression.h
@@ -23,7 +23,7 @@ public:
     uint64_t _numWordIds;	// Number of words in dictionary
     uint64_t _minWordNum;	// Minimum word number
 
-    PostingListCountFileDecodeContext(void)
+    PostingListCountFileDecodeContext()
         : ParentClass(),
           _avgBitsPerDoc(10),
           _minChunkDocs(262144),
@@ -57,7 +57,7 @@ public:
     uint64_t _numWordIds;	// Number of words in dictionary
     uint64_t _minWordNum;	// Mininum word number
 
-    PostingListCountFileEncodeContext(void)
+    PostingListCountFileEncodeContext()
         : ParentClass(),
           _avgBitsPerDoc(10),
           _minChunkDocs(262144),
@@ -72,7 +72,7 @@ public:
     void writeCounts(const PostingListCounts &counts);
     void writeWordNum(uint64_t wordNum);
 
-    static uint64_t noWordNum(void) {
+    static uint64_t noWordNum() {
         return std::numeric_limits<uint64_t>::max();
     }
 

--- a/searchlib/src/vespa/searchlib/bitcompression/pagedict4.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/pagedict4.cpp
@@ -246,7 +246,7 @@ PageDict4SSWriter::PageDict4SSWriter(SSEC &sse)
 {
 }
 
-PageDict4SSWriter::~PageDict4SSWriter(void)
+PageDict4SSWriter::~PageDict4SSWriter()
 {
 }
 
@@ -355,7 +355,7 @@ addOverflowCounts(const vespalib::stringref &word,
 
 
 void
-PageDict4SSWriter::flush(void)
+PageDict4SSWriter::flush()
 {
 }
 
@@ -454,13 +454,13 @@ PageDict4SPWriter::setup()
 }
 
 
-PageDict4SPWriter::~PageDict4SPWriter(void)
+PageDict4SPWriter::~PageDict4SPWriter()
 {
 }
 
 
 void
-PageDict4SPWriter::flushPage(void)
+PageDict4SPWriter::flushPage()
 {
     assert(_l3Entries > 0);
     assert(_l3Size > 0);
@@ -523,7 +523,7 @@ PageDict4SPWriter::flushPage(void)
 
 
 void
-PageDict4SPWriter::flush(void)
+PageDict4SPWriter::flush()
 {
     if (!empty()) {
         flushPage();
@@ -537,7 +537,7 @@ PageDict4SPWriter::flush(void)
 
 
 void
-PageDict4SPWriter::resetPage(void)
+PageDict4SPWriter::resetPage()
 {
     _eL3.setupWrite(_wcL3);
     _eL4.setupWrite(_wcL4);
@@ -837,13 +837,13 @@ PageDict4PWriter::setup()
 }
 
 
-PageDict4PWriter::~PageDict4PWriter(void)
+PageDict4PWriter::~PageDict4PWriter()
 {
 }
 
 
 void
-PageDict4PWriter::flushPage(void)
+PageDict4PWriter::flushPage()
 {
     assert(_countsEntries > 0);
     assert(_countsSize > 0);
@@ -904,7 +904,7 @@ PageDict4PWriter::flushPage(void)
 
 
 void
-PageDict4PWriter::flush(void)
+PageDict4PWriter::flush()
 {
     if (!empty()) {
         flushPage();
@@ -918,7 +918,7 @@ PageDict4PWriter::flush(void)
 
 
 void
-PageDict4PWriter::resetPage(void)
+PageDict4PWriter::resetPage()
 {
     _eCounts.setupWrite(_wcCounts);
     _eL1.setupWrite(_wcL1);
@@ -1195,7 +1195,7 @@ PageDict4PWriter::checkPointRead(vespalib::nbostream &in)
 
 
 PageDict4SSLookupRes::
-PageDict4SSLookupRes(void)
+PageDict4SSLookupRes()
     : _l6Word(),
       _lastWord(),
       _l6StartOffset(),
@@ -1211,7 +1211,7 @@ PageDict4SSLookupRes(void)
 
 
 PageDict4SSLookupRes::
-~PageDict4SSLookupRes(void)
+~PageDict4SSLookupRes()
 {
 }
 
@@ -1246,7 +1246,7 @@ PageDict4SSReader(ComprBuffer &cb,
 
 
 PageDict4SSReader::
-~PageDict4SSReader(void)
+~PageDict4SSReader()
 {
 }
 
@@ -1689,7 +1689,7 @@ PageDict4SSReader::checkPointRead(vespalib::nbostream &in)
 
 
 PageDict4SPLookupRes::
-PageDict4SPLookupRes(void)
+PageDict4SPLookupRes()
     : _l3Word(),
       _lastWord(),
       _l3StartOffset(),
@@ -1700,7 +1700,7 @@ PageDict4SPLookupRes(void)
 
 
 PageDict4SPLookupRes::
-~PageDict4SPLookupRes(void)
+~PageDict4SPLookupRes()
 {
 }
 
@@ -1888,7 +1888,7 @@ lookup(const SSReader &ssReader,
 
 
 PageDict4PLookupRes::
-PageDict4PLookupRes(void)
+PageDict4PLookupRes()
     : _counts(),
       _startOffset(),
       _wordNum(1u),
@@ -1899,7 +1899,7 @@ PageDict4PLookupRes(void)
 
 
 PageDict4PLookupRes::
-~PageDict4PLookupRes(void)
+~PageDict4PLookupRes()
 {
 }
 
@@ -2132,13 +2132,13 @@ PageDict4Reader::setup()
 }
 
 
-PageDict4Reader::~PageDict4Reader(void)
+PageDict4Reader::~PageDict4Reader()
 {
 }
 
 
 void
-PageDict4Reader::setupPage(void)
+PageDict4Reader::setupPage()
 {
 #if 0
     LOG(info,
@@ -2224,7 +2224,7 @@ PageDict4Reader::setupPage(void)
 
 
 void
-PageDict4Reader::setupSPage(void)
+PageDict4Reader::setupSPage()
 {
 #if 0
     LOG(info, "setupSPage(%d),", (int) _spd.getReadOffset());

--- a/searchlib/src/vespa/searchlib/bitcompression/pagedict4.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/pagedict4.h
@@ -19,7 +19,7 @@ public:
     uint64_t _fileOffset;
     uint64_t _accNumDocs;
 
-    PageDict4StartOffset(void)
+    PageDict4StartOffset()
         : _fileOffset(0u),
           _accNumDocs(0u)
     {
@@ -86,91 +86,21 @@ public:
     using Counts = index::PostingListCounts;
     typedef PageDict4StartOffset StartOffset;
 
-    static uint32_t
-    getPageByteSize(void)
-    {
-        return 4096;
-    }
-
-    static uint32_t
-    getPageBitSize(void)
-    {
-        return getPageByteSize() * 8;
-    }
-
-    static uint32_t
-    getPageHeaderBitSize(void)
-    {
-        return 15u + 15u + 15u + 12u;
-    }
-
-    static uint32_t
-    getMaxFileHeaderPad(void)
-    {
-        return 999u;
-    }
-
-    static uint32_t
-    getFileHeaderPad(uint32_t offset);
-
-    static uint32_t
-    getL1SkipStride(void)
-    {
-        return 16;
-    }
-
-    static uint32_t
-    getL2SkipStride(void)
-    {
-        return 8;
-    }
-
-    static uint32_t
-    getL4SkipStride(void)
-    {
-        return 16;
-    }
-
-    static uint32_t
-    getL5SkipStride(void)
-    {
-        return 8;
-    }
-
-    static uint32_t
-    getL7SkipStride(void)
-    {
-        return 8;
-    }
-
-    static uint32_t
-    noL7Ref(void)
-    {
-        return std::numeric_limits<uint32_t>::max();
-    }
-
-    static uint32_t
-    getL1Entries(uint32_t countsEntries)
-    {
-        return (countsEntries - 1) / getL1SkipStride();
-    }
-
-    static uint32_t
-    getL2Entries(uint32_t l1Entries)
-    {
-        return l1Entries / getL2SkipStride();
-    }
-
-    static uint32_t
-    getL4Entries(uint32_t l3Entries)
-    {
-        return (l3Entries - 1) / getL4SkipStride();
-    }
-
-    static uint32_t
-    getL5Entries(uint32_t l4Entries)
-    {
-        return l4Entries / getL5SkipStride();
+    static uint32_t getPageByteSize()      { return 4096; }
+    static uint32_t getPageBitSize()       { return getPageByteSize() * 8; }
+    static uint32_t getPageHeaderBitSize() { return 15u + 15u + 15u + 12u; }
+    static uint32_t getMaxFileHeaderPad()  { return 999u; }
+    static uint32_t getFileHeaderPad(uint32_t offset);
+    static uint32_t getL1SkipStride()      { return 16; }
+    static uint32_t getL2SkipStride()      { return 8; }
+    static uint32_t getL4SkipStride()      { return 16; }
+    static uint32_t getL5SkipStride()      { return 8; }
+    static uint32_t getL7SkipStride()      { return 8; }
+    static uint32_t noL7Ref() { return std::numeric_limits<uint32_t>::max(); }
+    static uint32_t getL1Entries(uint32_t countsEntries) { return (countsEntries - 1) / getL1SkipStride(); }
+    static uint32_t getL2Entries(uint32_t l1Entries) { return l1Entries / getL2SkipStride(); }
+    static uint32_t getL4Entries(uint32_t l3Entries) { return (l3Entries - 1) / getL4SkipStride(); }
+    static uint32_t getL5Entries(uint32_t l4Entries) { return l4Entries / getL5SkipStride();
     }
 };
 /*
@@ -203,7 +133,7 @@ private:
 public:
     PageDict4SSWriter(SSEC &sse);
 
-    ~PageDict4SSWriter(void);
+    ~PageDict4SSWriter();
 
     /*
      * Add L6 skip entry.
@@ -229,7 +159,7 @@ public:
                       uint64_t wordNum);
 
     void
-    flush(void);
+    flush();
 
 
     void
@@ -325,19 +255,19 @@ public:
     PageDict4SPWriter(SSWriter &sparseSparsewriter,
                       EC &spe);
 
-    ~PageDict4SPWriter(void);
+    ~PageDict4SPWriter();
 
     void
     setup();
 
     void
-    flushPage(void);
+    flushPage();
 
     void
-    flush(void);
+    flush();
 
     void
-    resetPage(void);
+    resetPage();
 
     void
     addL3Skip(const vespalib::stringref &word,
@@ -353,13 +283,13 @@ public:
     addL5Skip(size_t &lcp);
 
     bool
-    empty(void) const
+    empty() const
     {
         return _l3Entries == 0;
     }
 
     uint32_t
-    getSparsePageNum(void) const
+    getSparsePageNum() const
     {
         return _sparsePageNum;
     }
@@ -476,19 +406,19 @@ public:
     PageDict4PWriter(SPWriter &spWriter,
                      EC &pe);
 
-    ~PageDict4PWriter(void);
+    ~PageDict4PWriter();
 
     void
     setup();
 
     void
-    flushPage(void);
+    flushPage();
 
     void
-    flush(void);
+    flush();
 
     void
-    resetPage(void);
+    resetPage();
 
     void
     addCounts(const vespalib::stringref &word,
@@ -501,13 +431,13 @@ public:
     addL2Skip(size_t &lcp);
 
     bool
-    empty(void) const
+    empty() const
     {
         return _countsEntries == 0;
     }
 
     uint64_t
-    getPageNum(void) const
+    getPageNum() const
     {
         return _pageNum;
     }
@@ -543,9 +473,9 @@ public:
     bool _res;
     bool _overflow;
 
-    PageDict4SSLookupRes(void);
+    PageDict4SSLookupRes();
 
-    ~PageDict4SSLookupRes(void);
+    ~PageDict4SSLookupRes();
 };
 
 /* Reader for sparse sparse file.
@@ -671,7 +601,7 @@ public:
                       uint32_t pFileHeaderSize,
                       uint64_t pFileBitLen);
 
-    ~PageDict4SSReader(void);
+    ~PageDict4SSReader();
 
     void
     setup(DC &ssd);
@@ -683,7 +613,7 @@ public:
     lookupOverflow(uint64_t wordNum) const;
 
     const DC &
-    getSSD(void) const
+    getSSD() const
     {
         return _ssd;
     }
@@ -710,9 +640,9 @@ public:
     uint64_t _l3WordNum;
 
 public:
-    PageDict4SPLookupRes(void);
+    PageDict4SPLookupRes();
 
-    ~PageDict4SPLookupRes(void);
+    ~PageDict4SPLookupRes();
 
     void
     lookup(const SSReader &ssReader,
@@ -741,9 +671,9 @@ public:
     vespalib::string *_nextWord;
 
 public:
-    PageDict4PLookupRes(void);
+    PageDict4PLookupRes();
 
-    ~PageDict4PLookupRes(void);
+    ~PageDict4PLookupRes();
 
     bool
     lookup(const SSReader &ssReader,
@@ -794,7 +724,7 @@ public:
                     DC &spd,
                     DC &pd);
 
-    ~PageDict4Reader(void);
+    ~PageDict4Reader();
 
     void
     setup();

--- a/searchlib/src/vespa/searchlib/bitcompression/posocccompression.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/posocccompression.cpp
@@ -42,7 +42,7 @@ namespace search {
 namespace bitcompression {
 
 
-PosOccFieldParams::PosOccFieldParams(void)
+PosOccFieldParams::PosOccFieldParams()
     : _elemLenK(0),
       _hasElements(false),
       _hasElementWeights(false),
@@ -217,7 +217,7 @@ PosOccFieldParams::writeHeader(vespalib::GenericHeader &header,
 }
 
 
-PosOccFieldsParams::PosOccFieldsParams(void)
+PosOccFieldsParams::PosOccFieldsParams()
     : _numFields(0u),
       _fieldParams(NULL),
       _params()
@@ -710,7 +710,7 @@ readHeader(const vespalib::GenericHeader &header,
 
 template <bool bigEndian>
 const vespalib::string &
-EG2PosOccDecodeContext<bigEndian>::getIdentifier(void) const
+EG2PosOccDecodeContext<bigEndian>::getIdentifier() const
 {
     return EG64PosOccId2;
 }
@@ -728,7 +728,7 @@ writeHeader(vespalib::GenericHeader &header,
 
 template <bool bigEndian>
 const vespalib::string &
-EG2PosOccEncodeContext<bigEndian>::getIdentifier(void) const
+EG2PosOccEncodeContext<bigEndian>::getIdentifier() const
 {
     return EG64PosOccId2;
 }
@@ -1205,7 +1205,7 @@ readHeader(const vespalib::GenericHeader &header,
 
 template <bool bigEndian>
 const vespalib::string &
-EGPosOccDecodeContext<bigEndian>::getIdentifier(void) const
+EGPosOccDecodeContext<bigEndian>::getIdentifier() const
 {
     return EG64PosOccId;
 }
@@ -1223,7 +1223,7 @@ writeHeader(vespalib::GenericHeader &header,
 
 template <bool bigEndian>
 const vespalib::string &
-EGPosOccEncodeContext<bigEndian>::getIdentifier(void) const
+EGPosOccEncodeContext<bigEndian>::getIdentifier() const
 {
     return EG64PosOccId;
 }

--- a/searchlib/src/vespa/searchlib/bitcompression/posocccompression.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/posocccompression.h
@@ -134,7 +134,7 @@ public:
     }
 
     uint32_t getNumFields() const { return _numFields; }
-    const PosOccFieldParams *getFieldParams(void) const { return _fieldParams; }
+    const PosOccFieldParams *getFieldParams() const { return _fieldParams; }
     void getParams(PostingListParams &params) const;
     void setParams(const PostingListParams &params);
     void setSchemaParams(const Schema &schema, const uint32_t indexId);
@@ -195,7 +195,7 @@ public:
     }
 
     void readHeader(const vespalib::GenericHeader &header, const vespalib::string &prefix) override;
-    const vespalib::string &getIdentifier(void) const override;
+    const vespalib::string &getIdentifier() const override;
     void readFeatures(search::index::DocIdAndFeatures &features) override;
     void skipFeatures(unsigned int count) override;
     void unpackFeatures(const search::fef::TermFieldMatchDataArray &matchData, uint32_t docId) override;
@@ -290,7 +290,7 @@ public:
 
     void readHeader(const vespalib::GenericHeader &header, const vespalib::string &prefix) override;
     void writeHeader(vespalib::GenericHeader &header, const vespalib::string &prefix) const override;
-    const vespalib::string &getIdentifier(void) const override;
+    const vespalib::string &getIdentifier() const override;
     void writeFeatures(const DocIdAndFeatures &features) override;
     void setParams(const PostingListParams &params) override;
     void getParams(PostingListParams &params) const override;
@@ -347,7 +347,7 @@ public:
     }
 
     void readHeader(const vespalib::GenericHeader &header, const vespalib::string &prefix) override;
-    const vespalib::string &getIdentifier(void) const override;
+    const vespalib::string &getIdentifier() const override;
     void readFeatures(search::index::DocIdAndFeatures &features) override;
     void skipFeatures(unsigned int count) override;
     void unpackFeatures(const search::fef::TermFieldMatchDataArray &matchData, uint32_t docId) override;
@@ -441,7 +441,7 @@ public:
 
     void readHeader(const vespalib::GenericHeader &header, const vespalib::string &prefix) override;
     void writeHeader(vespalib::GenericHeader &header, const vespalib::string &prefix) const override;
-    const vespalib::string &getIdentifier(void) const override;
+    const vespalib::string &getIdentifier() const override;
     void writeFeatures(const DocIdAndFeatures &features) override;
     void setParams(const PostingListParams &params) override;
     void getParams(PostingListParams &params) const override;

--- a/searchlib/src/vespa/searchlib/btree/btree.h
+++ b/searchlib/src/vespa/searchlib/btree/btree.h
@@ -138,7 +138,7 @@ public:
     }
 
     const AggrT &
-    getAggregated(void) const
+    getAggregated() const
     {
         return _tree.getAggregated(_alloc);
     }

--- a/searchlib/src/vespa/searchlib/btree/btreebuilder.h
+++ b/searchlib/src/vespa/searchlib/btree/btreebuilder.h
@@ -50,19 +50,19 @@ private:
     const AggrCalcT &_aggrCalc;
 
     void
-    normalize(void);
+    normalize();
 
     void
-    allocNewLeafNode(void);
+    allocNewLeafNode();
 
     InternalNodeType *
-    createInternalNode(void);
+    createInternalNode();
 public:
     BTreeBuilder(NodeAllocatorType &allocator);
 
     BTreeBuilder(NodeAllocatorType &allocator, const AggrCalcT &aggrCalc);
 
-    ~BTreeBuilder(void);
+    ~BTreeBuilder();
 
     void
     recursiveDelete(NodeRef node);
@@ -71,13 +71,13 @@ public:
     insert(const KeyT &key, const DataT &data);
 
     NodeRef
-    handover(void);
+    handover();
 
     void
-    reuse(void);
+    reuse();
 
     void
-    clear(void);
+    clear();
 };
 
 extern template class BTreeBuilder<uint32_t, uint32_t,

--- a/searchlib/src/vespa/searchlib/btree/btreebuilder.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreebuilder.hpp
@@ -49,7 +49,7 @@ BTreeBuilder(NodeAllocatorType &allocator, const AggrCalcT &aggrCalc)
 template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS, class AggrCalcT>
 BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, AggrCalcT>::
-~BTreeBuilder(void)
+~BTreeBuilder()
 {
     clear();
 }
@@ -80,7 +80,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS, class AggrCalcT>
 void
 BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, AggrCalcT>::
-normalize(void)
+normalize()
 {
     std::vector<NodeRef> leftInodes;	// left to rightmost nodes in tree
     LeafNodeType *leftLeaf;
@@ -302,7 +302,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS, class AggrCalcT>
 void
 BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, AggrCalcT>::
-allocNewLeafNode(void)
+allocNewLeafNode()
 {
     InternalNodeType  *inode;
     NodeRef child;
@@ -392,7 +392,7 @@ template <typename KeyT, typename DataT, typename AggrT,
 typename BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS,
                       AggrCalcT>::NodeRef
 BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, AggrCalcT>::
-handover(void)
+handover()
 {
     NodeRef ret;
 
@@ -417,7 +417,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS, class AggrCalcT>
 void
 BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, AggrCalcT>::
-reuse(void)
+reuse()
 {
     clear();
     _leaf = _allocator.allocLeafNode();
@@ -430,7 +430,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS, class AggrCalcT>
 void
 BTreeBuilder<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, AggrCalcT>::
-clear(void)
+clear()
 {
     if (!_inodes.empty()) {
         recursiveDelete(_inodes.back().ref);

--- a/searchlib/src/vespa/searchlib/btree/btreeiterator.h
+++ b/searchlib/src/vespa/searchlib/btree/btreeiterator.h
@@ -41,13 +41,13 @@ class NodeElement
     uint32_t _idx;
 
     NodeType *
-    getWNode(void) const
+    getWNode() const
     {
         return const_cast<NodeType *>(_node);
     }
 
 public:
-    NodeElement(void)
+    NodeElement()
         : _node(NULL),
           _idx(0u)
     {
@@ -66,7 +66,7 @@ public:
     }
 
     const NodeType *
-    getNode(void) const
+    getNode() const
     {
         return _node;
     }
@@ -78,19 +78,19 @@ public:
     }
 
     uint32_t
-    getIdx(void) const
+    getIdx() const
     {
         return _idx;
     }
 
     void
-    incIdx(void)
+    incIdx()
     {
         ++_idx;
     }
 
     void
-    decIdx(void)
+    decIdx()
     {
         --_idx;
     }
@@ -121,7 +121,7 @@ public:
     }
 
     void
-    adjustLeftVictimKilled(void)
+    adjustLeftVictimKilled()
     {
         assert(_idx > 0);
         --_idx;
@@ -383,7 +383,7 @@ public:
      * Return if the tree has data or not (e.g. keys and data or only keys).
      */
     static bool
-    hasData(void)
+    hasData()
     {
         return LeafNodeType::hasData();
     }
@@ -392,19 +392,19 @@ public:
      * Move the iterator directly to end.  Used by findHelper method in BTree.
      */
     void
-    setupEnd(void);
+    setupEnd();
 
     /**
      * Setup iterator to be empty and not be associated with any tree.
      */
     void
-    setupEmpty(void);
+    setupEmpty();
 
     /**
      * Move iterator to beyond last element in the current tree.
      */
     void
-    end(void) __attribute__((noinline));
+    end() __attribute__((noinline));
 
     /**
      * Move iterator to beyond last element in the given tree.
@@ -418,7 +418,7 @@ public:
      * Move iterator to first element in the current tree.
      */
     void
-    begin(void);
+    begin();
 
     /**
      * Move iterator to first element in the given tree.
@@ -432,13 +432,13 @@ public:
      * Move iterator to last element in the current tree.
      */
     void
-    rbegin(void);
+    rbegin();
 
     /*
      * Get aggregated values for the current tree. 
      */
     const AggrT &
-    getAggregated(void) const;
+    getAggregated() const;
 
     bool
     identical(const BTreeIteratorBase &rhs) const;
@@ -756,7 +756,7 @@ public:
     }
 
     NodeAllocatorType &
-    getAllocator(void) const
+    getAllocator() const
     {
         return const_cast<NodeAllocatorType &>(*_allocator);
     }
@@ -808,7 +808,7 @@ private:
                 const AggrCalcT &aggrCalc);
 
     LeafNodeType *
-    getLeafNode(void) const
+    getLeafNode() const
     {
         return _leaf.getWNode();
     }
@@ -823,13 +823,13 @@ private:
     }
 
     uint32_t
-    getLeafNodeIdx(void) const
+    getLeafNodeIdx() const
     {
         return _leaf.getIdx();
     }
 
     uint32_t
-    getPathSize(void) const
+    getPathSize() const
     {
         return _pathSize;
     }

--- a/searchlib/src/vespa/searchlib/btree/btreeiterator.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreeiterator.hpp
@@ -104,7 +104,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           uint32_t INTERNAL_SLOTS, uint32_t LEAF_SLOTS, uint32_t PATH_SIZE>
 void
 BTreeIteratorBase<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, PATH_SIZE>::
-setupEnd(void)
+setupEnd()
 {
     _leaf.setNodeAndIdx(NULL, 0u);
 }
@@ -114,7 +114,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           uint32_t INTERNAL_SLOTS, uint32_t LEAF_SLOTS, uint32_t PATH_SIZE>
 void
 BTreeIteratorBase<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, PATH_SIZE>::
-setupEmpty(void)
+setupEmpty()
 {
     clearPath(0u);
     _leaf.setNodeAndIdx(NULL, 0u);
@@ -126,7 +126,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           uint32_t INTERNAL_SLOTS, uint32_t LEAF_SLOTS, uint32_t PATH_SIZE>
 void
 BTreeIteratorBase<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, PATH_SIZE>::
-end(void)
+end()
 {
     if (_pathSize == 0) {
         if (_leafRoot == NULL)
@@ -257,7 +257,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           uint32_t INTERNAL_SLOTS, uint32_t LEAF_SLOTS, uint32_t PATH_SIZE>
 void
 BTreeIteratorBase<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, PATH_SIZE>::
-begin(void)
+begin()
 {
     uint32_t pidx = _pathSize;
     if (pidx > 0u) {
@@ -320,7 +320,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           uint32_t INTERNAL_SLOTS, uint32_t LEAF_SLOTS, uint32_t PATH_SIZE>
 void
 BTreeIteratorBase<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, PATH_SIZE>::
-rbegin(void)
+rbegin()
 {
     uint32_t pidx = _pathSize;
     if (pidx > 0u) {
@@ -353,7 +353,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           uint32_t INTERNAL_SLOTS, uint32_t LEAF_SLOTS, uint32_t PATH_SIZE>
 const AggrT &
 BTreeIteratorBase<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS, PATH_SIZE>::
-getAggregated(void) const
+getAggregated() const
 {
     // XXX: Undefined behavior if tree is empty.
     uint32_t pidx = _pathSize;

--- a/searchlib/src/vespa/searchlib/btree/btreenode.h
+++ b/searchlib/src/vespa/searchlib/btree/btreenode.h
@@ -134,7 +134,7 @@ public:
         (void) data;
     }
 
-    static bool hasData(void) { return false; }
+    static bool hasData() { return false; }
 };
 
 
@@ -159,7 +159,7 @@ public:
     {}
 
     void setData(const DataT &data) { _data = data; }
-    const DataT &getData(void) const { return _data; }
+    const DataT &getData() const { return _data; }
 
     /**
      * This operator only works when using direct keys.  References to
@@ -189,7 +189,7 @@ public:
     }
 
     void setData(const BTreeNoLeafData &data) { (void) data; }
-    const BTreeNoLeafData &getData(void) const { return BTreeNoLeafData::_instance; }
+    const BTreeNoLeafData &getData() const { return BTreeNoLeafData::_instance; }
 
     /**
      * This operator only works when using direct keys.  References to

--- a/searchlib/src/vespa/searchlib/btree/btreenode.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreenode.hpp
@@ -229,7 +229,7 @@ BTreeNodeTT<KeyT, DataT, AggrT, NumSlots>::cleanRange(uint32_t from,
 
 template <typename KeyT, typename DataT, typename AggrT, uint32_t NumSlots>
 void
-BTreeNodeTT<KeyT, DataT, AggrT, NumSlots>::clean(void)
+BTreeNodeTT<KeyT, DataT, AggrT, NumSlots>::clean()
 {
     if (validSlots() == 0)
         return;
@@ -240,7 +240,7 @@ BTreeNodeTT<KeyT, DataT, AggrT, NumSlots>::clean(void)
 
 template <typename KeyT, typename DataT, typename AggrT, uint32_t NumSlots>
 void
-BTreeNodeTT<KeyT, DataT, AggrT, NumSlots>::cleanFrozen(void)
+BTreeNodeTT<KeyT, DataT, AggrT, NumSlots>::cleanFrozen()
 {
     assert(validSlots() <= NodeType::maxSlots());
     assert(getFrozen());
@@ -368,7 +368,7 @@ stealSomeFromRightNode(BTreeInternalNode *victim, NodeAllocatorType &allocator)
 
 template <typename KeyT, typename AggrT, uint32_t NumSlots>
 void
-BTreeInternalNode<KeyT, AggrT, NumSlots>::clean(void)
+BTreeInternalNode<KeyT, AggrT, NumSlots>::clean()
 {
     ParentType::clean();
     _validLeaves = 0;
@@ -377,7 +377,7 @@ BTreeInternalNode<KeyT, AggrT, NumSlots>::clean(void)
 
 template <typename KeyT, typename AggrT, uint32_t NumSlots>
 void
-BTreeInternalNode<KeyT, AggrT, NumSlots>::cleanFrozen(void)
+BTreeInternalNode<KeyT, AggrT, NumSlots>::cleanFrozen()
 {
     ParentType::cleanFrozen();
     _validLeaves = 0;

--- a/searchlib/src/vespa/searchlib/btree/btreenodeallocator.h
+++ b/searchlib/src/vespa/searchlib/btree/btreenodeallocator.h
@@ -61,9 +61,9 @@ private:
     RefVector _leafHoldUntilFreeze;
 
 public:
-    BTreeNodeAllocator(void);
+    BTreeNodeAllocator();
 
-    ~BTreeNodeAllocator(void);
+    ~BTreeNodeAllocator();
 
     void
     disableFreeLists() {
@@ -86,7 +86,7 @@ public:
      * Allocate leaf node.
      */
     LeafNodeTypeRefPair
-    allocLeafNode(void);
+    allocLeafNode();
 
     InternalNodeTypeRefPair
     thawNode(BTreeNode::Ref nodeRef, InternalNodeType *node);
@@ -120,7 +120,7 @@ public:
      * Freeze all nodes that are not already frozen.
      */
     void
-    freeze(void);
+    freeze();
 
     /**
      * Try to free held nodes if nobody can be referencing them.
@@ -138,7 +138,7 @@ public:
     transferHoldLists(generation_t generation);
 
     void
-    clearHoldLists(void);
+    clearHoldLists();
 
     static bool
     isValidRef(BTreeNode::Ref ref)
@@ -226,7 +226,7 @@ public:
     }
 
     std::vector<uint32_t>
-    startCompact(void)
+    startCompact()
     {
         return _nodeStore.startCompact();
     }

--- a/searchlib/src/vespa/searchlib/btree/btreenodeallocator.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreenodeallocator.hpp
@@ -14,7 +14,7 @@ namespace btree {
 template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-BTreeNodeAllocator(void)
+BTreeNodeAllocator()
     : _nodeStore(),
       _internalToFreeze(),
       _leafToFreeze(),
@@ -28,7 +28,7 @@ BTreeNodeAllocator(void)
 template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-~BTreeNodeAllocator(void)
+~BTreeNodeAllocator()
 {
     assert(_internalToFreeze.empty());
     assert(_leafToFreeze.empty());
@@ -70,7 +70,7 @@ template <typename KeyT, typename DataT, typename AggrT,
 typename BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
 LeafNodeTypeRefPair
 BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-allocLeafNode(void)
+allocLeafNode()
 {
     if (_leafHoldUntilFreeze.empty()) {
         LeafNodeTypeRefPair nodeRef = _nodeStore.allocLeafNode();
@@ -191,7 +191,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 void
 BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-freeze(void)
+freeze()
 {
     // Freeze nodes.
 
@@ -286,7 +286,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 void
 BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-clearHoldLists(void)
+clearHoldLists()
 {
     _nodeStore.clearHoldLists();
 }

--- a/searchlib/src/vespa/searchlib/btree/btreenodestore.h
+++ b/searchlib/src/vespa/searchlib/btree/btreenodestore.h
@@ -76,9 +76,9 @@ private:
     BTreeNodeBufferType<LeafNodeType> _leafNodeType;
 
 public:
-    BTreeNodeStore(void);
+    BTreeNodeStore();
 
-    ~BTreeNodeStore(void);
+    ~BTreeNodeStore();
 
     void
     disableFreeLists() {
@@ -207,7 +207,7 @@ public:
     }
 
     std::vector<uint32_t>
-    startCompact(void);
+    startCompact();
 
     void
     finishCompact(const std::vector<uint32_t> &toHold);
@@ -231,7 +231,7 @@ public:
     }
 
     void
-    clearHoldLists(void)
+    clearHoldLists()
     {
         _store.clearHoldLists();
     }

--- a/searchlib/src/vespa/searchlib/btree/btreenodestore.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreenodestore.hpp
@@ -44,7 +44,7 @@ BTreeNodeBufferType<EntryType>::cleanHold(void *buffer,
 template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 BTreeNodeStore<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-BTreeNodeStore(void)
+BTreeNodeStore()
     : _store(),
       _internalNodeType(MIN_CLUSTERS, RefType::offsetSize()),
       _leafNodeType(MIN_CLUSTERS, RefType::offsetSize())
@@ -58,7 +58,7 @@ BTreeNodeStore(void)
 template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 BTreeNodeStore<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-~BTreeNodeStore(void)
+~BTreeNodeStore()
 {
     _store.dropBuffers(); // Drop buffers before type handlers are dropped
 }
@@ -68,7 +68,7 @@ template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
 std::vector<uint32_t>
 BTreeNodeStore<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
-startCompact(void)
+startCompact()
 {
     std::vector<uint32_t> iToHold =
         _store.startCompact(NODETYPE_INTERNAL);

--- a/searchlib/src/vespa/searchlib/btree/btreeroot.h
+++ b/searchlib/src/vespa/searchlib/btree/btreeroot.h
@@ -84,16 +84,16 @@ public:
         }
 
         BTreeNode::Ref
-        getRoot(void) const
+        getRoot() const
         {
             return _frozenRoot;
         }
 
         size_t
-        size(void) const;
+        size() const;
 
         const NodeAllocatorType &
-        getAllocator(void) const
+        getAllocator() const
         {
             return _allocator;
         }

--- a/searchlib/src/vespa/searchlib/btree/btreeroot.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreeroot.hpp
@@ -211,7 +211,7 @@ template <typename KeyT, typename DataT, typename AggrT, typename CompareT,
           typename TraitsT>
 size_t
 BTreeRootT<KeyT, DataT, AggrT, CompareT, TraitsT>::
-FrozenView::size(void) const
+FrozenView::size() const
 {
     if (NodeAllocatorType::isValidRef(_frozenRoot)) {
         return _allocator.validLeaves(_frozenRoot);

--- a/searchlib/src/vespa/searchlib/btree/btreerootbase.h
+++ b/searchlib/src/vespa/searchlib/btree/btreerootbase.h
@@ -34,13 +34,13 @@ protected:
     static_assert(sizeof(_root) == sizeof(_frozenRoot),
                   "BTree root reference size mismatch");
 
-    BTreeRootBase(void);
+    BTreeRootBase();
 
     BTreeRootBase(const BTreeRootBase &rhs);
 
     BTreeRootBase &operator=(const BTreeRootBase &rhs);
 
-    ~BTreeRootBase(void);
+    ~BTreeRootBase();
 
 public:
     void
@@ -67,19 +67,19 @@ public:
     }
 
     BTreeNode::Ref
-    getRoot(void) const
+    getRoot() const
     {
         return _root;
     }
 
     BTreeNode::Ref
-    getFrozenRoot(void) const
+    getFrozenRoot() const
     {
         return BTreeNode::Ref(_frozenRoot.load(std::memory_order_acquire));
     }
 
     BTreeNode::Ref
-    getFrozenRootRelaxed(void) const
+    getFrozenRootRelaxed() const
     {
         return BTreeNode::Ref(_frozenRoot.load(std::memory_order_relaxed));
     }
@@ -91,7 +91,7 @@ public:
     }
 
     void
-    recycle(void)
+    recycle()
     {
         _root = BTreeNode::Ref();
         _frozenRoot = BTreeNode::Ref().ref();

--- a/searchlib/src/vespa/searchlib/btree/btreestore.h
+++ b/searchlib/src/vespa/searchlib/btree/btreestore.h
@@ -103,7 +103,7 @@ public:
 
     BTreeStore(bool init);
 
-    ~BTreeStore(void);
+    ~BTreeStore();
 
     const NodeAllocatorType &getAllocator() const { return _allocator; }
 
@@ -153,7 +153,7 @@ public:
     allocKeyDataCopy(const KeyDataType *rhs, uint32_t clusterSize);
 
     std::vector<uint32_t>
-    startCompact(void);
+    startCompact();
 
     void
     finishCompact(const std::vector<uint32_t> &toHold);
@@ -354,7 +354,7 @@ public:
     }
 
     void
-    clearHoldLists(void)
+    clearHoldLists()
     {
         _allocator.clearHoldLists();
         _store.clearHoldLists();
@@ -370,7 +370,7 @@ public:
     }
 
     void
-    clearBuilder(void)
+    clearBuilder()
     {
         _builder.clear();
     }

--- a/searchlib/src/vespa/searchlib/btree/btreestore.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreestore.hpp
@@ -60,7 +60,7 @@ BTreeStore(bool init)
 
 template <typename KeyT, typename DataT, typename AggrT, typename CompareT,
           typename TraitsT, typename AggrCalcT>
-BTreeStore<KeyT, DataT, AggrT, CompareT,TraitsT, AggrCalcT>::~BTreeStore(void)
+BTreeStore<KeyT, DataT, AggrT, CompareT,TraitsT, AggrCalcT>::~BTreeStore()
 {
     _builder.clear();
     _store.dropBuffers();	// Drop buffers before type handlers are dropped
@@ -123,7 +123,7 @@ allocKeyDataCopy(const KeyDataType *rhs, uint32_t clusterSize)
 template <typename KeyT, typename DataT, typename AggrT, typename CompareT,
           typename TraitsT, typename AggrCalcT>
 std::vector<uint32_t>
-BTreeStore<KeyT, DataT, AggrT, CompareT, TraitsT, AggrCalcT>::startCompact(void)
+BTreeStore<KeyT, DataT, AggrT, CompareT, TraitsT, AggrCalcT>::startCompact()
 {
     std::vector<uint32_t> ret = _store.startCompact(clusterLimit);
     for (uint32_t clusterSize = 1; clusterSize <= clusterLimit; ++clusterSize) {

--- a/searchlib/src/vespa/searchlib/btree/minmaxaggrcalc.h
+++ b/searchlib/src/vespa/searchlib/btree/minmaxaggrcalc.h
@@ -10,40 +10,12 @@ namespace btree
 class MinMaxAggrCalc
 {
 public:
-    MinMaxAggrCalc(void)
-    {
-    }
-
-    static bool
-    hasAggregated(void)
-    {
-        return true;
-    }
-
-    static int32_t
-    getVal(int32_t val)
-    {
-        return val;
-    }
-
-    static void
-    add(MinMaxAggregated &a, int32_t val)
-    {
-        a.add(val);
-    }
-
-    static void
-    add(MinMaxAggregated &a, const MinMaxAggregated &ca)
-    {
-        a.add(ca);
-    }
-
-    static void
-    add(MinMaxAggregated &a, const MinMaxAggregated &oldca,
-        const MinMaxAggregated &ca)
-    {
-        a.add(oldca, ca);
-    }
+    MinMaxAggrCalc() { }
+    static bool hasAggregated() { return true; }
+    static int32_t getVal(int32_t val) { return val; }
+    static void add(MinMaxAggregated &a, int32_t val) { a.add(val); }
+    static void add(MinMaxAggregated &a, const MinMaxAggregated &ca) { a.add(ca); }
+    static void add(MinMaxAggregated &a, const MinMaxAggregated &oldca, const MinMaxAggregated &ca) { a.add(oldca, ca); }
 
     /* Returns true if recalculation is needed */
     static bool

--- a/searchlib/src/vespa/searchlib/btree/minmaxaggregated.h
+++ b/searchlib/src/vespa/searchlib/btree/minmaxaggregated.h
@@ -14,7 +14,7 @@ class MinMaxAggregated
     int32_t _max;
     
 public:
-    MinMaxAggregated(void)
+    MinMaxAggregated()
         : _min(std::numeric_limits<int32_t>::max()),
           _max(std::numeric_limits<int32_t>::min())
     { }
@@ -24,8 +24,8 @@ public:
           _max(max)
     { }
 
-    int32_t getMin(void) const { return _min; }
-    int32_t getMax(void) const { return _max; }
+    int32_t getMin() const { return _min; }
+    int32_t getMax() const { return _max; }
 
     void
     add(int32_t val)

--- a/searchlib/src/vespa/searchlib/btree/noaggrcalc.h
+++ b/searchlib/src/vespa/searchlib/btree/noaggrcalc.h
@@ -10,12 +10,12 @@ namespace btree
 class NoAggrCalc
 {
 public:
-    NoAggrCalc(void)
+    NoAggrCalc()
     {
     }
 
     static bool
-    hasAggregated(void)
+    hasAggregated()
     {
         return false;
     }

--- a/searchlib/src/vespa/searchlib/btree/noaggregated.h
+++ b/searchlib/src/vespa/searchlib/btree/noaggregated.h
@@ -10,9 +10,7 @@ namespace btree
 class NoAggregated
 {
 public:
-    NoAggregated(void)
-    {
-    }
+    NoAggregated() { }
 };
 
 

--- a/searchlib/src/vespa/searchlib/common/fileheadercontext.cpp
+++ b/searchlib/src/vespa/searchlib/common/fileheadercontext.cpp
@@ -14,12 +14,12 @@ namespace common
 
 using vespalib::GenericHeader;
 
-FileHeaderContext::FileHeaderContext(void)
+FileHeaderContext::FileHeaderContext()
 {
 }
 
 
-FileHeaderContext::~FileHeaderContext(void)
+FileHeaderContext::~FileHeaderContext()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/common/fileheadercontext.h
+++ b/searchlib/src/vespa/searchlib/common/fileheadercontext.h
@@ -19,10 +19,10 @@ namespace common
 class FileHeaderContext
 {
 public:
-    FileHeaderContext(void);
+    FileHeaderContext();
 
     virtual
-    ~FileHeaderContext(void);
+    ~FileHeaderContext();
 
     virtual void
     addTags(vespalib::GenericHeader &header,

--- a/searchlib/src/vespa/searchlib/common/location.cpp
+++ b/searchlib/src/vespa/searchlib/common/location.cpp
@@ -7,7 +7,7 @@
 namespace search {
 namespace common {
 
-Location::Location(void) :
+Location::Location() :
       _zBoundingBox(0,0,0,0),
       _x(0),
       _y(0),

--- a/searchlib/src/vespa/searchlib/common/location.h
+++ b/searchlib/src/vespa/searchlib/common/location.h
@@ -17,7 +17,7 @@ private:
     bool getDimensionality(const char **pp);
 
 public:
-    Location(void);
+    Location();
     bool getRankOnDistance()       const { return _rankOnDistance; }
     bool getPruneOnDistance()      const { return _pruneOnDistance; }
     uint32_t getXAspect()          const { return _xAspect; }

--- a/searchlib/src/vespa/searchlib/common/partialbitvector.h
+++ b/searchlib/src/vespa/searchlib/common/partialbitvector.h
@@ -27,7 +27,7 @@ public:
     PartialBitVector(Index start, Index end);
     PartialBitVector(const BitVector & org, Index start, Index end);
 
-    virtual ~PartialBitVector(void);
+    virtual ~PartialBitVector();
 
 private:
     vespalib::alloc::Alloc  _alloc;

--- a/searchlib/src/vespa/searchlib/common/resultset.cpp
+++ b/searchlib/src/vespa/searchlib/common/resultset.cpp
@@ -13,7 +13,7 @@ namespace search {
 //Above 32M we hand back to the OS directly.
 constexpr size_t MMAP_LIMIT = 0x2000000;
 
-ResultSet::ResultSet(void)
+ResultSet::ResultSet()
     : _elemsUsedInRankedHitsArray(0u),
       _rankedHitsArrayAllocElements(0u),
       _bitOverflow(),
@@ -41,7 +41,7 @@ ResultSet::ResultSet(const ResultSet &other)
 }
 
 
-ResultSet::~ResultSet(void)
+ResultSet::~ResultSet()
 {
 }
 
@@ -78,14 +78,14 @@ ResultSet::setBitOverflow(BitVector::UP newBitOverflow)
 // Find number of hits
 //////////////////////////////////////////////////////////////////////
 unsigned int
-ResultSet::getNumHits(void) const
+ResultSet::getNumHits() const
 {
     return (_bitOverflow) ? _bitOverflow->countTrueBits() : _elemsUsedInRankedHitsArray;
 }
 
 
 void
-ResultSet::mergeWithBitOverflow(void)
+ResultSet::mergeWithBitOverflow()
 {
     if ( ! _bitOverflow) {
         return;

--- a/searchlib/src/vespa/searchlib/common/sortresults.h
+++ b/searchlib/src/vespa/searchlib/common/sortresults.h
@@ -35,7 +35,7 @@ struct FastS_IResultSorter {
     /**
      * Destructor.  No cleanup needed for base class.
      */
-    virtual ~FastS_IResultSorter(void) {}
+    virtual ~FastS_IResultSorter() {}
 
     /**
      * @return should bitvector hits also be sorted?

--- a/searchlib/src/vespa/searchlib/common/tunefileinfo.h
+++ b/searchlib/src/vespa/searchlib/common/tunefileinfo.h
@@ -104,7 +104,7 @@ private:
     int         _mmapFlags;
     int         _advise;
 public:
-    TuneFileRandRead(void)
+    TuneFileRandRead()
         : _tuneControl(NORMAL),
           _mmapFlags(0),
           _advise(0)
@@ -163,7 +163,7 @@ public:
     TuneFileSeqRead _read;
     TuneFileSeqWrite _write;
 
-    TuneFileIndexing(void) : _read(), _write() {}
+    TuneFileIndexing() : _read(), _write() {}
 
     TuneFileIndexing(const TuneFileSeqRead &r, const TuneFileSeqWrite &w) : _read(r), _write(w) { }
 
@@ -222,7 +222,7 @@ class TuneFileAttributes
 public:
     TuneFileSeqWrite _write;
 
-    TuneFileAttributes(void) : _write() { }
+    TuneFileAttributes() : _write() { }
 
     bool operator==(const TuneFileAttributes &rhs) const {
         return _write == rhs._write;
@@ -244,7 +244,7 @@ public:
     TuneFileSeqWrite _write;
     TuneFileRandRead _randRead;
 
-    TuneFileSummary(void) : _seqRead(), _write(), _randRead() { }
+    TuneFileSummary() : _seqRead(), _write(), _randRead() { }
 
     bool operator==(const TuneFileSummary &rhs) const {
         return _seqRead == rhs._seqRead &&

--- a/searchlib/src/vespa/searchlib/datastore/array_store.h
+++ b/searchlib/src/vespa/searchlib/datastore/array_store.h
@@ -97,7 +97,7 @@ public:
     // Pass on hold list management to underlying store
     void transferHoldLists(generation_t generation) { _store.transferHoldLists(generation); }
     void trimHoldLists(generation_t firstUsed) { _store.trimHoldLists(firstUsed); }
-    vespalib::GenerationHolder &getGenerationHolder(void) { return _store.getGenerationHolder(); }
+    vespalib::GenerationHolder &getGenerationHolder() { return _store.getGenerationHolder(); }
     void setInitializing(bool initializing) { _store.setInitializing(initializing); }
 
     // Should only be used for unit testing

--- a/searchlib/src/vespa/searchlib/datastore/buffer_type.cpp
+++ b/searchlib/src/vespa/searchlib/datastore/buffer_type.cpp
@@ -45,7 +45,7 @@ BufferTypeBase::getReservedElements(uint32_t bufferId) const
 }
 
 void
-BufferTypeBase::flushLastUsed(void)
+BufferTypeBase::flushLastUsed()
 {
     if (_lastUsedElems != NULL) {
         _activeUsedElems += *_lastUsedElems;

--- a/searchlib/src/vespa/searchlib/datastore/bufferstate.cpp
+++ b/searchlib/src/vespa/searchlib/datastore/bufferstate.cpp
@@ -8,13 +8,13 @@ using vespalib::alloc::Alloc;
 namespace search {
 namespace datastore {
 
-BufferState::FreeListList::~FreeListList(void)
+BufferState::FreeListList::~FreeListList()
 {
     assert(_head == NULL);	// Owner should have disabled free lists
 }
 
 
-BufferState::BufferState(void)
+BufferState::BufferState()
     : _usedElems(0),
       _allocElems(0),
       _deadElems(0u),
@@ -36,7 +36,7 @@ BufferState::BufferState(void)
 }
 
 
-BufferState::~BufferState(void)
+BufferState::~BufferState()
 {
     assert(_state == FREE);
     assert(_freeListList == NULL);
@@ -86,7 +86,7 @@ BufferState::onActive(uint32_t bufferId, uint32_t typeId,
 
 
 void
-BufferState::onHold(void)
+BufferState::onHold()
 {
     assert(_state == ACTIVE);
     assert(_typeHandler != NULL);
@@ -180,7 +180,7 @@ BufferState::setFreeListList(FreeListList *freeListList)
 
 
 void
-BufferState::addToFreeListList(void)
+BufferState::addToFreeListList()
 {
     assert(_freeListList != NULL && _freeListList->_head != this);
     assert(_nextHasFree == NULL);
@@ -199,7 +199,7 @@ BufferState::addToFreeListList(void)
 
 
 void
-BufferState::removeFromFreeListList(void)
+BufferState::removeFromFreeListList()
 {
     assert(_freeListList != NULL);
     assert(_nextHasFree != NULL);
@@ -220,7 +220,7 @@ BufferState::removeFromFreeListList(void)
 
 
 void
-BufferState::disableElemHoldList(void)
+BufferState::disableElemHoldList()
 {
     _disableElemHoldList = true;
 }

--- a/searchlib/src/vespa/searchlib/datastore/entryref.h
+++ b/searchlib/src/vespa/searchlib/datastore/entryref.h
@@ -11,10 +11,10 @@ class EntryRef {
 protected:
     uint32_t _ref;
 public:
-    EntryRef(void) : _ref(0u) { }
+    EntryRef() : _ref(0u) { }
     EntryRef(uint32_t ref_) : _ref(ref_) { }
-    uint32_t ref(void) const { return _ref; }
-    bool valid(void) const { return _ref != 0u; }
+    uint32_t ref() const { return _ref; }
+    bool valid() const { return _ref != 0u; }
     bool operator==(const EntryRef &rhs) const { return _ref == rhs._ref; }
     bool operator!=(const EntryRef &rhs) const { return _ref != rhs._ref; }
     bool operator <(const EntryRef &rhs) const { return _ref < rhs._ref; }

--- a/searchlib/src/vespa/searchlib/datastore/unique_store.h
+++ b/searchlib/src/vespa/searchlib/datastore/unique_store.h
@@ -104,7 +104,7 @@ public:
     // Pass on hold list management to underlying store
     void transferHoldLists(generation_t generation);
     void trimHoldLists(generation_t firstUsed);
-    vespalib::GenerationHolder &getGenerationHolder(void) { return _store.getGenerationHolder(); }
+    vespalib::GenerationHolder &getGenerationHolder() { return _store.getGenerationHolder(); }
     void setInitializing(bool initializing) { _store.setInitializing(initializing); }
     void freeze();
     uint32_t getNumUniques() const;

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
@@ -46,7 +46,7 @@ BitVectorFileWrite::BitVectorFileWrite(BitVectorKeyScope scope)
 }
 
 
-BitVectorFileWrite::~BitVectorFileWrite(void)
+BitVectorFileWrite::~BitVectorFileWrite()
 {
     // No implicit close() call, but cleanup memory allocations.
     delete _datFile;
@@ -167,7 +167,7 @@ BitVectorFileWrite::addWordSingle(uint64_t wordNum,
 
 
 void
-BitVectorFileWrite::flush(void)
+BitVectorFileWrite::flush()
 {
     Parent::flush();
     _datFile->Flush();
@@ -175,7 +175,7 @@ BitVectorFileWrite::flush(void)
 
 
 void
-BitVectorFileWrite::sync(void)
+BitVectorFileWrite::sync()
 {
     flush();
     Parent::syncCommon();
@@ -184,7 +184,7 @@ BitVectorFileWrite::sync(void)
 
 
 void
-BitVectorFileWrite::close(void)
+BitVectorFileWrite::close()
 {
     size_t bitmapbytes = BitVector::getFileBytes(_docIdLimit);
 

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.h
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.h
@@ -36,7 +36,7 @@ private:
 public:
     BitVectorFileWrite(BitVectorKeyScope scope);
 
-    ~BitVectorFileWrite(void);
+    ~BitVectorFileWrite();
 
     /**
      * Checkpoint write.  Used at semi-regular intervals during indexing
@@ -63,13 +63,13 @@ public:
     addWordSingle(uint64_t wordNum, const BitVector &bitVector);
 
     void
-    flush(void);
+    flush();
 
     void
-    sync(void);
+    sync();
 
     void
-    close(void);
+    close();
 
     void
     makeDatHeader(const common::FileHeaderContext &fileHeaderContext);
@@ -113,7 +113,7 @@ public:
     ~BitVectorCandidate();
 
     void
-    clear(void)
+    clear()
     {
         if (__builtin_expect(_numDocs > _bitVectorLimit, false)) {
             _bv->clear();
@@ -156,13 +156,13 @@ public:
      * Get number of documents buffered.  This might include duplicates.
      */
     uint64_t
-    getNumDocs(void) const
+    getNumDocs() const
     {
         return _numDocs;
     }
 
     bool
-    empty(void) const
+    empty() const
     {
         return _numDocs == 0;
     }
@@ -172,13 +172,13 @@ public:
      * populated.
      */
     bool
-    getCrossedBitVectorLimit(void) const
+    getCrossedBitVectorLimit() const
     {
         return _numDocs > _bitVectorLimit;
     }
 
     BitVector &
-    getBitVector(void)
+    getBitVector()
     {
         return *_bv;
     }

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
@@ -48,7 +48,7 @@ BitVectorIdxFileWrite::BitVectorIdxFileWrite(BitVectorKeyScope scope)
 }
 
 
-BitVectorIdxFileWrite::~BitVectorIdxFileWrite(void)
+BitVectorIdxFileWrite::~BitVectorIdxFileWrite()
 {
     // No implicit close() call, but cleanup memory allocations.
     delete _idxFile;
@@ -56,7 +56,7 @@ BitVectorIdxFileWrite::~BitVectorIdxFileWrite(void)
 
 
 uint64_t
-BitVectorIdxFileWrite::idxSize(void) const
+BitVectorIdxFileWrite::idxSize() const
 {
     return _idxHeaderLen +
         static_cast<int64_t>(_numKeys) * sizeof(BitVectorWordSingleKey);
@@ -186,7 +186,7 @@ BitVectorIdxFileWrite::addWordSingle(uint64_t wordNum, uint32_t numDocs)
 
 
 void
-BitVectorIdxFileWrite::flush(void)
+BitVectorIdxFileWrite::flush()
 {
     _idxFile->Flush();
 
@@ -204,7 +204,7 @@ BitVectorIdxFileWrite::syncCommon()
 
 
 void
-BitVectorIdxFileWrite::sync(void)
+BitVectorIdxFileWrite::sync()
 {
     flush();
     syncCommon();
@@ -212,7 +212,7 @@ BitVectorIdxFileWrite::sync(void)
 
 
 void
-BitVectorIdxFileWrite::close(void)
+BitVectorIdxFileWrite::close()
 {
     if (_idxFile != NULL) {
         if (_idxFile->IsOpened()) {

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.h
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.h
@@ -49,18 +49,14 @@ protected:
     uint32_t _idxHeaderLen;
     BitVectorKeyScope _scope;
 
-    uint64_t
-    idxSize(void) const;
-
-    void
-    checkPointWriteCommon(vespalib::nbostream &out);
-
+    uint64_t idxSize() const;
+    void checkPointWriteCommon(vespalib::nbostream &out);
     void syncCommon();
 
 public:
     BitVectorIdxFileWrite(BitVectorKeyScope scope);
 
-    ~BitVectorIdxFileWrite(void);
+    ~BitVectorIdxFileWrite();
 
     /**
      * Checkpoint write.  Used at semi-regular intervals during indexing
@@ -88,13 +84,13 @@ public:
     addWordSingle(uint64_t wordNum, uint32_t numDocs);
 
     void
-    flush(void);
+    flush();
 
     void
-    sync(void);
+    sync();
 
     void
-    close(void);
+    close();
 
     static uint32_t
     getBitVectorLimit(uint32_t docIdLimit)

--- a/searchlib/src/vespa/searchlib/diskindex/dictionarywordreader.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/dictionarywordreader.cpp
@@ -17,7 +17,7 @@ namespace diskindex
 using vespalib::getLastErrorString;
 using index::SchemaUtil;
 
-DictionaryWordReader::DictionaryWordReader(void)
+DictionaryWordReader::DictionaryWordReader()
     : _word(),
       _wordNum(noWordNumHigh()),
       _old2newwordfile(),
@@ -26,7 +26,7 @@ DictionaryWordReader::DictionaryWordReader(void)
 }
 
 
-DictionaryWordReader::~DictionaryWordReader(void)
+DictionaryWordReader::~DictionaryWordReader()
 {
 }
 
@@ -56,7 +56,7 @@ DictionaryWordReader::open(const vespalib::stringref &dictionaryName,
 }
 
 void
-DictionaryWordReader::close(void)
+DictionaryWordReader::close()
 {
     if (!_dictFile->close())
         LOG(error, "Error closing input dictionary");

--- a/searchlib/src/vespa/searchlib/diskindex/dictionarywordreader.h
+++ b/searchlib/src/vespa/searchlib/diskindex/dictionarywordreader.h
@@ -64,27 +64,27 @@ private:
     std::unique_ptr<DictionaryFileSeqRead> _dictFile;
 
     void
-    allocFiles(void);
+    allocFiles();
 
     static uint64_t
-    noWordNumHigh(void)
+    noWordNumHigh()
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
     static uint64_t
-    noWordNum(void)
+    noWordNum()
     {
         return 0u;
     }
 
 public:
-    DictionaryWordReader(void);
+    DictionaryWordReader();
 
-    ~DictionaryWordReader(void);
+    ~DictionaryWordReader();
 
     bool
-    isValid(void) const
+    isValid() const
     {
         return _wordNum != noWordNumHigh();
     }
@@ -100,7 +100,7 @@ public:
     }
 
     void
-    read(void)
+    read()
     {
         _dictFile->readWord(_word, _wordNum, _counts);
     }
@@ -111,7 +111,7 @@ public:
          const TuneFileSeqRead &tuneFileRead);
 
     void
-    close(void);
+    close();
 
     void
     writeNewWordNum(uint64_t newWordNum)

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
@@ -61,7 +61,7 @@ DiskIndex::DiskIndex(const vespalib::string &indexDir, size_t cacheSize)
 DiskIndex::~DiskIndex() {}
 
 bool
-DiskIndex::loadSchema(void)
+DiskIndex::loadSchema()
 {
     vespalib::string schemaName = _indexDir + "/schema.txt";
     if (!_schema.loadFromFile(schemaName)) {

--- a/searchlib/src/vespa/searchlib/diskindex/docidmapper.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/docidmapper.cpp
@@ -18,7 +18,7 @@ namespace diskindex
 {
 
 
-DocIdMapping::DocIdMapping(void)
+DocIdMapping::DocIdMapping()
     : _docIdLimit(0u),
       _selector(NULL),
       _selectorId(0)
@@ -27,7 +27,7 @@ DocIdMapping::DocIdMapping(void)
 
 
 void
-DocIdMapping::clear(void)
+DocIdMapping::clear()
 {
     _docIdLimit = 0;
     _selector = NULL;

--- a/searchlib/src/vespa/searchlib/diskindex/fieldreader.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/fieldreader.cpp
@@ -32,7 +32,7 @@ namespace diskindex
 {
 
 
-FieldReader::FieldReader(void)
+FieldReader::FieldReader()
     : _wordNum(noWordNumHigh()),
       _docIdAndFeatures(),
       _dictFile(),
@@ -48,13 +48,13 @@ FieldReader::FieldReader(void)
 }
 
 
-FieldReader::~FieldReader(void)
+FieldReader::~FieldReader()
 {
 }
 
 
 void
-FieldReader::readCounts(void)
+FieldReader::readCounts()
 {
     PostingListCounts counts;
     _dictFile->readWord(_word, _oldWordNum, counts);
@@ -70,7 +70,7 @@ FieldReader::readCounts(void)
 
 
 void
-FieldReader::readDocIdAndFeatures(void)
+FieldReader::readDocIdAndFeatures()
 {
     _oldposoccfile->readDocIdAndFeatures(_docIdAndFeatures);
     _docIdAndFeatures._docId = _docIdMapper.mapDocId(_docIdAndFeatures._docId);
@@ -78,7 +78,7 @@ FieldReader::readDocIdAndFeatures(void)
 
 
 void
-FieldReader::read(void)
+FieldReader::read()
 {
     for (;;) {
         while (_residue == 0) {
@@ -98,7 +98,7 @@ FieldReader::read(void)
 
 
 bool
-FieldReader::allowRawFeatures(void)
+FieldReader::allowRawFeatures()
 {
     return true;
 }
@@ -182,7 +182,7 @@ FieldReader::open(const vespalib::string &prefix,
 
 
 bool
-FieldReader::close(void)
+FieldReader::close()
 {
     bool ret = true;
 
@@ -320,14 +320,14 @@ FieldReaderStripInfo::FieldReaderStripInfo(const IndexIterator &index)
 
 
 bool
-FieldReaderStripInfo::allowRawFeatures(void)
+FieldReaderStripInfo::allowRawFeatures()
 {
     return false;
 }
 
 
 void
-FieldReaderStripInfo::read(void)
+FieldReaderStripInfo::read()
 {
     typedef search::index::WordDocElementFeatures Element;
 

--- a/searchlib/src/vespa/searchlib/diskindex/fieldreader.h
+++ b/searchlib/src/vespa/searchlib/diskindex/fieldreader.h
@@ -60,34 +60,34 @@ protected:
     vespalib::string _word;
 
     static uint64_t
-    noWordNumHigh(void)
+    noWordNumHigh()
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
     static uint64_t
-    noWordNum(void)
+    noWordNum()
     {
         return 0u;
     }
 
     void
-    readCounts(void);
+    readCounts();
 
     void
-    readDocIdAndFeatures(void);
+    readDocIdAndFeatures();
 
 public:
-    FieldReader(void);
+    FieldReader();
 
     virtual
-    ~FieldReader(void);
+    ~FieldReader();
 
     virtual void
-    read(void);
+    read();
 
     virtual bool
-    allowRawFeatures(void);
+    allowRawFeatures();
 
     void
     write(FieldWriter &writer)
@@ -99,7 +99,7 @@ public:
     }
 
     bool
-    isValid(void) const
+    isValid() const
     {
         return _wordNum != noWordNumHigh();
     }
@@ -128,7 +128,7 @@ public:
     open(const vespalib::string &prefix, const TuneFileSeqRead &tuneFileRead);
 
     virtual bool
-    close(void);
+    close();
 
     /*
      * To be called between words, not in the middle of one.
@@ -149,7 +149,7 @@ public:
     getFeatureParams(PostingListParams &params);
 
     uint32_t
-    getDocIdLimit(void) const
+    getDocIdLimit() const
     {
         return _docIdLimit;
     }
@@ -200,10 +200,10 @@ public:
     FieldReaderStripInfo(const IndexIterator &index);
 
     virtual bool
-    allowRawFeatures(void) override;
+    allowRawFeatures() override;
 
     virtual void
-    read(void) override;
+    read() override;
 
     virtual void
     getFeatureParams(PostingListParams &params) override;

--- a/searchlib/src/vespa/searchlib/diskindex/fieldwriter.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/fieldwriter.cpp
@@ -113,7 +113,7 @@ FieldWriter::lateOpen(const TuneFileSeqWrite &tuneFileWrite,
 
 
 void
-FieldWriter::flush(void)
+FieldWriter::flush()
 {
     _posoccfile->flushWord();
     PostingListCounts &counts = _posoccfile->getCounts();
@@ -155,7 +155,7 @@ FieldWriter::newWord(const vespalib::stringref &word)
 
 
 bool
-FieldWriter::close(void)
+FieldWriter::close()
 {
     bool ret = true;
     flush();

--- a/searchlib/src/vespa/searchlib/diskindex/fieldwriter.h
+++ b/searchlib/src/vespa/searchlib/diskindex/fieldwriter.h
@@ -32,7 +32,7 @@ private:
     uint64_t _wordNum;
     uint32_t _prevDocId;
 
-    static uint64_t noWordNum(void) { return 0u; }
+    static uint64_t noWordNum() { return 0u; }
 public:
 
     using DictionaryFileSeqWrite = index::DictionaryFileSeqWrite;

--- a/searchlib/src/vespa/searchlib/diskindex/fileheader.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/fileheader.cpp
@@ -17,7 +17,7 @@ namespace diskindex
 
 using bitcompression::FeatureDecodeContextBE;
 
-FileHeader::FileHeader(void)
+FileHeader::FileHeader()
     : _bigEndian(false),
       _hostEndian(false),
       _completed(false),
@@ -30,7 +30,7 @@ FileHeader::FileHeader(void)
 }
 
 
-FileHeader::~FileHeader(void)
+FileHeader::~FileHeader()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/diskindex/fileheader.h
+++ b/searchlib/src/vespa/searchlib/diskindex/fileheader.h
@@ -25,9 +25,9 @@ private:
     std::vector<vespalib::string> _formats;
 
 public:
-    FileHeader(void);
+    FileHeader();
 
-    ~FileHeader(void);
+    ~FileHeader();
 
     bool
     taste(const vespalib::string &name,
@@ -42,31 +42,31 @@ public:
           const TuneFileRandRead &tuneFileSearch);
 
     bool
-    getBigEndian(void) const
+    getBigEndian() const
     {
         return _bigEndian;
     }
 
     bool
-    getHostEndian(void) const
+    getHostEndian() const
     {
         return _hostEndian;
     }
 
     uint32_t
-    getVersion(void) const
+    getVersion() const
     {
         return _version;
     }
 
     uint32_t
-    getHeaderLen(void) const
+    getHeaderLen() const
     {
         return _headerLen;
     }
 
     const std::vector<vespalib::string> &
-    getFormats(void) const
+    getFormats() const
     {
         return _formats;
     }

--- a/searchlib/src/vespa/searchlib/diskindex/fusion.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/fusion.cpp
@@ -446,7 +446,7 @@ Fusion::makeTmpDirs()
 }
 
 bool
-Fusion::CleanTmpDirs(void)
+Fusion::CleanTmpDirs()
 {
     uint32_t i = 0;
     for (;;) {
@@ -483,14 +483,14 @@ Fusion::CleanTmpDirs(void)
 
 
 bool
-Fusion::checkSchemaCompat(void)
+Fusion::checkSchemaCompat()
 {
     return true;
 }
 
 
 bool
-Fusion::readSchemaFiles(void)
+Fusion::readSchemaFiles()
 {
     OldIndexIterator oldIndexIt = _oldIndexes.begin();
     OldIndexIterator oldIndexIte = _oldIndexes.end();

--- a/searchlib/src/vespa/searchlib/diskindex/fusion.h
+++ b/searchlib/src/vespa/searchlib/diskindex/fusion.h
@@ -45,7 +45,7 @@ private:
     index::Schema::SP _schema;
 
 public:
-    FusionInputIndex(void)
+    FusionInputIndex()
         : _path(),
           _wordNumMapping(),
           _docIdMapping(),
@@ -55,7 +55,7 @@ public:
     }
 
     virtual
-    ~FusionInputIndex(void)
+    ~FusionInputIndex()
     {
     }
 
@@ -66,7 +66,7 @@ public:
     }
 
     const vespalib::string &
-    getPath(void) const
+    getPath() const
     {
         return _path;
     }
@@ -78,37 +78,37 @@ public:
     }
 
     const vespalib::string &
-    getTmpPath(void) const
+    getTmpPath() const
     {
         return _tmpPath;
     }
 
     const WordNumMapping &
-    getWordNumMapping(void) const
+    getWordNumMapping() const
     {
         return _wordNumMapping;
     }
 
     WordNumMapping &
-    getWordNumMapping(void)
+    getWordNumMapping()
     {
         return _wordNumMapping;
     }
 
     const DocIdMapping &
-    getDocIdMapping(void) const
+    getDocIdMapping() const
     {
         return _docIdMapping;
     }
 
     DocIdMapping &
-    getDocIdMapping(void)
+    getDocIdMapping()
     {
         return _docIdMapping;
     }
 
     const index::Schema &
-    getSchema(void) const
+    getSchema() const
     {
         assert(_schema.get() != NULL);
         return *_schema.get();
@@ -135,7 +135,7 @@ public:
            const search::common::FileHeaderContext &fileHeaderContext);
 
     virtual
-    ~Fusion(void);
+    ~Fusion();
 
     void SetOldIndexList(const std::vector<vespalib::string> &oldIndexList);
 
@@ -166,13 +166,13 @@ public:
 
     void makeTmpDirs();
 
-    bool CleanTmpDirs(void);
+    bool CleanTmpDirs();
 
     bool
-    readSchemaFiles(void);
+    readSchemaFiles();
 
     bool
-    checkSchemaCompat(void);
+    checkSchemaCompat();
 
     template <class Reader, class Writer>
     static bool
@@ -182,7 +182,7 @@ protected:
     bool ReadMappingFiles(const SchemaUtil::IndexIterator *index);
     bool ReleaseMappingTables();
 
-    static unsigned int noGen(void)
+    static unsigned int noGen()
     {
         return static_cast<unsigned int>(-1);
     }
@@ -215,7 +215,7 @@ protected:
     const search::common::FileHeaderContext &_fileHeaderContext;
 
     const Schema &
-    getSchema(void) const
+    getSchema() const
     {
         assert(_schema != NULL);
         return *_schema;
@@ -235,13 +235,13 @@ public:
     }
 
     std::vector<std::shared_ptr<OldIndex> > &
-    getOldIndexes(void)
+    getOldIndexes()
     {
         return _oldIndexes;
     }
 
     virtual OldIndex *
-    allocOldIndex(void)
+    allocOldIndex()
     {
         return new OldIndex;
     }

--- a/searchlib/src/vespa/searchlib/diskindex/indexbuilder.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/indexbuilder.cpp
@@ -29,7 +29,7 @@ using index::schema::DataType;
 using vespalib::getLastErrorString;
 
 static uint32_t
-noWordPos(void)
+noWordPos()
 {
     return std::numeric_limits<uint32_t>::max();
 }
@@ -41,9 +41,9 @@ public:
     FieldWriter *_fieldWriter;
     DocIdAndFeatures _docIdAndFeatures;
 
-    FileHandle(void);
+    FileHandle();
 
-    ~FileHandle(void);
+    ~FileHandle();
 
     void
     open(const vespalib::stringref &dir,
@@ -53,7 +53,7 @@ public:
          const FileHeaderContext &fileHeaderContext);
 
     void
-    close(void);
+    close();
 };
 
 
@@ -73,16 +73,16 @@ public:
                 uint32_t fieldId,
                 IndexBuilder *ib);
 
-    ~FieldHandle(void);
+    ~FieldHandle();
 
     static uint32_t
-    noDocRef(void)
+    noDocRef()
     {
         return std::numeric_limits<uint32_t>::max();
     }
 
     static uint32_t
-    noElRef(void)
+    noElRef()
     {
         return std::numeric_limits<uint32_t>::max();
     }
@@ -100,19 +100,19 @@ public:
         }
 
         uint32_t
-        getDocId(void) const
+        getDocId() const
         {
             return _docId;
         }
 
         uint32_t
-        getNumElements(void) const
+        getNumElements() const
         {
             return _numElements;
         }
 
         void
-        incNumElements(void)
+        incNumElements()
         {
             ++_numElements;
         }
@@ -175,13 +175,13 @@ public:
     startWord(const vespalib::stringref &word);
 
     void
-    endWord(void);
+    endWord();
 
     void
     startDocument(uint32_t docId);
 
     void
-    endDocument(void);
+    endDocument();
 
     void
     startElement(uint32_t elementId,
@@ -189,31 +189,31 @@ public:
                  uint32_t elementLen);
 
     void
-    endElement(void);
+    endElement();
 
     void
     addOcc(const WordDocElementWordPosFeatures &features);
 
     void
-    setValid(void)
+    setValid()
     {
         _valid = true;
     }
 
     bool
-    getValid(void) const
+    getValid() const
     {
         return _valid;
     }
 
     const Schema::IndexField &
-    getSchemaField(void);
+    getSchemaField();
 
     const vespalib::string &
-    getName(void);
+    getName();
 
     vespalib::string
-    getDir(void);
+    getDir();
 
     void
     open(uint32_t docIdLimit, uint64_t numWordIds,
@@ -221,10 +221,10 @@ public:
          const FileHeaderContext &fileHeaderContext);
 
     void
-    close(void);
+    close();
 
     uint32_t
-    getIndexId(void) const
+    getIndexId() const
     {
         return _fieldId;
     }
@@ -250,7 +250,7 @@ public:
     appendFeatures(DocIdAndFeatures &features);
 
     bool
-    isValid(void) const
+    isValid() const
     {
         return _dFeatures != _dFeaturesE;
     }
@@ -268,14 +268,14 @@ public:
 }
 
 
-FileHandle::FileHandle(void)
+FileHandle::FileHandle()
     : _fieldWriter(NULL),
       _docIdAndFeatures()
 {
 }
 
 
-FileHandle::~FileHandle(void)
+FileHandle::~FileHandle()
 {
     delete _fieldWriter;
 }
@@ -307,7 +307,7 @@ FileHandle::open(const vespalib::stringref &dir,
 
 
 void
-FileHandle::close(void)
+FileHandle::close()
 {
     bool ret = true;
     if (_fieldWriter != NULL) {
@@ -344,7 +344,7 @@ IndexBuilder::FieldHandle::FieldHandle(const Schema &schema,
 }
 
 
-IndexBuilder::FieldHandle::~FieldHandle(void)
+IndexBuilder::FieldHandle::~FieldHandle()
 {
 }
 
@@ -389,7 +389,7 @@ IndexBuilder::FieldHandle::startDocument(uint32_t docId)
 
 
 void
-IndexBuilder::FieldHandle::endDocument(void)
+IndexBuilder::FieldHandle::endDocument()
 {
     assert(_docRef != noDocRef());
     assert(_elRef == noElRef());
@@ -423,7 +423,7 @@ startElement(uint32_t elementId,
 
 
 void
-IndexBuilder::FieldHandle::endElement(void)
+IndexBuilder::FieldHandle::endElement()
 {
     assert(_elRef != noElRef());
     FHWordDocElementFeatures &ef = _wdfef[_elRef];
@@ -451,14 +451,14 @@ addOcc(const WordDocElementWordPosFeatures &features)
 
 
 const Schema::IndexField &
-IndexBuilder::FieldHandle::getSchemaField(void)
+IndexBuilder::FieldHandle::getSchemaField()
 {
     return _schema->getIndexField(_fieldId);
 }
 
 
 const vespalib::string &
-IndexBuilder::FieldHandle::getName(void)
+IndexBuilder::FieldHandle::getName()
 {
     return getSchemaField().getName();
 
@@ -466,7 +466,7 @@ IndexBuilder::FieldHandle::getName(void)
 
 
 vespalib::string
-IndexBuilder::FieldHandle::getDir(void)
+IndexBuilder::FieldHandle::getDir()
 {
     return _ib->appendToPrefix(getName());
 }
@@ -484,7 +484,7 @@ IndexBuilder::FieldHandle::open(uint32_t docIdLimit, uint64_t numWordIds,
 
 
 void
-IndexBuilder::FieldHandle::close(void)
+IndexBuilder::FieldHandle::close()
 {
     _files.close();
 }
@@ -551,7 +551,7 @@ IndexBuilder::IndexBuilder(const Schema &schema)
 }
 
 
-IndexBuilder::~IndexBuilder(void)
+IndexBuilder::~IndexBuilder()
 {
 }
 
@@ -569,7 +569,7 @@ IndexBuilder::startWord(const vespalib::stringref &word)
 
 
 void
-IndexBuilder::endWord(void)
+IndexBuilder::endWord()
 {
     assert(_inWord);
     assert(_currentField != NULL);
@@ -593,7 +593,7 @@ IndexBuilder::startDocument(uint32_t docId)
 
 
 void
-IndexBuilder::endDocument(void)
+IndexBuilder::endDocument()
 {
     assert(_curDocId != noDocId());
     assert(_currentField != NULL);
@@ -616,7 +616,7 @@ IndexBuilder::startField(uint32_t fieldId)
 
 
 void
-IndexBuilder::endField(void)
+IndexBuilder::endField()
 {
     assert(_curDocId == noDocId());
     assert(!_inWord);
@@ -637,7 +637,7 @@ IndexBuilder::startElement(uint32_t elementId,
 
 
 void
-IndexBuilder::endElement(void)
+IndexBuilder::endElement()
 {
     assert(_currentField != NULL);
     _currentField->endElement();
@@ -698,7 +698,7 @@ IndexBuilder::open(uint32_t docIdLimit, uint64_t numWordIds,
 
 
 void
-IndexBuilder::close(void)
+IndexBuilder::close()
 {
     // TODO: Filter for text indexes
     for (FieldHandle & fh : _fields) {

--- a/searchlib/src/vespa/searchlib/diskindex/indexbuilder.h
+++ b/searchlib/src/vespa/searchlib/diskindex/indexbuilder.h
@@ -36,11 +36,11 @@ private:
 
     const Schema &_schema;	// Ptr to allow being std::vector member
 
-    static uint32_t noDocId(void) {
+    static uint32_t noDocId() {
         return std::numeric_limits<uint32_t>::max();
     }
 
-    static uint64_t noWordNumHigh(void) {
+    static uint64_t noWordNumHigh() {
         return std::numeric_limits<uint64_t>::max();
     }
 
@@ -49,16 +49,16 @@ public:
 
     // schema argument must live until indexbuilder has been deleted.
     IndexBuilder(const Schema &schema); 
-    virtual ~IndexBuilder(void);
+    virtual ~IndexBuilder();
 
-    virtual void startWord(const vespalib::stringref &word) override; 
-    virtual void endWord(void) override; 
-    virtual void startDocument(uint32_t docId) override; 
-    virtual void endDocument(void) override; 
-    virtual void startField(uint32_t fieldId) override; 
-    virtual void endField(void) override; 
+    virtual void startWord(const vespalib::stringref &word) override;
+    virtual void endWord() override;
+    virtual void startDocument(uint32_t docId) override;
+    virtual void endDocument() override;
+    virtual void startField(uint32_t fieldId) override;
+    virtual void endField() override;
     virtual void startElement(uint32_t elementId, int32_t weight, uint32_t elementLen) override;
-    virtual void endElement(void) override; 
+    virtual void endElement() override;
     virtual void addOcc(const WordDocElementWordPosFeatures &features) override;
 
     // TODO: methods for attribute vectors.
@@ -74,7 +74,7 @@ public:
          const TuneFileIndexing &tuneFileIndexing,
          const search::common::FileHeaderContext &fileHandleContext);
 
-    void close(void);
+    void close();
 };
 
 } // namespace diskindex

--- a/searchlib/src/vespa/searchlib/diskindex/pagedict4file.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/pagedict4file.cpp
@@ -48,7 +48,7 @@ const uint32_t headerAlign = 4096;
 
 }
 
-PageDict4FileSeqRead::PageDict4FileSeqRead(void)
+PageDict4FileSeqRead::PageDict4FileSeqRead()
     : _pReader(NULL),
       _ssReader(NULL),
       _ssd(),
@@ -78,7 +78,7 @@ PageDict4FileSeqRead::PageDict4FileSeqRead(void)
 }
 
 
-PageDict4FileSeqRead::~PageDict4FileSeqRead(void)
+PageDict4FileSeqRead::~PageDict4FileSeqRead()
 {
     delete _pReader;
     delete _ssReader;
@@ -120,7 +120,7 @@ PageDict4FileSeqRead::readSSHeader()
 
 
 void
-PageDict4FileSeqRead::readSPHeader(void)
+PageDict4FileSeqRead::readSPHeader()
 {
     DC &spd = _spd;
 
@@ -145,7 +145,7 @@ PageDict4FileSeqRead::readSPHeader(void)
 
 
 void
-PageDict4FileSeqRead::readPHeader(void)
+PageDict4FileSeqRead::readPHeader()
 {
     DC &pd = _pd;
 
@@ -284,7 +284,7 @@ PageDict4FileSeqRead::open(const vespalib::string &name,
 
 
 bool
-PageDict4FileSeqRead::close(void)
+PageDict4FileSeqRead::close()
 {
     delete _pReader;
     delete _ssReader;
@@ -350,7 +350,7 @@ PageDict4FileSeqRead::getParams(PostingListParams &params)
 }
 
 
-PageDict4FileSeqWrite::PageDict4FileSeqWrite(void)
+PageDict4FileSeqWrite::PageDict4FileSeqWrite()
     : _pWriter(NULL),
       _spWriter(NULL),
       _ssWriter(NULL),
@@ -373,7 +373,7 @@ PageDict4FileSeqWrite::PageDict4FileSeqWrite(void)
 }
 
 
-PageDict4FileSeqWrite::~PageDict4FileSeqWrite(void)
+PageDict4FileSeqWrite::~PageDict4FileSeqWrite()
 {
     delete _pWriter;
     delete _spWriter;
@@ -484,7 +484,7 @@ PageDict4FileSeqWrite::open(const vespalib::string &name,
 
 
 bool
-PageDict4FileSeqWrite::close(void)
+PageDict4FileSeqWrite::close()
 {
     _pWriter->flush();
     uint64_t usedPBits = _pe.getWriteOffset();

--- a/searchlib/src/vespa/searchlib/diskindex/pagedict4file.h
+++ b/searchlib/src/vespa/searchlib/diskindex/pagedict4file.h
@@ -64,17 +64,17 @@ class PageDict4FileSeqRead : public index::DictionaryFileSeqRead
     readSSHeader();
 
     void
-    readSPHeader(void);
+    readSPHeader();
 
     void
-    readPHeader(void);
+    readPHeader();
 
 public:
 
-    PageDict4FileSeqRead(void);
+    PageDict4FileSeqRead();
 
     virtual
-    ~PageDict4FileSeqRead(void);
+    ~PageDict4FileSeqRead();
 
     /**
      * Read word and counts.  Only nonzero counts are returned. If at
@@ -91,7 +91,7 @@ public:
     /**
      * Close dictionary file.
      */
-    virtual bool close(void) override;
+    virtual bool close() override;
 
     /**
      * Checkpoint write.  Used at semi-regular intervals during indexing
@@ -177,10 +177,10 @@ class PageDict4FileSeqWrite : public index::DictionaryFileSeqWrite
     updateSSHeader(uint64_t fileBitSize);
 
 public:
-    PageDict4FileSeqWrite(void);
+    PageDict4FileSeqWrite();
 
     virtual
-    ~PageDict4FileSeqWrite(void);
+    ~PageDict4FileSeqWrite();
 
     /**
      * Write word and counts.  Only nonzero counts should be supplied.
@@ -202,7 +202,7 @@ public:
      * Close dictionary file.
      */
     virtual bool
-    close(void) override;
+    close() override;
 
     /**
      * Checkpoint write.  Used at semi-regular intervals during indexing

--- a/searchlib/src/vespa/searchlib/diskindex/pagedict4randread.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/pagedict4randread.cpp
@@ -23,7 +23,7 @@ namespace search {
 namespace diskindex {
 
 
-PageDict4RandRead::PageDict4RandRead(void)
+PageDict4RandRead::PageDict4RandRead()
     : DictionaryFileRandRead(),
       _ssReader(),
       _ssd(),
@@ -80,7 +80,7 @@ PageDict4RandRead::readSSHeader()
 
 
 void
-PageDict4RandRead::readSPHeader(void)
+PageDict4RandRead::readSPHeader()
 {
     DC d;
     ComprFileReadContext rc(d);
@@ -113,7 +113,7 @@ PageDict4RandRead::readSPHeader(void)
 
 
 void
-PageDict4RandRead::readPHeader(void)
+PageDict4RandRead::readPHeader()
 {
     DC d;
     ComprFileReadContext rc(d);
@@ -254,7 +254,7 @@ PageDict4RandRead::open(const vespalib::string &name,
 
 
 bool
-PageDict4RandRead::close(void)
+PageDict4RandRead::close()
 {
     _ssReader.reset();
 
@@ -268,7 +268,7 @@ PageDict4RandRead::close(void)
 
 
 uint64_t
-PageDict4RandRead::getNumWordIds(void) const
+PageDict4RandRead::getNumWordIds() const
 {
     return _ssd._numWordIds;
 }

--- a/searchlib/src/vespa/searchlib/diskindex/wordnummapper.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/wordnummapper.cpp
@@ -13,7 +13,7 @@ namespace search
 namespace diskindex
 {
 
-WordNumMapping::WordNumMapping(void)
+WordNumMapping::WordNumMapping()
     : _old2newwords(),
       _oldDictSize(0u)
 {
@@ -46,7 +46,7 @@ WordNumMapping::readMappingFile(const vespalib::string &name,
 
 
 void
-WordNumMapping::noMappingFile(void)
+WordNumMapping::noMappingFile()
 {
     Array &map = _old2newwords;
     map.resize(2);
@@ -57,7 +57,7 @@ WordNumMapping::noMappingFile(void)
 
 
 void
-WordNumMapping::clear(void)
+WordNumMapping::clear()
 {
     Array &map = _old2newwords;
     map.clear();
@@ -90,7 +90,7 @@ WordNumMapper::sanityCheck(bool allowHoles)
 
 
 uint64_t
-WordNumMapping::getMaxMappedWordNum(void) const
+WordNumMapping::getMaxMappedWordNum() const
 {
     WordNumMapper mapper(*this);
     return mapper.getMaxMappedWordNum();

--- a/searchlib/src/vespa/searchlib/diskindex/wordnummapper.h
+++ b/searchlib/src/vespa/searchlib/diskindex/wordnummapper.h
@@ -17,13 +17,13 @@ class WordNumMapping
     typedef vespalib::Array<uint64_t> Array;
 
     static uint64_t
-    noWordNumHigh(void)
+    noWordNumHigh()
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
     static uint64_t
-    noWordNum(void)
+    noWordNum()
     {
         return 0u;
     }
@@ -32,10 +32,10 @@ class WordNumMapping
     uint64_t _oldDictSize;
 public:
 
-    WordNumMapping(void);
+    WordNumMapping();
 
     const uint64_t *
-    getOld2NewWordNums(void) const
+    getOld2NewWordNums() const
     {
         return (_old2newwords.empty())
             ? NULL
@@ -43,7 +43,7 @@ public:
     }
 
     uint64_t
-    getOldDictSize(void) const
+    getOldDictSize() const
     {
         return _oldDictSize;
     }
@@ -53,16 +53,16 @@ public:
                     const TuneFileSeqRead &tuneFileRead);
 
     void
-    noMappingFile(void);
+    noMappingFile();
 
     void
-    clear(void);
+    clear();
 
     void
     setup(uint32_t numWordIds);
 
     uint64_t
-    getMaxMappedWordNum(void) const;
+    getMaxMappedWordNum() const;
 
     void
     sanityCheck(bool allowHoles);
@@ -72,13 +72,13 @@ public:
 class WordNumMapper
 {
     static uint64_t
-    noWordNumHigh(void)
+    noWordNumHigh()
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
     static uint64_t
-    noWordNum(void)
+    noWordNum()
     {
         return 0u;
     }
@@ -87,7 +87,7 @@ class WordNumMapper
     uint64_t _oldDictSize;
 
 public:
-    WordNumMapper(void)
+    WordNumMapper()
         : _old2newwords(NULL),
           _oldDictSize(0)
     {
@@ -116,13 +116,13 @@ public:
     }
 
     uint64_t
-    getMaxWordNum(void) const
+    getMaxWordNum() const
     {
         return _oldDictSize;
     }
 
     uint64_t
-    getMaxMappedWordNum(void) const
+    getMaxMappedWordNum() const
     {
         return map(_oldDictSize);
     }

--- a/searchlib/src/vespa/searchlib/diskindex/zcposocc.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/zcposocc.cpp
@@ -55,7 +55,7 @@ setFeatureParams(const PostingListParams &params)
 
 
 const vespalib::string &
-Zc4PosOccSeqRead::getSubIdentifier(void)
+Zc4PosOccSeqRead::getSubIdentifier()
 {
     PosOccFieldsParams fieldsParams;
     EG2PosOccDecodeContext<true> d(&fieldsParams);
@@ -110,7 +110,7 @@ setFeatureParams(const PostingListParams &params)
 
 
 const vespalib::string &
-ZcPosOccSeqRead::getSubIdentifier(void)
+ZcPosOccSeqRead::getSubIdentifier()
 {
     PosOccFieldsParams fieldsParams;
     EGPosOccDecodeContext<true> d(&fieldsParams);

--- a/searchlib/src/vespa/searchlib/diskindex/zcposocc.h
+++ b/searchlib/src/vespa/searchlib/diskindex/zcposocc.h
@@ -45,7 +45,7 @@ private:
 public:
     ZcPosOccSeqRead(index::PostingListCountFileSeqRead *countFile);
     void setFeatureParams(const PostingListParams &params) override;
-    static const vespalib::string &getSubIdentifier(void);
+    static const vespalib::string &getSubIdentifier();
 };
 
 

--- a/searchlib/src/vespa/searchlib/diskindex/zcposoccrandread.h
+++ b/searchlib/src/vespa/searchlib/diskindex/zcposoccrandread.h
@@ -64,7 +64,7 @@ public:
 class Zc4PosOccRandRead : public ZcPosOccRandRead
 {
 public:
-    Zc4PosOccRandRead(void);
+    Zc4PosOccRandRead();
 
     /**
      * Create iterator for single word.  Semantic lifetime of counts and

--- a/searchlib/src/vespa/searchlib/diskindex/zcposting.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/zcposting.cpp
@@ -57,7 +57,7 @@ ZcBuf::clearReserve(size_t reserveSize)
 
 
 void
-ZcBuf::expand(void)
+ZcBuf::expand()
 {
     size_t newSize = _mallocSize * 2;
     size_t oldSize = size();
@@ -138,7 +138,7 @@ Zc4PostingSeqRead(PostingListCountFileSeqRead *countFile)
 }
 
 
-Zc4PostingSeqRead::~Zc4PostingSeqRead(void)
+Zc4PostingSeqRead::~Zc4PostingSeqRead()
 {
 }
 
@@ -302,7 +302,7 @@ Zc4PostingSeqRead::checkPointRead(nbostream &in)
 
 
 void
-Zc4PostingSeqRead::readWordStartWithSkip(void)
+Zc4PostingSeqRead::readWordStartWithSkip()
 {
     typedef FeatureEncodeContextBE EC;
     DecodeContext &d = *_decodeContext;
@@ -486,7 +486,7 @@ Zc4PostingSeqRead::readWordStartWithSkip(void)
 
 
 void
-Zc4PostingSeqRead::readWordStart(void)
+Zc4PostingSeqRead::readWordStart()
 {
     typedef FeatureEncodeContextBE EC;
     UC64_DECODECONTEXT_CONSTRUCTOR(o, _decodeContext->_);
@@ -591,7 +591,7 @@ Zc4PostingSeqRead::open(const vespalib::string &name,
 
 
 bool
-Zc4PostingSeqRead::close(void)
+Zc4PostingSeqRead::close()
 {
     _readContext.dropComprBuf();
     _file.Close();
@@ -630,7 +630,7 @@ Zc4PostingSeqRead::getFeatureParams(PostingListParams &params)
 
 
 void
-Zc4PostingSeqRead::readHeader(void)
+Zc4PostingSeqRead::readHeader()
 {
     FeatureDecodeContextBE &d = *_decodeContext;
     const vespalib::string &myId = _dynamicK ? myId5 : myId4;
@@ -672,14 +672,14 @@ Zc4PostingSeqRead::readHeader(void)
 
 
 const vespalib::string &
-Zc4PostingSeqRead::getIdentifier(void)
+Zc4PostingSeqRead::getIdentifier()
 {
     return myId4;
 }
 
 
 uint64_t
-Zc4PostingSeqRead::getCurrentPostingOffset(void) const
+Zc4PostingSeqRead::getCurrentPostingOffset() const
 {
     FeatureDecodeContextBE &d = *_decodeContext;
     return d.getReadOffset() - _headerBitLen;
@@ -743,7 +743,7 @@ Zc4PostingSeqWrite(PostingListCountFileSeqWrite *countFile)
 }
 
 
-Zc4PostingSeqWrite::~Zc4PostingSeqWrite(void)
+Zc4PostingSeqWrite::~Zc4PostingSeqWrite()
 {
 }
 
@@ -765,7 +765,7 @@ writeDocIdAndFeatures(const DocIdAndFeatures &features)
 
 
 void
-Zc4PostingSeqWrite::flushWord(void)
+Zc4PostingSeqWrite::flushWord()
 {
     if (__builtin_expect(_docIds.size() >= _minSkipDocs ||
                          !_counts._segments.empty(), false)) {
@@ -904,7 +904,7 @@ Zc4PostingSeqWrite::makeHeader(const FileHeaderContext &fileHeaderContext)
 
 
 void
-Zc4PostingSeqWrite::updateHeader(void)
+Zc4PostingSeqWrite::updateHeader()
 {
     vespalib::FileHeader h;
     FastOS_File f;
@@ -978,7 +978,7 @@ Zc4PostingSeqWrite::open(const vespalib::string &name,
 
 
 bool
-Zc4PostingSeqWrite::close(void)
+Zc4PostingSeqWrite::close()
 {
     EncodeContext &e = _encodeContext;
 
@@ -1059,7 +1059,7 @@ getFeatureParams(PostingListParams &params)
 
 
 void
-Zc4PostingSeqWrite::flushChunk(void)
+Zc4PostingSeqWrite::flushChunk()
 {
     /* TODO: Flush chunk and prepare for new (possible short) chunk  */
     flushWordWithSkip(true);
@@ -1072,7 +1072,7 @@ Zc4PostingSeqWrite::flushChunk(void)
 
 
 void
-Zc4PostingSeqWrite::calcSkipInfo(void)
+Zc4PostingSeqWrite::calcSkipInfo()
 {
     uint32_t lastDocId = 0u;
     uint32_t lastL1SkipDocId = 0u;
@@ -1322,7 +1322,7 @@ Zc4PostingSeqWrite::flushWordWithSkip(bool hasMore)
 
 
 void
-Zc4PostingSeqWrite::flushWordNoSkip(void)
+Zc4PostingSeqWrite::flushWordNoSkip()
 {
     // Too few document ids for skip info.
     assert(_docIds.size() < _minSkipDocs && _counts._segments.empty());
@@ -1357,7 +1357,7 @@ Zc4PostingSeqWrite::flushWordNoSkip(void)
 
 
 void
-Zc4PostingSeqWrite::resetWord(void)
+Zc4PostingSeqWrite::resetWord()
 {
     _docIds.clear();
     _encodeFeatures->setupWrite(_featureWriteContext);
@@ -1417,7 +1417,7 @@ readDocIdAndFeatures(DocIdAndFeatures &features)
 
 
 const vespalib::string &
-ZcPostingSeqRead::getIdentifier(void)
+ZcPostingSeqRead::getIdentifier()
 {
     return myId5;
 }
@@ -1431,7 +1431,7 @@ ZcPostingSeqWrite::ZcPostingSeqWrite(PostingListCountFileSeqWrite *countFile)
 
 
 void
-ZcPostingSeqWrite::flushWordNoSkip(void)
+ZcPostingSeqWrite::flushWordNoSkip()
 {
     // Too few document ids for skip info.
     assert(_docIds.size() < _minSkipDocs && _counts._segments.empty());

--- a/searchlib/src/vespa/searchlib/docstore/cachestats.h
+++ b/searchlib/src/vespa/searchlib/docstore/cachestats.h
@@ -13,7 +13,7 @@ struct CacheStats {
     size_t elements;
     size_t memory_used;
 
-    CacheStats(void)
+    CacheStats()
         : hits(0),
           misses(0),
           elements(0),

--- a/searchlib/src/vespa/searchlib/docstore/idocumentstore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/idocumentstore.cpp
@@ -5,7 +5,7 @@
 
 namespace search {
 
-IDocumentStore::IDocumentStore(void)
+IDocumentStore::IDocumentStore()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/docstore/idocumentstore.h
+++ b/searchlib/src/vespa/searchlib/docstore/idocumentstore.h
@@ -64,7 +64,7 @@ public:
      * @param docMan   The document type manager to use when deserializing.
      * @param baseDir  The path to a directory where the implementaion specific files will reside.
      **/
-    IDocumentStore(void);
+    IDocumentStore();
     virtual ~IDocumentStore();
 
     /**

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -562,7 +562,7 @@ LogDataStore::getDiskFootprint() const
 
 
 size_t
-LogDataStore::getDiskHeaderFootprint(void) const
+LogDataStore::getDiskHeaderFootprint() const
 {
     LockGuard guard(_updateLock);
     size_t sz(0);

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -229,7 +229,7 @@ private:
 
     void eraseDanglingDatFiles(const NameIdSet &partList, const NameIdSet &datPartList);
     NameIdSet eraseEmptyIdxFiles(const NameIdSet &partList);
-    void internalFlushAll(void);
+    void internalFlushAll();
 
     NameIdSet scanDir(const vespalib::string &dir, const vespalib::string &suffix);
     FileId allocateFileId(const LockGuard & guard);

--- a/searchlib/src/vespa/searchlib/docstore/randread.h
+++ b/searchlib/src/vespa/searchlib/docstore/randread.h
@@ -18,7 +18,7 @@ public:
     typedef std::shared_ptr<FastOS_FileInterface> FSP;
     virtual ~FileRandRead() { }
     virtual FSP read(size_t offset, vespalib::DataBuffer & buffer, size_t sz) = 0;
-    virtual int64_t getSize(void) = 0;
+    virtual int64_t getSize() = 0;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/docstore/visitcache.h
+++ b/searchlib/src/vespa/searchlib/docstore/visitcache.h
@@ -117,7 +117,7 @@ private:
         bool read(const KeySet &key, CompressedBlobSet &blobs) const;
         void write(const KeySet &, const CompressedBlobSet &) { }
         void erase(const KeySet &) { }
-        const document::CompressionConfig &getCompression(void) const { return _compression; }
+        const document::CompressionConfig &getCompression() const { return _compression; }
     private:
         IDataStore                        &_backingStore;
         const document::CompressionConfig  _compression;

--- a/searchlib/src/vespa/searchlib/index/bitvectorkeys.h
+++ b/searchlib/src/vespa/searchlib/index/bitvectorkeys.h
@@ -17,7 +17,7 @@ public:
     uint32_t _numDocs;
     uint32_t _pad;
 
-    BitVectorWordSingleKey(void)
+    BitVectorWordSingleKey()
         : _wordNum(0),
           _numDocs(0),
           _pad(0)

--- a/searchlib/src/vespa/searchlib/index/docbuilder.cpp
+++ b/searchlib/src/vespa/searchlib/index/docbuilder.cpp
@@ -270,7 +270,7 @@ DocBuilder::IndexFieldHandle::addStr(const vespalib::string &val)
 
 
 void
-DocBuilder::IndexFieldHandle::addSpace(void)
+DocBuilder::IndexFieldHandle::addSpace()
 {
     addNoWordStr(" ");
 }
@@ -345,7 +345,7 @@ DocBuilder::IndexFieldHandle::addSpan(size_t start, size_t len)
 
 
 void
-DocBuilder::IndexFieldHandle::addSpan(void)
+DocBuilder::IndexFieldHandle::addSpan()
 {
     size_t endPos = _strSymbols;
     assert(endPos > _spanStart);
@@ -355,7 +355,7 @@ DocBuilder::IndexFieldHandle::addSpan(void)
 
 
 void
-DocBuilder::IndexFieldHandle::addSpaceTokenAnnotation(void)
+DocBuilder::IndexFieldHandle::addSpaceTokenAnnotation()
 {
     assert(_spanTree.get() != NULL);
     assert(_lastSpan != NULL);
@@ -364,7 +364,7 @@ DocBuilder::IndexFieldHandle::addSpaceTokenAnnotation(void)
 
 
 void
-DocBuilder::IndexFieldHandle::addNumericTokenAnnotation(void)
+DocBuilder::IndexFieldHandle::addNumericTokenAnnotation()
 {
     assert(_spanTree.get() != NULL);
     assert(_lastSpan != NULL);
@@ -373,7 +373,7 @@ DocBuilder::IndexFieldHandle::addNumericTokenAnnotation(void)
 
 
 void
-DocBuilder::IndexFieldHandle::addAlphabeticTokenAnnotation(void)
+DocBuilder::IndexFieldHandle::addAlphabeticTokenAnnotation()
 {
     assert(_spanTree.get() != NULL);
     assert(_lastSpan != NULL);
@@ -382,7 +382,7 @@ DocBuilder::IndexFieldHandle::addAlphabeticTokenAnnotation(void)
 
 
 void
-DocBuilder::IndexFieldHandle::addTermAnnotation(void)
+DocBuilder::IndexFieldHandle::addTermAnnotation()
 {
     assert(_spanTree.get() != NULL);
     assert(_lastSpan != NULL);
@@ -402,7 +402,7 @@ DocBuilder::IndexFieldHandle::addTermAnnotation(const vespalib::string &val)
 
 
 void
-DocBuilder::IndexFieldHandle::onEndElement(void)
+DocBuilder::IndexFieldHandle::onEndElement()
 {
     // Flush data for index field.
     assert(_subField.empty());
@@ -434,7 +434,7 @@ DocBuilder::IndexFieldHandle::onEndElement(void)
 
 
 void
-DocBuilder::IndexFieldHandle::onEndField(void)
+DocBuilder::IndexFieldHandle::onEndField()
 {
     if (_sfield.getCollectionType() == CollectionType::SINGLE)
         onEndElement();
@@ -442,7 +442,7 @@ DocBuilder::IndexFieldHandle::onEndField(void)
 
 
 void
-DocBuilder::IndexFieldHandle::startAnnotate(void)
+DocBuilder::IndexFieldHandle::startAnnotate()
 {
     SpanList::UP span_list(new SpanList);
     _spanList = span_list.get();
@@ -475,7 +475,7 @@ DocBuilder::IndexFieldHandle::startSubField(const vespalib::string &subField)
 
 
 void
-DocBuilder::IndexFieldHandle::endSubField(void)
+DocBuilder::IndexFieldHandle::endSubField()
 {
     assert(!_subField.empty());
     assert(_uriField);
@@ -739,7 +739,7 @@ DocBuilder::addStr(const vespalib::string & str)
 }
 
 DocBuilder &
-DocBuilder::addSpace(void)
+DocBuilder::addSpace()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->addSpace();
@@ -815,7 +815,7 @@ DocBuilder::addSpan(size_t start, size_t len)
 
 
 DocBuilder &
-DocBuilder::addSpan(void)
+DocBuilder::addSpan()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->addSpan();
@@ -824,7 +824,7 @@ DocBuilder::addSpan(void)
 
 
 DocBuilder &
-DocBuilder::addSpaceTokenAnnotation(void)
+DocBuilder::addSpaceTokenAnnotation()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->addSpaceTokenAnnotation();
@@ -833,7 +833,7 @@ DocBuilder::addSpaceTokenAnnotation(void)
 
 
 DocBuilder &
-DocBuilder::addNumericTokenAnnotation(void)
+DocBuilder::addNumericTokenAnnotation()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->addNumericTokenAnnotation();
@@ -842,7 +842,7 @@ DocBuilder::addNumericTokenAnnotation(void)
 
 
 DocBuilder &
-DocBuilder::addAlphabeticTokenAnnotation(void)
+DocBuilder::addAlphabeticTokenAnnotation()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->addAlphabeticTokenAnnotation();
@@ -851,7 +851,7 @@ DocBuilder::addAlphabeticTokenAnnotation(void)
 
 
 DocBuilder&
-DocBuilder::addTermAnnotation(void)
+DocBuilder::addTermAnnotation()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->addTermAnnotation();
@@ -896,7 +896,7 @@ DocBuilder::startSubField(const vespalib::string &subField)
 
 
 DocBuilder &
-DocBuilder::endSubField(void)
+DocBuilder::endSubField()
 {
     assert(_currDoc != NULL);
     _currDoc->getFieldHandle()->endSubField();

--- a/searchlib/src/vespa/searchlib/index/doctypebuilder.cpp
+++ b/searchlib/src/vespa/searchlib/index/doctypebuilder.cpp
@@ -67,7 +67,7 @@ insertStructType(document::DocumenttypesConfig::Documenttype & cfg,
 
 }
 
-DocTypeBuilder::UriField::UriField(void)
+DocTypeBuilder::UriField::UriField()
     : _all(Schema::UNKNOWN_FIELD_ID),
       _scheme(Schema::UNKNOWN_FIELD_ID),
       _host(Schema::UNKNOWN_FIELD_ID),

--- a/searchlib/src/vespa/searchlib/index/doctypebuilder.h
+++ b/searchlib/src/vespa/searchlib/index/doctypebuilder.h
@@ -37,7 +37,7 @@ public:
                           const Schema::CollectionType &collectionType);
 
     public:
-        UriField(void);
+        UriField();
 
         bool broken(const Schema &schema, const Schema::CollectionType &collectionType) const;
         bool valid(const Schema &schema, const Schema::CollectionType &collectionType) const;

--- a/searchlib/src/vespa/searchlib/index/dummyfileheadercontext.cpp
+++ b/searchlib/src/vespa/searchlib/index/dummyfileheadercontext.cpp
@@ -16,7 +16,7 @@ namespace index
 
 vespalib::string DummyFileHeaderContext::_creator;
 
-DummyFileHeaderContext::DummyFileHeaderContext(void)
+DummyFileHeaderContext::DummyFileHeaderContext()
     : common::FileHeaderContext(),
       _disableFileName(false),
       _hostName(),
@@ -27,13 +27,13 @@ DummyFileHeaderContext::DummyFileHeaderContext(void)
 }
 
 
-DummyFileHeaderContext::~DummyFileHeaderContext(void)
+DummyFileHeaderContext::~DummyFileHeaderContext()
 {
 }
 
 
 void
-DummyFileHeaderContext::disableFileName(void)
+DummyFileHeaderContext::disableFileName()
 {
     _disableFileName = true;
 }

--- a/searchlib/src/vespa/searchlib/index/indexbuilder.cpp
+++ b/searchlib/src/vespa/searchlib/index/indexbuilder.cpp
@@ -18,7 +18,7 @@ IndexBuilder::IndexBuilder(const Schema &schema)
 }
 
 
-IndexBuilder::~IndexBuilder(void)
+IndexBuilder::~IndexBuilder()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/index/indexbuilder.h
+++ b/searchlib/src/vespa/searchlib/index/indexbuilder.h
@@ -21,31 +21,31 @@ public:
     IndexBuilder(const Schema &schema);
 
     virtual
-    ~IndexBuilder(void);
+    ~IndexBuilder();
 
     virtual void
     startWord(const vespalib::stringref & word) = 0;
 
     virtual void
-    endWord(void) = 0;
+    endWord() = 0;
 
     virtual void
     startDocument(uint32_t docId) = 0;
 
     virtual void
-    endDocument(void) = 0;
+    endDocument() = 0;
 
     virtual void
     startField(uint32_t fieldId) = 0;
 
     virtual void
-    endField(void) = 0;
+    endField() = 0;
 
     virtual void
     startElement(uint32_t elementId, int32_t weight, uint32_t elementLen) = 0;
 
     virtual void
-    endElement(void) = 0;
+    endElement() = 0;
 
     virtual void
     addOcc(const WordDocElementWordPosFeatures &features) = 0;

--- a/searchlib/src/vespa/searchlib/index/olddictionaryfile.cpp
+++ b/searchlib/src/vespa/searchlib/index/olddictionaryfile.cpp
@@ -12,7 +12,7 @@ namespace index
 {
 
 
-OldDictionaryIndexMapping::OldDictionaryIndexMapping(void)
+OldDictionaryIndexMapping::OldDictionaryIndexMapping()
     : _fieldIdToLocalId(),
       _indexNames(),
       _indexIds(),
@@ -21,7 +21,7 @@ OldDictionaryIndexMapping::OldDictionaryIndexMapping(void)
 }
 
 
-OldDictionaryIndexMapping::~OldDictionaryIndexMapping(void)
+OldDictionaryIndexMapping::~OldDictionaryIndexMapping()
 {
 }
 
@@ -100,12 +100,12 @@ OldDictionaryIndexMapping::setupHelper(const Schema &schema)
 }
 
 
-OldDictionaryFileSeqRead::~OldDictionaryFileSeqRead(void)
+OldDictionaryFileSeqRead::~OldDictionaryFileSeqRead()
 {
 }
 
 
-OldDictionaryFileSeqWrite::~OldDictionaryFileSeqWrite(void)
+OldDictionaryFileSeqWrite::~OldDictionaryFileSeqWrite()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/index/olddictionaryfile.h
+++ b/searchlib/src/vespa/searchlib/index/olddictionaryfile.h
@@ -35,12 +35,12 @@ private:
     setupHelper(const Schema &schema);
 
 public:
-    OldDictionaryIndexMapping(void);
+    OldDictionaryIndexMapping();
 
-    ~OldDictionaryIndexMapping(void);
+    ~OldDictionaryIndexMapping();
 
     static uint32_t
-    noLocalId(void)
+    noLocalId()
     {
         return std::numeric_limits<uint32_t>::max();
     }
@@ -69,25 +69,25 @@ public:
           const std::vector<uint32_t> &indexes);
 
     const std::vector<uint32_t> &
-    getIndexIds(void) const
+    getIndexIds() const
     {
         return _indexIds;
     }
 
     const std::vector<uint32_t> &
-    getWashedIndexIds(void) const
+    getWashedIndexIds() const
     {
         return _washedIndexIds;
     }
 
     const std::vector<vespalib::string> &
-    getIndexNames(void) const
+    getIndexNames() const
     {
         return _indexNames;
     }
 
     uint32_t
-    getNumIndexes(void) const
+    getNumIndexes() const
     {
         return _indexIds.size();
     }
@@ -102,12 +102,12 @@ public:
 class OldDictionaryFileSeqRead
 {
 public:
-    OldDictionaryFileSeqRead(void)
+    OldDictionaryFileSeqRead()
     {
     }
 
     virtual
-    ~OldDictionaryFileSeqRead(void);
+    ~OldDictionaryFileSeqRead();
 
     /**
      * Read word and counts.  Only nonzero counts are returned. If at
@@ -133,7 +133,7 @@ public:
      * Close dictionary file.
      */
     virtual bool
-    close(void) = 0;
+    close() = 0;
 
     /*
      * Get visible indexes available in dictionary.
@@ -142,13 +142,13 @@ public:
     getIndexes(std::vector<uint32_t> &indexes) = 0;
 
     static uint64_t
-    noWordNum(void)
+    noWordNum()
     {
         return 0u;
     }
 
     static uint64_t
-    noWordNumHigh(void)
+    noWordNumHigh()
     {
         return std::numeric_limits<uint64_t>::max();
     }
@@ -166,12 +166,12 @@ class OldDictionaryFileSeqWrite
 {
 protected:
 public:
-    OldDictionaryFileSeqWrite(void)
+    OldDictionaryFileSeqWrite()
     {
     }
 
     virtual
-    ~OldDictionaryFileSeqWrite(void);
+    ~OldDictionaryFileSeqWrite();
 
     /**
      * Write word and counts.  Only nonzero counts should be supplied.
@@ -198,7 +198,7 @@ public:
      * Close dictionary file.
      */
     virtual bool
-    close(void) = 0;
+    close() = 0;
 };
 
 

--- a/searchlib/src/vespa/searchlib/index/postinglistcountfile.cpp
+++ b/searchlib/src/vespa/searchlib/index/postinglistcountfile.cpp
@@ -11,12 +11,12 @@ namespace search
 namespace index
 {
 
-PostingListCountFileSeqRead::PostingListCountFileSeqRead(void)
+PostingListCountFileSeqRead::PostingListCountFileSeqRead()
 {
 }
 
 
-PostingListCountFileSeqRead::~PostingListCountFileSeqRead(void)
+PostingListCountFileSeqRead::~PostingListCountFileSeqRead()
 {
 }
 
@@ -29,12 +29,12 @@ getParams(PostingListParams &params)
 }
 
 
-PostingListCountFileSeqWrite::PostingListCountFileSeqWrite(void)
+PostingListCountFileSeqWrite::PostingListCountFileSeqWrite()
 {
 }
 
 
-PostingListCountFileSeqWrite::~PostingListCountFileSeqWrite(void)
+PostingListCountFileSeqWrite::~PostingListCountFileSeqWrite()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/index/postinglistfile.cpp
+++ b/searchlib/src/vespa/searchlib/index/postinglistfile.cpp
@@ -11,14 +11,14 @@ namespace search
 namespace index
 {
 
-PostingListFileSeqRead::PostingListFileSeqRead(void)
+PostingListFileSeqRead::PostingListFileSeqRead()
     : _counts(),
       _residueDocs(0)
 {
 }
 
 
-PostingListFileSeqRead::~PostingListFileSeqRead(void)
+PostingListFileSeqRead::~PostingListFileSeqRead()
 {
 }
 
@@ -47,13 +47,13 @@ getFeatureParams(PostingListParams &params)
 }
 
 
-PostingListFileSeqWrite::PostingListFileSeqWrite(void)
+PostingListFileSeqWrite::PostingListFileSeqWrite()
     : _counts()
 {
 }
 
 
-PostingListFileSeqWrite::~PostingListFileSeqWrite(void)
+PostingListFileSeqWrite::~PostingListFileSeqWrite()
 {
 }
 
@@ -91,13 +91,13 @@ getFeatureParams(PostingListParams &params)
 
 
 PostingListFileRandRead::
-PostingListFileRandRead(void)
+PostingListFileRandRead()
     : _memoryMapped(false)
 {
 }
 
 
-PostingListFileRandRead::~PostingListFileRandRead(void)
+PostingListFileRandRead::~PostingListFileRandRead()
 {
 }
 
@@ -118,7 +118,7 @@ PostingListFileRandReadPassThrough(PostingListFileRandRead *lower,
 }
 
 
-PostingListFileRandReadPassThrough::~PostingListFileRandReadPassThrough(void)
+PostingListFileRandReadPassThrough::~PostingListFileRandReadPassThrough()
 {
     if (_ownLower)
         delete _lower;
@@ -159,7 +159,7 @@ PostingListFileRandReadPassThrough::open(const vespalib::string &name,
 
 
 bool
-PostingListFileRandReadPassThrough::close(void)
+PostingListFileRandReadPassThrough::close()
 {
     return _lower->close();
 }

--- a/searchlib/src/vespa/searchlib/index/postinglistfile.h
+++ b/searchlib/src/vespa/searchlib/index/postinglistfile.h
@@ -180,7 +180,7 @@ public:
      */
     virtual void getFeatureParams(PostingListParams &params);
 
-    PostingListCounts &getCounts(void) { return _counts; }
+    PostingListCounts &getCounts() { return _counts; }
 };
 
 

--- a/searchlib/src/vespa/searchlib/index/postinglistparams.cpp
+++ b/searchlib/src/vespa/searchlib/index/postinglistparams.cpp
@@ -52,7 +52,7 @@ PostingListParams::getStr(const vespalib::string &key) const
 
 
 void
-PostingListParams::clear(void)
+PostingListParams::clear()
 {
     _map.clear();
 }

--- a/searchlib/src/vespa/searchlib/index/postinglistparams.h
+++ b/searchlib/src/vespa/searchlib/index/postinglistparams.h
@@ -33,7 +33,7 @@ public:
     getStr(const vespalib::string &key) const;
 
     void
-    clear(void);
+    clear();
 
     void
     erase(const vespalib::string &key);

--- a/searchlib/src/vespa/searchlib/memoryindex/dictionary.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/dictionary.cpp
@@ -37,7 +37,7 @@ Dictionary::Dictionary(const Schema & schema)
     }
 }
 
-Dictionary::~Dictionary(void)
+Dictionary::~Dictionary()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/memoryindex/dictionary.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/dictionary.h
@@ -22,7 +22,7 @@ private:
 
 public:
     Dictionary(const index::Schema &schema);
-    ~Dictionary(void);
+    ~Dictionary();
     PostingList::Iterator find(const vespalib::stringref word,
                                uint32_t fieldId) const
     {

--- a/searchlib/src/vespa/searchlib/memoryindex/documentinverter.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/documentinverter.h
@@ -69,7 +69,7 @@ private:
      * @return schema used by this index
      */
     const index::Schema &
-    getSchema(void) const
+    getSchema() const
     {
         return _schema;
     }

--- a/searchlib/src/vespa/searchlib/memoryindex/featurestore.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/featurestore.cpp
@@ -105,7 +105,7 @@ FeatureStore::FeatureStore(const Schema &schema)
 }
 
 
-FeatureStore::~FeatureStore(void)
+FeatureStore::~FeatureStore()
 {
     _store.dropBuffers();
 }

--- a/searchlib/src/vespa/searchlib/memoryindex/featurestore.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/featurestore.h
@@ -97,7 +97,7 @@ public:
      */
     FeatureStore(const Schema &schema);
 
-    ~FeatureStore(void);
+    ~FeatureStore();
 
     /**
      * Add features to feature store
@@ -233,7 +233,7 @@ public:
     }
 
     void
-    clearHoldLists(void)
+    clearHoldLists()
     {
         _store.clearHoldLists();
     }

--- a/searchlib/src/vespa/searchlib/memoryindex/fieldinverter.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/fieldinverter.cpp
@@ -182,7 +182,7 @@ struct WordRefRadix {
 };
 
 void
-FieldInverter::sortWords(void)
+FieldInverter::sortWords()
 {
     assert(_wordRefs.size() > 1);
 
@@ -235,7 +235,7 @@ FieldInverter::startElement(int32_t weight)
 
 
 void
-FieldInverter::endElement(void)
+FieldInverter::endElement()
 {
     _elems.back().setLen(_wpos);
     _wpos = 0;

--- a/searchlib/src/vespa/searchlib/memoryindex/fieldinverter.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/fieldinverter.h
@@ -215,7 +215,7 @@ public:
      * End an element.
      */
     void
-    endElement(void);
+    endElement();
 
 private:
     /**
@@ -305,7 +305,7 @@ private:
     }
 
     void
-    stepWordPos(void)
+    stepWordPos()
     {
         ++_wpos;
     }
@@ -330,7 +330,7 @@ private:
      * @return schema used by this index
      */
     const index::Schema &
-    getSchema(void) const
+    getSchema() const
     {
         return _schema;
     }
@@ -339,14 +339,14 @@ private:
      * Clear internal memory structures.
      */
     void
-    reset(void);
+    reset();
 
     /**
      * Calculate word numbers and replace word references with word
      * numbers in internal memory structures.
      */
     void
-    sortWords(void);
+    sortWords();
 
     void
     moveNotAbortedDocs(uint32_t &dstIdx, uint32_t srcIdx, uint32_t nextTrimIdx);

--- a/searchlib/src/vespa/searchlib/memoryindex/memoryfieldindex.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/memoryfieldindex.cpp
@@ -43,7 +43,7 @@ MemoryFieldIndex::MemoryFieldIndex(const Schema & schema, uint32_t fieldId)
       _inserter(std::make_unique<OrderedDocumentInserter>(*this))
 { }
 
-MemoryFieldIndex::~MemoryFieldIndex(void)
+MemoryFieldIndex::~MemoryFieldIndex()
 {
     _postingListStore.disableFreeLists();
     _postingListStore.disableElemHoldList();
@@ -96,7 +96,7 @@ MemoryFieldIndex::findFrozen(const vespalib::stringref word) const
 
 
 void
-MemoryFieldIndex::compactFeatures(void)
+MemoryFieldIndex::compactFeatures()
 {
     std::vector<uint32_t> toHold;
 

--- a/searchlib/src/vespa/searchlib/memoryindex/memoryfieldindex.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/memoryfieldindex.h
@@ -100,7 +100,7 @@ public:
     }
 
     MemoryFieldIndex(const index::Schema &schema, uint32_t fieldId);
-    ~MemoryFieldIndex(void);
+    ~MemoryFieldIndex();
     PostingList::Iterator find(const vespalib::stringref word) const;
 
     PostingList::ConstIterator
@@ -138,7 +138,7 @@ private:
     }
 
     void
-    incGeneration(void)
+    incGeneration()
     {
         _generationHandler.incGeneration();
     }
@@ -149,7 +149,7 @@ public:
     }
 
     void
-    compactFeatures(void);
+    compactFeatures();
 
     void dump(search::index::IndexBuilder & indexBuilder);
 

--- a/searchlib/src/vespa/searchlib/memoryindex/wordstore.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/wordstore.cpp
@@ -24,7 +24,7 @@ WordStore::WordStore()
 }
 
 
-WordStore::~WordStore(void)
+WordStore::~WordStore()
 {
     _store.dropBuffers();
 }

--- a/searchlib/src/vespa/searchlib/parsequery/parse.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.cpp
@@ -74,7 +74,7 @@ ParseItem::ParseItem(ItemType type, const char *term)
     SetTerm(term);
 }
 
-ParseItem::~ParseItem(void)
+ParseItem::~ParseItem()
 {
     delete _next;
     delete _sibling;
@@ -159,7 +159,7 @@ ParseItem::AppendBuffer(RawBuf *buf) const
 }
 
 size_t
-ParseItem::GetBufferLen(void) const
+ParseItem::GetBufferLen() const
 {
     // Calculate the length of the buffer.
     uint32_t indexLen = _indexName.size();

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -216,7 +216,7 @@ public:
      */
     void AppendBuffer(RawBuf *buf) const;
 
-    size_t GetBufferLen(void) const;
+    size_t GetBufferLen() const;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/parsequery/simplequerystack.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/simplequerystack.cpp
@@ -20,14 +20,14 @@ using vespalib::make_vespa_string;
 
 namespace search {
 
-SimpleQueryStack::SimpleQueryStack(void)
+SimpleQueryStack::SimpleQueryStack()
     : _numItems(0),
       _stack(NULL),
       _FP_queryOK(true)
 {
 }
 
-SimpleQueryStack::~SimpleQueryStack(void)
+SimpleQueryStack::~SimpleQueryStack()
 {
     delete _stack;
 }
@@ -49,7 +49,7 @@ SimpleQueryStack::Push(search::ParseItem *item)
 }
 
 search::ParseItem *
-SimpleQueryStack::Pop(void)
+SimpleQueryStack::Pop()
 {
     search::ParseItem *item = _stack;
     if (_stack != NULL) {
@@ -69,7 +69,7 @@ SimpleQueryStack::AppendBuffer(search::RawBuf *buf) const
 }
 
 size_t
-SimpleQueryStack::GetBufferLen(void) const
+SimpleQueryStack::GetBufferLen() const
 {
     size_t result;
 
@@ -83,13 +83,13 @@ SimpleQueryStack::GetBufferLen(void) const
 }
 
 uint32_t
-SimpleQueryStack::GetSize(void)
+SimpleQueryStack::GetSize()
 {
     return _numItems;
 }
 
 bool
-SimpleQueryStack::_FP_isAllowed(void)
+SimpleQueryStack::_FP_isAllowed()
 {
     return _FP_queryOK;
 }

--- a/searchlib/src/vespa/searchlib/parsequery/simplequerystack.h
+++ b/searchlib/src/vespa/searchlib/parsequery/simplequerystack.h
@@ -50,11 +50,11 @@ public:
     /**
      * Constructor for SimpleQueryStack.
      */
-    SimpleQueryStack(void);
+    SimpleQueryStack();
     /**
      * Destructor for SimpleQueryStack.
      */
-    ~SimpleQueryStack(void);
+    ~SimpleQueryStack();
     /**
      * Push an item on the stack.
      * @param item The search::ParseItem to push.
@@ -64,12 +64,12 @@ public:
      * Pop an item of the stack.
      * @return Pointer to the search::ParseItem poped, or NULL if stack is empty.
      */
-    search::ParseItem *Pop(void);
+    search::ParseItem *Pop();
     /**
      * Top node of the stack.
      * @return Pointer to the top search::ParseItem, or NULL if stack is empty.
      */
-    search::ParseItem *Top(void) { return _stack; }
+    search::ParseItem *Top() { return _stack; }
 
     /**
      * Encode the contents of the stack in a binary buffer.
@@ -77,12 +77,12 @@ public:
      */
     void AppendBuffer(search::RawBuf *buf) const;
 
-    size_t GetBufferLen(void) const;
+    size_t GetBufferLen() const;
     /**
      * Return the number of items on the stack.
      * @return The number of items on the stack.
      */
-    uint32_t GetSize(void);
+    uint32_t GetSize();
     /**
      * Set the number of items on the stack.
      * This can be used by QTs that change the stack
@@ -95,7 +95,7 @@ public:
      * Is it possible to run this query on FirstPage?
      * @return true if ok
      */
-    bool _FP_isAllowed(void);
+    bool _FP_isAllowed();
     /**
      * Make a string representation of the search::RawBuf representing a querystack.
      * @param theBuf The querystack encoded buffer.

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -93,25 +93,25 @@ public:
      * @return true if there is a new item, false if there are no more items
      * or if there was errors in extracting the next item.
      */
-    bool next(void);
+    bool next();
 
     /**
      * Get the number of the current item.
      *
      * @return The ordinal of the current item. -1 if at the start.
      */
-    int getNum(void) const { return _currNum; }
+    int getNum() const { return _currNum; }
 
     /**
      * Get the type of the current item.
      * @return the type.
      */
-    ParseItem::ItemType getType(void) const { return _currType; }
+    ParseItem::ItemType getType() const { return _currType; }
     /**
      * Get the type of the current item.
      * @return the type.
      */
-    ParseItem::ItemCreator getCreator(void) const { return _currCreator; }
+    ParseItem::ItemCreator getCreator() const { return _currCreator; }
 
     /**
      * Get the rank weight of the current item.
@@ -141,9 +141,9 @@ public:
      **/
     uint32_t getFlags() const { return _currFlags; }
 
-    uint32_t getArity(void) const { return _currArity; }
+    uint32_t getArity() const { return _currArity; }
 
-    uint32_t getArg1(void) const { return _currArg1; }
+    uint32_t getArg1() const { return _currArg1; }
 
     double getArg2() const { return _currArg2; }
 

--- a/searchlib/src/vespa/searchlib/query/base.cpp
+++ b/searchlib/src/vespa/searchlib/query/base.cpp
@@ -3,7 +3,7 @@
 
 namespace search {
 
-Object::~Object(void) { }
+Object::~Object() { }
 
 vespalib::string Object::toString() const
 {

--- a/searchlib/src/vespa/searchlib/query/base.h
+++ b/searchlib/src/vespa/searchlib/query/base.h
@@ -60,7 +60,7 @@ typedef std::vector<DocumentIdT> DocumentIdList;
 class Object
 {
  public:
-  virtual ~Object(void);
+  virtual ~Object();
   /// Returns an allocated(new) object that is identical to this one.
   virtual Object * duplicate() const = 0;
   /// Gives you streamability of the object. Object does nothing.

--- a/searchlib/src/vespa/searchlib/queryeval/isourceselector.h
+++ b/searchlib/src/vespa/searchlib/queryeval/isourceselector.h
@@ -32,7 +32,7 @@ public:
         return _source.getFast(docId);
     }
 
-    uint32_t getDocIdLimit(void) const {
+    uint32_t getDocIdLimit() const {
         return _source.getCommittedDocIdLimit();
     }
 private:

--- a/searchlib/src/vespa/searchlib/tensor/tensor_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_store.h
@@ -50,7 +50,7 @@ public:
     }
 
     void
-    clearHoldLists(void)
+    clearHoldLists()
     {
         _store.clearHoldLists();
     }

--- a/searchlib/src/vespa/searchlib/test/diskindex/testdiskindex.cpp
+++ b/searchlib/src/vespa/searchlib/test/diskindex/testdiskindex.cpp
@@ -55,7 +55,7 @@ struct Builder
 
 
 void
-TestDiskIndex::buildSchema(void)
+TestDiskIndex::buildSchema()
 {
     _schema.addIndexField(Schema::IndexField("f1", DataType::STRING));
     _schema.addIndexField(Schema::IndexField("f2", DataType::STRING));

--- a/searchlib/src/vespa/searchlib/test/diskindex/threelevelcountbuffers.cpp
+++ b/searchlib/src/vespa/searchlib/test/diskindex/threelevelcountbuffers.cpp
@@ -37,7 +37,7 @@ ThreeLevelCountWriteBuffers(EC &sse, EC &spe, EC &pe)
 
 
 void
-ThreeLevelCountWriteBuffers::flush(void)
+ThreeLevelCountWriteBuffers::flush()
 {
     _ssFileBitSize = _sse.getWriteOffset();
     _spFileBitSize = _spe.getWriteOffset();

--- a/searchlib/src/vespa/searchlib/test/diskindex/threelevelcountbuffers.h
+++ b/searchlib/src/vespa/searchlib/test/diskindex/threelevelcountbuffers.h
@@ -29,7 +29,7 @@ public:
     ThreeLevelCountWriteBuffers(EC &sse, EC &spe, EC &pe);
 
     void
-    flush(void);
+    flush();
 
     // unit test method.  Just pads without writing proper header
     void

--- a/searchlib/src/vespa/searchlib/test/fakedata/bitdecode64.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/bitdecode64.h
@@ -51,7 +51,7 @@ public:
     }
 
     uint64_t
-    getOffset(void) const
+    getOffset() const
     {
         return 64 * (_valI - _comprBase - 1) - this->_preRead -
             _bitOffsetBase;
@@ -64,13 +64,13 @@ public:
     }
 
     const uint64_t *
-    getComprBase(void) const
+    getComprBase() const
     {
         return _comprBase;
     }
 
     int
-    getBitOffsetBase(void) const
+    getBitOffsetBase() const
     {
         return _bitOffsetBase;
     }

--- a/searchlib/src/vespa/searchlib/test/fakedata/bitencode64.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/bitencode64.cpp
@@ -13,7 +13,7 @@ namespace fakedata
 {
 
 template <bool bigEndian>
-BitEncode64<bigEndian>::BitEncode64(void)
+BitEncode64<bigEndian>::BitEncode64()
     : bitcompression::EncodeContext64<bigEndian>(),
       _cbuf(*this)
 {
@@ -23,7 +23,7 @@ BitEncode64<bigEndian>::BitEncode64(void)
 
 
 template <bool bigEndian>
-BitEncode64<bigEndian>::~BitEncode64(void)
+BitEncode64<bigEndian>::~BitEncode64()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/fakedata/bitencode64.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/bitencode64.h
@@ -17,20 +17,20 @@ class BitEncode64 : public bitcompression::EncodeContext64<bigEndian>
     search::ComprFileWriteContext _cbuf;
 
 public:
-    BitEncode64(void);
+    BitEncode64();
 
-    ~BitEncode64(void);
+    ~BitEncode64();
 
     typedef bitcompression::EncodeContext64<bigEndian> EC;
 
     void
-    writeComprBuffer(void)
+    writeComprBuffer()
     {
         _cbuf.writeComprBuffer(true);
     }
 
     void
-    writeComprBufferIfNeeded(void)
+    writeComprBufferIfNeeded()
     {
         if (this->_valI >= this->_valE)
             _cbuf.writeComprBuffer(false);

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakeegcompr64filterocc.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakeegcompr64filterocc.cpp
@@ -412,7 +412,7 @@ setupT(const FakeWord &fw)
 }
 
 
-FakeEGCompr64FilterOcc::~FakeEGCompr64FilterOcc(void)
+FakeEGCompr64FilterOcc::~FakeEGCompr64FilterOcc()
 {
     free(_compressedMalloc);
     free(_l1SkipCompressedMalloc);
@@ -423,69 +423,69 @@ FakeEGCompr64FilterOcc::~FakeEGCompr64FilterOcc(void)
 
 
 void
-FakeEGCompr64FilterOcc::forceLink(void)
+FakeEGCompr64FilterOcc::forceLink()
 {
 }
 
 
 size_t
-FakeEGCompr64FilterOcc::bitSize(void) const
+FakeEGCompr64FilterOcc::bitSize() const
 {
     return _bitSize;
 }
 
 
 bool
-FakeEGCompr64FilterOcc::hasWordPositions(void) const
+FakeEGCompr64FilterOcc::hasWordPositions() const
 {
     return false;
 }
 
 
 size_t
-FakeEGCompr64FilterOcc::skipBitSize(void) const
+FakeEGCompr64FilterOcc::skipBitSize() const
 {
     return _l1SkipBitSize + _l2SkipBitSize + _l3SkipBitSize + _l4SkipBitSize;
 }
 
 
 size_t
-FakeEGCompr64FilterOcc::l1SkipBitSize(void) const
+FakeEGCompr64FilterOcc::l1SkipBitSize() const
 {
     return _l1SkipBitSize;
 }
 
 
 size_t
-FakeEGCompr64FilterOcc::l2SkipBitSize(void) const
+FakeEGCompr64FilterOcc::l2SkipBitSize() const
 {
     return _l2SkipBitSize;
 }
 
 
 size_t
-FakeEGCompr64FilterOcc::l3SkipBitSize(void) const
+FakeEGCompr64FilterOcc::l3SkipBitSize() const
 {
     return _l3SkipBitSize;
 }
 
 
 size_t
-FakeEGCompr64FilterOcc::l4SkipBitSize(void) const
+FakeEGCompr64FilterOcc::l4SkipBitSize() const
 {
     return _l4SkipBitSize;
 }
 
 
 int
-FakeEGCompr64FilterOcc::lowLevelSinglePostingScan(void) const
+FakeEGCompr64FilterOcc::lowLevelSinglePostingScan() const
 {
     return 0;
 }
 
 
 int
-FakeEGCompr64FilterOcc::lowLevelSinglePostingScanUnpack(void) const
+FakeEGCompr64FilterOcc::lowLevelSinglePostingScanUnpack() const
 {
     return 0;
 }
@@ -559,7 +559,7 @@ public:
     }
 
     uint32_t
-    getDocIdDelta(void)
+    getDocIdDelta()
     {
         uint32_t ret;
         unsigned int length;
@@ -571,7 +571,7 @@ public:
     }
 
     uint32_t
-    getL1SkipDocIdDelta(void)
+    getL1SkipDocIdDelta()
     {
         uint32_t ret;
         unsigned int length;
@@ -583,7 +583,7 @@ public:
     }
 
     uint32_t
-    getL2SkipDocIdDelta(void)
+    getL2SkipDocIdDelta()
     {
         uint32_t ret;
         unsigned int length;
@@ -595,7 +595,7 @@ public:
     }
 
     uint32_t
-    getL3SkipDocIdDelta(void)
+    getL3SkipDocIdDelta()
     {
         uint32_t ret;
         unsigned int length;
@@ -631,7 +631,7 @@ public:
                                              uint32_t lastDocId,
                                              const search::fef::TermFieldMatchDataArray &matchData);
 
-    ~FakeFilterOccEGCompressed64ArrayIterator(void);
+    ~FakeFilterOccEGCompressed64ArrayIterator();
 
     void doUnpack(uint32_t docId) override;
     void doSeek(uint32_t docId) override;
@@ -688,7 +688,7 @@ initRange(uint32_t begin, uint32_t end)
 
 template <bool bigEndian>
 FakeFilterOccEGCompressed64ArrayIterator<bigEndian>::
-~FakeFilterOccEGCompressed64ArrayIterator(void)
+~FakeFilterOccEGCompressed64ArrayIterator()
 {
 }
 
@@ -763,7 +763,7 @@ class FakeEGCompr64LEFilterOcc : public FakeEGCompr64FilterOcc
 public:
     FakeEGCompr64LEFilterOcc(const FakeWord &fw);
 
-    ~FakeEGCompr64LEFilterOcc(void);
+    ~FakeEGCompr64LEFilterOcc();
 };
 
 
@@ -773,7 +773,7 @@ FakeEGCompr64LEFilterOcc::FakeEGCompr64LEFilterOcc(const FakeWord &fw)
 }
 
 
-FakeEGCompr64LEFilterOcc::~FakeEGCompr64LEFilterOcc(void)
+FakeEGCompr64LEFilterOcc::~FakeEGCompr64LEFilterOcc()
 {
 }
 
@@ -818,7 +818,7 @@ FakeEGCompr64SkipFilterOcc<false>::FakeEGCompr64SkipFilterOcc(const FakeWord &fw
 
 
 template <bool doSkip>
-FakeEGCompr64SkipFilterOcc<doSkip>::~FakeEGCompr64SkipFilterOcc(void)
+FakeEGCompr64SkipFilterOcc<doSkip>::~FakeEGCompr64SkipFilterOcc()
 {
 }
 
@@ -873,7 +873,7 @@ public:
             const std::string &name,	
             const fef::TermFieldMatchDataArray &matchData);
 
-    ~FakeFilterOccEGCompressed64SkipArrayIterator(void);
+    ~FakeFilterOccEGCompressed64SkipArrayIterator();
 
 
     void doL4SkipSeek(uint32_t docid);
@@ -1003,7 +1003,7 @@ initRange(uint32_t begin, uint32_t end)
 
 template <bool doSkip>
 FakeFilterOccEGCompressed64SkipArrayIterator<doSkip>::
-~FakeFilterOccEGCompressed64SkipArrayIterator(void)
+~FakeFilterOccEGCompressed64SkipArrayIterator()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakefilterocc.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakefilterocc.cpp
@@ -44,40 +44,40 @@ FakeFilterOcc::FakeFilterOcc(const FakeWord &fw)
 }
 
 
-FakeFilterOcc::~FakeFilterOcc(void)
+FakeFilterOcc::~FakeFilterOcc()
 {
 }
 
 
 void
-FakeFilterOcc::forceLink(void)
+FakeFilterOcc::forceLink()
 {
 }
 
 
 size_t
-FakeFilterOcc::bitSize(void) const
+FakeFilterOcc::bitSize() const
 {
     return 32 * _uncompressed.size();
 }
 
 
 bool
-FakeFilterOcc::hasWordPositions(void) const
+FakeFilterOcc::hasWordPositions() const
 {
     return false;
 }
 
 
 int
-FakeFilterOcc::lowLevelSinglePostingScan(void) const
+FakeFilterOcc::lowLevelSinglePostingScan() const
 {
     return 0;
 }
 
 
 int
-FakeFilterOcc::lowLevelSinglePostingScanUnpack(void) const
+FakeFilterOcc::lowLevelSinglePostingScanUnpack() const
 {
     return 0;
 }
@@ -116,7 +116,7 @@ public:
                                const uint32_t *arrEnd,
                                const fef::TermFieldMatchDataArray &matchData);
 
-    ~FakeFilterOccArrayIterator(void);
+    ~FakeFilterOccArrayIterator();
 
     void doUnpack(uint32_t docId) override;
     void doSeek(uint32_t docId) override;
@@ -175,7 +175,7 @@ FakeFilterOccArrayIterator::initRange(uint32_t begin, uint32_t end)
 }
 
 
-FakeFilterOccArrayIterator::~FakeFilterOccArrayIterator(void)
+FakeFilterOccArrayIterator::~FakeFilterOccArrayIterator()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakefilterocc.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakefilterocc.h
@@ -25,9 +25,9 @@ public:
     static void forceLink();
 
     size_t bitSize() const override;
-    bool hasWordPositions(void) const override;
-    int lowLevelSinglePostingScan(void) const override;
-    int lowLevelSinglePostingScanUnpack(void) const override;
+    bool hasWordPositions() const override;
+    int lowLevelSinglePostingScan() const override;
+    int lowLevelSinglePostingScanUnpack() const override;
     int lowLevelAndPairPostingScan(const FakePosting &rhs) const override;
     int lowLevelAndPairPostingScanUnpack(const FakePosting &rhs) const override;
     queryeval::SearchIterator * createIterator(const fef::TermFieldMatchDataArray &matchData) const override;

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakememtreeocc.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakememtreeocc.cpp
@@ -72,40 +72,40 @@ FakeMemTreeOcc::FakeMemTreeOcc(const FakeWord &fw,
 }
 
 
-FakeMemTreeOcc::~FakeMemTreeOcc(void)
+FakeMemTreeOcc::~FakeMemTreeOcc()
 {
 }
 
 
 void
-FakeMemTreeOcc::forceLink(void)
+FakeMemTreeOcc::forceLink()
 {
 }
 
 
 size_t
-FakeMemTreeOcc::bitSize(void) const
+FakeMemTreeOcc::bitSize() const
 {
     return _tree.bitSize(_allocator) + _featureBitSize;
 }
 
 
 bool
-FakeMemTreeOcc::hasWordPositions(void) const
+FakeMemTreeOcc::hasWordPositions() const
 {
     return true;
 }
 
 
 int
-FakeMemTreeOcc::lowLevelSinglePostingScan(void) const
+FakeMemTreeOcc::lowLevelSinglePostingScan() const
 {
     return 0;
 }
 
 
 int
-FakeMemTreeOcc::lowLevelSinglePostingScanUnpack(void) const
+FakeMemTreeOcc::lowLevelSinglePostingScanUnpack() const
 {
     return 0;
 }
@@ -152,7 +152,7 @@ FakeMemTreeOccMgr::FakeMemTreeOccMgr(const Schema &schema)
 }
 
 
-FakeMemTreeOccMgr::~FakeMemTreeOccMgr(void)
+FakeMemTreeOccMgr::~FakeMemTreeOccMgr()
 {
     std::vector<std::shared_ptr<PostingIdx> >::iterator
         it(_postingIdxs.begin());
@@ -167,34 +167,34 @@ FakeMemTreeOccMgr::~FakeMemTreeOccMgr(void)
 
 
 void
-FakeMemTreeOccMgr::freeze(void)
+FakeMemTreeOccMgr::freeze()
 {
     _allocator.freeze();
 }
 
 
 void
-FakeMemTreeOccMgr::transferHoldLists(void)
+FakeMemTreeOccMgr::transferHoldLists()
 {
     _allocator.transferHoldLists(_generationHandler.getCurrentGeneration());
 }
 
 void
-FakeMemTreeOccMgr::incGeneration(void)
+FakeMemTreeOccMgr::incGeneration()
 {
     _generationHandler.incGeneration();
 }
 
 
 void
-FakeMemTreeOccMgr::trimHoldLists(void)
+FakeMemTreeOccMgr::trimHoldLists()
 {
     _allocator.trimHoldLists(_generationHandler.getFirstUsedGeneration());
 }
 
 
 void
-FakeMemTreeOccMgr::sync(void)
+FakeMemTreeOccMgr::sync()
 {
     freeze();
     transferHoldLists();
@@ -233,7 +233,7 @@ FakeMemTreeOccMgr::remove(uint32_t wordIdx, uint32_t docId)
 
 
 void
-FakeMemTreeOccMgr::sortUnflushed(void)
+FakeMemTreeOccMgr::sortUnflushed()
 {
     typedef std::vector<PendingOp>::iterator I;
     uint32_t seq = 0;
@@ -245,7 +245,7 @@ FakeMemTreeOccMgr::sortUnflushed(void)
 
 
 void
-FakeMemTreeOccMgr::flush(void)
+FakeMemTreeOccMgr::flush()
 {
     typedef FeatureStore::RefType RefType;
     typedef std::vector<PendingOp>::iterator I;
@@ -286,7 +286,7 @@ FakeMemTreeOccMgr::flush(void)
 }
 
 void
-FakeMemTreeOccMgr::compactTrees(void)
+FakeMemTreeOccMgr::compactTrees()
 {
     // compact full trees by calling incremental compaction methods in a loop
 
@@ -307,7 +307,7 @@ FakeMemTreeOccMgr::compactTrees(void)
 }
 
 void
-FakeMemTreeOccMgr::finalize(void)
+FakeMemTreeOccMgr::finalize()
 {
     flush();
 }
@@ -319,7 +319,7 @@ FakeMemTreeOccFactory::FakeMemTreeOccFactory(const Schema &schema)
 }
 
 
-FakeMemTreeOccFactory::~FakeMemTreeOccFactory(void)
+FakeMemTreeOccFactory::~FakeMemTreeOccFactory()
 {
 }
 
@@ -389,7 +389,7 @@ FakeMemTreeOcc2Factory::FakeMemTreeOcc2Factory(const Schema &schema)
 }
 
 
-FakeMemTreeOcc2Factory::~FakeMemTreeOcc2Factory(void)
+FakeMemTreeOcc2Factory::~FakeMemTreeOcc2Factory()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakememtreeocc.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakememtreeocc.h
@@ -69,9 +69,9 @@ public:
         {}
 
         void setSeq(uint32_t seq) { _seq = seq; }
-        uint32_t getWordIdx(void) const { return _wordIdx; }
-        uint32_t getDocId(void) const { return _docId; }
-        EntryRef getFeatureRef(void) const { return _features; }
+        uint32_t getWordIdx() const { return _wordIdx; }
+        uint32_t getDocId() const { return _docId; }
+        EntryRef getFeatureRef() const { return _features; }
         bool getRemove() const { return _removal; }
 
         bool operator<(const PendingOp &rhs) const {

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakeposting.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakeposting.cpp
@@ -17,41 +17,41 @@ FakePosting::FakePosting(const std::string &name)
 }
 
 
-FakePosting::~FakePosting(void)
+FakePosting::~FakePosting()
 {
 }
 
 
 size_t
-FakePosting::skipBitSize(void) const
+FakePosting::skipBitSize() const
 {
     return l1SkipBitSize() + l2SkipBitSize() + l3SkipBitSize() +
         l4SkipBitSize();
 }
 
 size_t
-FakePosting::l1SkipBitSize(void) const
+FakePosting::l1SkipBitSize() const
 {
     return 0;
 }
 
 
 size_t
-FakePosting::l2SkipBitSize(void) const
+FakePosting::l2SkipBitSize() const
 {
     return 0;
 }
 
 
 size_t
-FakePosting::l3SkipBitSize(void) const
+FakePosting::l3SkipBitSize() const
 {
     return 0;
 }
 
 
 size_t
-FakePosting::l4SkipBitSize(void) const
+FakePosting::l4SkipBitSize() const
 {
     return 0;
 }

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakeposting.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakeposting.h
@@ -36,43 +36,43 @@ public:
 
     FakePosting(const std::string &name);
 
-    virtual ~FakePosting(void);
+    virtual ~FakePosting();
 
     /*
      * Size of posting list, in bits.
      */
     virtual size_t
-    bitSize(void) const = 0;
+    bitSize() const = 0;
 
     virtual size_t
-    skipBitSize(void) const;
+    skipBitSize() const;
 
     virtual size_t
-    l1SkipBitSize(void) const;
+    l1SkipBitSize() const;
 
     virtual size_t
-    l2SkipBitSize(void) const;
+    l2SkipBitSize() const;
 
     virtual size_t
-    l3SkipBitSize(void) const;
+    l3SkipBitSize() const;
 
     virtual size_t
-    l4SkipBitSize(void) const;
+    l4SkipBitSize() const;
 
     virtual bool
-    hasWordPositions(void) const = 0;
+    hasWordPositions() const = 0;
 
     /*
      * Single posting list performance, without feature unpack.
      */
     virtual int
-    lowLevelSinglePostingScan(void) const = 0;
+    lowLevelSinglePostingScan() const = 0;
 
     /*
      * Single posting list performance, with feature unpack.
      */
     virtual int
-    lowLevelSinglePostingScanUnpack(void) const = 0;
+    lowLevelSinglePostingScanUnpack() const = 0;
 
     /*
      * Two posting lists performance (same format) without feature unpack.
@@ -93,7 +93,7 @@ public:
     virtual search::queryeval::SearchIterator *
     createIterator(const fef::TermFieldMatchDataArray &matchData) const = 0;
 
-    const std::string &getName(void) const
+    const std::string &getName() const
     {
         return _name;
     }

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakeword.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakeword.cpp
@@ -95,7 +95,7 @@ fillcorrelatedbitset(search::BitVector &bitvector,
 }
 
 
-FakeWord::DocWordPosFeature::DocWordPosFeature(void)
+FakeWord::DocWordPosFeature::DocWordPosFeature()
     : _elementId(0),
       _wordPos(0),
       _elementWeight(1),
@@ -104,22 +104,22 @@ FakeWord::DocWordPosFeature::DocWordPosFeature(void)
 }
 
 
-FakeWord::DocWordPosFeature::~DocWordPosFeature(void)
+FakeWord::DocWordPosFeature::~DocWordPosFeature()
 {
 }
 
 
-FakeWord::DocWordCollapsedFeature::DocWordCollapsedFeature(void)
+FakeWord::DocWordCollapsedFeature::DocWordCollapsedFeature()
 {
 }
 
 
-FakeWord::DocWordCollapsedFeature::~DocWordCollapsedFeature(void)
+FakeWord::DocWordCollapsedFeature::~DocWordCollapsedFeature()
 {
 }
 
 
-FakeWord::DocWordFeature::DocWordFeature(void)
+FakeWord::DocWordFeature::DocWordFeature()
     : _docId(0),
       _collapsedDocWordFeatures(),
       _positions(0),
@@ -127,7 +127,7 @@ FakeWord::DocWordFeature::DocWordFeature(void)
 {
 }
 
-FakeWord::DocWordFeature::~DocWordFeature(void)
+FakeWord::DocWordFeature::~DocWordFeature()
 {
 }
 
@@ -208,7 +208,7 @@ FakeWord::FakeWord(uint32_t docIdLimit,
 }
 
 
-FakeWord::~FakeWord(void)
+FakeWord::~FakeWord()
 {
 }
 
@@ -752,7 +752,7 @@ FakeWord::dump(std::shared_ptr<FieldWriter> &fieldWriter,
 }
 
 
-FakeWord::RandomizedReader::RandomizedReader(void)
+FakeWord::RandomizedReader::RandomizedReader()
     : _r(),
       _fw(NULL),
       _wordIdx(0u),
@@ -764,7 +764,7 @@ FakeWord::RandomizedReader::RandomizedReader(void)
 
 
 void
-FakeWord::RandomizedReader::read(void)
+FakeWord::RandomizedReader::read()
 {
     if (_ri != _re) {
         _r = *_ri;
@@ -786,7 +786,7 @@ FakeWord::RandomizedReader::setup(const FakeWord *fw,
 }
 
 
-FakeWord::RandomizedWriter::~RandomizedWriter(void)
+FakeWord::RandomizedWriter::~RandomizedWriter()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakewordset.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakewordset.cpp
@@ -33,7 +33,7 @@ applyDocIdBiasToVector(std::vector<FakeWord *> &v, uint32_t docIdBias)
 }
 
 
-FakeWordSet::FakeWordSet(void)
+FakeWordSet::FakeWordSet()
     : _words(NUM_WORDCLASSES),
       _schema(),
       _fieldsParams()
@@ -52,7 +52,7 @@ FakeWordSet::FakeWordSet(bool hasElements,
 }
 
 
-FakeWordSet::~FakeWordSet(void)
+FakeWordSet::~FakeWordSet()
 {
     dropWords();
 }
@@ -130,7 +130,7 @@ FakeWordSet::setupWords(search::Rand48 &rnd,
 
 
 void
-FakeWordSet::dropWords(void)
+FakeWordSet::dropWords()
 {
     for (unsigned int i = 0; i < _words.size(); ++i)
         clearFakeWordVector(_words[i]);
@@ -138,7 +138,7 @@ FakeWordSet::dropWords(void)
 
 
 int
-FakeWordSet::getNumWords(void)
+FakeWordSet::getNumWords()
 {
     int ret = 0;
     for (unsigned int i = 0; i < _words.size(); ++i)

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakewordset.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakewordset.h
@@ -35,12 +35,12 @@ public:
     Schema _schema;
     std::vector<PosOccFieldsParams> _fieldsParams;
 
-    FakeWordSet(void);
+    FakeWordSet();
 
     FakeWordSet(bool hasElements,
                 bool hasElementWeights);
 
-    ~FakeWordSet(void);
+    ~FakeWordSet();
 
     void
     setupParams(bool hasElements,
@@ -53,31 +53,31 @@ public:
                unsigned int numWordsPerWordClass);
 
     void
-    dropWords(void);
+    dropWords();
 
     int
-    getNumWords(void);
+    getNumWords();
 
     const PosOccFieldsParams &
-    getFieldsParams(void) const
+    getFieldsParams() const
     {
         return _fieldsParams.back();
     }
 
     uint32_t
-    getPackedIndex(void) const
+    getPackedIndex() const
     {
         return _fieldsParams.size() - 1;
     }
 
     const std::vector<PosOccFieldsParams> &
-    getAllFieldsParams(void) const
+    getAllFieldsParams() const
     {
         return _fieldsParams;
     }
 
     const Schema &
-    getSchema(void) const
+    getSchema() const
     {
         return _schema;
     }

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakezcbfilterocc.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakezcbfilterocc.cpp
@@ -102,40 +102,40 @@ FakeZcbFilterOcc::FakeZcbFilterOcc(const FakeWord &fw)
 }
 
 
-FakeZcbFilterOcc::~FakeZcbFilterOcc(void)
+FakeZcbFilterOcc::~FakeZcbFilterOcc()
 {
 }
 
 
 void
-FakeZcbFilterOcc::forceLink(void)
+FakeZcbFilterOcc::forceLink()
 {
 }
 
 
 size_t
-FakeZcbFilterOcc::bitSize(void) const
+FakeZcbFilterOcc::bitSize() const
 {
     // Do not count the 3 padding bytes here.
     return 8 * (_compressed.size() - 3) ;
 }
 
 bool
-FakeZcbFilterOcc::hasWordPositions(void) const
+FakeZcbFilterOcc::hasWordPositions() const
 {
     return false;
 }
 
 
 int
-FakeZcbFilterOcc::lowLevelSinglePostingScan(void) const
+FakeZcbFilterOcc::lowLevelSinglePostingScan() const
 {
     return 0;
 }
 
 
 int
-FakeZcbFilterOcc::lowLevelSinglePostingScanUnpack(void) const
+FakeZcbFilterOcc::lowLevelSinglePostingScanUnpack() const
 {
     return 0;
 }
@@ -178,7 +178,7 @@ public:
                                   unsigned int residue,
                                   const fef::TermFieldMatchDataArray &matchData);
 
-    ~FakeFilterOccZCBArrayIterator(void);
+    ~FakeFilterOccZCBArrayIterator();
 
     void doUnpack(uint32_t docId) override;
     void doSeek(uint32_t docId) override;
@@ -212,8 +212,7 @@ FakeFilterOccZCBArrayIterator::initRange(uint32_t begin, uint32_t end)
 }
 
 
-FakeFilterOccZCBArrayIterator::
-~FakeFilterOccZCBArrayIterator(void)
+FakeFilterOccZCBArrayIterator::~FakeFilterOccZCBArrayIterator()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakezcfilterocc.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakezcfilterocc.cpp
@@ -493,20 +493,20 @@ FakeZcFilterOcc::setupT(const FakeWord &fw, bool doFeatures,
 }
 
 
-FakeZcFilterOcc::~FakeZcFilterOcc(void)
+FakeZcFilterOcc::~FakeZcFilterOcc()
 {
     free(_compressedMalloc);
 }
 
 
 void
-FakeZcFilterOcc::forceLink(void)
+FakeZcFilterOcc::forceLink()
 {
 }
 
 
 size_t
-FakeZcFilterOcc::bitSize(void) const
+FakeZcFilterOcc::bitSize() const
 {
     return _compressedBits -
         (_l1SkipSize + _l2SkipSize + _l3SkipSize + _l4SkipSize) * 8;
@@ -514,56 +514,56 @@ FakeZcFilterOcc::bitSize(void) const
 
 
 bool
-FakeZcFilterOcc::hasWordPositions(void) const
+FakeZcFilterOcc::hasWordPositions() const
 {
     return false;
 }
 
 
 size_t
-FakeZcFilterOcc::skipBitSize(void) const
+FakeZcFilterOcc::skipBitSize() const
 {
     return (_l1SkipSize + _l2SkipSize + _l3SkipSize + _l4SkipSize) * 8;
 }
 
 
 size_t
-FakeZcFilterOcc::l1SkipBitSize(void) const
+FakeZcFilterOcc::l1SkipBitSize() const
 {
     return _l1SkipSize * 8;
 }
 
 
 size_t
-FakeZcFilterOcc::l2SkipBitSize(void) const
+FakeZcFilterOcc::l2SkipBitSize() const
 {
     return _l2SkipSize * 8;
 }
 
 
 size_t
-FakeZcFilterOcc::l3SkipBitSize(void) const
+FakeZcFilterOcc::l3SkipBitSize() const
 {
     return _l3SkipSize * 8;
 }
 
 
 size_t
-FakeZcFilterOcc::l4SkipBitSize(void) const
+FakeZcFilterOcc::l4SkipBitSize() const
 {
     return _l4SkipSize * 8;
 }
 
 
 int
-FakeZcFilterOcc::lowLevelSinglePostingScan(void) const
+FakeZcFilterOcc::lowLevelSinglePostingScan() const
 {
     return 0;
 }
 
 
 int
-FakeZcFilterOcc::lowLevelSinglePostingScanUnpack(void) const
+FakeZcFilterOcc::lowLevelSinglePostingScanUnpack() const
 {
     return 0;
 }
@@ -612,7 +612,7 @@ public:
                                  uint32_t docIdLimit,
                                  const fef::TermFieldMatchDataArray &matchData);
 
-    ~FakeFilterOccZCArrayIterator(void);
+    ~FakeFilterOccZCArrayIterator();
 
     void doUnpack(uint32_t docId) override; 
     void doSeek(uint32_t docId) override;
@@ -702,7 +702,7 @@ FakeFilterOccZCArrayIterator::initRange(uint32_t begin, uint32_t end)
 
 
 FakeFilterOccZCArrayIterator::
-~FakeFilterOccZCArrayIterator(void)
+~FakeFilterOccZCArrayIterator()
 {
 }
 
@@ -789,7 +789,7 @@ FakeZcSkipFilterOcc<true>::FakeZcSkipFilterOcc(const FakeWord &fw)
 
 
 template <bool doSkip>
-FakeZcSkipFilterOcc<doSkip>::~FakeZcSkipFilterOcc(void)
+FakeZcSkipFilterOcc<doSkip>::~FakeZcSkipFilterOcc()
 {
 }
 
@@ -842,7 +842,7 @@ public:
                                      uint32_t docIdLimit,
                                      const TermFieldMatchDataArray &matchData);
 
-    ~FakeFilterOccZCSkipArrayIterator(void);
+    ~FakeFilterOccZCSkipArrayIterator();
 
     void doL4SkipSeek(uint32_t docId);
     void doL3SkipSeek(uint32_t docId);
@@ -1021,7 +1021,7 @@ initRange(uint32_t begin, uint32_t end)
 
 template <bool doSkip>
 FakeFilterOccZCSkipArrayIterator<doSkip>::
-~FakeFilterOccZCSkipArrayIterator(void)
+~FakeFilterOccZCSkipArrayIterator()
 {
 }
 
@@ -1390,7 +1390,7 @@ FakeEGCompr64PosOcc<bigEndian>::FakeEGCompr64PosOcc(const FakeWord &fw)
 
 
 template <bool bigEndian>
-FakeEGCompr64PosOcc<bigEndian>::~FakeEGCompr64PosOcc(void)
+FakeEGCompr64PosOcc<bigEndian>::~FakeEGCompr64PosOcc()
 {
 }
 
@@ -1517,7 +1517,7 @@ FakeEG2Compr64PosOcc<bigEndian>::FakeEG2Compr64PosOcc(const FakeWord &fw)
 
 
 template <bool bigEndian>
-FakeEG2Compr64PosOcc<bigEndian>::~FakeEG2Compr64PosOcc(void)
+FakeEG2Compr64PosOcc<bigEndian>::~FakeEG2Compr64PosOcc()
 {
 }
 
@@ -1596,7 +1596,7 @@ FakeEG2Compr64PosOcc<bigEndian>::setup(const FakeWord &fw)
 
 template <bool bigEndian>
 size_t
-FakeEG2Compr64PosOcc<bigEndian>::bitSize(void) const
+FakeEG2Compr64PosOcc<bigEndian>::bitSize() const
 {
     return _compressedBits;
 }
@@ -1604,7 +1604,7 @@ FakeEG2Compr64PosOcc<bigEndian>::bitSize(void) const
 
 template <bool bigEndian>
 bool
-FakeEG2Compr64PosOcc<bigEndian>::hasWordPositions(void) const
+FakeEG2Compr64PosOcc<bigEndian>::hasWordPositions() const
 {
     return true;
 }

--- a/searchlib/src/vespa/searchlib/test/fakedata/fpfactory.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fpfactory.cpp
@@ -72,7 +72,7 @@ getFPFactory(const std::string &name, const Schema &schema)
 
 
 std::vector<std::string>
-getPostingTypes(void)
+getPostingTypes()
 {
     std::vector<std::string> res;
 
@@ -93,7 +93,7 @@ FPFactoryInit::FPFactoryInit(const FPFactoryMapEntry &fpFactoryMapEntry)
     fpFactoryMap->insert(fpFactoryMapEntry);
 }
 
-FPFactoryInit::~FPFactoryInit(void)
+FPFactoryInit::~FPFactoryInit()
 {
     assert(fpFactoryMap != NULL);
     size_t eraseRes = fpFactoryMap->erase(_key);
@@ -106,7 +106,7 @@ FPFactoryInit::~FPFactoryInit(void)
 }
 
 void
-FPFactoryInit::forceLink(void)
+FPFactoryInit::forceLink()
 {
     FakeEGCompr64FilterOcc::forceLink();
     FakeFilterOcc::forceLink();

--- a/searchlib/src/vespa/searchlib/test/fakedata/fpfactory.h
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fpfactory.h
@@ -19,7 +19,7 @@ class FPFactory
 {
 public:
     virtual
-    ~FPFactory(void);
+    ~FPFactory();
 
     virtual FakePosting::SP
     make(const FakeWord &fw) = 0;
@@ -62,7 +62,7 @@ FPFactory *
 getFPFactory(const std::string &name, const index::Schema &schema);
 
 std::vector<std::string>
-getPostingTypes(void);
+getPostingTypes();
 
 class FPFactoryInit
 {
@@ -70,10 +70,10 @@ class FPFactoryInit
 public:
     FPFactoryInit(const FPFactoryMapEntry &fpFactoryMapEntry);
 
-    ~FPFactoryInit(void);
+    ~FPFactoryInit();
 
     static void
-    forceLink(void);
+    forceLink();
 };
 
 } // namespace fakedata

--- a/searchlib/src/vespa/searchlib/test/memoryindex/ordereddocumentinserter.h
+++ b/searchlib/src/vespa/searchlib/test/memoryindex/ordereddocumentinserter.h
@@ -99,7 +99,7 @@ public:
     }
 
     std::string
-    toStr(void) const
+    toStr() const
     {
         return _ss.str();
     }

--- a/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
@@ -390,7 +390,7 @@ int Domain::subscribe(const Domain::SP & domain, const SerialNum & from, FRT_Sup
 
 
 Domain::SerialNumList
-Domain::scanDir(void)
+Domain::scanDir()
 {
     SerialNumList res;
 

--- a/searchlib/src/vespa/searchlib/transactionlog/domainpart.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/domainpart.h
@@ -45,7 +45,7 @@ public:
     void sync();
     SerialNumRange range() const { return _range; }
 
-    SerialNum getSynced(void) const {
+    SerialNum getSynced() const {
         vespalib::LockGuard guard(_writeLock);
         return _syncedSerial; 
     }

--- a/searchlib/src/vespa/searchlib/transactionlog/nosyncproxy.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/nosyncproxy.cpp
@@ -7,12 +7,12 @@ namespace search
 namespace transactionlog
 {
 
-NoSyncProxy::NoSyncProxy(void)
+NoSyncProxy::NoSyncProxy()
 {
 }
 
 
-NoSyncProxy::~NoSyncProxy(void)
+NoSyncProxy::~NoSyncProxy()
 {
 }
 

--- a/searchlib/src/vespa/searchlib/transactionlog/syncproxy.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/syncproxy.h
@@ -12,13 +12,8 @@ namespace transactionlog
 class SyncProxy
 {
 public:
-    virtual
-    ~SyncProxy(void)
-    {
-    }
-
-    virtual void
-    sync(SerialNum syncTo) = 0;
+    virtual ~SyncProxy() { }
+    virtual void sync(SerialNum syncTo) = 0;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
@@ -36,8 +36,8 @@ public:
                 const TransLogServer::Session::SP &session,
                 SerialNum syncTo);
 
-    ~SyncHandler(void);
-    void PerformTask(void) override;
+    ~SyncHandler();
+    void PerformTask() override;
 };
 
 
@@ -55,13 +55,13 @@ SyncHandler::SyncHandler(FRT_Supervisor *supervisor,
 }
 
 
-SyncHandler::~SyncHandler(void)
+SyncHandler::~SyncHandler()
 {
 }
 
 
 void
-SyncHandler::PerformTask(void)
+SyncHandler::PerformTask()
 {
     SerialNum synced(_domain->getSynced());
     if (_session->getDown() ||

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.h
@@ -50,9 +50,9 @@ public:
     public:
         typedef std::shared_ptr<Session> SP;
 
-        Session(void) : _down(false) { }
-        bool getDown(void) const { return _down; }
-        void setDown(void) { _down = true; }
+        Session() : _down(false) { }
+        bool getDown() const { return _down; }
+        void setDown() { _down = true; }
     };
 
 private:

--- a/searchlib/src/vespa/searchlib/util/comprbuffer.h
+++ b/searchlib/src/vespa/searchlib/util/comprbuffer.h
@@ -11,7 +11,7 @@ namespace search {
 class ComprBuffer
 {
 private:
-    void allocComprBuf(void);
+    void allocComprBuf();
 public:
     void *_comprBuf;
     size_t _comprBufSize;

--- a/searchlib/src/vespa/searchlib/util/comprfile.cpp
+++ b/searchlib/src/vespa/searchlib/util/comprfile.cpp
@@ -321,7 +321,7 @@ ComprFileReadContext(uint32_t unitSize)
 }
 
 
-ComprFileReadContext::~ComprFileReadContext(void)
+ComprFileReadContext::~ComprFileReadContext()
 {
 }
 
@@ -341,7 +341,7 @@ ComprFileReadContext::readComprBuffer(uint64_t stopOffset, bool readAll)
 
 
 void
-ComprFileReadContext::readComprBuffer(void)
+ComprFileReadContext::readComprBuffer()
 {
     search::ComprFileReadBase::ReadComprBuffer(_stopOffset,
             _readAll,
@@ -545,7 +545,7 @@ ComprFileWriteContext(uint32_t unitSize)
 }
 
 
-ComprFileWriteContext::~ComprFileWriteContext(void)
+ComprFileWriteContext::~ComprFileWriteContext()
 {
 }
 
@@ -599,7 +599,7 @@ ComprFileWriteContext::allocComprBuf(unsigned int comprBufSize,
 
 
 void
-ComprFileWriteContext::allocComprBuf(void)
+ComprFileWriteContext::allocComprBuf()
 {
     allocComprBuf(32768, 32768);
 }

--- a/searchlib/src/vespa/searchlib/util/comprfile.h
+++ b/searchlib/src/vespa/searchlib/util/comprfile.h
@@ -51,7 +51,7 @@ public:
      */
     virtual void setupBits(int bitOffset) = 0;
     virtual uint64_t getBitPos(int bitOffset, uint64_t bufferEndFilePos) const = 0;
-    virtual uint64_t getBitPosV(void) const = 0;
+    virtual uint64_t getBitPosV() const = 0;
     virtual void skipBits(int bits) = 0;
     virtual void adjUnitPtr(int newRemainingUnits) = 0;
     virtual void emptyBuffer(uint64_t newBitPosition) = 0;
@@ -59,7 +59,7 @@ public:
     /**
      * Get size of each unit (typically 4 or 8)
      */
-    virtual uint32_t getUnitByteSize(void) const = 0;
+    virtual uint32_t getUnitByteSize() const = 0;
 
     /**
      * Checkpoint write.  Used at semi-regular intervals during indexing
@@ -97,7 +97,7 @@ public:
                             ComprBuffer &cbuf);
 
 protected:
-    virtual ~ComprFileReadBase(void) { }
+    virtual ~ComprFileReadBase() { }
 };
 
 
@@ -229,7 +229,7 @@ public:
      */
     virtual void checkPointRead(vespalib::nbostream &in) = 0;
 
-    virtual uint64_t getBitPosV(void) const = 0;
+    virtual uint64_t getBitPosV() const = 0;
 };
 
 class ComprFileWriteBase
@@ -260,16 +260,16 @@ public:
 
     void writeComprBuffer(bool flushSlack);
     void allocComprBuf(unsigned int comprBufSize, size_t preferredFileAlignment);
-    void allocComprBuf(void);
+    void allocComprBuf();
     void setEncodeContext(ComprFileEncodeContext *encodeContext) { _encodeContext = encodeContext; }
-    ComprFileEncodeContext *getEncodeContext(void) const { return _encodeContext; }
+    ComprFileEncodeContext *getEncodeContext() const { return _encodeContext; }
     void setFile(FastOS_FileInterface *file) { _file = file; }
-    FastOS_FileInterface *getFile(void) const { return _file; }
+    FastOS_FileInterface *getFile() const { return _file; }
 
     /**
      * Get file offset for start of compressed buffer.
      */
-    uint64_t getBufferStartFilePos(void) const { return _fileWriteByteOffset; }
+    uint64_t getBufferStartFilePos() const { return _fileWriteByteOffset; }
 
     /**
      * Set file offset for start of compressed byffer.

--- a/searchlib/src/vespa/searchlib/util/dirtraverse.cpp
+++ b/searchlib/src/vespa/searchlib/util/dirtraverse.cpp
@@ -77,7 +77,7 @@ DirectoryTraverse::PushRemoveDir(const char *name)
 
 
 void
-DirectoryTraverse::PushPushedDirs(void)
+DirectoryTraverse::PushPushedDirs()
 {
     Name *n;
     while (_pdirHead != NULL) {
@@ -92,7 +92,7 @@ DirectoryTraverse::PushPushedDirs(void)
 
 
 DirectoryTraverse::Name *
-DirectoryTraverse::UnQueueDir(void)
+DirectoryTraverse::UnQueueDir()
 {
     Name *n;
     PushPushedDirs();
@@ -107,7 +107,7 @@ DirectoryTraverse::UnQueueDir(void)
 }
 
 DirectoryTraverse::Name *
-DirectoryTraverse::UnQueueName(void)
+DirectoryTraverse::UnQueueName()
 {
     Name *n;
     if (_nameHead == NULL)
@@ -121,7 +121,7 @@ DirectoryTraverse::UnQueueName(void)
 
 
 void
-DirectoryTraverse::ScanSingleDir(void)
+DirectoryTraverse::ScanSingleDir()
 {
     assert(_nameHead == NULL);
     assert(_nameCount == 0);
@@ -156,7 +156,7 @@ DirectoryTraverse::ScanSingleDir(void)
 
 
 bool
-DirectoryTraverse::NextName(void)
+DirectoryTraverse::NextName()
 {
     delete _curName;
     _curName = NULL;
@@ -177,7 +177,7 @@ DirectoryTraverse::NextName(void)
 
 
 bool
-DirectoryTraverse::NextRemoveDir(void)
+DirectoryTraverse::NextRemoveDir()
 {
     Name *curName;
 
@@ -200,7 +200,7 @@ DirectoryTraverse::NextRemoveDir(void)
 
 
 bool
-DirectoryTraverse::RemoveTree(void)
+DirectoryTraverse::RemoveTree()
 {
     FastOS_StatInfo statInfo;
 
@@ -265,7 +265,7 @@ DirectoryTraverse::DirectoryTraverse(const char *baseDir)
 }
 
 
-DirectoryTraverse::~DirectoryTraverse(void)
+DirectoryTraverse::~DirectoryTraverse()
 {
     free(_fullDirName);
     free(_fullName);

--- a/searchlib/src/vespa/searchlib/util/dirtraverse.h
+++ b/searchlib/src/vespa/searchlib/util/dirtraverse.h
@@ -29,7 +29,7 @@ public:
         {
             _name = strdup(name);
         }
-        ~Name(void) { free(_name); }
+        ~Name() { free(_name); }
         static Name *sort(Name *head, int count);
     };
 private:
@@ -46,21 +46,21 @@ private:
     char *_fullName;
     char *_relName;
 public:
-    const char *GetFullName(void) const { return _fullName; }
-    const char *GetRelName(void) const { return _relName; }
+    const char *GetFullName() const { return _fullName; }
+    const char *GetRelName() const { return _relName; }
     void QueueDir(const char *name);
     void PushDir(const char *name);
     void PushRemoveDir(const char *name);
-    void PushPushedDirs(void);
-    Name *UnQueueDir(void);
-    Name *UnQueueName(void);
-    void ScanSingleDir(void);
-    bool NextName(void);
-    bool NextRemoveDir(void);
-    bool RemoveTree(void);
+    void PushPushedDirs();
+    Name *UnQueueDir();
+    Name *UnQueueName();
+    void ScanSingleDir();
+    bool NextName();
+    bool NextRemoveDir();
+    bool RemoveTree();
     uint64_t GetTreeSize(); // Returns size of directory in bytes
     explicit DirectoryTraverse(const char *baseDir);
-    ~DirectoryTraverse(void);
+    ~DirectoryTraverse();
 };
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/util/foldedstringcompare.h
+++ b/searchlib/src/vespa/searchlib/util/foldedstringcompare.h
@@ -9,7 +9,7 @@ namespace search {
 class FoldedStringCompare
 {
 public:
-    FoldedStringCompare(void) {}
+    FoldedStringCompare() {}
 
     /**
      * count number of UCS-4 characters in utf8 string

--- a/searchlib/src/vespa/searchlib/util/ioerrorhandler.cpp
+++ b/searchlib/src/vespa/searchlib/util/ioerrorhandler.cpp
@@ -20,7 +20,7 @@ std::atomic<int> nesting;
 }
 
 void
-IOErrorHandler::trap(void)
+IOErrorHandler::trap()
 {
     _instance = this;
     FastOS_File::SetFailedHandler(forward);
@@ -29,7 +29,7 @@ IOErrorHandler::trap(void)
 
 
 void
-IOErrorHandler::untrap(void)
+IOErrorHandler::untrap()
 {
 #ifdef notyet
     FastOS_File::SetFailedHandler(nullptr);

--- a/searchlib/src/vespa/searchlib/util/memoryusage.h
+++ b/searchlib/src/vespa/searchlib/util/memoryusage.h
@@ -28,10 +28,10 @@ public:
           _allocatedBytesOnHold(onHold)
     { }
 
-    size_t allocatedBytes(void) const { return _allocatedBytes; }
-    size_t usedBytes(void) const { return _usedBytes; }
-    size_t deadBytes(void) const { return _deadBytes; }
-    size_t allocatedBytesOnHold(void) const { return _allocatedBytesOnHold; }
+    size_t allocatedBytes() const { return _allocatedBytes; }
+    size_t usedBytes() const { return _usedBytes; }
+    size_t deadBytes() const { return _deadBytes; }
+    size_t allocatedBytesOnHold() const { return _allocatedBytesOnHold; }
     void incAllocatedBytes(size_t inc) { _allocatedBytes += inc; }
     void decAllocatedBytes(size_t dec) { _allocatedBytes -= dec; }
     void incUsedBytes(size_t inc) { _usedBytes += inc; }

--- a/searchlib/src/vespa/searchlib/util/postingpriorityqueue.h
+++ b/searchlib/src/vespa/searchlib/util/postingpriorityqueue.h
@@ -30,7 +30,7 @@ public:
         }
 
         IN *
-        get(void) const
+        get() const
         {
             return _ref;
         }
@@ -39,19 +39,19 @@ public:
     typedef std::vector<Ref> Vector;
     Vector _vec;
 
-    PostingPriorityQueue(void)
+    PostingPriorityQueue()
         : _vec()
     {
     }
 
     bool
-    empty(void) const
+    empty() const
     {
         return _vec.empty();
     }
 
     void
-    clear(void)
+    clear()
     {
         _vec.clear();
     }
@@ -67,7 +67,7 @@ public:
      * and adjust() can be used.
      */
     void
-    sort(void)
+    sort()
     {
         std::sort(_vec.begin(), _vec.end());
     }
@@ -76,7 +76,7 @@ public:
      * Return lowest value.  Assumes vector is sorted.
      */
     IN *
-    lowest(void) const
+    lowest() const
     {
         return _vec.front().get();
     }
@@ -86,7 +86,7 @@ public:
      * value.  Perform adjustments to make vector sorted again.
      */
     void
-    adjust(void);
+    adjust();
 
 
     template <class OUT>
@@ -116,7 +116,7 @@ public:
 
 template <class IN>
 void
-PostingPriorityQueue<IN>::adjust(void)
+PostingPriorityQueue<IN>::adjust()
 {
     typedef typename Vector::iterator VIT;
     if (!_vec.front().get()->isValid()) {

--- a/searchlib/src/vespa/searchlib/util/rand48.h
+++ b/searchlib/src/vespa/searchlib/util/rand48.h
@@ -21,7 +21,7 @@ public:
         _state = ((static_cast<uint64_t>(seed & 0xffffffffu)) << 16) + 0x330e;
     }
 
-    Rand48(void)
+    Rand48()
         : _state(0)
     {
         srand48(0x1234abcd);

--- a/searchlib/src/vespa/searchlib/util/rawbuf.cpp
+++ b/searchlib/src/vespa/searchlib/util/rawbuf.cpp
@@ -41,7 +41,7 @@ RawBuf::RawBuf(char *start, size_t size)
 }
 
 
-RawBuf::~RawBuf(void)
+RawBuf::~RawBuf()
 {
     if (_bufStart != _initialBufStart)
         free(_bufStart);
@@ -113,7 +113,7 @@ RawBuf::appendCompressedNumber(int64_t n)
  * Has the entire contents of the buffer been used up, i.e. freed?
  */
 bool
-RawBuf::IsEmpty(void)
+RawBuf::IsEmpty()
 {
     return _bufFillPos == _bufDrainPos;
 }
@@ -159,7 +159,7 @@ RawBuf::preAlloc(size_t len)
 
 
 void
-RawBuf::Compact(void)
+RawBuf::Compact()
 {
     if (_bufDrainPos == _bufStart)
         return;
@@ -171,7 +171,7 @@ RawBuf::Compact(void)
 
 
 void
-RawBuf::Reuse(void)
+RawBuf::Reuse()
 {
     if (static_cast<size_t>(_bufEnd - _bufStart) > _initialSize * 4) {
         free(_bufStart);

--- a/searchlib/src/vespa/searchlib/util/rawbuf.h
+++ b/searchlib/src/vespa/searchlib/util/rawbuf.h
@@ -35,7 +35,7 @@ public:
 
     RawBuf(char *start, size_t size);// Initially use provided buffer
     RawBuf(size_t size);	// malloc-s given size, assigns to _bufStart
-    ~RawBuf(void);		// Frees _bufStart, i.e. the char[].
+    ~RawBuf();		// Frees _bufStart, i.e. the char[].
 
     void	operator+=(const char *src);
     void	operator+=(const RawBuf& buffer);
@@ -52,23 +52,23 @@ public:
     void    appendLong(uint64_t n);
     void    appendCompressedPositiveNumber(uint64_t n);
     void    appendCompressedNumber(int64_t n);
-    bool	IsEmpty(void);	// Return whether all written.
+    bool	IsEmpty();	// Return whether all written.
     void 	expandBuf(size_t needlen);
-    size_t      GetFreeLen(void) const { return _bufEnd - _bufFillPos; }
-    size_t      GetDrainLen(void) const { return _bufDrainPos - _bufStart; }
-    const char *GetDrainPos(void) const { return _bufDrainPos; }
-    const char *GetFillPos(void) const { return _bufFillPos; }
-    char *      GetWritableFillPos(void) const { return _bufFillPos; }
+    size_t      GetFreeLen() const { return _bufEnd - _bufFillPos; }
+    size_t      GetDrainLen() const { return _bufDrainPos - _bufStart; }
+    const char *GetDrainPos() const { return _bufDrainPos; }
+    const char *GetFillPos() const { return _bufFillPos; }
+    char *      GetWritableFillPos() const { return _bufFillPos; }
     char *      GetWritableFillPos(size_t len) { preAlloc(len); return _bufFillPos; }
     char *      GetWritableDrainPos(size_t offset) { return _bufDrainPos + offset; }
     void    truncate(size_t offset) { _bufFillPos = _bufDrainPos + offset; }
     void	preAlloc(size_t len);	// Ensure room for 'len' more bytes.
     size_t  readFile(FastOS_FileInterface &file, size_t maxlen);
-    void	reset(void) { _bufDrainPos = _bufFillPos = _bufStart; }
-    void    Compact(void);
-    void    Reuse(void);
-    size_t  GetUsedAndDrainLen(void) const { return _bufFillPos - _bufStart; }
-    size_t  GetUsedLen(void) const { return _bufFillPos - _bufDrainPos; }
+    void	reset() { _bufDrainPos = _bufFillPos = _bufStart; }
+    void    Compact();
+    void    Reuse();
+    size_t  GetUsedAndDrainLen() const { return _bufFillPos - _bufStart; }
+    size_t  GetUsedLen() const { return _bufFillPos - _bufDrainPos; }
     void	Drain(size_t len);	// Adjust drain pos.
     void    Fill(size_t len) { _bufFillPos += len; }
 

--- a/searchlib/src/vespa/searchlib/util/sigbushandler.cpp
+++ b/searchlib/src/vespa/searchlib/util/sigbushandler.cpp
@@ -63,7 +63,7 @@ mystderr(const char *msg) noexcept
 }
 
 void
-SigBusHandler::trap(void)
+SigBusHandler::trap()
 {
     struct sigaction sa;
     _instance = this;
@@ -78,7 +78,7 @@ SigBusHandler::trap(void)
 
 
 void
-SigBusHandler::untrap(void)
+SigBusHandler::untrap()
 {
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));

--- a/searchlib/src/vespa/searchlib/util/statefile.h
+++ b/searchlib/src/vespa/searchlib/util/statefile.h
@@ -100,7 +100,7 @@ public:
      * Get current state generation (bumped whenever new state is written).
      */
     int
-    getGen(void) const;
+    getGen() const;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/util/url.cpp
+++ b/searchlib/src/vespa/searchlib/util/url.cpp
@@ -195,7 +195,7 @@ URL::URL(const unsigned char *url, size_t len) :
 
 
 void
-URL::Reset(void)
+URL::Reset()
 {
     _gotCompleteURL = false;
 
@@ -410,7 +410,7 @@ URL::SetURL(const unsigned char *url, size_t length)
 }
 
 bool
-URL::IsBaseURL(void) const
+URL::IsBaseURL() const
 {
     return (_scheme[0] != '\0' &&
             _host[0] != '\0' &&
@@ -494,7 +494,7 @@ URL::ContextName(URL_CONTEXT ctx)
 }
 
 void
-URL::Dump(void)
+URL::Dump()
 {
     printf("URL: '%s'\n", _url);
 

--- a/searchlib/src/vespa/searchlib/util/url.h
+++ b/searchlib/src/vespa/searchlib/util/url.h
@@ -87,7 +87,7 @@ protected:
 
     bool _gotCompleteURL;
 
-    void Reset(void);
+    void Reset();
 
     template <bool (*IsPartChar)(unsigned char c)>
     static unsigned char *ParseURLPart(unsigned char *url,
@@ -138,7 +138,7 @@ public:
      *
      * @return true if this is an absolute URL, false otherwise.
      */
-    bool IsBaseURL(void) const;
+    bool IsBaseURL() const;
 
     /**
      * Get a pointer to the current URL.
@@ -268,7 +268,7 @@ public:
      * Dump the contents of the URL and subelements to stdout. Only
      * elements that contains information are shown.
      */
-    void Dump(void);
+    void Dump();
 };
 
 }


### PR DESCRIPTION
@baldersheim, please review