### PR TITLE
[VESPA-7654] Write configs on container start as well

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -239,6 +239,8 @@ public class NodeAgentImpl implements NodeAgent {
         dockerOperations.startContainer(containerName, nodeSpec);
         lastCpuMetric = new CpuUsageReporter(clock.instant());
 
+        writeConfigs(nodeSpec);
+
         addDebugMessage("startContainerIfNeeded: containerState " + containerState + " -> " +
                 RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN);
         containerState = RUNNING_HOWEVER_RESUME_SCRIPT_NOT_RUN;
@@ -410,10 +412,7 @@ public class NodeAgentImpl implements NodeAgent {
             // TODO: Should be retried if writing fails
             metricReceiver.unsetMetricsForContainer(hostname);
             if (container.isPresent()) {
-                storageMaintainer.ifPresent(maintainer -> {
-                    maintainer.writeMetricsConfig(containerName, nodeSpec);
-                    maintainer.writeFilebeatConfig(containerName, nodeSpec);
-                });
+                writeConfigs(nodeSpec);
             }
         }
 
@@ -604,6 +603,13 @@ public class NodeAgentImpl implements NodeAgent {
         } catch (Throwable e) {
             logger.warning("Failed to update " + yamasName + " metric with value " + metricsMap.get(metricName), e);
         }
+    }
+
+    private void writeConfigs(ContainerNodeSpec nodeSpec) {
+        storageMaintainer.ifPresent(maintainer -> {
+            maintainer.writeMetricsConfig(containerName, nodeSpec);
+            maintainer.writeFilebeatConfig(containerName, nodeSpec);
+        });
     }
 
     private Optional<Container> getContainer() {


### PR DESCRIPTION
* When starting a new container, the `nodeSpec` must've just changed, but at the time we check if it changed the container is not yet started - so write config in https://github.com/yahoo/vespa/blob/6c0635f98fb73cfb135da799f4afb0f89b024098/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java#L414 is an no-op.
* When re-starting a dead container, the `nodeSpec` has not been changed, thus the config will not be written.

Fix for both scenarios is to also write configs when starting a container.