### PR TITLE
Freva/add want to uprovision flag

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirer.java
@@ -96,12 +96,12 @@ public class NodeRetirer extends Maintainer {
                     Flavor flavorWithMinSpareNodes = getMinAmongstKeys(numSpareNodesByFlavor, possibleReplacementFlavors);
                     long spareNodesForMinFlavor = numSpareNodesByFlavor.getOrDefault(flavorWithMinSpareNodes, 0L);
                     if (spareNodesForMinFlavor > 0) {
-                        log.info("Setting node " + retireableNode + " to wantToRetire and wantToUnprovision. Policy: " +
+                        log.info("Setting node " + retireableNode + " to wantToRetire and wantToDeprovision. Policy: " +
                                 retirementPolicy.getClass().getSimpleName());
                         Node updatedNode = retireableNode
                                 .with(retireableNode.status()
                                         .withWantToRetire(true)
-                                        .withWantToUnprovision(true));
+                                        .withWantToDeprovision(true));
                         nodeRepository().write(updatedNode);
                         numSpareNodesByFlavor.put(flavorWithMinSpareNodes, spareNodesForMinFlavor - 1);
                         numNodesAllowedToRetire--;
@@ -151,7 +151,7 @@ public class NodeRetirer extends Maintainer {
     }
 
     /**
-     * Parks and sets wantToUnprovision for a subset of size 'limit' of nodes
+     * Parks and sets wantToDeprovision for a subset of size 'limit' of nodes
      *
      * @param nodesToPark Nodes that we want to park
      * @param limit Maximum number of nodes we want to park
@@ -161,7 +161,7 @@ public class NodeRetirer extends Maintainer {
         nodesToPark.stream()
                 .limit(limit)
                 .forEach(node -> {
-                    nodeRepository().write(node.with(node.status().withWantToUnprovision(true)));
+                    nodeRepository().write(node.with(node.status().withWantToDeprovision(true)));
                     nodeRepository().park(node.hostname(), Agent.NodeRetirer, "Policy: " + retirementPolicy.getClass().getSimpleName());
                 });
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
@@ -22,6 +22,7 @@ public class Status {
     private final int failCount;
     private final Optional<HardwareFailureType> hardwareFailure;
     private final boolean wantToRetire;
+    private final boolean wantToUnprovision;
     
     public enum HardwareFailureType {
         
@@ -40,7 +41,8 @@ public class Status {
                   Optional<String> stateVersion,
                   int failCount,
                   Optional<HardwareFailureType> hardwareFailure,
-                  boolean wantToRetire) {
+                  boolean wantToRetire,
+                  boolean wantToUnprovision) {
         this.reboot = generation;
         this.vespaVersion = vespaVersion;
         this.hostedVersion = hostedVersion;
@@ -48,28 +50,29 @@ public class Status {
         this.failCount = failCount;
         this.hardwareFailure = hardwareFailure;
         this.wantToRetire = wantToRetire;
+        this.wantToUnprovision = wantToUnprovision;
     }
 
     /** Returns a copy of this with the reboot generation changed */
-    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire); }
+    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
 
     /** Returns the reboot generation of this node */
     public Generation reboot() { return reboot; }
 
     /** Returns a copy of this with the vespa version changed */
-    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire); }
+    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
 
     /** Returns the Vespa version installed on the node, if known */
     public Optional<Version> vespaVersion() { return vespaVersion; }
 
     /** Returns a copy of this with the hosted version changed */
-    public Status withHostedVersion(Version version) { return new Status(reboot, vespaVersion, Optional.of(version), stateVersion, failCount, hardwareFailure, wantToRetire); }
+    public Status withHostedVersion(Version version) { return new Status(reboot, vespaVersion, Optional.of(version), stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
 
     /** Returns the hosted version installed on the node, if known */
     public Optional<Version> hostedVersion() { return hostedVersion; }
 
     /** Returns a copy of this with the state version changed */
-    public Status withStateVersion(String version) { return new Status(reboot, vespaVersion, hostedVersion, Optional.of(version), failCount, hardwareFailure, wantToRetire); }
+    public Status withStateVersion(String version) { return new Status(reboot, vespaVersion, hostedVersion, Optional.of(version), failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
 
     /**
      * Returns the state version the node last successfully converged with.
@@ -85,29 +88,29 @@ public class Status {
                 .filter(image -> !image.isEmpty())
                 .map(DockerImage::new)
                 .map(DockerImage::tagAsVersion);
-        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire);
+        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision);
     }
 
     /** Returns the current docker image the node is running, if known. */
     public Optional<String> dockerImage() { return vespaVersion.map(DockerImage.defaultImage::withTag).map(DockerImage::toString); }
 
-    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount + 1, hardwareFailure, wantToRetire); }
+    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount + 1, hardwareFailure, wantToRetire, wantToUnprovision); }
 
-    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount - 1, hardwareFailure, wantToRetire); }
+    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount - 1, hardwareFailure, wantToRetire, wantToUnprovision); }
 
-    public Status setFailCount(Integer value) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, value, hardwareFailure, wantToRetire); }
+    public Status setFailCount(Integer value) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, value, hardwareFailure, wantToRetire, wantToUnprovision); }
 
     /** Returns how many times this node has been moved to the failed state. */
     public int failCount() { return failCount; }
 
-    public Status withHardwareFailure(Optional<HardwareFailureType> hardwareFailure) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire); }
+    public Status withHardwareFailure(Optional<HardwareFailureType> hardwareFailure) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
 
     /** Returns the type of the last hardware failure detected on this node, or empty if none */
     public Optional<HardwareFailureType> hardwareFailure() { return hardwareFailure; }
 
     /** Returns a copy of this with the want to retire flag changed */
     public Status withWantToRetire(boolean wantToRetire) {
-        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire);
+        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision);
     }
 
     /**
@@ -118,7 +121,19 @@ public class Status {
         return wantToRetire;
     }
 
+    /** Returns a copy of this with the want to unprovision flag changed */
+    public Status withWantToUnprovision(boolean wantToUnprovision) {
+        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision);
+    }
+
+    /**
+     * Returns whether this node should be unprovisioned when possible.
+     */
+    public boolean wantToUnprovision() {
+        return wantToUnprovision;
+    }
+
     /** Returns the initial status of a newly provisioned node */
-    public static Status initial() { return new Status(Generation.inital(), Optional.empty(), Optional.empty(), Optional.empty(), 0, Optional.empty(), false); }
+    public static Status initial() { return new Status(Generation.inital(), Optional.empty(), Optional.empty(), Optional.empty(), 0, Optional.empty(), false, false); }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
@@ -22,7 +22,7 @@ public class Status {
     private final int failCount;
     private final Optional<HardwareFailureType> hardwareFailure;
     private final boolean wantToRetire;
-    private final boolean wantToUnprovision;
+    private final boolean wantToDeprovision;
     
     public enum HardwareFailureType {
         
@@ -42,7 +42,7 @@ public class Status {
                   int failCount,
                   Optional<HardwareFailureType> hardwareFailure,
                   boolean wantToRetire,
-                  boolean wantToUnprovision) {
+                  boolean wantToDeprovision) {
         this.reboot = generation;
         this.vespaVersion = vespaVersion;
         this.hostedVersion = hostedVersion;
@@ -50,29 +50,29 @@ public class Status {
         this.failCount = failCount;
         this.hardwareFailure = hardwareFailure;
         this.wantToRetire = wantToRetire;
-        this.wantToUnprovision = wantToUnprovision;
+        this.wantToDeprovision = wantToDeprovision;
     }
 
     /** Returns a copy of this with the reboot generation changed */
-    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision); }
 
     /** Returns the reboot generation of this node */
     public Generation reboot() { return reboot; }
 
     /** Returns a copy of this with the vespa version changed */
-    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision); }
 
     /** Returns the Vespa version installed on the node, if known */
     public Optional<Version> vespaVersion() { return vespaVersion; }
 
     /** Returns a copy of this with the hosted version changed */
-    public Status withHostedVersion(Version version) { return new Status(reboot, vespaVersion, Optional.of(version), stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withHostedVersion(Version version) { return new Status(reboot, vespaVersion, Optional.of(version), stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision); }
 
     /** Returns the hosted version installed on the node, if known */
     public Optional<Version> hostedVersion() { return hostedVersion; }
 
     /** Returns a copy of this with the state version changed */
-    public Status withStateVersion(String version) { return new Status(reboot, vespaVersion, hostedVersion, Optional.of(version), failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withStateVersion(String version) { return new Status(reboot, vespaVersion, hostedVersion, Optional.of(version), failCount, hardwareFailure, wantToRetire, wantToDeprovision); }
 
     /**
      * Returns the state version the node last successfully converged with.
@@ -88,29 +88,29 @@ public class Status {
                 .filter(image -> !image.isEmpty())
                 .map(DockerImage::new)
                 .map(DockerImage::tagAsVersion);
-        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision);
+        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision);
     }
 
     /** Returns the current docker image the node is running, if known. */
     public Optional<String> dockerImage() { return vespaVersion.map(DockerImage.defaultImage::withTag).map(DockerImage::toString); }
 
-    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount + 1, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount + 1, hardwareFailure, wantToRetire, wantToDeprovision); }
 
-    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount - 1, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount - 1, hardwareFailure, wantToRetire, wantToDeprovision); }
 
-    public Status setFailCount(Integer value) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, value, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status setFailCount(Integer value) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, value, hardwareFailure, wantToRetire, wantToDeprovision); }
 
     /** Returns how many times this node has been moved to the failed state. */
     public int failCount() { return failCount; }
 
-    public Status withHardwareFailure(Optional<HardwareFailureType> hardwareFailure) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision); }
+    public Status withHardwareFailure(Optional<HardwareFailureType> hardwareFailure) { return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision); }
 
     /** Returns the type of the last hardware failure detected on this node, or empty if none */
     public Optional<HardwareFailureType> hardwareFailure() { return hardwareFailure; }
 
     /** Returns a copy of this with the want to retire flag changed */
     public Status withWantToRetire(boolean wantToRetire) {
-        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision);
+        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision);
     }
 
     /**
@@ -121,16 +121,16 @@ public class Status {
         return wantToRetire;
     }
 
-    /** Returns a copy of this with the want to unprovision flag changed */
-    public Status withWantToUnprovision(boolean wantToUnprovision) {
-        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToUnprovision);
+    /** Returns a copy of this with the want to deprovision flag changed */
+    public Status withWantToDeprovision(boolean wantToDeprovision) {
+        return new Status(reboot, vespaVersion, hostedVersion, stateVersion, failCount, hardwareFailure, wantToRetire, wantToDeprovision);
     }
 
     /**
-     * Returns whether this node should be unprovisioned when possible.
+     * Returns whether this node should be deprovisioned when possible.
      */
-    public boolean wantToUnprovision() {
-        return wantToUnprovision;
+    public boolean wantToDeprovision() {
+        return wantToDeprovision;
     }
 
     /** Returns the initial status of a newly provisioned node */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -60,7 +60,7 @@ public class NodeSerializer {
     private static final String hardwareFailureKey = "hardwareFailure";
     private static final String nodeTypeKey = "type";
     private static final String wantToRetireKey = "wantToRetire";
-    private static final String wantToUnprovisionKey = "wantToUnprovision";
+    private static final String wantToDeprovisionKey = "wantToDeprovision";
 
     // Configuration fields
     private static final String flavorKey = "flavor";
@@ -113,7 +113,7 @@ public class NodeSerializer {
         object.setLong(failCountKey, node.status().failCount());
         node.status().hardwareFailure().ifPresent(failure -> object.setString(hardwareFailureKey, toString(failure)));
         object.setBool(wantToRetireKey, node.status().wantToRetire());
-        object.setBool(wantToUnprovisionKey, node.status().wantToUnprovision());
+        object.setBool(wantToDeprovisionKey, node.status().wantToDeprovision());
         node.allocation().ifPresent(allocation -> toSlime(allocation, object.setObject(instanceKey)));
         toSlime(node.history(), object.setArray(historyKey));
         object.setString(nodeTypeKey, toString(node.type()));
@@ -167,7 +167,7 @@ public class NodeSerializer {
 
     private Status statusFromSlime(Inspector object) {
         // TODO: Simplify after June 2017
-        boolean wantToUnprovision = object.field(wantToUnprovisionKey).valid() && object.field(wantToUnprovisionKey).asBool();
+        boolean wantToDeprovision = object.field(wantToDeprovisionKey).valid() && object.field(wantToDeprovisionKey).asBool();
         return new Status(generationFromSlime(object, rebootGenerationKey, currentRebootGenerationKey),
                           versionFromSlime(object.field(vespaVersionKey)),
                           versionFromSlime(object.field(hostedVersionKey)),
@@ -175,7 +175,7 @@ public class NodeSerializer {
                           (int)object.field(failCountKey).asLong(),
                           hardwareFailureFromSlime(object.field(hardwareFailureKey)),
                           object.field(wantToRetireKey).asBool(),
-                          wantToUnprovision);
+                          wantToDeprovision);
     }
 
     private Flavor flavorFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -60,6 +60,7 @@ public class NodeSerializer {
     private static final String hardwareFailureKey = "hardwareFailure";
     private static final String nodeTypeKey = "type";
     private static final String wantToRetireKey = "wantToRetire";
+    private static final String wantToUnprovisionKey = "wantToUnprovision";
 
     // Configuration fields
     private static final String flavorKey = "flavor";
@@ -112,6 +113,7 @@ public class NodeSerializer {
         object.setLong(failCountKey, node.status().failCount());
         node.status().hardwareFailure().ifPresent(failure -> object.setString(hardwareFailureKey, toString(failure)));
         object.setBool(wantToRetireKey, node.status().wantToRetire());
+        object.setBool(wantToUnprovisionKey, node.status().wantToUnprovision());
         node.allocation().ifPresent(allocation -> toSlime(allocation, object.setObject(instanceKey)));
         toSlime(node.history(), object.setArray(historyKey));
         object.setString(nodeTypeKey, toString(node.type()));
@@ -170,7 +172,8 @@ public class NodeSerializer {
                           optionalString(object.field(stateVersionKey)),
                           (int)object.field(failCountKey).asLong(),
                           hardwareFailureFromSlime(object.field(hardwareFailureKey)),
-                          object.field(wantToRetireKey).asBool());
+                          object.field(wantToRetireKey).asBool(),
+                          object.field(wantToUnprovisionKey).asBool());
     }
 
     private Flavor flavorFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -166,6 +166,8 @@ public class NodeSerializer {
     }
 
     private Status statusFromSlime(Inspector object) {
+        // TODO: Simplify after June 2017
+        boolean wantToUnprovision = object.field(wantToUnprovisionKey).valid() && object.field(wantToUnprovisionKey).asBool();
         return new Status(generationFromSlime(object, rebootGenerationKey, currentRebootGenerationKey),
                           versionFromSlime(object.field(vespaVersionKey)),
                           versionFromSlime(object.field(hostedVersionKey)),
@@ -173,7 +175,7 @@ public class NodeSerializer {
                           (int)object.field(failCountKey).asLong(),
                           hardwareFailureFromSlime(object.field(hardwareFailureKey)),
                           object.field(wantToRetireKey).asBool(),
-                          object.field(wantToUnprovisionKey).asBool());
+                          wantToUnprovision);
     }
 
     private Flavor flavorFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -87,8 +87,8 @@ public class NodePatcher {
                 return node.withAdditionalIpAddresses(asStringSet(value));
             case "wantToRetire" :
                 return node.with(node.status().withWantToRetire(asBoolean(value)));
-            case "wantToUnprovision" :
-                return node.with(node.status().withWantToUnprovision(asBoolean(value)));
+            case "wantToDeprovision" :
+                return node.with(node.status().withWantToDeprovision(asBoolean(value)));
             default :
                 throw new IllegalArgumentException("Could not apply field '" + name + "' on a node: No such modifiable field");
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -87,6 +87,8 @@ public class NodePatcher {
                 return node.withAdditionalIpAddresses(asStringSet(value));
             case "wantToRetire" :
                 return node.with(node.status().withWantToRetire(asBoolean(value)));
+            case "wantToUnprovision" :
+                return node.with(node.status().withWantToUnprovision(asBoolean(value)));
             default :
                 throw new IllegalArgumentException("Could not apply field '" + name + "' on a node: No such modifiable field");
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -171,7 +171,7 @@ class NodesResponse extends HttpResponse {
         object.setBool("hardwareFailure", node.status().hardwareFailure().isPresent());
         node.status().hardwareFailure().ifPresent(failure -> object.setString("hardwareFailureType", toString(failure)));
         object.setBool("wantToRetire", node.status().wantToRetire());
-        object.setBool("wantToUnprovision", node.status().wantToUnprovision());
+        object.setBool("wantToDeprovision", node.status().wantToDeprovision());
         toSlime(node.history(), object.setArray("history"));
         ipAddressesToSlime(node.ipAddresses(), object.setArray("ipAddresses"));
         ipAddressesToSlime(node.additionalIpAddresses(), object.setArray("additionalIpAddresses"));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -171,6 +171,7 @@ class NodesResponse extends HttpResponse {
         object.setBool("hardwareFailure", node.status().hardwareFailure().isPresent());
         node.status().hardwareFailure().ifPresent(failure -> object.setString("hardwareFailureType", toString(failure)));
         object.setBool("wantToRetire", node.status().wantToRetire());
+        object.setBool("wantToUnprovision", node.status().wantToUnprovision());
         toSlime(node.history(), object.setArray("history"));
         ipAddressesToSlime(node.ipAddresses(), object.setArray("ipAddresses"));
         ipAddressesToSlime(node.additionalIpAddresses(), object.setArray("additionalIpAddresses"));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTest.java
@@ -73,6 +73,7 @@ public class NodeRetirerTest {
                     .forEach(node -> {
                         Agent parkingAgent = node.history().event(History.Event.Type.parked).orElseThrow(RuntimeException::new).agent();
                         assertEquals(Agent.NodeRetirer, parkingAgent);
+                        assertTrue("Nodes parked by NodeRetirer should also have wantToUnprovision flag set", node.status().wantToUnprovision());
                         tester.nodeRepository.write(node.withIpAddresses(Collections.singleton("::2")));
                         tester.nodeRepository.setDirty(node.hostname());
                         tester.nodeRepository.setReady(node.hostname());
@@ -143,6 +144,10 @@ public class NodeRetirerTest {
             // min flavor count for both flavor clusters is now 0, so no further change is expected
             retireThenAssertSpareAndParkedCounts(new long[]{2, 40, 25, 0, 0, 1}, new long[]{6, 3, 5, 2, 1});
             retireThenAssertSpareAndParkedCounts(new long[]{2, 40, 25, 0, 0, 1}, new long[]{6, 3, 5, 2, 1});
+
+            tester.nodeRepository.getNodes(Node.State.parked)
+                    .forEach(node -> assertTrue("Nodes parked by NodeRetirer should also have wantToUnprovision flag set",
+                            node.status().wantToUnprovision()));
         }
 
         @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTest.java
@@ -73,7 +73,7 @@ public class NodeRetirerTest {
                     .forEach(node -> {
                         Agent parkingAgent = node.history().event(History.Event.Type.parked).orElseThrow(RuntimeException::new).agent();
                         assertEquals(Agent.NodeRetirer, parkingAgent);
-                        assertTrue("Nodes parked by NodeRetirer should also have wantToUnprovision flag set", node.status().wantToUnprovision());
+                        assertTrue("Nodes parked by NodeRetirer should also have wantToDeprovision flag set", node.status().wantToDeprovision());
                         tester.nodeRepository.write(node.withIpAddresses(Collections.singleton("::2")));
                         tester.nodeRepository.setDirty(node.hostname());
                         tester.nodeRepository.setReady(node.hostname());
@@ -146,8 +146,8 @@ public class NodeRetirerTest {
             retireThenAssertSpareAndParkedCounts(new long[]{2, 40, 25, 0, 0, 1}, new long[]{6, 3, 5, 2, 1});
 
             tester.nodeRepository.getNodes(Node.State.parked)
-                    .forEach(node -> assertTrue("Nodes parked by NodeRetirer should also have wantToUnprovision flag set",
-                            node.status().wantToUnprovision()));
+                    .forEach(node -> assertTrue("Nodes parked by NodeRetirer should also have wantToDeprovision flag set",
+                            node.status().wantToDeprovision()));
         }
 
         @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -325,7 +325,7 @@ public class SerializationTest {
     }
 
     @Test
-    public void want_to_unprovision_defaults_to_false() {
+    public void want_to_deprovision_defaults_to_false() {
         String nodeData =
                 "{\n" +
                         "   \"type\" : \"tenant\",\n" +
@@ -335,7 +335,7 @@ public class SerializationTest {
                         "   \"ipAddresses\" : [\"127.0.0.1\"]\n" +
                         "}";
         Node node = nodeSerializer.fromJson(State.provisioned, Utf8.toBytes(nodeData));
-        assertFalse(node.status().wantToUnprovision());
+        assertFalse(node.status().wantToDeprovision());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -325,6 +325,20 @@ public class SerializationTest {
     }
 
     @Test
+    public void want_to_unprovision_defaults_to_false() {
+        String nodeData =
+                "{\n" +
+                        "   \"type\" : \"tenant\",\n" +
+                        "   \"flavor\" : \"large\",\n" +
+                        "   \"openStackId\" : \"myId\",\n" +
+                        "   \"hostname\" : \"myHostname\",\n" +
+                        "   \"ipAddresses\" : [\"127.0.0.1\"]\n" +
+                        "}";
+        Node node = nodeSerializer.fromJson(State.provisioned, Utf8.toBytes(nodeData));
+        assertFalse(node.status().wantToUnprovision());
+    }
+
+    @Test
     public void vespa_version_serialization() throws Exception {
         String nodeWithWantedVespaVersion =
                 "{\n" +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -196,6 +196,9 @@ public class RestApiTest {
                                    Utf8.toBytes("{\"wantToRetire\": true}"), Request.Method.PATCH),
                        "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+                        Utf8.toBytes("{\"wantToUnprovision\": true}"), Request.Method.PATCH),
+                "{\"message\":\"Updated host4.yahoo.com\"}");
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
                                    Utf8.toBytes("{\"currentDockerImage\": \"ignored-image-name:4443/vespa/ci:6.43.0\"}"), Request.Method.PATCH),
                        "{\"message\":\"Updated host4.yahoo.com\"}");
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -196,7 +196,7 @@ public class RestApiTest {
                                    Utf8.toBytes("{\"wantToRetire\": true}"), Request.Method.PATCH),
                        "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-                        Utf8.toBytes("{\"wantToUnprovision\": true}"), Request.Method.PATCH),
+                        Utf8.toBytes("{\"wantToDeprovision\": true}"), Request.Method.PATCH),
                 "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
                                    Utf8.toBytes("{\"currentDockerImage\": \"ignored-image-name:4443/vespa/ci:6.43.0\"}"), Request.Method.PATCH),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
@@ -33,6 +33,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
@@ -33,7 +33,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -38,6 +38,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -38,7 +38,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
@@ -18,6 +18,7 @@
   "failCount":0,
   "hardwareFailure":false,
   "wantToRetire":false,
+  "wantToUnprovision" : false,
   "history":[],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
@@ -18,7 +18,7 @@
   "failCount":0,
   "hardwareFailure":false,
   "wantToRetire":false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
@@ -33,6 +33,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
@@ -33,7 +33,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
@@ -31,7 +31,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
@@ -31,6 +31,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -39,6 +39,7 @@
   "hardwareFailure": true,
   "hardwareFailureType": "memory_mcelog",
   "wantToRetire" : true,
+  "wantToUnprovision" : true,
   "history": [
     {
       "event": "readied",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -39,7 +39,7 @@
   "hardwareFailure": true,
   "hardwareFailureType": "memory_mcelog",
   "wantToRetire" : true,
-  "wantToUnprovision" : true,
+  "wantToDeprovision" : true,
   "history": [
     {
       "event": "readied",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
@@ -36,7 +36,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
@@ -36,6 +36,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
@@ -18,7 +18,7 @@
   "failCount": 1,
   "hardwareFailure": false,
   "wantToRetire": false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"failed","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
@@ -18,6 +18,7 @@
   "failCount": 1,
   "hardwareFailure": false,
   "wantToRetire": false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"failed","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
@@ -20,6 +20,7 @@
   "failCount": 1,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"failed","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
@@ -20,7 +20,7 @@
   "failCount": 1,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"failed","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -17,7 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"deallocated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -17,6 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"deallocated","at":123,"agent":"system"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
@@ -33,6 +33,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
@@ -33,7 +33,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[{"event":"readied","at":123,"agent":"system"},{"event":"reserved","at":123,"agent":"application"},{"event":"activated","at":123,"agent":"application"}],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
@@ -17,6 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
@@ -17,7 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
@@ -17,6 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[],
   "ipAddresses":["127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
@@ -17,7 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[],
   "ipAddresses":["127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
@@ -17,6 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history":[],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
@@ -17,7 +17,7 @@
   "failCount": 0,
   "hardwareFailure" : false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history":[],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
@@ -17,6 +17,7 @@
   "failCount": 0,
   "hardwareFailure": false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history": [
     {
       "event": "readied",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
@@ -17,7 +17,7 @@
   "failCount": 0,
   "hardwareFailure": false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history": [
     {
       "event": "readied",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
@@ -17,6 +17,7 @@
   "failCount": 0,
   "hardwareFailure": false,
   "wantToRetire" : false,
+  "wantToUnprovision" : false,
   "history": [],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
@@ -17,7 +17,7 @@
   "failCount": 0,
   "hardwareFailure": false,
   "wantToRetire" : false,
-  "wantToUnprovision" : false,
+  "wantToDeprovision" : false,
   "history": [],
   "ipAddresses":["::1", "127.0.0.1"],
   "additionalIpAddresses":[]


### PR DESCRIPTION
Adds a `wantToUnprovision` flag to `Node` that shall be used by the automatic deprovisioner instead of looking at the `Agent` that parked the node. 