### PR TITLE
Add new metric set for system metrics, and add to predefined sets.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
@@ -1,21 +1,29 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.admin.monitoring;
 
+import com.google.common.collect.ImmutableList;
+
+import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
+import static java.util.Collections.emptyList;
+
 /**
- * This class sets up the default 'vespa' metrics consumer.
+ * This class sets up the default 'Vespa' metrics consumer.
  *
- * @author <a href="mailto:trygve@yahoo-inc.com">Trygve Bolsø Berdal</a>
+ * @author trygve
  * @author gjoranv
  */
 public class DefaultMetricsConsumer {
 
     public static final String VESPA_CONSUMER_ID = "Vespa";
 
-    private static final MetricSet vespaMetricSet = new VespaMetricSet();
+    private static final MetricSet defaultConsumerMetrics = new MetricSet("default-consumer",
+                                                                          emptyList(),
+                                                                          ImmutableList.of(new VespaMetricSet(),
+                                                                                           systemMetricSet));
 
     @SuppressWarnings("UnusedDeclaration")
     public static MetricsConsumer getDefaultMetricsConsumer() {
-        return new MetricsConsumer(VESPA_CONSUMER_ID, vespaMetricSet);
+        return new MetricsConsumer(VESPA_CONSUMER_ID, defaultConsumerMetrics);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/SystemMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/SystemMetrics.java
@@ -1,0 +1,51 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.admin.monitoring;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * @author gjoranv
+ */
+@SuppressWarnings("UnusedDeclaration") // Used by model amenders
+public class SystemMetrics {
+    public static final String CPU_UTIL = "cpu.util";
+    public static final String DISK_LIMIT = "disk.limit";
+    public static final String DISK_USED = "disk.used";
+    public static final String DISK_UTIL = "disk.util";
+    public static final String MEM_LIMIT = "mem.limit";
+    public static final String MEM_USED = "mem.used";
+    public static final String MEM_UTIL = "mem.util";
+
+    public static final MetricSet systemMetricSet = createSystemMetricSet();
+
+    private static MetricSet createSystemMetricSet() {
+        Set<Metric> dockerNodeMetrics =
+                ImmutableSet.of(new Metric(CPU_UTIL),
+                                new Metric(DISK_LIMIT),
+                                new Metric(DISK_USED),
+                                new Metric(DISK_UTIL),
+                                new Metric(MEM_LIMIT),
+                                new Metric(MEM_USED),
+                                new Metric(MEM_UTIL)
+                );
+
+        Set<Metric> nonDockerNodeMetrics =
+                // Disk metrics should be based on /home, or else '/' - or simply add filesystem as dimension
+                ImmutableSet.of(new Metric("cpu.busy.pct", CPU_UTIL),
+                                new Metric("mem.used.pct", MEM_UTIL),
+                                new Metric("memory.usage", MEM_USED),
+                                new Metric("mem.total.kb", MEM_LIMIT),
+                                new Metric("fs.used.kb", DISK_USED),
+                                new Metric("fs.capacity.kb", DISK_LIMIT)
+                );
+
+        Set<Metric> systemMetrics = ImmutableSet.<Metric>builder()
+                .addAll(dockerNodeMetrics)
+                .addAll(nonDockerNodeMetrics)
+                .build();
+
+        return new MetricSet("system", systemMetrics);
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -7,6 +7,9 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
+ * Encapsulates vespa service metrics.
+ * IS-A metric set for convenience only (to avoid one indirection to what would have been this class' HAS-A metric set).
+ *
  * @author gjoranv
  */
 @SuppressWarnings("UnusedDeclaration") // Used by model amenders

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.admin.monitoring.builder;
 
 import com.yahoo.vespa.model.admin.monitoring.MetricSet;
+import com.yahoo.vespa.model.admin.monitoring.SystemMetrics;
 import com.yahoo.vespa.model.admin.monitoring.VespaMetricSet;
 
 import java.util.Collections;
@@ -16,7 +17,8 @@ import java.util.Map;
 public class PredefinedMetricSets {
 
     public static final Map<String, MetricSet> predefinedMetricSets = toMapById(
-            new VespaMetricSet()
+            new VespaMetricSet(),
+            SystemMetrics.systemMetricSet
     );
 
     private static Map<String, MetricSet> toMapById(MetricSet... metricSets) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.yahoo.vespa.model.admin.monitoring.DefaultMetricsConsumer.VESPA_CONSUMER_ID;
+import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
 
 /**
  * @author gjoranv
@@ -51,6 +52,8 @@ public class MetricsBuilder {
         List<MetricSet> metricSets = XML.getChildren(consumerElement, "metric-set").stream()
                 .map(metricSetElement -> availableMetricSets.get(metricSetElement.getAttribute(ID_ATTRIBUTE)))
                 .collect(Collectors.toCollection(LinkedList::new));
+
+        metricSets.add(systemMetricSet);
 
         return new MetricSet(metricSetId(consumerId), metrics, metricSets);
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/monitoring/MetricSetTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/monitoring/MetricSetTest.java
@@ -1,18 +1,35 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.admin.monitoring;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.junit.Test;
 
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author gjoranv
  */
 public class MetricSetTest {
+
+    @Test
+    public void metrics_from_children_are_added() {
+        MetricSet child1 = new MetricSet("child1",
+                                         ImmutableList.of(new Metric("child1_metric")));
+        MetricSet child2 = new MetricSet("child2",
+                                         ImmutableList.of(new Metric("child2_metric")));
+        MetricSet parent = new MetricSet("parent", emptyList(), ImmutableList.of(child1, child2));
+
+        Map<String, Metric> parentMetrics = parent.getMetrics();
+        assertEquals(2, parentMetrics.size());
+        assertNotNull(parentMetrics.get("child1_metric"));
+        assertNotNull(parentMetrics.get("child2_metric"));
+    }
 
     @Test
     public void internal_metrics_take_precedence_over_metrics_from_children() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/monitoring/MetricSetTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/monitoring/MetricSetTest.java
@@ -19,16 +19,24 @@ public class MetricSetTest {
 
     @Test
     public void metrics_from_children_are_added() {
-        MetricSet child1 = new MetricSet("child1",
-                                         ImmutableList.of(new Metric("child1_metric")));
-        MetricSet child2 = new MetricSet("child2",
-                                         ImmutableList.of(new Metric("child2_metric")));
+        MetricSet child1 = new MetricSet("child1", ImmutableList.of(new Metric("child1_metric")));
+        MetricSet child2 = new MetricSet("child2", ImmutableList.of(new Metric("child2_metric")));
         MetricSet parent = new MetricSet("parent", emptyList(), ImmutableList.of(child1, child2));
 
         Map<String, Metric> parentMetrics = parent.getMetrics();
         assertEquals(2, parentMetrics.size());
         assertNotNull(parentMetrics.get("child1_metric"));
         assertNotNull(parentMetrics.get("child2_metric"));
+    }
+
+    @Test
+    public void adding_the_same_child_set_twice_has_no_effect() {
+        MetricSet child = new MetricSet("child", ImmutableList.of(new Metric("child_metric")));
+        MetricSet parent = new MetricSet("parent", emptyList(), ImmutableList.of(child, child));
+
+        Map<String, Metric> parentMetrics = parent.getMetrics();
+        assertEquals(1, parentMetrics.size());
+        assertNotNull(parentMetrics.get("child_metric"));
     }
 
     @Test


### PR DESCRIPTION
@ldalves I will add a separate commit to enable the output of these metrics by adding the set to the consumers. This just adds the set to the predefined metric sets.
EDIT: the set is now added to both the default consumer and all custom consumers.
FYI: @smorgrav 