### PR TITLE
Log jaxrs requests and responses if loglevel is below info

### DIFF
--- a/jaxrs_client_utils/src/main/java/com/yahoo/vespa/jaxrs/client/JerseyJaxRsClientFactory.java
+++ b/jaxrs_client_utils/src/main/java/com/yahoo/vespa/jaxrs/client/JerseyJaxRsClientFactory.java
@@ -11,7 +11,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.UriBuilder;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -24,7 +23,6 @@ public class JerseyJaxRsClientFactory implements JaxRsClientFactory {
 
     private final int connectTimeoutMs;
     private final int readTimeoutMs;
-    private final Consumer<String> logger;
 
     public JerseyJaxRsClientFactory() {
         this(DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
@@ -33,13 +31,6 @@ public class JerseyJaxRsClientFactory implements JaxRsClientFactory {
     public JerseyJaxRsClientFactory(final int connectTimeoutMs, final int readTimeoutMs) {
         this.connectTimeoutMs = connectTimeoutMs;
         this.readTimeoutMs = readTimeoutMs;
-        logger = s -> {};
-    }
-
-    public JerseyJaxRsClientFactory(final int connectTimeoutMs, final int readTimeoutMs, Consumer<String> logger) {
-        this.connectTimeoutMs = connectTimeoutMs;
-        this.readTimeoutMs = readTimeoutMs;
-        this.logger = logger;
     }
 
     /**


### PR DESCRIPTION
For the TODOs; I see no reason to change API to avoid empty puts and Java 8 uses heap for class information.

@hakonhall 