### PR TITLE
Avoid activating without changes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Maintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Maintainer.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
  */
 public abstract class Maintainer extends AbstractComponent implements Runnable {
 
-    protected static final Logger log = Logger.getLogger(Maintainer.class.getName());
+    protected final Logger log = Logger.getLogger(this.getClass().getName());
 
     private final NodeRepository nodeRepository;
     private final Duration interval;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredEarlyExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredEarlyExpirer.java
@@ -60,6 +60,10 @@ public class RetiredEarlyExpirer extends Maintainer {
                         nodesToRemove.add(node);
                     }
                 }
+                
+                if (nodesToRemove.isEmpty()) {
+                    continue;
+                }
 
                 nodeRepository().setRemovable(application, nodesToRemove);
 


### PR DESCRIPTION
Skip preparing and activating application if there are no nodes to
remove/deactivate in RetiredEarlyExpirer.

Also, make sure the runtime/subclass Maintainer class name is used in logging.