### PR TITLE
Keep more log on config server nodes

### DIFF
--- a/configserver/src/main/resources/logd/logd.cfg
+++ b/configserver/src/main/resources/logd/logd.cfg
@@ -7,3 +7,4 @@ loglevel.info.forward false
 loglevel.event.forward false
 loglevel.debug.forward false
 loglevel.spam.forward false
+remove.totalmegabytes 5000


### PR DESCRIPTION
Default is 1000 megabytes, increase to 5000.