### PR TITLE
Allow 200 response without content

### DIFF
--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceTest.java
@@ -440,7 +440,7 @@ public class HttpServerConformanceTest extends ServerProviderConformanceTest {
     @Override
     @Test
     public void testRequestContentCloseWithNondeterministicAsyncFailure() throws Throwable {
-        new TestRunner().expect(anyOf(success(), serverError()))
+        new TestRunner().expect(anyOf(success(), successNoContent(), serverError()))
                         .execute();
     }
 


### PR DESCRIPTION
There is a window between the response is committed (headers including
response code is set) and the response body is written, where the exception
from the request handler can be catched. If that happens, the output
stream will be closed before response body is written.