### PR TITLE
Orchestrator support for setting host status

### DIFF
--- a/docker-api/pom.xml
+++ b/docker-api/pom.xml
@@ -97,12 +97,6 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
-            <artifactId>jaxrs_utils</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.yahoo.vespa</groupId>
             <artifactId>jaxrs_client_utils</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/node-admin/pom.xml
+++ b/node-admin/pom.xml
@@ -69,12 +69,6 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
-            <artifactId>jaxrs_utils</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.yahoo.vespa</groupId>
             <artifactId>jaxrs_client_utils</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/OrchestratorMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/OrchestratorMock.java
@@ -33,6 +33,9 @@ public class OrchestratorMock implements Orchestrator {
     }
 
     @Override
+    public void setNodeStatus(HostName hostName, HostStatus state) throws OrchestrationException {}
+
+    @Override
     public void resume(HostName hostName) throws HostStateChangeDeniedException, HostNameNotFoundException {}
 
     @Override

--- a/orchestrator-restapi/pom.xml
+++ b/orchestrator-restapi/pom.xml
@@ -22,6 +22,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>jaxrs_utils</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson2.version}</version>

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
@@ -2,8 +2,11 @@
 package com.yahoo.vespa.orchestrator.restapi;
 
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
+import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostRequest;
+import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.UpdateHostResponse;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -35,6 +38,15 @@ public interface HostApi {
     @Path("/{hostname}")
     @Produces(MediaType.APPLICATION_JSON)
     GetHostResponse getHost(@PathParam("hostname") String hostNameString);
+
+    /**
+     * Tweak internal Orchestrator state for host.
+     */
+    @PUT
+    @Path("/{hostname}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    PatchHostResponse patch(@PathParam("hostname") String hostNameString, PatchHostRequest request);
 
     /**
      * Ask for permission to temporarily suspend all services on a host.

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
@@ -1,6 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.restapi;
 
+import com.yahoo.vespa.jaxrs.annotation.PATCH;
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostRequest;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostResponse;
@@ -42,7 +43,7 @@ public interface HostApi {
     /**
      * Tweak internal Orchestrator state for host.
      */
-    @PUT
+    @PATCH
     @Path("/{hostname}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/PatchHostRequest.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/PatchHostRequest.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.restapi.wire;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PatchHostRequest {
+    /** String representation of HostStatus enum value. */
+    @JsonProperty public String state;
+}

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/PatchHostResponse.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/PatchHostResponse.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.restapi.wire;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PatchHostResponse {
+    /** Description of the HTTP response status code. */
+    @JsonProperty public String description;
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/Orchestrator.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/Orchestrator.java
@@ -41,6 +41,8 @@ public interface Orchestrator {
      */
     HostStatus getNodeStatus(HostName hostName) throws HostNameNotFoundException;
 
+    void setNodeStatus(HostName hostName, HostStatus state) throws OrchestrationException;
+
     /**
      * Resume normal operation for this host.
      *

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
@@ -83,7 +83,15 @@ public class OrchestratorImpl implements Orchestrator {
 
     @Override
     public HostStatus getNodeStatus(HostName hostName) throws HostNameNotFoundException {
-        return getNodeStatus(getApplicationInstance(hostName).reference(),hostName);
+        return getNodeStatus(getApplicationInstance(hostName).reference(), hostName);
+    }
+
+    @Override
+    public void setNodeStatus(HostName hostName, HostStatus status) throws OrchestrationException {
+        ApplicationInstanceReference reference = getApplicationInstance(hostName).reference();
+        try (MutableStatusRegistry statusRegistry = statusService.lockApplicationInstance_forCurrentThreadOnly(reference)) {
+            statusRegistry.setHostState(hostName, status);
+        }
     }
 
     @Override

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostResource.java
@@ -5,17 +5,23 @@ import com.yahoo.container.jaxrs.annotation.Component;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.orchestrator.HostNameNotFoundException;
+import com.yahoo.vespa.orchestrator.OrchestrationException;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.restapi.HostApi;
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.HostStateChangeDenialReason;
+import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostRequest;
+import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.UpdateHostResponse;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 
 import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -45,6 +51,35 @@ public class HostResource implements HostApi {
             log.log(LogLevel.INFO, "Host not found: " + hostName);
             throw new NotFoundException(e);
         }
+    }
+
+    @Override
+    public PatchHostResponse patch(@PathParam("hostname") String hostNameString, PatchHostRequest request) {
+        HostName hostName = new HostName(hostNameString);
+
+        if (request.state != null) {
+            HostStatus state;
+            try {
+                state = HostStatus.valueOf(request.state);
+            } catch (IllegalArgumentException dummy) {
+                throw new BadRequestException("Bad state in request: '" + request.state + "'");
+            }
+
+            try {
+                orchestrator.setNodeStatus(hostName, state);
+            } catch (HostNameNotFoundException e) {
+                log.log(LogLevel.INFO, "Host not found: " + hostName);
+                throw new NotFoundException(e);
+            } catch (OrchestrationException e) {
+                String message = "Failed to set " + hostName + " to " + state + ": " + e.getMessage();
+                log.log(LogLevel.INFO, message, e);
+                throw new InternalServerErrorException(message);
+            }
+        }
+
+        PatchHostResponse response = new PatchHostResponse();
+        response.description = "ok";
+        return response;
     }
 
     @Override

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
@@ -218,6 +218,15 @@ public class OrchestratorImplTest {
     }
 
     @Test
+    public void testSetNodeState() throws OrchestrationException {
+        assertEquals(HostStatus.NO_REMARKS, orchestrator.getNodeStatus(app1_host1));
+        orchestrator.setNodeStatus(app1_host1, HostStatus.ALLOWED_TO_BE_DOWN);
+        assertEquals(HostStatus.ALLOWED_TO_BE_DOWN, orchestrator.getNodeStatus(app1_host1));
+        orchestrator.setNodeStatus(app1_host1, HostStatus.NO_REMARKS);
+        assertEquals(HostStatus.NO_REMARKS, orchestrator.getNodeStatus(app1_host1));
+    }
+
+    @Test
     public void rollbackWorks() throws Exception {
         // A spy is preferential because suspendAll() relies on delegating the hard work to suspend() and resume().
         OrchestratorImpl orchestrator = spy(this.orchestrator);


### PR DESCRIPTION
Directly setting the host status can be useful for an operator, e.g. to break a
deadlock.

Unfortunately, some code use the term "host status" while others use "host
state".  I haven't settled yet on which is preferred, e.g. 'state' is used in
REST APIs, but 'status' is the original term and slightly more used.  This PR
maintains the local use of the terms, meaning it adds 'state' where that's
normally used and 'status' other places.

Setting the deadlock is done with a PATCH request, which is defined in
jaxrs_utils. jaxrs_utils only defines PATCH, and that's not used anywhere else
except in jaxrs_client_utils tests.  So I remove this module as a dependency a
couple of places.