### PR TITLE
Freva/simplify tests

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
@@ -32,14 +32,13 @@ public class DockerFailTest {
                 Thread.sleep(10);
             }
 
-            CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
-            callOrderVerifier.assertInOrder(
+            dockerTester.callOrderVerifier.assertInOrder(
                     "createContainerCommand with DockerImage { imageId=dockerImage }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
                     "executeInContainerAsRoot with ContainerName { name=host1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");
 
-            dockerTester.deleteContainer(new ContainerName("host1"));
+            dockerTester.dockerMock.deleteContainer(new ContainerName("host1"));
 
-            callOrderVerifier.assertInOrder(
+            dockerTester.callOrderVerifier.assertInOrder(
                     "deleteContainer with ContainerName { name=host1 }",
                     "createContainerCommand with DockerImage { imageId=dockerImage }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
                     "executeInContainerAsRoot with ContainerName { name=host1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", resume]");

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
@@ -36,10 +36,10 @@ public class RebootTest {
                 Thread.sleep(10);
             }
 
-            CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             // Check that the container is started and NodeRepo has received the PATCH update
-            callOrderVerifier.assertInOrder("createContainerCommand with DockerImage { imageId=dockerImage }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
-                                            "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=null,  dockerImage=dockerImage, vespaVersion='null'}");
+            dockerTester.callOrderVerifier.assertInOrder(
+                    "createContainerCommand with DockerImage { imageId=dockerImage }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
+                    "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=null,  dockerImage=dockerImage, vespaVersion='null'}");
 
             NodeAdminStateUpdater updater = dockerTester.getNodeAdminStateUpdater();
             assertThat(updater.setResumeStateAndCheckIfResumed(NodeAdminStateUpdater.State.SUSPENDED),
@@ -56,7 +56,8 @@ public class RebootTest {
 
             assertTrue(nodeAdmin.setFrozen(false));
 
-            callOrderVerifier.assertInOrder("executeInContainer with ContainerName { name=host1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", stop]");
+            dockerTester.callOrderVerifier.assertInOrder(
+                    "executeInContainer with ContainerName { name=host1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", stop]");
         }
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -29,17 +29,18 @@ public class RestartTest {
                 Thread.sleep(10);
             }
 
-            CallOrderVerifier callOrderVerifier = dockerTester.getCallOrderVerifier();
             // Check that the container is started and NodeRepo has received the PATCH update
-            callOrderVerifier.assertInOrder("createContainerCommand with DockerImage { imageId=image:1.2.3 }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
-                                            "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image:1.2.3, vespaVersion='1.2.3'}");
+            dockerTester.callOrderVerifier.assertInOrder(
+                    "createContainerCommand with DockerImage { imageId=image:1.2.3 }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
+                    "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image:1.2.3, vespaVersion='1.2.3'}");
 
             wantedRestartGeneration = 2;
             currentRestartGeneration = 1;
-            dockerTester.updateContainerNodeSpec(createContainerNodeSpec(wantedRestartGeneration, currentRestartGeneration));
+            dockerTester.addContainerNodeSpec(createContainerNodeSpec(wantedRestartGeneration, currentRestartGeneration));
 
-            callOrderVerifier.assertInOrder("Suspend for host1.test.yahoo.com",
-                                            "executeInContainerAsRoot with ContainerName { name=host1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", restart-vespa]");
+            dockerTester.callOrderVerifier.assertInOrder(
+                    "Suspend for host1.test.yahoo.com",
+                    "executeInContainerAsRoot with ContainerName { name=host1 }, args: [" + DockerOperationsImpl.NODE_PROGRAM + ", restart-vespa]");
         }
     }
 


### PR DESCRIPTION
Tried to get rid of all the *Mock classes, but it looks like there is no way to do `Mockito.inOrder` with a timeout, so I simplified a little instead.