### PR TITLE
Rename slobrok programs to have vespa- prefix.

### DIFF
--- a/dist/post_install.sh
+++ b/dist/post_install.sh
@@ -127,3 +127,7 @@ ln -s vespa-fbench $INSTALLPATH/bin/fbench
 ln -s vespa-fbench-filter-file $INSTALLPATH/bin/filterfile
 ln -s vespa-geturl $INSTALLPATH/bin/geturl
 ln -s vespa-fbench-split-file $INSTALLPATH/bin/splitfile
+
+# Temporary when renaming programs in slobrok
+ln -s vespa-slobrok $INSTALLPATH/bin/slobrok
+ln -s vespa-slobrok-cmd $INSTALLPATH/bin/sbcmd

--- a/jrt_test/src/binref/env.sh.in
+++ b/jrt_test/src/binref/env.sh.in
@@ -1,6 +1,6 @@
 BINREF=@CMAKE_CURRENT_BINARY_DIR@
-SBCMD=@PROJECT_BINARY_DIR@/slobrok/src/apps/sbcmd/sbcmd
-SLOBROK=@PROJECT_BINARY_DIR@/slobrok/src/apps/slobrok/slobrok
+SBCMD=@PROJECT_BINARY_DIR@/slobrok/src/apps/sbcmd/vespa-slobrok-cmd
+SLOBROK=@PROJECT_BINARY_DIR@/slobrok/src/apps/slobrok/vespa-slobrok
 SIMPLESERVER=@PROJECT_BINARY_DIR@/jrt_test/src/jrt-test/simpleserver/jrt_test_simpleserver_app
 export BINREF SBCMD SLOBROK SIMPLESERVER
 # port numbers allocated for this module:

--- a/slobrok/src/apps/check_slobrok/CMakeLists.txt
+++ b/slobrok/src/apps/check_slobrok/CMakeLists.txt
@@ -2,6 +2,5 @@
 vespa_add_executable(slobrok_check_slobrok_app
     SOURCES
     check_slobrok.cpp
-    INSTALL bin
     DEPENDS
 )

--- a/slobrok/src/apps/sbcmd/.gitignore
+++ b/slobrok/src/apps/sbcmd/.gitignore
@@ -1,3 +1,3 @@
 /.depend
 /Makefile
-/sbcmd
+/vespa-slobrok-cmd

--- a/slobrok/src/apps/sbcmd/CMakeLists.txt
+++ b/slobrok/src/apps/sbcmd/CMakeLists.txt
@@ -2,7 +2,7 @@
 vespa_add_executable(slobrok_sbcmd_app
     SOURCES
     sbcmd.cpp
-    OUTPUT_NAME sbcmd
+    OUTPUT_NAME vespa-slobrok-cmd
     INSTALL bin
     DEPENDS
 )

--- a/slobrok/src/apps/sbcmd/sbcmd.cpp
+++ b/slobrok/src/apps/sbcmd/sbcmd.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 
 #include <vespa/log/log.h>
-LOG_SETUP("sb-cmd");
+LOG_SETUP("vespa-slobrok-cmd");
 
 class Slobrok_CMD : public FastOS_Application
 {
@@ -135,7 +135,7 @@ Slobrok_CMD::Main()
     _target->InvokeSync(req, 5.0);
 
     if (req->IsError()) {
-        fprintf(stderr, "sb-cmd error %d: %s\n",
+        fprintf(stderr, "vespa-slobrok-cmd error %d: %s\n",
                 req->GetErrorCode(), req->GetErrorMessage());
     } else {
         FRT_Values &answer = *(req->GetReturn());
@@ -163,7 +163,7 @@ Slobrok_CMD::Main()
                        answer[1]._string_array._pt[j]._str);
             }
         } else {
-            fprintf(stderr, "sb-cmd OK, returntypes '%s'\n", atypes);
+            fprintf(stderr, "vespa-slobrok-cmd OK, returntypes '%s'\n", atypes);
             uint32_t idx = 0;
             while (atypes != NULL && *atypes != '\0') {
                 switch (*atypes) {

--- a/slobrok/src/apps/slobrok/.gitignore
+++ b/slobrok/src/apps/slobrok/.gitignore
@@ -1,3 +1,3 @@
 /.depend
 /Makefile
-/slobrok
+/vespa-slobrok

--- a/slobrok/src/apps/slobrok/CMakeLists.txt
+++ b/slobrok/src/apps/slobrok/CMakeLists.txt
@@ -2,7 +2,7 @@
 vespa_add_executable(slobrok_app
     SOURCES
     slobrok.cpp
-    OUTPUT_NAME slobrok
+    OUTPUT_NAME vespa-slobrok
     INSTALL bin
     DEPENDS
     slobrok_slobrokserver

--- a/slobrok/src/apps/slobrok/slobrok.cpp
+++ b/slobrok/src/apps/slobrok/slobrok.cpp
@@ -6,7 +6,7 @@
 #include <vespa/fastos/app.h>
 
 #include <vespa/log/log.h>
-LOG_SETUP("slobrok");
+LOG_SETUP("vespa-slobrok");
 
 /**
  * @brief namespace for the actual slobrok application.

--- a/slobrok/src/tests/startsome/startsome.sh
+++ b/slobrok/src/tests/startsome/startsome.sh
@@ -2,8 +2,8 @@
 # Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 set -e
 
-SBCMD=../../apps/sbcmd/sbcmd
-SLOBROK=../../apps/slobrok/slobrok
+SBCMD=../../apps/sbcmd/vespa-slobrok-cmd
+SLOBROK=../../apps/slobrok/vespa-slobrok
 
 
 listall () {


### PR DESCRIPTION
Temporarily add symlinks from old name to new name.

@geirst, please review