### PR TITLE
Use PUT

### DIFF
--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
@@ -1,7 +1,6 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.restapi;
 
-import com.yahoo.vespa.jaxrs.annotation.PATCH;
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostRequest;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostResponse;
@@ -42,8 +41,9 @@ public interface HostApi {
 
     /**
      * Tweak internal Orchestrator state for host.
+     * Note: This should really be a patch method, but I was unable to get that working with PATCH from jaxrs_utils!?
      */
-    @PATCH
+    @PUT
     @Path("/{hostname}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
I'm getting 405 Method Not Allowed with PATCH against host with Orchestrator, and I suspect this is related to using non-standar PATCH method: I get the same response with other unimplemented HTTP methods.

Therefore, I would like to try PUT to see if that works.