### PR TITLE
Rename filedistribution programs to have vespa- prefix.

### DIFF
--- a/configserver/src/main/sh/start-filedistribution
+++ b/configserver/src/main/sh/start-filedistribution
@@ -78,5 +78,5 @@ if [ "$multitenant" = "true" ]; then
     export VESPA_LOG_CONTROL_DIR
     export VESPA_LOG_CONTROL_FILE
     cd ${ROOT}
-    vespa-runserver -r 30 -s filedistributor -p $PIDFILE_FILEDISTRIBUTOR -- ${ROOT}/sbin/filedistributor --configid $VESPA_CONFIG_ID
+    vespa-runserver -r 30 -s filedistributor -p $PIDFILE_FILEDISTRIBUTOR -- ${ROOT}/sbin/vespa-filedistributor --configid $VESPA_CONFIG_ID
 fi

--- a/dist/post_install.sh
+++ b/dist/post_install.sh
@@ -69,6 +69,10 @@ ln -s $PREFIX/lib/jars/zkfacade-jar-with-dependencies.jar $INSTALLPATH/conf/conf
 ln -s $PREFIX/conf/configserver-app/components $INSTALLPATH/lib/jars/config-models
 ln -s vespa-storaged-bin $INSTALLPATH/sbin/vespa-distributord-bin
 
+# Temporary when renaming programs in filedistribution
+ln -s vespa-filedistributor $INSTALLPATH/sbin/filedistributor
+ln -s vespa-filedistributor-bin $INSTALLPATH/sbin/filedistributor-bin
+
 # Temporary when renaming binaries in fnet
 ln -s vespa-rpc-info $INSTALLPATH/bin/rpc_info
 ln -s vespa-rpc-invoke $INSTALLPATH/bin/rpc_invoke

--- a/filedistribution/src/apps/filedistributor/.gitignore
+++ b/filedistribution/src/apps/filedistributor/.gitignore
@@ -1,2 +1,2 @@
 /filedistributor
-filedistributor-bin
+vespa-filedistributor-bin

--- a/filedistribution/src/apps/filedistributor/CMakeLists.txt
+++ b/filedistribution/src/apps/filedistributor/CMakeLists.txt
@@ -2,7 +2,7 @@
 vespa_add_executable(filedistribution_filedistributor_app
     SOURCES
     filedistributor.cpp
-    OUTPUT_NAME filedistributor-bin
+    OUTPUT_NAME vespa-filedistributor-bin
     INSTALL sbin
     DEPENDS
     filedistribution_distributor

--- a/filedistribution/src/apps/status/.gitignore
+++ b/filedistribution/src/apps/status/.gitignore
@@ -1,2 +1,2 @@
-/status-filedistribution
+/vespa-status-filedistribution-bin
 filedistribution_status-filedistribution_app

--- a/filedistribution/src/apps/status/CMakeLists.txt
+++ b/filedistribution/src/apps/status/CMakeLists.txt
@@ -3,7 +3,7 @@ vespa_add_executable(filedistribution_status-filedistribution_app
     SOURCES
     status-filedistribution.cpp
     INSTALL bin
-    OUTPUT_NAME status-filedistribution
+    OUTPUT_NAME vespa-status-filedistribution-bin
     DEPENDS
     filedistribution_filedistributionmodel
     filedistribution_common

--- a/filedistribution/src/apps/status/vespa-status-filedistribution.sh
+++ b/filedistribution/src/apps/status/vespa-status-filedistribution.sh
@@ -65,4 +65,4 @@ ROOT=${VESPA_HOME%/}
 ZKSTRING=$($ROOT/libexec/vespa/vespa-config.pl -zkstring)
 test -z "$VESPA_LOG_LEVEL" && VESPA_LOG_LEVEL=warning
 export VESPA_LOG_LEVEL
-exec $ROOT/bin/status-filedistribution --zkstring "$ZKSTRING" $@
+exec $ROOT/bin/vespa-status-filedistribution-bin --zkstring "$ZKSTRING" $@

--- a/vespabase/CMakeLists.txt
+++ b/vespabase/CMakeLists.txt
@@ -11,7 +11,7 @@ vespa_install_script(src/start-cbinaries.sh vespa-transactionlog-inspect bin)
 vespa_install_script(src/start-cbinaries.sh vespa-vds-disktool bin)
 vespa_install_script(src/start-cbinaries.sh vespa-distributord sbin)
 vespa_install_script(src/start-cbinaries.sh vespa-fdispatch sbin)
-vespa_install_script(src/start-cbinaries.sh filedistributor sbin)
+vespa_install_script(src/start-cbinaries.sh vespa-filedistributor sbin)
 vespa_install_script(src/start-cbinaries.sh vespa-proton sbin)
 vespa_install_script(src/start-cbinaries.sh vespa-storaged sbin)
 


### PR DESCRIPTION
Temporarily add symlinks from old name to new name.

@geirst, please review