### PR TITLE
Freva/node retirer one per cluster

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ServiceMonitorStub.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ServiceMonitorStub.java
@@ -77,7 +77,7 @@ public class ServiceMonitorStub implements ServiceMonitor {
                                                            getHostStatus(node.hostname())));
             }
             Set<ServiceCluster<ServiceMonitorStatus>> serviceClusters = new HashSet<>();
-            serviceClusters.add(new ServiceCluster<>(new ClusterId(app.getValue().cluster().id().value()),
+            serviceClusters.add(new ServiceCluster<>(new ClusterId(app.getValue().clusterContexts().get(0).cluster().id().value()),
                                                      new ServiceType("serviceType"),
                                                      serviceInstances));
             TenantId tenantId = new TenantId(app.getKey().tenant().value());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTest.java
@@ -34,24 +34,25 @@ public class NodeRetirerTest {
         retirer = tester.makeNodeRetirer(policy);
 
         tester.createReadyNodesByFlavor(21, 42, 27, 15, 8);
-        tester.deployApp("vespa", "calendar", 3, 7);
-        tester.deployApp("vespa", "notes", 0, 3);
-        tester.deployApp("sports", "results", 0, 6);
-        tester.deployApp("search", "images", 3, 4);
-        tester.deployApp("search", "videos", 2, 2);
+        tester.deployApp("vespa",  "calendar",  new int[]{3},       new int[]{7});
+        tester.deployApp("vespa",  "notes",     new int[]{0},       new int[]{3});
+        tester.deployApp("sports", "results",   new int[]{0},       new int[]{6});
+        tester.deployApp("search", "images",    new int[]{3},       new int[]{4});
+        tester.deployApp("search", "videos",    new int[]{2},       new int[]{2});
+        tester.deployApp("tester", "my-app",    new int[]{1, 2},    new int[]{4, 6});
     }
 
     @Test
     public void testRetireUnallocated() {
-        tester.assertCountsForStateByFlavor(Node.State.ready, 12, 42, 25, 4, 8);
-        tester.setNumberAllowedUnallocatedRetirementsPerFlavor(6, 30, 20, 2, 4);
+        tester.assertCountsForStateByFlavor(Node.State.ready, 12, 38, 19, 4, 8);
+        tester.setNumberAllowedUnallocatedRetirementsPerFlavor(6, 30, 15, 2, 4);
         assertFalse(retirer.retireUnallocated());
-        tester.assertCountsForStateByFlavor(Node.State.parked, 6, 30, 20, 2, 4);
+        tester.assertCountsForStateByFlavor(Node.State.parked, 6, 30, 15, 2, 4);
 
-        tester.assertCountsForStateByFlavor(Node.State.ready, 6, 12, 5, 2, 4);
+        tester.assertCountsForStateByFlavor(Node.State.ready, 6, 8, 4, 2, 4);
         tester.setNumberAllowedUnallocatedRetirementsPerFlavor(10, 20, 5, 5, 4);
         assertTrue(retirer.retireUnallocated());
-        tester.assertCountsForStateByFlavor(Node.State.parked, 12, 42, 25, 4, 8);
+        tester.assertCountsForStateByFlavor(Node.State.parked, 12, 38, 19, 4, 8);
 
         tester.nodeRepository.getNodes().forEach(node ->
                 assertEquals(node.status().wantToDeprovision(), node.state() == Node.State.parked));
@@ -63,25 +64,27 @@ public class NodeRetirerTest {
         tester.nodeRepository.getNodes(Node.State.ready)
                 .forEach(node -> tester.nodeRepository.write(node.withIpAddresses(Collections.singleton("::2"))));
 
-        tester.assertCountsForStateByFlavor(Node.State.active, 9, -1, 2, 11, -1);
+        tester.assertCountsForStateByFlavor(Node.State.active, 9, 4, 8, 11, -1);
 
-        tester.setNumberAllowedAllocatedRetirementsPerFlavor(3, 2, 3, 2);
+        tester.setNumberAllowedAllocatedRetirementsPerFlavor(3, 2, 4, 2);
         retirer.retireAllocated();
-        tester.assertParkedCountsByApplication(-1, -1, -1, -1, -1); // Nodes should be in retired, but not yet parked
+        tester.assertParkedCountsByApplication(-1, -1, -1, -1, -1, -1); // Nodes should be in retired, but not yet parked
 
         tester.iterateMaintainers();
-        tester.assertParkedCountsByApplication(1, 1, 1, 1, 1);
+        tester.assertParkedCountsByApplication(1, 1, 1, 1, 1, 2);
 
-        // We can only retire 1 more of flavor 0 and 1 more of flavor 2, app 3 is the largest that is on flavor 0
-        // and app 5 is the only one on flavor 2
+        // We can retire 1 more of flavor-0, 1 more of flavor-1, 2 more of flavor-2:
+        //  app 6 has the most nodes, so it gets to retire flavor-1 and flavor-2
+        //  app 3 is the largest that is on flavor-0, so it gets the last node
+        //  app 5 is gets the last node with flavor-2
         retirer.retireAllocated();
         tester.iterateMaintainers();
-        tester.assertParkedCountsByApplication(1, 1, 2, 1, 2);
+        tester.assertParkedCountsByApplication(1, 1, 2, 1, 2, 4);
 
         // No more retirements are possible
         retirer.retireAllocated();
         tester.iterateMaintainers();
-        tester.assertParkedCountsByApplication(1, 1, 2, 1, 2);
+        tester.assertParkedCountsByApplication(1, 1, 2, 1, 2, 4);
 
         tester.nodeRepository.getNodes().forEach(node ->
                 assertEquals(node.status().wantToDeprovision(), node.state() == Node.State.parked));
@@ -90,7 +93,7 @@ public class NodeRetirerTest {
     @Test
     public void testGetActiveApplicationIds() {
         List<String> expectedOrder = Arrays.asList(
-                "vespa.calendar", "sports.results", "search.images", "vespa.notes", "search.videos");
+                "tester.my-app", "vespa.calendar", "sports.results", "search.images", "vespa.notes", "search.videos");
         List<String> actualOrder = retirer.getActiveApplicationIds(tester.nodeRepository.getNodes()).stream()
                 .map(applicationId -> applicationId.toShortString().replace(":default", ""))
                 .collect(Collectors.toList());
@@ -121,21 +124,21 @@ public class NodeRetirerTest {
     }
 
     @Test
-    public void testGetNumberNodesAllowToRetireForApplication() {
+    public void testGetNumberNodesAllowToRetireForCluster() {
         ApplicationId app = new ApplicationId.Builder().tenant("vespa").applicationName("calendar").build();
-        long actualAllActive = retirer.getNumberNodesAllowToRetireForApplication(tester.nodeRepository.getNodes(app), 2);
+        long actualAllActive = retirer.getNumberNodesAllowToRetireForCluster(tester.nodeRepository.getNodes(app), 2);
         assertEquals(2, actualAllActive);
 
         // Lets put 3 random nodes in wantToRetire
         List<Node> nodesToRetire = tester.nodeRepository.getNodes(app).stream().limit(3).collect(Collectors.toList());
         nodesToRetire.forEach(node -> tester.nodeRepository.write(node.with(node.status().withWantToRetire(true))));
-        long actualOneWantToRetire = retirer.getNumberNodesAllowToRetireForApplication(tester.nodeRepository.getNodes(app), 2);
+        long actualOneWantToRetire = retirer.getNumberNodesAllowToRetireForCluster(tester.nodeRepository.getNodes(app), 2);
         assertEquals(0, actualOneWantToRetire);
 
         // Now 2 of those finish retiring and go to parked
         nodesToRetire.stream().limit(2).forEach(node ->
                 tester.nodeRepository.park(node.hostname(), Agent.system, "Parked for unit testing"));
-        long actualOneRetired = retirer.getNumberNodesAllowToRetireForApplication(tester.nodeRepository.getNodes(app), 2);
+        long actualOneRetired = retirer.getNumberNodesAllowToRetireForCluster(tester.nodeRepository.getNodes(app), 2);
         assertEquals(1, actualOneRetired);
     }
 }


### PR DESCRIPTION
Allows retiring 1 node per cluster instead of per application.