### PR TITLE
Make patch work

### DIFF
--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
@@ -1,6 +1,7 @@
 // Copyright 2016 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.restapi;
 
+import com.yahoo.vespa.jaxrs.annotation.PATCH;
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostRequest;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostResponse;
@@ -43,7 +44,7 @@ public interface HostApi {
      * Tweak internal Orchestrator state for host.
      * Note: This should really be a patch method, but I was unable to get that working with PATCH from jaxrs_utils!?
      */
-    @PUT
+    @PATCH
     @Path("/{hostname}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/HostApi.java
@@ -42,7 +42,6 @@ public interface HostApi {
 
     /**
      * Tweak internal Orchestrator state for host.
-     * Note: This should really be a patch method, but I was unable to get that working with PATCH from jaxrs_utils!?
      */
     @PATCH
     @Path("/{hostname}")

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostResource.java
@@ -21,7 +21,6 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -54,7 +53,7 @@ public class HostResource implements HostApi {
     }
 
     @Override
-    public PatchHostResponse patch(@PathParam("hostname") String hostNameString, PatchHostRequest request) {
+    public PatchHostResponse patch(String hostNameString, PatchHostRequest request) {
         HostName hostName = new HostName(hostNameString);
 
         if (request.state != null) {


### PR DESCRIPTION
Removes the PathParams annotation on the subclass, which caused Jersey to
ignore the annotations on the superclass(!?).  I have verified these changes
work in CD.