### PR TITLE
Upgrade maven-install-plugin to 2.5.2

### DIFF
--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -239,7 +239,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>

--- a/docprocs/pom.xml
+++ b/docprocs/pom.xml
@@ -153,7 +153,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>

--- a/documentgen-test/pom.xml
+++ b/documentgen-test/pom.xml
@@ -75,7 +75,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>

--- a/jrt/pom.xml
+++ b/jrt/pom.xml
@@ -52,7 +52,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>

--- a/libmlr/pom.xml
+++ b/libmlr/pom.xml
@@ -39,7 +39,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.3.1</version>
+                    <version>2.5.2</version>
                     <configuration>
                         <updateReleaseInfo>true</updateReleaseInfo>
                     </configuration>

--- a/vdslib/pom.xml
+++ b/vdslib/pom.xml
@@ -99,7 +99,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>


### PR DESCRIPTION
Old version of `maven-install-plugin` occasionally hangs on multithread build.