### PR TITLE
Revert "Encode as UTF-8"

### DIFF
--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/specialtokens.cfg
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/specialtokens.cfg
@@ -6,7 +6,7 @@ tokenlist[0].tokens[1].token c++
 tokenlist[0].tokens[2].token b.s.d.
 tokenlist[0].tokens[3].token with space
 tokenlist[0].tokens[4].token c#
-tokenlist[0].tokens[5].token dvd\xB1r
+tokenlist[0].tokens[5].token dvd±r
 tokenlist[1].name other
 tokenlist[1].tokens[4]
 tokenlist[1].tokens[0].token [huh]

--- a/fastlib/src/vespa/fastlib/testsuite/cpptest.el
+++ b/fastlib/src/vespa/fastlib/testsuite/cpptest.el
@@ -2,7 +2,7 @@
 
 ;; $Revision: 1.179 $ $Date: 2004-02-17 17:01:15 $
 
-;; Author: Nils SandÃ¸y <nils.sandoy@fast.no>
+;; Author: Nils Sandøy <nils.sandoy@fast.no>
 
 ;; Keywords: C++, tools
 ;;

--- a/fastlib/src/vespa/fastlib/testsuite/testproject.el
+++ b/fastlib/src/vespa/fastlib/testsuite/testproject.el
@@ -6,7 +6,7 @@
 ;; the class(es) you want to test.
 
 ;; $Revision: 1.6 $ $Date: 2003-09-11 09:14:01 $
-;; Author: Nils SandÃ¸y <nils.sandoy@fast.no>
+;; Author: Nils Sandøy <nils.sandoy@fast.no>
 
 ;; Just a message to show that this file is beeing read. Look for this
 ;; in the *Messages* buffer.

--- a/fastlib/src/vespa/fastlib/text/tests/wordfolderstest.h
+++ b/fastlib/src/vespa/fastlib/text/tests/wordfolderstest.h
@@ -99,9 +99,9 @@ class WordFoldersTest : public Test
 
     bool AccentRemovalTest() {
         auto freefunction = [] (char * ptr) { free(ptr); };
-        auto input = std::unique_ptr<char, decltype(freefunction)>(Fast_UnicodeUtil::strdupLAT1("\xA1\xA2\xA3\xA4\xA5\xA6\xA7\xA8\xA9\xAA\xAB\xAC\xAD\xAE\xAF\xB0\xB1\xB2\xB3\xB4\xB5\xB6\xB7\xB8\xB9\xBA\xBB\xBC\xBD\xBE\xBF\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD7\xD8\xD9\xDA\xDB\xDC\xDD\xDE\xDF\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\x70\xFE\x21"),
+        auto input = std::unique_ptr<char, decltype(freefunction)>(Fast_UnicodeUtil::strdupLAT1("¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþpþ!"),
                                                                    freefunction);
-        auto yelloutput = std::unique_ptr<char, decltype(freefunction)>(Fast_UnicodeUtil::strdupLAT1("\xA1\xA2\xA3\xA4\xA5\xA6\xA7\xA8\xA9\xAA\xAB\xAC\xAD\xAE\xAF\xB0\xB1\xB2\xB3\xB4\xB5\xB6\xB7\xB8\xB9\xBA\xBB\xBC\xBD\xBE\xBFAAAAAEAAAECEEEEIIIIDNOOOOOE\xD7OEUUUUEYTHssaaaaaeaaaeceeeeiiiidnoooooe\xF7oeuuuueythpth!"),
+        auto yelloutput = std::unique_ptr<char, decltype(freefunction)>(Fast_UnicodeUtil::strdupLAT1("¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿AAAAAEAAAECEEEEIIIIDNOOOOOE×OEUUUUEYTHssaaaaaeaaaeceeeeiiiidnoooooe÷oeuuuueythpth!"),
                                                                         freefunction);
         Fast_NormalizeWordFolder wordfolder;
         int len = wordfolder.FoldedSizeAsUTF8(input.get());

--- a/fastlib/src/vespa/fastlib/util/testproject.el
+++ b/fastlib/src/vespa/fastlib/util/testproject.el
@@ -2,7 +2,7 @@
 
 ;;  Local configurations for the cpptest Emacs unit-test framework
 
-;; Author: Nils SandÃ¸y <nils.sandoy@fast.no>
+;; Author: Nils Sandøy <nils.sandoy@fast.no>
 
 (message "Setting local test configuration")
 

--- a/juniper/src/testproject.el
+++ b/juniper/src/testproject.el
@@ -6,7 +6,7 @@
 ;; the class(es) you want to test.
 
 ;; $Revision: 1.2 $ $Date: 2003-02-27 12:32:24 $
-;; Author: Nils SandÃ¸y <nils.sandoy@fast.no>
+;; Author: Nils Sandøy <nils.sandoy@fast.no>
 
 ;; Just a message to show that this file is beeing read. Look for this
 ;; in the *Messages* buffer.


### PR DESCRIPTION
Reverts yahoo/vespa#2761

$HOME/git/vespa/fastlib/src/vespa/fastlib/text/tests/wordfolderstest.h:102: error: hex escape sequence out of range [-Werror]

@aressem, please review
@bratseth, FYI