### PR TITLE
Use builder to instantiate default node.

### DIFF
--- a/config-lib/src/main/java/com/yahoo/config/InnerNodeVector.java
+++ b/config-lib/src/main/java/com/yahoo/config/InnerNodeVector.java
@@ -3,6 +3,7 @@ package com.yahoo.config;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -40,9 +41,20 @@ public class InnerNodeVector<NODE extends InnerNode> extends NodeVector<NODE> {
     @SuppressWarnings("unchecked")
     protected NODE createNew() {
         try {
-            Constructor<? extends InnerNode> ctor  = defaultNode.getClass().getDeclaredConstructor();
-            ctor.setAccessible(true);
-            return (NODE) ctor.newInstance();
+            Class<? extends InnerNode> nodeClass = defaultNode.getClass();
+            Class<?> builderClass = Arrays.stream(nodeClass.getClasses())
+                    .filter(klass -> klass.getSimpleName().equals("Builder"))
+                    .findFirst()
+                    .orElseThrow(() -> new ConfigurationRuntimeException("Could not find builder class for " + nodeClass.getName()));
+
+            Constructor<?> builderCtor = builderClass.getConstructor();
+            Object builderInstance = builderCtor.newInstance();
+            if (! (builderInstance instanceof ConfigBuilder))
+                throw new ConfigurationRuntimeException("Builder is not a ConfigBuilder, has class: " + builderInstance.getClass().getName());
+
+            Constructor<? extends InnerNode> nodeCtor = nodeClass.getDeclaredConstructor(builderClass, boolean.class);
+            nodeCtor.setAccessible(true);
+            return (NODE) nodeCtor.newInstance(builderInstance, false);
         } catch (InvocationTargetException | IllegalAccessException | InstantiationException | NoSuchMethodException e) {
             throw new ConfigurationRuntimeException(e);
         }

--- a/config-lib/src/main/java/com/yahoo/config/InnerNodeVector.java
+++ b/config-lib/src/main/java/com/yahoo/config/InnerNodeVector.java
@@ -37,7 +37,7 @@ public class InnerNodeVector<NODE extends InnerNode> extends NodeVector<NODE> {
     /**
      * Creates a new Node by creating a new instance with the 0-argument constructor
      */
-    // TODO: remove when the library uses reflection via builders
+    // TODO: remove, only used for NodeVector.setSize which only seems to be used by unit tests.
     @SuppressWarnings("unchecked")
     protected NODE createNew() {
         try {

--- a/config-lib/src/main/java/com/yahoo/config/NodeVector.java
+++ b/config-lib/src/main/java/com/yahoo/config/NodeVector.java
@@ -34,7 +34,7 @@ public abstract class NodeVector<NODE> implements java.util.List<NODE> {
      *
      * @param n the new size of this NodeVector
      */
-    // TODO: remove when the library uses reflection via builders, and resizing won't be necessary
+    // TODO: remove, only used by unit tests
     public void setSize(int n) {
         while (size() > n) vector.remove(n);
         while (size() < n) vector.add(createNew());


### PR DESCRIPTION
@hmusum 
FYI: @bjorncs 

The constructor used in this PR has always been there, so this should be ok for any version, new or old. My aim is to remove createNew() and just ignore the 'defaultNode' given in the ctor. I don't think we actually need it anymore. It's only used for NodeVector.setSize() but that is only used in unit tests from what I can see now.