### PR TITLE
Use yum-builddep to fetch direct build dependencies to avoid specifyi…

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -4,39 +4,10 @@ FROM centos:7
 RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo && \
     yum -y install epel-release && \
     yum -y install centos-release-scl && \
-    yum -y --enablerepo=epel-testing install \
-                   devtoolset-6-gcc-c++ \
-                   devtoolset-6-libatomic-devel \
-                   devtoolset-6-binutils \
-                   git \
-                   make \
-                   cmake3 \
+    yum -y install git \
                    ccache \
-                   Judy-devel \
-                   lz4-devel \
-                   libzstd-devel \
-                   zlib-devel \
-                   maven \
-                   libicu-devel \
-                   llvm3.9-devel \
-                   llvm3.9-static \
-                   java-1.8.0-openjdk-devel \
-                   openssl \
-                   openssl-devel \
                    rpm-build \
-                   perl \
-                   perl-Env \
-                   perl-JSON \
-                   perl-IO-Socket-IP \
-                   perl-Data-Dumper \
-                   perl-libwww-perl \
-                   perl-Net-INET6Glue \
-                   perl-URI \
-                   sudo \
-                   vespa-boost-devel \
-                   vespa-libtorrent-devel \
-                   vespa-zookeeper-c-client-devel \
-                   vespa-cppunit-devel && \
+                   sudo && \
     echo "source /opt/rh/devtoolset-6/enable" > /etc/profile.d/devtoolset-6.sh && \
     echo "*          soft    nproc     32768" > /etc/security/limits.d/90-nproc.conf 
 

--- a/docker/build-vespa-internal.sh
+++ b/docker/build-vespa-internal.sh
@@ -12,6 +12,7 @@ CALLER_GID=$3
 
 cd /vespa
 ./dist.sh ${VESPA_VERSION}
+yum-builddep -y ~/rpmbuild/SPECS/vespa-${VESPA_VERSION}.spec
 rpmbuild -bb ~/rpmbuild/SPECS/vespa-${VESPA_VERSION}.spec
 chown ${CALLER_UID}:${CALLER_GID} ~/rpmbuild/RPMS/x86_64/*.rpm
 mv ~/rpmbuild/RPMS/x86_64/*.rpm /vespa/docker 

--- a/docker/vespa-ci-internal.sh
+++ b/docker/vespa-ci-internal.sh
@@ -19,6 +19,7 @@ mkdir "${BUILD_DIR}"
 git clone --no-checkout --local --no-hardlinks file:///vespa "${SOURCE_DIR}"
 cd "${SOURCE_DIR}"
 git checkout --detach ${GIT_COMMIT}
+yum-builddep -y ./dist/vespa.spec
 source /opt/rh/devtoolset-6/enable || true
 sh ./bootstrap.sh full
 MAVEN_OPTS="-Xms512m -Xmx512m" mvn install


### PR DESCRIPTION
…ng this multiple places.

@kkraune 

This will make it easier to manage build dependencies as well. The spec file is now the only source of direct build dependencies.