### PR TITLE
Increase docker daemon timeout for running commands in container

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -612,9 +612,9 @@ public class NodeAgentImpl implements NodeAgent {
         metricReceiver.declareGauge(MetricReceiverWrapper.APPLICATION_HOST_LIFE, dimensions, "uptime").sample(lastCpuMetric.getUptime());
         metricReceiver.declareGauge(MetricReceiverWrapper.APPLICATION_HOST_LIFE, dimensions, "alive").sample(1);
 
-        // Push metrics to the metrics proxy in each container - give it maximum 1 seconds to complete
+        // Push metrics to the metrics proxy in each container
         try {
-            dockerOperations.executeCommandInContainerAsRoot(containerName, 1L, "rpc_invoke",  "-t 1",  "tcp/localhost:19091",  "setExtraMetrics", buildRPCArgumentFromMetrics());
+            dockerOperations.executeCommandInContainerAsRoot(containerName, 3L, "rpc_invoke",  "-t 1",  "tcp/localhost:19091",  "setExtraMetrics", buildRPCArgumentFromMetrics());
         } catch (DockerExecTimeoutException|JsonProcessingException e) {
             logger.warning("Unable to push metrics to container: " + containerName, e);
         }


### PR DESCRIPTION
The rcp invoke timeout and docker timeout was the same. Ww saw that the rpc invoke was ok, but the daemon was timing out. Increasing the latter to see if that makes it work again.