### PR TITLE
Factor out btree printing from unit test.

### DIFF
--- a/searchlib/src/vespa/searchlib/test/btree/aggregated_printer.h
+++ b/searchlib/src/vespa/searchlib/test/btree/aggregated_printer.h
@@ -1,0 +1,26 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/btree/noaggregated.h>
+#include <vespa/searchlib/btree/minmaxaggregated.h>
+
+namespace search::btree::test {
+
+template <typename ostream, typename Aggregated>
+void printAggregated(ostream &os, const Aggregated &aggr);
+
+template <typename ostream>
+void printAggregated(ostream &os, const NoAggregated &aggr)
+{
+    (void) aggr;
+    os << "[noaggr]";
+}
+
+template <typename ostream>
+void printAggregated(ostream &os, const MinMaxAggregated &aggr)
+{
+    os << "[min=" << aggr.getMin() << ",max=" << aggr.getMax() << "]";
+}
+
+} // namespace search::btree::test

--- a/searchlib/src/vespa/searchlib/test/btree/btree_printer.h
+++ b/searchlib/src/vespa/searchlib/test/btree/btree_printer.h
@@ -1,0 +1,103 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "data_printer.h"
+#include "aggregated_printer.h"
+#include <vespa/searchlib/btree/btreenodeallocator.h>
+
+namespace search::btree::test {
+
+template <typename ostream, typename NodeAllocator>
+class BTreePrinter
+{
+    using LeafNode = typename NodeAllocator::LeafNodeType;
+    using InternalNode = typename NodeAllocator::InternalNodeType;
+    ostream &_os;
+    const NodeAllocator &_allocator;
+    bool _levelFirst;
+    uint8_t _printLevel;
+
+    void printLeafNode(const LeafNode &n) {
+        if (!_levelFirst) {
+            _os << ",";
+        }
+        _levelFirst = false;
+        _os << "{";
+        for (uint32_t i = 0; i < n.validSlots(); ++i) {
+            if (i > 0) _os << ",";
+            _os << n.getKey(i) << ":" << n.getData(i);
+        }
+        printAggregated(_os, n.getAggregated());
+        _os << "}";
+    }
+
+    void printInternalNode(const InternalNode &n) {
+        if (!_levelFirst) {
+            _os << ",";
+        }
+        _levelFirst = false;
+        _os << "{";
+        for (uint32_t i = 0; i < n.validSlots(); ++i) {
+            if (i > 0) _os << ",";
+            _os << n.getKey(i);
+        }
+        printAggregated(_os, n.getAggregated());
+        _os << "}";
+    }
+
+    void printNode(BTreeNode::Ref ref) {
+        if (!ref.valid()) {
+            _os << "[]";
+        }
+        if (_allocator.isLeafRef(ref)) {
+            printLeafNode(*_allocator.mapLeafRef(ref));
+            return;
+        }
+        const InternalNode &n(*_allocator.mapInternalRef(ref));
+        if (n.getLevel() == _printLevel) {
+            printInternalNode(n);
+            return;
+        }
+        for (uint32_t i = 0; i < n.validSlots(); ++i) {
+            printNode(n.getData(i));
+        }
+    }
+
+public:
+
+    BTreePrinter(ostream &os, const NodeAllocator &allocator)
+        : _os(os),
+          _allocator(allocator),
+          _levelFirst(true),
+          _printLevel(0)
+    {
+    }
+
+    ~BTreePrinter() { }
+
+    void print(BTreeNode::Ref ref) {
+        if (!ref.valid()) {
+            _os << "{}";
+            return;
+        }
+        _printLevel = 0;
+        if (!_allocator.isLeafRef(ref)) {
+            const InternalNode &n(*_allocator.mapInternalRef(ref));
+            _printLevel = n.getLevel();
+        }
+        while (_printLevel > 0) {
+            _os << "{";
+            _levelFirst = true;
+            printNode(ref);
+            _os << "} -> ";
+            --_printLevel;
+        }
+        _os << "{";
+        _levelFirst = true;
+        printNode(ref);
+        _os << "}";
+    }
+};
+
+} // namespace search::btree::test

--- a/searchlib/src/vespa/searchlib/test/btree/data_printer.h
+++ b/searchlib/src/vespa/searchlib/test/btree/data_printer.h
@@ -1,0 +1,28 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace search::btree {
+
+class BtreeNoLeafData;
+
+namespace test {
+
+template <typename ostream, typename DataT>
+void printData(ostream &os, const DataT &data);
+
+template <typename ostream, typename DataT>
+void printData(ostream &os, const DataT &data)
+{
+    os << ":" << data;
+}
+
+template <typename ostream>
+void printData(ostream &os, const BTreeNoLeafData &data)
+{
+    (void) os;
+    (void) data;
+}
+
+} // namespace search::btree::test
+} // namespace search::btree


### PR DESCRIPTION
Print btree layer by layer.
Tweak formatting of printed btree.

@geirst, please review