### PR TITLE
Update dependencies for bundle-plugin

### DIFF
--- a/bundle-plugin/pom.xml
+++ b/bundle-plugin/pom.xml
@@ -24,6 +24,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
         </dependency>
         <dependency>
@@ -34,10 +39,6 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -69,10 +70,6 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jar-plugin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.8</version>
+                <version>1.11</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -806,17 +806,17 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
-                <version>3.1.1</version>
+                <version>3.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
-                <version>3.1.1</version>
+                <version>3.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model</artifactId>
-                <version>3.1.1</version>
+                <version>3.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
@@ -834,14 +834,9 @@
                 <version>2.2.1</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-interactivity-api</artifactId>
-                <version>1.0-alpha-5</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.0.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.surefire</groupId>
@@ -1013,7 +1008,7 @@
             <dependency>
                 <groupId>org.twdata.maven</groupId>
                 <artifactId>mojo-executor</artifactId>
-                <version>2.2.0</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <groupId>net.jcip</groupId>


### PR DESCRIPTION
`MavenArchiver.createArchive()` will now calls `JarArchive.cleanup()`, so we cannot reuse the `JarArchive` instance for both jar-without-dependencies and jar-with-dependencies.