### PR TITLE
Avoid the implicit sorting that deepIterator does as a sideeffect.

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastHit.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastHit.java
@@ -143,7 +143,8 @@ public class FastHit extends Hit {
         if (useRowInIndexUri)
             rowString = String.valueOf(getRow());
 
-        return new URI("index:" + getSourceNumber() + "/" + getColumn() + "/" + rowString + "/" + asHexString(getGlobalId()));
+        indexUri = new URI("index:" + getSourceNumber() + "/" + getColumn() + "/" + rowString + "/" + asHexString(getGlobalId()));
+        return indexUri;
     }
 
     /** Returns the global id of this document in the backend node which produced it */

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -92,9 +92,9 @@ public class Dispatcher extends AbstractComponent {
     }
 
     /** Return a map of hits by their search node (partition) id */
-    private ListMap<Integer, FastHit> hitsByNode(Result result) {
+    private static ListMap<Integer, FastHit> hitsByNode(Result result) {
         ListMap<Integer, FastHit> hitsByPartition = new ListMap<>();
-        for (Iterator<Hit> i = result.hits().deepIterator() ; i.hasNext(); ) {
+        for (Iterator<Hit> i = result.hits().unorderedDeepIterator() ; i.hasNext(); ) {
             Hit h = i.next();
             if ( ! (h instanceof FastHit)) continue;
             FastHit hit = (FastHit)h;


### PR DESCRIPTION
It is not worthwhile. Especially when you do not have a document id.
@bratseth This consumes 55% of the cpu in the container for gemini native when we use dispatch.summaries and have a summary class with no documentid.....