### PR TITLE
Try to redistribute elements with left or right sibling leaf node if …

### DIFF
--- a/searchlib/src/tests/btree/btree_test.cpp
+++ b/searchlib/src/tests/btree/btree_test.cpp
@@ -356,6 +356,19 @@ Test::requireThatTreeInsertWorks()
                                "{{1:101,3:103,7:107,9:109},"
                                "{10:110,11:111,13:113,15:115}}", t));
     }
+    { // give to left node to avoid split, and move to left node
+        Tree t;
+        populateTree(t, 8, 2);
+        t.remove(3);
+        t.remove(5);
+        EXPECT_TRUE(assertTree("{{7,15}} -> "
+                               "{{1:101,7:107},"
+                               "{9:109,11:111,13:113,15:115}}", t));
+        t.insert(8, 108);
+        EXPECT_TRUE(assertTree("{{9,15}} -> "
+                               "{{1:101,7:107,8:108,9:109},"
+                               "{11:111,13:113,15:115}}", t));
+    }
     { // not give to left node to avoid split, but insert at end at left node
         Tree t;
         populateTree(t, 8, 2);
@@ -379,6 +392,23 @@ Test::requireThatTreeInsertWorks()
         EXPECT_TRUE(assertTree("{{5,15}} -> "
                                "{{1:101,3:103,4:104,5:105},"
                                "{7:107,9:109,11:111,15:115}}", t));
+    }
+    { // give to right node to avoid split and move to right node
+        using MyTraits6 = BTreeTraits<6, 6, 31, false>;
+        using Tree6 = BTree<MyKey, int32_t, btree::NoAggregated, MyComp, MyTraits6>;
+
+        Tree6 t;
+        populateTree(t, 12, 2);
+        t.remove(19);
+        t.remove(21);
+        t.remove(23);
+        EXPECT_TRUE(assertTree("{{11,17}} -> "
+                               "{{1:101,3:103,5:105,7:107,9:109,11:111},"
+                               "{13:113,15:115,17:117}}", t));
+        t.insert(10, 110);
+        EXPECT_TRUE(assertTree("{{7,17}} -> "
+                               "{{1:101,3:103,5:105,7:107},"
+                               "{9:109,10:110,11:111,13:113,15:115,17:117}}", t));
     }
 }
 

--- a/searchlib/src/tests/btree/btree_test.cpp
+++ b/searchlib/src/tests/btree/btree_test.cpp
@@ -147,12 +147,22 @@ assertTree(const std::string &exp, const Tree &t)
 
 template <typename Tree>
 void
+populateTree(Tree &t, uint32_t count, uint32_t delta)
+{
+    uint32_t key = 1;
+    int32_t value = 101;
+    for (uint32_t i = 0; i < count; ++i) {
+        t.insert(key, value);
+        key += delta;
+        value += delta;
+    }
+}
+
+template <typename Tree>
+void
 populateLeafNode(Tree &t)
 {
-    t.insert(1, 101);
-    t.insert(3, 103);
-    t.insert(5, 105);
-    t.insert(7, 107);
+    populateTree(t, 4, 2);
 }
 
 
@@ -319,24 +329,57 @@ Test::requireThatTreeInsertWorks()
     }
     { // multi level node split
         Tree t;
-        for (uint32_t i = 1; i < 27; i += 2) {
-            t.insert(i, i + 100);
-        }
-        EXPECT_TRUE(assertTree("{{5,11,17,25}} -> "
-                               "{{1:101,3:103,5:105},"
-                               "{7:107,9:109,11:111},"
-                               "{13:113,15:115,17:117},"
-                               "{19:119,21:121,23:123,25:125}}", t));
-        t.insert(27, 127);
-        EXPECT_TRUE(assertTree("{{17,27}} -> "
-                               "{{5,11,17},{23,27}} -> "
-                               "{{1:101,3:103,5:105},"
-                               "{7:107,9:109,11:111},"
-                               "{13:113,15:115,17:117},"
-                               "{19:119,21:121,23:123},"
-                               "{25:125,27:127}}", t));
+        populateTree(t, 16, 2);
+        EXPECT_TRUE(assertTree("{{7,15,23,31}} -> "
+                               "{{1:101,3:103,5:105,7:107},"
+                               "{9:109,11:111,13:113,15:115},"
+                               "{17:117,19:119,21:121,23:123},"
+                               "{25:125,27:127,29:129,31:131}}", t));
+        t.insert(33, 133);
+        EXPECT_TRUE(assertTree("{{23,33}} -> "
+                               "{{7,15,23},{29,33}} -> "
+                               "{{1:101,3:103,5:105,7:107},"
+                               "{9:109,11:111,13:113,15:115},"
+                               "{17:117,19:119,21:121,23:123},"
+                               "{25:125,27:127,29:129},"
+                               "{31:131,33:133}}", t));
     }
-
+    { // give to left node to avoid split
+        Tree t;
+        populateTree(t, 8, 2);
+        t.remove(5);
+        EXPECT_TRUE(assertTree("{{7,15}} -> "
+                               "{{1:101,3:103,7:107},"
+                               "{9:109,11:111,13:113,15:115}}", t));
+        t.insert(10, 110);
+        EXPECT_TRUE(assertTree("{{9,15}} -> "
+                               "{{1:101,3:103,7:107,9:109},"
+                               "{10:110,11:111,13:113,15:115}}", t));
+    }
+    { // not give to left node to avoid split, but insert at end at left node
+        Tree t;
+        populateTree(t, 8, 2);
+        t.remove(5);
+        EXPECT_TRUE(assertTree("{{7,15}} -> "
+                               "{{1:101,3:103,7:107},"
+                               "{9:109,11:111,13:113,15:115}}", t));
+        t.insert(8, 108);
+        EXPECT_TRUE(assertTree("{{8,15}} -> "
+                               "{{1:101,3:103,7:107,8:108},"
+                               "{9:109,11:111,13:113,15:115}}", t));
+    }
+    { // give to right node to avoid split
+        Tree t;
+        populateTree(t, 8, 2);
+        t.remove(13);
+        EXPECT_TRUE(assertTree("{{7,15}} -> "
+                               "{{1:101,3:103,5:105,7:107},"
+                               "{9:109,11:111,15:115}}", t));
+        t.insert(4, 104);
+        EXPECT_TRUE(assertTree("{{5,15}} -> "
+                               "{{1:101,3:103,4:104,5:105},"
+                               "{7:107,9:109,11:111,15:115}}", t));
+    }
 }
 
 MyLeafNode::RefPair

--- a/searchlib/src/tests/btree/btreeaggregation_test.cpp
+++ b/searchlib/src/tests/btree/btreeaggregation_test.cpp
@@ -409,8 +409,9 @@ Test::requireThatNodeInsertWorks()
     EXPECT_TRUE(assertTree("{{10:101,20:102,30:103,40:104[min=101,max=104]}}", t));
 }
 
+template <typename Tree>
 void
-populateTree(MyTree &t, uint32_t count, uint32_t delta)
+populateTree(Tree &t, uint32_t count, uint32_t delta)
 {
     uint32_t key = 1;
     int32_t value = 101;
@@ -488,6 +489,19 @@ Test::requireThatTreeInsertWorks()
                                "{{1:101,3:103,7:107,9:109[min=101,max=109]},"
                                "{10:110,11:111,13:113,15:115[min=110,max=115]}}", t));
     }
+    { // give to left node to avoid split, and move to left node
+        MyTree t;
+        populateTree(t, 8, 2);
+        t.remove(3);
+        t.remove(5);
+        EXPECT_TRUE(assertTree("{{7,15[min=101,max=115]}} -> "
+                               "{{1:101,7:107[min=101,max=107]},"
+                               "{9:109,11:111,13:113,15:115[min=109,max=115]}}", t));
+        t.insert(8, 108);
+        EXPECT_TRUE(assertTree("{{9,15[min=101,max=115]}} -> "
+                               "{{1:101,7:107,8:108,9:109[min=101,max=109]},"
+                               "{11:111,13:113,15:115[min=111,max=115]}}", t));
+    }
     { // not give to left node to avoid split, but insert at end at left node
         MyTree t;
         populateTree(t, 8, 2);
@@ -511,6 +525,23 @@ Test::requireThatTreeInsertWorks()
         EXPECT_TRUE(assertTree("{{5,15[min=101,max=115]}} -> "
                                "{{1:101,3:103,4:104,5:105[min=101,max=105]},"
                                "{7:107,9:109,11:111,15:115[min=107,max=115]}}", t));
+    }
+    { // give to right node to avoid split and move to right node
+        using MyTraits6 = BTreeTraits<6, 6, 31, false>;
+        using Tree6 = BTree<MyKey, int32_t, btree::MinMaxAggregated, MyComp, MyTraits6, MinMaxAggrCalc>;
+
+        Tree6 t;
+        populateTree(t, 12, 2);
+        t.remove(19);
+        t.remove(21);
+        t.remove(23);
+        EXPECT_TRUE(assertTree("{{11,17[min=101,max=117]}} -> "
+                               "{{1:101,3:103,5:105,7:107,9:109,11:111[min=101,max=111]},"
+                               "{13:113,15:115,17:117[min=113,max=117]}}", t));
+        t.insert(10, 110);
+        EXPECT_TRUE(assertTree("{{7,17[min=101,max=117]}} -> "
+                               "{{1:101,3:103,5:105,7:107[min=101,max=107]},"
+                               "{9:109,10:110,11:111,13:113,15:115,17:117[min=109,max=117]}}", t));
     }
 }
 

--- a/searchlib/src/tests/btree/btreeaggregation_test.cpp
+++ b/searchlib/src/tests/btree/btreeaggregation_test.cpp
@@ -312,6 +312,7 @@ private:
 
     void requireThatNodeInsertWorks();
     void requireThatNodeSplitInsertWorks();
+    void requireThatTreeInsertWorks();
     void requireThatNodeStealWorks();
     void requireThatNodeRemoveWorks();
     void requireThatWeCanInsertAndRemoveFromTree();
@@ -409,13 +410,21 @@ Test::requireThatNodeInsertWorks()
 }
 
 void
-getLeafNode(MyTree &t)
+populateTree(MyTree &t, uint32_t count, uint32_t delta)
 {
-    t.insert(1, 101);
-    t.insert(3, 103);
-    t.insert(5, 105);
-    t.insert(7, 107);
-//    EXPECT_TRUE(assertTree("[1:101,3:103,5:105,7:107[min=101,max=107]]", t));
+    uint32_t key = 1;
+    int32_t value = 101;
+    for (uint32_t i = 0; i < count; ++i) {
+        t.insert(key, value);
+        key += delta;
+        value += delta;
+    }
+}
+
+void
+populateLeafNode(MyTree &t)
+{
+    populateTree(t, 4, 2);
 }
 
 void
@@ -423,7 +432,7 @@ Test::requireThatNodeSplitInsertWorks()
 {
     { // new entry in current node
         MyTree t;
-        getLeafNode(t);
+        populateLeafNode(t);
         t.insert(4, 104);
         EXPECT_TRUE(assertTree("{{4,7[min=101,max=107]}} -> "
                                "{{1:101,3:103,4:104[min=101,max=104]},"
@@ -431,7 +440,7 @@ Test::requireThatNodeSplitInsertWorks()
     }
     { // new entry in split node
         MyTree t;
-        getLeafNode(t);
+        populateLeafNode(t);
         t.insert(6, 106);
         EXPECT_TRUE(assertTree("{{5,7[min=101,max=107]}} -> "
                                "{{1:101,3:103,5:105[min=101,max=105]},"
@@ -439,11 +448,69 @@ Test::requireThatNodeSplitInsertWorks()
     }
     { // new entry at end
         MyTree t;
-        getLeafNode(t);
+        populateLeafNode(t);
         t.insert(8, 108);
         EXPECT_TRUE(assertTree("{{5,8[min=101,max=108]}} -> "
                                "{{1:101,3:103,5:105[min=101,max=105]},"
                                "{7:107,8:108[min=107,max=108]}}", t));
+    }
+}
+
+void
+Test::requireThatTreeInsertWorks()
+{
+    { // multi level node split
+        MyTree t;
+        populateTree(t, 16, 2);
+        EXPECT_TRUE(assertTree("{{7,15,23,31[min=101,max=131]}} -> "
+                               "{{1:101,3:103,5:105,7:107[min=101,max=107]},"
+                               "{9:109,11:111,13:113,15:115[min=109,max=115]},"
+                               "{17:117,19:119,21:121,23:123[min=117,max=123]},"
+                               "{25:125,27:127,29:129,31:131[min=125,max=131]}}", t));
+        t.insert(33, 133);
+        EXPECT_TRUE(assertTree("{{23,33[min=101,max=133]}} -> "
+                               "{{7,15,23[min=101,max=123]},{29,33[min=125,max=133]}} -> "
+                               "{{1:101,3:103,5:105,7:107[min=101,max=107]},"
+                               "{9:109,11:111,13:113,15:115[min=109,max=115]},"
+                               "{17:117,19:119,21:121,23:123[min=117,max=123]},"
+                               "{25:125,27:127,29:129[min=125,max=129]},"
+                               "{31:131,33:133[min=131,max=133]}}", t));
+    }
+    { // give to left node to avoid split
+        MyTree t;
+        populateTree(t, 8, 2);
+        t.remove(5);
+        EXPECT_TRUE(assertTree("{{7,15[min=101,max=115]}} -> "
+                               "{{1:101,3:103,7:107[min=101,max=107]},"
+                               "{9:109,11:111,13:113,15:115[min=109,max=115]}}", t));
+        t.insert(10, 110);
+        EXPECT_TRUE(assertTree("{{9,15[min=101,max=115]}} -> "
+                               "{{1:101,3:103,7:107,9:109[min=101,max=109]},"
+                               "{10:110,11:111,13:113,15:115[min=110,max=115]}}", t));
+    }
+    { // not give to left node to avoid split, but insert at end at left node
+        MyTree t;
+        populateTree(t, 8, 2);
+        t.remove(5);
+        EXPECT_TRUE(assertTree("{{7,15[min=101,max=115]}} -> "
+                               "{{1:101,3:103,7:107[min=101,max=107]},"
+                               "{9:109,11:111,13:113,15:115[min=109,max=115]}}", t));
+        t.insert(8, 108);
+        EXPECT_TRUE(assertTree("{{8,15[min=101,max=115]}} -> "
+                               "{{1:101,3:103,7:107,8:108[min=101,max=108]},"
+                               "{9:109,11:111,13:113,15:115[min=109,max=115]}}", t));
+    }
+    { // give to right node to avoid split
+        MyTree t;
+        populateTree(t, 8, 2);
+        t.remove(13);
+        EXPECT_TRUE(assertTree("{{7,15[min=101,max=115]}} -> "
+                               "{{1:101,3:103,5:105,7:107[min=101,max=107]},"
+                               "{9:109,11:111,15:115[min=109,max=115]}}", t));
+        t.insert(4, 104);
+        EXPECT_TRUE(assertTree("{{5,15[min=101,max=115]}} -> "
+                               "{{1:101,3:103,4:104,5:105[min=101,max=105]},"
+                               "{7:107,9:109,11:111,15:115[min=107,max=115]}}", t));
     }
 }
 
@@ -538,7 +605,7 @@ void
 Test::requireThatNodeRemoveWorks()
 {
     MyTree t;
-    getLeafNode(t);
+    populateLeafNode(t);
     t.remove(3);
     EXPECT_TRUE(assertTree("{{1:101,5:105,7:107[min=101,max=107]}}", t));
     t.remove(1);
@@ -1037,6 +1104,7 @@ Test::Main()
 
     requireThatNodeInsertWorks();
     requireThatNodeSplitInsertWorks();
+    requireThatTreeInsertWorks();
     requireThatNodeStealWorks();
     requireThatNodeRemoveWorks();
     requireThatWeCanInsertAndRemoveFromTree();

--- a/searchlib/src/vespa/searchlib/btree/btreeinserter.h
+++ b/searchlib/src/vespa/searchlib/btree/btreeinserter.h
@@ -44,8 +44,10 @@ public:
     typedef typename LeafNodeType::RefPair LeafNodeTypeRefPair;
     using Inserter = BTreeInserter<KeyT, DataT, AggrT, CompareT, TraitsT, AggrCalcT>;
 
-    static void giveLeafEntries(LeafNodeType *sNode, Iterator &itr, AggrCalcT aggrCalc);
+private:
+    static void rebalanceLeafEntries(LeafNodeType *leafNode, Iterator &itr, AggrCalcT aggrCalc);
 
+public:
     static void
     insert(BTreeNode::Ref &root,
            Iterator &itr,

--- a/searchlib/src/vespa/searchlib/btree/btreeinserter.h
+++ b/searchlib/src/vespa/searchlib/btree/btreeinserter.h
@@ -42,6 +42,9 @@ public:
     typedef DataT DataType;
     typedef typename InternalNodeType::RefPair InternalNodeTypeRefPair;
     typedef typename LeafNodeType::RefPair LeafNodeTypeRefPair;
+    using Inserter = BTreeInserter<KeyT, DataT, AggrT, CompareT, TraitsT, AggrCalcT>;
+
+    static void giveLeafEntries(LeafNodeType *sNode, Iterator &itr, AggrCalcT aggrCalc);
 
     static void
     insert(BTreeNode::Ref &root,

--- a/searchlib/src/vespa/searchlib/btree/btreeinserter.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreeinserter.hpp
@@ -10,6 +10,68 @@
 namespace search {
 namespace btree {
 
+template <typename KeyT, typename DataT, typename AggrT, typename CompareT,
+          typename TraitsT, class AggrCalcT>
+void
+BTreeInserter<KeyT, DataT, AggrT, CompareT, TraitsT, AggrCalcT>::giveLeafEntries(LeafNodeType *sNode, Iterator &itr, AggrCalcT aggrCalc)
+{
+    NodeAllocatorType &allocator(itr.getAllocator());
+    typename Iterator::PathElement &pe = itr.getPath(0);
+    InternalNodeType *pNode = pe.getWNode();
+    uint32_t idx = pe.getIdx();
+    BTreeNode::Ref sNodeRef = pNode->getChild(idx);
+    BTreeNode::Ref leftRef = BTreeNode::Ref();
+    LeafNodeType * leftNode = nullptr;
+    BTreeNode::Ref rightRef = BTreeNode::Ref();
+    LeafNodeType * rightNode = nullptr;
+    if (idx > 0) {
+        leftRef = pNode->getChild(idx - 1);
+        leftNode = allocator.template mapLeafRef(leftRef);
+    }
+    if (idx + 1 < pNode->validSlots()) {
+        rightRef = pNode->getChild(idx + 1);
+        rightNode = allocator.template mapLeafRef(rightRef);
+    }
+    if (leftNode != nullptr && leftNode->validSlots() < LeafNodeType::maxSlots() &&
+        (rightNode == nullptr || leftNode->validSlots() < rightNode->validSlots())) {
+        if (leftNode->getFrozen()) {
+            LeafNodeTypeRefPair thawed =
+                allocator.thawNode(leftRef, leftNode);
+            leftRef = thawed.ref;
+            leftNode = thawed.data;
+        }
+        uint32_t oldLeftValid = leftNode->validSlots();
+        if (itr.getLeafNodeIdx() == 0 && (oldLeftValid + 1 == LeafNodeType::maxSlots())) {
+            pNode->update(idx - 1, leftNode->getLastKey(), leftRef);
+            itr.adjustGivenNoEntriesToLeftLeafNode();
+        } else {
+            leftNode->stealSomeFromRightNode(sNode, allocator);
+            uint32_t given = leftNode->validSlots() - oldLeftValid;
+            pNode->update(idx, sNode->getLastKey(), sNodeRef);
+            pNode->update(idx - 1, leftNode->getLastKey(), leftRef);
+            if (AggrCalcT::hasAggregated()) {
+                Aggregator::recalc(*leftNode, allocator, aggrCalc);
+                Aggregator::recalc(*sNode, allocator, aggrCalc);
+            }
+            itr.adjustGivenEntriesToLeftLeafNode(given);
+        }
+    } else if (rightNode != nullptr && rightNode->validSlots() < LeafNodeType::maxSlots()) {
+        if (rightNode->getFrozen()) {
+            LeafNodeTypeRefPair thawed =
+                allocator.thawNode(rightRef, rightNode);
+            rightRef = thawed.ref;
+            rightNode = thawed.data;
+        }
+        rightNode->stealSomeFromLeftNode(sNode, allocator);
+        pNode->update(idx, sNode->getLastKey(), sNodeRef);
+        pNode->update(idx + 1, rightNode->getLastKey(), rightRef);
+        if (AggrCalcT::hasAggregated()) {
+            Aggregator::recalc(*rightNode, allocator, aggrCalc);
+            Aggregator::recalc(*sNode, allocator, aggrCalc);
+        }
+        itr.adjustGivenEntriesToRightLeafNode();
+    }
+}
 
 template <typename KeyT, typename DataT, typename AggrT, typename CompareT,
           typename TraitsT, class AggrCalcT>
@@ -30,8 +92,12 @@ insert(BTreeNode::Ref &root,
         --itr;
     }
     root = itr.thaw(root);
-    uint32_t idx = itr.getLeafNodeIdx() + (inRange ? 0 : 1);
     LeafNodeType * lnode = itr.getLeafNode();
+    if (lnode->isFull() && itr.getPathSize() > 0) {
+        giveLeafEntries(lnode, itr, aggrCalc);
+        lnode = itr.getLeafNode();
+    }
+    uint32_t idx = itr.getLeafNodeIdx() + (inRange ? 0 : 1);
     BTreeNode::Ref splitNodeRef;
     const KeyT *splitLastKey = nullptr;
     bool inRightSplit = false;

--- a/searchlib/src/vespa/searchlib/btree/btreeiterator.h
+++ b/searchlib/src/vespa/searchlib/btree/btreeiterator.h
@@ -865,6 +865,10 @@ private:
                 _leaf.adjustSteal(stolen);
         }
     }
+
+    void adjustGivenNoEntriesToLeftLeafNode();
+    void adjustGivenEntriesToLeftLeafNode(uint32_t given);
+    void adjustGivenEntriesToRightLeafNode();
 };
 
 

--- a/searchlib/src/vespa/searchlib/btree/btreeiterator.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreeiterator.hpp
@@ -1329,30 +1329,30 @@ template <typename KeyT, typename DataT, typename AggrT, typename CompareT, type
 void
 BTreeIterator<KeyT, DataT, AggrT, CompareT, TraitsT>::adjustGivenNoEntriesToLeftLeafNode()
 {
-    auto &pe = _path[0];
-    uint32_t pidx = pe.getIdx() - 1;
-    BTreeNode::Ref sRef = pe.getNode()->getChild(pidx);
-    const LeafNodeType *sNode = _allocator->mapLeafRef(sRef);
-    pe.setIdx(pidx);
-    _leaf.setNodeAndIdx(sNode, sNode->validSlots());
+    auto &pathElem = _path[0];
+    uint32_t parentIdx = pathElem.getIdx() - 1;
+    BTreeNode::Ref leafRef = pathElem.getNode()->getChild(parentIdx);
+    const LeafNodeType *leafNode = _allocator->mapLeafRef(leafRef);
+    pathElem.setIdx(parentIdx);
+    _leaf.setNodeAndIdx(leafNode, leafNode->validSlots());
 }
 
 template <typename KeyT, typename DataT, typename AggrT, typename CompareT, typename TraitsT>
 void
 BTreeIterator<KeyT, DataT, AggrT, CompareT, TraitsT>::adjustGivenEntriesToLeftLeafNode(uint32_t given)
 {
-    uint32_t idx = _leaf.getIdx();
-    if (idx >= given) {
-        _leaf.setIdx(idx - given);
+    uint32_t leafIdx = _leaf.getIdx();
+    if (leafIdx >= given) {
+        _leaf.setIdx(leafIdx - given);
     } else {
-        auto &pe = _path[0];
-        uint32_t pidx = pe.getIdx() - 1;
-        BTreeNode::Ref sRef = pe.getNode()->getChild(pidx);
-        const LeafNodeType *sNode = _allocator->mapLeafRef(sRef);
-        idx += sNode->validSlots();
-        assert(given <= idx);
-        pe.setIdx(pidx);
-        _leaf.setNodeAndIdx(sNode, idx - given);
+        auto &pathElem = _path[0];
+        uint32_t parentIdx = pathElem.getIdx() - 1;
+        BTreeNode::Ref leafRef = pathElem.getNode()->getChild(parentIdx);
+        const LeafNodeType *leafNode = _allocator->mapLeafRef(leafRef);
+        leafIdx += leafNode->validSlots();
+        assert(given <= leafIdx);
+        pathElem.setIdx(parentIdx);
+        _leaf.setNodeAndIdx(leafNode, leafIdx - given);
     }
 }
 
@@ -1360,18 +1360,18 @@ template <typename KeyT, typename DataT, typename AggrT, typename CompareT, type
 void
 BTreeIterator<KeyT, DataT, AggrT, CompareT, TraitsT>::adjustGivenEntriesToRightLeafNode()
 {
-    uint32_t idx = _leaf.getIdx();
-    const LeafNodeType *sNode = _leaf.getNode();
-    if (idx > sNode->validSlots()) {
-        auto &pe = _path[0];
-        const InternalNodeType *pNode = pe.getNode();
-        uint32_t pidx = pe.getIdx() + 1;
-        idx -= sNode->validSlots();
-        BTreeNode::Ref sRef = pNode->getChild(pidx);
-        sNode = _allocator->mapLeafRef(sRef);
-        assert(idx <= sNode->validSlots());
-        pe.setIdx(pidx);
-        _leaf.setNodeAndIdx(sNode, idx);
+    uint32_t leafIdx = _leaf.getIdx();
+    const LeafNodeType *leafNode = _leaf.getNode();
+    if (leafIdx > leafNode->validSlots()) {
+        auto &pathElem = _path[0];
+        const InternalNodeType *parentNode = pathElem.getNode();
+        uint32_t parentIdx = pathElem.getIdx() + 1;
+        leafIdx -= leafNode->validSlots();
+        BTreeNode::Ref leafRef = parentNode->getChild(parentIdx);
+        leafNode = _allocator->mapLeafRef(leafRef);
+        assert(leafIdx <= leafNode->validSlots());
+        pathElem.setIdx(parentIdx);
+        _leaf.setNodeAndIdx(leafNode, leafIdx);
     }
 }
 


### PR DESCRIPTION
…current

leaf node is full.  This eliminates som leaf node split operations and
increases the number of entries used in each leaf node when keys are inserted
in sorted order (i.e. fewer leaf nodes needed for the same number of entries).