### PR TITLE
Remove mod function and make fmod consistent with backend

### DIFF
--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/Function.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/Function.java
@@ -38,11 +38,10 @@ public enum Function implements Serializable {
     tanh      { public double evaluate(double x, double y) { return tanh(x); } },
 
     atan2(2)  { public double evaluate(double x, double y) { return atan2(x,y); } },
-    fmod(2)   { public double evaluate(double x, double y) { return IEEEremainder(x,y); } },
+    fmod(2)   { public double evaluate(double x, double y) { return x % y; } },
     ldexp(2)  { public double evaluate(double x, double y) { return x*pow(2,y); } },
     max(2)    { public double evaluate(double x, double y) { return max(x,y); } },
     min(2)    { public double evaluate(double x, double y) { return min(x,y); } },
-    mod(2)    { public double evaluate(double x, double y) { return x % y; } },
     pow(2)    { public double evaluate(double x, double y) { return pow(x,y); } };
 
     private final int arity;

--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -115,7 +115,6 @@ TOKEN :
     <LDEXP: "ldexp"> |
     // MAX
     // MIN
-    <MOD: "mod"> |
     <POW: "pow"> |
 
     <MAP: "map"> |
@@ -351,9 +350,9 @@ ExpressionNode tensorFunction() :
     ExpressionNode tensorExpression;
 }
 {
-    ( 
+    (
         tensorExpression = tensorMap() |
-        tensorExpression = tensorReduce() | 
+        tensorExpression = tensorReduce() |
         tensorExpression = tensorReduceComposites() |
         tensorExpression = tensorJoin() |
         tensorExpression = tensorRename() |
@@ -380,7 +379,7 @@ ExpressionNode tensorMap() :
 }
 {
     <MAP> <LBRACE> tensor = expression() <COMMA> doubleMapper = lambdaFunction() <RBRACE>
-    { return new TensorFunctionNode(new Map(TensorFunctionNode.wrapArgument(tensor), 
+    { return new TensorFunctionNode(new Map(TensorFunctionNode.wrapArgument(tensor),
                                             doubleMapper.asDoubleUnaryOperator())); }
 }
 
@@ -414,8 +413,8 @@ ExpressionNode tensorJoin() :
 }
 {
     <JOIN> <LBRACE> tensor1 = expression() <COMMA> tensor2 = expression() <COMMA> doubleJoiner = lambdaFunction() <RBRACE>
-    { return new TensorFunctionNode(new Join(TensorFunctionNode.wrapArgument(tensor1), 
-                                             TensorFunctionNode.wrapArgument(tensor2), 
+    { return new TensorFunctionNode(new Join(TensorFunctionNode.wrapArgument(tensor1),
+                                             TensorFunctionNode.wrapArgument(tensor2),
                                              doubleJoiner.asDoubleBinaryOperator())); }
 }
 
@@ -425,9 +424,9 @@ ExpressionNode tensorRename() :
     List<String> fromDimensions, toDimensions;
 }
 {
-    <RENAME> <LBRACE> tensor = expression() <COMMA> 
-                      fromDimensions = bracedIdentifierList() <COMMA> 
-                      toDimensions = bracedIdentifierList() 
+    <RENAME> <LBRACE> tensor = expression() <COMMA>
+                      fromDimensions = bracedIdentifierList() <COMMA>
+                      toDimensions = bracedIdentifierList()
              <RBRACE>
     { return new TensorFunctionNode(new Rename(TensorFunctionNode.wrapArgument(tensor), fromDimensions, toDimensions)); }
 }
@@ -439,8 +438,8 @@ ExpressionNode tensorConcat() :
 }
 {
     <CONCAT> <LBRACE> tensor1 = expression() <COMMA> tensor2 = expression() <COMMA> dimension = tag() <RBRACE>
-    { return new TensorFunctionNode(new Concat(TensorFunctionNode.wrapArgument(tensor1), 
-                                               TensorFunctionNode.wrapArgument(tensor2), 
+    { return new TensorFunctionNode(new Concat(TensorFunctionNode.wrapArgument(tensor1),
+                                               TensorFunctionNode.wrapArgument(tensor2),
                                                dimension)); }
 }
 
@@ -508,8 +507,8 @@ ExpressionNode tensorMatmul() :
 }
 {
     <MATMUL> <LBRACE> tensor1 = expression() <COMMA> tensor2 = expression() <COMMA> dimension = identifier() <RBRACE>
-    { return new TensorFunctionNode(new Matmul(TensorFunctionNode.wrapArgument(tensor1), 
-                                               TensorFunctionNode.wrapArgument(tensor2), 
+    { return new TensorFunctionNode(new Matmul(TensorFunctionNode.wrapArgument(tensor1),
+                                               TensorFunctionNode.wrapArgument(tensor2),
                                                dimension)); }
 }
 
@@ -529,13 +528,13 @@ ExpressionNode tensorXwPlusB() :
     String dimension;
 }
 {
-    <XW_PLUS_B> <LBRACE> tensor1 = expression() <COMMA> 
-                         tensor2 = expression() <COMMA> 
+    <XW_PLUS_B> <LBRACE> tensor1 = expression() <COMMA>
+                         tensor2 = expression() <COMMA>
                          tensor3 = expression() <COMMA>
                          dimension = identifier() <RBRACE>
-    { return new TensorFunctionNode(new XwPlusB(TensorFunctionNode.wrapArgument(tensor1), 
-                                                TensorFunctionNode.wrapArgument(tensor2), 
-                                                TensorFunctionNode.wrapArgument(tensor3), 
+    { return new TensorFunctionNode(new XwPlusB(TensorFunctionNode.wrapArgument(tensor1),
+                                                TensorFunctionNode.wrapArgument(tensor2),
+                                                TensorFunctionNode.wrapArgument(tensor3),
                                                 dimension)); }
 }
 
@@ -566,7 +565,7 @@ LambdaFunctionNode lambdaFunction() :
 }
 {
      ( <F> <LBRACE> variables = identifierList() <RBRACE> <LBRACE> functionExpression = expression() <RBRACE> )
-     { return new LambdaFunctionNode(variables, functionExpression); } 
+     { return new LambdaFunctionNode(variables, functionExpression); }
 }
 
 Reduce.Aggregator tensorReduceAggregator() :
@@ -582,8 +581,8 @@ TensorType tensorTypeArgument() :
     TensorType.Builder builder = new TensorType.Builder();
 }
 {
-    <LBRACE> 
-    ( tensorTypeDimension(builder) ) ? 
+    <LBRACE>
+    ( tensorTypeDimension(builder) ) ?
     ( <COMMA> tensorTypeDimension(builder) ) *
     <RBRACE>
     { return builder.build(); }
@@ -596,7 +595,7 @@ void tensorTypeDimension(TensorType.Builder builder) :
     int size;
 }
 {
-    name = identifier() <LSQUARE> size = integerNumber() <RSQUARE> 
+    name = identifier() <LSQUARE> size = integerNumber() <RSQUARE>
     { builder.indexed(name, size); }
 }
 
@@ -661,8 +660,7 @@ Function binaryFunctionName() : { }
     <LDEXP> { return Function.ldexp; } |
     <MAX>   { return Function.max;   } |
     <MIN>   { return Function.min;   } |
-    <MOD>   { return Function.mod;   } |
-    <POW>   { return Function.pow;   } 
+    <POW>   { return Function.pow;   }
 }
 
 List<ExpressionNode> expressionList() :

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -95,7 +95,7 @@ public class EvaluationTestCase {
         tester.assertEvaluates("{ {d1:0}:4, {d1:1}:9, {d1:2 }:16 }",
                               "map(tensor0, f(x) (x * x))", "{ {d1:0}:2, {d1:1}:3, {d1:2}:4 }");
         // -- tensor map composites
-        tester.assertEvaluates("{ {d1:0}:1, {d1:1}:2, {d1:2 }:3 }", 
+        tester.assertEvaluates("{ {d1:0}:1, {d1:1}:2, {d1:2 }:3 }",
                                "log10(tensor0)", "{ {d1:0}:10, {d1:1}:100, {d1:2}:1000 }");
         tester.assertEvaluates("{ {d1:0}:-10, {d1:1}:-100, {d1:2 }:-1000 }",
                                "- tensor0", "{ {d1:0}:10, {d1:1}:100, {d1:2}:1000 }");
@@ -118,7 +118,7 @@ public class EvaluationTestCase {
         tester.assertEvaluates("{ {x:0}:0, {x:1}:0 }",     "isNan(tensor0)",  "{ {x:0}:1, {x:1}:2 }");
         tester.assertEvaluates("{ {x:0}:0, {x:1}:0 }",     "log(tensor0)",    "{ {x:0}:1, {x:1}:1 }");
         tester.assertEvaluates("{ {x:0}:0, {x:1}:1 }",     "log10(tensor0)",  "{ {x:0}:1, {x:1}:10 }");
-        tester.assertEvaluates("{ {x:0}:0, {x:1}:2 }",     "mod(tensor0, 3)", "{ {x:0}:3, {x:1}:8 }");
+        tester.assertEvaluates("{ {x:0}:0, {x:1}:2 }",     "fmod(tensor0, 3)", "{ {x:0}:3, {x:1}:8 }");
         tester.assertEvaluates("{ {x:0}:1, {x:1}:8 }",     "pow(tensor0, 3)", "{ {x:0}:1, {x:1}:2 }");
         tester.assertEvaluates("{ {x:0}:1, {x:1}:2 }",     "relu(tensor0)",   "{ {x:0}:1, {x:1}:2 }");
         tester.assertEvaluates("{ {x:0}:1, {x:1}:2 }",     "round(tensor0)",  "{ {x:0}:1, {x:1}:1.8 }");
@@ -177,7 +177,7 @@ public class EvaluationTestCase {
         tester.assertEvaluates("{ {x:0,y:0}:15, {x:1,y:0}:35 }", "join(tensor0, tensor1, f(x,y) (x*y))", "{ {x:0}:3, {x:1}:7 }", "{ {y:0}:5 }");
         // -- join composites
         tester.assertEvaluates("{ }", "tensor0 * tensor0", "{}");
-        tester.assertEvaluates("{{x:0,y:0,z:0}:0.0}", "( tensor0 * tensor1 ) * ( tensor2 * tensor1 )", 
+        tester.assertEvaluates("{{x:0,y:0,z:0}:0.0}", "( tensor0 * tensor1 ) * ( tensor2 * tensor1 )",
                                "{{x:0}:1}", "{}", "{{y:0,z:0}:1}");
         tester.assertEvaluates("tensor(x{}):{}",
                                "tensor0 * tensor1", "{ {x:0}:3 }", "tensor(x{}):{ {x:1}:5 }");
@@ -225,14 +225,14 @@ public class EvaluationTestCase {
                                "tensor0 != tensor1", "{ {x:0}:3, {x:1}:7 }", "{ {y:0}:7 }");
         // TODO
         // argmax
-        // argmin        
+        // argmin
         tester.assertEvaluates("{ {x:0,y:0}:1, {x:1,y:0}:0 }",
                                "tensor0 != tensor1", "{ {x:0}:3, {x:1}:7 }", "{ {y:0}:7 }");
 
         // tensor rename
         tester.assertEvaluates("{ {newX:0,y:0}:3 }", "rename(tensor0, x, newX)", "{ {x:0,y:0}:3.0 }");
         tester.assertEvaluates("{  {x:0,y:0}:3, {x:1,y:0}:5 }", "rename(tensor0, (x, y), (y, x))", "{ {x:0,y:0}:3.0, {x:0,y:1}:5.0 }");
-        
+
         // tensor generate
         tester.assertEvaluates("{ {x:0,y:0}:0, {x:1,y:0}:0, {x:0,y:1}:1, {x:1,y:1}:0, {x:0,y:2}:0, {x:1,y:2}:1 }", "tensor(x[2],y[3])(x+1==y)");
         tester.assertEvaluates("{ {y:0,x:0}:0, {y:1,x:0}:0, {y:0,x:1}:1, {y:1,x:1}:0, {y:0,x:2}:0, {y:1,x:2}:1 }", "tensor(y[2],x[3])(y+1==x)");
@@ -241,7 +241,7 @@ public class EvaluationTestCase {
         tester.assertEvaluates("{ {x:0}:0, {x:1}:1, {x:2}:2 }", "range(x[3])");
         tester.assertEvaluates("{ {x:0,y:0,z:0}:1, {x:0,y:0,z:1}:0, {x:0,y:1,z:0}:0, {x:0,y:1,z:1}:0, {x:1,y:0,z:0}:0, {x:1,y:0,z:1}:0, {x:1,y:1,z:0}:0, {x:1,y:1,z:1}:1, }", "diag(x[2],y[2],z[2])");
         tester.assertEvaluates("6", "reduce(random(x[2],y[3]), count)");
-        
+
         // composite functions
         tester.assertEvaluates("{ {x:0}:0.25, {x:1}:0.75 }", "l1_normalize(tensor0, x)", "{ {x:0}:1, {x:1}:3 }");
         tester.assertEvaluates("{ {x:0}:0.31622776601683794, {x:1}:0.9486832980505138 }", "l2_normalize(tensor0, x)", "{ {x:0}:1, {x:1}:3 }");
@@ -279,7 +279,7 @@ public class EvaluationTestCase {
         tester.assertEvaluates("tensor(x{}):{}", "tensor0 * tensor1", "{ {x:0}:1 }", "tensor(x{}):{ {x:1}:1 }");
         tester.assertEvaluates("tensor(x{},y{}):{}", "tensor0 * tensor1", "{ {x:0}:1 }", "tensor(x{},y{}):{ {x:1,y:0}:1, {x:2,y:1}:1 }");
     }
-    
+
     @Test
     public void testProgrammaticBuildingAndPrecedence() {
         RankingExpression standardPrecedence = new RankingExpression(new ArithmeticNode(constant(2), ArithmeticOperator.PLUS, new ArithmeticNode(constant(3), ArithmeticOperator.MULTIPLY, constant(4))));


### PR DESCRIPTION
@bratseth Please review.

"mod" is not a function in backend, only "fmod". So removing "mod", as a rank expression with mod would fail deploy anyway.

Our Java implementation of "fmod" was implemented as IEEERemainder, which is not the same as std::fmod in C++ (C++ has std::remainder). 