### PR TITLE
Resume before updating node repo

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -117,10 +117,8 @@ public class NodeAgentImplTest {
         verify(dockerOperations, never()).scheduleDownloadOfImage(eq(containerName), any(), any());
 
         final InOrder inOrder = inOrder(dockerOperations, orchestrator, nodeRepository);
-        // TODO: Verify this isn't run unless 1st time
-        inOrder.verify(dockerOperations, times(1)).resumeNode(eq(containerName));
+        inOrder.verify(dockerOperations).resumeNode(eq(containerName));
         inOrder.verify(orchestrator).resume(hostName);
-        // TODO: This should not happen when nothing is changed. Now it happens 1st time through.
         inOrder.verify(nodeRepository).updateNodeAttributes(
                 hostName,
                 new NodeAttributes()
@@ -135,7 +133,17 @@ public class NodeAgentImplTest {
         verify(orchestrator, never()).suspend(any(String.class));
         verify(dockerOperations, never()).scheduleDownloadOfImage(eq(containerName), any(), any());
 
+        // Should not be called 2nd time
+        inOrder.verify(dockerOperations, never()).resumeNode(eq(containerName));
         inOrder.verify(orchestrator).resume(hostName);
+        // Should not be called 2nd time
+        inOrder.verify(nodeRepository, never()).updateNodeAttributes(
+                hostName,
+                new NodeAttributes()
+                        .withRestartGeneration(restartGeneration)
+                        .withRebootGeneration(rebootGeneration)
+                        .withDockerImage(dockerImage)
+                        .withVespaVersion(vespaVersion));
     }
 
     @Test

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -119,6 +119,7 @@ public class NodeAgentImplTest {
         final InOrder inOrder = inOrder(dockerOperations, orchestrator, nodeRepository);
         // TODO: Verify this isn't run unless 1st time
         inOrder.verify(dockerOperations, times(1)).resumeNode(eq(containerName));
+        inOrder.verify(orchestrator).resume(hostName);
         // TODO: This should not happen when nothing is changed. Now it happens 1st time through.
         inOrder.verify(nodeRepository).updateNodeAttributes(
                 hostName,
@@ -127,6 +128,13 @@ public class NodeAgentImplTest {
                         .withRebootGeneration(rebootGeneration)
                         .withDockerImage(dockerImage)
                         .withVespaVersion(vespaVersion));
+
+        nodeAgent.converge();
+
+        verify(dockerOperations, never()).removeContainer(any());
+        verify(orchestrator, never()).suspend(any(String.class));
+        verify(dockerOperations, never()).scheduleDownloadOfImage(eq(containerName), any(), any());
+
         inOrder.verify(orchestrator).resume(hostName);
     }
 
@@ -158,13 +166,13 @@ public class NodeAgentImplTest {
         inOrder.verify(aclMaintainer, times(1)).run();
         inOrder.verify(dockerOperations, times(1)).startContainer(eq(containerName), eq(nodeSpec));
         inOrder.verify(dockerOperations, times(1)).resumeNode(eq(containerName));
+        inOrder.verify(orchestrator).resume(hostName);
         inOrder.verify(nodeRepository).updateNodeAttributes(
                 hostName, new NodeAttributes()
                         .withRestartGeneration(restartGeneration)
                         .withRebootGeneration(rebootGeneration)
                         .withDockerImage(dockerImage)
                         .withVespaVersion(vespaVersion));
-        inOrder.verify(orchestrator).resume(hostName);
     }
 
     @Test
@@ -463,6 +471,7 @@ public class NodeAgentImplTest {
 
         inOrder.verify(dockerOperations).resumeNode(any());
         inOrder.verify(orchestrator).resume(hostName);
+        inOrder.verify(nodeRepository).updateNodeAttributes(eq(hostName), any());
         inOrder.verifyNoMoreInteractions();
     }
 


### PR DESCRIPTION
Calls resume against the Orchestrator before updating the node repo with the newly converged version.

This change ensures all storage nodes are (have been) UP before wait-for-convergence completes and post-wait-for-convergence tests runs.  canary-docker's test failed due to coverage edge effects at the maintenance->up transition in CD.