### PR TITLE
Revert "Resume before updating node repo"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -467,13 +467,19 @@ public class NodeAgentImpl implements NodeAgent {
                 }
 
                 runLocalResumeScriptIfNeeded(nodeSpec);
-
-                orchestrator.resume(hostname);
-
-                // Updating the node repo is best-effort:  Since resume has succeeded when getting here,
-                // suspension of the next node wil be granted.  However, the rollout of a new release IS
-                // gated on this succeeding.
+                // Because it's more important to stop a bad release from rolling out in prod,
+                // we put the resume call last. So if we fail after updating the node repo attributes
+                // but before resume, the app may go through the tenant pipeline but will halt in prod.
+                //
+                // Note that this problem exists only because there are 2 different mechanisms
+                // that should really be parts of a single mechanism:
+                //  - The content of node repo is used to determine whether a new Vespa+application
+                //    has been successfully rolled out.
+                //  - Slobrok and internal orchestrator state is used to determine whether
+                //    to allow upgrade (suspend).
                 updateNodeRepoWithCurrentAttributes(nodeSpec);
+                logger.info("Call resume against Orchestrator");
+                orchestrator.resume(hostname);
                 break;
             case inactive:
                 storageMaintainer.ifPresent(maintainer -> maintainer.removeOldFilesFromNode(containerName));


### PR DESCRIPTION
Reverts yahoo/vespa#2887

The problem is as follows:
 - Permission to restart content node is granted
 - Restart is done
 - Resume fails because the search node is not up immediately (which is reasonable to expect)
 - We never reach update of the node repo, so current restart generation is never updated
 - On the next tick of the node agent - trying to converge the state for the content node, the node agent realizes the node should restart (since the wanted generation > current).
