### PR TITLE
Add mapped hash join to make mapped tensor join more efficient

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Join.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Join.java
@@ -295,8 +295,8 @@ public class Join extends PrimitiveTensorFunction {
             return mappedGeneralJoin(a, b, joinedType); // fallback
         }
 
-        boolean switchTensors = a.size() > b.size();
-        if (switchTensors) {
+        boolean swapTensors = a.size() > b.size();
+        if (swapTensors) {
             Tensor temp = a;
             a = b;
             b = temp;
@@ -326,7 +326,7 @@ public class Join extends PrimitiveTensorFunction {
                 TensorAddress combinedAddress = joinAddresses(aCell.getKey(), aIndexesInJoined,
                         bCell.getKey(), bIndexesInJoined, joinedType);
                 if (combinedAddress == null) continue; // not combinable
-                double combinedValue = switchTensors ?
+                double combinedValue = swapTensors ?
                         combinator.applyAsDouble(bCell.getValue(), aCell.getValue()) :
                         combinator.applyAsDouble(aCell.getValue(), bCell.getValue());
                 builder.cell(combinedAddress, combinedValue);

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorFunctionBenchmark.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorFunctionBenchmark.java
@@ -107,11 +107,11 @@ public class TensorFunctionBenchmark {
         double time = 0;
 
         // ---------------- Mapped with extra space (sidesteps current special-case optimizations):
-        // 11.2 ms
-        time = new TensorFunctionBenchmark().benchmark(500, vectors(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
+        // 9.9 ms
+        time = new TensorFunctionBenchmark().benchmark(1000, vectors(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
         System.out.printf("Mapped vectors, x space  time per join: %1$8.3f ms\n", time);
-        // 10.8 ms
-        time = new TensorFunctionBenchmark().benchmark(500, matrix(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
+        // 10.5 ms
+        time = new TensorFunctionBenchmark().benchmark(1000, matrix(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
         System.out.printf("Mapped matrix, x space   time per join: %1$8.3f ms\n", time);
 
         // ---------------- Mapped:

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorFunctionBenchmark.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorFunctionBenchmark.java
@@ -107,11 +107,11 @@ public class TensorFunctionBenchmark {
         double time = 0;
 
         // ---------------- Mapped with extra space (sidesteps current special-case optimizations):
-        // 410 ms
-        time = new TensorFunctionBenchmark().benchmark(20, vectors(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
+        // 11.2 ms
+        time = new TensorFunctionBenchmark().benchmark(500, vectors(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
         System.out.printf("Mapped vectors, x space  time per join: %1$8.3f ms\n", time);
-        // 770 ms
-        time = new TensorFunctionBenchmark().benchmark(20, matrix(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
+        // 10.8 ms
+        time = new TensorFunctionBenchmark().benchmark(500, matrix(100, 300, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped, true);
         System.out.printf("Mapped matrix, x space   time per join: %1$8.3f ms\n", time);
 
         // ---------------- Mapped:


### PR DESCRIPTION
@bratseth Please review.

Without loss of generality, improves benchmark with 40-80x. Please advise if you see any further improvements. 
