### PR TITLE
Return 409 if there is a conflict when activating

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ActivationConflictException.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ActivationConflictException.java
@@ -8,8 +8,8 @@ package com.yahoo.vespa.config.server;
  *
  * @author hmusum
  */
-public class ActivationException extends RuntimeException {
-    public ActivationException(String s) {
+public class ActivationConflictException extends RuntimeException {
+    public ActivationConflictException(String s) {
         super(s);
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ActivationException.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ActivationException.java
@@ -1,0 +1,15 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server;
+
+/**
+ * Exception used when activation cannot be done because activation is for
+ * an older session than the one that is active now or because current active
+ * session has changed since the session to be activated was created
+ *
+ * @author hmusum
+ */
+public class ActivationException extends RuntimeException {
+    public ActivationException(String s) {
+        super(s);
+    }
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -9,6 +9,7 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.transaction.Transaction;
+import com.yahoo.vespa.config.server.ActivationException;
 import com.yahoo.vespa.config.server.tenant.ActivateLock;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.TimeoutBudget;
@@ -202,25 +203,25 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                                 ", current active session=" + currentActiveSessionSessionId);
         if (currentActiveSession.isNewerThan(activeSessionAtCreate) &&
                 currentActiveSessionSessionId != sessionId) {
-            String errMsg = currentActiveSession.logPre()+"Cannot activate session " +
+            String errMsg = currentActiveSession.logPre() + "Cannot activate session " +
                             sessionId + " because the currently active session (" +
                             currentActiveSessionSessionId + ") has changed since session " + sessionId +
                             " was created (was " + activeSessionAtCreate + " at creation time)";
             if (ignoreStaleSessionFailure) {
                 log.warning(errMsg + " (Continuing because of force.)");
             } else {
-                throw new IllegalStateException(errMsg);
+                throw new ActivationException(errMsg);
             }
         }
     }
 
-    // As of now, config generation is based on session id, and config generation must be an monotonically
+    // As of now, config generation is based on session id, and config generation must be a monotonically
     // increasing number
     private void checkIfActiveIsNewerThanSessionToBeActivated(long sessionId, long currentActiveSessionId) {
         if (sessionId < currentActiveSessionId) {
-            throw new IllegalArgumentException("It is not possible to activate session " + sessionId +
-                                               ", because it is older than current active session (" + 
-                                               currentActiveSessionId + ")");
+            throw new ActivationException("It is not possible to activate session " + sessionId +
+                                          ", because it is older than current active session (" +
+                                          currentActiveSessionId + ")");
         }
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -9,7 +9,7 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.transaction.Transaction;
-import com.yahoo.vespa.config.server.ActivationException;
+import com.yahoo.vespa.config.server.ActivationConflictException;
 import com.yahoo.vespa.config.server.tenant.ActivateLock;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.TimeoutBudget;
@@ -210,7 +210,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
             if (ignoreStaleSessionFailure) {
                 log.warning(errMsg + " (Continuing because of force.)");
             } else {
-                throw new ActivationException(errMsg);
+                throw new ActivationConflictException(errMsg);
             }
         }
     }
@@ -219,7 +219,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
     // increasing number
     private void checkIfActiveIsNewerThanSessionToBeActivated(long sessionId, long currentActiveSessionId) {
         if (sessionId < currentActiveSessionId) {
-            throw new ActivationException("It is not possible to activate session " + sessionId +
+            throw new ActivationConflictException("It is not possible to activate session " + sessionId +
                                           ", because it is older than current active session (" +
                                           currentActiveSessionId + ")");
         }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpErrorResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpErrorResponse.java
@@ -35,6 +35,7 @@ public class HttpErrorResponse extends HttpResponse {
     public enum errorCodes {
         APPLICATION_LOCK_FAILURE,
         BAD_REQUEST,
+        ACTIVATION_FAILED,
         INTERNAL_SERVER_ERROR,
         INVALID_APPLICATION_PACKAGE,
         METHOD_NOT_ALLOWED,
@@ -62,6 +63,10 @@ public class HttpErrorResponse extends HttpResponse {
 
     public static HttpErrorResponse badRequest(String msg) {
         return new HttpErrorResponse(BAD_REQUEST, errorCodes.BAD_REQUEST.name(), msg);
+    }
+
+    public static HttpErrorResponse conflictWhenActivating(String msg) {
+        return new HttpErrorResponse(CONFLICT, errorCodes.ACTIVATION_FAILED.name(), msg);
     }
 
     public static HttpErrorResponse methodNotAllowed(String msg) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -8,6 +8,7 @@ import com.yahoo.container.jdisc.LoggingRequestHandler;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.log.LogLevel;
 import com.yahoo.config.provision.OutOfCapacityException;
+import com.yahoo.vespa.config.server.ActivationException;
 import com.yahoo.yolean.Exceptions;
 
 import java.io.PrintWriter;
@@ -47,6 +48,8 @@ public class HttpHandler extends LoggingRequestHandler {
             }
         } catch (NotFoundException | com.yahoo.vespa.config.server.NotFoundException e) {
             return HttpErrorResponse.notFoundError(getMessage(e, request));
+        } catch (ActivationException e) {
+            return HttpErrorResponse.conflictWhenActivating(getMessage(e, request));
         } catch (BadRequestException | IllegalArgumentException | IllegalStateException e) {
             return HttpErrorResponse.badRequest(getMessage(e, request));
         } catch (OutOfCapacityException e) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -8,7 +8,7 @@ import com.yahoo.container.jdisc.LoggingRequestHandler;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.log.LogLevel;
 import com.yahoo.config.provision.OutOfCapacityException;
-import com.yahoo.vespa.config.server.ActivationException;
+import com.yahoo.vespa.config.server.ActivationConflictException;
 import com.yahoo.yolean.Exceptions;
 
 import java.io.PrintWriter;
@@ -48,7 +48,7 @@ public class HttpHandler extends LoggingRequestHandler {
             }
         } catch (NotFoundException | com.yahoo.vespa.config.server.NotFoundException e) {
             return HttpErrorResponse.notFoundError(getMessage(e, request));
-        } catch (ActivationException e) {
+        } catch (ActivationConflictException e) {
             return HttpErrorResponse.conflictWhenActivating(getMessage(e, request));
         } catch (BadRequestException | IllegalArgumentException | IllegalStateException e) {
             return HttpErrorResponse.badRequest(getMessage(e, request));


### PR DESCRIPTION
Today, you get 400 Bad Request when activation fails due to a conflict. Using 409 seems correct and will also gives us the possibility to retry deployment if we want to avoid deployment failures in this scenario.

Doc will be updated in another PR.