### PR TITLE
Move code that puts config in cache

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ProxyServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ProxyServer.java
@@ -80,7 +80,7 @@ public class ProxyServer implements Runnable {
         this.delayedResponseHandling = delayedResponseHandling;
         this.memoryCache = memoryCache;
         this.rpcServer = createRpcServer(spec);
-        clientUpdater = new ClientUpdater(memoryCache, rpcServer, statistics, delayedResponses, mode);
+        clientUpdater = new ClientUpdater(rpcServer, statistics, delayedResponses);
         this.configClient = createClient(clientUpdater, delayedResponses, source, timingValues, memoryCache, configClient);
     }
 
@@ -262,7 +262,7 @@ public class ProxyServer implements Runnable {
         }
     }
 
-    public MemoryCache getMemoryCache() {
+    MemoryCache getMemoryCache() {
         return memoryCache;
     }
 

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/RpcConfigSourceClient.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/RpcConfigSourceClient.java
@@ -153,7 +153,7 @@ class RpcConfigSourceClient implements ConfigSourceClient {
                 log.log(LogLevel.DEBUG, "Already a subscriber running for: " + configCacheKey);
             } else {
                 log.log(LogLevel.DEBUG, "Could not find good config in cache, creating subscriber for: " + configCacheKey);
-                UpstreamConfigSubscriber subscriber = new UpstreamConfigSubscriber(input, clientUpdater, configSourceSet, timingValues, requesterPool);
+                UpstreamConfigSubscriber subscriber = new UpstreamConfigSubscriber(input, clientUpdater, configSourceSet, timingValues, requesterPool, memoryCache);
                 try {
                     subscriber.subscribe();
                     activeSubscribers.put(configCacheKey, subscriber);

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/UpstreamConfigSubscriber.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/UpstreamConfigSubscriber.java
@@ -25,7 +25,8 @@ public class UpstreamConfigSubscriber implements Subscriber {
     private final ClientUpdater clientUpdater;
     private final ConfigSource configSourceSet;
     private final TimingValues timingValues;
-    private Map<ConfigSourceSet, JRTConfigRequester> requesterPool;
+    private final Map<ConfigSourceSet, JRTConfigRequester> requesterPool;
+    private final MemoryCache memoryCache;
     private GenericConfigSubscriber subscriber;
     private GenericConfigHandle handle;
 
@@ -33,12 +34,14 @@ public class UpstreamConfigSubscriber implements Subscriber {
                              ClientUpdater clientUpdater,
                              ConfigSource configSourceSet,
                              TimingValues timingValues,
-                             Map<ConfigSourceSet, JRTConfigRequester> requesterPool) {
+                             Map<ConfigSourceSet, JRTConfigRequester> requesterPool,
+                             MemoryCache memoryCache) {
         this.config = config;
         this.clientUpdater = clientUpdater;
         this.configSourceSet = configSourceSet;
         this.timingValues = timingValues;
         this.requesterPool = requesterPool;
+        this.memoryCache = memoryCache;
     }
 
     void subscribe() {
@@ -68,7 +71,7 @@ public class UpstreamConfigSubscriber implements Subscriber {
                     "', generation=" + newConfig.getGeneration() +
                     ", payload=" + newConfig.getPayload());
         }
-        // memoryCache.put(); TODO: Add here later and remove in ClientUpdater
+        memoryCache.put(newConfig);
         clientUpdater.updateSubscribers(newConfig);
     }
 

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ConfigTester.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ConfigTester.java
@@ -19,7 +19,7 @@ import java.util.Optional;
  */
 public class ConfigTester {
 
-    private final long defaultTimeout = 10000;
+    private static final long defaultTimeout = 10000;
 
     public JRTServerConfigRequest createRequest(RawConfig config) {
         return createRequest(config, defaultTimeout);
@@ -28,10 +28,6 @@ public class ConfigTester {
     public JRTServerConfigRequest createRequest(RawConfig config, long timeout) {
         return createRequest(config.getName(), config.getConfigId(), config.getNamespace(),
                              config.getConfigMd5(), config.getDefMd5(), config.getGeneration(), timeout);
-    }
-
-    public JRTServerConfigRequest createRequest(String configName, String configId, String namespace) {
-        return createRequest(configName, configId, namespace, defaultTimeout);
     }
 
     public JRTServerConfigRequest createRequest(String configName, String configId, String namespace, long timeout) {

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/DelayedResponseHandlerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/DelayedResponseHandlerTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
  */
 public class DelayedResponseHandlerTest {
 
-    private final MockConfigSource source = new MockConfigSource(new MockClientUpdater(new MemoryCache()));
+    private final MockConfigSource source = new MockConfigSource(new MockClientUpdater());
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/MockClientUpdater.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/MockClientUpdater.java
@@ -10,12 +10,12 @@ import java.time.Instant;
 class MockClientUpdater extends ClientUpdater {
     private RawConfig lastConfig;
 
-    MockClientUpdater(MemoryCache memoryCache) {
-        this(new ConfigProxyStatistics(), new Mode(), memoryCache);
+    MockClientUpdater() {
+        this(new ConfigProxyStatistics());
     }
 
-    private MockClientUpdater(ConfigProxyStatistics statistics, Mode mode, MemoryCache memoryCache) {
-        super(memoryCache, new MockRpcServer(), statistics, new DelayedResponses(statistics), mode);
+    private MockClientUpdater(ConfigProxyStatistics statistics) {
+        super(new MockRpcServer(), statistics, new DelayedResponses(statistics));
     }
 
     @Override

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/MockConfigSourceClient.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/MockConfigSourceClient.java
@@ -14,18 +14,18 @@ import java.util.List;
  * @author hmusum
  */
 public class MockConfigSourceClient implements ConfigSourceClient{
-    private final ClientUpdater clientUpdater;
     private final MockConfigSource configSource;
+    private final MemoryCache memoryCache;
 
-    MockConfigSourceClient(ClientUpdater clientUpdater, MockConfigSource configSource) {
-        this.clientUpdater = clientUpdater;
+    MockConfigSourceClient(MockConfigSource configSource, MemoryCache memoryCache) {
         this.configSource = configSource;
+        this.memoryCache = memoryCache;
     }
 
     @Override
     public RawConfig getConfig(RawConfig input, JRTServerConfigRequest request) {
         final RawConfig config = getConfig(input.getKey());
-        clientUpdater.getMemoryCache().put(config);
+        memoryCache.put(config);
         return config;
     }
 

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ProxyServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ProxyServerTest.java
@@ -23,9 +23,9 @@ import static org.junit.Assert.*;
 public class ProxyServerTest {
 
     private final MemoryCache memoryCache = new MemoryCache();
-    private MockClientUpdater clientUpdater = new MockClientUpdater(memoryCache);
+    private MockClientUpdater clientUpdater = new MockClientUpdater();
     private final MockConfigSource source = new MockConfigSource(clientUpdater);
-    private MockConfigSourceClient client = new MockConfigSourceClient(clientUpdater, source);
+    private MockConfigSourceClient client = new MockConfigSourceClient(source, memoryCache);
     private final ConfigProxyStatistics statistics = new ConfigProxyStatistics();
     private ProxyServer proxy;
 


### PR DESCRIPTION
The important change here is moving the code that puts config in cache from ClientUpdater to UpstreamConfigSubscriber. Since UpstreamConfigSubscriber is only used in 'default' mode the early return in updateSubscribers() could be removed as well, since it will never be run.