### PR TITLE
Deconstruct components in non-daemon thread

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -23,7 +23,7 @@ public class Deconstructor implements ComponentDeconstructor {
     private static final Logger log = Logger.getLogger(Deconstructor.class.getName());
 
     private final ScheduledExecutorService executor =
-            Executors.newScheduledThreadPool(1, ThreadFactoryFactory.getDaemonThreadFactory("deconstructor"));
+            Executors.newScheduledThreadPool(1, ThreadFactoryFactory.getThreadFactory("deconstructor"));
 
     private final int delay;
 


### PR DESCRIPTION
The JVM may core dump if it is shutting down during
deconstruction of a JNI component. This change will force the JVM to
wait for deconstruction to finish.