### PR TITLE
Upgrade maven-javadoc-plugin to 2.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
                     <configuration>
                         <additionalparam>-Xdoclint:${doclint} -Xdoclint:-missing</additionalparam>
                     </configuration>
-                    <version>2.9</version>
+                    <version>2.10.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Some useless warnings in the Maven output disappears after upgrading this plugin :)