### PR TITLE
Increase number of deployments known to filedistributor

### DIFF
--- a/filedistribution/src/vespa/filedistribution/model/deployedfilestodownload.h
+++ b/filedistribution/src/vespa/filedistribution/model/deployedfilestodownload.h
@@ -9,8 +9,8 @@ namespace filedistribution {
 const std::string readApplicationId(ZKFacade & zk, const Path & deployNode);
 
 class DeployedFilesToDownload {
-    //includes the current deployment. Want at least 3 ('original' + 2, since there might be concurrent deployments, e.g both external and internal)
-    static const size_t numberOfDeploymentsToKeepFilesFrom = 3;
+    //includes the current deployment. Want 2 * number of config models, since deployment is per model
+    static const size_t numberOfDeploymentsToKeepFilesFrom = 14;
 
     ZKFacade& _zk;
 


### PR DESCRIPTION
* Deployment for filedistributor is per config model version, so
  need to keep track of more of them