### PR TITLE
[VESPA-8156] Remove disk usage metric cache

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -124,7 +124,7 @@ public class StorageMaintainer {
         }
     }
 
-    public Optional<Long> updateIfNeededAndGetDiskMetricsFor(ContainerName containerName) {
+    public Optional<Long> getDiskUsageFor(ContainerName containerName) {
         Path containerDir = environment.pathInNodeAdminFromPathInNode(containerName, "/home/");
         try {
             return Optional.of(getDiscUsedInBytes(containerDir));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -127,7 +127,7 @@ public class StorageMaintainer {
     public Optional<Long> getDiskUsageFor(ContainerName containerName) {
         Path containerDir = environment.pathInNodeAdminFromPathInNode(containerName, "/home/");
         try {
-            return Optional.of(getDiscUsedInBytes(containerDir));
+            return Optional.of(getDiskUsedInBytes(containerDir));
         } catch (Throwable e) {
             PrefixLogger logger = PrefixLogger.getNodeAgentLogger(StorageMaintainer.class, containerName);
             logger.error("Problems during disk usage calculations in " + containerDir.toAbsolutePath(), e);
@@ -136,7 +136,7 @@ public class StorageMaintainer {
     }
 
     // Public for testing
-    long getDiscUsedInBytes(Path path) throws IOException, InterruptedException {
+    long getDiskUsedInBytes(Path path) throws IOException, InterruptedException {
         final String[] command = {"du", "-xsk", path.toString()};
 
         Process duCommand = new ProcessBuilder().command(command).start();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -51,10 +51,7 @@ public class StorageMaintainer {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static Optional<String> kernelVersion = Optional.empty();
 
-    private static final long intervalSec = 1000;
-
     private final Logger logger = Logger.getLogger(StorageMaintainer.class.getName());
-    private final Object monitor = new Object();
     private final CounterWrapper numberOfNodeAdminMaintenanceFails;
     private final Docker docker;
     private final Environment environment;
@@ -128,25 +125,14 @@ public class StorageMaintainer {
     }
 
     public Optional<Long> updateIfNeededAndGetDiskMetricsFor(ContainerName containerName) {
-        // Calculating disk usage is IO expensive operation and its value changes relatively slowly, we want to perform
-        // that calculation rarely. Additionally, we spread out the calculation for different containers by adding
-        // a random deviation.
-        MaintenanceThrottler maintenanceThrottler = getMaintenanceThrottlerFor(containerName);
-        if (maintenanceThrottler.shouldUpdateDiskUsageNow()) {
-            // Throttle to one disk usage calculation at a time.
-            synchronized (monitor) {
-                PrefixLogger logger = PrefixLogger.getNodeAgentLogger(StorageMaintainer.class, containerName);
-                Path containerDir = environment.pathInNodeAdminFromPathInNode(containerName, "/home/");
-                try {
-                    long used = getDiscUsedInBytes(containerDir);
-                    maintenanceThrottler.setDiskUsage(used);
-                } catch (Throwable e) {
-                    logger.error("Problems during disk usage calculations: " + e.getMessage());
-                }
-            }
+        Path containerDir = environment.pathInNodeAdminFromPathInNode(containerName, "/home/");
+        try {
+            return Optional.of(getDiscUsedInBytes(containerDir));
+        } catch (Throwable e) {
+            PrefixLogger logger = PrefixLogger.getNodeAgentLogger(StorageMaintainer.class, containerName);
+            logger.error("Problems during disk usage calculations in " + containerDir.toAbsolutePath(), e);
+            return Optional.empty();
         }
-
-        return maintenanceThrottler.diskUsage;
     }
 
     // Public for testing
@@ -418,23 +404,11 @@ public class StorageMaintainer {
     }
 
     private class MaintenanceThrottler {
-        private Instant nextDiskUsageUpdateAt;
         private Instant nextRemoveOldFilesAt;
         private Instant nextHandleOldCoredumpsAt;
-        private Optional<Long> diskUsage = Optional.empty();
 
         MaintenanceThrottler() {
             reset();
-        }
-
-        boolean shouldUpdateDiskUsageNow() {
-            return !nextDiskUsageUpdateAt.isAfter(clock.instant());
-        }
-
-        void setDiskUsage(long diskUsage) {
-            this.diskUsage = Optional.of(diskUsage);
-            long distributedSecs = (long) (intervalSec * (0.5 + Math.random()));
-            nextDiskUsageUpdateAt = clock.instant().plusSeconds(distributedSecs);
         }
 
         void updateNextRemoveOldFilesTime() {
@@ -454,9 +428,8 @@ public class StorageMaintainer {
         }
 
         void reset() {
-            nextDiskUsageUpdateAt = clock.instant().minus(Duration.ofDays(1));
-            nextRemoveOldFilesAt = clock.instant().minus(Duration.ofDays(1));
-            nextHandleOldCoredumpsAt = clock.instant().minus(Duration.ofDays(1));
+            nextRemoveOldFilesAt = Instant.EPOCH;
+            nextHandleOldCoredumpsAt = Instant.EPOCH;
         }
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -527,7 +527,7 @@ public class NodeAgentImpl implements NodeAgent {
         final long memoryTotalBytesCache = ((Number) ((Map) stats.getMemoryStats().get("stats")).get("cache")).longValue();
         final Optional<Long> diskTotalBytes = nodeSpec.minDiskAvailableGb.map(size -> (long) (size * bytesInGB));
         final Optional<Long> diskTotalBytesUsed = storageMaintainer.flatMap(maintainer -> maintainer
-                        .updateIfNeededAndGetDiskMetricsFor(containerName));
+                        .getDiskUsageFor(containerName));
 
         // CPU usage by a container as percentage of total host CPU, cpuPercentageOfHost, is given by dividing used
         // CPU time by the container with CPU time used by the entire system.

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
@@ -24,7 +24,7 @@ public class StorageMaintainerMock extends StorageMaintainer {
     }
 
     @Override
-    public Optional<Long> updateIfNeededAndGetDiskMetricsFor(ContainerName containerName) {
+    public Optional<Long> getDiskUsageFor(ContainerName containerName) {
         return Optional.empty();
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -48,7 +48,7 @@ public class StorageMaintainerTest {
         int writeSize = 10000;
         writeNBytesToFile(folder.newFile(), writeSize);
 
-        long usedBytes = storageMaintainer.getDiscUsedInBytes(folder.getRoot().toPath());
+        long usedBytes = storageMaintainer.getDiskUsedInBytes(folder.getRoot().toPath());
         if (usedBytes * 4 < writeSize || usedBytes > writeSize * 4)
             fail("Used bytes is " + usedBytes + ", but wrote " + writeSize + " bytes, not even close.");
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -524,7 +524,7 @@ public class NodeAgentImplTest {
         NodeAgentImpl nodeAgent = makeNodeAgent(dockerImage, true);
 
         when(nodeRepository.getContainerNodeSpec(eq(hostName))).thenReturn(Optional.of(nodeSpec));
-        when(storageMaintainer.updateIfNeededAndGetDiskMetricsFor(eq(containerName))).thenReturn(Optional.of(42547019776L));
+        when(storageMaintainer.getDiskUsageFor(eq(containerName))).thenReturn(Optional.of(42547019776L));
         when(storageMaintainer.getHostTotalMemoryGb()).thenReturn(10d);
         when(dockerOperations.getContainerStats(eq(containerName)))
                 .thenReturn(Optional.of(stats1))


### PR DESCRIPTION
Because the filesystem inside docker containers is not its own partition/disk, the total disk size used by the container is calculated using simple `du -xsk /path` command,  this is much slower than the `statfs()` that is used on non-docker host. Today, docker hosts are on SSDs and in practice the command seems to be instantaneous anyway
```
4790026552	/home/docker/container-storage/le03918-v6-32/

real	0m0.045s
user	0m0.003s
sys	0m0.012s
```
so this PR removes the throttling and caching of disk usage metric and runs `du` command every time instead.