### PR TITLE
[VESPA-8066] Mount container's /proc on host

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -48,6 +48,7 @@ public class DockerOperationsImpl implements DockerOperations {
     private static final Map<String, Boolean> DIRECTORIES_TO_MOUNT = new HashMap<>();
 
     static {
+        DIRECTORIES_TO_MOUNT.put("/proc", false);
         DIRECTORIES_TO_MOUNT.put("/etc/yamas-agent", true);
         DIRECTORIES_TO_MOUNT.put("/etc/filebeat", true);
         DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/daemontools_y"), false);


### PR DESCRIPTION
In order to calculate number of open file descriptors inside container, `node-admin` needs to iterate over container's `/proc/*/fd/` directories and count number of files inside each. 
But first we need to mount the containers `/proc` directory to host under `/home/docker/container-storage/[container name]/proc` to make it accessible to `node-admin`.