### PR TITLE
Revert "[VESPA-8066] Mount container's /proc on host"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -48,7 +48,6 @@ public class DockerOperationsImpl implements DockerOperations {
     private static final Map<String, Boolean> DIRECTORIES_TO_MOUNT = new HashMap<>();
 
     static {
-        DIRECTORIES_TO_MOUNT.put("/proc", false);
         DIRECTORIES_TO_MOUNT.put("/etc/yamas-agent", true);
         DIRECTORIES_TO_MOUNT.put("/etc/filebeat", true);
         DIRECTORIES_TO_MOUNT.put(getDefaults().underVespaHome("logs/daemontools_y"), false);


### PR DESCRIPTION
Reverts yahoo/vespa#3029

Fails with 
```
[2017-08-01 02:08:21.355] ERROR   : container        Container.com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl        
        NodeAgent-13305702-v6-18: Caught a DockerExecption, resetting containerState to UNKNOWN
        exception=
        com.yahoo.vespa.hosted.dockerapi.DockerException: Failed to start container '13305702-v6-18'
        at com.yahoo.vespa.hosted.dockerapi.DockerImpl.startContainer(DockerImpl.java:313)
        at com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl.startContainer(DockerOperationsImpl.java:158)
        at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.startContainer(NodeAgentImpl.java:253)
        at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.converge(NodeAgentImpl.java:466)
        at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.tick(NodeAgentImpl.java:401)
        at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.lambda$start$1(NodeAgentImpl.java:190)
        at java.lang.Thread.run(Thread.java:748)
        Caused by: com.github.dockerjava.api.exception.InternalServerErrorException: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \\"process_linux.go:359: container init caused \\\\\\"rootfs_linux.go:53: mounting \\\\\\\\\\\\\\"/home/docker/container-storage/13305702-v6-18/proc\\\\\\\\\\\\\\" to rootfs \\\\\\\\\\\\\\"/home/docker/data/devicemapper/mnt/ed4fd3f1e429764df8e78f1bf6a206b489f326a85c2c4dfebb2cff65cf88cf67/rootfs\\\\\\\\\\\\\\" at \\\\\\\\\\\\\\"/proc\\\\\\\\\\\\\\" caused \\\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"/home/docker/data/devicemapper/mnt/ed4fd3f1e429764df8e78f1bf6a206b489f326a85c2c4dfebb2cff65cf88cf67/rootfs/proc\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" cannot be mounted because it is located inside \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"/proc\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\"\\\\\\"\\"\
        "
        
        at com.github.dockerjava.jaxrs.filter.ResponseStatusExceptionFilter.filter(ResponseStatusExceptionFilter.java:53)
        at org.glassfish.jersey.client.ClientFilteringStages$ResponseFilterStage.apply(ClientFilteringStages.java:140)
        at org.glassfish.jersey.client.ClientFilteringStages$ResponseFilterStage.apply(ClientFilteringStages.java:128)
        at org.glassfish.jersey.process.internal.Stages.process(Stages.java:171)
        at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:257)
        at org.glassfish.jersey.client.JerseyInvocation$1.call(JerseyInvocation.java:684)
        at org.glassfish.jersey.client.JerseyInvocation$1.call(JerseyInvocation.java:681)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:228)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:444)
        at org.glassfish.jersey.client.JerseyInvocation.invoke(JerseyInvocation.java:681)
        at org.glassfish.jersey.client.JerseyInvocation$Builder.method(JerseyInvocation.java:437)
        at org.glassfish.jersey.client.JerseyInvocation$Builder.post(JerseyInvocation.java:343)
        at com.github.dockerjava.jaxrs.StartContainerCmdExec.execute(StartContainerCmdExec.java:29)
        at com.github.dockerjava.jaxrs.StartContainerCmdExec.execute(StartContainerCmdExec.java:12)
        at com.github.dockerjava.jaxrs.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:23)
        at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
        at com.github.dockerjava.core.command.StartContainerCmdImpl.exec(StartContainerCmdImpl.java:46)
        at com.yahoo.vespa.hosted.dockerapi.DockerImpl.startContainer(DockerImpl.java:308)
        ... 6 more
```
