### PR TITLE
Balder/optimize applyto with transaction concept

### DIFF
--- a/document/src/tests/documentselectparsertest.cpp
+++ b/document/src/tests/documentselectparsertest.cpp
@@ -50,7 +50,7 @@ class DocumentSelectParserTest : public CppUnit::TestFixture {
             const std::string& doctype, const std::string& id, uint32_t hint,
             const std::string& hstr);
 
-    select::FieldValueNode
+    std::unique_ptr<select::FieldValueNode>
     parseFieldValue(const std::string expression);
 
     template <typename ContainsType>
@@ -1220,30 +1220,30 @@ void DocumentSelectParserTest::testUtf8()
 //    PARSE("testdoctype1.hstringval =~ \"H.kon\"", *_doc[_doc.size()-1], True);
 }
 
-select::FieldValueNode
+std::unique_ptr<select::FieldValueNode>
 DocumentSelectParserTest::parseFieldValue(const std::string expression) {
-    return dynamic_cast<const select::FieldValueNode &>(
-        *dynamic_cast<const select::Compare &>(*_parser->parse(expression)).getLeft().clone());
+    return std::unique_ptr<select::FieldValueNode>(dynamic_cast<select::FieldValueNode *>(
+        dynamic_cast<const select::Compare &>(*_parser->parse(expression)).getLeft().clone().release()));
 }
 
 void DocumentSelectParserTest::testThatSimpleFieldValuesHaveCorrectFieldName() {
     CPPUNIT_ASSERT_EQUAL(
         vespalib::string("headerval"),
-        parseFieldValue("testdoctype1.headerval").getRealFieldName());
+        parseFieldValue("testdoctype1.headerval")->getRealFieldName());
 }
 
 void DocumentSelectParserTest::testThatComplexFieldValuesHaveCorrectFieldNames() {
     CPPUNIT_ASSERT_EQUAL(
         vespalib::string("headerval"),
-        parseFieldValue("testdoctype1.headerval{test}").getRealFieldName());
+        parseFieldValue("testdoctype1.headerval{test}")->getRealFieldName());
 
     CPPUNIT_ASSERT_EQUAL(
         vespalib::string("headerval"),
-        parseFieldValue("testdoctype1.headerval[42]").getRealFieldName());
+        parseFieldValue("testdoctype1.headerval[42]")->getRealFieldName());
 
     CPPUNIT_ASSERT_EQUAL(
         vespalib::string("headerval"),
-        parseFieldValue("testdoctype1.headerval.meow.meow{test}").getRealFieldName());
+        parseFieldValue("testdoctype1.headerval.meow.meow{test}")->getRealFieldName());
 }
 
 } // document

--- a/document/src/tests/documenttestcase.cpp
+++ b/document/src/tests/documenttestcase.cpp
@@ -76,9 +76,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(DocumentTest);
 
 void DocumentTest::testSizeOf()
 {
-    CPPUNIT_ASSERT_EQUAL(120ul, sizeof(Document));
-    CPPUNIT_ASSERT_EQUAL(64ul, sizeof(StructFieldValue));
-    CPPUNIT_ASSERT_EQUAL(16ul, sizeof(StructuredFieldValue));
+    CPPUNIT_ASSERT_EQUAL(136ul, sizeof(Document));
+    CPPUNIT_ASSERT_EQUAL(72ul, sizeof(StructFieldValue));
+    CPPUNIT_ASSERT_EQUAL(24ul, sizeof(StructuredFieldValue));
     CPPUNIT_ASSERT_EQUAL(64ul, sizeof(SerializableArray));
 }
 

--- a/document/src/tests/documenttestcase.cpp
+++ b/document/src/tests/documenttestcase.cpp
@@ -99,10 +99,10 @@ void DocumentTest::testFieldPath()
                                        "{\"\"}", "", ""
                                      };
     for (size_t i(0); i < sizeof(testValues)/sizeof(testValues[0]); i+=3) {
-        vespalib::string tmp = testValues[i];
+        vespalib::stringref tmp = testValues[i];
         vespalib::string key = FieldPathEntry::parseKey(tmp);
         CPPUNIT_ASSERT_EQUAL(testValues[i+1], key);
-        CPPUNIT_ASSERT_EQUAL(testValues[i+2], tmp);
+        CPPUNIT_ASSERT_EQUAL(testValues[i+2], vespalib::string(tmp));
     }
 }
 

--- a/document/src/vespa/document/base/field.h
+++ b/document/src/vespa/document/base/field.h
@@ -80,6 +80,7 @@ public:
     bool contains(const FieldSet& fields) const override;
     Type getType() const override { return FIELD; }
     bool valid() const { return _fieldId != 0; }
+    uint32_t hash() const { return getId(); }
 private:
     int calculateIdV7();
 

--- a/document/src/vespa/document/base/fieldpath.cpp
+++ b/document/src/vespa/document/base/fieldpath.cpp
@@ -145,23 +145,25 @@ vespalib::string FieldPathEntry::parseKey(vespalib::stringref & key)
     if ((c < e) && (c[0] == '{')) {
         for(c++;(c < e) && isspace(c[0]); c++);
         if ((c < e) && (c[0] == '"')) {
-            for (c++; (c < e) && (c[0] != '"'); c++) {
+            const char * start = ++c;
+            for (; (c < e) && (c[0] != '"'); c++) {
                 if (c[0] == '\\') {
-                    c++;
-                }
-                if (c < e) {
-                    v += c[0];
+                    v.append(start, c-start);
+                    start = ++c;
                 }
             }
+            v.append(start, c-start);
             if ((c < e) && (c[0] == '"')) {
                 c++;
             } else {
                 throw IllegalArgumentException(make_string("Escaped key '%s' is incomplete. No matching '\"'", key.c_str()), VESPA_STRLOC);
             }
         } else {
-            for (;(c < e) && (c[0] != '}'); c++) {
-                v += c[0];
+            const char * start = c;
+            while ((c < e) && (c[0] != '}')) {
+                c++;
             }
+            v.append(start, c-start);
         }
         for(;(c < e) && isspace(c[0]); c++);
         if ((c < e) && (c[0] == '}')) {

--- a/document/src/vespa/document/base/fieldpath.cpp
+++ b/document/src/vespa/document/base/fieldpath.cpp
@@ -178,28 +178,11 @@ FieldPath::FieldPath(const FieldPath &) = default;
 FieldPath & FieldPath::operator=(const FieldPath &) = default;
 FieldPath::~FieldPath() { }
 
-FieldPath::iterator
-FieldPath::insert(iterator pos, FieldPathEntry && entry)
-{
-    return _path.insert(pos, std::move(entry));
-}
-void
-FieldPath::push_back(FieldPathEntry && entry)
-{
-    _path.push_back(std::move(entry));
-}
-
-void
-FieldPath::pop_back()
-{
-    _path.pop_back();
-}
-
-void
-FieldPath::clear()
-{
-    _path.clear();
-}
+FieldPath::iterator FieldPath::insert(iterator pos, FieldPathEntry && entry) { return _path.insert(pos, std::move(entry)); }
+void FieldPath::push_back(FieldPathEntry && entry) { _path.push_back(std::move(entry)); }
+void FieldPath::pop_back() { _path.pop_back(); }
+void FieldPath::clear() { _path.clear(); }
+void FieldPath::reserve(size_t sz) { _path.reserve(sz); }
 
 void
 FieldPath::visitMembers(vespalib::ObjectVisitor& visitor) const

--- a/document/src/vespa/document/base/fieldpath.cpp
+++ b/document/src/vespa/document/base/fieldpath.cpp
@@ -136,7 +136,7 @@ FieldPathEntry::visitMembers(vespalib::ObjectVisitor &visitor) const
     visit(visitor, "fillInVal", _fillInVal);
 }
 
-vespalib::string FieldPathEntry::parseKey(vespalib::string & key)
+vespalib::string FieldPathEntry::parseKey(vespalib::stringref & key)
 {
     vespalib::string v;
     const char *c = key.c_str();

--- a/document/src/vespa/document/base/fieldpath.cpp
+++ b/document/src/vespa/document/base/fieldpath.cpp
@@ -183,8 +183,10 @@ FieldPath::FieldPath(const FieldPath &) = default;
 FieldPath & FieldPath::operator=(const FieldPath &) = default;
 FieldPath::~FieldPath() { }
 
-FieldPath::iterator FieldPath::insert(iterator pos, FieldPathEntry && entry) { return _path.insert(pos, std::move(entry)); }
-void FieldPath::push_back(FieldPathEntry && entry) { _path.push_back(std::move(entry)); }
+FieldPath::iterator FieldPath::insert(iterator pos, std::unique_ptr<FieldPathEntry> entry) {
+    return _path.insert(pos, vespalib::CloneablePtr<FieldPathEntry>(entry.release()));
+}
+void FieldPath::push_back(std::unique_ptr<FieldPathEntry> entry) { _path.emplace_back(entry.release()); }
 void FieldPath::pop_back() { _path.pop_back(); }
 void FieldPath::clear() { _path.clear(); }
 void FieldPath::reserve(size_t sz) { _path.reserve(sz); }

--- a/document/src/vespa/document/base/fieldpath.cpp
+++ b/document/src/vespa/document/base/fieldpath.cpp
@@ -179,8 +179,8 @@ FieldPath::FieldPath()
     : _path()
 { }
 
-//FieldPath::FieldPath(const FieldPath &) = default;
-//FieldPath & FieldPath::operator=(const FieldPath &) = default;
+FieldPath::FieldPath(const FieldPath &) = default;
+FieldPath & FieldPath::operator=(const FieldPath &) = default;
 FieldPath::~FieldPath() { }
 
 FieldPath::iterator FieldPath::insert(iterator pos, FieldPathEntry && entry) { return _path.insert(pos, std::move(entry)); }

--- a/document/src/vespa/document/base/fieldpath.h
+++ b/document/src/vespa/document/base/fieldpath.h
@@ -53,7 +53,7 @@ public:
     /**
        Creates a field path entry for a map or wset key lookup.
     */
-    FieldPathEntry(const DataType & dataType, const DataType& fillType, const FieldValueCP & lookupKey);
+    FieldPathEntry(const DataType & dataType, const DataType& fillType, std::unique_ptr<FieldValue> lookupKey);
 
     /**
        Creates a field path entry for a map key or value only traversal.
@@ -117,8 +117,8 @@ public:
     typedef std::unique_ptr<FieldPath> UP;
 
     FieldPath();
-    FieldPath(const FieldPath &);
-    FieldPath & operator=(const FieldPath &);
+    FieldPath(const FieldPath &) = delete;
+    FieldPath & operator=(const FieldPath &) = delete;
     FieldPath(FieldPath &&) = default;
     FieldPath & operator=(FieldPath &&) = default;
     ~FieldPath();

--- a/document/src/vespa/document/base/fieldpath.h
+++ b/document/src/vespa/document/base/fieldpath.h
@@ -35,8 +35,8 @@ public:
     */
     FieldPathEntry();
 
-    FieldPathEntry(FieldPathEntry &&) = default;
-    FieldPathEntry & operator=(FieldPathEntry &&) = default;
+    FieldPathEntry(FieldPathEntry &&) noexcept = default;
+    FieldPathEntry & operator=(FieldPathEntry &&) noexcept = default;
     FieldPathEntry(const FieldPathEntry &);
     FieldPathEntry & operator=(const FieldPathEntry &);
 
@@ -147,6 +147,7 @@ public:
 
     void pop_back();
     void clear();
+    void reserve(size_t sz);
 
     Container::size_type size() const { return _path.size(); }
     bool empty() const { return _path.empty(); }

--- a/document/src/vespa/document/base/fieldpath.h
+++ b/document/src/vespa/document/base/fieldpath.h
@@ -117,8 +117,8 @@ public:
     typedef std::unique_ptr<FieldPath> UP;
 
     FieldPath();
-    FieldPath(const FieldPath &) = delete;
-    FieldPath & operator=(const FieldPath &) = delete;
+    FieldPath(const FieldPath &);
+    FieldPath & operator=(const FieldPath &);
     FieldPath(FieldPath &&) = default;
     FieldPath & operator=(FieldPath &&) = default;
     ~FieldPath();

--- a/document/src/vespa/document/base/fieldpath.h
+++ b/document/src/vespa/document/base/fieldpath.h
@@ -67,6 +67,8 @@ public:
     */
     FieldPathEntry(const DataType & dataType, const vespalib::stringref & variableName);
 
+    FieldPathEntry * clone() const { return new FieldPathEntry(*this); }
+
     Type getType() const { return _type; }
     const vespalib::string & getName() const { return _name; }
 
@@ -106,7 +108,7 @@ private:
 //typedef std::deque<FieldPathEntry> FieldPath;
 // Facade over FieldPathEntry container that exposes cloneability
 class FieldPath {
-    typedef std::vector<FieldPathEntry> Container;
+    typedef std::vector<vespalib::CloneablePtr<FieldPathEntry>> Container;
 public:
     typedef Container::reference reference;
     typedef Container::const_reference const_reference;
@@ -128,8 +130,8 @@ public:
         : _path(first, last)
     { }
 
-    iterator insert(iterator pos, FieldPathEntry && entry);
-    void push_back(FieldPathEntry && entry);
+    iterator insert(iterator pos, std::unique_ptr<FieldPathEntry> entry);
+    void push_back(std::unique_ptr<FieldPathEntry> entry);
 
     iterator begin() { return _path.begin(); }
     iterator end() { return _path.end(); }
@@ -140,10 +142,10 @@ public:
     const_reverse_iterator rbegin() const { return _path.rbegin(); }
     const_reverse_iterator rend() const { return _path.rend(); }
 
-    reference front() { return _path.front(); }
-    const_reference front() const { return _path.front(); }
-    reference back() { return _path.back(); }
-    const_reference back() const { return _path.back(); }
+    FieldPathEntry & front() { return *_path.front(); }
+    const FieldPathEntry & front() const { return *_path.front(); }
+    FieldPathEntry & back() { return *_path.back(); }
+    const FieldPathEntry & back() const { return *_path.back(); }
 
     void pop_back();
     void clear();
@@ -151,9 +153,9 @@ public:
 
     Container::size_type size() const { return _path.size(); }
     bool empty() const { return _path.empty(); }
-    reference operator[](Container::size_type i) { return _path[i]; }
+    FieldPathEntry & operator[](Container::size_type i) { return *_path[i]; }
 
-    const_reference operator[](Container::size_type i) const { return _path[i]; }
+    const FieldPathEntry & operator[](Container::size_type i) const { return *_path[i]; }
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const;
 
@@ -164,7 +166,7 @@ public:
         Range(IT begin_, IT end_) : _begin(begin_), _end(end_) { }
         Range next() const { return Range(_begin+1, _end); }
         bool atEnd() const { return _begin == _end; }
-        const FieldPathEntry & cur() { return *_begin; }
+        const FieldPathEntry & cur() { return **_begin; }
     private:
         IT _begin;
         IT _end;

--- a/document/src/vespa/document/base/fieldpath.h
+++ b/document/src/vespa/document/base/fieldpath.h
@@ -92,7 +92,7 @@ public:
      * @param key is the incoming value, and contains what is left when done.
      * *return The unescaped value
      */
-    static vespalib::string parseKey(vespalib::string & key);
+    static vespalib::string parseKey(vespalib::stringref & key);
 private:
     void setFillValue(const DataType & dataType);
     Type                 _type;

--- a/document/src/vespa/document/datatype/arraydatatype.cpp
+++ b/document/src/vespa/document/datatype/arraydatatype.cpp
@@ -58,9 +58,9 @@ ArrayDataType::onBuildFieldPath(FieldPath & path, const vespalib::stringref & re
             getNestedType().buildFieldPath(path, remainFieldName.substr(pos));
 
             if (remainFieldName[1] == '$') {
-                path.insert(path.begin(), FieldPathEntry(getNestedType(), remainFieldName.substr(2, endPos - 2)));
+                path.insert(path.begin(), std::make_unique<FieldPathEntry>(getNestedType(), remainFieldName.substr(2, endPos - 2)));
             } else {
-                path.insert(path.begin(), FieldPathEntry(getNestedType(), atoi(remainFieldName.substr(1, endPos - 1).c_str())));
+                path.insert(path.begin(), std::make_unique<FieldPathEntry>(getNestedType(), atoi(remainFieldName.substr(1, endPos - 1).c_str())));
             }
         }
     } else {

--- a/document/src/vespa/document/datatype/datatype.cpp
+++ b/document/src/vespa/document/datatype/datatype.cpp
@@ -171,7 +171,7 @@ DataType::operator<(const DataType& other) const
 }
 
 void
-DataType::buildFieldPath(FieldPath & path, const vespalib::stringref  & remainFieldName) const
+DataType::buildFieldPath(FieldPath & path, const vespalib::stringref & remainFieldName) const
 {
     if ( !remainFieldName.empty() ) {
         path.reserve(4);  // Optimize for short paths

--- a/document/src/vespa/document/datatype/datatype.cpp
+++ b/document/src/vespa/document/datatype/datatype.cpp
@@ -174,6 +174,7 @@ void
 DataType::buildFieldPath(FieldPath & path, const vespalib::stringref  & remainFieldName) const
 {
     if ( !remainFieldName.empty() ) {
+        path.reserve(4);  // Optimize for short paths
         onBuildFieldPath(path,remainFieldName);
     }
 }

--- a/document/src/vespa/document/datatype/mapdatatype.cpp
+++ b/document/src/vespa/document/datatype/mapdatatype.cpp
@@ -61,7 +61,7 @@ MapDataType::buildFieldPathImpl(FieldPath & path, const DataType &dataType,
                                 const DataType &keyType, const DataType &valueType)
 {
     if (!remainFieldName.empty() && remainFieldName[0] == '{') {
-        vespalib::string rest = remainFieldName;
+        vespalib::stringref rest = remainFieldName;
         vespalib::string keyValue = FieldPathEntry::parseKey(rest);
 
         valueType.buildFieldPath(path, (rest[0] == '.') ? rest.substr(1) : rest);

--- a/document/src/vespa/document/datatype/mapdatatype.cpp
+++ b/document/src/vespa/document/datatype/mapdatatype.cpp
@@ -67,11 +67,11 @@ MapDataType::buildFieldPathImpl(FieldPath & path, const DataType &dataType,
         valueType.buildFieldPath(path, (rest[0] == '.') ? rest.substr(1) : rest);
 
         if (remainFieldName[1] == '$') {
-            path.insert(path.begin(), FieldPathEntry(valueType, keyValue.substr(1)));
+            path.insert(path.begin(), std::make_unique<FieldPathEntry>(valueType, keyValue.substr(1)));
         } else {
             FieldValue::UP fv = keyType.createFieldValue();
             *fv = keyValue;
-            path.insert(path.begin(), FieldPathEntry(valueType, dataType, std::move(fv)));
+            path.insert(path.begin(), std::make_unique<FieldPathEntry>(valueType, dataType, std::move(fv)));
         }
     } else if (memcmp(remainFieldName.c_str(), "key", 3) == 0) {
         size_t endPos = 3;
@@ -81,7 +81,7 @@ MapDataType::buildFieldPathImpl(FieldPath & path, const DataType &dataType,
 
         keyType.buildFieldPath(path, remainFieldName.substr(endPos));
 
-        path.insert(path.begin(), FieldPathEntry(dataType, keyType, valueType, true, false));
+        path.insert(path.begin(), std::make_unique<FieldPathEntry>(dataType, keyType, valueType, true, false));
     } else if (memcmp(remainFieldName.c_str(), "value", 5) == 0) {
         size_t endPos = 5;
         if (remainFieldName[endPos] == '.') {
@@ -90,7 +90,7 @@ MapDataType::buildFieldPathImpl(FieldPath & path, const DataType &dataType,
 
         valueType.buildFieldPath(path, remainFieldName.substr(endPos));
 
-        path.insert(path.begin(), FieldPathEntry(dataType, keyType, valueType, false, true));
+        path.insert(path.begin(), std::make_unique<FieldPathEntry>(dataType, keyType, valueType, false, true));
     } else {
         keyType.buildFieldPath(path, remainFieldName);
     }

--- a/document/src/vespa/document/datatype/mapdatatype.cpp
+++ b/document/src/vespa/document/datatype/mapdatatype.cpp
@@ -71,7 +71,7 @@ MapDataType::buildFieldPathImpl(FieldPath & path, const DataType &dataType,
         } else {
             FieldValue::UP fv = keyType.createFieldValue();
             *fv = keyValue;
-            path.insert(path.begin(), FieldPathEntry(valueType, dataType, vespalib::CloneablePtr<FieldValue>(fv.release())));
+            path.insert(path.begin(), FieldPathEntry(valueType, dataType, std::move(fv)));
         }
     } else if (memcmp(remainFieldName.c_str(), "key", 3) == 0) {
         size_t endPos = 3;

--- a/document/src/vespa/document/datatype/structureddatatype.cpp
+++ b/document/src/vespa/document/datatype/structureddatatype.cpp
@@ -79,7 +79,7 @@ StructuredDataType::onBuildFieldPath(FieldPath & path, const vespalib::stringref
         const document::Field &fp = getField(currFieldName);
         fp.getDataType().buildFieldPath(path, subFieldName);
 
-        path.insert(path.begin(), FieldPathEntry(fp));
+        path.insert(path.begin(), std::make_unique<FieldPathEntry>(fp));
     } else {
         throw FieldNotFoundException(currFieldName, make_string("Invalid field path '%s', no field named '%s'",
                                                    remainFieldName.c_str(), currFieldName.c_str()));

--- a/document/src/vespa/document/fieldvalue/fieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/fieldvalue.cpp
@@ -74,6 +74,11 @@ FieldValue::compare(const FieldValue& other) const {
              : 0;
 }
 
+int
+FieldValue::fastCompare(const FieldValue& other) const {
+    return compare(other);
+}
+
 FieldValue&
 FieldValue::assign(const FieldValue& value)
 {

--- a/document/src/vespa/document/fieldvalue/fieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/fieldvalue.h
@@ -84,6 +84,13 @@ public:
     virtual int compare(const FieldValue& other) const;
 
     /**
+     * Same as normal compar, but this one expects the types to be equal
+     * @param other
+     * @return See compare
+     */
+    virtual int fastCompare(const FieldValue& other) const;
+
+    /**
      * Returns true if this object have been altered since last
      * serialization/deserialization. If hasChanged() is false, then cached
      * information from last serialization effort is still valid.

--- a/document/src/vespa/document/fieldvalue/literalfieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/literalfieldvalue.cpp
@@ -63,11 +63,17 @@ int
 LiteralFieldValueB::compare(const FieldValue& other) const
 {
     if (*getDataType() == *other.getDataType()) {
-        const LiteralFieldValueB& sval(
-                static_cast<const LiteralFieldValueB&>(other));
+        const LiteralFieldValueB& sval(static_cast<const LiteralFieldValueB&>(other));
         return getValueRef().compare(sval.getValueRef());
     }
     return (getDataType()->getId() - other.getDataType()->getId());
+}
+
+int
+LiteralFieldValueB::fastCompare(const FieldValue& other) const
+{
+    const LiteralFieldValueB& sval(static_cast<const LiteralFieldValueB&>(other));
+    return getValueRef().compare(sval.getValueRef());
 }
 
 void

--- a/document/src/vespa/document/fieldvalue/literalfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/literalfieldvalue.h
@@ -58,13 +58,13 @@ public:
     void setValue(const char* val, size_t size) { setValue(stringref(val, size)); }
 
     int compare(const FieldValue& other) const override;
+    int fastCompare(const FieldValue& other) const override;
 
     vespalib::string getAsString() const override;
     std::pair<const char*, size_t> getAsRaw() const override;
 
     void printXml(XmlOutputStream& out) const override;
-    void print(std::ostream& out, bool verbose,
-                       const std::string& indent) const override;
+    void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     FieldValue& assign(const FieldValue&) override;
     bool hasChanged() const  override{ return _altered; }
 

--- a/document/src/vespa/document/fieldvalue/literalfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/literalfieldvalue.h
@@ -54,11 +54,11 @@ public:
         _value = _backing;
         _altered = true;
     }
-    size_t hash() const override { return vespalib::hashValue(_value.c_str()); }
+    size_t hash() const override final { return vespalib::hashValue(_value.c_str()); }
     void setValue(const char* val, size_t size) { setValue(stringref(val, size)); }
 
     int compare(const FieldValue& other) const override;
-    int fastCompare(const FieldValue& other) const override;
+    int fastCompare(const FieldValue& other) const override final;
 
     vespalib::string getAsString() const override;
     std::pair<const char*, size_t> getAsRaw() const override;

--- a/document/src/vespa/document/fieldvalue/mapfieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/mapfieldvalue.cpp
@@ -252,9 +252,12 @@ MapFieldValue::hasChanged() const
 MapFieldValue::const_iterator
 MapFieldValue::find(const FieldValue& key) const
 {
-    for(size_t i(0), m(_keys->size()); i < m; i++) {
-        if ((*_keys)[i] == key) {
-            return const_iterator(*this, i);
+    size_t sz = _keys->size();
+    if ((sz > 0) && (key.getClass().id() == (*_keys)[0].getClass().id())) {
+        for (size_t i(0), m(_keys->size()); i < m; i++) {
+            if ((*_keys)[i].fastCompare(key) == 0) {
+                return const_iterator(*this, i);
+            }
         }
     }
     return end();
@@ -263,17 +266,18 @@ MapFieldValue::find(const FieldValue& key) const
 MapFieldValue::iterator
 MapFieldValue::find(const FieldValue& key)
 {
-    for(size_t i(0), m(_keys->size()); i < m; i++) {
-        if ((*_keys)[i] == key) {
-            return iterator(*this, i);
+    size_t sz = _keys->size();
+    if ((sz > 0) && (key.getClass().id() == (*_keys)[0].getClass().id())) {
+        for (size_t i(0), m(_keys->size()); i < m; i++) {
+            if ((*_keys)[i].fastCompare(key) == 0) {
+                return iterator(*this, i);
+            }
         }
     }
     return end();
 }
 bool
-MapFieldValue::checkAndRemove(const FieldValue& key,
-                             ModificationStatus status,
-                              bool wasModified,
+MapFieldValue::checkAndRemove(const FieldValue& key, ModificationStatus status, bool wasModified,
                               std::vector<const FieldValue*>& keysToRemove) const
 {
     if (status == ModificationStatus::REMOVED) {

--- a/document/src/vespa/document/fieldvalue/numericfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/numericfieldvalue.h
@@ -38,6 +38,7 @@ public:
 
     FieldValue& assign(const FieldValue&) override ;
     int compare(const FieldValue& other) const override;
+    int fastCompare(const FieldValue& other) const override;
 
     FieldValue& operator=(const vespalib::stringref &) override;
     FieldValue& operator=(int32_t) override;

--- a/document/src/vespa/document/fieldvalue/numericfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/numericfieldvalue.h
@@ -38,14 +38,14 @@ public:
 
     FieldValue& assign(const FieldValue&) override ;
     int compare(const FieldValue& other) const override;
-    int fastCompare(const FieldValue& other) const override;
+    int fastCompare(const FieldValue& other) const override final;
 
     FieldValue& operator=(const vespalib::stringref &) override;
     FieldValue& operator=(int32_t) override;
     FieldValue& operator=(int64_t) override;
     FieldValue& operator=(float) override;
     FieldValue& operator=(double) override;
-    size_t hash() const override { return vespalib::hash<Number>()(_value); }
+    size_t hash() const override final { return vespalib::hash<Number>()(_value); }
 
     char getAsByte() const override;
     int32_t getAsInt() const override;
@@ -55,7 +55,7 @@ public:
     vespalib::string getAsString() const override;
 
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
-    bool hasChanged() const override { return _altered; }
+    bool hasChanged() const override final { return _altered; }
 };
 
 } // document

--- a/document/src/vespa/document/fieldvalue/numericfieldvalue.hpp
+++ b/document/src/vespa/document/fieldvalue/numericfieldvalue.hpp
@@ -53,9 +53,21 @@ NumericFieldValue<Number>::compare( const FieldValue& other) const
 }
 
 template<typename Number>
+int
+NumericFieldValue<Number>::fastCompare( const FieldValue& other) const
+{
+
+    const NumericFieldValue & otherNumber(static_cast<const NumericFieldValue &>(other));
+    return  (_value == otherNumber._value)
+            ? 0
+            : (_value - otherNumber._value > 0)
+              ? 1
+              : -1;
+}
+
+template<typename Number>
 void
-NumericFieldValue<Number>::print(
-        std::ostream& out, bool, const std::string&) const
+NumericFieldValue<Number>::print(std::ostream& out, bool, const std::string&) const
 {
     if (sizeof(Number) == 1) { // Make sure char's are printed as numbers
         out << (int) _value;

--- a/document/src/vespa/document/select/valuenodes.cpp
+++ b/document/src/vespa/document/select/valuenodes.cpp
@@ -195,9 +195,6 @@ FieldValueNode::FieldValueNode(const vespalib::string& doctype,
 {
 }
 
-//FieldValueNode::FieldValueNode(const FieldValueNode &) = default;
-//FieldValueNode & FieldValueNode::operator = (const FieldValueNode &) = default;
-
 FieldValueNode::~FieldValueNode() {}
 vespalib::string
 FieldValueNode::extractFieldName(const std::string & fieldExpression) {

--- a/document/src/vespa/document/select/valuenodes.cpp
+++ b/document/src/vespa/document/select/valuenodes.cpp
@@ -195,8 +195,8 @@ FieldValueNode::FieldValueNode(const vespalib::string& doctype,
 {
 }
 
-FieldValueNode::FieldValueNode(const FieldValueNode &) = default;
-FieldValueNode & FieldValueNode::operator = (const FieldValueNode &) = default;
+//FieldValueNode::FieldValueNode(const FieldValueNode &) = default;
+//FieldValueNode & FieldValueNode::operator = (const FieldValueNode &) = default;
 
 FieldValueNode::~FieldValueNode() {}
 vespalib::string

--- a/document/src/vespa/document/select/valuenodes.h
+++ b/document/src/vespa/document/select/valuenodes.h
@@ -157,8 +157,8 @@ class FieldValueNode : public ValueNode
 
 public:
     FieldValueNode(const vespalib::string& doctype, const vespalib::string& fieldExpression);
-    FieldValueNode(const FieldValueNode &);
-    FieldValueNode & operator = (const FieldValueNode &);
+    FieldValueNode(const FieldValueNode &) = delete;
+    FieldValueNode & operator = (const FieldValueNode &) = delete;
     FieldValueNode(FieldValueNode &&) = default;
     FieldValueNode & operator = (FieldValueNode &&) = default;
     ~FieldValueNode();

--- a/document/src/vespa/document/update/documentupdate.cpp
+++ b/document/src/vespa/document/update/documentupdate.cpp
@@ -174,6 +174,7 @@ DocumentUpdate::applyTo(Document& doc) const
     for(const auto & update : _updates) {
         update.applyTo(doc);
     }
+    TransactionGuard guard(doc);
     // Apply fieldpath updates
     for (const auto & update : _fieldPathUpdates) {
         update->applyTo(doc);

--- a/document/src/vespa/document/update/fieldpathupdate.cpp
+++ b/document/src/vespa/document/update/fieldpathupdate.cpp
@@ -113,7 +113,7 @@ FieldPathUpdate::getResultingDataType(const FieldPath & path) const
     if (path.empty()) {
         throw vespalib::IllegalStateException("Cannot get resulting data type from an empty field path", VESPA_STRLOC);
     }
-    return path.rbegin()->getDataType();
+    return path.back().getDataType();
 }
 
 vespalib::string

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
@@ -29,7 +29,7 @@ DocumentFieldNode::~DocumentFieldNode()
 
 DocumentFieldNode::DocumentFieldNode(const DocumentFieldNode & rhs) :
     DocumentAccessorNode(rhs),
-    _fieldPath(rhs._fieldPath),
+//    _fieldPath(rhs._fieldPath),
     _value(rhs._value),
     _fieldName(rhs._fieldName),
     _doc(NULL)
@@ -40,7 +40,7 @@ DocumentFieldNode & DocumentFieldNode::operator = (const DocumentFieldNode & rhs
 {
     if (this != &rhs) {
         DocumentAccessorNode::operator=(rhs);
-        _fieldPath = rhs._fieldPath;
+//        _fieldPath = rhs._fieldPath;
         _value = rhs._value;
         _fieldName = rhs._fieldName;
         _doc = NULL;

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
@@ -112,8 +112,9 @@ void DocumentFieldNode::onPrepare(bool preserveAccurateTypes)
     if ( !_fieldPath.empty() ) {
         bool nestedMultiValue(false);
         for(document::FieldPath::const_iterator it(_fieldPath.begin()), mt(_fieldPath.end()); !nestedMultiValue && (it != mt); it++) {
-            if (it->getType() == document::FieldPathEntry::STRUCT_FIELD) {
-                const vespalib::Identifiable::RuntimeClass & cInfo(it->getFieldValueToSet().getClass());
+            const FieldPathEntry & fpe = **it;
+            if (fpe.getType() == document::FieldPathEntry::STRUCT_FIELD) {
+                const vespalib::Identifiable::RuntimeClass & cInfo(fpe.getFieldValueToSet().getClass());
                 nestedMultiValue = cInfo.inherits(CollectionFieldValue::classId) || cInfo.inherits(MapFieldValue::classId);
             }
         }

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
@@ -29,7 +29,7 @@ DocumentFieldNode::~DocumentFieldNode()
 
 DocumentFieldNode::DocumentFieldNode(const DocumentFieldNode & rhs) :
     DocumentAccessorNode(rhs),
-//    _fieldPath(rhs._fieldPath),
+    _fieldPath(rhs._fieldPath),
     _value(rhs._value),
     _fieldName(rhs._fieldName),
     _doc(NULL)
@@ -40,7 +40,7 @@ DocumentFieldNode & DocumentFieldNode::operator = (const DocumentFieldNode & rhs
 {
     if (this != &rhs) {
         DocumentAccessorNode::operator=(rhs);
-//        _fieldPath = rhs._fieldPath;
+        _fieldPath = rhs._fieldPath;
         _value = rhs._value;
         _fieldName = rhs._fieldName;
         _doc = NULL;

--- a/staging_vespalib/src/vespa/vespalib/util/polymorphicarrays.h
+++ b/staging_vespalib/src/vespa/vespalib/util/polymorphicarrays.h
@@ -9,7 +9,7 @@
 namespace vespalib {
 
 template <typename T, typename B>
-class PrimitiveArrayT : public IArrayT<B>
+class PrimitiveArrayT final : public IArrayT<B>
 {
     using typename IArrayT<B>::iterator;
 public:
@@ -33,7 +33,7 @@ private:
 };
 
 template <typename B>
-class ComplexArrayT : public IArrayT<B>
+class ComplexArrayT final : public IArrayT<B>
 {
     using typename IArrayT<B>::iterator;
 public:

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -51,7 +51,7 @@ public:
         uint8_t _priority;
 
         MessageEntry(const std::shared_ptr<api::StorageMessage>& cmd, const document::BucketId& bId);
-        MessageEntry(MessageEntry &&);
+        MessageEntry(MessageEntry &&) noexcept ;
         MessageEntry(const MessageEntry &);
         MessageEntry & operator = (const MessageEntry &) = delete;
         ~MessageEntry();

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -735,13 +735,13 @@ void SearchVisitor::setupAttributeVector(const FieldPath &fieldPath) {
     vespalib::string attrName(fieldPath.front().getName());
     for (FieldPath::const_iterator ft(fieldPath.begin() + 1), fmt(fieldPath.end()); ft != fmt; ft++) {
         attrName.append(".");
-        attrName.append(ft->getName());
+        attrName.append((*ft)->getName());
     }
 
     enum FieldDataType { OTHER = 0, ARRAY, WSET };
     FieldDataType typeSeen = OTHER;
-    for (const document::FieldPathEntry & entry : fieldPath) {
-        int dataTypeId(entry.getDataType().getClass().id());
+    for (const auto & entry : fieldPath) {
+        int dataTypeId(entry->getDataType().getClass().id());
         if (dataTypeId == document::ArrayDataType::classId) {
             typeSeen = ARRAY;
         } else if (dataTypeId == document::MapDataType::classId) {

--- a/vespalib/src/vespa/vespalib/stllike/string.h
+++ b/vespalib/src/vespa/vespalib/stllike/string.h
@@ -180,8 +180,8 @@ public:
     small_string(const void * s, size_type sz) : _buf(_stack), _sz(sz) { init(s); }
     small_string(const stringref & s) : _buf(_stack), _sz(s.size()) { init(s.c_str()); }
     small_string(const std::string & s) : _buf(_stack), _sz(s.size()) { init(s.c_str()); }
-    small_string(const small_string & rhs) : _buf(_stack), _sz(rhs.size()) { init(rhs.c_str()); }
-    small_string(const small_string & rhs, size_type pos, size_type sz=npos)
+    small_string(const small_string & rhs) noexcept : _buf(_stack), _sz(rhs.size()) { init(rhs.c_str()); }
+    small_string(const small_string & rhs, size_type pos, size_type sz=npos) noexcept
         : _buf(_stack), _sz(std::min(sz, rhs.size()-pos))
     {
         init(rhs.c_str()+pos);
@@ -520,7 +520,7 @@ public:
     }
 private:
     void assign_slower(const void * s, size_type sz) __attribute((noinline));
-    void init_slower(const void *s) __attribute((noinline));
+    void init_slower(const void *s) noexcept __attribute((noinline));
     void _reserveBytes(size_type newBufferSize);
     void reserveBytes(size_type newBufferSize) {
         if (newBufferSize > _bufferSize) {
@@ -533,7 +533,7 @@ private:
     char * buffer() { return _buf; }
     const char * buffer() const { return _buf; }
     void appendAlloc(const void * s, size_type sz) __attribute__((noinline));
-    void init(const void *s) {
+    void init(const void *s) noexcept {
         if (__builtin_expect(_sz < StackSize, true)) {
             _bufferSize = StackSize;
             memcpy(_stack, s, _sz);

--- a/vespalib/src/vespa/vespalib/stllike/string.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/string.hpp
@@ -91,7 +91,7 @@ void small_string<StackSize>::assign_slower(const void * s, size_type sz)
 }
 
 template <uint32_t StackSize>
-void small_string<StackSize>::init_slower(const void *s)
+void small_string<StackSize>::init_slower(const void *s) noexcept
 {   
     _bufferSize = _sz+1;
     _buf = (char *) malloc(_bufferSize);

--- a/vsm/src/vespa/vsm/vsm/docsumfilter.cpp
+++ b/vsm/src/vespa/vsm/vsm/docsumfilter.cpp
@@ -156,9 +156,6 @@ DocsumFilter::prepareFieldSpec(DocsumFieldSpec & spec, const DocsumTools::FieldS
                     FieldPath relPath(fieldPathMap[field].begin() + 1,
                                       fieldPathMap[field].end());
                     LOG(debug, "map[%u] -> %zu elements", field, fieldPathMap[field].end() - fieldPathMap[field].begin());
-                    for (document::FieldPathEntry entry : fieldPathMap[field]) {
-                        LOG(debug, "entry: %s", entry.getName().c_str());
-                    }
                     // skip the element that correspond to the start field value
                     spec.getInputFields().push_back(DocsumFieldSpec::FieldIdentifier
                                                     (field, FieldPath(fieldPathMap[field].begin() + 1,


### PR DESCRIPTION
@toregge PR
@vekterli FYI
This brought a 12 x improvement for the psearch use case updating 8% of the keys in the map.
In essence it avoids deserialisation/serialisation on every fieldpath update.