### PR TITLE
Set numDocs and committedDocIdLimit when loading reference attribute.

### DIFF
--- a/searchlib/src/tests/attribute/reference_attribute/reference_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/reference_attribute/reference_attribute_test.cpp
@@ -243,6 +243,7 @@ TEST_F("require that we can save and load attribute", Fixture)
     f.commit();
     f.save();
     f.load();
+    EXPECT_EQUAL(5u, f.attr().getNumDocs());
     TEST_DO(f.assertNoRef(3));
     TEST_DO(f.assertRef(doc1, 1));
     TEST_DO(f.assertRef(doc2, 2));

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
@@ -84,6 +84,8 @@ public:
     DocId getReferencedLid(DocId doc) const;
     void notifyGidToLidChange(const GlobalId &gid, DocId referencedLid);
     void populateReferencedLids();
+    virtual void clearDocs(DocId lidLow, DocId lidLimit) override;
+    virtual void onShrinkLidSpace() override;
 };
 
 }


### PR DESCRIPTION
Handle shrinking of reference attribute.

@baldersheim, please review
