### PR TITLE
Bratseth/default to 16 distribution bits

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -597,7 +597,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
      * in config and not remove it again if they reduce the node count.
      */
     public int distributionBits() {
-        if (zone.environment() == Environment.prod) {
+        if (zone.environment() == Environment.prod && ! zone.equals(Zone.defaultZone())) {
             return 16;
         }
         else { // hosted test zone, or self-hosted system
@@ -605,10 +605,6 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
             // self hosted systems: should probably default to 16 bits, but the transition may cause problems
             return DistributionBitCalculator.getDistributionBits(getNodeCountPerGroup(), getDistributionMode());
         }
-    }
-
-    private Zone createZone(Environment environment, String region) {
-        return new Zone(environment, RegionName.from(region));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -597,19 +597,14 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
      * in config and not remove it again if they reduce the node count.
      */
     public int distributionBits() {
-        // TODO: Enable for all hosted zones (i.e when zone isn't default)
-        List<Zone> zonesWith16DistributionBits = Arrays.asList(createZone(Environment.prod, "us-west-1"),
-                                                               createZone(Environment.prod, "us-central-1"),
-                                                               createZone(Environment.prod, "eu-west-1"),
-                                                               createZone(Environment.prod, "ap-northeast-1"),
-                                                               createZone(Environment.prod, "ap-northeast-2"),
-                                                               createZone(Environment.prod, "ap-southeast-1"),
-                                                               createZone(Environment.prod, "ap-aue-1"),
-                                                               createZone(Environment.prod, "us-east-3"));
-        if (zone.system() == SystemName.cd || zonesWith16DistributionBits.contains(zone))
+        if (zone.environment() == Environment.prod) {
             return 16;
-        else
+        }
+        else { // hosted test zone, or self-hosted system
+            // hosted test zones: have few nodes and use visiting in tests: This is slow with 16 bits (to many buckets)
+            // self hosted systems: should probably default to 16 bits, but the transition may cause problems
             return DistributionBitCalculator.getDistributionBits(getNodeCountPerGroup(), getDistributionMode());
+        }
     }
 
     private Zone createZone(Environment environment, String region) {


### PR DESCRIPTION
@yngveaasheim please review

Note that:
- This changes to 16 distribution bits in corp-prod
- This changes to 8 distribution bits in CD non-prod

I don't think we should treat CD differently.