### PR TITLE
Remove annotations from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -931,7 +931,6 @@
     </properties>
 
     <modules>
-        <module>annotations</module>
         <module>application</module>
         <module>application-deploy-plugin</module>
         <module>application-model</module>


### PR DESCRIPTION
The bundle plugin depends on annotations, and annotations should therefor
only be build as part of maven-plugins. The bundle plugin will sometimes
fail during osgi manifest generation if annotations is installed as part
of the build.

FYI @toregge @aressem @arnej27959 