### PR TITLE
Avoid opening idxfile to early for writing. Especially as it might ge…

### DIFF
--- a/fastos/src/vespa/fastos/file.h
+++ b/fastos/src/vespa/fastos/file.h
@@ -514,6 +514,8 @@ public:
 
     virtual void EnableSyncWrites();
 
+    bool useSyncWrites() const { return _syncWritesEnabled; }
+
     /**
      * Set the write chunk size used in WriteBuf.
      */

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -296,17 +296,21 @@ TEST("testTruncatedIdxFile"){
                                fileHeaderContext, tlSyncer, NULL);
         EXPECT_EQUAL(354ul, datastore.lastSyncToken());
     }
+    const char * magic = "mumbo jumbo";
     {
         LogDataStore datastore(executor, "bug-7257706-truncated", config,
                                GrowStrategy(), TuneFileSummary(),
                                fileHeaderContext, tlSyncer, NULL);
         EXPECT_EQUAL(331ul, datastore.lastSyncToken());
+        datastore.write(332, 7, magic, strlen(magic));
+        datastore.write(333, 8, magic, strlen(magic));
+        datastore.flush(datastore.initFlush(334));
     }
     {
         LogDataStore datastore(executor, "bug-7257706-truncated", config,
                                GrowStrategy(), TuneFileSummary(),
                                fileHeaderContext, tlSyncer, NULL);
-        EXPECT_EQUAL(331ul, datastore.lastSyncToken());
+        EXPECT_EQUAL(334ul, datastore.lastSyncToken());
     }
 }
 

--- a/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
@@ -194,6 +194,7 @@ FileChunk::updateLidMap(const LockGuard &guard, ISetLid &ds, uint64_t serialNum,
                     } else {
                         throw SummaryException("Open for truncation failed.", toTruncate, VESPA_STRLOC);
                     }
+                    break;
                 }
             }
             if ( ! tempVector.empty()) {

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -90,7 +90,7 @@ private:
     void restart(uint32_t nextChunkId);
     ProcessedChunkQ drainQ();
     void readDataHeader();
-    void readIdxHeader();
+    void readIdxHeader(FastOS_FileInterface & idxFile);
     void writeDataHeader(const common::FileHeaderContext &fileHeaderContext);
     bool needFlushPendingChunks(uint64_t serialNum, uint64_t datFileLen);
     bool needFlushPendingChunks(const vespalib::MonitorGuard & guard, uint64_t serialNum, uint64_t datFileLen);
@@ -105,6 +105,7 @@ private:
     void updateChunkInfo(const ProcessedChunkQ & chunks, const ChunkMetaV & cmetaV, size_t sz);
     void updateCurrentDiskFootprint();
     size_t getDiskFootprint(const vespalib::MonitorGuard & guard) const;
+    std::unique_ptr<FastOS_FileInterface> openIdx();
 
     Config            _config;
     SerialNum         _serialNum;
@@ -114,13 +115,13 @@ private:
     vespalib::Lock    _writeLock;
     vespalib::Lock    _flushLock;
     FastOS_File       _dataFile;
-    FastOS_File       _idxFile;
     using ChunkMap = std::map<uint32_t, Chunk::UP>;
     ChunkMap          _chunkMap;
     using PendingChunks = std::deque<std::shared_ptr<PendingChunk>>;
     PendingChunks     _pendingChunks;
     uint64_t          _pendingIdx;
     uint64_t          _pendingDat;
+    uint64_t          _idxFileSize;
     uint64_t          _currentDiskFootprint;
     uint32_t          _nextChunkId;
     Chunk::UP         _active;


### PR DESCRIPTION
…t truncated due to error handling later on.

Instead just open the file when you need to write it. It does not happen that often to warrant keeping it open all the time.
@toregge PR