### PR TITLE
Fix docker CPU usage metric

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
@@ -46,7 +45,6 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
  * @author freva
  */
 public class StorageMaintainer {
-    private static final Pattern TOTAL_MEMORY_PATTERN = Pattern.compile("^MemTotal:\\s*(?<totalMem>\\d+) kB$", Pattern.MULTILINE);
     private static final ContainerName NODE_ADMIN = new ContainerName("node-admin");
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static Optional<String> kernelVersion = Optional.empty();
@@ -56,7 +54,6 @@ public class StorageMaintainer {
     private final Docker docker;
     private final Environment environment;
     private final Clock clock;
-    private double hostTotalMemoryGb = 0;
 
     private Map<ContainerName, MaintenanceThrottler> maintenanceThrottlerByContainerName = new ConcurrentHashMap<>();
 
@@ -167,21 +164,6 @@ public class StorageMaintainer {
             logger.log(LogLevel.WARNING, "Failed to read meminfo", e);
             return Optional.empty();
         }
-    }
-
-    public double getHostTotalMemoryGb() {
-        if (hostTotalMemoryGb == 0) {
-            readMeminfo().ifPresent(memInfo -> {
-                Matcher matcher = TOTAL_MEMORY_PATTERN.matcher(memInfo);
-                if (matcher.find()) {
-                    hostTotalMemoryGb = Integer.valueOf(matcher.group("totalMem")) / 1024d / 1024;
-                } else {
-                    logger.log(LogLevel.WARNING, "Failed to parse total memory from meminfo: " + memInfo);
-                }
-            });
-        }
-
-        return hostTotalMemoryGb;
     }
 
     /**

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -525,7 +525,6 @@ public class NodeAgentImplTest {
 
         when(nodeRepository.getContainerNodeSpec(eq(hostName))).thenReturn(Optional.of(nodeSpec));
         when(storageMaintainer.getDiskUsageFor(eq(containerName))).thenReturn(Optional.of(42547019776L));
-        when(storageMaintainer.getHostTotalMemoryGb()).thenReturn(10d);
         when(dockerOperations.getContainerStats(eq(containerName)))
                 .thenReturn(Optional.of(stats1))
                 .thenReturn(Optional.of(stats2));

--- a/node-admin/src/test/resources/expected.container.system.metrics.txt
+++ b/node-admin/src/test/resources/expected.container.system.metrics.txt
@@ -12,7 +12,7 @@ s:
         "mem.used": 1073741824,
         "disk.used": 42547019776,
         "disk.util": 15.85,
-        "cpu.util": 6.75,
+        "cpu.util": 5.4,
         "mem.util": 25.0,
         "disk.limit": 268435456000
     },


### PR DESCRIPTION
Fixes the CPU usage metric for docker containers:
The final step in calculating CPU usage is to divide the CPU usage by a container as percentage of CPU usage of entire host by the ratio of resources the container is allowed to use. For example, if a container uses 4% CPU of entire host, and the container is supposed to occupy the entire host (same `minDiskAvailableGb`, `minMainMemoryAvailableGb` and `minCpuCores`), then container's CPU util is also 4%. If container was only entitled to 1/8 of the entire host, then it's CPU util would be 4%*8 = 32%.

Currently that ratio was calculated by dividing actual host memory by memory allocated to container from NodeSpec. This created the wrong metric when container was allocated the entire memory of the host, but only a portion of the CPU.

This PR calculates the ratio by dividing number of CPU cores the container is entitled to (from NodeSpec) by total number of cores as seen by the Docker daemon (docker stats contains an array with total CPU time used by each core, see https://docs.docker.com/engine/api/v1.24/#get-container-stats-based-on-resource-usage). (I assume the `minCpuCores` for DHs is actual number of cores?) 

FYI: @yngveaasheim 