### PR TITLE
Link with static libgcc to avoid unresolved symbol __cpu_model when creating shared library.

### DIFF
--- a/vespalib/src/vespa/vespalib/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/CMakeLists.txt
@@ -21,4 +21,5 @@ vespa_add_library(vespalib
     INSTALL lib64
     DEPENDS
     vespalib_vespalib_test
+    gcc
 )


### PR DESCRIPTION
@baldersheim, please review