### PR TITLE
Repair assert that broke during removal of homegrown atomics.

### DIFF
--- a/fnet/src/vespa/fnet/frt/rpcrequest.cpp
+++ b/fnet/src/vespa/fnet/frt/rpcrequest.cpp
@@ -129,7 +129,7 @@ void
 FRT_RPCRequest::SubRef()
 {
     int oldVal = _refcnt.fetch_sub(1);
-    assert(oldVal > 1);
+    assert(oldVal > 0);
     if (oldVal == 1) {
         Reset();
         delete this;


### PR DESCRIPTION
@baldersheim, please review.