### PR TITLE
Which and valgrind is used in startup scripts.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -38,6 +38,8 @@ BuildRequires: vespa-libtorrent-devel >= 1.0.11-6
 BuildRequires: vespa-zookeeper-c-client-devel >= 3.4.9-6
 BuildRequires: systemd
 Requires: epel-release 
+Requires: which
+Requires: valgrind
 Requires: Judy
 Requires: lz4
 Requires: libzstd


### PR DESCRIPTION
@kkraune 

These are actually used in the startup scripts but not part of the install. Vespa still works, but we need to include what we use.