### PR TITLE
Properly initialize forward mapping when loading reference attribute.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
@@ -119,6 +119,7 @@ ReferenceMappings::onLoad(uint32_t docIdLimit)
 {
     _referencedLids.clear();
     _referencedLids.unsafe_reserve(docIdLimit);
+    _referencedLids.ensure_size(docIdLimit);
 }
 
 void


### PR DESCRIPTION
@geirst, please review