### PR TITLE
Add a new metric set for network metrics.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetricsConsumer.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.admin.monitoring;
 
 import com.google.common.collect.ImmutableList;
 
+import static com.yahoo.vespa.model.admin.monitoring.NetworkMetrics.networkMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.VespaMetricSet.vespaMetricSet;
 import static java.util.Collections.emptyList;
@@ -19,7 +20,9 @@ public class DefaultMetricsConsumer {
 
     private static final MetricSet defaultConsumerMetrics = new MetricSet("default-consumer",
                                                                           emptyList(),
-                                                                          ImmutableList.of(vespaMetricSet,  systemMetricSet));
+                                                                          ImmutableList.of(vespaMetricSet,
+                                                                                           systemMetricSet,
+                                                                                           networkMetricSet));
 
     @SuppressWarnings("UnusedDeclaration")
     public static MetricsConsumer getDefaultMetricsConsumer() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/NetworkMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/NetworkMetrics.java
@@ -1,0 +1,31 @@
+// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.admin.monitoring;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * @author gjoranv
+ */
+public class NetworkMetrics {
+
+    public static final MetricSet networkMetricSet = createNetworkMetricSet();
+
+    private static MetricSet createNetworkMetricSet() {
+        Set<Metric> dockerNetworkMetrics =
+                ImmutableSet.of(new Metric("net.in.bytes"),
+                                new Metric("net.in.errors"),
+                                new Metric("net.in.dropped"),
+                                new Metric("net.out.bytes"),
+                                new Metric("net.out.errors"),
+                                new Metric("net.out.dropped")
+                );
+
+        Set<Metric> networkMetrics = ImmutableSet.<Metric>builder()
+                .addAll(dockerNetworkMetrics)
+                .build();
+
+        return new MetricSet("network", networkMetrics);
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static com.yahoo.vespa.model.admin.monitoring.NetworkMetrics.networkMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.VespaMetricSet.vespaMetricSet;
@@ -21,7 +22,8 @@ public class PredefinedMetricSets {
     public static final Map<String, MetricSet> predefinedMetricSets = toMapById(
             defaultVespaMetricSet,
             vespaMetricSet,
-            systemMetricSet
+            systemMetricSet,
+            networkMetricSet
     );
 
     private static Map<String, MetricSet> toMapById(MetricSet... metricSets) {


### PR DESCRIPTION
@ldalves, @bratseth FYI: This will add a new set of metrics that the user can enable by adding
`<metric-set>network</metric-set>` to services.xml. We don't intend to document it anywhere, but can't see the point of hiding it either.