### PR TITLE
Add ImportedAttributeVectorReadGuard, used to handle imported attributes

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/imported_attributes_context.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/imported_attributes_context.h
@@ -29,20 +29,7 @@ private:
     using IAttributeVector = search::attribute::IAttributeVector;
     using ImportedAttributeVector = search::attribute::ImportedAttributeVector;
 
-    class GuardedAttribute {
-    private:
-        std::shared_ptr<ImportedAttributeVector> _attr;
-        std::unique_ptr<AttributeGuard> _guard;
-
-    public:
-        GuardedAttribute(std::shared_ptr<ImportedAttributeVector> attr, bool stableEnumGuard);
-        ~GuardedAttribute();
-        GuardedAttribute(GuardedAttribute &&rhs) = default;
-        GuardedAttribute &operator=(GuardedAttribute &&rhs) = default;
-        const IAttributeVector *get() const;
-    };
-
-    using AttributeCache = std::unordered_map<vespalib::string, GuardedAttribute, vespalib::hash<vespalib::string>>;
+    using AttributeCache = std::unordered_map<vespalib::string, std::unique_ptr<ImportedAttributeVector>, vespalib::hash<vespalib::string>>;
     using LockGuard = std::lock_guard<std::mutex>;
 
     const ImportedAttributesRepo &_repo;

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -46,6 +46,7 @@ vespa_add_library(searchlib_attribute OBJECT
     iattributemanager.cpp
     iattributesavetarget.cpp
     imported_attribute_vector.cpp
+    imported_attribute_vector_read_guard.cpp
     imported_search_context.cpp
     integerbase.cpp
     ipostinglistsearchcontext.cpp

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "imported_attribute_vector.h"
+#include "imported_attribute_vector_read_guard.h"
 #include "imported_search_context.h"
 #include "attributeguard.h"
 #include <vespa/searchlib/query/queryterm.h>
@@ -20,6 +21,13 @@ ImportedAttributeVector::ImportedAttributeVector(
 }
 
 ImportedAttributeVector::~ImportedAttributeVector() {
+}
+
+std::unique_ptr<ImportedAttributeVector>
+ImportedAttributeVector::makeReadGuard(bool stableEnumGuard) const
+{
+    return std::make_unique<ImportedAttributeVectorReadGuard>
+        (getName(), getReferenceAttribute(), getTargetAttribute(), stableEnumGuard);
 }
 
 const vespalib::string& search::attribute::ImportedAttributeVector::getName() const {

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
@@ -80,7 +80,11 @@ public:
      */
     std::unique_ptr<AttributeEnumGuard> acquireEnumGuard() const;
 
-private:
+    /*
+     * Create an imported attribute with a snapshot of lid to lid mapping.
+     */
+    std::unique_ptr<ImportedAttributeVector> makeReadGuard(bool stableEnumGuard) const;
+protected:
     long onSerializeForAscendingSort(DocId doc, void * serTo, long available,
                                      const common::BlobConverter * bc) const override;
     long onSerializeForDescendingSort(DocId doc, void * serTo, long available,

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -1,0 +1,84 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "imported_attribute_vector_read_guard.h"
+
+namespace search {
+namespace attribute {
+
+ImportedAttributeVectorReadGuard::ImportedAttributeVectorReadGuard(
+        vespalib::stringref name,
+        std::shared_ptr<ReferenceAttribute> reference_attribute,
+        std::shared_ptr<AttributeVector> target_attribute,
+        bool stableEnumGuard)
+    : ImportedAttributeVector(name, std::move(reference_attribute), std::move(target_attribute)),
+      _referencedLids(),
+      _referencedLidLimit(0u),
+      _reference_attribute_guard(_reference_attribute),
+      _target_attribute_guard(stableEnumGuard ? std::shared_ptr<AttributeVector>() : _target_attribute),
+      _target_attribute_enum_guard(stableEnumGuard ? _target_attribute : std::shared_ptr<AttributeVector>())
+{
+    _referencedLids = _reference_attribute->getReferencedLids();
+    _referencedLidLimit = _target_attribute->getCommittedDocIdLimit();
+}
+
+ImportedAttributeVectorReadGuard::~ImportedAttributeVectorReadGuard() {
+}
+
+uint32_t ImportedAttributeVectorReadGuard::getValueCount(uint32_t doc) const {
+    return _target_attribute->getValueCount(getReferencedLid(doc));
+}
+
+IAttributeVector::largeint_t ImportedAttributeVectorReadGuard::getInt(DocId doc) const {
+    return _target_attribute->getInt(getReferencedLid(doc));
+}
+
+double ImportedAttributeVectorReadGuard::getFloat(DocId doc) const {
+    return _target_attribute->getFloat(getReferencedLid(doc));
+}
+
+const char *ImportedAttributeVectorReadGuard::getString(DocId doc, char *buffer, size_t sz) const {
+    return _target_attribute->getString(getReferencedLid(doc), buffer, sz);
+}
+
+IAttributeVector::EnumHandle ImportedAttributeVectorReadGuard::getEnum(DocId doc) const {
+    return _target_attribute->getEnum(getReferencedLid(doc));
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, largeint_t *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, double *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, const char **buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, EnumHandle *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, WeightedInt *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, WeightedFloat *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, WeightedString *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, WeightedConstChar *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+uint32_t ImportedAttributeVectorReadGuard::get(DocId docId, WeightedEnum *buffer, uint32_t sz) const {
+    return _target_attribute->get(getReferencedLid(docId), buffer, sz);
+}
+
+}
+}

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -1,0 +1,53 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "imported_attribute_vector.h"
+#include "attributeguard.h"
+
+namespace search::attribute {
+
+/*
+ * Short lived attribute vector that does not store values on its own.
+ *
+ * Extra information for direct lid to referenced lid mapping with
+ * boundary check is setup during construction.
+ */
+class ImportedAttributeVectorReadGuard : public ImportedAttributeVector
+{
+    using ReferencedLids = vespalib::ConstArrayRef<uint32_t>;
+    ReferencedLids                      _referencedLids;
+    uint32_t                            _referencedLidLimit;
+    AttributeGuard                      _reference_attribute_guard;
+    AttributeGuard                      _target_attribute_guard;
+    AttributeEnumGuard                  _target_attribute_enum_guard;
+
+    uint32_t getReferencedLid(uint32_t lid) const {
+        uint32_t referencedLid = _referencedLids[lid];
+        return ((referencedLid >= _referencedLidLimit) ? 0u : referencedLid);
+    }
+
+public:
+    ImportedAttributeVectorReadGuard(vespalib::stringref name,
+                                     std::shared_ptr<ReferenceAttribute> reference_attribute,
+                                     std::shared_ptr<AttributeVector> target_attribute,
+                                     bool stableEnumGuard);
+    ~ImportedAttributeVectorReadGuard();
+
+    virtual uint32_t getValueCount(uint32_t doc) const override;
+    virtual largeint_t getInt(DocId doc) const override;
+    virtual double getFloat(DocId doc) const override;
+    virtual const char *getString(DocId doc, char *buffer, size_t sz) const override;
+    virtual EnumHandle getEnum(DocId doc) const override;
+    virtual uint32_t get(DocId docId, largeint_t *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, double *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, const char **buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, EnumHandle *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, WeightedInt *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, WeightedFloat *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, WeightedString *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, WeightedConstChar *buffer, uint32_t sz) const override;
+    virtual uint32_t get(DocId docId, WeightedEnum *buffer, uint32_t sz) const override;
+};
+
+}


### PR DESCRIPTION
via ImportedAttributesContext in a safe manner.

@geirst, please review
@vekterli FYI