### PR TITLE
Rethrow all RuntimeExceptions from docker-java

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -151,7 +151,7 @@ public class DockerImpl implements Docker {
         try {
             dockerClient.copyArchiveToContainerCmd(destinationContainer.asString())
                     .withHostResource(sourcePath).withRemotePath(destinationPath).exec();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to copy container " + sourcePath + " to " +
                     destinationContainer + ":" + destinationPath, e);
@@ -171,7 +171,7 @@ public class DockerImpl implements Docker {
 
         try {
             dockerClient.pullImageCmd(image.asString()).exec(new ImagePullCallback(image));
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to pull image '" + image.asString() + "'", e);
         }
@@ -197,7 +197,7 @@ public class DockerImpl implements Docker {
         try {
             return dockerClient.listImagesCmd().withShowAll(true)
                     .withImageNameFilter(dockerImage.asString()).exec().stream().findFirst();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to inspect image '" + dockerImage.asString() + "'", e);
         }
@@ -214,7 +214,7 @@ public class DockerImpl implements Docker {
             dockerClient.connectToNetworkCmd()
                     .withContainerId(containerName.asString())
                     .withNetworkId(networkName).exec();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to connect container '" + containerName.asString() +
                     "' to network '" + networkName + "'", e);
@@ -268,7 +268,7 @@ public class DockerImpl implements Docker {
             assert exitCode != null;
 
             return new ProcessResult(exitCode, new String(output.toByteArray()), new String(errors.toByteArray()));
-        } catch (com.github.dockerjava.api.exception.DockerException | InterruptedException e) {
+        } catch (RuntimeException | InterruptedException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Container '" + containerName.asString()
                     + "' failed to execute " + Arrays.toString(command), e);
@@ -280,7 +280,7 @@ public class DockerImpl implements Docker {
             return Optional.of(dockerClient.inspectContainerCmd(container).exec());
         } catch (NotFoundException ignored) {
             return Optional.empty();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to get info for container '" + container + "'", e);
         }
@@ -296,7 +296,7 @@ public class DockerImpl implements Docker {
                     stats.getNetworks(), stats.getCpuStats(), stats.getMemoryStats(), stats.getBlkioStats()));
         } catch (NotFoundException ignored) {
             return Optional.empty();
-        } catch (com.github.dockerjava.api.exception.DockerException | InterruptedException e) {
+        } catch (RuntimeException | InterruptedException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to get stats for container '" + containerName.asString() + "'", e);
         }
@@ -308,7 +308,7 @@ public class DockerImpl implements Docker {
             dockerClient.startContainerCmd(containerName.asString()).exec();
         } catch (NotModifiedException ignored) {
             // If is already started, ignore
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to start container '" + containerName.asString() + "'", e);
         }
@@ -320,7 +320,7 @@ public class DockerImpl implements Docker {
             dockerClient.stopContainerCmd(containerName.asString()).withTimeout(SECONDS_TO_WAIT_BEFORE_KILLING).exec();
         } catch (NotModifiedException ignored) {
             // If is already stopped, ignore
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to stop container '" + containerName.asString() + "'", e);
         }
@@ -337,7 +337,7 @@ public class DockerImpl implements Docker {
             dockerClient.removeContainerCmd(containerName.asString()).exec();
         } catch (NotFoundException ignored) {
             // If container doesn't exist ignore
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to delete container '" + containerName.asString() + "'", e);
         }
@@ -391,7 +391,7 @@ public class DockerImpl implements Docker {
     private List<com.github.dockerjava.api.model.Container> listAllContainers() {
         try {
             return dockerClient.listContainersCmd().withShowAll(true).exec();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to list all containers", e);
         }
@@ -400,7 +400,7 @@ public class DockerImpl implements Docker {
     private List<Image> listAllImages() {
         try {
             return dockerClient.listImagesCmd().withShowAll(true).exec();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to list all images", e);
         }
@@ -412,7 +412,7 @@ public class DockerImpl implements Docker {
             dockerClient.removeImageCmd(dockerImage.asString()).exec();
         } catch (NotFoundException ignored) {
             // Image was already deleted, ignore
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to delete docker image " + dockerImage.asString(), e);
         }
@@ -423,7 +423,7 @@ public class DockerImpl implements Docker {
         try {
             dockerClient.buildImageCmd(dockerfile).withTag(image.asString())
                     .exec(new BuildImageResultCallback()).awaitImageId();
-        } catch (com.github.dockerjava.api.exception.DockerException e) {
+        } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();
             throw new DockerException("Failed to build image " + image.asString(), e);
         }


### PR DESCRIPTION
Apperantly when trying to start a container with a container name that is already taken, it throws an `com.github.dockerjava.api.exception.ConflictException`, which is not an `com.github.dockerjava.api.exception.DockerException`. 

NodeAgent relies on exceptions from docker-java to force to update its believed container state. If an exception was re-thrown in this case, node-agent would've update its state and wouldn't attempt to start an already started container.
