### PR TITLE
Stop trying to get attribute field from old schema when determining if

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/reprocessing/attribute_reprocessing_initializer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/attribute_reprocessing_initializer.cpp
@@ -81,14 +81,6 @@ getAttributesToPopulate(const ARIConfig &newCfg,
     return IReprocessingReader::SP();
 }
 
-Schema::AttributeField
-getAttributeField(const Schema &schema, const vespalib::string &name)
-{
-    uint32_t attrFieldId = schema.getAttributeFieldId(name);
-    assert(attrFieldId != Schema::UNKNOWN_FIELD_ID);
-    return schema.getAttributeField(attrFieldId);
-}
-
 std::vector<IReprocessingRewriter::SP>
 getFieldsToPopulate(const ARIConfig &newCfg,
                     const ARIConfig &oldCfg,
@@ -101,7 +93,6 @@ getFieldsToPopulate(const ARIConfig &newCfg,
     oldCfg.getAttrMgr()->getAttributeList(attrList);
     for (const auto &guard : attrList) {
         const vespalib::string &name = guard->getName();
-        Schema::AttributeField attrField = getAttributeField(oldCfg.getSchema(), name);
         BasicType attrType(guard->getConfig().basicType());
         bool inNewAttrMgr = newCfg.getAttrMgr()->getAttribute(name)->valid();
         bool unchangedField = inspector.hasUnchangedField(name);


### PR DESCRIPTION
document store needs to be populated from attribute that is being removed.

If attribute aspect removal has been delayed during an earlier reconfig
then the old schema won't have information about the attribute.

@baldersheim, please review
@geirst, FYI