### PR TITLE
Only create Docker nodes for active Docker hosts

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -185,7 +185,7 @@ public class NodePrioritizer {
         DockerHostCapacity capacity = new DockerHostCapacity(allNodes);
 
         for (Node node : allNodes) {
-            if (node.type() == NodeType.host) {
+            if (node.type() == NodeType.host && node.state() == Node.State.active) {
                 boolean conflictingCluster = false;
                 NodeList list = new NodeList(allNodes);
                 NodeList childrenWithSameApp = list.childNodes(node).owner(appId);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -229,7 +229,7 @@ public class ProvisioningTester implements AutoCloseable {
         return makeReadyNodes(n, UUID.randomUUID().toString(), flavor, type, additionalIps);
     }
 
-    public List<Node> makeReadyNodes(int n, String prefix, String flavor, NodeType type, int additionalIps) {
+    public List<Node> makeProvisionedNodes(int n, String prefix, String flavor, NodeType type, int additionalIps) {
         List<Node> nodes = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             Set<String> ips = IntStream.range(additionalIps * i, additionalIps * (i+1))
@@ -245,6 +245,11 @@ public class ProvisioningTester implements AutoCloseable {
                     type));
         }
         nodes = nodeRepository.addNodes(nodes);
+        return nodes;
+    }
+
+    public List<Node> makeReadyNodes(int n, String prefix, String flavor, NodeType type, int additionalIps) {
+        List<Node> nodes = makeProvisionedNodes(n, prefix, flavor, type, additionalIps);
         nodes = nodeRepository.setDirty(nodes);
         return nodeRepository.setReady(nodes);
     }


### PR DESCRIPTION
* Make sure to only create Docker nodes when using dynamic
  allocation when Docker host is in active state