### PR TITLE
Handle host being null in toString method

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
@@ -551,6 +551,6 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
 
     @Override
     public String toString() {
-        return getServiceName() + " on " + getHost().toString();
+        return getServiceName() + " on " + (getHost() == null ? "no host" : getHost().toString());
     }
 }


### PR DESCRIPTION
This actually happens and getting a NullPointerException instead of the real error message makes it hard to pin down the actual problem