### PR TITLE
Freva/always handle coredumps in dirty

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -318,7 +318,7 @@ public class StorageMaintainer {
      * Runs node-maintainer's SpecVerifier and returns its output
      * @throws RuntimeException if exit code != 0
      */
-    public String getHardwardDivergence() {
+    public String getHardwareDivergence() {
         String configServers = environment.getConfigServerHosts().stream()
                 .map(configServer -> "http://" +  configServer + ":" + 4080)
                 .collect(Collectors.joining(","));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -241,7 +241,7 @@ public class StorageMaintainer {
             attributes.put("kernel_version", "unknown");
         }
 
-        nodeSpec.wantedDockerImage.ifPresent(image -> attributes.put("docker_image", image.asString()));
+        nodeSpec.currentDockerImage.ifPresent(image -> attributes.put("docker_image", image.asString()));
         nodeSpec.vespaVersion.ifPresent(version -> attributes.put("vespa_version", version));
         nodeSpec.owner.ifPresent(owner -> {
             attributes.put("tenant", owner.tenant);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +49,6 @@ public class StorageMaintainer {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static Optional<String> kernelVersion = Optional.empty();
 
-    private final Logger logger = Logger.getLogger(StorageMaintainer.class.getName());
     private final CounterWrapper numberOfNodeAdminMaintenanceFails;
     private final Docker docker;
     private final ProcessExecuter processExecuter;
@@ -168,12 +166,19 @@ public class StorageMaintainer {
         if (! getMaintenanceThrottlerFor(containerName).shouldRemoveOldFilesNow()) return;
 
         MaintainerExecutor maintainerExecutor = new MaintainerExecutor();
+        addRemoveOldFilesCommand(maintainerExecutor, containerName);
+
+        maintainerExecutor.execute();
+        getMaintenanceThrottlerFor(containerName).updateNextRemoveOldFilesTime();
+    }
+
+    private void addRemoveOldFilesCommand(MaintainerExecutor maintainerExecutor, ContainerName containerName) {
         String[] pathsToClean = {
-            getDefaults().underVespaHome("logs/elasticsearch2"),
-            getDefaults().underVespaHome("logs/logstash2"),
-            getDefaults().underVespaHome("logs/daemontools_y"),
-            getDefaults().underVespaHome("logs/nginx"),
-            getDefaults().underVespaHome("logs/vespa")
+                getDefaults().underVespaHome("logs/elasticsearch2"),
+                getDefaults().underVespaHome("logs/logstash2"),
+                getDefaults().underVespaHome("logs/daemontools_y"),
+                getDefaults().underVespaHome("logs/nginx"),
+                getDefaults().underVespaHome("logs/vespa")
         };
 
         for (String pathToClean : pathsToClean) {
@@ -193,22 +198,19 @@ public class StorageMaintainer {
             }
         }
 
-        Path logArchiveDir = environment.pathInNodeAdminFromPathInNode(containerName,
-                                                                       getDefaults().underVespaHome("logs/vespa/logarchive"));
+        Path logArchiveDir = environment.pathInNodeAdminFromPathInNode(
+                containerName, getDefaults().underVespaHome("logs/vespa/logarchive"));
         maintainerExecutor.addJob("delete-files")
                 .withArgument("basePath", logArchiveDir)
                 .withArgument("maxAgeSeconds", Duration.ofDays(31).getSeconds())
                 .withArgument("recursive", false);
 
-        Path fileDistrDir = environment.pathInNodeAdminFromPathInNode(containerName,
-                                                                      getDefaults().underVespaHome("var/db/vespa/filedistribution"));
+        Path fileDistrDir = environment.pathInNodeAdminFromPathInNode(
+                containerName, getDefaults().underVespaHome("var/db/vespa/filedistribution"));
         maintainerExecutor.addJob("delete-files")
                 .withArgument("basePath", fileDistrDir)
                 .withArgument("maxAgeSeconds", Duration.ofDays(31).getSeconds())
                 .withArgument("recursive", true);
-
-        maintainerExecutor.execute();
-        getMaintenanceThrottlerFor(containerName).updateNextRemoveOldFilesTime();
     }
 
     /**
@@ -217,6 +219,14 @@ public class StorageMaintainer {
     public void handleCoreDumpsForContainer(ContainerName containerName, ContainerNodeSpec nodeSpec, Environment environment) {
         if (! getMaintenanceThrottlerFor(containerName).shouldHandleCoredumpsNow()) return;
 
+        MaintainerExecutor maintainerExecutor = new MaintainerExecutor();
+        addHandleCoredumpsCommand(maintainerExecutor, containerName, nodeSpec);
+
+        maintainerExecutor.execute();
+        getMaintenanceThrottlerFor(containerName).updateNextHandleCoredumpsTime();
+    }
+
+    private void addHandleCoredumpsCommand(MaintainerExecutor maintainerExecutor, ContainerName containerName, ContainerNodeSpec nodeSpec) {
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("hostname", nodeSpec.hostname);
         attributes.put("parent_hostname", HostName.getLocalhost());
@@ -237,17 +247,12 @@ public class StorageMaintainer {
             attributes.put("instance", owner.instance);
         });
 
-        MaintainerExecutor maintainerExecutor = new MaintainerExecutor();
         maintainerExecutor.addJob("handle-core-dumps")
                 .withArgument("doneCoredumpsPath", environment.pathInNodeAdminToDoneCoredumps())
-                .withArgument("coredumpsPath",
-                              environment.pathInNodeAdminFromPathInNode(containerName,
-                                      getDefaults().underVespaHome("var/crash")))
+                .withArgument("coredumpsPath", environment.pathInNodeAdminFromPathInNode(
+                        containerName, getDefaults().underVespaHome("var/crash")))
                 .withArgument("feedEndpoint", environment.getCoredumpFeedEndpoint())
                 .withArgument("attributes", attributes);
-
-        maintainerExecutor.execute();
-        getMaintenanceThrottlerFor(containerName).updateNextHandleCoredumpsTime();
     }
 
     /**
@@ -265,13 +270,15 @@ public class StorageMaintainer {
                 .withArgument("maxAgeSeconds", Duration.ofDays(7).getSeconds())
                 .withArgument("dirNameRegex", "^" + Pattern.quote(Environment.APPLICATION_STORAGE_CLEANUP_PATH_PREFIX));
 
-        Path nodeAdminJDiskLogsPath = environment.pathInNodeAdminFromPathInNode(NODE_ADMIN, getDefaults().underVespaHome("logs/vespa/"));
+        Path nodeAdminJDiskLogsPath = environment.pathInNodeAdminFromPathInNode(
+                NODE_ADMIN, getDefaults().underVespaHome("logs/vespa/"));
         maintainerExecutor.addJob("delete-files")
                 .withArgument("basePath", nodeAdminJDiskLogsPath)
                 .withArgument("maxAgeSeconds", Duration.ofDays(31).getSeconds())
                 .withArgument("recursive", false);
 
-        Path fileDistrDir = environment.pathInNodeAdminFromPathInNode(NODE_ADMIN, getDefaults().underVespaHome("var/db/vespa/filedistribution"));
+        Path fileDistrDir = environment.pathInNodeAdminFromPathInNode(
+                NODE_ADMIN, getDefaults().underVespaHome("var/db/vespa/filedistribution"));
         maintainerExecutor.addJob("delete-files")
                 .withArgument("basePath", fileDistrDir)
                 .withArgument("maxAgeSeconds", Duration.ofDays(31).getSeconds())
@@ -286,15 +293,20 @@ public class StorageMaintainer {
      */
     public void archiveNodeData(ContainerName containerName) {
         MaintainerExecutor maintainerExecutor = new MaintainerExecutor();
+        addArchiveNodeData(maintainerExecutor, containerName);
+
+        maintainerExecutor.execute();
+        getMaintenanceThrottlerFor(containerName).reset();
+    }
+
+    private void addArchiveNodeData(MaintainerExecutor maintainerExecutor, ContainerName containerName) {
         maintainerExecutor.addJob("recursive-delete")
-            .withArgument("path", environment.pathInNodeAdminFromPathInNode(containerName, getDefaults().underVespaHome("var")));
+                .withArgument("path", environment.pathInNodeAdminFromPathInNode(
+                        containerName, getDefaults().underVespaHome("var")));
 
         maintainerExecutor.addJob("move-files")
                 .withArgument("from", environment.pathInNodeAdminFromPathInNode(containerName, "/"))
                 .withArgument("to", environment.pathInNodeAdminToNodeCleanup(containerName));
-
-        maintainerExecutor.execute();
-        getMaintenanceThrottlerFor(containerName).reset();
     }
 
     /**
@@ -388,20 +400,13 @@ public class StorageMaintainer {
     }
 
     private MaintenanceThrottler getMaintenanceThrottlerFor(ContainerName containerName) {
-        if (! maintenanceThrottlerByContainerName.containsKey(containerName)) {
-            maintenanceThrottlerByContainerName.put(containerName, new MaintenanceThrottler());
-        }
-
+        maintenanceThrottlerByContainerName.putIfAbsent(containerName, new MaintenanceThrottler());
         return maintenanceThrottlerByContainerName.get(containerName);
     }
 
     private class MaintenanceThrottler {
-        private Instant nextRemoveOldFilesAt;
-        private Instant nextHandleOldCoredumpsAt;
-
-        MaintenanceThrottler() {
-            reset();
-        }
+        private Instant nextRemoveOldFilesAt = Instant.EPOCH;
+        private Instant nextHandleOldCoredumpsAt = Instant.EPOCH;
 
         void updateNextRemoveOldFilesTime() {
             nextRemoveOldFilesAt = clock.instant().plus(Duration.ofHours(1));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -101,7 +101,7 @@ public class NodeAdminStateUpdater extends AbstractComponent {
         if (currentState != RESUMED) return;
 
         try {
-            String hardwareDivergence = maintainer.getHardwardDivergence();
+            String hardwareDivergence = maintainer.getHardwareDivergence();
             NodeAttributes nodeAttributes = new NodeAttributes().withHardwareDivergence(hardwareDivergence);
             nodeRepository.updateNodeAttributes(dockerHostHostName, nodeAttributes);
         } catch (RuntimeException e) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/StorageMaintainerMock.java
@@ -30,7 +30,7 @@ public class StorageMaintainerMock extends StorageMaintainer {
     }
 
     @Override
-    public void handleCoreDumpsForContainer(ContainerName containerName, ContainerNodeSpec nodeSpec, Environment environment) {
+    public void handleCoreDumpsForContainer(ContainerName containerName, ContainerNodeSpec nodeSpec, boolean force) {
     }
 
     @Override
@@ -42,7 +42,7 @@ public class StorageMaintainerMock extends StorageMaintainer {
     }
 
     @Override
-    public void archiveNodeData(ContainerName containerName) {
+    public void cleanupNodeStorage(ContainerName containerName, ContainerNodeSpec nodeSpec) {
         callOrderVerifier.add("DeleteContainerStorage with " + containerName);
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -77,7 +77,7 @@ public class StorageMaintainerTest {
         verifyProcessExecuterCalled(1);
 
         // Coredump handler has its own throttler
-        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, environment);
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, false);
         verifyProcessExecuterCalled(2);
 
 
@@ -85,21 +85,30 @@ public class StorageMaintainerTest {
         storageMaintainer.removeOldFilesFromNode(containerName);
         verifyProcessExecuterCalled(3);
 
-        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, environment);
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, false);
         verifyProcessExecuterCalled(4);
 
-        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, environment);
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, false);
         verifyProcessExecuterCalled(4);
 
-
-        // archiveNodeData is unthrottled and it should reset previous times
-        storageMaintainer.archiveNodeData(containerName);
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, true);
         verifyProcessExecuterCalled(5);
-        storageMaintainer.archiveNodeData(containerName);
+
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, true);
         verifyProcessExecuterCalled(6);
 
-        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, environment);
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, false);
+        verifyProcessExecuterCalled(6);
+
+
+        // cleanupNodeStorage is unthrottled and it should reset previous times
+        storageMaintainer.cleanupNodeStorage(containerName, nodeSpec);
         verifyProcessExecuterCalled(7);
+        storageMaintainer.cleanupNodeStorage(containerName, nodeSpec);
+        verifyProcessExecuterCalled(8);
+
+        storageMaintainer.handleCoreDumpsForContainer(containerName, nodeSpec, false);
+        verifyProcessExecuterCalled(9);
     }
 
     @Test

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -367,9 +367,8 @@ public class NodeAgentImplTest {
         nodeAgent.converge();
 
         final InOrder inOrder = inOrder(storageMaintainer, dockerOperations, nodeRepository);
-        inOrder.verify(storageMaintainer, times(1)).removeOldFilesFromNode(eq(containerName));
         inOrder.verify(dockerOperations, times(1)).removeContainer(any());
-        inOrder.verify(storageMaintainer, times(1)).archiveNodeData(eq(containerName));
+        inOrder.verify(storageMaintainer, times(1)).cleanupNodeStorage(eq(containerName), eq(nodeSpec));
         inOrder.verify(nodeRepository, times(1)).markNodeAvailableForNewAllocation(eq(hostName));
 
         verify(dockerOperations, never()).startContainer(eq(containerName), any());


### PR DESCRIPTION
This addresses three problems with current coredump handling:
1. Because coredump handling is executed once per hour, if the container crashes and there is a coredump, it would not be reported unless we got lucky and it crashed at the hour mark. This PR will always handle coredumps as part of the node cleanup while in dirty state.
2. If the container crashes, it can be restarted with different image/version, so by the time the coredump is reported, the version may have changed. This PR will force handle coredumps before starting a new container.
3. Fixes a bug where `wantedDockerImage` was reported instead of `currentDockerImage`