### PR TITLE
Disable common assembly ids

### DIFF
--- a/controller-api/OWNERS
+++ b/controller-api/OWNERS
@@ -1,0 +1,2 @@
+bratseth
+mpolden

--- a/controller-api/pom.xml
+++ b/controller-api/pom.xml
@@ -150,6 +150,9 @@
                 <groupId>com.yahoo.vespa</groupId>
                 <artifactId>bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <useCommonAssemblyIds>false</useCommonAssemblyIds>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/controller-server/OWNERS
+++ b/controller-server/OWNERS
@@ -1,0 +1,2 @@
+bratseth
+mpolden

--- a/controller-server/pom.xml
+++ b/controller-server/pom.xml
@@ -160,6 +160,7 @@
                 <groupId>com.yahoo.vespa</groupId>
                 <artifactId>bundle-plugin</artifactId>
                 <configuration>
+                    <useCommonAssemblyIds>false</useCommonAssemblyIds>
                     <WebInfUrl>/WEB-INF/web.xml</WebInfUrl>
                 </configuration>
                 <extensions>true</extensions>


### PR DESCRIPTION
This was `false` in Hosted (which is the default). However, the parent POM in this project sets it to `true`.