### PR TITLE
Reduce ccache size to 1GB

### DIFF
--- a/travis/travis-build-cpp.sh
+++ b/travis/travis-build-cpp.sh
@@ -7,7 +7,7 @@ BUILD_DIR=~/build
 
 mkdir "${BUILD_DIR}"
 
-export CCACHE_SIZE="4G"
+export CCACHE_SIZE="1G"
 export CCACHE_COMPRESS=1
 NUM_THREADS=4
 


### PR DESCRIPTION
Building Vespa consumes <1GB ccache (given cccache compression enabled).