### PR TITLE
Add boundary check when mapping to referenced lid, to avoid

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -33,6 +33,7 @@ ImportedSearchContext::ImportedSearchContext(
       _target_attribute(*_imported_attribute.getTargetAttribute()),
       _target_search_context(_target_attribute.getSearch(std::move(term), params)),
       _referencedLids(_reference_attribute.getReferencedLids()),
+      _referencedLidLimit(_target_attribute.getCommittedDocIdLimit()),
       _merger(_reference_attribute.getCommittedDocIdLimit()),
       _fetchPostingsDone(false)
 {
@@ -188,14 +189,6 @@ const QueryTermBase& ImportedSearchContext::queryTerm() const {
 
 const vespalib::string& ImportedSearchContext::attributeName() const {
     return _imported_attribute.getName();
-}
-
-bool ImportedSearchContext::cmp(DocId docId, int32_t& weight) const {
-    return _target_search_context->cmp(_referencedLids[docId], weight);
-}
-
-bool ImportedSearchContext::cmp(DocId docId) const {
-    return _target_search_context->cmp(_referencedLids[docId]);
 }
 
 } // attribute

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -35,8 +35,14 @@ class ImportedSearchContext : public ISearchContext {
     const AttributeVector&                          _target_attribute;
     std::unique_ptr<AttributeVector::SearchContext> _target_search_context;
     ReferencedLids                                  _referencedLids;
+    uint32_t                                        _referencedLidLimit;
     PostingListMerger<int32_t>                      _merger;
     bool                                            _fetchPostingsDone;
+
+    uint32_t getReferencedLid(uint32_t lid) const {
+        uint32_t referencedLid = _referencedLids[lid];
+        return ((referencedLid >= _referencedLidLimit) ? 0u : referencedLid);
+    }
 
     void makeMergedPostings();
 public:
@@ -62,8 +68,13 @@ public:
 
     using DocId = IAttributeVector::DocId;
 
-    bool cmp(DocId docId, int32_t& weight) const;
-    bool cmp(DocId docId) const;
+    bool cmp(DocId docId, int32_t& weight) const {
+        return _target_search_context->cmp(getReferencedLid(docId), weight);
+}
+
+    bool cmp(DocId docId) const {
+        return _target_search_context->cmp(getReferencedLid(docId));
+    }
 
     const ReferenceAttribute& attribute() const noexcept { return _reference_attribute; }
 
@@ -74,6 +85,3 @@ public:
 
 } // attribute
 } // search
-
-
-

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -70,7 +70,7 @@ public:
 
     bool cmp(DocId docId, int32_t& weight) const {
         return _target_search_context->cmp(getReferencedLid(docId), weight);
-}
+    }
 
     bool cmp(DocId docId) const {
         return _target_search_context->cmp(getReferencedLid(docId));


### PR DESCRIPTION
accessing unmapped or uninitialized data in target attribute.

@geirst, please review
