### PR TITLE
Ignore stale job data in failure re-deployer

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
@@ -80,19 +80,9 @@ public class ApplicationList {
         return listOf(list.stream().filter(application -> ! failingOn(version, application)));
     }
 
-    /** Returns the subset of applications which have one or more deployment jobs failing for the current change */
-    public ApplicationList hasDeploymentFailures() {
-        return listOf(list.stream().filter(application -> application.deploying().isPresent() && application.deploymentJobs().failingOn(application.deploying().get())));
-    }
-
     /** Returns the subset of applications which have at least one deployment */
     public ApplicationList hasDeployment() {
         return listOf(list.stream().filter(a -> !a.deployments().isEmpty()));
-    }
-
-    /** Returns the subset of applications that are currently deploying a change */
-    public ApplicationList isDeploying() {
-        return listOf(list.stream().filter(application -> application.deploying().isPresent()));
     }
 
     /** Returns the subset of applications which started failing after the given instant */
@@ -138,18 +128,6 @@ public class ApplicationList {
     /** Returns the subset of applications which currently do not have any job in progress for the given change */
     public ApplicationList notRunningJobFor(Change.VersionChange change) {
         return listOf(list.stream().filter(a -> !hasRunningJob(a, change)));
-    }
-
-    /** Returns the subset of applications which currently do not have any job in progress */
-    public ApplicationList notRunningJob() {
-        return listOf(list.stream().filter(a -> !a.deploymentJobs().inProgress()));
-    }
-
-    /** Returns the subset of applications which has a job that started running before the given instant */
-    public ApplicationList jobRunningSince(Instant instant) {
-        return listOf(list.stream().filter(a -> a.deploymentJobs().runningSince()
-                .map(at -> at.isBefore(instant))
-                .orElse(false)));
     }
 
     /** Returns the subset of applications which deploys to given environment and region */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -14,7 +14,6 @@ import com.yahoo.vespa.hosted.controller.Controller;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -118,11 +117,6 @@ public class DeploymentJobs {
         return status.values().stream().anyMatch(JobStatus::inProgress);
     }
 
-    /** Returns whether any job is failing for the given change */
-    public boolean failingOn(Change change) {
-        return status.values().stream().anyMatch(jobStatus -> !jobStatus.isSuccess() && jobStatus.lastCompletedFor(change));
-    }
-
     /** Returns whether change can be deployed to the given environment */
     public boolean isDeployableTo(Environment environment, Optional<Change> change) {
         if (environment == null || !change.isPresent()) {
@@ -145,15 +139,6 @@ public class DeploymentJobs {
                 failingSince = jobStatus.firstFailing().get().at();
         }
         return failingSince;
-    }
-
-    /** Returns the time at which the oldest running job started */
-    public Optional<Instant> runningSince() {
-        return jobStatus().values().stream()
-                .filter(JobStatus::inProgress)
-                .sorted(Comparator.comparing(jobStatus -> jobStatus.lastTriggered().get().at()))
-                .map(jobStatus -> jobStatus.lastTriggered().get().at())
-                .findFirst();
     }
 
     /**

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployer.java
@@ -3,12 +3,15 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.Controller;
-import com.yahoo.vespa.hosted.controller.application.ApplicationList;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType;
+import com.yahoo.vespa.hosted.controller.application.JobStatus;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Attempts redeployment of failed jobs and deployments.
@@ -16,6 +19,8 @@ import java.util.List;
  * @author bratseth
  */
 public class FailureRedeployer extends Maintainer {
+
+    private final static Duration jobTimeout = Duration.ofHours(12);
     
     public FailureRedeployer(Controller controller, Duration interval, JobControl jobControl) {
         super(controller, interval, jobControl);
@@ -23,20 +28,54 @@ public class FailureRedeployer extends Maintainer {
 
     @Override
     public void maintain() {
-        ApplicationList applications = ApplicationList.from(controller().applications().asList()).isDeploying();
-        List<Application> toTrigger = new ArrayList<>();
+        List<Application> applications = controller().applications().asList();
+        retryFailingJobs(applications);
+        retryStuckJobs(applications);
+    }
 
-        // Applications with deployment failures for current change and no running jobs
-        toTrigger.addAll(applications.hasDeploymentFailures()
-                                 .notRunningJob()
-                                 .asList());
+    private void retryFailingJobs(List<Application> applications) {
+        for (Application application : applications) {
+            if (!application.deploying().isPresent()) {
+                continue;
+            }
+            if (application.deploymentJobs().inProgress()) {
+                continue;
+            }
+            Optional<Map.Entry<JobType, JobStatus>> failingJob = jobFailingFor(application);
+            failingJob.ifPresent(job -> triggerFailing(application, "Job " + job.getKey().id() +
+                    " has been failing since " + job.getValue().lastCompleted().get()));
+        }
+    }
 
-        // Applications with jobs that have been in progress for more than 12 hours
-        Instant twelveHoursAgo = controller().clock().instant().minus(Duration.ofHours(12));
-        toTrigger.addAll(applications.jobRunningSince(twelveHoursAgo).asList());
+    private void retryStuckJobs(List<Application> applications) {
+        Instant maxAge = controller().clock().instant().minus(jobTimeout);
+        for (Application application : applications) {
+            if (!application.deploying().isPresent()) {
+                continue;
+            }
+            Optional<Map.Entry<JobType, JobStatus>> job = oldestRunningJob(application);
+            if (job.isPresent() && job.get().getValue().lastTriggered().get().at().isBefore(maxAge)) {
+                triggerFailing(application, "Job " + job.get().getKey().id() +
+                        " has been running for more than " + jobTimeout);
+            }
+        }
+    }
 
-        toTrigger.forEach(application -> controller().applications().deploymentTrigger()
-                .triggerFailing(application.id()));
+    private Optional<Map.Entry<JobType, JobStatus>> jobFailingFor(Application application) {
+        return application.deploymentJobs().jobStatus().entrySet().stream()
+                .filter(e -> !e.getValue().isSuccess() && e.getValue().lastCompletedFor(application.deploying().get()))
+                .findFirst();
+    }
+
+    private Optional<Map.Entry<JobType, JobStatus>> oldestRunningJob(Application application) {
+        return application.deploymentJobs().jobStatus().entrySet().stream()
+                .filter(kv -> kv.getValue().inProgress())
+                .sorted(Comparator.comparing(kv -> kv.getValue().lastTriggered().get().at()))
+                .findFirst();
+    }
+
+    private void triggerFailing(Application application, String cause) {
+        controller().applications().deploymentTrigger().triggerFailing(application.id(), cause);
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployer.java
@@ -54,7 +54,14 @@ public class FailureRedeployer extends Maintainer {
                 continue;
             }
             Optional<Map.Entry<JobType, JobStatus>> job = oldestRunningJob(application);
-            if (job.isPresent() && job.get().getValue().lastTriggered().get().at().isBefore(maxAge)) {
+            if (!job.isPresent()) {
+                continue;
+            }
+            // Ignore job if it doesn't belong to a zone in this system
+            if (!job.get().getKey().zone(controller().system()).isPresent()) {
+                continue;
+            }
+            if (job.get().getValue().lastTriggered().get().at().isBefore(maxAge)) {
                 triggerFailing(application, "Job " + job.get().getKey().id() +
                         " has been running for more than " + jobTimeout);
             }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ZoneRegistryMock.java
@@ -27,9 +27,11 @@ public class ZoneRegistryMock implements ZoneRegistry {
         deploymentTimeToLive.put(zone, duration);
     }
 
+    private SystemName system = SystemName.main;
+
     @Override
     public SystemName system() {
-        return SystemName.main;
+        return system;
     }
 
     @Override
@@ -70,5 +72,9 @@ public class ZoneRegistryMock implements ZoneRegistry {
     @Override
     public URI getDashboardUri() {
         return URI.create("http://dashboard.test");
+    }
+
+    public void setSystem(SystemName system) {
+        this.system = system;
     }
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
@@ -160,7 +160,7 @@ public class DeploymentTester {
     }
 
     public void deploy(JobType job, Application application, ApplicationPackage applicationPackage, boolean deployCurrentVersion) {
-        job.zone(SystemName.main).ifPresent(zone -> tester.deploy(application, zone, applicationPackage, deployCurrentVersion));
+        job.zone(controller().system()).ifPresent(zone -> tester.deploy(application, zone, applicationPackage, deployCurrentVersion));
     }
 
     public void deployAndNotify(JobType job, Application application, ApplicationPackage applicationPackage, boolean success) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -34,14 +34,14 @@ public class DeploymentTriggerTest {
         tester.buildSystem().takeJobsToRun();
         assertEquals("Job removed", 0, tester.buildSystem().jobs().size());        
         tester.clock().advance(Duration.ofHours(2));
-        tester.deploymentTrigger().triggerFailing(app1.id());
+        tester.deploymentTrigger().triggerFailing(app1.id(), "unit test");
         assertEquals("Retried job", 1, tester.buildSystem().jobs().size());
         assertEquals(JobType.stagingTest.id(), tester.buildSystem().jobs().get(0).jobName());
 
         tester.buildSystem().takeJobsToRun();
         assertEquals("Job removed", 0, tester.buildSystem().jobs().size());
         tester.clock().advance(Duration.ofHours(7));
-        tester.deploymentTrigger().triggerFailing(app1.id());
+        tester.deploymentTrigger().triggerFailing(app1.id(), "unit test");
         assertEquals("Retried from the beginning", 1, tester.buildSystem().jobs().size());
         assertEquals(JobType.component.id(), tester.buildSystem().jobs().get(0).jobName());
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/testdata/canary-with-stale-data.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/testdata/canary-with-stale-data.json
@@ -1,0 +1,295 @@
+{
+  "id": "vespa:canary:default",
+  "deploymentSpecField": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<deployment version=\"1.0\">\n    <upgrade policy='canary'/>\n    <test />\n    <staging />\n    <prod>\n        <region active=\"true\">cd-us-central-1</region>\n    </prod>\n</deployment>\n",
+  "validationOverrides": "<validation-overrides>\n    <allow until=\"2017-04-27\">force-automatic-tenant-upgrade-test</allow>\n</validation-overrides>\n",
+  "deployments": [
+    {
+      "zone": {
+        "environment": "prod",
+        "region": "cd-us-central-1"
+      },
+      "version": "6.141.117",
+      "deployTime": 1503901783487,
+      "applicationPackageRevision": {
+        "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+        "sourceRevision": {
+          "repositoryField": "git@git.test:vespa/canary-application.git",
+          "branchField": "origin/canary-cd",
+          "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+        }
+      }
+    }
+  ],
+  "deploymentJobs": {
+    "projectId": 191186,
+    "jobStatus": [
+      {
+        "jobType": "production-eu-west-1",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493034019032
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493033995026
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493033995026
+        }
+      },
+      {
+        "jobType": "production-cd-us-central-1",
+        "jobError": "unknown",
+        "lastTriggered": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503903384816
+        },
+        "lastCompleted": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503903659364
+        },
+        "firstFailing": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503903659364
+        },
+        "lastSuccess": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503903556127
+        }
+      },
+      {
+        "jobType": "component",
+        "lastTriggered": {
+          "version": "6.141.109",
+          "at": 1503867517105
+        },
+        "lastCompleted": {
+          "version": "6.141.109",
+          "at": 1503867704464
+        },
+        "lastSuccess": {
+          "version": "6.141.109",
+          "at": 1503867704464
+        }
+      },
+      {
+        "jobType": "production-corp-us-east-1",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493034428590
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493034114538
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493034114538
+        }
+      },
+      {
+        "jobType": "production-ap-southeast-1",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493034265146
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493034097617
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493034097617
+        }
+      },
+      {
+        "jobType": "production-us-central-1",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493033800484
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493034273753
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493034273753
+        }
+      },
+      {
+        "jobType": "staging-test",
+        "lastTriggered": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503900683154
+        },
+        "lastCompleted": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503901635745
+        },
+        "lastSuccess": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503901635745
+        }
+      },
+      {
+        "jobType": "system-test",
+        "lastTriggered": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503899621243
+        },
+        "lastCompleted": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503900025214
+        },
+        "lastSuccess": {
+          "version": "6.141.117",
+          "revision": {
+            "applicationPackageHash": "72c3961314b96b1155a310f4785ae57ec74b1273",
+            "sourceRevision": {
+              "repositoryField": "git@git.test:vespa/canary-application.git",
+              "branchField": "origin/canary-cd",
+              "commitField": "566b7b30ee7886b845bb70958a0e1bdab2868633"
+            }
+          },
+          "at": 1503900025214
+        }
+      },
+      {
+        "jobType": "production-us-west-1",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493034273768
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493034019015
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493034019015
+        }
+      },
+      {
+        "jobType": "production-ap-northeast-1",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493033995045
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493034257206
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493034257206
+        }
+      },
+      {
+        "jobType": "production-ap-northeast-2",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493034257222
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493034265048
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493034265048
+        }
+      },
+      {
+        "jobType": "production-us-east-3",
+        "lastTriggered": {
+          "version": "6.98.12",
+          "at": 1493034114555
+        },
+        "lastCompleted": {
+          "version": "6.98.12",
+          "at": 1493033800469
+        },
+        "lastSuccess": {
+          "version": "6.98.12",
+          "at": 1493033800469
+        }
+      }
+    ],
+    "selfTriggering": false
+  },
+  "outstandingChangeField": false
+}


### PR DESCRIPTION
Turns out the unnecessary triggering was caused by the stale job data in CD. Until all the stale data is gone, we need this extra check.

I also added more logging to the failure re-redeployer to make debugging easier (first commit).