### PR TITLE
Restore old beahvior on clone.

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -153,7 +153,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
     private QueryContext context = null;
 
     /** Used for downstream session caches */
-    private final AtomicReference<UniqueRequestId> sessionId = new AtomicReference<>();
+    private UniqueRequestId requestId = null;
 
     //--------------- Owned sub-objects containing query properties ----------------
 
@@ -962,18 +962,13 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
      * @return the session id of this query, or null if not set and create is false
      */
     public SessionId getSessionId(boolean create) {
-        UniqueRequestId uniqId = sessionId.get();
-        if (uniqId == null && ! create) return null;
+        if (requestId == null && ! create) return null;
 
-        if (uniqId == null && create) {
-            uniqId = UniqueRequestId.next();
-            sessionId.compareAndSet(null, uniqId);
-            uniqId = sessionId.get();
+        if (requestId == null && create) {
+            requestId = UniqueRequestId.next();
         }
 
-        String rankProfile = getRanking().getProfile();
-
-        return new SessionId(uniqId, rankProfile);
+        return new SessionId(requestId, getRanking().getProfile());
     }
 
     public boolean hasEncodableProperties() {

--- a/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
@@ -670,6 +670,20 @@ public class QueryTestCase {
     }
 
     @Test
+    public void testThatSessionIdIsNotSharedIfCreatedAfterClone() {
+        Query q = new Query();
+        Query q2 = q.clone();
+        assertNull(q.getSessionId(false));
+        assertNull(q2.getSessionId(false));
+
+        assertNotNull(q.getSessionId(true));
+        assertNull(q2.getSessionId(false));
+
+        assertNotNull(q2.getSessionId(true));
+        assertNotEquals(q.getSessionId(false), q2.getSessionId(false));
+    }
+
+    @Test
     public void testPositiveTerms() {
         Query q = new Query(httpEncode("/?query=-a \"b c\" d e"));
         Item i = q.getModel().getQueryTree().getRoot();


### PR DESCRIPTION
- If getSessionId(true) has been called prior to clone, allcones will share sessionid with parent.
- If not, they will all get their own.
@bratseth PR