### PR TITLE
Use priority class LOW for generated GC operations

### DIFF
--- a/storage/src/vespa/storage/distributor/statecheckers.cpp
+++ b/storage/src/vespa/storage/distributor/statecheckers.cpp
@@ -1140,7 +1140,7 @@ GarbageCollectionStateChecker::check(Context& c)
         op->setPriority(c.distributorConfig.getMaintenancePriorities()
                         .garbageCollection);
         op->setDetailedReason(reason.c_str());
-        return Result::createStoredResult(std::move(op), MaintenancePriority::MEDIUM);
+        return Result::createStoredResult(std::move(op), MaintenancePriority::LOW);
     } else {
         return Result::noMaintenanceNeeded();
     }


### PR DESCRIPTION
@hakonhall please review, see #3249 for context.

Avoids starvation of merge (and split) operations when GC ops are
preempted on heavily loaded content nodes.