### PR TITLE
Reduce number of config server worker threads from default (500)

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -2,6 +2,10 @@
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <services version="1.0" xmlns:preprocess="properties">
   <jdisc id="configserver" jetty="true" version="1.0">
+    <config name="container.handler.threadpool">
+      <maxthreads>100</maxthreads> <!-- Reduced thread count to minimize memory consumption -->
+    </config>
+
     <accesslog type="vespa" fileNamePattern="logs/vespa/configserver/access.log.%Y%m%d%H%M%S" rotationScheme="date" symlinkName="access.log" />
     <component id="com.yahoo.vespa.config.server.ConfigServerBootstrap" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.monitoring.Metrics" bundle="configserver" />


### PR DESCRIPTION
Reduce the number of worker threads will have a positive impact on
the memory consumption.