### PR TITLE
Application serialization fix

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -12,6 +12,7 @@ import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
+import com.yahoo.slime.Type;
 import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.application.ApplicationRevision;
@@ -229,7 +230,8 @@ public class ApplicationSerializer {
     }
 
     private Optional<Change> changeFromSlime(Inspector object) {
-        if ( ! object.valid()) return Optional.empty();
+        // TODO: Remove NIX check after Sep 2017
+        if ( ! object.valid() || object.type() == Type.NIX) return Optional.empty();
         Inspector versionFieldValue = object.field(versionField);
         if (versionFieldValue.valid())
             return Optional.of(new Change.VersionChange(Version.fromString(versionFieldValue.asString())));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -241,14 +241,7 @@ public class ApplicationSerializer {
     
     private List<JobStatus> jobStatusListFromSlime(Inspector array) {
         List<JobStatus> jobStatusList = new ArrayList<>();
-        array.traverse((ArrayTraverser) (int i, Inspector item) -> {
-            // TODO: This zone has been removed. Remove after Aug 2017
-            String jobId = item.field(jobTypeField).asString();
-            if ("production-ap-aue-1".equals(jobId)) {
-                return;
-            }
-            jobStatusList.add(jobStatusFromSlime(item));
-        });
+        array.traverse((ArrayTraverser) (int i, Inspector item) -> jobStatusList.add(jobStatusFromSlime(item)));
         return jobStatusList;
     }
     

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -133,6 +133,42 @@ public class ApplicationSerializerTest {
         assertEquals(JobError.unknown, applicationWithFailingJob.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.systemTest).jobError().get());
     }
 
+    // TODO: Tests NIX check: Remove after Sep 2017
+    @Test
+    public void serializeLegacyDeployingField() {
+        String json = "{\n" +
+                "  \"id\": \"t1:a1:i1\",\n" +
+                "  \"deploymentSpecField\": \"<deployment version='1.0'/>\",\n" +
+                "  \"deploymentJobs\": {\n" +
+                "    \"projectId\": 123,\n" +
+                "    \"jobStatus\": [\n" +
+                "      {\n" +
+                "        \"jobType\": \"system-test\",\n" +
+                "        \"version\": \"5.6.7\",\n" +
+                "        \"completionTime\": 7,\n" +
+                "        \"lastTriggered\": 8\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"jobType\": \"production-us-west-1\",\n" +
+                "        \"version\": \"5.6.7\",\n" +
+                "        \"completionTime\": 7,\n" +
+                "        \"lastTriggered\": 8\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"jobType\": \"staging-test\",\n" +
+                "        \"version\": \"5.6.7\",\n" +
+                "        \"completionTime\": 7,\n" +
+                "        \"lastTriggered\": 8\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"selfTriggering\": false\n" +
+                "  },\n" +
+                "  \"deployingField\": null\n" +
+                "}\n";
+        Application app = applicationSerializer.fromSlime(SlimeUtils.jsonToSlime(json.getBytes(StandardCharsets.UTF_8)));
+        assertFalse("No change present", app.deploying().isPresent());
+    }
+
     private Slime applicationSlime(boolean error) {
         return SlimeUtils.jsonToSlime(applicationJson(error).getBytes(StandardCharsets.UTF_8));
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -133,41 +133,6 @@ public class ApplicationSerializerTest {
         assertEquals(JobError.unknown, applicationWithFailingJob.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.systemTest).jobError().get());
     }
 
-    // TODO: Remove after Aug 2017
-    @Test
-    public void serializeWithRemovedZone() throws Exception {
-        String json = "{\n" +
-                "  \"id\": \"t1:a1:i1\",\n" +
-                "  \"deploymentSpecField\": \"<deployment version='1.0'/>\",\n" +
-                "  \"deploymentJobs\": {\n" +
-                "    \"projectId\": 123,\n" +
-                "    \"jobStatus\": [\n" +
-                "      {\n" +
-                "        \"jobType\": \"system-test\",\n" +
-                "        \"version\": \"5.6.7\",\n" +
-                "        \"completionTime\": 7,\n" +
-                "        \"lastTriggered\": 8\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"jobType\": \"production-ap-aue-1\",\n" +
-                "        \"version\": \"5.6.7\",\n" +
-                "        \"completionTime\": 7,\n" +
-                "        \"lastTriggered\": 8\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"jobType\": \"staging-test\",\n" +
-                "        \"version\": \"5.6.7\",\n" +
-                "        \"completionTime\": 7,\n" +
-                "        \"lastTriggered\": 8\n" +
-                "      }\n" +
-                "    ],\n" +
-                "    \"selfTriggering\": false\n" +
-                "  }\n" +
-                "}\n";
-        Application app = applicationSerializer.fromSlime(SlimeUtils.jsonToSlime(json.getBytes(StandardCharsets.UTF_8)));
-        assertEquals(2, app.deploymentJobs().jobStatus().size());
-    }
-
     private Slime applicationSlime(boolean error) {
         return SlimeUtils.jsonToSlime(applicationJson(error).getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
We have applications in main that have persisted `null` as the value for `deployingField`. Unsure why this has happened as the current version omits the field if `deploying()` is empty. I assume the logic was different in past versions of the serializer.

The `null` value is deserialized to an unknown application change which causes other components (DelayedDeployer in this case) to think there's an change to roll out.

FYI @bratseth 