### PR TITLE
Implement recursive delete in node-repo

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -175,6 +175,7 @@ public class NodeRepositoryImpl implements NodeRepository {
                 NodeMessageResponse.class);
         NODE_ADMIN_LOGGER.info(response.message);
 
+        System.out.println(response.message);
         if (response.errorCode == null || response.errorCode.isEmpty()) {
             return;
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -175,7 +175,6 @@ public class NodeRepositoryImpl implements NodeRepository {
                 NodeMessageResponse.class);
         NODE_ADMIN_LOGGER.info(response.message);
 
-        System.out.println(response.message);
         if (response.errorCode == null || response.errorCode.isEmpty()) {
             return;
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
@@ -149,6 +149,7 @@ public class NodeRepositoryImplTest {
         NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
         waitForJdiscContainerToServe();
 
+        nodeRepositoryApi.markAsDirty("host5.yahoo.com");
         nodeRepositoryApi.markNodeAvailableForNewAllocation("host5.yahoo.com");
 
         try {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -106,18 +106,21 @@ public class CuratorDatabaseClient {
     }
 
     /**
-     * Removes a node.
+     * Removes multiple nodes in a single transaction.
      *
-     * @param state the current state of the node
-     * @param hostName the host name of the node to remove
+     * @param nodes list of the nodes to remove
      */
-    public void removeNode(Node.State state, String hostName) {
-        Path path = toPath(state, hostName);
+    public void removeNodes(List<Node> nodes) {
         NestedTransaction transaction = new NestedTransaction();
-        CuratorTransaction curatorTransaction = curatorDatabase.newCuratorTransactionIn(transaction);
-        curatorTransaction.add(CuratorOperations.delete(path.getAbsolute()));
+
+        for (Node node : nodes) {
+            Path path = toPath(node.state(), node.hostname());
+            CuratorTransaction curatorTransaction = curatorDatabase.newCuratorTransactionIn(transaction);
+            curatorTransaction.add(CuratorOperations.delete(path.getAbsolute()));
+        }
+
         transaction.commit();
-        log.log(LogLevel.INFO, "Removed: " + state + " node " + hostName);
+        nodes.forEach(node -> log.log(LogLevel.INFO, "Removed node " + node.hostname() + " in state " + node.state()));
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -125,20 +125,21 @@ public class NodesApiHandler extends LoggingRequestHandler {
             return new MessageResponse("Moved " + lastElement(path) + " to active");
         }
         else if (path.startsWith("/nodes/v2/state/availablefornewallocations/")) {
-            /**
+            /*
              * This is a temporary "state" or rest call that we use to enable a smooth rollout of
              * dynamic docker flavor allocations. Once we have switch everything we remove this
-             * and change the code in the nodeadmin to delete directly (remember to allow deletion of dirty nodes then).
+             * and change the code in the nodeadmin to delete directly (remember to allow deletion of ready nodes then).
              *
              * Should only be called by node-admin for docker containers (the docker constraint is
              * enforced in the remove method)
              */
             String hostname = lastElement(path);
+            nodeRepository.setReady(hostname);
+
             if (nodeRepository.dynamicAllocationEnabled()) {
-                nodeRepository.remove(hostname);
-                return new MessageResponse("Removed " + hostname);
+                List<Node> removedNodes = nodeRepository.removeRecursively(hostname);
+                return new MessageResponse("Removed " + removedNodes.stream().map(Node::hostname).collect(Collectors.joining(", ")));
             } else {
-                nodeRepository.setReady(hostname);
                 return new MessageResponse("Moved " + hostname + " to ready");
             }
         }
@@ -180,8 +181,8 @@ public class NodesApiHandler extends LoggingRequestHandler {
         String path = request.getUri().getPath();
         if (path.startsWith("/nodes/v2/node/")) {
             String hostname = lastElement(path);
-            nodeRepository.remove(hostname);
-            return new MessageResponse("Removed " + hostname);
+            List<Node> removedNodes = nodeRepository.removeRecursively(hostname);
+            return new MessageResponse("Removed " + removedNodes.stream().map(Node::hostname).collect(Collectors.joining(", ")));
         }
         else if (path.startsWith("/nodes/v2/maintenance/inactive/")) {
             return setActive(lastElement(path), true);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -125,23 +125,10 @@ public class NodesApiHandler extends LoggingRequestHandler {
             return new MessageResponse("Moved " + lastElement(path) + " to active");
         }
         else if (path.startsWith("/nodes/v2/state/availablefornewallocations/")) {
-            /*
-             * This is a temporary "state" or rest call that we use to enable a smooth rollout of
-             * dynamic docker flavor allocations. Once we have switch everything we remove this
-             * and change the code in the nodeadmin to delete directly (remember to allow deletion of ready nodes then).
-             *
-             * Should only be called by node-admin for docker containers (the docker constraint is
-             * enforced in the remove method)
-             */
             String hostname = lastElement(path);
-            nodeRepository.setReady(hostname);
-
-            if (nodeRepository.dynamicAllocationEnabled()) {
-                List<Node> removedNodes = nodeRepository.removeRecursively(hostname);
-                return new MessageResponse("Removed " + removedNodes.stream().map(Node::hostname).collect(Collectors.joining(", ")));
-            } else {
-                return new MessageResponse("Moved " + hostname + " to ready");
-            }
+            List<Node> available = nodeRepository.markNodeAvailableForNewAllocation(hostname);
+            return new MessageResponse("Marked following nodes as available for new allocation: " +
+                    available.stream().map(Node::hostname).collect(Collectors.joining(", ")));
         }
 
         throw new NotFoundException("Cannot put to path '" + path + "'");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -70,23 +70,20 @@ public class NodeRepositoryTest {
     }
 
     @Test
-    public void only_allow_docker_containers_remove_in_provisioned_or_ready() {
+    public void only_allow_docker_containers_remove_in_ready() {
         NodeRepositoryTester tester = new NodeRepositoryTester();
         tester.addNode("id1", "host1", "docker", NodeType.tenant);
-        tester.addNode("id2", "host2", "docker", NodeType.tenant);
-        tester.nodeRepository().fail("host2", Agent.system, "Failed for testing");
 
-        tester.nodeRepository().removeRecursively("host1"); // host1 is in state provisioned
         try {
-            tester.nodeRepository().removeRecursively("host2");
-            fail("Should not be able to delete docker tenant node in state dirty");
+            tester.nodeRepository().removeRecursively("host1"); // host1 is in state provisioned
+            fail("Should not be able to delete docker container node by itself in state provisioned");
         } catch (IllegalArgumentException ignored) {
             // Expected
         }
 
-        tester.nodeRepository().setDirty("host2");
-        tester.nodeRepository().setReady("host2");
-        tester.nodeRepository().removeRecursively("host2");
+        tester.nodeRepository().setDirty("host1");
+        tester.nodeRepository().setReady("host1");
+        tester.nodeRepository().removeRecursively("host1");
     }
 
     @Test
@@ -105,7 +102,7 @@ public class NodeRepositoryTest {
 
         try {
             tester.nodeRepository().removeRecursively("host1");
-            fail("Should not be able to delete host node, one of the children are in state dirty");
+            fail("Should not be able to delete host node, one of the children is in state dirty");
         } catch (IllegalArgumentException ignored) {
             // Expected
         }
@@ -117,7 +114,7 @@ public class NodeRepositoryTest {
 
         // Now node10 and node12 are in provisioned, set node11 to ready, and it should be OK to delete host1
         tester.nodeRepository().setReady("node11");
-        tester.nodeRepository().removeRecursively("node12"); // Remove one of the children first instead
+        tester.nodeRepository().removeRecursively("node11"); // Remove one of the children first instead
         assertEquals(3, tester.nodeRepository().getNodes().size());
 
         tester.nodeRepository().removeRecursively("host1");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -8,6 +8,7 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.hosted.provision.node.Agent;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -69,7 +70,7 @@ public class NodeRepositoryTest {
         assertTrue(tester.nodeRepository().dynamicAllocationEnabled());
     }
 
-    @Test
+    @Test @Ignore // TODO: Enable once controller no longer deletes child nodes manually
     public void only_allow_docker_containers_remove_in_ready() {
         NodeRepositoryTester tester = new NodeRepositoryTester();
         tester.addNode("id1", "host1", "docker", NodeType.tenant);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -28,18 +28,18 @@ public class NodeRepositoryTest {
     @Test
     public void nodeRepositoryTest() {
         NodeRepositoryTester tester = new NodeRepositoryTester();
-        assertEquals(0, tester.getNodes(NodeType.tenant).size());
+        assertEquals(0, tester.nodeRepository().getNodes().size());
 
         tester.addNode("id1", "host1", "default", NodeType.tenant);
         tester.addNode("id2", "host2", "default", NodeType.tenant);
         tester.addNode("id3", "host3", "default", NodeType.tenant);
 
-        assertEquals(3, tester.getNodes(NodeType.tenant).size());
+        assertEquals(3, tester.nodeRepository().getNodes().size());
         
         tester.nodeRepository().park("host2", Agent.system, "Parking to unit test");
-        tester.nodeRepository().remove("host2");
+        tester.nodeRepository().removeRecursively("host2");
 
-        assertEquals(2, tester.getNodes(NodeType.tenant).size());
+        assertEquals(2, tester.nodeRepository().getNodes().size());
     }
 
     @Test
@@ -70,20 +70,57 @@ public class NodeRepositoryTest {
     }
 
     @Test
-    public void only_allow_to_delete_dirty_nodes_when_dynamic_allocation_feature_enabled() {
+    public void only_allow_docker_containers_remove_in_provisioned_or_ready() {
         NodeRepositoryTester tester = new NodeRepositoryTester();
-        tester.addNode("id1", "host1", "default", NodeType.host);
+        tester.addNode("id1", "host1", "docker", NodeType.tenant);
         tester.addNode("id2", "host2", "docker", NodeType.tenant);
-        tester.nodeRepository().setDirty("host2");
+        tester.nodeRepository().fail("host2", Agent.system, "Failed for testing");
 
+        tester.nodeRepository().removeRecursively("host1"); // host1 is in state provisioned
         try {
-            tester.nodeRepository().remove("host2");
-            fail("Should not be able to delete tenant node in state dirty");
+            tester.nodeRepository().removeRecursively("host2");
+            fail("Should not be able to delete docker tenant node in state dirty");
         } catch (IllegalArgumentException ignored) {
             // Expected
         }
 
-        tester.curator().set(Path.fromString("/provision/v1/dynamicDockerAllocation"), new byte[0]);
-        tester.nodeRepository().remove("host2");
+        tester.nodeRepository().setDirty("host2");
+        tester.nodeRepository().setReady("host2");
+        tester.nodeRepository().removeRecursively("host2");
+    }
+
+    @Test
+    public void delete_host_only_after_all_the_children_have_been_deleted() {
+        NodeRepositoryTester tester = new NodeRepositoryTester();
+
+        tester.addNode("id1", "host1", "default", NodeType.host);
+        tester.addNode("id2", "host2", "default", NodeType.host);
+        tester.addNode("node10", "node10", "host1", "docker", NodeType.tenant);
+        tester.addNode("node11", "node11", "host1", "docker", NodeType.tenant);
+        tester.addNode("node12", "node12", "host1", "docker", NodeType.tenant);
+        tester.addNode("node20", "node20", "host2", "docker", NodeType.tenant);
+        assertEquals(6, tester.nodeRepository().getNodes().size());
+
+        tester.nodeRepository().setDirty("node11");
+
+        try {
+            tester.nodeRepository().removeRecursively("host1");
+            fail("Should not be able to delete host node, one of the children are in state dirty");
+        } catch (IllegalArgumentException ignored) {
+            // Expected
+        }
+        assertEquals(6, tester.nodeRepository().getNodes().size());
+
+        // Should be OK to delete host2 as both host2 and its only child, node20, are in state provisioned
+        tester.nodeRepository().removeRecursively("host2");
+        assertEquals(4, tester.nodeRepository().getNodes().size());
+
+        // Now node10 and node12 are in provisioned, set node11 to ready, and it should be OK to delete host1
+        tester.nodeRepository().setReady("node11");
+        tester.nodeRepository().removeRecursively("node12"); // Remove one of the children first instead
+        assertEquals(3, tester.nodeRepository().getNodes().size());
+
+        tester.nodeRepository().removeRecursively("host1");
+        assertEquals(0, tester.nodeRepository().getNodes().size());
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
@@ -51,6 +51,12 @@ public class NodeRepositoryTester {
         return nodeRepository.addNodes(Collections.singletonList(node)).get(0);
     }
 
+    public Node addNode(String id, String hostname, String parentHostname, String flavor, NodeType type) {
+        Node node = nodeRepository.createNode(id, hostname, Optional.of(parentHostname),
+                nodeFlavors.getFlavorOrThrow(flavor), type);
+        return nodeRepository.addNodes(Collections.singletonList(node)).get(0);
+    }
+
     private FlavorsConfig createConfig() {
         FlavorConfigBuilder b = new FlavorConfigBuilder();
         b.addFlavor("default", 2., 4., 100, Flavor.Type.BARE_METAL).cost(3);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
@@ -342,7 +342,7 @@ public class NodeFailerTest {
         assertEquals(15, tester.nodeRepository.getNodes(NodeType.proxy, Node.State.active).size());
 
         // The first down host is removed, which causes the second one to be moved to failed
-        tester.nodeRepository.remove(failedHost1);
+        tester.nodeRepository.removeRecursively(failedHost1);
         tester.failer.run();
         assertEquals( 2, tester.deployer.redeployments);
         assertEquals(14, tester.nodeRepository.getNodes(NodeType.proxy, Node.State.active).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZooKeeperAccessMaintainerTest.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepositoryTester;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.zookeeper.ZooKeeperServer;
@@ -49,7 +48,7 @@ public class ZooKeeperAccessMaintainerTest {
         assertEquals(asSet("host1,host2,host3,host4,host5,server1,server2"), ZooKeeperServer.getAllowedClientHostnames());
 
         tester.nodeRepository().park("host2", Agent.system, "Parking to unit test");
-        tester.nodeRepository().remove("host2");
+        tester.nodeRepository().removeRecursively("host2");
         maintainer.maintain();
 
         assertEquals(2, tester.getNodes(NodeType.tenant).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -401,7 +401,7 @@ public class RestApiTest {
         // Attempt to DELETE a node which is not put in a deletable state first
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host2.yahoo.com",
                                    new byte[0], Request.Method.DELETE),
-                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Failed to delete host2.yahoo.com: host2.yahoo.com can only be removed from following states: provisioned, failed, parked\"}");
+                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Failed to delete host2.yahoo.com: Node host2.yahoo.com can only be removed from following states: provisioned, failed, parked\"}");
 
         // PUT current restart generation with string instead of long
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -401,7 +401,7 @@ public class RestApiTest {
         // Attempt to DELETE a node which is not put in a deletable state first
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host2.yahoo.com",
                                    new byte[0], Request.Method.DELETE),
-                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Can only remove node from following states: provisioned, failed, parked, dirty\"}");
+                       400, "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Failed to delete host2.yahoo.com: host2.yahoo.com can only be removed from following states: provisioned, failed, parked\"}");
 
         // PUT current restart generation with string instead of long
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",


### PR DESCRIPTION
* Replaces the simple single node `remove()` with `removeRecursively()` that removes all the children and the node itself in a single transaction.
* Allows docker tenant nodes to only be deleted in state `provisioned` and `ready`.
* `PUT` to `/nodes/v2/state/availablefornewallocations/[hostname]` will now always set the node to `ready` first. If dynamic allocation is on, the node will then be removed in a separate call.