### PR TITLE
Revert "Fix serialization of legacy deploying value"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -12,7 +12,6 @@ import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
-import com.yahoo.slime.Type;
 import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.application.ApplicationRevision;
@@ -230,8 +229,7 @@ public class ApplicationSerializer {
     }
 
     private Optional<Change> changeFromSlime(Inspector object) {
-        // TODO: Remove NIX check after Sep 2017
-        if ( ! object.valid() || object.type() == Type.NIX) return Optional.empty();
+        if ( ! object.valid()) return Optional.empty();
         Inspector versionFieldValue = object.field(versionField);
         if (versionFieldValue.valid())
             return Optional.of(new Change.VersionChange(Version.fromString(versionFieldValue.asString())));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -133,42 +133,6 @@ public class ApplicationSerializerTest {
         assertEquals(JobError.unknown, applicationWithFailingJob.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.systemTest).jobError().get());
     }
 
-    // TODO: Tests NIX check: Remove after Sep 2017
-    @Test
-    public void serializeLegacyDeployingField() {
-        String json = "{\n" +
-                "  \"id\": \"t1:a1:i1\",\n" +
-                "  \"deploymentSpecField\": \"<deployment version='1.0'/>\",\n" +
-                "  \"deploymentJobs\": {\n" +
-                "    \"projectId\": 123,\n" +
-                "    \"jobStatus\": [\n" +
-                "      {\n" +
-                "        \"jobType\": \"system-test\",\n" +
-                "        \"version\": \"5.6.7\",\n" +
-                "        \"completionTime\": 7,\n" +
-                "        \"lastTriggered\": 8\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"jobType\": \"production-us-west-1\",\n" +
-                "        \"version\": \"5.6.7\",\n" +
-                "        \"completionTime\": 7,\n" +
-                "        \"lastTriggered\": 8\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"jobType\": \"staging-test\",\n" +
-                "        \"version\": \"5.6.7\",\n" +
-                "        \"completionTime\": 7,\n" +
-                "        \"lastTriggered\": 8\n" +
-                "      }\n" +
-                "    ],\n" +
-                "    \"selfTriggering\": false\n" +
-                "  },\n" +
-                "  \"deployingField\": null\n" +
-                "}\n";
-        Application app = applicationSerializer.fromSlime(SlimeUtils.jsonToSlime(json.getBytes(StandardCharsets.UTF_8)));
-        assertFalse("No change present", app.deploying().isPresent());
-    }
-
     private Slime applicationSlime(boolean error) {
         return SlimeUtils.jsonToSlime(applicationJson(error).getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
This reverts commit 44cd92e6ff96b2e40c990fc18cad8c56a85fe73d.

@jonmv Had a closer look at the code, it's confusing, but seems to do the right thing. The serialized null evidently means "unknown application change". Please review after the fact. 

An unknown change is rendered as `"deploying": {}` in the application API, which just adds to the confusion.