### PR TITLE
Avoid validating XML twice

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -161,7 +161,6 @@ public class VespaModelFactory implements ModelFactory {
 
     private List<ConfigChangeAction> validateModel(VespaModel model, DeployState deployState, boolean ignoreValidationErrors) {
         try {
-            deployState.getApplicationPackage().validateXML();
             return Validation.validate(model, ignoreValidationErrors, deployState);
         } catch (IllegalArgumentException e) {
             rethrowUnlessIgnoreErrors(e, ignoreValidationErrors);


### PR DESCRIPTION
validateXml() is always called before validateModel(), so remove this duplicate execution of that code.