### PR TITLE
Make antlr and antlr4 invisible for customer projects.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -75,6 +75,18 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- All dependencies that should be visible in test classpath, but not compile classpath,
+         for user projects must be added in compile scope here.
+         These dependencies are explicitly excluded (or set to non-compile scope) in the container-dev module. -->
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -112,11 +112,33 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-search-and-docproc</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-bundle</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Dependencies below are added explicitly to exclude transitive deps that are not provided runtime by the container,
+         and hence make them invisible to user projects' build classpath.
+        Excluded artifacts should be added explicitly to the application module to make then visible in users' test classpath. -->
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>predicate-search-core</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 </project>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -143,7 +143,6 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <version>4.5</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -211,7 +210,7 @@
       <plugin> <!-- For the YQL query language -->
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
-        <version>4.5</version>
+        <version>${antlr4.version}</version>
         <executions>
           <execution>
             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr3-maven-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${antlr.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -574,7 +574,12 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr-runtime</artifactId>
-                <version>3.5.2</version>
+                <version>${antlr.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr4.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.aries.spifly</groupId>
@@ -889,6 +894,8 @@
 
     <properties>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version> <!-- must be kept in sync with version used by current jersey2.version -->
+        <antlr.version>3.5.2</antlr.version>
+        <antlr4.version>4.5</antlr4.version>
         <aries.spifly.version>1.0.8</aries.spifly.version>
         <aries.util.version>1.0.0</aries.util.version>
         <asm-debug-all.version>5.0.3</asm-debug-all.version>


### PR DESCRIPTION
They will now only be visible in the test classpath for customer projects. I think it's better to use 'application' to control the test classpath of user projects, rather than introducing yet another test dependency that users must relate to.

`antlr4-runtime` was very straight forward, but `antlr-runtime` caused quite a bit of head scratching before I got it right.