### PR TITLE
Revert "Make antlr and antlr4 invisible for customer projects."

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -75,18 +75,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- All dependencies that should be visible in test classpath, but not compile classpath,
-         for user projects must be added in compile scope here.
-         These dependencies are explicitly excluded (or set to non-compile scope) in the container-dev module. -->
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr-runtime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -112,33 +112,11 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-search-and-docproc</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.antlr</groupId>
-          <artifactId>antlr4-runtime</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-bundle</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Dependencies below are added explicitly to exclude transitive deps that are not provided runtime by the container,
-         and hence make them invisible to user projects' build classpath.
-        Excluded artifacts should be added explicitly to the application module to make then visible in users' test classpath. -->
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>predicate-search-core</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.antlr</groupId>
-          <artifactId>antlr-runtime</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
   </dependencies>
 </project>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -143,6 +143,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
+      <version>4.5</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -210,7 +211,7 @@
       <plugin> <!-- For the YQL query language -->
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
-        <version>${antlr4.version}</version>
+        <version>4.5</version>
         <executions>
           <execution>
             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr3-maven-plugin</artifactId>
-                    <version>${antlr.version}</version>
+                    <version>3.5.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -574,12 +574,7 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr-runtime</artifactId>
-                <version>${antlr.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>${antlr4.version}</version>
+                <version>3.5.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.aries.spifly</groupId>
@@ -894,8 +889,6 @@
 
     <properties>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version> <!-- must be kept in sync with version used by current jersey2.version -->
-        <antlr.version>3.5.2</antlr.version>
-        <antlr4.version>4.5</antlr4.version>
         <aries.spifly.version>1.0.8</aries.spifly.version>
         <aries.util.version>1.0.0</aries.util.version>
         <asm-debug-all.version>5.0.3</asm-debug-all.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#3271

@gv or @bjorncs or @hmusum 

System tests are failing:
```
[16:59:39.343] Exception in thread "main" java.lang.NoClassDefFoundError: org/antlr/runtime/RecognitionException
[16:59:39.343] 	at com.yahoo.vespaxmlparser.VespaXMLFieldReader.read(VespaXMLFieldReader.java:414)
[16:59:39.343] 	at com.yahoo.document.datatypes.PredicateFieldValue.deserialize(PredicateFieldValue.java:81)
[16:59:39.343] 	at com.yahoo.vespaxmlparser.VespaXMLFieldReader.read(VespaXMLFieldReader.java:111)
[16:59:39.343] 	at com.yahoo.vespaxmlparser.VespaXMLDocumentReader.read(VespaXMLDocumentReader.java:47)
[16:59:39.343] 	at com.yahoo.document.Document.<init>(Document.java:78)
[16:59:39.343] 	at com.yahoo.vespaxmlparser.VespaXMLFeedReader.read(VespaXMLFeedReader.java:236)
[16:59:39.343] 	at com.yahoo.feedapi.Feeder.parse(Feeder.java:84)
[16:59:39.343] 	at com.yahoo.feedhandler.VespaFeedHandler.handle(VespaFeedHandler.java:96)
[16:59:39.343] 	at com.yahoo.vespafeeder.VespaFeeder.parseFiles(VespaFeeder.java:103)
[16:59:39.343] 	at com.yahoo.vespafeeder.VespaFeeder.main(VespaFeeder.java:153)
```