### PR TITLE
Show log output during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ install: true
 
 language: minimal
 
-script: travis_wait 120 ./travis/travis.sh $PLATFORM_LANGUAGE
+script: ./travis/travis.sh $PLATFORM_LANGUAGE
 

--- a/travis/travis.sh
+++ b/travis/travis.sh
@@ -2,8 +2,19 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 set -e
 
+# Workaround for Travis log output timeout (jobs without output over 10 minutes are killed)
+function bell() {
+  while true; do
+    echo -e "\a"
+    sleep 300
+  done
+}
+
 PLATFORM_LANGUAGE=$1
 DOCKER_IMAGE=vespaengine/vespa-dev:latest
+
+bell &
 docker run --rm -v ${HOME}/.m2:/root/.m2 -v ${HOME}/.ccache:/root/.ccache -v $(pwd):/source \
            --entrypoint /source/travis/travis-build-${PLATFORM_LANGUAGE}.sh ${DOCKER_IMAGE}
+exit $?
 


### PR DESCRIPTION
Stop using travis_wait as it hides log output during build