### PR TITLE
Put back removed ConfigGenerator.createClassName.

### DIFF
--- a/configgen/src/main/scala/com/yahoo/config/codegen/ConfigGenerator.scala
+++ b/configgen/src/main/scala/com/yahoo/config/codegen/ConfigGenerator.scala
@@ -3,10 +3,11 @@ package com.yahoo.config.codegen
 
 
 import com.yahoo.config.codegen.BuilderGenerator.getBuilder
-import com.yahoo.config.codegen.ConfiggenUtil.createClassName
 import com.yahoo.config.codegen.JavaClassBuilder.Indentation
 import com.yahoo.config.codegen.LeafCNode._
 import com.yahoo.config.codegen.ReservedWords.{INTERNAL_PREFIX => InternalPrefix}
+
+import scala.util.parsing.combinator.JavaTokenParsers
 
 /**
  * @author gjoranv
@@ -409,7 +410,7 @@ object ConfigGenerator {
     node match {
       case emptyName: CNode if node.getName.length == 0 =>
         throw new CodegenRuntimeException("Node with empty name, under parent " + emptyName.getParent.getName)
-      case root: InnerCNode if root.getParent == null => createClassName(root.getName)
+      case root: InnerCNode if root.getParent == null => ConfiggenUtil.createClassName(root.getName)
       case b: BooleanLeaf   => "BooleanNode"
       case d: DoubleLeaf    => "DoubleNode"
       case f: FileLeaf      => "FileNode"
@@ -449,4 +450,18 @@ object ConfigGenerator {
     }
   }
 
+  /**
+    * Deprecated!
+    * TODO: Remove when no longer used in the oldest active config model version.
+    */
+  @deprecated("Use ConfiggenUtil.createClassName() instead", "6.143")
+  def createClassName(defName: String): String = {
+    val className = defName.split("-").map (_.capitalize).mkString + "Config"
+    val parser = new JavaTokenParsers {}
+    parser.parseAll(parser.ident, className) match {
+      case parser.NoSuccess(msg, _) =>
+        throw new CodegenRuntimeException("Illegal config definition file name '" + defName + "': " + msg)
+      case success => success.get
+    }
+  }
 }


### PR DESCRIPTION
- It will still be used for a while by older config models.
  (By classes InstanceResolver and VespaModel.)

FYI: @hmusum, @aressem I think this is why at least one of the cloudconfig system tests started failing. 

@hmusum, it seems that the configserver does not log when a thread dies due to not finding the ConfigGenerator.createClassName method. Probably missing some error handling. Maybe an exception is caught, but not an error.