### PR TITLE
Fail on unresolved ip adresses

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -111,7 +111,10 @@ public class NodeRepository extends AbstractComponent {
 
     /** Returns the Docker image to use for nodes in this */
     public DockerImage dockerImage() { return dockerImage; }
-    
+
+    /** @return The name resolver used to resolve hostname and ip addresses */
+    public NameResolver nameResolver() { return nameResolver; }
+
     // ---------------- Query API ----------------------------------------------------------------
 
     /**
@@ -258,6 +261,7 @@ public class NodeRepository extends AbstractComponent {
         if (ipAddresses.isEmpty()) {
             ipAddresses = nameResolver.getAllByNameOrThrow(hostname);
         }
+
         return Node.create(openStackId, ImmutableSet.copyOf(ipAddresses), additionalIpAddresses, hostname, parentHostname, flavor, type);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.persistence;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -10,6 +11,20 @@ import java.util.Set;
  */
 public interface NameResolver {
 
+    /**
+     * Get IP addresses for given host name
+     *
+     * @param hostname The hostname to resolve
+     * @return A set of IPv4 or IPv6 addresses
+     */
     Set<String> getAllByNameOrThrow(String hostname);
+
+    /**
+     * Get hostname from IP address
+     *
+     * @param ipAddress The IPv4 or IPv6 address for the host
+     * @return Empty if the IP does not resolve or the hostname if it does
+     */
+    Optional<String> getHostname(String ipAddress);
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NameResolver.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Interface for a basic name to IP address resolver.
+ * Interface for a hostname/ip resolver.
  *
  * @author mpolden
  */
@@ -20,7 +20,7 @@ public interface NameResolver {
     Set<String> getAllByNameOrThrow(String hostname);
 
     /**
-     * Get hostname from IP address
+     * Get hostname from IP address.
      *
      * @param ipAddress The IPv4 or IPv6 address for the host
      * @return Empty if the IP does not resolve or the hostname if it does

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -54,12 +54,11 @@ class GroupPreparer {
 
                 // Create a prioritized set of nodes
                 NodePrioritizer prioritizer = new NodePrioritizer(nodeRepository.getNodes(),
-                        application,
-                        cluster,
-                        requestedNodes,
-                        nodeRepository.getAvailableFlavors(),
-                        nofSpares,
-                        nodeRepository.nameResolver());
+                                                                  application,
+                                                                  cluster,
+                                                                  requestedNodes,
+                                                                  nodeRepository.getAvailableFlavors(),
+                                                                  nofSpares);
 
                 prioritizer.addApplicationNodes();
                 prioritizer.addSurplusNodes(surplusActiveNodes);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -54,11 +54,12 @@ class GroupPreparer {
 
                 // Create a prioritized set of nodes
                 NodePrioritizer prioritizer = new NodePrioritizer(nodeRepository.getNodes(),
-                                                                  application,
-                                                                  cluster,
-                                                                  requestedNodes,
-                                                                  nodeRepository.getAvailableFlavors(),
-                                                                  nofSpares);
+                        application,
+                        cluster,
+                        requestedNodes,
+                        nodeRepository.getAvailableFlavors(),
+                        nofSpares,
+                        nodeRepository.nameResolver());
 
                 prioritizer.addApplicationNodes();
                 prioritizer.addSurplusNodes(surplusActiveNodes);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -58,7 +58,8 @@ class GroupPreparer {
                                                                   cluster,
                                                                   requestedNodes,
                                                                   nodeRepository.getAvailableFlavors(),
-                                                                  nofSpares);
+                                                                  nofSpares,
+                                                                  nodeRepository.nameResolver());
 
                 prioritizer.addApplicationNodes();
                 prioritizer.addSurplusNodes(surplusActiveNodes);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -43,9 +43,6 @@ public class NodePrioritizer {
     private final Set<Node> spareHosts;
     private final Map<Node, ResourceCapacity> headroomHosts;
 
-    /** This is before we mock DNS to resolve on test IP that we use in tests */
-    public static boolean unitTesting = false;
-
     NodePrioritizer(List<Node> allNodes, ApplicationId appId, ClusterSpec clusterSpec, NodeSpec nodeSpec, NodeFlavors nodeFlavors, int spares, NameResolver nameResolver) {
         this.allNodes = Collections.unmodifiableList(allNodes);
         this.requestedNodes = nodeSpec;
@@ -221,7 +218,7 @@ public class NodePrioritizer {
     }
 
     /**
-     * Add nodes already provisioned, but not allocatied to any application
+     * Add nodes already provisioned, but not allocated to any application
      */
     void addReadyNodes() {
         allNodes.stream()

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
+import com.google.common.net.InetAddresses;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Flavor;
@@ -20,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -77,11 +80,12 @@ class NodePrioritizer {
      *
      * @return hostname or null if not able to do the lookup
      */
-    private static String lookupHostname(String ipAddress) {
+    static String lookupHostname(String ipAddress) {
         try {
-            return InetAddress.getByName(ipAddress).getHostName();
+            String hostname = InetAddress.getByName(ipAddress).getHostName();
+            return InetAddresses.isInetAddress(hostname) ? null : hostname;
         } catch (UnknownHostException e) {
-            e.printStackTrace();
+            Logger.getLogger(NodePrioritizer.class.getName()).log(Level.FINER, "Unable to resolve ipaddress", e);
         }
         return null;
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  *
  * @author smorgrav
  */
-class NodePrioritizer {
+public class NodePrioritizer {
 
     private final Map<Node, PrioritizableNode> nodes = new HashMap<>();
     private final List<Node> allNodes;
@@ -46,6 +46,9 @@ class NodePrioritizer {
     private final boolean isAllocatingForReplacement;
     private final Set<Node> spareHosts;
     private final Map<Node, ResourceCapacity> headroomHosts;
+
+    /** This is before we mock DNS to resolve on test IP that we use in tests */
+    public static boolean unitTesting = false;
 
     NodePrioritizer(List<Node> allNodes, ApplicationId appId, ClusterSpec clusterSpec, NodeSpec nodeSpec, NodeFlavors nodeFlavors, int spares) {
         this.allNodes = Collections.unmodifiableList(allNodes);
@@ -83,6 +86,7 @@ class NodePrioritizer {
     static String lookupHostname(String ipAddress) {
         try {
             String hostname = InetAddress.getByName(ipAddress).getHostName();
+            if (unitTesting) return hostname;
             return InetAddresses.isInetAddress(hostname) ? null : hostname;
         } catch (UnknownHostException e) {
             Logger.getLogger(NodePrioritizer.class.getName()).log(Level.FINER, "Unable to resolve ipaddress", e);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
@@ -59,6 +59,7 @@ public class MockNameResolver implements NameResolver {
         if (mockAnyLookup) {
             Set<String> ipAddresses = Collections.singleton(randomIpAddress());
             records.put(hostname, ipAddresses);
+            return ipAddresses;
         }
         throw new RuntimeException(new UnknownHostException("Could not resolve: " + hostname));
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -68,6 +69,10 @@ public class MockNameResolver implements NameResolver {
     public Optional<String> getHostname(String ipAddress) {
         for (String host : records.keySet()) {
             if (records.get(host).contains(ipAddress)) return Optional.of(host);
+        }
+        if (mockAnyLookup) {
+            String hostname = UUID.randomUUID().toString();
+            records.put(hostname, Collections.singleton(ipAddress));
         }
         return Optional.empty();
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNameResolver.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -56,9 +57,18 @@ public class MockNameResolver implements NameResolver {
             return records.get(hostname);
         }
         if (mockAnyLookup) {
-            return Collections.singleton(randomIpAddress());
+            Set<String> ipAddresses = Collections.singleton(randomIpAddress());
+            records.put(hostname, ipAddresses);
         }
         throw new RuntimeException(new UnknownHostException("Could not resolve: " + hostname));
+    }
+
+    @Override
+    public Optional<String> getHostname(String ipAddress) {
+        for (String host : records.keySet()) {
+            if (records.get(host).contains(ipAddress)) return Optional.of(host);
+        }
+        return Optional.empty();
     }
 
     private static String randomIpAddress() {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -105,6 +105,7 @@ public class MockNodeRepository extends NodeRepository {
         nodes.remove(7);
         nodes = setDirty(nodes);
         setReady(nodes);
+
         fail("host5.yahoo.com", Agent.system, "Failing to unit test");
         setDirty("host55.yahoo.com");
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -62,6 +62,10 @@ public class MockNodeRepository extends NodeRepository {
         NodePrioritizer.unitTesting = true;
         List<Node> nodes = new ArrayList<>();
 
+        MockNameResolver nameResolver = (MockNameResolver)nameResolver();
+        nameResolver.addRecord("docker-node-1", "::2");
+        nameResolver.addRecord("docker-node-2", "::3");
+        nameResolver.addRecord("docker-node-3", "::4");
         final List<String> ipAddressesForAllHost = Arrays.asList("127.0.0.1", "::1");
         Collections.sort(ipAddressesForAllHost);
         final HashSet<String> ipAddresses = new HashSet<>(ipAddressesForAllHost);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Status;
+import com.yahoo.vespa.hosted.provision.provisioning.NodePrioritizer;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 
 import java.time.Clock;
@@ -58,7 +59,7 @@ public class MockNodeRepository extends NodeRepository {
 
     private void populate() {
         NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(this, flavors, Zone.defaultZone());
-
+        NodePrioritizer.unitTesting = true;
         List<Node> nodes = new ArrayList<>();
 
         final List<String> ipAddressesForAllHost = Arrays.asList("127.0.0.1", "::1");

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -19,7 +19,6 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Status;
-import com.yahoo.vespa.hosted.provision.provisioning.NodePrioritizer;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 
 import java.time.Clock;
@@ -59,13 +58,9 @@ public class MockNodeRepository extends NodeRepository {
 
     private void populate() {
         NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(this, flavors, Zone.defaultZone());
-        NodePrioritizer.unitTesting = true;
+
         List<Node> nodes = new ArrayList<>();
 
-        MockNameResolver nameResolver = (MockNameResolver)nameResolver();
-        nameResolver.addRecord("docker-node-1", "::2");
-        nameResolver.addRecord("docker-node-2", "::3");
-        nameResolver.addRecord("docker-node-3", "::4");
         final List<String> ipAddressesForAllHost = Arrays.asList("127.0.0.1", "::1");
         Collections.sort(ipAddressesForAllHost);
         final HashSet<String> ipAddresses = new HashSet<>(ipAddressesForAllHost);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisioningTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -70,7 +69,7 @@ public class DynamicDockerProvisioningTest {
     public void relocate_nodes_from_headroom_hosts() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.perf, RegionName.from("us-east")), flavorsConfig(true));
         enableDynamicAllocation(tester);
-        tester.makeReadyNodes(4, "host", "host-small", NodeType.host, 32);
+        tester.makeReadyNodes(4, "host-small", NodeType.host, 32);
         deployZoneApp(tester);
         List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
         Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("d-1");
@@ -118,7 +117,7 @@ public class DynamicDockerProvisioningTest {
     public void relocate_nodes_from_spare_hosts() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")), flavorsConfig());
         enableDynamicAllocation(tester);
-        tester.makeReadyNodes(4, "host", "host-small", NodeType.host, 32);
+        tester.makeReadyNodes(4, "host-small", NodeType.host, 32);
         deployZoneApp(tester);
         List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
         Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("d-1");
@@ -164,7 +163,7 @@ public class DynamicDockerProvisioningTest {
     public void new_docker_nodes_are_marked_as_headroom_violations() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.perf, RegionName.from("us-east")), flavorsConfig(true));
         enableDynamicAllocation(tester);
-        tester.makeReadyNodes(4, "host", "host-small", NodeType.host, 32);
+        tester.makeReadyNodes(4, "host-small", NodeType.host, 32);
         deployZoneApp(tester);
         List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
         Flavor flavorD2 = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("d-2");
@@ -220,7 +219,7 @@ public class DynamicDockerProvisioningTest {
     public void only_preferred_container_is_moved_from_hosts_with_headroom_violations() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.perf, RegionName.from("us-east")), flavorsConfig(true));
         enableDynamicAllocation(tester);
-        tester.makeReadyNodes(4, "host", "host-medium", NodeType.host, 32);
+        tester.makeReadyNodes(4, "host-medium", NodeType.host, 32);
         deployZoneApp(tester);
         List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
         Flavor flavorD2 = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("d-2");
@@ -289,7 +288,7 @@ public class DynamicDockerProvisioningTest {
     public void reloacte_failed_nodes() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")), flavorsConfig());
         enableDynamicAllocation(tester);
-        tester.makeReadyNodes(5, "host", "host-small", NodeType.host, 32);
+        tester.makeReadyNodes(5, "host-small", NodeType.host, 32);
         deployZoneApp(tester);
         List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
         Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("d-1");
@@ -348,7 +347,7 @@ public class DynamicDockerProvisioningTest {
     public void do_not_relocate_nodes_from_spare_if_no_where_to_reloacte_them() {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")), flavorsConfig());
         enableDynamicAllocation(tester);
-        tester.makeReadyNodes(2, "host", "host-small", NodeType.host, 32);
+        tester.makeReadyNodes(2, "host-small", NodeType.host, 32);
         deployZoneApp(tester);
         List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
         Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("d-1");
@@ -458,7 +457,7 @@ public class DynamicDockerProvisioningTest {
         ProvisioningTester tester = new ProvisioningTester(new Zone(Environment.prod, RegionName.from("us-east")), flavorsConfig());
         enableDynamicAllocation(tester);
 
-        tester.makeProvisionedNodes(3, UUID.randomUUID().toString(), "host-small", NodeType.host, 32);
+        tester.makeProvisionedNodes(3, "host-small", NodeType.host, 32);
         deployZoneApp(tester);
 
         ApplicationId application = tester.makeApplicationId();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisioningTest.java
@@ -22,6 +22,7 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -45,6 +46,11 @@ import static org.junit.Assert.fail;
  * @author mortent
  */
 public class DynamicDockerProvisioningTest {
+
+    @Before
+    public void setup() {
+        NodePrioritizer.unitTesting = true;
+    }
 
     /**
      * Test relocation of nodes that violate headroom.

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisioningTest.java
@@ -22,7 +22,6 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -45,11 +44,6 @@ import static org.junit.Assert.fail;
  * @author mortent
  */
 public class DynamicDockerProvisioningTest {
-
-    @Before
-    public void setup() {
-        NodePrioritizer.unitTesting = true;
-    }
 
     /**
      * Test relocation of nodes that violate headroom.

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizerTest.java
@@ -86,6 +86,9 @@ public class NodePrioritizerTest {
 
     @Test
     public void ignore_hosts_that_is_unresolved_in_dns() {
+        // Here we are testing the behavoir we need in production
+        NodePrioritizer.unitTesting = false;
+
         // Random IP that is not resolving
         String hostname = NodePrioritizer.lookupHostname("34.23.12.23");
         Assert.assertNull(hostname);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizerTest.java
@@ -83,26 +83,4 @@ public class NodePrioritizerTest {
         b.addFlavor("d2", 2, 2., 2, Flavor.Type.DOCKER_CONTAINER);
         return b.build();
     }
-
-    @Test
-    public void ignore_hosts_that_is_unresolved_in_dns() {
-        // Here we are testing the behavoir we need in production
-        NodePrioritizer.unitTesting = false;
-
-        // Random IP that is not resolving
-        String hostname = NodePrioritizer.lookupHostname("34.23.12.23");
-        Assert.assertNull(hostname);
-
-        // Localhost is always resolving
-        hostname = NodePrioritizer.lookupHostname("127.0.0.1");
-        Assert.assertNotNull(hostname);
-
-        // IPv6 Localhost is always resolving to a hostname
-        hostname = NodePrioritizer.lookupHostname("::1");
-        Assert.assertNotNull(hostname);
-
-        // Unspecified IPv6 should not resolve to a hostname
-        hostname = NodePrioritizer.lookupHostname("::");
-        Assert.assertNull(hostname);
-    }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizerTest.java
@@ -83,4 +83,23 @@ public class NodePrioritizerTest {
         b.addFlavor("d2", 2, 2., 2, Flavor.Type.DOCKER_CONTAINER);
         return b.build();
     }
+
+    @Test
+    public void ignore_hosts_that_is_unresolved_in_dns() {
+        // Random IP that is not resolving
+        String hostname = NodePrioritizer.lookupHostname("34.23.12.23");
+        Assert.assertNull(hostname);
+
+        // Localhost is always resolving
+        hostname = NodePrioritizer.lookupHostname("127.0.0.1");
+        Assert.assertNotNull(hostname);
+
+        // IPv6 Localhost is always resolving to a hostname
+        hostname = NodePrioritizer.lookupHostname("::1");
+        Assert.assertNotNull(hostname);
+
+        // Unspecified IPv6 should not resolve to a hostname
+        hostname = NodePrioritizer.lookupHostname("::");
+        Assert.assertNull(hostname);
+    }
 }


### PR DESCRIPTION
When creating docker nodes we lookup the hostname for one of the free ip adresses on the parent. If this fails, there is probably something wrong and we want to abort. 

One complication is that for testing we are using IP adresses that are not present in DNS so this check invalidates many tests. To circumvent this without sending a mock name resolver very deep in the code, I created a public static variable that we set in test. This seems a little hackish but is a pragmatic solution that I can live with. 
