### PR TITLE
Fix docker image pull retry

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
@@ -6,7 +6,6 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * API to simplify the com.github.dockerjava API for clients,
@@ -60,9 +59,14 @@ public interface Docker {
 
     Optional<Container> getContainer(ContainerName containerName);
 
-    CompletableFuture<DockerImage> pullImageAsync(DockerImage image);
-
-    boolean imageIsDownloaded(DockerImage image);
+    /**
+     * Checks if the image is currently being pulled or is already pulled, if not, starts an async
+     * pull of the image
+     *
+     * @param image Docker image to pull
+     * @return true iff image being pulled, false otherwise
+     */
+    boolean pullImageAsyncIfNeeded(DockerImage image);
 
     void deleteImage(DockerImage dockerImage);
 

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -29,21 +28,6 @@ public class DockerTest {
     private DockerImpl docker;
     private static final DockerImage dockerImage = new DockerImage("simple-ipv6-server:Dockerfile");
     private static final String MANAGER_NAME = "docker-test";
-
-    // It is ignored since it is a bit slow and unstable, at least on Mac.
-    @Ignore
-    @Test
-    public void testDockerImagePullDelete() throws ExecutionException, InterruptedException {
-        DockerImage dockerImage = new DockerImage("busybox:1.24.0");
-
-        // Pull the image and wait for the pull to complete
-        docker.pullImageAsync(dockerImage).get();
-        assertTrue("Failed to download " + dockerImage.asString() + " image", docker.imageIsDownloaded(dockerImage));
-
-        // Remove the image
-        docker.deleteImage(dockerImage);
-        assertFalse("Failed to delete " + dockerImage.asString() + " image", docker.imageIsDownloaded(dockerImage));
-    }
 
     // Ignored because the test is very slow (several minutes) when swap is enabled, to disable: (Linux)
     // $ sudo swapoff -a

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/RunSystemTests.java
@@ -151,9 +151,11 @@ public class RunSystemTests {
     }
 
     private void buildVespaSystestDockerImage(Docker docker, DockerImage vespaBaseImage) throws IOException, ExecutionException, InterruptedException {
-        if (!docker.imageIsDownloaded(vespaBaseImage)) {
+        if (docker.pullImageAsyncIfNeeded(vespaBaseImage)) {
             logger.info("Pulling " + vespaBaseImage.asString() + " (This may take a while)");
-            docker.pullImageAsync(vespaBaseImage).get();
+            while (docker.pullImageAsyncIfNeeded(vespaBaseImage)) {
+                Thread.sleep(5000);
+            };
         }
 
         Path systestBuildDirectory = pathToVespaRepoInHost.resolve("docker-api/src/test/resources/systest/");

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperations.java
@@ -17,12 +17,9 @@ public interface DockerOperations {
 
     void removeContainer(Container existingContainer);
 
-    // Returns false if image is already downloaded
-    boolean shouldScheduleDownloadOfImage(DockerImage dockerImage);
-
     Optional<Container> getContainer(ContainerName containerName);
 
-    void scheduleDownloadOfImage(ContainerName containerName, DockerImage dockerImage, Runnable callback);
+    boolean pullImageAsyncIfNeeded(DockerImage dockerImage);
 
     ProcessResult executeCommandInContainerAsRoot(ContainerName containerName, String... command);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -352,14 +352,8 @@ public class NodeAgentImpl implements NodeAgent {
     private void scheduleDownLoadIfNeeded(ContainerNodeSpec nodeSpec) {
         if (nodeSpec.currentDockerImage.equals(nodeSpec.wantedDockerImage)) return;
 
-        if (dockerOperations.shouldScheduleDownloadOfImage(nodeSpec.wantedDockerImage.get())) {
-            if (nodeSpec.wantedDockerImage.get().equals(imageBeingDownloaded)) {
-                // Downloading already scheduled, but not done.
-                return;
-            }
+        if (dockerOperations.pullImageAsyncIfNeeded(nodeSpec.wantedDockerImage.get())) {
             imageBeingDownloaded = nodeSpec.wantedDockerImage.get();
-            // Create a signalWorkToBeDone when download is finished.
-            dockerOperations.scheduleDownloadOfImage(containerName, imageBeingDownloaded, this::signalWorkToBeDone);
         } else if (imageBeingDownloaded != null) { // Image was downloading, but now it's ready
             imageBeingDownloaded = null;
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -111,28 +110,11 @@ public class DockerMock implements Docker {
     }
 
     @Override
-    public CompletableFuture<DockerImage> pullImageAsync(DockerImage image) {
+    public boolean pullImageAsyncIfNeeded(DockerImage image) {
         synchronized (monitor) {
-            callOrderVerifier.add("pullImageAsync with " + image);
-            final CompletableFuture<DockerImage> completableFuture = new CompletableFuture<>();
-            new Thread() {
-                public void run() {
-                    try {
-                        Thread.sleep(500);
-                        completableFuture.complete(image);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-
-                }
-            }.start();
-            return completableFuture;
+            callOrderVerifier.add("pullImageAsyncIfNeeded with " + image);
+            return false;
         }
-    }
-
-    @Override
-    public boolean imageIsDownloaded(DockerImage image) {
-        return true;
     }
 
     @Override

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -114,7 +114,7 @@ public class NodeAgentImplTest {
 
         verify(dockerOperations, never()).removeContainer(any());
         verify(orchestrator, never()).suspend(any(String.class));
-        verify(dockerOperations, never()).scheduleDownloadOfImage(eq(containerName), any(), any());
+        verify(dockerOperations, never()).pullImageAsyncIfNeeded(any());
 
         final InOrder inOrder = inOrder(dockerOperations, orchestrator, nodeRepository);
         // TODO: Verify this isn't run unless 1st time
@@ -147,14 +147,15 @@ public class NodeAgentImplTest {
 
         when(nodeRepository.getContainerNodeSpec(hostName)).thenReturn(Optional.of(nodeSpec));
         when(pathResolver.getApplicationStoragePathForNodeAdmin()).thenReturn(Files.createTempDirectory("foo"));
+        when(dockerOperations.pullImageAsyncIfNeeded(eq(dockerImage))).thenReturn(false);
 
         nodeAgent.converge();
 
         verify(dockerOperations, never()).removeContainer(any());
         verify(orchestrator, never()).suspend(any(String.class));
-        verify(dockerOperations, never()).scheduleDownloadOfImage(eq(containerName), any(), any());
 
         final InOrder inOrder = inOrder(dockerOperations, orchestrator, nodeRepository, aclMaintainer);
+        inOrder.verify(dockerOperations, times(1)).pullImageAsyncIfNeeded(eq(dockerImage));
         inOrder.verify(aclMaintainer, times(1)).run();
         inOrder.verify(dockerOperations, times(1)).startContainer(eq(containerName), eq(nodeSpec));
         inOrder.verify(dockerOperations, times(1)).resumeNode(eq(containerName));
@@ -185,7 +186,7 @@ public class NodeAgentImplTest {
         NodeAgentImpl nodeAgent = makeNodeAgent(dockerImage, true);
 
         when(nodeRepository.getContainerNodeSpec(hostName)).thenReturn(Optional.of(nodeSpec));
-        when(dockerOperations.shouldScheduleDownloadOfImage(any())).thenReturn(true);
+        when(dockerOperations.pullImageAsyncIfNeeded(any())).thenReturn(true);
 
         nodeAgent.converge();
 
@@ -194,8 +195,7 @@ public class NodeAgentImplTest {
         verify(dockerOperations, never()).removeContainer(any());
 
         final InOrder inOrder = inOrder(dockerOperations);
-        inOrder.verify(dockerOperations, times(1)).shouldScheduleDownloadOfImage(eq(newDockerImage));
-        inOrder.verify(dockerOperations, times(1)).scheduleDownloadOfImage(eq(containerName), eq(newDockerImage), any());
+        inOrder.verify(dockerOperations, times(1)).pullImageAsyncIfNeeded(eq(newDockerImage));
     }
 
     @Test


### PR DESCRIPTION
This simplifies the `docker-api` interface from having `imageIsDownloaded()` and `pullImageAsync()` to a single method that always check the state of the image and pulls image if need (`pullImageAsyncIfNeeded()`), which will automatically retry pull if it fails.

Removed callback from the interface because it was invalid anyway; the callback had to be stored per image, per container - not just per image. This would make it overly complicated for the tiny benefit: `NodeAgent` runs every 30 sec, so the callback would only save 15 sec on avg.