### PR TITLE
Remove FQDN check as not all systems are configured with $(hostname)=$(hostname --fqdn)

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/Host.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/Host.java
@@ -42,16 +42,10 @@ public final class Host extends AbstractConfigProducer<AbstractConfigProducer<?>
 
     private void checkName(HostSystem parent, String hostname) {
         // Give a warning if the host does not exist
-        // Host exists - warn if given hostname is not a fully qualified one.
-        String canonical = hostname;
         try {
-            canonical = parent.getCanonicalHostname(hostname);
+            parent.getCanonicalHostname(hostname);
         } catch (UnknownHostException e) {
             deployLogger().log(Level.WARNING, "Unable to find canonical hostname of host: " + hostname);
-        }
-        if ((null != canonical) && (! hostname.equals(canonical))) {
-            deployLogger().log(Level.WARNING, "Host named '" + hostname + "' will not receive any config " +
-                                              "since it does not match its canonical hostname: " + canonical);
         }
     }
 


### PR DESCRIPTION
@hmusum this check is causing a lot of issues on envs where 'hostname' does not return the same as hostname -f which is pretty common. Maybe you remember the reason it's there? 

CC @arnej27959 @bratseth  