### PR TITLE
Revert "Request shutdown instead of doing a std::quick_exit."

### DIFF
--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/util/host_name.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/component/vtag.h>
+#include <sstream>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".status");
@@ -91,8 +92,8 @@ void StatusWebServer::configure(std::unique_ptr<vespa::config::content::core::St
             if (_httpServer.get() != 0) {
                 ost << " Status server still running on port " << _port << " instead of suggested port " << newPort;
             }
-            LOG(fatal, "%s.", ost.str().c_str());
-            _component->requestShutdown(ost.str());
+            LOG(fatal, "Failed to start status HTTP server using port %u. Old port was %u. Exiting.", newPort, _port);
+            std::quick_exit(67);
         }
             // Now that we know config update went well, update internal state
         _port = server->getListenPort();


### PR DESCRIPTION
Reverts vespa-engine/vespa#3325
requestshutdown obviously did not do the right thing.