### PR TITLE
Use alias in record lookup

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/MemoryNameService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/MemoryNameService.java
@@ -2,9 +2,10 @@
 package com.yahoo.vespa.hosted.controller.api.integration.dns;
 
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -14,11 +15,15 @@ import java.util.UUID;
  */
 public class MemoryNameService implements NameService {
 
-    private final Set<Record> records = new HashSet<>();
+    private final List<Record> records = new ArrayList<>();
+
+    public List<Record> records() {
+        return Collections.unmodifiableList(records);
+    }
 
     @Override
     public RecordId createCname(String alias, String canonicalName) {
-        records.add(new Record("CNAME", alias, canonicalName));
+        records.add(new Record(Record.Type.CNAME.name(), alias, canonicalName));
         return new RecordId(UUID.randomUUID().toString());
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -373,7 +373,7 @@ public class ApplicationController {
         Rotation rotation = applicationRotation.rotations().iterator().next(); // at this time there should be only one rotation assigned
         String endpointName = alias.toString();
         try {
-            Optional<Record> record = nameService.findRecord(Record.Type.CNAME, rotation.rotationName);
+            Optional<Record> record = nameService.findRecord(Record.Type.CNAME, endpointName);
             if (!record.isPresent()) {
                 RecordId recordId = nameService.createCname(endpointName, rotation.rotationName);
                 log.info("Registered mapping with record ID " + recordId.id() + ": " +

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -63,12 +63,14 @@ public final class ControllerTester {
     private final ZoneRegistryMock zoneRegistryMock = new ZoneRegistryMock();
     private final GitHubMock gitHubMock = new GitHubMock();
     private final CuratorDb curator = new MockCuratorDb();
-    private Controller controller = createController(db, curator, configServerClientMock, clock, gitHubMock, zoneRegistryMock, athensDb);
+    private final MemoryNameService memoryNameService = new MemoryNameService();
+    private Controller controller = createController(db, curator, configServerClientMock, clock, gitHubMock,
+                                                     zoneRegistryMock, athensDb, memoryNameService);
     
     private static final Controller createController(ControllerDb db, CuratorDb curator,
                                                      ConfigServerClientMock configServerClientMock, ManualClock clock,
                                                      GitHubMock gitHubClientMock, ZoneRegistryMock zoneRegistryMock,
-                                                     AthensDbMock athensDb) {
+                                                     AthensDbMock athensDb, MemoryNameService nameService) {
         Controller controller = new Controller(db,
                                                curator,
                                                new MemoryRotationRepository(),
@@ -80,7 +82,7 @@ public final class ControllerTester {
                                                new CostMock(new MockInsightBackend()),
                                                configServerClientMock,
                                                new MockMetricsService(),
-                                               new MemoryNameService(),
+                                               nameService,
                                                new MockRoutingGenerator(),
                                                new ChefMock(),
                                                clock,
@@ -93,10 +95,12 @@ public final class ControllerTester {
     public CuratorDb curator() { return curator; }
     public ManualClock clock() { return clock; }
     public AthensDbMock athensDb() { return athensDb; }
+    public MemoryNameService nameService() { return memoryNameService; }
 
     /** Create a new controller instance. Useful to verify that controller state is rebuilt from persistence */
     public final void createNewController() {
-        controller = createController(db, curator, configServerClientMock, clock, gitHubMock, zoneRegistryMock, athensDb);
+        controller = createController(db, curator, configServerClientMock, clock, gitHubMock, zoneRegistryMock,
+                                      athensDb, memoryNameService);
     }
 
     public ZoneRegistryMock getZoneRegistryMock() { return zoneRegistryMock; }


### PR DESCRIPTION
Rotation name was incorrectly passed instead of the CNAME when looking for the existing record.