### PR TITLE
Remove boundary check for mapping from lid to referenced lid since

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -12,13 +12,11 @@ ImportedAttributeVectorReadGuard::ImportedAttributeVectorReadGuard(
         bool stableEnumGuard)
     : ImportedAttributeVector(name, std::move(reference_attribute), std::move(target_attribute)),
       _referencedLids(),
-      _referencedLidLimit(0u),
       _reference_attribute_guard(_reference_attribute),
       _target_attribute_guard(stableEnumGuard ? std::shared_ptr<AttributeVector>() : _target_attribute),
       _target_attribute_enum_guard(stableEnumGuard ? _target_attribute : std::shared_ptr<AttributeVector>())
 {
     _referencedLids = _reference_attribute->getReferencedLids();
-    _referencedLidLimit = _target_attribute->getCommittedDocIdLimit();
 }
 
 ImportedAttributeVectorReadGuard::~ImportedAttributeVectorReadGuard() {

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -17,14 +17,12 @@ class ImportedAttributeVectorReadGuard : public ImportedAttributeVector
 {
     using ReferencedLids = vespalib::ConstArrayRef<uint32_t>;
     ReferencedLids                      _referencedLids;
-    uint32_t                            _referencedLidLimit;
     AttributeGuard                      _reference_attribute_guard;
     AttributeGuard                      _target_attribute_guard;
     AttributeEnumGuard                  _target_attribute_enum_guard;
 
     uint32_t getReferencedLid(uint32_t lid) const {
-        uint32_t referencedLid = _referencedLids[lid];
-        return ((referencedLid >= _referencedLidLimit) ? 0u : referencedLid);
+        return _referencedLids[lid];
     }
 
 public:

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -28,7 +28,6 @@ ImportedSearchContext::ImportedSearchContext(
       _target_attribute(*_imported_attribute.getTargetAttribute()),
       _target_search_context(_target_attribute.getSearch(std::move(term), params)),
       _referencedLids(_reference_attribute.getReferencedLids()),
-      _referencedLidLimit(_target_attribute.getCommittedDocIdLimit()),
       _merger(_reference_attribute.getCommittedDocIdLimit()),
       _fetchPostingsDone(false)
 {

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -30,13 +30,11 @@ class ImportedSearchContext : public ISearchContext {
     const AttributeVector&                          _target_attribute;
     std::unique_ptr<AttributeVector::SearchContext> _target_search_context;
     ReferencedLids                                  _referencedLids;
-    uint32_t                                        _referencedLidLimit;
     PostingListMerger<int32_t>                      _merger;
     bool                                            _fetchPostingsDone;
 
     uint32_t getReferencedLid(uint32_t lid) const {
-        uint32_t referencedLid = _referencedLids[lid];
-        return ((referencedLid >= _referencedLidLimit) ? 0u : referencedLid);
+        return _referencedLids[lid];
     }
 
     void makeMergedPostings(bool isFilter);

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.cpp
@@ -35,7 +35,7 @@ ReferenceAttribute::ReferenceAttribute(const vespalib::stringref baseFileName,
       _indices(getGenerationHolder()),
       _cachedUniqueStoreMemoryUsage(),
       _gidToLidMapperFactory(),
-      _referenceMappings(getGenerationHolder())
+      _referenceMappings(getGenerationHolder(), getCommittedDocIdLimitRef())
 {
     setEnum(true);
     enableEnumeratedSave(true);

--- a/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
@@ -7,11 +7,12 @@
 
 namespace search::attribute {
 
-ReferenceMappings::ReferenceMappings(GenerationHolder &genHolder)
+ReferenceMappings::ReferenceMappings(GenerationHolder &genHolder, const uint32_t &committedDocIdLimit)
     : _reverseMappingIndices(genHolder),
       _referencedLidLimit(0),
       _reverseMapping(),
-      _referencedLids(genHolder)
+      _referencedLids(genHolder),
+      _committedDocIdLimit(committedDocIdLimit)
 {
 }
 


### PR DESCRIPTION
target attribute is populated before referenced lid is added to
mapping.

Adjust getReferencedLids() method to return const array ref with
safe size.

@geirst, please review