### PR TITLE
Gjoranv/remove fat model import

### DIFF
--- a/config-model-fat/pom.xml
+++ b/config-model-fat/pom.xml
@@ -321,7 +321,6 @@
               <!-- TODO: The fat bundle becomes more brittle for each package added below. Use interfaces in model-api instead. -->
               com.yahoo.vespa.config,
               com.yahoo.vespa.config.buildergen,
-              com.yahoo.config.codegen <!-- TODO remove when InnerCNode is no longer exposed by model-api -->
             </Import-Package>
           </instructions>
         </configuration>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -16,6 +16,7 @@
     <name>${project.artifactId}</name>
     <dependencies>
         <dependency>
+            <!-- Newer version than the one in rt.jar, including the ElementTraversal class needed by Xerces (Aug. 2015)-->
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>


### PR DESCRIPTION
There was a real and quite intricate reason for the failure of the "multiple config model versions" test. It all originated from a workaround in the pom.xml file of the fat models (see explanation in the code comment). 