### PR TITLE
Ensure that async deployment locks application

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainer.java
@@ -3,23 +3,14 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployer;
-import com.yahoo.config.provision.Deployment;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
-import com.yahoo.vespa.hosted.provision.node.History;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -62,6 +53,7 @@ public class OperatorChangeApplicationMaintainer extends ApplicationMaintainer {
                 .anyMatch(event -> event.agent() == Agent.operator && event.at().isAfter(instant));
     }
 
+    @Override
     protected void throttle(int applicationCount) { }
 
     /** 
@@ -69,9 +61,9 @@ public class OperatorChangeApplicationMaintainer extends ApplicationMaintainer {
      * longer to deploy than the (short) maintenance interval of this
      */
     @Override
-    protected void deploy(ApplicationId applicationId, Deployment deployment) {
-        deployment.activate();
-        log.info("Redeployed application " + applicationId.toShortString() + 
+    protected void deploy(ApplicationId application) {
+        deployWithLock(application);
+        log.info("Redeployed application " + application.toShortString() +
                  " as a manual change was made to its nodes");
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
@@ -1,23 +1,12 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployer;
-import com.yahoo.config.provision.Deployment;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import java.time.Duration;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 /**
  * The application maintainer regularly redeploys all applications to make sure the node repo and application
@@ -33,6 +22,7 @@ public class PeriodicApplicationMaintainer extends ApplicationMaintainer {
         super(deployer, nodeRepository, interval, jobControl);
     }
 
+    @Override
     protected void throttle(int applicationCount) {
         // Sleep for a length of time that will spread deployment evenly over the maintenance period
         try { Thread.sleep(interval().toMillis() / applicationCount); } catch (InterruptedException e) { return; }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -7,7 +7,6 @@ import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Deployer;
-import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.HostSpec;
@@ -217,8 +216,8 @@ public class PeriodicApplicationMaintainerTest {
         }
 
         @Override
-        protected void deploy(ApplicationId application, Deployment deployment) {
-            deployment.activate();
+        protected void deploy(ApplicationId application) {
+            deployWithLock(application);
         }
 
         protected void throttle(int applicationCount) { }


### PR DESCRIPTION
The previous implementation would release the lock as soon as the async implementation of `deploy` returned (which is immediately as it delegates to a executor which runs the deployment at a later time).

Observed this bug in the CD system, where an application was immediately reactivated after deletion.

FYI @bratseth 