### PR TITLE
Revert "Gjoranv/remove fat model import"

### DIFF
--- a/config-model-fat/pom.xml
+++ b/config-model-fat/pom.xml
@@ -321,6 +321,7 @@
               <!-- TODO: The fat bundle becomes more brittle for each package added below. Use interfaces in model-api instead. -->
               com.yahoo.vespa.config,
               com.yahoo.vespa.config.buildergen,
+              com.yahoo.config.codegen <!-- TODO remove when InnerCNode is no longer exposed by model-api -->
             </Import-Package>
           </instructions>
         </configuration>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -16,7 +16,6 @@
     <name>${project.artifactId}</name>
     <dependencies>
         <dependency>
-            <!-- Newer version than the one in rt.jar, including the ElementTraversal class needed by Xerces (Aug. 2015)-->
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#3362

Classloading error in configserver:
```
[2017-09-07 14:11:28.383] ERROR   : configserver     Container.com.yahoo.protect.Process
        java.lang.Error handling request
        exception=
        java.lang.LinkageError: loader constraint violation: when resolving method "com.yahoo.vespa.config.buildergen.ConfigDefinition.getCNode()Lcom/yahoo/config/codegen/InnerCNode;" the class loader (instance of or
g/apache/felix/framework/BundleWiringImpl$BundleClassLoaderJava5) of the current class, com/yahoo/config/model/deploy/DeployState$1, and the class loader (instance of org/apache/felix/framework/BundleWiringImpl$Bundl
eClassLoaderJava5) for the method's defining class, com/yahoo/vespa/config/buildergen/ConfigDefinition, have different Class objects for the ty
pe com/yahoo/config/codegen/InnerCNode used in the signature
        at com.yahoo.config.model.deploy.DeployState$1.parse(DeployState.java:147)
        at com.yahoo.config.model.deploy.DeployState.getConfigDefinition(DeployState.java:135)
        at com.yahoo.vespa.model.builder.UserConfigBuilder.buildElement(UserConfigBuilder.java:41)
        at com.yahoo.vespa.model.builder.UserConfigBuilder.build(UserConfigBuilder.java:31)
        at com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder$DomConfigProducerBuilder.initializeProducer(VespaDomBuilder.java:129)
        at com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder$DomConfigProducerBuilder.build(VespaDomBuilder.java:118)
        at com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder.getRoot(VespaDomBuilder.java:88)
        at com.yahoo.vespa.model.VespaModel.<init>(VespaModel.java:145)
        at com.yahoo.vespa.model.VespaModel.<init>(VespaModel.java:136)
        at com.yahoo.vespa.model.VespaModelFactory.buildModel(VespaModelFactory.java:123)
        at com.yahoo.vespa.model.VespaModelFactory.createAndValidateModel(VespaModelFactory.java:98)
        at com.yahoo.vespa.config.server.modelfactory.PreparedModelsBuilder.buildModelVersion(PreparedModelsBuilder.java:111)
        at com.yahoo.vespa.config.server.modelfactory.PreparedModelsBuilder.buildModelVersion(PreparedModelsBuilder.java:41)
        at com.yahoo.vespa.config.server.modelfactory.ModelsBuilder.buildModelVersion(ModelsBuilder.java:114)
        at com.yahoo.vespa.config.server.modelfactory.ModelsBuilder.buildModels(ModelsBuilder.java:82)
        at com.yahoo.vespa.config.server.session.SessionPreparer$Preparation.buildModels(SessionPreparer.java:182)
        at com.yahoo.vespa.config.server.session.SessionPreparer.prepare(SessionPreparer.java:95)
        at com.yahoo.vespa.config.server.session.LocalSession.prepare(LocalSession.java:68)
        at com.yahoo.vespa.config.server.ApplicationRepository.prepare(ApplicationRepository.java:310)
        at com.yahoo.vespa.config.server.http.v2.SessionPrepareHandler.handlePUT(SessionPrepareHandler.java:65)
        at com.yahoo.vespa.config.server.http.HttpHandler.handle(HttpHandler.java:43)
        at com.yahoo.container.jdisc.ThreadedHttpRequestHandler.handle(ThreadedHttpRequestHandler.java:67)
        at com.yahoo.container.jdisc.ThreadedHttpRequestHandler.handleRequest(ThreadedHttpRequestHandler.java:80)
        at com.yahoo.container.jdisc.ThreadedRequestHandler$RequestTask.processRequest(ThreadedRequestHandler.java:160)
        at com.yahoo.container.jdisc.ThreadedRequestHandler$RequestTask.run(ThreadedRequestHandler.java:154)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```