### PR TITLE
Exclude scala-xml from provided classpath

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -75,6 +75,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_${scala.major-version}</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- All dependencies that should be visible in test classpath, but not compile classpath,
          for user projects must be added in compile scope here.

--- a/config-bundle/pom.xml
+++ b/config-bundle/pom.xml
@@ -33,6 +33,13 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>configgen</artifactId>
       <version>${project.version}</version>
+      <!-- TODO: uncomment when the oldest available config-model uses the Java version of createClassName()
+      <exclusions>
+        <exclusion>
+          <groupId>org.scala-lang.modules</groupId>
+          <artifactId>scala-xml_${scala.major-version}</artifactId>
+        </exclusion>
+      </exclusions> -->
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -308,6 +308,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_${scala.major-version}</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -87,6 +87,11 @@
       <groupId>net.jpountz.lz4</groupId>
       <artifactId>lz4</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_${scala.major-version}</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/configgen/src/main/scala/com/yahoo/config/codegen/ConfigGenerator.scala
+++ b/configgen/src/main/scala/com/yahoo/config/codegen/ConfigGenerator.scala
@@ -452,7 +452,7 @@ object ConfigGenerator {
 
   /**
     * Deprecated!
-    * TODO: Remove when no longer used in config-model
+    * TODO: Remove when no longer used by the oldest available config-model.
     */
   @deprecated("Use ConfiggenUtil.createClassName() instead", "6.143")
   def createClassName(defName: String): String = {

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -139,6 +139,13 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-bundle</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- TODO: Remove exclusion when scala-xml is excluded in config-bundle pom -->
+          <groupId>org.scala-lang.modules</groupId>
+          <artifactId>scala-xml_${scala.major-version}</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Dependencies below are added explicitly to exclude transitive deps that are not provided runtime by the container,

--- a/standalone-container/pom.xml
+++ b/standalone-container/pom.xml
@@ -68,6 +68,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_${scala.major-version}</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
FYI: @hmusum 

- To prevent import-package for its packages.
- scala-xml is only used to generate config classes, and is not
  needed or provided runtime.
- Add scala-xml in scope test where it's used in unit tests.
- Do not exclude scala-xml from config-bundle until the oldest
  active config model uses the new Java version of
  createClassName.