### PR TITLE
Expose HdrHistogram in test scope instead of provided for users.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -92,6 +92,10 @@
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -42,6 +42,12 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>simplemetrics</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hdrhistogram</groupId>
+          <artifactId>HdrHistogram</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -738,6 +738,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>2.1.8</version>
+            </dependency>
+            <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20090211</version>

--- a/simplemetrics/pom.xml
+++ b/simplemetrics/pom.xml
@@ -20,7 +20,6 @@
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
@hmusum or @bratseth 

- It's not provided runtime, but we should consider doing so, as
  simplemetric:UntypedMetric exposes a public method that returns
  an org.HdrHistogram.DoubleHistogram.