### PR TITLE
Exclude findbugs artifacts from provided classpath.

### DIFF
--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -53,6 +53,16 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-lib</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -93,6 +103,14 @@
       <artifactId>container-disc</artifactId>
       <version>${project.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-lang</groupId>
           <artifactId>commons-lang</artifactId>
@@ -146,6 +164,10 @@
       <artifactId>config-bundle</artifactId>
       <version>${project.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
         <exclusion>
           <!-- TODO: Remove exclusion when scala-xml is excluded in config-bundle pom -->
           <groupId>org.scala-lang.modules</groupId>


### PR DESCRIPTION
- com.google.code.findbugs:annotations:jar:1.3.9
- com.google.code.findbugs:jsr305:jar:1.3.9
* There should be no reason to expose these in test scope, they
  only contain annotations.