### PR TITLE
Keep a gid to lid mapper live during the lifetime of an imported attr…

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -35,6 +35,7 @@ LOG_SETUP("attribute_manager_test");
 #include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/predicate/predicate_tree_annotator.h>
 #include <vespa/searchlib/test/directory_handler.h>
+#include <vespa/searchlib/test/mock_gid_to_lid_mapping.h>
 #include <vespa/searchlib/util/filekit.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
@@ -58,6 +59,7 @@ using search::attribute::IAttributeContext;
 using search::attribute::IAttributeVector;
 using search::attribute::ImportedAttributeVector;
 using search::attribute::ReferenceAttribute;
+using search::attribute::test::MockGidToLidMapperFactory;
 using search::index::DummyFileHeaderContext;
 using search::predicate::PredicateIndex;
 using search::predicate::PredicateTreeAnnotations;
@@ -132,6 +134,7 @@ struct ImportedAttributesRepoBuilder {
     ImportedAttributesRepoBuilder() : _repo(std::make_unique<ImportedAttributesRepo>()) {}
     void add(const vespalib::string &name) {
         auto refAttr = std::make_shared<ReferenceAttribute>(name + "_ref", AVConfig(BasicType::REFERENCE));
+        refAttr->setGidToLidMapperFactory(std::make_shared<MockGidToLidMapperFactory>());
         auto targetAttr = search::AttributeFactory::createAttribute(name + "_target", INT32_SINGLE);
         auto importedAttr = std::make_shared<ImportedAttributeVector>(name, refAttr, targetAttr, false);
         _repo->add(name, importedAttr);

--- a/searchcore/src/tests/proton/attribute/imported_attributes_context/imported_attributes_context_test.cpp
+++ b/searchcore/src/tests/proton/attribute/imported_attributes_context/imported_attributes_context_test.cpp
@@ -8,6 +8,7 @@ LOG_SETUP("imported_attributes_context_test");
 #include <vespa/searchlib/attribute/attribute.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector.h>
+#include <vespa/searchlib/test/mock_gid_to_lid_mapping.h>
 #include <future>
 
 using namespace proton;
@@ -17,12 +18,15 @@ using search::attribute::Config;
 using search::attribute::IAttributeVector;
 using search::attribute::ImportedAttributeVector;
 using search::attribute::ReferenceAttribute;
+using search::attribute::test::MockGidToLidMapperFactory;
 using generation_t = AttributeVector::generation_t;
 
 ReferenceAttribute::SP
 createReferenceAttribute(const vespalib::string &name)
 {
-    return std::make_shared<ReferenceAttribute>(name, Config(BasicType::REFERENCE));
+    auto refAttr = std::make_shared<ReferenceAttribute>(name, Config(BasicType::REFERENCE));
+    refAttr->setGidToLidMapperFactory(std::make_shared<MockGidToLidMapperFactory>());
+    return refAttr;
 }
 
 AttributeVector::SP

--- a/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_mapper.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_mapper.cpp
@@ -16,17 +16,6 @@ GidToLidMapper::~GidToLidMapper()
 {
 }
 
-uint32_t
-GidToLidMapper::mapGidToLid(const document::GlobalId &gid) const
-{
-    uint32_t lid = 0;
-    if (_dms.getLid(gid, lid)) {
-        return lid;
-    } else {
-        return 0u;
-    }
-}
-
 void
 GidToLidMapper::foreach(const search::IGidToLidMapperVisitor &visitor) const
 {

--- a/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_mapper.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_mapper.h
@@ -21,7 +21,6 @@ public:
     GidToLidMapper(vespalib::GenerationHandler::Guard &&guard,
                    const DocumentMetaStore &dms);
     virtual ~GidToLidMapper();
-    virtual uint32_t mapGidToLid(const document::GlobalId &gid) const override;
     virtual void foreach(const search::IGidToLidMapperVisitor &visitor) const override;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "imported_attribute_vector_read_guard.h"
+#include <vespa/searchlib/common/i_gid_to_lid_mapper.h>
+#include <vespa/searchlib/common/i_gid_to_lid_mapper_factory.h>
 
 namespace search {
 namespace attribute {
@@ -15,7 +17,8 @@ ImportedAttributeVectorReadGuard::ImportedAttributeVectorReadGuard(
       _referencedLids(),
       _reference_attribute_guard(_reference_attribute),
       _target_attribute_guard(stableEnumGuard ? std::shared_ptr<AttributeVector>() : _target_attribute),
-      _target_attribute_enum_guard(stableEnumGuard ? _target_attribute : std::shared_ptr<AttributeVector>())
+      _target_attribute_enum_guard(stableEnumGuard ? _target_attribute : std::shared_ptr<AttributeVector>()),
+      _mapper(_reference_attribute->getGidToLidMapperFactory()->getMapper())
 {
     _referencedLids = _reference_attribute->getReferencedLids();
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -5,6 +5,8 @@
 #include "imported_attribute_vector.h"
 #include "attributeguard.h"
 
+namespace search { class IGidToLidMapper; }
+
 namespace search::attribute {
 
 class BitVectorSearchCache;
@@ -22,6 +24,7 @@ class ImportedAttributeVectorReadGuard : public ImportedAttributeVector
     AttributeGuard                      _reference_attribute_guard;
     AttributeGuard                      _target_attribute_guard;
     AttributeEnumGuard                  _target_attribute_enum_guard;
+    std::unique_ptr<IGidToLidMapper>    _mapper;
 
     uint32_t getReferencedLid(uint32_t lid) const {
         return _referencedLids[lid];

--- a/searchlib/src/vespa/searchlib/common/i_gid_to_lid_mapper.h
+++ b/searchlib/src/vespa/searchlib/common/i_gid_to_lid_mapper.h
@@ -29,7 +29,6 @@ class IGidToLidMapper
 {
 public:
     virtual ~IGidToLidMapper() { }
-    virtual uint32_t mapGidToLid(const document::GlobalId &gid) const = 0;
     virtual void foreach(const IGidToLidMapperVisitor &visitor) const = 0;
 };
 

--- a/searchlib/src/vespa/searchlib/test/mock_gid_to_lid_mapping.h
+++ b/searchlib/src/vespa/searchlib/test/mock_gid_to_lid_mapping.h
@@ -21,15 +21,6 @@ struct MockGidToLidMapper : public search::IGidToLidMapper {
     {
     }
 
-    uint32_t mapGidToLid(const document::GlobalId &gid) const override {
-        auto itr = _map.find(gid);
-        if (itr != _map.end()) {
-            return itr->second;
-        } else {
-            return 0u;
-        }
-    }
-
     void foreach(const search::IGidToLidMapperVisitor &visitor) const override {
         for (const auto &kv : _map) {
             if (kv.second != 0) {


### PR DESCRIPTION
…ibute

read guard, to avoid premature reuse of referenced lid.

@geirst, please review