### PR TITLE
Exclude org.ow2.asm:asm from provided classpath.

### DIFF
--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -103,6 +103,12 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-jersey2</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
- Test classpath already contains org.ow2.asm:asm-debug-all.