### PR TITLE
Add component managing the SuperModel

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationListener.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationListener.java
@@ -1,0 +1,24 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.config.server;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.TenantName;
+import com.yahoo.vespa.config.server.application.ApplicationSet;
+
+public interface ApplicationListener {
+    /**
+     * Configs has been activated for an application: Either an application
+     * has been deployed for the first time, or it has been externally or internally redeployed.
+     *
+     * Must be thread-safe.
+     */
+    void configActivated(TenantName tenant, ApplicationSet application);
+
+    /**
+     * Application has been removed.
+     *
+     * Must be thread-safe.
+     */
+    void applicationRemoved(ApplicationId applicationId);
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ReloadListener.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ReloadListener.java
@@ -15,16 +15,7 @@ import java.util.Collection;
  * @author lulf
  * @since 5.1
  */
-public interface ReloadListener {
-    
-    /**
-     * Signal the listener that config has been reloaded.
-     *
-     * @param tenant Name of tenant for which config was reloaded.
-     * @param application the {@link com.yahoo.vespa.config.server.application.Application} that will be reloaded
-     */
-    public void configReloaded(TenantName tenant, ApplicationSet application);
-
+public interface ReloadListener extends ApplicationListener {
     /**
      * Signal the listener that hosts used by by a particular tenant.
      *
@@ -35,18 +26,10 @@ public interface ReloadListener {
 
     /**
      * Verify that given hosts are available for use by tenant.
-     * TODO: Does not belong here...
      *
      * @param tenant tenant that wants to allocate hosts.
      * @param newHosts a {@link java.util.Collection} of hosts that tenant wants to allocate.
      * @throws java.lang.IllegalArgumentException if one or more of the hosts are in use by another tenant.
      */
     void verifyHostsAreAvailable(TenantName tenant, Collection<String> newHosts);
-
-    /**
-     * Notifies listener that application with id {@link ApplicationId} has been removed.
-     *
-     * @param applicationId The {@link ApplicationId} of the removed application.
-     */
-    void applicationRemoved(ApplicationId applicationId);
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelController.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelController.java
@@ -68,7 +68,7 @@ public class SuperModelController {
         }
     }
 
-    SuperModel getSuperModel() {
+    public SuperModel getSuperModel() {
         return model;
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelListener.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelListener.java
@@ -1,0 +1,23 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.config.server;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.config.server.application.Application;
+import com.yahoo.vespa.config.server.model.SuperModel;
+
+/**
+ * Interface for those wanting to be notified about changes to the SuperModel.
+ */
+public interface SuperModelListener {
+    /**
+     * Application has been activated: Either deployed the first time,
+     * internally redeployed, or externally triggered redeploy.
+     */
+    void applicationActivated(SuperModel superModel, Application application);
+
+    /**
+     * Application has been removed.
+     */
+    void applicationRemoved(SuperModel superModel, ApplicationId applicationId);
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelManager.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelManager.java
@@ -1,0 +1,108 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.config.server;
+
+import com.google.inject.Inject;
+import com.yahoo.cloud.config.ConfigserverConfig;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.config.provision.TenantName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.vespa.config.GenerationCounter;
+import com.yahoo.vespa.config.server.application.Application;
+import com.yahoo.vespa.config.server.application.ApplicationSet;
+import com.yahoo.vespa.config.server.model.SuperModel;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Provides a SuperModel - a model of all application instances,  and makes it stays
+ * up to date as applications are added, redeployed, and removed.
+ */
+public class SuperModelManager implements SuperModelProvider, ApplicationListener {
+    private final Zone zone;
+    private SuperModel superModel;  // Guarded by 'this' monitor
+    private final List<SuperModelListener> listeners = new ArrayList<>();  // Guarded by 'this' monitor
+
+    // Generation of the super model
+    private long generation;
+    private final long masterGeneration; // ConfigserverConfig's generation
+    private final GenerationCounter generationCounter;
+
+    @Inject
+    public SuperModelManager(ConfigserverConfig configserverConfig,
+                             NodeFlavors nodeFlavors,
+                             GenerationCounter generationCounter) {
+        this.zone = new Zone(configserverConfig, nodeFlavors);
+        this.generationCounter = generationCounter;
+        this.masterGeneration = configserverConfig.masterGeneration();
+        makeNewSuperModel(new HashMap<>());
+    }
+
+    @Override
+    public synchronized SuperModel getSuperModel() {
+        return superModel;
+    }
+
+    @Override
+    public synchronized long getGeneration() {
+        return generation;
+    }
+
+    @Override
+    public synchronized void registerListener(SuperModelListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public synchronized void configActivated(TenantName tenant, ApplicationSet applicationSet) {
+        Map<TenantName, Map<ApplicationId, Application>> newModels = createModelCopy();
+        if (!newModels.containsKey(tenant)) {
+            // New application has been activated
+            newModels.put(tenant, new LinkedHashMap<>());
+        } else {
+            // Application has been redeployed
+        }
+
+        // TODO: Should supermodel care about multiple versions?
+        Application application = applicationSet.getForVersionOrLatest(Optional.empty(), Instant.now());
+        newModels.get(tenant).put(applicationSet.getId(), application);
+
+        makeNewSuperModel(newModels);
+        listeners.stream().forEach(listener -> listener.applicationActivated(superModel, application));
+    }
+
+    @Override
+    public synchronized void applicationRemoved(ApplicationId applicationId) {
+        Map<TenantName, Map<ApplicationId, Application>> newModels = createModelCopy();
+        if (newModels.containsKey(applicationId.tenant())) {
+            newModels.get(applicationId.tenant()).remove(applicationId);
+            if (newModels.get(applicationId.tenant()).isEmpty()) {
+                newModels.remove(applicationId.tenant());
+            }
+        }
+
+        makeNewSuperModel(newModels);
+        listeners.stream().forEach(listener -> listener.applicationRemoved(superModel, applicationId));
+    }
+
+    private void makeNewSuperModel(Map<TenantName, Map<ApplicationId, Application>> newModels) {
+        generation = masterGeneration + generationCounter.get();
+        superModel = new SuperModel(newModels, zone);
+    }
+
+    private Map<TenantName, Map<ApplicationId, Application>> createModelCopy() {
+        Map<TenantName, Map<ApplicationId, Application>> currentModels = superModel.applicationModels();
+        Map<TenantName, Map<ApplicationId, Application>> newModels = new LinkedHashMap<>();
+        for (Map.Entry<TenantName, Map<ApplicationId, Application>> entry : currentModels.entrySet()) {
+            Map<ApplicationId, Application> appMap = new LinkedHashMap<>();
+            newModels.put(entry.getKey(), appMap);
+            for (Map.Entry<ApplicationId, Application> appEntry : entry.getValue().entrySet()) {
+                appMap.put(appEntry.getKey(), appEntry.getValue());
+            }
+        }
+
+        return newModels;
+    }
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelProvider.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelProvider.java
@@ -1,0 +1,12 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.config.server;
+
+import com.yahoo.vespa.config.server.model.SuperModel;
+
+interface SuperModelProvider {
+    SuperModel getSuperModel();
+    long getGeneration();
+
+    void registerListener(SuperModelListener listener);
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelRequestHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/SuperModelRequestHandler.java
@@ -7,30 +7,26 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.provision.NodeFlavors;
 import com.yahoo.config.provision.Version;
-import com.yahoo.config.provision.Zone;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
+import com.yahoo.vespa.config.GenerationCounter;
 import com.yahoo.vespa.config.GetConfigRequest;
 import com.yahoo.vespa.config.protocol.ConfigResponse;
 import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
-import com.yahoo.vespa.config.GenerationCounter;
 import com.yahoo.vespa.config.server.application.ApplicationSet;
-import com.yahoo.vespa.config.server.model.SuperModel;
 import com.yahoo.vespa.config.server.rpc.ConfigResponseFactory;
 import com.yahoo.vespa.config.server.rpc.ConfigResponseFactoryFactory;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 /**
- * Handles request for supermodel config
+ * Handles request for supermodel config.
  *
  * @author lulf
  * @since 5.9
@@ -39,82 +35,47 @@ public class SuperModelRequestHandler implements RequestHandler {
 
     private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(SuperModelRequestHandler.class.getName());
     private volatile SuperModelController handler;
-    private final GenerationCounter generationCounter;
-    private final Zone zone;
-    private final long masterGeneration;
     private final ConfigDefinitionRepo configDefinitionRepo;
     private final ConfigResponseFactory responseFactory;
+    private final SuperModelManager superModelManager;
     private volatile boolean enabled = false;
 
     /**
      * Creates a supermodel controller
      */
     @Inject
-    public SuperModelRequestHandler(GenerationCounter generationCounter, ConfigDefinitionRepo configDefinitionRepo,
-                                    ConfigserverConfig configserverConfig, NodeFlavors nodeFlavors) {
-        this.generationCounter = generationCounter;
+    public SuperModelRequestHandler(ConfigDefinitionRepo configDefinitionRepo,
+                                    ConfigserverConfig configserverConfig,
+                                    SuperModelManager superModelManager) {
         this.configDefinitionRepo = configDefinitionRepo;
-        this.masterGeneration = configserverConfig.masterGeneration();
         this.responseFactory = ConfigResponseFactoryFactory.createFactory(configserverConfig);
-        this.zone = new Zone(configserverConfig, nodeFlavors);
-        this.handler = createNewHandler(Collections.emptyMap());
+        this.superModelManager = superModelManager;
+        updateHandler();
     }
 
     /**
      * Signals that config has been reloaded for an {@link com.yahoo.vespa.config.server.application.Application}
      * belonging to a tenant.
      *
-     * TODO: This is a bit too complex I think.
-     *
      * @param tenant Name of tenant owning the application.
      * @param applicationSet The reloaded set of {@link com.yahoo.vespa.config.server.application.Application}.
      */
     public synchronized void reloadConfig(TenantName tenant, ApplicationSet applicationSet) {
-        Map<TenantName, Map<ApplicationId, Application>> newModels = createModelCopy();
-        if (!newModels.containsKey(tenant)) {
-            newModels.put(tenant, new LinkedHashMap<>());
-        }
-        // TODO: Should supermodel care about multiple versions?
-        newModels.get(tenant).put(applicationSet.getId(), applicationSet.getForVersionOrLatest(Optional.empty(), Instant.now()));
-        handler = createNewHandler(newModels);
+        superModelManager.configActivated(tenant, applicationSet);
+        updateHandler();
     }
 
     public synchronized void removeApplication(ApplicationId applicationId) {
-        Map<TenantName, Map<ApplicationId, Application>> newModels = createModelCopy();
-        if (newModels.containsKey(applicationId.tenant())) {
-            newModels.get(applicationId.tenant()).remove(applicationId);
-            if (newModels.get(applicationId.tenant()).isEmpty()) {
-                newModels.remove(applicationId.tenant());
-            }
-        }
-        handler = createNewHandler(newModels);
+        superModelManager.applicationRemoved(applicationId);
+        updateHandler();
     }
 
-    private SuperModelController createNewHandler(Map<TenantName, Map<ApplicationId, Application>> newModels) {
-        long generation = generationCounter.get() + masterGeneration;
-        SuperModel model = new SuperModel(newModels, zone);
-        return new SuperModelController(model, configDefinitionRepo, generation, responseFactory);
-    }
-
-    private Map<TenantName, Map<ApplicationId, Application>> getCurrentModels() {
-        if (handler != null) {
-            return handler.getSuperModel().applicationModels();
-        } else {
-            return new LinkedHashMap<>();
-        }
-    }
-
-    private Map<TenantName, Map<ApplicationId, Application>> createModelCopy() {
-        Map<TenantName, Map<ApplicationId, Application>> currentModels = getCurrentModels();
-        Map<TenantName, Map<ApplicationId, Application>> newModels = new LinkedHashMap<>();
-        for (Map.Entry<TenantName, Map<ApplicationId, Application>> entry : currentModels.entrySet()) {
-            Map<ApplicationId, Application> appMap = new LinkedHashMap<>();
-            newModels.put(entry.getKey(), appMap);
-            for (Map.Entry<ApplicationId, Application> appEntry : entry.getValue().entrySet()) {
-                appMap.put(appEntry.getKey(), appEntry.getValue());
-            }
-        }
-        return newModels;
+    private void updateHandler() {
+        handler = new SuperModelController(
+                superModelManager.getSuperModel(),
+                configDefinitionRepo,
+                superModelManager.getGeneration(),
+                responseFactory);
     }
 
     public SuperModelController getHandler() { return handler; }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/model/SuperModel.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/model/SuperModel.java
@@ -13,6 +13,7 @@ import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.server.application.Application;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -26,7 +27,7 @@ public class SuperModel implements LbServicesConfig.Producer, RoutingConfig.Prod
     private final Map<TenantName, Map<ApplicationId, Application>> models;
     private final LbServicesProducer lbProd;
     private final RoutingProducer zoneProd;
-    
+
     public SuperModel(Map<TenantName, Map<ApplicationId, Application>> models, Zone zone) {
         this.models = models;
         this.lbProd = new LbServicesProducer(Collections.unmodifiableMap(models), zone);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
@@ -187,7 +187,7 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
      * This method should be called when config is reloaded in the server.
      */
     @Override
-    public void configReloaded(TenantName tenant, ApplicationSet applicationSet) {
+    public void configActivated(TenantName tenant, ApplicationSet applicationSet) {
         ApplicationId applicationId = applicationSet.getId();
         configReloaded(delayedConfigResponses.drainQueue(applicationId), Tenants.logPre(applicationId));
         reloadSuperModel(tenant, applicationSet);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandler.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.config.server.tenant;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.util.*;
 
 import com.yahoo.config.provision.Version;
@@ -81,7 +80,7 @@ public class TenantRequestHandler implements RequestHandler, ReloadHandler, Host
     private void notifyReloadListeners(ApplicationSet applicationSet) {
         for (ReloadListener reloadListener : reloadListeners) {
             reloadListener.hostsUpdated(tenant, hostRegistry.getAllHosts());
-            reloadListener.configReloaded(tenant, applicationSet);
+            reloadListener.configActivated(tenant, applicationSet);
         }
     }
 

--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -15,6 +15,7 @@
     <component id="com.yahoo.vespa.config.server.session.FileDistributionFactory" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.modelfactory.ModelFactoryRegistry" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.SuperModelGenerationCounter" bundle="configserver" />
+    <component id="com.yahoo.vespa.config.server.SuperModelManager" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.session.SessionPreparer" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.SuperModelRequestHandler" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.StaticConfigDefinitionRepo" bundle="configserver" />

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/SuperModelRequestHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/SuperModelRequestHandlerTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.*;
 public class SuperModelRequestHandlerTest {
 
     private static final File testApp = new File("src/test/resources/deploy/app");
+    private SuperModelManager manager;
     private SuperModelGenerationCounter counter;
     private SuperModelRequestHandler controller;
 
@@ -43,10 +44,9 @@ public class SuperModelRequestHandlerTest {
     @Before
     public void setup() throws IOException {
         counter = new SuperModelGenerationCounter(new MockCurator());
-        controller = new SuperModelRequestHandler(counter,
-                                                  new TestConfigDefinitionRepo(),
-                                                  new ConfigserverConfig(new ConfigserverConfig.Builder()),
-                                                  emptyNodeFlavors());
+        ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder());
+        manager = new SuperModelManager(configserverConfig, emptyNodeFlavors(), counter);
+        controller = new SuperModelRequestHandler(new TestConfigDefinitionRepo(), configserverConfig, manager);
     }
 
     @Test
@@ -95,10 +95,9 @@ public class SuperModelRequestHandlerTest {
     public void test_super_model_master_generation() throws IOException, SAXException {
         TenantName tenantA = TenantName.from("a");
         long masterGen = 10;
-        controller = new SuperModelRequestHandler(counter,
-                                                  new TestConfigDefinitionRepo(),
-                                                  new ConfigserverConfig(new ConfigserverConfig.Builder().masterGeneration(masterGen)),
-                                                  emptyNodeFlavors());
+        ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder().masterGeneration(masterGen));
+        manager = new SuperModelManager(configserverConfig, emptyNodeFlavors(), counter);
+        controller = new SuperModelRequestHandler(new TestConfigDefinitionRepo(), configserverConfig, manager);
 
         long gen = counter.increment();
         controller.reloadConfig(tenantA, createApp(tenantA, "foo", 3L, 1));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/RpcServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/RpcServerTest.java
@@ -75,7 +75,7 @@ public class RpcServerTest extends TestWithRpc {
         generationCounter.increment();
         Application app = new Application(new VespaModel(MockApplicationPackage.createEmpty()), new ServerCache(), 2l, Version.fromIntValues(1, 2, 3), MetricUpdater.createTestUpdater(), ApplicationId.defaultId());
         ApplicationSet appSet = ApplicationSet.fromSingle(app);
-        rpcServer.configReloaded(TenantName.defaultName(), appSet);
+        rpcServer.configActivated(TenantName.defaultName(), appSet);
         ConfigKey<?> key = new ConfigKey<>(LbServicesConfig.class, "*");
         JRTClientConfigRequest clientReq = JRTClientConfigRequestV3.createFromRaw(new RawConfig(key, LbServicesConfig.CONFIG_DEF_MD5), 120_000, Trace.createDummy(), CompressionType.UNCOMPRESSED, Optional.empty());
         assertTrue(clientReq.validateParameters());

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/TestWithRpc.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/TestWithRpc.java
@@ -11,12 +11,9 @@ import com.yahoo.jrt.Transport;
 import com.yahoo.net.HostName;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.config.GenerationCounter;
-import com.yahoo.vespa.config.server.SuperModelRequestHandler;
+import com.yahoo.vespa.config.server.*;
 import com.yahoo.vespa.config.server.host.ConfigRequestHostLivenessTracker;
 import com.yahoo.vespa.config.server.host.HostRegistries;
-import com.yahoo.vespa.config.server.MemoryGenerationCounter;
-import com.yahoo.vespa.config.server.PortRangeAllocator;
-import com.yahoo.vespa.config.server.TestConfigDefinitionRepo;
 import com.yahoo.vespa.config.server.monitoring.Metrics;
 import com.yahoo.vespa.config.server.tenant.MockTenantProvider;
 import org.junit.After;
@@ -82,11 +79,14 @@ public class TestWithRpc {
     }
 
     protected void createAndStartRpcServer(boolean hostedVespa) {
+        ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder());
         rpcServer = new RpcServer(new ConfigserverConfig(new ConfigserverConfig.Builder().rpcport(port).numthreads(1).maxgetconfigclients(1).hostedVespa(hostedVespa)),
-                                  new SuperModelRequestHandler(generationCounter,
-                                                               new TestConfigDefinitionRepo(),
-                                                               new ConfigserverConfig(new ConfigserverConfig.Builder()),
-                                                               emptyNodeFlavors()),
+                                  new SuperModelRequestHandler(new TestConfigDefinitionRepo(),
+                                                               configserverConfig,
+                                                               new SuperModelManager(
+                                                                       configserverConfig,
+                                                                       emptyNodeFlavors(),
+                                                                       generationCounter)),
                                   Metrics.createTestMetrics(), new HostRegistries(),
                                   hostLivenessTracker);
         rpcServer.onTenantCreate(TenantName.from("default"), tenantProvider);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandlerTest.java
@@ -242,7 +242,7 @@ public class TenantRequestHandlerTest extends TestWithCurator {
         public AtomicInteger removed = new AtomicInteger(0);
         public Map<String, Collection<String>> tenantHosts = new LinkedHashMap<>();
         @Override
-        public void configReloaded(TenantName tenant, ApplicationSet application) {
+        public void configActivated(TenantName tenant, ApplicationSet application) {
             reloaded.incrementAndGet();
         }
 


### PR DESCRIPTION
This is the prerequisite step for having the Orchestrator depend on the
SuperModel component, getting notified via SuperModelListener about newly
activated or removed applications.

The Orchestrator will then register for Slobrok as necessary, and also update
its data structures of the model.