### PR TITLE
Only set override for the canonical service endpoint

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingEndpoint.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingEndpoint.java
@@ -8,23 +8,32 @@ public class RoutingEndpoint {
 
     private final boolean isGlobal;
     private final String endpoint;
+    private final String hostname;
 
     public RoutingEndpoint(String endpoint, boolean isGlobal) {
         this.endpoint = endpoint;
+        this.hostname = null;
         this.isGlobal = isGlobal;
     }
 
-    /**
-     * @return True if the endpoint is global
-     */
+    public RoutingEndpoint(String endpoint, String hostname, boolean isGlobal) {
+        this.endpoint = endpoint;
+        this.hostname = hostname;
+        this.isGlobal = isGlobal;
+    }
+
+    /** @return True if the endpoint is global */
     public boolean isGlobal() {
         return isGlobal;
     }
 
-    /*
-     * @return The URI for the endpoint
-     */
+    /* @return The URI for the endpoint */
     public String getEndpoint() {
         return endpoint;
+    }
+
+    /** @return The hostname for this endpoint */
+    public String getHostname() {
+        return hostname;
     }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -145,7 +145,7 @@ public class ApplicationController {
     /**
      * Set the rotations marked as 'global' either 'in' or 'out of' service.
      *
-     * @return The conanical endpoint altered if any
+     * @return The canonical endpoint altered if any
      * @throws IOException if rotation status cannot be updated
      */
     public List<String> setGlobalRotationStatus(DeploymentId deploymentId, EndpointStatus status) throws IOException {
@@ -179,16 +179,16 @@ public class ApplicationController {
     }
 
     /**
-     * Global rotations (plural as we can aliases) map to exactly one service endpoint.
+     * Global rotations (plural as we can have aliases) map to exactly one service endpoint.
      * This method finds that one service endpoint and strips the URI part that
-     * the routingGenerator is wrapping the endpoint in.
+     * the routingGenerator is wrapping around the endpoint.
      *
      * @param deploymentId The deployment to retrieve global service endpoint for
      * @return Empty if no global endpoint exist, otherwise the service endpoint ([clustername.]app.tenant.region.env)
      */
     Optional<String> getCanonicalGlobalEndpoint(DeploymentId deploymentId) throws IOException {
         Map<String, RoutingEndpoint> hostToGlobalEndpoint = new HashMap<>();
-        Map<String, String> hostToCanocicalEndpoint = new HashMap<>();
+        Map<String, String> hostToCanonicalEndpoint = new HashMap<>();
 
         for (RoutingEndpoint endpoint : routingGenerator.endpoints(deploymentId)) {
             try {
@@ -208,12 +208,12 @@ public class ApplicationController {
                     if (endpoint.isGlobal()) {
                         hostToGlobalEndpoint.put(hostname, endpoint);
                     } else {
-                        hostToCanocicalEndpoint.put(hostname, canonicalEndpoint);
+                        hostToCanonicalEndpoint.put(hostname, canonicalEndpoint);
                     }
 
                     // Return as soon as we have a map between a global and a canonical endpoint
-                    if (hostToGlobalEndpoint.containsKey(hostname) && hostToCanocicalEndpoint.containsKey(hostname)) {
-                        return Optional.of(hostToCanocicalEndpoint.get(hostname));
+                    if (hostToGlobalEndpoint.containsKey(hostname) && hostToCanonicalEndpoint.containsKey(hostname)) {
+                        return Optional.of(hostToCanonicalEndpoint.get(hostname));
                     }
                 }
             } catch (URISyntaxException use) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -186,7 +186,7 @@ public class ApplicationController {
      * @param deploymentId The deployment to retrieve global service endpoint for
      * @return Empty if no global endpoint exist, otherwise the service endpoint ([clustername.]app.tenant.region.env)
      */
-    Optional<String> getCanonicalGlobalEndpoint(DeploymentId deploymentId) {
+    Optional<String> getCanonicalGlobalEndpoint(DeploymentId deploymentId) throws IOException {
         Map<String, RoutingEndpoint> hostToGlobalEndpoint = new HashMap<>();
         Map<String, String> hostToCanocicalEndpoint = new HashMap<>();
 
@@ -195,7 +195,7 @@ public class ApplicationController {
                 URI uri = new URI(endpoint.getEndpoint());
                 String serviceEndpoint = uri.getHost();
                 if (serviceEndpoint == null) {
-                    throw new RuntimeException("Unexpected endpoints returned from the Routing Generator");
+                    throw new IOException("Unexpected endpoints returned from the Routing Generator");
                 }
                 String canonicalEndpoint = serviceEndpoint.replaceAll(".vespa.yahooapis.com", "");
                 String hostname = endpoint.getHostname();
@@ -217,7 +217,7 @@ public class ApplicationController {
                     }
                 }
             } catch (URISyntaxException use) {
-                log.log(Level.INFO, use.getMessage());
+                throw new IOException(use);
             }
         }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -145,36 +145,85 @@ public class ApplicationController {
     /**
      * Set the rotations marked as 'global' either 'in' or 'out of' service.
      *
-     * @return The list of endpoints successfully alertered
+     * @return The conanical endpoint altered if any
      * @throws IOException if rotation status cannot be updated
      */
     public List<String> setGlobalRotationStatus(DeploymentId deploymentId, EndpointStatus status) throws IOException {
         List<String> rotations = new ArrayList<>();
-        for (RoutingEndpoint endpoint : routingGenerator.endpoints(deploymentId)) {
-            if (endpoint.isGlobal()) {
-                configserverClient.setGlobalRotationStatus(deploymentId, endpoint.getEndpoint(), status);
-                rotations.add(endpoint.getEndpoint());
-            }
+        Optional<String> endpoint = getCanonicalGlobalEndpoint(deploymentId);
+
+        if (endpoint.isPresent()) {
+            configserverClient.setGlobalRotationStatus(deploymentId, endpoint.get(), status);
+            rotations.add(endpoint.get());
         }
+
         return rotations;
     }
 
     /**
-     * Get the endpoint status for rotations marked as 'global'
+     * Get the endpoint status for the global endpoint of this application
      *
-     * @return The list of endpoints successfully alertered
+     * @return Map between the endpoint and the rotation status
      * @throws IOException if global rotation status cannot be determined
      */
     public Map<String, EndpointStatus> getGlobalRotationStatus(DeploymentId deploymentId) throws IOException {
         Map<String, EndpointStatus> result = new HashMap<>();
-        for (RoutingEndpoint endpoint : routingGenerator.endpoints(deploymentId)) {
-            if (endpoint.isGlobal()) {
-                EndpointStatus status = configserverClient.getGlobalRotationStatus(deploymentId, endpoint.getEndpoint());
-                result.put(endpoint.getEndpoint(), status);
-            }
+        Optional<String> endpoint = getCanonicalGlobalEndpoint(deploymentId);
+
+        if (endpoint.isPresent()) {
+            EndpointStatus status = configserverClient.getGlobalRotationStatus(deploymentId, endpoint.get());
+            result.put(endpoint.get(), status);
         }
+
         return result;
     }
+
+    /**
+     * Global rotations (plural as we can aliases) map to exactly one service endpoint.
+     * This method finds that one service endpoint and strips the URI part that
+     * the routingGenerator is wrapping the endpoint in.
+     *
+     * @param deploymentId The deployment to retrieve global service endpoint for
+     * @return Empty if no global endpoint exist, otherwise the service endpoint ([clustername.]app.tenant.region.env)
+     */
+    Optional<String> getCanonicalGlobalEndpoint(DeploymentId deploymentId) {
+        Map<String, RoutingEndpoint> hostToGlobalEndpoint = new HashMap<>();
+        Map<String, String> hostToCanocicalEndpoint = new HashMap<>();
+
+        for (RoutingEndpoint endpoint : routingGenerator.endpoints(deploymentId)) {
+            try {
+                URI uri = new URI(endpoint.getEndpoint());
+                String serviceEndpoint = uri.getHost();
+                if (serviceEndpoint == null) {
+                    throw new RuntimeException("Unexpected endpoints returned from the Routing Generator");
+                }
+                String canonicalEndpoint = serviceEndpoint.replaceAll(".vespa.yahooapis.com", "");
+                String hostname = endpoint.getHostname();
+
+                // This check is needed until the old implementations of
+                // RoutingEndpoints that lacks hostname is gone
+                if (hostname != null) {
+
+                    // Book-keeping
+                    if (endpoint.isGlobal()) {
+                        hostToGlobalEndpoint.put(hostname, endpoint);
+                    } else {
+                        hostToCanocicalEndpoint.put(hostname, canonicalEndpoint);
+                    }
+
+                    // Return as soon as we have a map between a global and a canonical endpoint
+                    if (hostToGlobalEndpoint.containsKey(hostname) && hostToCanocicalEndpoint.containsKey(hostname)) {
+                        return Optional.of(hostToCanocicalEndpoint.get(hostname));
+                    }
+                }
+            } catch (URISyntaxException use) {
+                log.log(Level.INFO, use.getMessage());
+            }
+        }
+
+        return Optional.empty();
+    }
+
 
     /**
      * Creates a new application for an existing tenant.

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -516,22 +516,20 @@ public class ControllerTest {
 
         // Check initial rotation status
         Map<String, EndpointStatus> rotationStatus = tester.controller().applications().getGlobalRotationStatus(deployId);
-        assertEquals(2, rotationStatus.size());
+        assertEquals(1, rotationStatus.size());
 
-        assertTrue(rotationStatus.get("global-endpoint").getStatus().equals(EndpointStatus.Status.in));
-        assertTrue(rotationStatus.get("alias-endpoint").getStatus().equals(EndpointStatus.Status.in));
+        assertTrue(rotationStatus.get("qrs-endpoint").getStatus().equals(EndpointStatus.Status.in));
 
         // Set the global rotations out of service
         EndpointStatus status = new EndpointStatus(EndpointStatus.Status.out, "Testing I said", "Test", tester.clock().instant().getEpochSecond());
         List<String> overrides = tester.controller().applications().setGlobalRotationStatus(deployId, status);
-        assertEquals(2, overrides.size());
+        assertEquals(1, overrides.size());
 
         // Recheck the override rotation status
         rotationStatus = tester.controller().applications().getGlobalRotationStatus(deployId);
-        assertEquals(2, rotationStatus.size());
-        assertTrue(rotationStatus.get("global-endpoint").getStatus().equals(EndpointStatus.Status.out));
-        assertTrue(rotationStatus.get("alias-endpoint").getStatus().equals(EndpointStatus.Status.out));
-        assertTrue(rotationStatus.get("alias-endpoint").getReason().equals("Testing I said"));
+        assertEquals(1, rotationStatus.size());
+        assertTrue(rotationStatus.get("qrs-endpoint").getStatus().equals(EndpointStatus.Status.out));
+        assertTrue(rotationStatus.get("qrs-endpoint").getReason().equals("Testing I said"));
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -1,6 +1,6 @@
 {
   "serviceUrls": [
-    "qrs-endpoint","feeding-endpoint","global-endpoint","alias-endpoint"
+    "http://old-endpoint.vespa.yahooapis.com:4080","http://qrs-endpoint.vespa.yahooapis.com:4080","http://feeding-endpoint.vespa.yahooapis.com:4080","http://global-endpoint.vespa.yahooapis.com:4080","http://alias-endpoint.vespa.yahooapis.com:4080"
   ],
   "nodes": "http://localhost:8080/zone/v2/prod/corp-us-east-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
   "elkUrl": "http://log.prod.corp-us-east-1.test/#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'HV-tenant:%22tenant1%22%20AND%20HV-application:%22application1%22%20AND%20HV-region:%22corp-us-east-1%22%20AND%20HV-instance:%22default%22%20AND%20HV-environment:%22prod%22')),sort:!('@timestamp',desc))",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-delete.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-delete.json
@@ -1,1 +1,1 @@
-{"message":"Rotations [global-endpoint, alias-endpoint] successfully set to in service"}
+{"message":"Rotations [qrs-endpoint] successfully set to in service"}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-get.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-get.json
@@ -1,1 +1,1 @@
-{"globalrotationoverride":["global-endpoint",{"status":"in","reason":"","agent":"","timestamp":1497618757},"alias-endpoint",{"status":"in","reason":"","agent":"","timestamp":1497618757}]}
+{"globalrotationoverride":["qrs-endpoint",{"status":"in","reason":"","agent":"","timestamp":1497618757}]}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-put.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-put.json
@@ -1,1 +1,1 @@
-{"message":"Rotations [global-endpoint, alias-endpoint] successfully set to out of service"}
+{"message":"Rotations [qrs-endpoint] successfully set to out of service"}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/MockRoutingGenerator.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/MockRoutingGenerator.java
@@ -16,10 +16,11 @@ public class MockRoutingGenerator implements RoutingGenerator {
     @Override
     public List<RoutingEndpoint> endpoints(DeploymentId deployment) {
         List<RoutingEndpoint> endpoints = new ArrayList<>();
-        endpoints.add(new RoutingEndpoint("qrs-endpoint", false));
-        endpoints.add(new RoutingEndpoint("feeding-endpoint", false));
-        endpoints.add(new RoutingEndpoint("global-endpoint", true));
-        endpoints.add(new RoutingEndpoint("alias-endpoint", true));
+        endpoints.add(new RoutingEndpoint("http://old-endpoint.vespa.yahooapis.com:4080", false));
+        endpoints.add(new RoutingEndpoint("http://qrs-endpoint.vespa.yahooapis.com:4080", "host1", false));
+        endpoints.add(new RoutingEndpoint("http://feeding-endpoint.vespa.yahooapis.com:4080", "host2", false));
+        endpoints.add(new RoutingEndpoint("http://global-endpoint.vespa.yahooapis.com:4080", "host1", true));
+        endpoints.add(new RoutingEndpoint("http://alias-endpoint.vespa.yahooapis.com:4080", "host1", true));
         return endpoints;
     }
 


### PR DESCRIPTION
The BCP status service is using canonical service endpoints and not the the global or aliased URIs used by nginx. 

The relationships between the Vespa interfaces and external systems here are a bit confusing and there might be something we could do to simplify the design here. I'm open for suggestions. One option is to duplicate the RoutingResource to Vespa and call nginx directly