### PR TITLE
Make sure description is not empty to avois spamming log

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/stubs/LoggingIssues.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/stubs/LoggingIssues.java
@@ -89,7 +89,7 @@ public class LoggingIssues implements Issues {
         if (info != null) // we still remember this issue
             return info;
         else // we forgot this issue (due to restart) - recreate it here to avoid log noise
-            return file(issueId, new Issue("(Forgotten)", ""));
+            return file(issueId, new Issue("(Forgotten)", "(Forgotten)"));
     }
 
 }


### PR DESCRIPTION
Avoid throwing IllegalArgumentException because description is empty.