### PR TITLE
Add --no-wait option to vespa-set-node-state

### DIFF
--- a/vespaclient/src/perl/lib/Yahoo/Vespa/Bin/SetNodeState.pm
+++ b/vespaclient/src/perl/lib/Yahoo/Vespa/Bin/SetNodeState.pm
@@ -21,6 +21,7 @@ our $wanted_state;
 our $wanted_state_description;
 our $nodes_attempted_set;
 our $success;
+our $no_wait;
 
 return 1;
 
@@ -58,6 +59,10 @@ EOS
               . "will show up in various admin tools. (Use double quotes to "
               . "give a reason with whitespace in it)");
 
+    setOptionHeader("Options related to operation visibility:");
+    setFlagOption(['n', 'no-wait'], \$no_wait, "Do not wait for node state "
+                . "changes to be visible in the cluster before returning.");
+
     Yahoo::Vespa::ContentNodeSelection::registerCommandLineArguments();
     Yahoo::Vespa::VespaModel::registerCommandLineArguments();
     handleCommandLineArguments($args);
@@ -83,7 +88,7 @@ sub execute { # ()
         exitApplication(1);
     }
     if (!$success) {
-	exitApplication(1);
+        exitApplication(1);
     }
 }
 
@@ -92,6 +97,6 @@ sub setNodeStateForNode {
     my ($cluster, $type, $index) = (
             $$info{'cluster'}, $$info{'type'}, $$info{'index'});
     $success &&= setNodeUserState($cluster, $type, $index, $wanted_state,
-                                  $wanted_state_description);
+                                  $wanted_state_description, $no_wait);
     ++$nodes_attempted_set;
 }

--- a/vespaclient/src/perl/lib/Yahoo/Vespa/ClusterController.pm
+++ b/vespaclient/src/perl/lib/Yahoo/Vespa/ClusterController.pm
@@ -80,8 +80,8 @@ sub detectClusterController { # ()
         enableAutomaticLineBreaks($oldVal);
     }
 }
-sub setNodeUserState { # (ClusterName, NodeType, Index, State, Reason)
-    my ($cluster, $service, $index, $state, $reason) = @_;
+sub setNodeUserState { # (ClusterName, NodeType, Index, State, Reason, NoWait)
+    my ($cluster, $service, $index, $state, $reason, $no_wait) = @_;
     my @params = ();
     my @headers = (
         'Content-Type' => 'application/json'
@@ -100,6 +100,9 @@ sub setNodeUserState { # (ClusterName, NodeType, Index, State, Reason)
             }
         }
     };
+    if ($no_wait) {
+        $request->{'response-wait'} = 'no-wait';
+    }
     my $content = Json::encode($request);
 
     my $path = &getPathToNode($cluster, $service, $index);

--- a/vespaclient/src/perl/test/Yahoo/Vespa/Bin/SetNodeStateTest.pl
+++ b/vespaclient/src/perl/test/Yahoo/Vespa/Bin/SetNodeStateTest.pl
@@ -65,6 +65,10 @@ Options:
  -s                       : Create less verbose output.
  --show-hidden            : Also show hidden undocumented debug options.
 
+Options related to operation visibility:
+ -n --no-wait             : Do not wait for node state changes to be visible in
+                            the cluster before returning.
+
 Node selection options. By default, nodes running locally will be selected:
  -c --cluster             : Cluster name of cluster to query. If unspecified,
                             and vespa is installed on current node, information


### PR DESCRIPTION
@hakonhall please review

If option is set, will add a response-wait: no-wait field to request
JSON. If not set, controller default is used.