### PR TITLE
Catch Throwable in maintainer

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Maintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Maintainer.java
@@ -54,8 +54,8 @@ public abstract class Maintainer extends AbstractComponent implements Runnable {
         catch (UncheckedTimeoutException e) {
             // another controller instance is running this job at the moment; ok
         }
-        catch (RuntimeException e) {
-            log.log(Level.WARNING, this + " failed. Will retry in " + maintenanceInterval.toMinutes() + " minutes", e);
+        catch (Throwable t) {
+            log.log(Level.WARNING, this + " failed. Will retry in " + maintenanceInterval.toMinutes() + " minutes", t);
         }
     }
 


### PR DESCRIPTION
Need to catch throwable so that all possible errors are logged. E.g. if an `LinkageError` occurs in a maintainer, the executor thread will stop and not be restarted, and nothing will be logged.