### PR TITLE
Allow child node to only be deleted in state ready

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -529,14 +529,13 @@ public class NodeRepository extends AbstractComponent {
      *    If also removing the parent node: child is in state provisioned|failed|parked|ready
      */
     private boolean verifyRemovalIsAllowed(Node nodeToRemove, boolean deletingAsChild) {
-        // TODO: Enable once controller no longer deletes child nodes manually
-        /*if (nodeToRemove.flavor().getType() == Flavor.Type.DOCKER_CONTAINER && !deletingAsChild) {
+        if (nodeToRemove.flavor().getType() == Flavor.Type.DOCKER_CONTAINER && !deletingAsChild) {
             if (nodeToRemove.state() != Node.State.ready) {
                 throw new IllegalArgumentException(
                         String.format("Docker container node %s can only be removed when in state ready", nodeToRemove.hostname()));
             }
 
-        } else */ if (nodeToRemove.flavor().getType() == Flavor.Type.DOCKER_CONTAINER) {
+        } else if (nodeToRemove.flavor().getType() == Flavor.Type.DOCKER_CONTAINER) {
             List<Node.State> legalStates = Arrays.asList(Node.State.provisioned, Node.State.failed, Node.State.parked, Node.State.ready);
 
             if (! legalStates.contains(nodeToRemove.state())) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -8,7 +8,6 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.hosted.provision.node.Agent;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -70,7 +69,7 @@ public class NodeRepositoryTest {
         assertTrue(tester.nodeRepository().dynamicAllocationEnabled());
     }
 
-    @Test @Ignore // TODO: Enable once controller no longer deletes child nodes manually
+    @Test
     public void only_allow_docker_containers_remove_in_ready() {
         NodeRepositoryTester tester = new NodeRepositoryTester();
         tester.addNode("id1", "host1", "docker", NodeType.tenant);


### PR DESCRIPTION
This was temporary disabled in #3253 to allow smooth rollout. Must be merged together with the corresponding change in `vespa/hosted`.