### PR TITLE
Pass extra args in zkcli to ZooKeeperMain

### DIFF
--- a/zkfacade/src/main/sh/zkcli
+++ b/zkfacade/src/main/sh/zkcli
@@ -61,4 +61,4 @@ findroot
 sudo -u ${VESPA_USER} java \
 	-cp $VESPA_HOME/lib/jars/zkctl-jar-with-dependencies.jar \
 	-Dlog4j.configuration=file:$VESPA_HOME/etc/log4j-vespa.properties \
-	org.apache.zookeeper.ZooKeeperMain
+	org.apache.zookeeper.ZooKeeperMain "$@"


### PR DESCRIPTION
This is to make it easier to work with ZK running on ports other than `2181`. E.g. for controller zk: `echo 'ls /' | zkcli -server localhost:2281`.

@hmusum or @bratseth 