### PR TITLE
Inhibit scheduling of merges towards nodes that are marked busy

### DIFF
--- a/storage/src/tests/distributor/nodeinfotest.cpp
+++ b/storage/src/tests/distributor/nodeinfotest.cpp
@@ -57,11 +57,11 @@ NodeInfoTest::testSimple()
     CPPUNIT_ASSERT_EQUAL(1, (int)info.getPendingCount(7));
     CPPUNIT_ASSERT_EQUAL(0, (int)info.getPendingCount(5));
 
-    info.setBusy(5);
+    info.setBusy(5, std::chrono::seconds(60));
     clock.addSecondsToTime(10);
-    info.setBusy(1);
+    info.setBusy(1, std::chrono::seconds(60));
     clock.addSecondsToTime(20);
-    info.setBusy(42);
+    info.setBusy(42, std::chrono::seconds(60));
 
     CPPUNIT_ASSERT_EQUAL(true, info.isBusy(5));
     CPPUNIT_ASSERT_EQUAL(true, info.isBusy(1));

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -27,6 +27,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _maxVisitorsPerNodePerClientVisitor(4),
       _minBucketsPerVisitor(5),
       _maxClusterClockSkew(0),
+      _inhibitMergeSendingOnBusyNodeDuration(std::chrono::seconds(60)),
       _doInlineSplit(true),
       _enableJoinForSiblingLessBuckets(false),
       _enableInconsistentJoin(false),
@@ -149,8 +150,10 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     configureMaintenancePriorities(config);
 
     if (config.maxClusterClockSkewSec >= 0) {
-        _maxClusterClockSkew = std::chrono::seconds(
-                config.maxClusterClockSkewSec);
+        _maxClusterClockSkew = std::chrono::seconds(config.maxClusterClockSkewSec);
+    }
+    if (config.inhibitMergeSendingOnBusyNodeDurationSec >= 0) {
+        _inhibitMergeSendingOnBusyNodeDuration = std::chrono::seconds(config.inhibitMergeSendingOnBusyNodeDurationSec);
     }
     
     LOG(debug,

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -15,7 +15,7 @@ namespace distributor {
 
 class DistributorConfiguration {
 public: 
-    DistributorConfiguration(StorageComponent& component);
+    explicit DistributorConfiguration(StorageComponent& component);
     ~DistributorConfiguration();
 
     struct MaintenancePriorities
@@ -225,6 +225,9 @@ public:
     std::chrono::seconds getMaxClusterClockSkew() const noexcept {
         return _maxClusterClockSkew;
     }
+    std::chrono::seconds getInhibitMergesOnBusyNodeDuration() const noexcept {
+        return _inhibitMergeSendingOnBusyNodeDuration;
+    }
 
     bool getSequenceMutatingOperations() const noexcept {
         return _sequenceMutatingOperations;
@@ -263,6 +266,7 @@ private:
 
     MaintenancePriorities _maintenancePriorities;
     std::chrono::seconds _maxClusterClockSkew;
+    std::chrono::seconds _inhibitMergeSendingOnBusyNodeDuration;
 
     bool _doInlineSplit;
     bool _enableJoinForSiblingLessBuckets;

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -180,3 +180,7 @@ max_cluster_clock_skew_sec int default=1
 ## modifications to documents when sent from multiple feed clients.
 sequence_mutating_operations bool default=true
 
+## Number of seconds that scheduling of new merge operations should be inhibited
+## towards a node if it has indicated that its merge queues are full or it is
+## suffering from resource exhaustion.
+inhibit_merge_sending_on_busy_node_duration_sec int default=30

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -684,12 +684,10 @@ Distributor::doNonCriticalTick(framework::ThreadIndex)
 void
 Distributor::enableNextConfig()
 {
-    _hostInfoReporter.enableReporting(
-            getConfig().getEnableHostInfoReporting());
-    _bucketDBMetricUpdater.setMinimumReplicaCountingMode(
-            getConfig().getMinimumReplicaCountingMode());
-    _ownershipSafeTimeCalc->setMaxClusterClockSkew(
-            getConfig().getMaxClusterClockSkew());
+    _hostInfoReporter.enableReporting(getConfig().getEnableHostInfoReporting());
+    _bucketDBMetricUpdater.setMinimumReplicaCountingMode(getConfig().getMinimumReplicaCountingMode());
+    _ownershipSafeTimeCalc->setMaxClusterClockSkew(getConfig().getMaxClusterClockSkew());
+    _pendingMessageTracker.setNodeBusyDuration(getConfig().getInhibitMergesOnBusyNodeDuration());
 }
 
 void

--- a/storage/src/vespa/storage/distributor/nodeinfo.h
+++ b/storage/src/vespa/storage/distributor/nodeinfo.h
@@ -14,13 +14,13 @@ namespace storage::distributor {
 
 class NodeInfo {
 public:
-    NodeInfo(const framework::Clock& clock);
+    explicit NodeInfo(const framework::Clock& clock);
 
     uint32_t getPendingCount(uint16_t idx) const;
 
     bool isBusy(uint16_t idx) const;
 
-    void setBusy(uint16_t idx);
+    void setBusy(uint16_t idx, framework::MonotonicDuration for_duration);
 
     void incPending(uint16_t idx);
 
@@ -30,11 +30,10 @@ public:
 
 private:
     struct SingleNodeInfo {
-        SingleNodeInfo()
-            : _pending(0), _busyTime(0) {};
+        SingleNodeInfo() : _pending(0), _busyUntilTime() {}
 
         uint32_t _pending;
-        mutable framework::SecondTime _busyTime;
+        mutable framework::MonotonicTimePoint _busyUntilTime;
     };
 
     mutable std::vector<SingleNodeInfo> _nodes;

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
@@ -46,7 +46,8 @@ public:
             const document::BucketId&, MergeLimiter&,
             std::vector<MergeMetaData>&);
 
-    bool shouldBlockThisOperation(uint32_t messageType, uint8_t pri) const override ;
+    bool shouldBlockThisOperation(uint32_t messageType, uint8_t pri) const override;
+    bool isBlocked(const PendingMessageTracker& pendingMessages) const override;
 private:
     static void addIdealNodes(
             const std::vector<uint16_t>& idealNodes,

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -21,6 +21,7 @@
 
 #include <set>
 #include <unordered_map>
+#include <chrono>
 
 namespace storage {
 namespace distributor {
@@ -106,7 +107,7 @@ public:
      * storage node. "Completed" here means both successful and failed
      * operations. Statistics are monotonically increasing within the scope of
      * the process' lifetime and are never reset. This models how the Linux
-     * kernel reports its internal stats and means the caller must maintan
+     * kernel reports its internal stats and means the caller must maintain
      * value snapshots to extract meaningful time series information.
      *
      * If stats are requested for a node that has not had any operations
@@ -135,6 +136,10 @@ public:
 
     LatencyStatisticsProvider& getLatencyStatisticsProvider() {
         return _statisticsForwarder;
+    }
+
+    void setNodeBusyDuration(std::chrono::seconds secs) noexcept {
+        _nodeBusyDuration = secs;
     }
 
 private:
@@ -210,6 +215,7 @@ private:
     std::unordered_map<uint16_t, NodeStats> _nodeIndexToStats;
     NodeInfo _nodeInfo;
     ForwardingLatencyStatisticsProvider _statisticsForwarder;
+    std::chrono::seconds _nodeBusyDuration;
 
     // Since distributor is currently single-threaded, this will only
     // contend when status page is being accessed. It is, however, required

--- a/storage/src/vespa/storage/distributor/throttlingoperationstarter.cpp
+++ b/storage/src/vespa/storage/distributor/throttlingoperationstarter.cpp
@@ -26,7 +26,7 @@ ThrottlingOperationStarter::start(const std::shared_ptr<Operation>& operation,
     if (!canStart(_pendingCount, priority)) {
         return false;
     }
-    Operation::SP wrappedOp(new ThrottlingOperation(operation, *this));
+    auto wrappedOp = std::make_shared<ThrottlingOperation>(operation, *this);
     ++_pendingCount;
     return _starterImpl.start(wrappedOp, priority);
 }


### PR DESCRIPTION
@hakonhall Please review

Utilizes existing maintenance operation scheduler system which checks
if an operation is considered blocked and does not start it if this
is the case. We now block a merge operation if any of the nodes in its
node set are marked busy by the pending message tracker.

Duration for which nodes are marked busy is live-configurable.