### PR TITLE
Filter log on correct package prefix for Curator

### DIFF
--- a/vespalog/src/main/java/com/yahoo/log/InvalidLogFormatException.java
+++ b/vespalog/src/main/java/com/yahoo/log/InvalidLogFormatException.java
@@ -5,7 +5,7 @@ package com.yahoo.log;
  * This (checked) exception is used to flag invalid log messages,
  * primarily for use in the factory methods of LogMessage.
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class InvalidLogFormatException extends Exception
 {

--- a/vespalog/src/main/java/com/yahoo/log/LogMessage.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogMessage.java
@@ -15,7 +15,7 @@ import com.yahoo.log.event.MalformedEventException;
  * chosen the name LogMessage to avoid confusion with LogRecord
  * which is used in java.util.logging.
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class LogMessage
 {

--- a/vespalog/src/main/java/com/yahoo/log/LogSetup.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogSetup.java
@@ -187,7 +187,7 @@ public class LogSetup {
         public boolean isLoggable(LogRecord record) {
             if (record.getLoggerName() == null) return true;
             if (!record.getLoggerName().startsWith("org.apache.zookeeper.") &&
-                    !record.getLoggerName().startsWith("com.netflix.curator")) {
+                    !record.getLoggerName().startsWith("org.apache.curator")) {
                 return true;
             }
             fileHandler.publish(record);

--- a/vespalog/src/main/java/com/yahoo/log/event/Collection.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Collection.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Collection extends Event {
     public Collection () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Count.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Count.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Count extends Event {
     public Count () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Crash.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Crash.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Crash extends Event {
     public Crash () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Event.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Event.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
  * logging events, rather than making events him/herself and stuffing
  * them through the logging API.
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public abstract class Event implements Serializable {
     private static Logger log = Logger.getLogger(Event.class.getName());

--- a/vespalog/src/main/java/com/yahoo/log/event/Progress.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Progress.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Progress extends Event {
     public Progress () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Reloaded.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Reloaded.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Reloaded extends Event {
     public Reloaded () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Reloading.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Reloading.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Reloading extends Event {
     public Reloading () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Started.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Started.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Started extends Event {
     public Started () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Starting.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Starting.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Starting extends Event {
     public Starting () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Stopped.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Stopped.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Stopped extends Event {
     public Stopped () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Stopping.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Stopping.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Stopping extends Event {
     public Stopping () {

--- a/vespalog/src/main/java/com/yahoo/log/event/Unknown.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Unknown.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author <a href="mailto:borud@yahoo-inc.com">Bjorn Borud </a>
+ * @author Bjorn Borud
  */
 public class Unknown extends Event {
     public Unknown() {

--- a/vespalog/src/main/java/com/yahoo/log/event/Value.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Value.java
@@ -3,7 +3,7 @@ package com.yahoo.log.event;
 
 /**
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class Value extends Event {
     public Value () {

--- a/vespalog/src/test/java/com/yahoo/log/LogLevelTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogLevelTestCase.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 /**
  * Testcases for LogLevel
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class LogLevelTestCase {
 

--- a/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
@@ -18,7 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 /**
  * Make sure we can install the logging stuff properly.
  *
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author Bjorn Borud
  */
 public class LogSetupTestCase {
     // For testing zookeeper log records
@@ -45,7 +45,7 @@ public class LogSetupTestCase {
         zookeeperLogRecord.setMillis(1107011348029L);
 
         curatorLogRecord = new LogRecord(Level.WARNING, "curator log record");
-        curatorLogRecord.setLoggerName("com.netflix.curator.utils.DefaultTracerDriver");
+        curatorLogRecord.setLoggerName("org.apache.curator.utils.DefaultTracerDriver");
         curatorLogRecord.setMillis(1107011348029L);
 
         hostname = Util.getHostName();
@@ -63,7 +63,7 @@ public class LogSetupTestCase {
         zookeeperLogRecordError.setMillis(1107011348029L);
 
         curatorLogRecordError = new LogRecord(Level.SEVERE, "curator log record");
-        curatorLogRecordError.setLoggerName("com.netflix.curator.utils.DefaultTracerDriver");
+        curatorLogRecordError.setLoggerName("org.apache.curator.utils.DefaultTracerDriver");
         curatorLogRecordError.setMillis(1107011348029L);
 
         notzookeeperLogRecord = new LogRecord(Level.WARNING, "not zookeeper log record");

--- a/vespalog/src/test/java/com/yahoo/log/UtilTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/UtilTestCase.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class UtilTestCase {
 

--- a/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
 
 /**
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class VespaFormatterTestCase {
 

--- a/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
@@ -18,7 +18,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 /**
- * @author  <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author  Bjorn Borud
  */
 public class VespaLogHandlerTestCase {
     protected static String hostname;


### PR DESCRIPTION
Filtering is done to avoid getting curator/zookeeper log in vespa.log, the log is written to another file instead