### PR TITLE
Exclude xerces:xercesImpl from provided classpath.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -104,6 +104,10 @@
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
     </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -153,6 +153,10 @@
           <groupId>org.antlr</groupId>
           <artifactId>antlr4-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
@bjorncs 
Due to https://jira.corp.yahoo.com/browse/VESPA-7765, I'm unable to build vespa on my laptop.
EDIT: built ok now