### PR TITLE
Add section in CMakeLists.txt to enable project open in CLion on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(vespa CXX C)
 
+# allows import of project in CLion on OSX
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+endif()
+
 # TODO: Move this to where it's actually needed
 find_package(JNI REQUIRED)
 


### PR DESCRIPTION
@aressem Please review.

This is what enables project to be opened on OSX. Will this interfere with normal build operations?