### PR TITLE
Immediately complete remote tasks when not leader

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -665,7 +665,8 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
             final RemoteClusterControllerTask task = remoteTasks.poll();
             log.finest(() -> String.format("Processing remote task of type '%s'", task.getClass().getName()));
             task.doRemoteFleetControllerTask(context);
-            if (!task.hasVersionAckDependency()) {
+            // We cannot introduce a version barrier for tasks when we're not the master (and therefore will not publish new versions).
+            if (!isMaster() || !task.hasVersionAckDependency()) {
                 log.finest(() -> String.format("Done processing remote task of type '%s'", task.getClass().getName()));
                 task.notifyCompleted();
             } else {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -1508,4 +1508,19 @@ public class StateChangeTest extends FleetControllerTest {
         assertTrue(task.isCompleted());
     }
 
+    @Test
+    public void synchronous_task_immediately_answered_when_not_leader() throws Exception {
+        FleetControllerOptions options = optionsWithZeroTransitionTime();
+        options.fleetControllerCount = 3;
+        RemoteTaskFixture fixture = createFixtureWith(options);
+
+        fixture.loseLeadership();
+        markAllNodesAsUp(options);
+
+        MockTask task = fixture.scheduleVersionDependentTaskWithSideEffects();
+
+        assertTrue(task.isInvoked());
+        assertTrue(task.isCompleted());
+    }
+
 }


### PR DESCRIPTION
@hakonhall please review

Avoids edge case where set-node-state requests sent to followers would
have their response delayed indefinitely due to controller not
publishing any versions that the task's ACK barrier could be released by.