### PR TITLE
Temporarily disable set-node-state version ACK dependency

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
@@ -67,7 +67,9 @@ public class SetNodeStateRequest extends Request<SetResponse> {
 
     @Override
     public boolean hasVersionAckDependency() {
-        return (this.responseWait == SetUnitStateRequest.ResponseWait.WAIT_UNTIL_CLUSTER_ACKED);
+        // FIXME this is a temporary change while edge cases in interactions between controller
+        // and orchestration are sorted out.
+        return false;
     }
 
     static SetResponse setWantedState(

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -374,10 +374,11 @@ public class SetNodeStateTest extends StateRestApiTest {
                 .setNewState("user", "maintenance", "whatever reason."));
     }
 
+    // FIXME requests should be tagged as version dependent; temporary workaround
     @Test
-    public void set_node_state_requests_are_by_default_tagged_as_having_version_ack_dependency() {
+    public void set_node_state_requests_are_by_default_not_tagged_as_having_version_ack_dependency() {
         SetNodeStateRequest request = createDummySetNodeStateRequest();
-        assertTrue(request.hasVersionAckDependency());
+        assertFalse(request.hasVersionAckDependency());
     }
 
     @Test


### PR DESCRIPTION
@hakonhall please review

Effectively reverts to legacy behavior while some more thinking is
done on how to deal with blocking requests during leader elections
and non-converging clusters.