### PR TITLE
Use Jetty v9.4.7

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -184,8 +184,7 @@ public class ServletResponseController {
 
     private static void setHeaders_holdingLock(Response jdiscResponse, HttpServletResponse servletResponse) {
         for (final Map.Entry<String, String> entry : jdiscResponse.headers().entries()) {
-            final String value = entry.getValue();
-            servletResponse.addHeader(entry.getKey(), value != null ? value : "");
+            servletResponse.addHeader(entry.getKey(), entry.getValue());
         }
 
         if (servletResponse.getContentType() == null) {

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -371,6 +371,7 @@ public class HttpServerTest {
     }
 
     // Header with no value is disallowed by https://tools.ietf.org/html/rfc7230#section-3.2
+    // Details in https://github.com/eclipse/jetty.project/issues/1116
     @Test
     public void requireThatHeaderWithNullValueIsOmitted() throws Exception {
         final TestDriver driver = TestDrivers.newInstance(new EchoWithHeaderRequestHandler("X-Foo", null));
@@ -380,13 +381,14 @@ public class HttpServerTest {
         assertThat(driver.close(), is(true));
     }
 
-    // Header with no value is disallowed by https://tools.ietf.org/html/rfc7230#section-3.2
+    // Header with empty value is allowed by https://tools.ietf.org/html/rfc7230#section-3.2
+    // Details in https://github.com/eclipse/jetty.project/issues/1116
     @Test
-    public void requireThatHeaderWithEmptyValueIsOmitted() throws Exception {
+    public void requireThatHeaderWithEmptyValueIsAllowed() throws Exception {
         final TestDriver driver = TestDrivers.newInstance(new EchoWithHeaderRequestHandler("X-Foo", ""));
         driver.client().get("/status.html")
                 .expectStatusCode(is(OK))
-                .expectNoHeader("X-Foo");
+                .expectHeader("X-Foo", is(""));
         assertThat(driver.close(), is(true));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -902,7 +902,7 @@
         <curator.version>2.9.1</curator.version>
         <jackson2.version>2.8.3</jackson2.version>
         <jersey2.version>2.23.2</jersey2.version>
-        <jetty.version>9.4.6.v20170531</jetty.version>
+        <jetty.version>9.4.7.v20170914</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.hide>true</test.hide>


### PR DESCRIPTION
Upgrade to newest Jetty and add support for empty HTTP header values.
Release notes Jetty: http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00111.html