### PR TITLE
Remove or update outdated copyright notices

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/NetworkMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/NetworkMetrics.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.admin.monitoring;
 
 import com.google.common.collect.ImmutableSet;

--- a/document/src/tests/gid_filter_test.cpp
+++ b/document/src/tests/gid_filter_test.cpp
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright 2016 Yahoo! Technologies Norway AS
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>

--- a/document/src/tests/heapdebugger.h
+++ b/document/src/tests/heapdebugger.h
@@ -1,14 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @file heapdebugger.h
- *
- * @author Ove Martin Malm
- * @date Creation date: 2000-08-09
- * @version $Id$
- * @file mcheckhooks.h
- *
- * Copyright (c) : 1997-2000 Fast Search & Transfer ASA
- * ALL RIGHTS RESERVED
+/*
+ * Author: Ove Martin Malm
  */
 
 #pragma once

--- a/document/src/tests/heapdebuggerlinux.cpp
+++ b/document/src/tests/heapdebuggerlinux.cpp
@@ -1,12 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- *
- * @author Ove Martin Malm
- * @date Creation date: 2000-21-08
- * @version $Id$
- *
- * Copyright (c) : 1997-2000 Fast Search & Transfer ASA
- * ALL RIGHTS RESERVED
+/*
+ * Author: Ove Martin Malm
  */
 
 

--- a/document/src/tests/heapdebuggerother.cpp
+++ b/document/src/tests/heapdebuggerother.cpp
@@ -1,12 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- *
- * @author Ove Martin Malm
- * @date Creation date: 2000-21-08
- * @version $Id$
- *
- * Copyright (c) : 1997-2000 Fast Search & Transfer ASA
- * ALL RIGHTS RESERVED
+/*
+ * Author: Ove Martin Malm
  */
 
 #include <stdlib.h>

--- a/documentapi/src/tests/messages/error_codes_test.cpp
+++ b/documentapi/src/tests/messages/error_codes_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright 2015 Yahoo Technologies Norway AS
+
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/documentapi/messagebus/documentprotocol.h>
 #include <iostream>

--- a/fastlib/src/vespa/fastlib/io/bufferedfile.h
+++ b/fastlib/src/vespa/fastlib/io/bufferedfile.h
@@ -1,14 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-//************************************************************************
-/**
- * Class definitions for Fast_BufferedInputStream
- *
- */
-/*
- * Creation date    : 2001-05-22
- * Copyright (c)    : 1997-2002 Fast Search & Transfer ASA
- *                    ALL RIGHTS RESERVED
- *************************************************************************/
 
 #pragma once
 

--- a/fastlib/src/vespa/fastlib/io/bufferedoutputstream.cpp
+++ b/fastlib/src/vespa/fastlib/io/bufferedoutputstream.cpp
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Markus Bjartveit Krüger
-* @date            Creation date: 2001-10-30
-*
-* Generic buffered output stream
-*
-* Copyright (c)  : 2001 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Generic buffered output stream
+ *
+ * Author: Markus Bjartveit Krüger
+ */
 
 #include "bufferedoutputstream.h"
 #include <cstring>

--- a/fastlib/src/vespa/fastlib/io/fileinputstream.cpp
+++ b/fastlib/src/vespa/fastlib/io/fileinputstream.cpp
@@ -1,16 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-10-07
-*
-* FileInputStream class implementation
-*
-* Copyright (c)  : 1997-2000 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Author: Stein Hardy Danielsen
+ */
 
 #include "fileinputstream.h"
 

--- a/fastlib/src/vespa/fastlib/io/fileoutputstream.cpp
+++ b/fastlib/src/vespa/fastlib/io/fileoutputstream.cpp
@@ -1,16 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-10-07
-*
-* FileOutputStream class implementation
-*
-* Copyright (c)  : 1997-2000 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Author: Stein Hardy Danielsen
+ */
 
 #include "fileoutputstream.h"
 #include <vespa/fastos/file.h>

--- a/fastlib/src/vespa/fastlib/io/filterinputstream.h
+++ b/fastlib/src/vespa/fastlib/io/filterinputstream.h
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-1-14
-*
-* Generic filter input stream
-*
-* Copyright (c)  : 1997-1999 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Generic filter input stream
+ *
+ * Author: Stein Hardy Danielsen
+ */
 #pragma once
 
 #include "inputstream.h"

--- a/fastlib/src/vespa/fastlib/io/outputstream.h
+++ b/fastlib/src/vespa/fastlib/io/outputstream.h
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-1-14
-*
-* Generic output stream interface
-*
-* Copyright (c)  : 1997-1999 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Generic output stream interface
+ *
+ * Author Stein Hardy Danielsen
+ */
 #pragma once
 
 #include <cstdlib>

--- a/fastlib/src/vespa/fastlib/net/httpchunkedinputstream.cpp
+++ b/fastlib/src/vespa/fastlib/net/httpchunkedinputstream.cpp
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Markus Bjartveit Krüger
-* @date            Creation date: 2001-11-21
-*
-* HTTP chunked input stream.
-*
-* Copyright (c)  : 2001 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * HTTP chunked input stream.
+ *
+ * Author: Markus Bjartveit Krüger
+ */
 
 #include "httpchunkedinputstream.h"
 #include <cstring>

--- a/fastlib/src/vespa/fastlib/net/httpchunkedoutputstream.cpp
+++ b/fastlib/src/vespa/fastlib/net/httpchunkedoutputstream.cpp
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Markus Bjartveit Krüger
-* @date            Creation date: 2001-11-21
-*
-* HTTP chunked output stream.
-*
-* Copyright (c)  : 2001 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * HTTP chunked output stream.
+ *
+ * Author: Markus Bjartveit Krüger
+ */
 
 #include "httpchunkedoutputstream.h"
 #include <cassert>

--- a/fastlib/src/vespa/fastlib/net/httpserver.h
+++ b/fastlib/src/vespa/fastlib/net/httpserver.h
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
-*******************************************************************************
-*
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-1-7
-*
-* Generic http server and connection classes
-*
-* Copyright (c)  : 1997-1999 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Generic http server and connection classes
+ *
+ * Author: Stein Hardy Danielsen
+ */
 
 
 #pragma once
@@ -30,19 +23,9 @@ class Fast_HTTPServer;
 #define FASTLIB_SUCCESS (0)
 #define FASTLIB_FAILURE (1)
 
-/**
-********************************************************************************
-*
-* Generic HTTP connection class
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-1-7
-*
-* Generic HTTP connection class
-*
-* Copyright (c)  : 1997-1999 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Generic HTTP connection class
+ */
 
 // Error codes
 #define FASTLIB_HTTPSERVER_NEWTHREADFAILED (2)
@@ -135,18 +118,9 @@ public:
 
 
 
-/**
-********************************************************************************
-*
-* Generic HTTP server class
-*
-* @author Stein Hardy Danielsen
-* @date            Creation date: 2000-1-7
-*
-* Copyright (c)  : 1997-1999 Fast Search & Transfer ASA
-*                  ALL RIGHTS RESERVED
-*
-******************************************************************************/
+/*
+ * Generic HTTP server class
+ */
 class Fast_HTTPServer : public FastOS_Runnable
 {
 private:

--- a/fastlib/src/vespa/fastlib/net/url.cpp
+++ b/fastlib/src/vespa/fastlib/net/url.cpp
@@ -1,15 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 /**
- *
- * @file url.cpp
- * @author Michael Susæg
- * @date Creation date: 1999-11-23
- *
  * This file contains different URL string functions
  *
- * Copyright (c)        : 1997-2000 Fast Search & Transfer ASA.
- *                        ALL RIGHTS RESERVED
- *
+ * Author: Michael Susæg
  */
 
 

--- a/fastlib/src/vespa/fastlib/net/url.h
+++ b/fastlib/src/vespa/fastlib/net/url.h
@@ -1,15 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- *
- * @file url.h
- * @author Michael Susæg
- * @date Creation date:
- *
- * This file is the header file for the url class.
- *
- * Copyright (c)        : 1997-2000 Fast Search & Transfer ASA.
- *                        ALL RIGHTS RESERVED
- *
+/*
+ * Author: Michael Susæg
  */
 
 #pragma once

--- a/fastlib/src/vespa/fastlib/testsuite/suite.h
+++ b/fastlib/src/vespa/fastlib/testsuite/suite.h
@@ -1,13 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 /**************************************************************************
- * @author Bård Kvalheim
+ * Author: Bård Kvalheim
  *
  * A test suite. Modified from the suite written by Chuck Allison.
  * http://www.cuj.com/archive/1809/feature.html
  *
- * @date Creation date: 2000-12-15
- * Copyright (c) : 1997-1999 Fast Search & Transfer ASA
- * ALL RIGHTS RESERVED
  * Licensed to Yahoo, and relicensed under the terms of the Apache 2.0 license
  *
  * The usage of suite is simple:

--- a/fastlib/src/vespa/fastlib/testsuite/test.h
+++ b/fastlib/src/vespa/fastlib/testsuite/test.h
@@ -1,13 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 /**************************************************************************
- * @author Bård Kvalheim
+ * Author: Bård Kvalheim
  *
  * The test class of the testsuite. Written by Chuck Allison.
  * http://www.cuj.com/archive/1809/feature.html
- *
- * @date Creation date: 2000-12-15
- * Copyright (c)    : 1997-2000 Fast Search & Transfer ASA
- *                    ALL RIGHTS RESERVED
  *
  * Apart for a trick the usage of the test class is very simple:
  *

--- a/fastlib/src/vespa/fastlib/text/apps/extcase.cpp
+++ b/fastlib/src/vespa/fastlib/text/apps/extcase.cpp
@@ -1,17 +1,12 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author Tor Egge
- * @author Vidar Larsen
- *
+/*
  * Extract case information from Unicode property files.
- * This program read the UnicodeData-4.0.0.txt file and generates
+ * This program reads the UnicodeData-4.0.0.txt file and generates
  * the unicodeutil-lowercase.cpp file that gives a mapping from
  * unicode characters to their lowercase equivalents.
  *
- * Copyright (C) 2000 - 2003 Fast Search & Transfer ASA
- * Copyright (C) 2003 Overture Services Norway AS
- *
- *                ALL RIGHTS RESERVED
+ * Author: Tor Egge
+ * Author: Vidar Larsen
  */
 
 #include <vespa/fastlib/io/bufferedfile.h>

--- a/fastos/src/tests/prefetchtest.cpp
+++ b/fastos/src/tests/prefetchtest.cpp
@@ -1,16 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-//************************************************************************
-/**
+/*
  * FastOS_Prefetch test program.
  *
- * @author  Olaf Birkeland
- * @version $Id$
+ * Author: Olaf Birkeland
  */
- /*
- * Creation date    : 2000-12-11
- * Copyright (c)    : 1997-2001 Fast Search & Transfer ASA
- *                    ALL RIGHTS RESERVED
- *************************************************************************/
 
 #include "tests.h"
 #include <vespa/fastos/time.h>

--- a/juniper/src/test/matchobjectTest.cpp
+++ b/juniper/src/test/matchobjectTest.cpp
@@ -1,21 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Implementation of the automated unit test class for the MatchObject
- * class.
- *
- * @file matchobjectTest.cpp
- *
- * @author Knut Omang
- *
- * @date Created 21 Feb 2003
- *
- * $Id$
- *
- * <pre>
- *              Copyright (c) : 2003 Fast Search & Transfer ASA
- *                              ALL RIGHTS RESERVED
- * </pre>
- ***************************************************************************/
+/*
+ * Author: Knut Omang
+ */
 #include "matchobjectTest.h"
 #include "fakerewriter.h"
 

--- a/juniper/src/test/matchobjectTest.h
+++ b/juniper/src/test/matchobjectTest.h
@@ -1,20 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Definition of the automated unit test class for the MatchObject class.
- *
- * @file matchobjectTest.h
- *
- * @author Knut Omang
- *
- * @date Created 21 Feb 2003
- *
- * $Id$
- *
- * <pre>
- *              Copyright (c) : 2003 Fast Search & Transfer ASA
- *                              ALL RIGHTS RESERVED
- * </pre>
- ***************************************************************************/
+/*
+ * Author: Knut Omang
+ */
 #pragma once
 
 #include "testenv.h"

--- a/juniper/src/test/mcandTest.cpp
+++ b/juniper/src/test/mcandTest.cpp
@@ -1,21 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Implementation of the automated unit test class for the MatchCandidate
- * class.
- *
- * @file mcandTest.cpp
- *
- * @author Knut Omang
- *
- * @date Created 27 Feb 2003
- *
- * $Id$
- *
- * <pre>
- *              Copyright (c) : 2003 Fast Search & Transfer ASA
- *                              ALL RIGHTS RESERVED
- * </pre>
- ***************************************************************************/
+/*
+ * Author: Knut Omang
+ */
 
 #include "mcandTest.h"
 

--- a/juniper/src/test/mcandTest.h
+++ b/juniper/src/test/mcandTest.h
@@ -1,21 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Definition of the automated unit test class for the MatchCandidate
- * class.
- *
- * @file mcandTest.h
- *
- * @author Knut Omang
- *
- * @date Created 27 Feb 2003
- *
- * $Id$
- *
- * <pre>
- *              Copyright (c) : 2003 Fast Search & Transfer ASA
- *                              ALL RIGHTS RESERVED
- * </pre>
- ***************************************************************************/
+/*
+ * Author Knut Omang
+ */
 #pragma once
 
 #include <map>

--- a/juniper/src/test/queryparserTest.cpp
+++ b/juniper/src/test/queryparserTest.cpp
@@ -1,21 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Implementation of the automated unit test class for the QueryParser
- * class.
- *
- * @file queryparserTest.cpp
- *
- * @author Knut Omang
- *
- * @date Created 24 Feb 2003
- *
- * $Id$
- *
- * <pre>
- *              Copyright (c) : 2003 Fast Search & Transfer ASA
- *                              ALL RIGHTS RESERVED
- * </pre>
- ***************************************************************************/
+/*
+ * Author Knut Omang
+ */
 #include "queryparserTest.h"
 #include "fakerewriter.h"
 

--- a/juniper/src/test/queryparserTest.h
+++ b/juniper/src/test/queryparserTest.h
@@ -1,20 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Definition of the automated unit test class for the QueryParser class.
- *
- * @file queryparserTest.h
- *
- * @author Knut Omang
- *
- * @date Created 24 Feb 2003
- *
- * $Id$
- *
- * <pre>
- *              Copyright (c) : 2003 Fast Search & Transfer ASA
- *                              ALL RIGHTS RESERVED
- * </pre>
- ***************************************************************************/
+/*
+ * Author Knut Omang
+ */
 #pragma once
 
 #include "testenv.h"

--- a/searchcommon/src/vespa/searchcommon/common/range.h
+++ b/searchcommon/src/vespa/searchcommon/common/range.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/common/appcontext.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/common/appcontext.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/common/perftask.cpp
+++ b/searchcore/src/vespa/searchcore/fdispatch/common/perftask.cpp
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2005 Overture Services Norway AS
 
 #include "perftask.h"
 #include "appcontext.h"

--- a/searchcore/src/vespa/searchcore/fdispatch/common/perftask.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/common/perftask.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2005 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/common/properties.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/common/properties.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/program/fdispatch.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/program/fdispatch.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/dataset_base.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/dataset_base.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/datasetcollection.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/datasetcollection.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/engine_base.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/engine_base.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/fnet_dataset.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/fnet_dataset.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/fnet_search.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/fnet_search.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/plain_dataset.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/plain_dataset.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/query.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/query.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/querycacheutil.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/querycacheutil.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/rowstate.cpp
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/rowstate.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include <vespa/searchcore/fdispatch/search/rowstate.h>
 

--- a/searchcore/src/vespa/searchcore/fdispatch/search/rowstate.h
+++ b/searchcore/src/vespa/searchcore/fdispatch/search/rowstate.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/util/autoptr.h
+++ b/searchcore/src/vespa/searchcore/util/autoptr.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/util/log.h
+++ b/searchcore/src/vespa/searchcore/util/log.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2000-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchcore/src/vespa/searchcore/util/stlishheap.h
+++ b/searchcore/src/vespa/searchcore/util/stlishheap.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/tests/index/docbuilder/docbuilder_test.cpp
+++ b/searchlib/src/tests/index/docbuilder/docbuilder_test.cpp
@@ -1,13 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/* -*- mode: C++; coding: utf-8; -*- */
-
-/*   $Id$
- *
- *   Copyright (C) 2011 Yahoo! Technologies Norway AS
- *
- *   All Rights Reserved
- *
- */
 
 #include <vespa/log/log.h>
 LOG_SETUP("docbuilder_test");

--- a/searchlib/src/tests/postinglistbm/postinglistbm.cpp
+++ b/searchlib/src/tests/postinglistbm/postinglistbm.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/common/resultset.h>

--- a/searchlib/src/tests/sortresults/sorttest.cpp
+++ b/searchlib/src/tests/sortresults/sorttest.cpp
@@ -1,7 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
-
 
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/common/sortresults.h>

--- a/searchlib/src/tests/stackdumpiterator/stackdumpiteratortest.cpp
+++ b/searchlib/src/tests/stackdumpiterator/stackdumpiteratortest.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "stackdumpiteratortest.h"
 #include <vespa/searchlib/parsequery/simplequerystack.h>

--- a/searchlib/src/tests/stackdumpiterator/stackdumpiteratortest.h
+++ b/searchlib/src/tests/stackdumpiterator/stackdumpiteratortest.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/tests/stringenum/stringenum_test.cpp
+++ b/searchlib/src/tests/stringenum/stringenum_test.cpp
@@ -1,7 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
-
 
 #include <vespa/log/log.h>
 LOG_SETUP("stringenum");

--- a/searchlib/src/tests/url/testurl.cpp
+++ b/searchlib/src/tests/url/testurl.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2000-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include <vespa/searchlib/util/url.h>
 #include <cstdio>

--- a/searchlib/src/vespa/searchlib/bitcompression/countcompression.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/countcompression.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "compression.h"
 #include "countcompression.h"

--- a/searchlib/src/vespa/searchlib/bitcompression/posocccompression.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/posocccompression.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "compression.h"
 #include "posocccompression.h"

--- a/searchlib/src/vespa/searchlib/bitcompression/posocccompression.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/posocccompression.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 #include <vespa/searchlib/index/docidandfeatures.h>

--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.h
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/base.h
+++ b/searchlib/src/vespa/searchlib/common/base.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/documentsummary.cpp
+++ b/searchlib/src/vespa/searchlib/common/documentsummary.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "documentsummary.h"
 #include <vespa/fastlib/io/bufferedfile.h>

--- a/searchlib/src/vespa/searchlib/common/documentsummary.h
+++ b/searchlib/src/vespa/searchlib/common/documentsummary.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/gid.h
+++ b/searchlib/src/vespa/searchlib/common/gid.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/growablebitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/growablebitvector.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "growablebitvector.h"
 

--- a/searchlib/src/vespa/searchlib/common/growablebitvector.h
+++ b/searchlib/src/vespa/searchlib/common/growablebitvector.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/location.cpp
+++ b/searchlib/src/vespa/searchlib/common/location.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "location.h"
 #include <limits>

--- a/searchlib/src/vespa/searchlib/common/location.h
+++ b/searchlib/src/vespa/searchlib/common/location.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2004 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/partialbitvector.h
+++ b/searchlib/src/vespa/searchlib/common/partialbitvector.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/rankedhit.h
+++ b/searchlib/src/vespa/searchlib/common/rankedhit.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/reserved.h
+++ b/searchlib/src/vespa/searchlib/common/reserved.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/common/resultset.cpp
+++ b/searchlib/src/vespa/searchlib/common/resultset.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "resultset.h"
 #include "bitvector.h"

--- a/searchlib/src/vespa/searchlib/common/sortresults.cpp
+++ b/searchlib/src/vespa/searchlib/common/sortresults.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "sortresults.h"
 #include <vespa/searchlib/util/sort.h>

--- a/searchlib/src/vespa/searchlib/common/sortresults.h
+++ b/searchlib/src/vespa/searchlib/common/sortresults.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "bitvectorfile.h"
 #include <vespa/searchlib/index/bitvectorkeys.h>

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.h
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.h
@@ -1,6 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
+
 #pragma once
 
 #include <vespa/fastlib/io/bufferedfile.h>

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "bitvectoridxfile.h"
 #include <vespa/searchlib/index/bitvectorkeys.h>

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.h
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.h
@@ -1,6 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
+
 #pragma once
 
 #include <vespa/fastlib/io/bufferedfile.h>

--- a/searchlib/src/vespa/searchlib/diskindex/extposocc.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/extposocc.cpp
@@ -1,7 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
-
 
 #include "extposocc.h"
 #include "zcposocc.h"

--- a/searchlib/src/vespa/searchlib/diskindex/extposocc.h
+++ b/searchlib/src/vespa/searchlib/diskindex/extposocc.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/diskindex/fusion.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/fusion.cpp
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2003 Fast Search & Transfer ASA
 
 #include "fusion.h"
 #include "fieldreader.h"

--- a/searchlib/src/vespa/searchlib/diskindex/fusion.h
+++ b/searchlib/src/vespa/searchlib/diskindex/fusion.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/engine/errorcodes.h
+++ b/searchlib/src/vespa/searchlib/engine/errorcodes.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/index/bitvectorkeys.h
+++ b/searchlib/src/vespa/searchlib/index/bitvectorkeys.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/parsequery/simplequerystack.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/simplequerystack.cpp
@@ -1,12 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Creation date: 2000-05-15
- * Implementation of the simple query stack.
- *
- *   Copyright (C) 1997-2003 Fast Search & Transfer ASA
- *   Copyright (C) 2003 Overture Services Norway AS
- *               ALL RIGHTS RESERVED
- */
+
 #include "simplequerystack.h"
 #include <vespa/vespalib/util/compress.h>
 #include <vespa/vespalib/objects/nbo.h>

--- a/searchlib/src/vespa/searchlib/parsequery/simplequerystack.h
+++ b/searchlib/src/vespa/searchlib/parsequery/simplequerystack.h
@@ -1,13 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Creation date: 2000-05-15
- *
- * Declaration of the SimpleQueryStack
- *
- *   Copyright (C) 1997-2003 Fast Search & Transfer ASA
- *   Copyright (C) 2003 Overture Services Norway AS
- *               ALL RIGHTS RESERVED
- */
+
 #pragma once
 
 #include <vespa/searchlib/parsequery/parse.h>

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -1,11 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Implementation of the simple query stack dump iterator.
- *
- *   Copyright (C) 1997-2003 Fast Search & Transfer ASA
- *   Copyright (C) 2003 Overture Services Norway AS
- *               ALL RIGHTS RESERVED
- */
+
 #include "stackdumpiterator.h"
 #include <vespa/vespalib/util/compress.h>
 #include <vespa/vespalib/objects/nbo.h>

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -1,11 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * Declaration of the SimpleQueryStack dump iterator
- *
- *   Copyright (C) 1997-2003 Fast Search & Transfer ASA
- *   Copyright (C) 2003 Overture Services Norway AS
- *               ALL RIGHTS RESERVED
- */
+
 #pragma once
 
 #include <vespa/searchlib/parsequery/parse.h>

--- a/searchlib/src/vespa/searchlib/queryeval/iterators.h
+++ b/searchlib/src/vespa/searchlib/queryeval/iterators.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/test/datastore/memstats.h
+++ b/searchlib/src/vespa/searchlib/test/datastore/memstats.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright 2017 Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/comprbuffer.h
+++ b/searchlib/src/vespa/searchlib/util/comprbuffer.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/comprfile.cpp
+++ b/searchlib/src/vespa/searchlib/util/comprfile.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "comprfile.h"
 #include <vespa/vespalib/objects/nbostream.h>

--- a/searchlib/src/vespa/searchlib/util/dirtraverse.cpp
+++ b/searchlib/src/vespa/searchlib/util/dirtraverse.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "dirtraverse.h"
 #include <vespa/fastos/file.h>

--- a/searchlib/src/vespa/searchlib/util/dirtraverse.h
+++ b/searchlib/src/vespa/searchlib/util/dirtraverse.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2002-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/filekit.cpp
+++ b/searchlib/src/vespa/searchlib/util/filekit.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include <vespa/searchlib/util/filekit.h>
 #include <vespa/vespalib/util/error.h>

--- a/searchlib/src/vespa/searchlib/util/filekit.h
+++ b/searchlib/src/vespa/searchlib/util/filekit.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/rawbuf.cpp
+++ b/searchlib/src/vespa/searchlib/util/rawbuf.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "rawbuf.h"
 #include <vespa/vespalib/util/compress.h>

--- a/searchlib/src/vespa/searchlib/util/rawbuf.h
+++ b/searchlib/src/vespa/searchlib/util/rawbuf.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/sort.h
+++ b/searchlib/src/vespa/searchlib/util/sort.h
@@ -1,7 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
-
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/stringenum.cpp
+++ b/searchlib/src/vespa/searchlib/util/stringenum.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "stringenum.h"
 #include <vespa/fastlib/io/bufferedfile.h>

--- a/searchlib/src/vespa/searchlib/util/stringenum.h
+++ b/searchlib/src/vespa/searchlib/util/stringenum.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchlib/src/vespa/searchlib/util/url.cpp
+++ b/searchlib/src/vespa/searchlib/util/url.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2000-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "url.h"
 

--- a/searchlib/src/vespa/searchlib/util/url.h
+++ b/searchlib/src/vespa/searchlib/util/url.h
@@ -1,6 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2000-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
+
 #pragma once
 
 #ifndef MAX_URL_LEN

--- a/searchsummary/src/tests/docsumformat/docsum-parse.cpp
+++ b/searchsummary/src/tests/docsumformat/docsum-parse.cpp
@@ -1,7 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
-
 
 #include <vespa/log/log.h>
 LOG_SETUP("docsum-parse");

--- a/searchsummary/src/tests/extractkeywords/extractkeywordstest.cpp
+++ b/searchsummary/src/tests/extractkeywords/extractkeywordstest.cpp
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #include "extractkeywordstest.h"
 #include <vespa/searchsummary/docsummary/keywordextractor.h>

--- a/searchsummary/src/tests/extractkeywords/extractkeywordstest.h
+++ b/searchsummary/src/tests/extractkeywords/extractkeywordstest.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchsummary/src/tests/extractkeywords/runtests.sh
+++ b/searchsummary/src/tests/extractkeywords/runtests.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#
-# $Id$
-#
-# Copyright (C) 2000-2003 Fast Search & Transfer ASA
-# Copyright (C) 2003 Overture Services Norway AS
-#
-# All Rights Reserved
-#
+
 set -e
 
 if $VALGRIND ./searchsummary_extractkeywordstest_app -

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumconfig.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumconfig.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumstore.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumstore.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2003 Overture Services Norway AS
-// Copyright (C) 1999-2003 Fast Search & Transfer ASA
 
 #pragma once
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2001-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/staging_vespalib/src/vespa/vespalib/util/rand48.h
+++ b/staging_vespalib/src/vespa/vespalib/util/rand48.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/hwaccelrated/generic.h
+++ b/vespalib/src/vespa/vespalib/hwaccelrated/generic.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/alignedmemory.h
+++ b/vespalib/src/vespa/vespalib/util/alignedmemory.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2009 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/arrayqueue.hpp
+++ b/vespalib/src/vespa/vespalib/util/arrayqueue.hpp
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2009 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/barrier.h
+++ b/vespalib/src/vespa/vespalib/util/barrier.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/blockingthreadstackexecutor.h
+++ b/vespalib/src/vespa/vespalib/util/blockingthreadstackexecutor.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/bobhash.h
+++ b/vespalib/src/vespa/vespalib/util/bobhash.h
@@ -5,21 +5,14 @@
 
 namespace vespalib {
 
-/**
- * @class BobHash
+/*
+ * Hash function based on
+ * http://burtleburtle.net/bob/hash/index.html
+ * by Bob Jenkins, 1996. bob_jenkins@burtleburtle.net. You may use this
+ * code any way you wish, private, educational, or commercial. It's free.
  *
- * @brief Hash function based on
- *        http://burtleburtle.net/bob/hash/index.html
- *        by Bob Jenkins, 1996. bob_jenkins@burtleburtle.net. You may use this
- *        code any way you wish, private, educational, or commercial. It's free.
- *
- * @author        Michael Susag
- * @date          Creation date: 2003-04-16
- * @version       $Id$
- *
- * Copyright (c)  2003 Fast Search & Transfer ASA
- *                ALL RIGHTS RESERVED
- **/
+ * Author: Michael Susag
+ */
 
 
 

--- a/vespalib/src/vespa/vespalib/util/delegatelist.hpp
+++ b/vespalib/src/vespa/vespalib/util/delegatelist.hpp
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2009 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/eventbarrier.hpp
+++ b/vespalib/src/vespa/vespalib/util/eventbarrier.hpp
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2009 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/exception.h
+++ b/vespalib/src/vespa/vespalib/util/exception.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2006 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/executor.h
+++ b/vespalib/src/vespa/vespalib/util/executor.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/guard.h
+++ b/vespalib/src/vespa/vespalib/util/guard.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2006 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/macro.h
+++ b/vespalib/src/vespa/vespalib/util/macro.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2006 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/memory.h
+++ b/vespalib/src/vespa/vespalib/util/memory.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2006 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/optimized.h
+++ b/vespalib/src/vespa/vespalib/util/optimized.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/ptrholder.h
+++ b/vespalib/src/vespa/vespalib/util/ptrholder.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2004 Overture Services Norway AS
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/rwlock.h
+++ b/vespalib/src/vespa/vespalib/util/rwlock.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2006 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/sequence.h
+++ b/vespalib/src/vespa/vespalib/util/sequence.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/slaveproc.h
+++ b/vespalib/src/vespa/vespalib/util/slaveproc.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2004 Overture Services Norway AS
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/sync.h
+++ b/vespalib/src/vespa/vespalib/util/sync.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2006 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/syncable.h
+++ b/vespalib/src/vespa/vespalib/util/syncable.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/threadexecutor.h
+++ b/vespalib/src/vespa/vespalib/util/threadexecutor.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vespalib/src/vespa/vespalib/util/threadstackexecutorbase.h
+++ b/vespalib/src/vespa/vespalib/util/threadstackexecutorbase.h
@@ -1,5 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 2010 Yahoo
 
 #pragma once
 

--- a/vsm/src/vespa/vsm/vsm/docsumconfig.h
+++ b/vsm/src/vespa/vsm/vsm/docsumconfig.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/vsm/src/vespa/vsm/vsm/docsumfilter.h
+++ b/vsm/src/vespa/vsm/vsm/docsumfilter.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 

--- a/vsm/src/vespa/vsm/vsm/vsm-adapter.h
+++ b/vsm/src/vespa/vsm/vsm/vsm-adapter.h
@@ -1,6 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-// Copyright (C) 1998-2003 Fast Search & Transfer ASA
-// Copyright (C) 2003 Overture Services Norway AS
 
 #pragma once
 


### PR DESCRIPTION
Remove copyright notices from past lives. Have preserved authors where present.

@bratseth please review
@geirst FYI