### PR TITLE
Make attribute disk usage estimate more robust.  Use cached values in…

### DIFF
--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -459,6 +459,7 @@ void AttributeTest::testReload(const AttributePtr & a, const AttributePtr & b, c
         (*(static_cast<VectorType *>(a.get())), *(static_cast<VectorType *>(b.get())));
     a->setCreateSerialNum(43u);
     EXPECT_TRUE( a->saveAs(b->getBaseFileName()) );
+    a->commit(true);
     if (preciseEstimatedSize(*a)) {
         EXPECT_EQUAL(statSize(*b), a->getEstimatedSaveByteSize());
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -805,8 +805,8 @@ uint64_t
 AttributeVector::getEstimatedSaveByteSize() const
 {
     uint64_t headerSize = 4096;
-    uint64_t totalValueCount = getTotalValueCount();
-    uint64_t uniqueValueCount = getUniqueValueCount();
+    uint64_t totalValueCount = _status.getNumValues();
+    uint64_t uniqueValueCount = _status.getNumUniqueValues();
     uint64_t docIdLimit = getCommittedDocIdLimit();
     uint64_t datFileSize = 0;
     uint64_t weightFileSize = 0;


### PR DESCRIPTION
…stead

of calling methods that require an attribute guard being held.

@geirst, please review