### PR TITLE
Handle multiple notifications from last job

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -128,10 +128,13 @@ public class DeploymentJobs {
     }
 
     /** Returns whether change has been deployed completely */
-    public boolean isDeployed(Change change) {
+    public boolean isDeployed(Optional<Change> change) {
+        if (!change.isPresent()) {
+            return true;
+        }
         return status.values().stream()
                 .filter(status -> status.type().isProduction())
-                .allMatch(status -> isSuccessful(change, status.type()));
+                .allMatch(status -> isSuccessful(change.get(), status.type()));
     }
 
     /** Returns whether job has completed successfully */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -72,7 +72,7 @@ public class DeploymentTrigger {
                 else { // start a new change deployment
                     application = application.withDeploying(Optional.of(Change.ApplicationChange.unknown()));
                 }
-            } else if (order.isLast(report.jobType(), application) && report.success() && application.deploymentJobs().isDeployed(application.deploying().get())) {
+            } else if (order.isLast(report.jobType(), application) && report.success() && application.deploymentJobs().isDeployed(application.deploying())) {
                 application = application.withDeploying(Optional.empty());
             }
 


### PR DESCRIPTION
If the last job in a pipeline is executed twice (e.g. by manually triggering), we should handle it and not fail the reporting step.