### PR TITLE
Fix coredump handler failure

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -319,7 +319,8 @@ public class StorageMaintainer {
 
     private String executeMaintainer(String mainClass, String... args) {
         String[] command = Stream.concat(
-                Stream.of("sudo", "-E", getDefaults().underVespaHome("libexec/vespa/node-admin/maintenance.sh"), mainClass),
+                Stream.of("sudo", "VESPA_HOME=" + getDefaults().vespaHome(),
+                        getDefaults().underVespaHome("libexec/vespa/node-admin/maintenance.sh"), mainClass),
                 Stream.of(args))
                 .toArray(String[]::new);
 


### PR DESCRIPTION
I've tested this two times now, and it works with this change. For some reason it fails with the `-E` (preserve environment), so just set the `VESPA_HOME` only, since that's all we need.