### PR TITLE
ensure error messages are propagated

### DIFF
--- a/vespabase/src/vespa-start-configserver.sh
+++ b/vespabase/src/vespa-start-configserver.sh
@@ -61,7 +61,7 @@ findroot
 ${VESPA_HOME}/bin/vespa-prestart.sh || exit 1
 willrun=${VESPA_HOME}/libexec/vespa/start-configserver
 if [ -x $willrun ]; then
-    echo "Starting $willrun" >&2
+    echo "Running $willrun" >&2
     exec $willrun
 fi
 echo "FATAL cannot run: $willrun"

--- a/vespabase/src/vespa-start-configserver.sh
+++ b/vespabase/src/vespa-start-configserver.sh
@@ -61,11 +61,8 @@ findroot
 ${VESPA_HOME}/bin/vespa-prestart.sh || exit 1
 willrun=${VESPA_HOME}/libexec/vespa/start-configserver
 if [ -x $willrun ]; then
-    echo "Starting $willrun as a background process." >&2
-    exec </dev/null
-    exec >/dev/null 2>&1
-    nohup $willrun &
-    exit 0
+    echo "Starting $willrun" >&2
+    exec $willrun
 fi
 echo "FATAL cannot run: $willrun"
 exit 1

--- a/vespabase/src/vespa-start-services.sh
+++ b/vespabase/src/vespa-start-services.sh
@@ -61,7 +61,7 @@ findroot
 ${VESPA_HOME}/bin/vespa-prestart.sh || exit 1
 willrun=${VESPA_HOME}/libexec/vespa/start-vespa-base.sh
 if [ -x $willrun ]; then
-    echo "Starting $willrun" >&2
+    echo "Running $willrun" >&2
     exec $willrun
 fi
 echo "FATAL cannot run: $willrun"

--- a/vespabase/src/vespa-start-services.sh
+++ b/vespabase/src/vespa-start-services.sh
@@ -61,11 +61,8 @@ findroot
 ${VESPA_HOME}/bin/vespa-prestart.sh || exit 1
 willrun=${VESPA_HOME}/libexec/vespa/start-vespa-base.sh
 if [ -x $willrun ]; then
-    echo "Starting $willrun as a background process." >&2
-    exec </dev/null
-    exec >/dev/null 2>&1
-    nohup $willrun &
-    exit 0
+    echo "Starting $willrun" >&2
+    exec $willrun
 fi
 echo "FATAL cannot run: $willrun"
 exit 1


### PR DESCRIPTION
* this should ensure that failures to start send any
  error messages back so they are available.  Tested
  both in the docker and the systemd startup cases.

@havardpe please review and merge
@aressem FYI