### PR TITLE
Avoid the phrase 'boolean search' for predicate fields

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/document/BooleanIndexDefinition.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/document/BooleanIndexDefinition.java
@@ -6,13 +6,12 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 /**
- * Encapsulates values required for native implementation of boolean search.
+ * Encapsulates values required for predicate fields.
  *
- * @author <a href="mailto:lesters@yahoo-inc.com">Lester Solbakken</a>
- * @since 5.2
+ * @author lesters
  */
-public final class BooleanIndexDefinition
-{
+public final class BooleanIndexDefinition {
+
     public static final int DEFAULT_ARITY = 8;
     public static final long DEFAULT_UPPER_BOUND = Long.MAX_VALUE;
     public static final long DEFAULT_LOWER_BOUND = Long.MIN_VALUE;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/fieldoperation/IndexOperation.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/fieldoperation/IndexOperation.java
@@ -15,16 +15,17 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 /**
- * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
+ * @author Einar M R Rosenvinge
  */
 public class IndexOperation implements FieldOperation {
+
     private String indexName;
     private Optional<Boolean> prefix = Optional.empty();
     private List<String> aliases = new LinkedList<>();
     private Optional<String> stemming = Optional.empty();
     private Optional<Type> type = Optional.empty();
 
-    private OptionalInt arity = OptionalInt.empty(); // For predicate data type in boolean search
+    private OptionalInt arity = OptionalInt.empty(); // For predicate data type
     private OptionalLong lowerBound = OptionalLong.empty();
     private OptionalLong upperBound = OptionalLong.empty();
     private OptionalDouble densePostingListThreshold = OptionalDouble.empty();
@@ -111,4 +112,5 @@ public class IndexOperation implements FieldOperation {
     public void setDensePostingListThreshold(double densePostingListThreshold) {
         this.densePostingListThreshold = OptionalDouble.of(densePostingListThreshold);
     }
+
 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/PredicateProcessor.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/PredicateProcessor.java
@@ -73,7 +73,7 @@ public class PredicateProcessor extends Processor {
             } else if (field.getDataType().getPrimitiveType() == DataType.PREDICATE) {
                 fail(search, field, "Collections of predicates are not allowed.");
             } else if (field.getDataType() == DataType.RAW && field.doesIndexing()) {
-                fail(search, field, "Indexing of RAW fields are not supported. If you are using RAW fields for boolean search, use predicate data type instead.");
+                fail(search, field, "Indexing of RAW fields is not supported.");
             } else {
                 // if field is not a predicate, disallow predicate-related index parameters
                 for (Index index : field.getIndices().values()) {

--- a/predicate-search-core/src/main/java/com/yahoo/search/predicate/SubqueryBitmap.java
+++ b/predicate-search-core/src/main/java/com/yahoo/search/predicate/SubqueryBitmap.java
@@ -2,7 +2,8 @@
 package com.yahoo.search.predicate;
 
 /**
- * Constants related to the subquery bitmap in predicate/boolean search.
+ * Constants related to the subquery bitmap in predicate search.
+ * 
  * @author bjorncs
  */
 public interface SubqueryBitmap {
@@ -16,6 +17,5 @@ public interface SubqueryBitmap {
      * Default subquery bitmap.
      */
     long DEFAULT_VALUE = ALL_SUBQUERIES;
-
 
 }

--- a/predicate-search/README.md
+++ b/predicate-search/README.md
@@ -1,3 +1,3 @@
-# Boolean search library
+# Predicate search library
 
-Java library for indexing boolean expressions and querying them using boolean constraints.
+Java library for indexing predicates and querying them using boolean constraints.

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/index/PredicateSearch.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/index/PredicateSearch.java
@@ -15,12 +15,13 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * Implementation of the "Interval" boolean search algorithm.
+ * Implementation of the "Interval" predicate search algorithm.
  *
- * @author <a href="mailto:magnarn@yahoo-inc.com">Magnar Nedland</a>
+ * @author Magnar Nedland
  * @author bjorncs
  */
 public class PredicateSearch {
+
     private final PostingList[] postingLists;
     private final byte[] nPostingListsForDocument;
     private final byte[] minFeatureIndex;
@@ -37,6 +38,7 @@ public class PredicateSearch {
 
     /**
      * Creates a search for a set of posting lists.
+     * 
      * @param postingLists Posting lists for the boolean variables that evaluate to true
      * @param nPostingListsForDocument The number of posting list for each docId
      * @param minFeatureIndex Index from docId to min-feature value.
@@ -278,4 +280,5 @@ public class PredicateSearch {
         }
 
     }
+
 }

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
@@ -25,7 +25,7 @@ private:
 /**
  * Attribute that manages a predicate index. It is not a traditional
  * attribute in that it doesn't store values for each document, but
- * rather keeps an index for boolean search. Summaries are not fetched
+ * rather keeps an index for predicate search. Summaries are not fetched
  * from the attribute, but rather using the summary store like a
  * non-index field.
  */

--- a/searchlib/src/vespa/searchlib/predicate/predicate_hash.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_hash.h
@@ -7,7 +7,7 @@
 namespace search {
 namespace predicate {
 /**
- * Hash function coming from the RISE code base, used in boolean search.
+ * Hash function used for predicate fields.
  */
 struct PredicateHash {
     static uint64_t hash64(vespalib::stringref aKey) {


### PR DESCRIPTION
This is to avoid any confusion with boolean search in the meaning of
combining query operators with boolean combinators.

@bjorncs please review