### PR TITLE
Disable directory scan for now, it causes bad behavior when system

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -76,7 +76,7 @@ sampleDiskUsageOnFileSystem(const fs::path &path)
 void
 DiskMemUsageSampler::sampleDiskUsage()
 {
-    bool slowDisk = _filter.getHwInfo().slowDisk();
+    bool slowDisk = _filter.getHwInfo().slowDisk() || true;
     _filter.setDiskStats(slowDisk ? sampleDiskUsageOnFileSystem(_protonBaseDir) :
                          sampleDiskUsageInDirectory(_vespaHomeDir));
 }


### PR DESCRIPTION
believes disk is fast while it is a spinning disk.

@geirst, please review
@baldersheim FYI