### PR TITLE
Freva/node admin stop

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
@@ -39,8 +38,6 @@ public class DockerOperationsImpl implements DockerOperations {
     private static final String[] SUSPEND_NODE_COMMAND = new String[]{NODE_PROGRAM, "suspend"};
     private static final String[] RESTART_VESPA_ON_NODE_COMMAND = new String[]{NODE_PROGRAM, "restart-vespa"};
     private static final String[] STOP_NODE_COMMAND = new String[]{NODE_PROGRAM, "stop"};
-
-    private static final Pattern VESPA_VERSION_PATTERN = Pattern.compile("^(\\S*)$", Pattern.MULTILINE);
 
     private static final String MANAGER_NAME = "node-admin";
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdmin.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdmin.java
@@ -62,5 +62,5 @@ public interface NodeAdmin {
     /**
      * Stop the NodeAgent. Will not delete the storage or stop the container.
      */
-    void shutdown();
+    void stop();
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -179,24 +179,21 @@ public class NodeAdminImpl implements NodeAdmin {
     }
 
     @Override
-    public void shutdown() {
+    public void stop() {
         metricsScheduler.shutdown();
         aclScheduler.shutdown();
-        try {
-            boolean metricsSchedulerShutdown = metricsScheduler.awaitTermination(30, TimeUnit.SECONDS);
-            boolean aclSchedulerShutdown = aclScheduler.awaitTermination(30, TimeUnit.SECONDS);
-            if (! (metricsSchedulerShutdown && aclSchedulerShutdown)) {
-                throw new RuntimeException("Failed shutting down all scheduler(s), shutdown status:\n" +
-                        "\tMetrics Scheduler: " + metricsSchedulerShutdown + "\n" +
-                        "\tACL Scheduler: " + aclSchedulerShutdown);
-            }
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
 
-        for (NodeAgent nodeAgent : nodeAgents.values()) {
-            nodeAgent.stop();
-        }
+        // Stop all node-agents in parallel, will block until the last NodeAgent is stopped
+        nodeAgents.values().parallelStream().forEach(NodeAgent::stop);
+
+        do {
+            try {
+                metricsScheduler.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+                aclScheduler.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException e) {
+                logger.info("Was interrupted while waiting for metricsScheduler and aclScheduler to shutdown");
+            }
+        } while (!metricsScheduler.isTerminated() || !aclScheduler.isTerminated());
     }
 
     // Set-difference. Returns minuend minus subtrahend.

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -55,8 +55,6 @@ public class NodeAdminImpl implements NodeAdmin {
 
     private final Map<ContainerName, NodeAgent> nodeAgents = new ConcurrentHashMap<>();
 
-    private final int nodeAgentScanIntervalMillis;
-
     private final GaugeWrapper numberOfContainersInLoadImageState;
     private final CounterWrapper numberOfUnhandledExceptionsInNodeAgent;
 
@@ -64,13 +62,11 @@ public class NodeAdminImpl implements NodeAdmin {
                          final Function<String, NodeAgent> nodeAgentFactory,
                          final StorageMaintainer storageMaintainer,
                          final AclMaintainer aclMaintainer,
-                         final int nodeAgentScanIntervalMillis,
                          final MetricReceiverWrapper metricReceiver,
                          final Clock clock) {
         this.dockerOperations = dockerOperations;
         this.nodeAgentFactory = nodeAgentFactory;
         this.storageMaintainer = storageMaintainer;
-        this.nodeAgentScanIntervalMillis = nodeAgentScanIntervalMillis;
 
         this.clock = clock;
         this.previousWantFrozen = true;
@@ -257,7 +253,7 @@ public class NodeAdminImpl implements NodeAdmin {
         }
 
         final NodeAgent agent = nodeAgentFactory.apply(hostname);
-        agent.start(nodeAgentScanIntervalMillis);
+        agent.start();
         nodeAgents.put(containerName, agent);
         try {
             Thread.sleep(1000);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -68,7 +68,6 @@ public class NodeAdminStateUpdater {
             String dockerHostHostName,
             Clock clock,
             Duration nodeAdminConvergeStateInterval) {
-        log.log(LogLevel.INFO, objectToString() + ": Creating object");
         this.nodeRepository = nodeRepository;
         this.orchestrator = orchestrator;
         this.storageMaintainer = storageMaintainer;
@@ -77,10 +76,6 @@ public class NodeAdminStateUpdater {
         this.clock = clock;
         this.nodeAdminConvergeStateInterval = nodeAdminConvergeStateInterval;
         this.lastTick = clock.instant();
-    }
-
-    private String objectToString() {
-        return this.getClass().getSimpleName() + "@" + Integer.toString(System.identityHashCode(this));
     }
 
     public enum State { RESUMED, SUSPENDED_NODE_ADMIN, SUSPENDED}
@@ -281,7 +276,6 @@ public class NodeAdminStateUpdater {
         if (!terminated.compareAndSet(false, true)) {
             throw new RuntimeException("Can not re-stop a node agent.");
         }
-        log.log(LogLevel.INFO, objectToString() + ": Stop called");
 
         // First we need to stop NodeAdminStateUpdater thread to make sure no new NodeAgents are spawned
         signalWorkToBeDone();
@@ -297,6 +291,5 @@ public class NodeAdminStateUpdater {
 
         // Finally, stop NodeAdmin and all the NodeAgents
         nodeAdmin.stop();
-        log.log(LogLevel.INFO, objectToString() + ": Stop complete");
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgent.java
@@ -29,7 +29,7 @@ public interface NodeAgent {
      * Starts the agent. After this method is called, the agent will asynchronously maintain the node, continuously
      * striving to make the current state equal to the wanted state.
      */
-    void start(int intervalMillis);
+    void start();
 
     /**
      * Signals to the agent that the node is at the end of its lifecycle and no longer needs a managing agent.

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
  * @author stiankri
  */
 public interface NodeRepository {
-    List<ContainerNodeSpec> getContainersToRun() throws IOException;
+    List<ContainerNodeSpec> getContainersToRun(String baseHostName) throws IOException;
 
     Optional<ContainerNodeSpec> getContainerNodeSpec(String hostName);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -28,18 +28,17 @@ import java.util.stream.Collectors;
  */
 public class NodeRepositoryImpl implements NodeRepository {
     private static final PrefixLogger NODE_ADMIN_LOGGER = PrefixLogger.getNodeAdminLogger(NodeRepositoryImpl.class);
-    private final String baseHostName;
-    private final int port;
-    private final ConfigServerHttpRequestExecutor requestExecutor;
 
-    public NodeRepositoryImpl(ConfigServerHttpRequestExecutor requestExecutor, int configPort, String baseHostName) {
-        this.baseHostName = baseHostName;
-        this.port = configPort;
+    private final ConfigServerHttpRequestExecutor requestExecutor;
+    private final int port;
+
+    public NodeRepositoryImpl(ConfigServerHttpRequestExecutor requestExecutor, int port) {
         this.requestExecutor = requestExecutor;
+        this.port = port;
     }
 
     @Override
-    public List<ContainerNodeSpec> getContainersToRun() throws IOException {
+    public List<ContainerNodeSpec> getContainersToRun(String baseHostName) throws IOException {
         try {
             final GetNodesResponse nodesForHost = requestExecutor.get(
                     "/nodes/v2/node/?parentHost=" + baseHostName + "&recursive=true",

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorImpl.java
@@ -1,8 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.orchestrator;
 
-import com.yahoo.vespa.defaults.Defaults;
-
 import com.yahoo.vespa.hosted.node.admin.util.ConfigServerHttpRequestExecutor;
 
 import com.yahoo.vespa.orchestrator.restapi.HostApi;
@@ -19,7 +17,6 @@ import java.util.Optional;
  * @author dybis
  */
 public class OrchestratorImpl implements Orchestrator {
-    static final int WEB_SERVICE_PORT = Defaults.getDefaults().vespaWebServicePort();
     // TODO: Find a way to avoid duplicating this (present in orchestrator's services.xml also).
     private static final String ORCHESTRATOR_PATH_PREFIX = "/orchestrator";
     static final String ORCHESTRATOR_PATH_PREFIX_HOST_API
@@ -28,9 +25,11 @@ public class OrchestratorImpl implements Orchestrator {
             = ORCHESTRATOR_PATH_PREFIX + HostSuspensionApi.PATH_PREFIX;
 
     private final ConfigServerHttpRequestExecutor requestExecutor;
+    private final int port;
 
-    public OrchestratorImpl(ConfigServerHttpRequestExecutor requestExecutor) {
+    public OrchestratorImpl(ConfigServerHttpRequestExecutor requestExecutor, int port) {
         this.requestExecutor = requestExecutor;
+        this.port = port;
     }
 
     @Override
@@ -38,7 +37,7 @@ public class OrchestratorImpl implements Orchestrator {
         UpdateHostResponse response;
         try {
             response = requestExecutor.put(getSuspendPath(hostName),
-                    WEB_SERVICE_PORT,
+                    port,
                     Optional.empty(), /* body */
                     UpdateHostResponse.class);
         } catch (ConfigServerHttpRequestExecutor.NotFoundException n) {
@@ -58,7 +57,7 @@ public class OrchestratorImpl implements Orchestrator {
         try {
              batchOperationResult = requestExecutor.put(
                     ORCHESTRATOR_PATH_PREFIX_HOST_SUSPENSION_API,
-                    WEB_SERVICE_PORT,
+                     port,
                     Optional.of(new BatchHostSuspendRequest(parentHostName, hostNames)),
                     BatchOperationResult.class);
         } catch (Exception e) {
@@ -75,7 +74,7 @@ public class OrchestratorImpl implements Orchestrator {
         UpdateHostResponse response;
         try {
             String path = getSuspendPath(hostName);
-            response = requestExecutor.delete(path, WEB_SERVICE_PORT, UpdateHostResponse.class);
+            response = requestExecutor.delete(path, port, UpdateHostResponse.class);
         } catch (ConfigServerHttpRequestExecutor.NotFoundException n) {
             throw new OrchestratorNotFoundException("Failed to resume " + hostName + ", host not found");
         } catch (Exception e) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProvider.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProvider.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.provider;
 
-import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
 
 /**
@@ -11,6 +10,4 @@ import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
  */
 public interface ComponentsProvider {
     NodeAdminStateUpdater getNodeAdminStateUpdater();
-
-    MetricReceiverWrapper getMetricReceiverWrapper();
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -3,10 +3,8 @@ package com.yahoo.vespa.hosted.node.admin.provider;
 
 import com.google.inject.Inject;
 import com.yahoo.net.HostName;
-import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
 import com.yahoo.system.ProcessExecuter;
-import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
@@ -24,14 +22,12 @@ import com.yahoo.vespa.hosted.node.admin.orchestrator.Orchestrator;
 import com.yahoo.vespa.hosted.node.admin.orchestrator.OrchestratorImpl;
 import com.yahoo.vespa.hosted.node.admin.util.ConfigServerHttpRequestExecutor;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
-import com.yahoo.vespa.hosted.node.admin.util.SecretAgentScheduleMaker;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Clock;
-import java.util.Set;
+import java.time.Duration;
 import java.util.function.Function;
+
+import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
 /**
  * Set up node admin for production.
@@ -39,80 +35,40 @@ import java.util.function.Function;
  * @author dybis
  */
 public class ComponentsProviderImpl implements ComponentsProvider {
-    private static final ContainerName NODE_ADMIN_CONTAINER_NAME = new ContainerName("node-admin");
-
     private final NodeAdminStateUpdater nodeAdminStateUpdater;
-    private final MetricReceiverWrapper metricReceiverWrapper;
 
-    private static final int NODE_AGENT_SCAN_INTERVAL_MILLIS = 30000;
     private static final int WEB_SERVICE_PORT = getDefaults().vespaWebServicePort();
-
-    // Converge towards desired node admin state every 30 seconds
-    private static final int NODE_ADMIN_CONVERGE_STATE_INTERVAL_MILLIS = 30000;
+    private static final Duration NODE_AGENT_SCAN_INTERVAL = Duration.ofSeconds(30);
+    private static final Duration NODE_ADMIN_CONVERGE_STATE_INTERVAL = Duration.ofSeconds(30);
 
     @Inject
     public ComponentsProviderImpl(Docker docker, MetricReceiverWrapper metricReceiver) {
-        String baseHostName = HostName.getLocalhost();
-        Environment environment = new Environment();
-        Set<String> configServerHosts = environment.getConfigServerHosts();
-        if (configServerHosts.isEmpty()) {
-            throw new IllegalStateException("Environment setting for config servers missing or empty.");
-        }
-
         Clock clock = Clock.systemUTC();
+        String dockerHostHostName = HostName.getLocalhost();
         ProcessExecuter processExecuter = new ProcessExecuter();
-        ConfigServerHttpRequestExecutor requestExecutor = ConfigServerHttpRequestExecutor.create(configServerHosts);
-        Orchestrator orchestrator = new OrchestratorImpl(requestExecutor);
-        NodeRepository nodeRepository = new NodeRepositoryImpl(requestExecutor, WEB_SERVICE_PORT, baseHostName);
+        Environment environment = new Environment();
+
+        ConfigServerHttpRequestExecutor requestExecutor = ConfigServerHttpRequestExecutor.create(environment.getConfigServerHosts());
+        NodeRepository nodeRepository = new NodeRepositoryImpl(requestExecutor, WEB_SERVICE_PORT);
+        Orchestrator orchestrator = new OrchestratorImpl(requestExecutor, WEB_SERVICE_PORT);
         DockerOperations dockerOperations = new DockerOperationsImpl(docker, environment, processExecuter);
 
         StorageMaintainer storageMaintainer = new StorageMaintainer(docker, processExecuter, metricReceiver, environment, clock);
-        AclMaintainer aclMaintainer = new AclMaintainer(dockerOperations, nodeRepository, baseHostName);
+        AclMaintainer aclMaintainer = new AclMaintainer(dockerOperations, nodeRepository, dockerHostHostName);
 
         Function<String, NodeAgent> nodeAgentFactory =
                 (hostName) -> new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
-                        storageMaintainer, aclMaintainer, environment, clock);
+                        storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL);
         NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer, aclMaintainer,
-                NODE_AGENT_SCAN_INTERVAL_MILLIS, metricReceiver, clock);
-        nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepository, nodeAdmin, storageMaintainer, clock, orchestrator, baseHostName);
-        nodeAdminStateUpdater.start(NODE_ADMIN_CONVERGE_STATE_INTERVAL_MILLIS);
+                metricReceiver, clock);
 
-        metricReceiverWrapper = metricReceiver;
-
-        setCorePattern(docker);
-        initializeNodeAgentSecretAgent(docker);
+        nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepository, orchestrator, storageMaintainer, nodeAdmin,
+                dockerHostHostName, clock, NODE_ADMIN_CONVERGE_STATE_INTERVAL);
+        nodeAdminStateUpdater.start();
     }
 
     @Override
     public NodeAdminStateUpdater getNodeAdminStateUpdater() {
         return nodeAdminStateUpdater;
-    }
-
-    @Override
-    public MetricReceiverWrapper getMetricReceiverWrapper() {
-        return metricReceiverWrapper;
-    }
-
-
-    private void setCorePattern(Docker docker) {
-        final String[] sysctlCorePattern = {"sysctl", "-w", "kernel.core_pattern=" +
-                                            getDefaults().underVespaHome("var/crash/%e.core.%p")};
-        docker.executeInContainerAsRoot(NODE_ADMIN_CONTAINER_NAME, sysctlCorePattern);
-    }
-
-    private void initializeNodeAgentSecretAgent(Docker docker) {
-        final Path yamasAgentFolder = Paths.get("/etc/yamas-agent/");
-        docker.executeInContainerAsRoot(NODE_ADMIN_CONTAINER_NAME, "chmod", "a+w", yamasAgentFolder.toString());
-
-        Path nodeAdminCheckPath = Paths.get("/usr/bin/curl");
-        SecretAgentScheduleMaker scheduleMaker = new SecretAgentScheduleMaker("node-admin", 60, nodeAdminCheckPath,
-                "localhost:4080/rest/metrics");
-
-        try {
-            scheduleMaker.writeTo(yamasAgentFolder);
-            docker.executeInContainerAsRoot(NODE_ADMIN_CONTAINER_NAME, "service", "yamas-agent", "restart");
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to write secret-agent schedules for node-admin", e);
-        }
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -27,6 +27,7 @@ import com.yahoo.vespa.hosted.node.admin.util.Environment;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
@@ -36,14 +37,18 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
  * @author dybis
  */
 public class ComponentsProviderImpl extends AbstractComponent implements ComponentsProvider {
-    private final NodeAdminStateUpdater nodeAdminStateUpdater;
 
     private static final int WEB_SERVICE_PORT = getDefaults().vespaWebServicePort();
     private static final Duration NODE_AGENT_SCAN_INTERVAL = Duration.ofSeconds(30);
     private static final Duration NODE_ADMIN_CONVERGE_STATE_INTERVAL = Duration.ofSeconds(30);
 
+    private final Logger log = Logger.getLogger(ComponentsProviderImpl.class.getName());
+    private final NodeAdminStateUpdater nodeAdminStateUpdater;
+
     @Inject
     public ComponentsProviderImpl(Docker docker, MetricReceiverWrapper metricReceiver) {
+        log.info(objectToString() + ": Creating object");
+
         Clock clock = Clock.systemUTC();
         String dockerHostHostName = HostName.getLocalhost();
         ProcessExecuter processExecuter = new ProcessExecuter();
@@ -75,6 +80,13 @@ public class ComponentsProviderImpl extends AbstractComponent implements Compone
 
     @Override
     public void deconstruct() {
+        log.info(objectToString() + ": Stop called");
         nodeAdminStateUpdater.stop();
+        log.info(objectToString() + ": Stop complete");
+    }
+
+
+    private String objectToString() {
+        return this.getClass().getSimpleName() + "@" + Integer.toString(System.identityHashCode(this));
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/ComponentsProviderImpl.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.provider;
 
 import com.google.inject.Inject;
+import com.yahoo.component.AbstractComponent;
 import com.yahoo.net.HostName;
 
 import com.yahoo.system.ProcessExecuter;
@@ -34,7 +35,7 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
  *
  * @author dybis
  */
-public class ComponentsProviderImpl implements ComponentsProvider {
+public class ComponentsProviderImpl extends AbstractComponent implements ComponentsProvider {
     private final NodeAdminStateUpdater nodeAdminStateUpdater;
 
     private static final int WEB_SERVICE_PORT = getDefaults().vespaWebServicePort();
@@ -70,5 +71,10 @@ public class ComponentsProviderImpl implements ComponentsProvider {
     @Override
     public NodeAdminStateUpdater getNodeAdminStateUpdater() {
         return nodeAdminStateUpdater;
+    }
+
+    @Override
+    public void deconstruct() {
+        nodeAdminStateUpdater.stop();
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/restapi/RestApiHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/restapi/RestApiHandler.java
@@ -12,6 +12,7 @@ import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
 import com.yahoo.vespa.hosted.node.admin.provider.ComponentsProvider;
 
+import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -36,10 +37,13 @@ public class RestApiHandler extends LoggingRequestHandler{
     private final NodeAdminStateUpdater refresher;
     private final MetricReceiverWrapper metricReceiverWrapper;
 
-    public RestApiHandler(Executor executor, AccessLog accessLog, ComponentsProvider componentsProvider) {
+    @Inject
+    public RestApiHandler(Executor executor, AccessLog accessLog,
+                          ComponentsProvider componentsProvider,
+                          MetricReceiverWrapper metricReceiverWrapper) {
         super(executor, accessLog);
         this.refresher = componentsProvider.getNodeAdminStateUpdater();
-        this.metricReceiverWrapper = componentsProvider.getMetricReceiverWrapper();
+        this.metricReceiverWrapper = metricReceiverWrapper;
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/ConfigServerHttpRequestExecutor.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/ConfigServerHttpRequestExecutor.java
@@ -52,6 +52,10 @@ public class ConfigServerHttpRequestExecutor {
     }
 
     public static ConfigServerHttpRequestExecutor create(Set<String> configServerHosts) {
+        if (configServerHosts.isEmpty()) {
+            throw new IllegalStateException("Environment setting for config servers missing or empty.");
+        }
+
         PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
         // Increase max total connections to 200, which should be enough
         cm.setMaxTotal(200);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/ComponentsProviderWithMocks.java
@@ -17,6 +17,7 @@ import com.yahoo.vespa.hosted.node.admin.provider.ComponentsProvider;
 import com.yahoo.vespa.hosted.node.admin.util.Environment;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.function.Function;
 
 import static org.mockito.Mockito.mock;
@@ -27,6 +28,9 @@ import static org.mockito.Mockito.mock;
  * @author dybis
  */
 public class ComponentsProviderWithMocks implements ComponentsProvider {
+    private static final Duration NODE_AGENT_SCAN_INTERVAL = Duration.ofMillis(100);
+    private static final Duration NODE_ADMIN_CONVERGE_STATE_INTERVAL = Duration.ofMillis(5);
+
     static final NodeRepository nodeRepositoryMock = mock(NodeRepository.class);
     static final Orchestrator orchestratorMock = mock(Orchestrator.class);
     static final DockerOperations dockerOperationsMock = mock(DockerOperations.class);
@@ -36,22 +40,18 @@ public class ComponentsProviderWithMocks implements ComponentsProvider {
     private final Environment environment = new Environment.Builder().build();
     private final MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
     private final Function<String, NodeAgent> nodeAgentFactory =
-            (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock, orchestratorMock,
-                    dockerOperationsMock, storageMaintainer, aclMaintainer, environment, Clock.systemUTC());
-    private final NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperationsMock, nodeAgentFactory, storageMaintainer, aclMaintainer, 100, mr, Clock.systemUTC());
-    private final NodeAdminStateUpdater nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepositoryMock, nodeAdmin, storageMaintainer, Clock.systemUTC(), orchestratorMock, "localhost.test.yahoo.com");
+            (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock, orchestratorMock, dockerOperationsMock,
+                    storageMaintainer, aclMaintainer, environment, Clock.systemUTC(), NODE_AGENT_SCAN_INTERVAL);
+    private final NodeAdmin nodeAdmin = new NodeAdminImpl(dockerOperationsMock, nodeAgentFactory, storageMaintainer, aclMaintainer, mr, Clock.systemUTC());
+    private final NodeAdminStateUpdater nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepositoryMock,
+            orchestratorMock, storageMaintainer, nodeAdmin, "localhost.test.yahoo.com", Clock.systemUTC(), NODE_ADMIN_CONVERGE_STATE_INTERVAL);
 
     public ComponentsProviderWithMocks() {
-        nodeAdminStateUpdater.start(10);
+        nodeAdminStateUpdater.start();
     }
 
     @Override
     public NodeAdminStateUpdater getNodeAdminStateUpdater() {
         return nodeAdminStateUpdater;
-    }
-
-    @Override
-    public MetricReceiverWrapper getMetricReceiverWrapper() {
-        return null;
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -76,6 +76,6 @@ public class DockerTester implements AutoCloseable {
 
     @Override
     public void close() {
-        nodeAdminStateUpdater.deconstruct();
+        nodeAdminStateUpdater.stop();
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.function.Function;
 
 import static org.mockito.Matchers.any;
@@ -32,6 +33,9 @@ import static org.mockito.Mockito.when;
  */
 // Need to deconstruct nodeAdminStateUpdater
 public class DockerTester implements AutoCloseable {
+    private static final Duration NODE_AGENT_SCAN_INTERVAL = Duration.ofMillis(100);
+    private static final Duration NODE_ADMIN_CONVERGE_STATE_INTERVAL = Duration.ofMillis(10);
+
     final CallOrderVerifier callOrderVerifier = new CallOrderVerifier();
     final Docker dockerMock = new DockerMock(callOrderVerifier);
     final NodeRepoMock nodeRepositoryMock = new NodeRepoMock(callOrderVerifier);
@@ -40,7 +44,7 @@ public class DockerTester implements AutoCloseable {
     private final OrchestratorMock orchestratorMock = new OrchestratorMock(callOrderVerifier);
 
 
-    public DockerTester() {
+    DockerTester() {
         InetAddressResolver inetAddressResolver = mock(InetAddressResolver.class);
         try {
             when(inetAddressResolver.getInetAddressForHost(any(String.class))).thenReturn(InetAddress.getByName("1.1.1.1"));
@@ -57,16 +61,16 @@ public class DockerTester implements AutoCloseable {
 
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
-        final DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, null);
+        DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, null);
         Function<String, NodeAgent> nodeAgentFactory = (hostName) -> new NodeAgentImpl(hostName, nodeRepositoryMock,
-                orchestratorMock, dockerOperations, storageMaintainer, aclMaintainer, environment, clock);
-        nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer, aclMaintainer, 100, mr, Clock.systemUTC());
-        nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepositoryMock, nodeAdmin, storageMaintainer,
-                clock, orchestratorMock, "basehostname");
-        nodeAdminStateUpdater.start(5);
+                orchestratorMock, dockerOperations, storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL);
+        nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer, aclMaintainer, mr, Clock.systemUTC());
+        nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeRepositoryMock, orchestratorMock, storageMaintainer,
+                nodeAdmin, "basehostname", clock, NODE_ADMIN_CONVERGE_STATE_INTERVAL);
+        nodeAdminStateUpdater.start();
     }
 
-    public void addContainerNodeSpec(ContainerNodeSpec containerNodeSpec) {
+    void addContainerNodeSpec(ContainerNodeSpec containerNodeSpec) {
         nodeRepositoryMock.updateContainerNodeSpec(containerNodeSpec);
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
@@ -32,7 +32,7 @@ public class NodeRepoMock implements NodeRepository {
     }
 
     @Override
-    public List<ContainerNodeSpec> getContainersToRun() throws IOException {
+    public List<ContainerNodeSpec> getContainersToRun(String dockerHostHostname) throws IOException {
         synchronized (monitor) {
             return new ArrayList<>(containerNodeSpecsByHostname.values());
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RunInContainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RunInContainerTest.java
@@ -118,7 +118,7 @@ public class RunInContainerTest {
     @Test
     public void testGetContainersToRunAPi() throws IOException, InterruptedException {
         doThrow(new OrchestratorException("Cannot suspend because...")).when(orchestrator).suspend(parentHostname);
-        when(ComponentsProviderWithMocks.nodeRepositoryMock.getContainersToRun()).thenReturn(Collections.emptyList());
+        when(ComponentsProviderWithMocks.nodeRepositoryMock.getContainersToRun(eq(parentHostname))).thenReturn(Collections.emptyList());
         waitForJdiscContainerToServe();
 
         assertTrue("The initial resume command should fail because it needs to converge first",
@@ -144,7 +144,7 @@ public class RunInContainerTest {
         assertTrue(verifyWithRetries("resume", true));
 
         // Lets try the same, but with an active container running on this host
-        when(ComponentsProviderWithMocks.nodeRepositoryMock.getContainersToRun()).thenReturn(
+        when(ComponentsProviderWithMocks.nodeRepositoryMock.getContainersToRun(eq(parentHostname))).thenReturn(
                 Collections.singletonList(new ContainerNodeSpec.Builder()
                         .hostname("host1.test.yahoo.com")
                         .wantedDockerImage(new DockerImage("dockerImage"))

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -53,7 +52,7 @@ public class NodeAdminImplTest {
     private final ManualClock clock = new ManualClock();
 
     private final NodeAdminImpl nodeAdmin = new NodeAdminImpl(dockerOperations, nodeAgentFactory, storageMaintainer, aclMaintainer,
-            100, new MetricReceiverWrapper(MetricReceiver.nullImplementation), clock);
+            new MetricReceiverWrapper(MetricReceiver.nullImplementation), clock);
 
     @Test
     public void nodeAgentsAreProperlyLifeCycleManaged() throws Exception {
@@ -72,12 +71,12 @@ public class NodeAdminImplTest {
 
         nodeAdmin.synchronizeNodeSpecsToNodeAgents(Collections.singletonList(hostName1), Collections.singletonList(containerName1));
         inOrder.verify(nodeAgentFactory).apply(hostName1);
-        inOrder.verify(nodeAgent1).start(100);
+        inOrder.verify(nodeAgent1).start();
         inOrder.verify(nodeAgent1, never()).stop();
 
         nodeAdmin.synchronizeNodeSpecsToNodeAgents(Collections.singletonList(hostName1), Collections.singletonList(containerName1));
         inOrder.verify(nodeAgentFactory, never()).apply(any(String.class));
-        inOrder.verify(nodeAgent1, never()).start(anyInt());
+        inOrder.verify(nodeAgent1, never()).start();
         inOrder.verify(nodeAgent1, never()).stop();
 
         nodeAdmin.synchronizeNodeSpecsToNodeAgents(Collections.emptyList(), Collections.singletonList(containerName1));
@@ -86,13 +85,13 @@ public class NodeAdminImplTest {
 
         nodeAdmin.synchronizeNodeSpecsToNodeAgents(Collections.singletonList(hostName2), Collections.singletonList(containerName1));
         inOrder.verify(nodeAgentFactory).apply(hostName2);
-        inOrder.verify(nodeAgent2).start(100);
+        inOrder.verify(nodeAgent2).start();
         inOrder.verify(nodeAgent2, never()).stop();
         verify(nodeAgent1).stop();
 
         nodeAdmin.synchronizeNodeSpecsToNodeAgents(Collections.emptyList(), Collections.emptyList());
         inOrder.verify(nodeAgentFactory, never()).apply(any(String.class));
-        inOrder.verify(nodeAgent2, never()).start(anyInt());
+        inOrder.verify(nodeAgent2, never()).start();
         inOrder.verify(nodeAgent2).stop();
 
         verifyNoMoreInteractions(nodeAgent1);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterTest.java
@@ -32,18 +32,20 @@ import static org.mockito.Mockito.when;
 
 /**
  * Basic test of NodeAdminStateUpdater
+ *
  * @author freva
  */
 public class NodeAdminStateUpdaterTest {
-    private final String parentHostname = "basehost1.test.yahoo.com";
-
-    private final ManualClock clock = new ManualClock();
     private final NodeRepository nodeRepository = mock(NodeRepository.class);
-    private final NodeAdmin nodeAdmin = mock(NodeAdmin.class);
-    private final StorageMaintainer storageMaintainer = mock(StorageMaintainer.class);
     private final Orchestrator orchestrator = mock(Orchestrator.class);
+    private final StorageMaintainer storageMaintainer = mock(StorageMaintainer.class);
+    private final NodeAdmin nodeAdmin = mock(NodeAdmin.class);
+    private final String parentHostname = "basehost1.test.yahoo.com";
+    private final ManualClock clock = new ManualClock();
+    private final Duration convergeStateInterval = Duration.ofSeconds(30);
+
     private final NodeAdminStateUpdater refresher = spy(new NodeAdminStateUpdater(
-            nodeRepository, nodeAdmin, storageMaintainer, clock, orchestrator, parentHostname));
+            nodeRepository, orchestrator, storageMaintainer, nodeAdmin, parentHostname, clock, convergeStateInterval));
 
 
     @Test
@@ -66,7 +68,7 @@ public class NodeAdminStateUpdaterTest {
         List<String> suspendHostnames = new ArrayList<>(activeHostnames);
         suspendHostnames.add(parentHostname);
 
-        when(nodeRepository.getContainersToRun()).thenReturn(containersToRun);
+        when(nodeRepository.getContainersToRun(eq(parentHostname))).thenReturn(containersToRun);
 
         // Initially everything is frozen to force convergence
         assertFalse(refresher.setResumeStateAndCheckIfResumed(NodeAdminStateUpdater.State.RESUMED));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.when;
  * @author bakksjo
  */
 public class NodeAgentImplTest {
+    private static final Duration NODE_AGENT_SCAN_INTERVAL = Duration.ofSeconds(30);
     private static final double MIN_CPU_CORES = 2;
     private static final double MIN_MAIN_MEMORY_AVAILABLE_GB = 16;
     private static final double MIN_DISK_AVAILABLE_GB = 250;
@@ -621,6 +622,6 @@ public class NodeAgentImplTest {
         doNothing().when(storageMaintainer).writeMetricsConfig(any(), any());
 
         return new NodeAgentImpl(hostName, nodeRepository, orchestrator, dockerOperations,
-                storageMaintainer, aclMaintainer, environment, clock);
+                storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL);
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImplTest.java
@@ -63,10 +63,10 @@ public class NodeRepositoryImplTest {
 
     private void waitForJdiscContainerToServe() throws InterruptedException {
         Instant start = Instant.now();
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "foobar");
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
         while (Instant.now().minusSeconds(120).isBefore(start)) {
             try {
-                nodeRepositoryApi.getContainersToRun();
+                nodeRepositoryApi.getContainersToRun("foobar");
                 return;
             } catch (Exception e) {
                 Thread.sleep(100);
@@ -85,8 +85,10 @@ public class NodeRepositoryImplTest {
     @Test
     public void testGetContainersToRunApi() throws IOException, InterruptedException {
         waitForJdiscContainerToServe();
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
-        final List<ContainerNodeSpec> containersToRun = nodeRepositoryApi.getContainersToRun();
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
+        String dockerHostHostname = "dockerhost1.yahoo.com";
+
+        final List<ContainerNodeSpec> containersToRun = nodeRepositoryApi.getContainersToRun(dockerHostHostname);
         assertThat(containersToRun.size(), is(1));
         final ContainerNodeSpec nodeSpec = containersToRun.get(0);
         assertThat(nodeSpec.hostname, is("host4.yahoo.com"));
@@ -102,7 +104,7 @@ public class NodeRepositoryImplTest {
     @Test
     public void testGetContainer() throws InterruptedException, IOException {
         waitForJdiscContainerToServe();
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
         String hostname = "host4.yahoo.com";
         Optional<ContainerNodeSpec> nodeSpec = nodeRepositoryApi.getContainerNodeSpec(hostname);
         assertThat(nodeSpec.isPresent(), is(true));
@@ -112,7 +114,7 @@ public class NodeRepositoryImplTest {
     @Test
     public void testGetContainerForNonExistingNode() throws InterruptedException, IOException {
         waitForJdiscContainerToServe();
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
         String hostname = "host-that-does-not-exist";
         Optional<ContainerNodeSpec> nodeSpec = nodeRepositoryApi.getContainerNodeSpec(hostname);
         assertFalse(nodeSpec.isPresent());
@@ -121,7 +123,7 @@ public class NodeRepositoryImplTest {
     @Test
     public void testUpdateNodeAttributes() throws InterruptedException, IOException {
         waitForJdiscContainerToServe();
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
         String hostname = "host4.yahoo.com";
         nodeRepositoryApi.updateNodeAttributes(
                 hostname,
@@ -134,7 +136,7 @@ public class NodeRepositoryImplTest {
     @Test(expected = RuntimeException.class)
     public void testUpdateNodeAttributesWithBadValue() throws InterruptedException, IOException {
         waitForJdiscContainerToServe();
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
         String hostname = "host4.yahoo.com";
         nodeRepositoryApi.updateNodeAttributes(
                 hostname,
@@ -146,7 +148,7 @@ public class NodeRepositoryImplTest {
 
     @Test
     public void testMarkAsReady() throws InterruptedException, IOException {
-        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port, "dockerhost1.yahoo.com");
+        NodeRepository nodeRepositoryApi = new NodeRepositoryImpl(requestExecutor, port);
         waitForJdiscContainerToServe();
 
         nodeRepositoryApi.markAsDirty("host5.yahoo.com");

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/orchestrator/OrchestratorImplTest.java
@@ -6,7 +6,6 @@ import com.yahoo.vespa.orchestrator.restapi.wire.BatchHostSuspendRequest;
 import com.yahoo.vespa.orchestrator.restapi.wire.BatchOperationResult;
 import com.yahoo.vespa.orchestrator.restapi.wire.HostStateChangeDenialReason;
 import com.yahoo.vespa.orchestrator.restapi.wire.UpdateHostResponse;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -20,20 +19,17 @@ import static org.mockito.Mockito.*;
  */
 public class OrchestratorImplTest {
     private static final String hostName = "host123.yahoo.com";
-    private ConfigServerHttpRequestExecutor requestExecutor;
-    private OrchestratorImpl orchestrator;
 
-    @Before
-    public void setup() {
-        requestExecutor = mock(ConfigServerHttpRequestExecutor.class);
-        orchestrator = new OrchestratorImpl(requestExecutor);
-    }
+    private final ConfigServerHttpRequestExecutor requestExecutor = mock(ConfigServerHttpRequestExecutor.class);
+    private final int port = 1234;
+    private final OrchestratorImpl orchestrator = new OrchestratorImpl(requestExecutor, port);
+
 
     @Test
     public void testSuspendCall() {
         when(requestExecutor.put(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_API + "/" + hostName+ "/suspended",
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 Optional.empty(),
                 UpdateHostResponse.class
         )).thenReturn(new UpdateHostResponse(hostName, null));
@@ -45,7 +41,7 @@ public class OrchestratorImplTest {
     public void testSuspendCallWithFailureReason() {
         when(requestExecutor.put(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_API + "/" + hostName+ "/suspended",
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 Optional.empty(),
                 UpdateHostResponse.class
         )).thenReturn(new UpdateHostResponse(hostName, new HostStateChangeDenialReason("hostname", "fail")));
@@ -82,7 +78,7 @@ public class OrchestratorImplTest {
     public void testResumeCall() {
         when(requestExecutor.delete(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_API + "/" + hostName+ "/suspended",
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 UpdateHostResponse.class
         )).thenReturn(new UpdateHostResponse(hostName, null));
 
@@ -93,7 +89,7 @@ public class OrchestratorImplTest {
     public void testResumeCallWithFailureReason() {
         when(requestExecutor.delete(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_API + "/" + hostName+ "/suspended",
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 UpdateHostResponse.class
         )).thenReturn(new UpdateHostResponse(hostName, new HostStateChangeDenialReason("hostname", "fail")));
 
@@ -131,7 +127,7 @@ public class OrchestratorImplTest {
 
         when(requestExecutor.put(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_SUSPENSION_API,
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 Optional.of(new BatchHostSuspendRequest(parentHostName, hostNames)),
                 BatchOperationResult.class
         )).thenReturn(BatchOperationResult.successResult());
@@ -147,7 +143,7 @@ public class OrchestratorImplTest {
 
         when(requestExecutor.put(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_SUSPENSION_API,
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 Optional.of(new BatchHostSuspendRequest(parentHostName, hostNames)),
                 BatchOperationResult.class
         )).thenReturn(new BatchOperationResult(failureReason));
@@ -163,7 +159,7 @@ public class OrchestratorImplTest {
 
         when(requestExecutor.put(
                 OrchestratorImpl.ORCHESTRATOR_PATH_PREFIX_HOST_SUSPENSION_API,
-                OrchestratorImpl.WEB_SERVICE_PORT,
+                port,
                 Optional.of(new BatchHostSuspendRequest(parentHostName, hostNames)),
                 BatchOperationResult.class
         )).thenThrow(new RuntimeException(exceptionMessage));


### PR DESCRIPTION
The first 7 commits are cherry-picked from #3464, this PR limits changes to only `node-admin`, does not include any of the lock changes and keeps the `ContainerProvider*` names.