### PR TITLE
Give config server some time to come up before starting services

### DIFF
--- a/docker/run/run-vespa-internal.sh
+++ b/docker/run/run-vespa-internal.sh
@@ -17,6 +17,8 @@ chown -R vespa:vespa /opt/vespa
 export VESPA_CONFIG_SERVERS=$(hostname)
 
 /opt/vespa/bin/vespa-start-configserver
+# Give config server some time to come up before starting services
+sleep 5
 /opt/vespa/bin/vespa-start-services
 
 # Print log forever


### PR DESCRIPTION
Config server takes some time to come up, waiting a bit with starting services will avoid some warnings about config server being down or not able to serve config. 