### PR TITLE
Let fail count indicate hw failure in cd too

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -80,7 +79,6 @@ public class FailedExpirer extends Expirer {
 
     private boolean failCountIndicatesHwFail(Zone zone, Node node) {
         if (node.flavor().getType() == Flavor.Type.DOCKER_CONTAINER) return false;
-        if (zone.system() == SystemName.cd) return false;
         return zone.environment() == Environment.prod || zone.environment() == Environment.staging;
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
@@ -75,8 +75,8 @@ public class FailedExpirerTest {
         clock.advance(Duration.ofDays(5));
         failedExpirer.run();
 
+        assertNodeHostnames(Node.State.failed, "node1");
         assertNodeHostnames(Node.State.parked, "node2", "node3");
-        assertNodeHostnames(Node.State.dirty, "node1");
     }
 
     @Test


### PR DESCRIPTION
This will avoid issues with nodes in dirty that do not reboot and which otherwise stalls integration tests