### PR TITLE
Revert "Remove self-triggering support"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -280,6 +280,11 @@ public class DeploymentTrigger {
             return application;
         }
 
+        if (application.deploymentJobs().isSelfTriggering()) {
+            log.info("Not triggering " + jobType + " for self-triggering " + application);
+            return application;
+        }
+
         log.info(String.format("Triggering %s for %s, %s: %s", jobType, application,
                                application.deploying().map(d -> "deploying " + d).orElse("restarted deployment"),
                                cause));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -125,6 +125,7 @@ public class ApplicationSerializer {
         deploymentJobs.projectId().ifPresent(projectId -> cursor.setLong(projectIdField, projectId));
         jobStatusToSlime(deploymentJobs.jobStatus().values(), cursor.setArray(jobStatusField));
         deploymentJobs.jiraIssueId().ifPresent(jiraIssueId -> cursor.setString(jiraIssueIdField, jiraIssueId));
+        cursor.setBool(selfTriggeringField, deploymentJobs.isSelfTriggering());
     }
 
     private void jobStatusToSlime(Collection<JobStatus> jobStatuses, Cursor jobStatusArray) {
@@ -219,7 +220,7 @@ public class ApplicationSerializer {
         Optional<String> jiraIssueKey = optionalString(object.field(jiraIssueIdField));
         boolean selfTriggering = object.field(selfTriggeringField).asBool();
 
-        return new DeploymentJobs(projectId, jobStatusList, jiraIssueKey);
+        return new DeploymentJobs(projectId, jobStatusList, jiraIssueKey, selfTriggering);
     }
 
     private Optional<Change> changeFromSlime(Inspector object) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/screwdriver/ScrewdriverApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/screwdriver/ScrewdriverApiHandler.java
@@ -147,7 +147,8 @@ public class ScrewdriverApiHandler extends LoggingRequestHandler {
                 JobType.fromId(report.field("jobName").asString()),
                 report.field("projectId").asLong(),
                 report.field("buildNumber").asLong(),
-                jobError
+                jobError,
+                report.field("selfTriggering").asBool()
         );
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
@@ -194,7 +194,8 @@ public class DeploymentTester {
                 jobType,
                 application.deploymentJobs().projectId().get(),
                 42,
-                jobError
+                jobError,
+                false
         );
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/MockBuildService.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/MockBuildService.java
@@ -161,7 +161,8 @@ public class MockBuildService implements BuildService {
                                 jobType,
                                 projectId,
                                 42,
-                                JobError.from(success)
+                                JobError.from(success),
+                                false
                         ));
         }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/PolledBuildSystemTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/PolledBuildSystemTest.java
@@ -2,9 +2,12 @@
 package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.api.integration.BuildService.BuildJob;
-import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType;
+import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
 import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,16 +37,15 @@ public class PolledBuildSystemTest {
 
     @Test
     public void throttle_capacity_constrained_jobs() {
-        DeploymentTester tester = new DeploymentTester();
+        ControllerTester tester = new ControllerTester();
         BuildSystem buildSystem = new PolledBuildSystem(tester.controller(), new MockCuratorDb());
 
-        int fooProjectId = 1;
-        int barProjectId = 2;
-        ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
-                .region("us-west-1")
-                .build();
-        ApplicationId foo = tester.createAndDeploy("app1", fooProjectId, applicationPackage).id();
-        ApplicationId bar = tester.createAndDeploy("app2", barProjectId, applicationPackage).id();
+        long fooProjectId = 1;
+        long barProjectId = 2;
+        ApplicationId foo = tester.createAndDeploy("tenant1", "domain1", "app1",
+                                                   Environment.prod, fooProjectId).id();
+        ApplicationId bar = tester.createAndDeploy("tenant2", "domain2", "app2",
+                                                   Environment.prod, barProjectId).id();
 
         // Trigger jobs in capacity constrained environment
         buildSystem.addJob(foo, jobType, false);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentExpirerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentExpirerTest.java
@@ -1,22 +1,16 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
-import com.yahoo.vespa.hosted.controller.Application;
-import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
-import com.yahoo.vespa.hosted.controller.application.Deployment;
-import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
-import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
+import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,50 +19,28 @@ import static org.junit.Assert.assertEquals;
  */
 public class DeploymentExpirerTest {
 
-    private DeploymentTester tester;
-
-    @Before
-    public void before() {
-        tester = new DeploymentTester();
-    }
-
     @Test
     public void testDeploymentExpiry() throws IOException, InterruptedException {
-        tester.controllerTester().getZoneRegistryMock().setDeploymentTimeToLive(new Zone(Environment.dev, RegionName.from("us-east-1")), Duration.ofDays(14));
+        ControllerTester tester = new ControllerTester();
+        tester.getZoneRegistryMock().setDeploymentTimeToLive(new Zone(Environment.dev, RegionName.from("us-east-1")), Duration.ofDays(14));
         DeploymentExpirer expirer = new DeploymentExpirer(tester.controller(), Duration.ofDays(10),
                                                           tester.clock(), new JobControl(new MockCuratorDb()));
-        Application devApp = tester.createApplication("app1", "tenant1", 123L, 1L);
-        Application prodApp = tester.createApplication("app2", "tenant2", 456L, 2L);
+        ApplicationId devApp = tester.createAndDeploy("tenant1", "domain1", "app1", Environment.dev, 123).id();
+        ApplicationId prodApp = tester.createAndDeploy("tenant2", "domain2", "app2", Environment.prod, 456).id();
 
-        // Deploy dev
-        tester.controllerTester().deploy(devApp, tester.controllerTester().toZone(Environment.dev));
-
-        // Deploy prod
-        ApplicationPackage prodAppPackage = new ApplicationPackageBuilder()
-                .region("us-west-1")
-                .build();
-        tester.deployCompletely(prodApp, prodAppPackage);
-
-        assertEquals(1, permanentDeployments(devApp).size());
-        assertEquals(1, permanentDeployments(prodApp).size());
+        assertEquals(1, tester.controller().applications().get(devApp).get().deployments().size());
+        assertEquals(1, tester.controller().applications().get(prodApp).get().deployments().size());
 
         // Not expired at first
         expirer.maintain();
-        assertEquals(1, permanentDeployments(devApp).size());
-        assertEquals(1, permanentDeployments(prodApp).size());
+        assertEquals(1, tester.controller().applications().get(devApp).get().deployments().size());
+        assertEquals(1, tester.controller().applications().get(prodApp).get().deployments().size());
 
         // The dev application is removed
         tester.clock().advance(Duration.ofDays(15));
         expirer.maintain();
-        assertEquals(0, permanentDeployments(devApp).size());
-        assertEquals(1, permanentDeployments(prodApp).size());
-    }
-
-    private List<Deployment> permanentDeployments(Application application) {
-        return tester.controller().applications().get(application.id()).get().deployments().values().stream()
-                .filter(deployment -> deployment.zone().environment() != Environment.test &&
-                                      deployment.zone().environment() != Environment.staging)
-                .collect(Collectors.toList());
+        assertEquals(0, tester.controller().applications().get(devApp).get().deployments().size());
+        assertEquals(1, tester.controller().applications().get(prodApp).get().deployments().size());
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -67,7 +67,7 @@ public class ApplicationSerializerTest {
                                 .withTriggering(Version.fromString("5.6.6"), Optional.empty(), true, Instant.ofEpochMilli(5))
                                 .withCompletion(Optional.of(JobError.unknown), Instant.ofEpochMilli(6), tester.controller()));
 
-        DeploymentJobs deploymentJobs = new DeploymentJobs(projectId, statusList, Optional.empty());
+        DeploymentJobs deploymentJobs = new DeploymentJobs(projectId, statusList, Optional.empty(), false);
 
         Application original = new Application(ApplicationId.from("t1", "a1", "i1"), 
                                                deploymentSpec, 
@@ -98,6 +98,7 @@ public class ApplicationSerializerTest {
         assertEquals(  original.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.stagingTest),
                      serialized.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.stagingTest));
         assertEquals(original.deploymentJobs().failingSince(), serialized.deploymentJobs().failingSince());
+        assertEquals(original.deploymentJobs().isSelfTriggering(), serialized.deploymentJobs().isSelfTriggering());
         
         assertEquals(original.hasOutstandingChange(), serialized.hasOutstandingChange());
         

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerControllerTester.java
@@ -89,8 +89,8 @@ public class ContainerControllerTester {
     public void notifyJobCompletion(ApplicationId applicationId, long projectId, boolean success, DeploymentJobs.JobType job) {
         controller().applications().notifyJobCompletion(new DeploymentJobs.JobReport(applicationId, job, projectId,
                                                                                      42,
-                                                                                     success ? Optional.empty() : Optional.of(DeploymentJobs.JobError.unknown)
-        ));
+                                                                                     success ? Optional.empty() : Optional.of(DeploymentJobs.JobError.unknown),
+                                                                                     false));
     }
 
     public AthensDomain addTenantAthensDomain(String domainName, String userName) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
@@ -274,7 +274,8 @@ public class VersionStatusTest {
                 jobType,
                 application.deploymentJobs().projectId().get(),
                 42,
-                JobError.from(success)
+                JobError.from(success),
+                false
         );
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#3497

Integration tests still require self-triggering support