### PR TITLE
Ignore applications missing project ID in build system

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployer.java
@@ -50,7 +50,7 @@ public class FailureRedeployer extends Maintainer {
     }
 
     private void retryStuckJobs(List<Application> applications) {
-        Instant maxAge = controller().clock().instant().minus(jobTimeout);
+        Instant startOfGracePeriod = controller().clock().instant().minus(jobTimeout);
         for (Application application : applications) {
             Optional<JobStatus> job = oldestRunningJob(application);
             if (!job.isPresent()) {
@@ -60,7 +60,7 @@ public class FailureRedeployer extends Maintainer {
             if (!job.get().type().zone(controller().system()).isPresent()) {
                 continue;
             }
-            if (job.get().lastTriggered().get().at().isBefore(maxAge)) {
+            if (job.get().lastTriggered().get().at().isBefore(startOfGracePeriod)) {
                 triggerFailing(application, "Job " + job.get().type().id() +
                         " has been running for more than " + jobTimeout);
             }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
@@ -299,7 +299,6 @@ public class FailureRedeployerTest {
     @Test
     public void ignoresPullRequestInstances() throws Exception {
         DeploymentTester tester = new DeploymentTester();
-        tester.controllerTester().getZoneRegistryMock().setSystem(SystemName.cd);
 
         // Current system version, matches version in test data
         Version version = Version.fromString("6.42.1");
@@ -310,6 +309,31 @@ public class FailureRedeployerTest {
         // Load test data data
         ApplicationSerializer serializer = new ApplicationSerializer();
         byte[] json = Files.readAllBytes(Paths.get("src/test/java/com/yahoo/vespa/hosted/controller/maintenance/testdata/pr-instance-with-dead-locked-job.json"));
+        Slime slime = SlimeUtils.jsonToSlime(json);
+        Application application = serializer.fromSlime(slime);
+
+        try (Lock lock = tester.controller().applications().lock(application.id())) {
+            tester.controller().applications().store(application, lock);
+        }
+
+        // Failure redeployer does not restart deployment
+        tester.failureRedeployer().maintain();
+        assertTrue("No jobs scheduled", tester.buildSystem().jobs().isEmpty());
+    }
+
+    @Test
+    public void applicationWithoutProjectIdIsNotTriggered() throws Exception {
+        DeploymentTester tester = new DeploymentTester();
+
+        // Current system version, matches version in test data
+        Version version = Version.fromString("6.42.1");
+        tester.configServerClientMock().setDefaultConfigServerVersion(version);
+        tester.updateVersionStatus(version);
+        assertEquals(version, tester.controller().versionStatus().systemVersion().get().versionNumber());
+
+        // Load test data data
+        ApplicationSerializer serializer = new ApplicationSerializer();
+        byte[] json = Files.readAllBytes(Paths.get("src/test/java/com/yahoo/vespa/hosted/controller/maintenance/testdata/application-without-project-id.json"));
         Slime slime = SlimeUtils.jsonToSlime(json);
         Application application = serializer.fromSlime(slime);
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/testdata/application-without-project-id.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/testdata/application-without-project-id.json
@@ -1,0 +1,20 @@
+{
+  "id": "tenant1:app1:default",
+  "deploymentSpecField": "<deployment version='1.0'>\n  <test />\n  <staging />\n  <prod>\n     <region active=\"true\">cd-us-central-1</region>\n     <region active=\"true\">cd-us-central-2</region>\n  </prod>\n</deployment>\n",
+  "validationOverrides": "<deployment version='1.0'/>",
+  "deployments": [],
+  "deploymentJobs": {
+    "jobStatus": [
+      {
+        "jobType": "system-test",
+        "lastTriggered": {
+          "version": "6.42.1",
+          "upgrade": false,
+          "at": 1506330088050
+        }
+      }
+    ],
+    "selfTriggering": false
+  },
+  "outstandingChangeField": false
+}


### PR DESCRIPTION
This should not really happen in the normal case, but the model allows it so it does. Either way, this avoids the build system failing completely when ID is missing.