### PR TITLE
The cost of preserving the framepointer is small enough to allow it b…

### DIFF
--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -135,6 +135,7 @@ fixddir $bundlecachedir
 vespa-run-as-vespa-user vespa-runserver -s configserver -r 30 -p $pidfile -- \
 	java \
 	-Xms128m -Xmx2048m \
+        -XX:+PreserveFramePointer \
 	-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${VESPA_HOME}/var/crash \
 	-XX:OnOutOfMemoryError='kill -9 %p' \
 	$jvmargs \

--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -186,6 +186,7 @@ exec_jsvc () {
     configure_preload
     exec $numactlcmd $envcmd $jsvc_binary_name \
         -Dconfig.id="${VESPA_CONFIG_ID}" \
+        -XX:+PreserveFramePointer \
         ${jsvc_opts} \
         ${memory_options} \
         ${jvm_gcopts} \
@@ -258,6 +259,7 @@ maybe_use_jsvc
 
 exec $numactlcmd $envcmd java \
         -Dconfig.id="${VESPA_CONFIG_ID}" \
+        -XX:+PreserveFramePointer \
         ${memory_options} \
         ${jvm_gcopts} \
         -XX:MaxJavaStackTraceDepth=-1 \


### PR DESCRIPTION
…eing default.

Performance information benefits is significant and will over time counter the cost.
Observed cost has been below the noise level in the 1% range.
@bjorncs PR