### PR TITLE
Use explicit version or range for all deps.

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -5,12 +5,23 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.yahoo.vespa</groupId>
+    <parent>
+        <groupId>com.yahoo.vespa</groupId>
+        <artifactId>parent</artifactId>
+        <version>6-SNAPSHOT</version>
+    </parent>
+
     <artifactId>container-dependencies-enforcer</artifactId>
     <version>6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>application</artifactId>
@@ -57,64 +68,67 @@
                                             </excludes>
                                             <includes>
                                                 <include>com.yahoo.vespa</include>
-                                                <include>aopalliance:aopalliance:1.0:jar:provided</include>
-                                                <include>com.fasterxml.jackson.core:jackson-annotations:2.8.3:jar:provided</include>
-                                                <include>com.fasterxml.jackson.core:jackson-core:2.8.3:jar:provided</include>
-                                                <include>com.fasterxml.jackson.core:jackson-databind:2.8.3:jar:provided</include>
-                                                <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.8.3:jar:provided</include>
-                                                <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.5.4:jar:provided</include>
-                                                <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.5.4:jar:provided</include>
-                                                <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.5.4:jar:provided</include>
-                                                <include>com.google.code.findbugs:annotations:1.3.9:jar:provided</include>
-                                                <include>com.google.code.findbugs:jsr305:1.3.9:jar:provided</include>
-                                                <include>com.google.guava:guava:18.0:jar:provided</include>
-                                                <include>com.google.inject.extensions:guice-assistedinject:3.0:jar:provided</include>
-                                                <include>com.google.inject.extensions:guice-multibindings:3.0:jar:provided</include>
-                                                <include>com.google.inject:guice:3.0:jar:provided:no_aop</include>
-                                                <include>commons-codec:commons-codec:1.4:jar:provided</include>
-                                                <include>commons-daemon:commons-daemon:1.0.3:jar:provided</include>
-                                                <include>commons-logging:commons-logging:1.1.1:jar:provided</include>
-                                                <include>javax.annotation:javax.annotation-api:1.2:jar:provided</include>
-                                                <include>javax.inject:javax.inject:1:jar:provided</include>
-                                                <include>javax.servlet:javax.servlet-api:3.1.0:jar:provided</include>
-                                                <include>javax.validation:validation-api:1.1.0.Final:jar:provided</include>
-                                                <include>javax.ws.rs:javax.ws.rs-api:2.0.1:jar:provided</include>
-                                                <include>net.jcip:jcip-annotations:1.0:jar:provided</include>
-                                                <include>net.jpountz.lz4:lz4:1.3.0:jar:provided</include>
-                                                <include>org.apache.felix:org.apache.felix.framework:4.2.1:jar:provided</include>
-                                                <include>org.apache.felix:org.apache.felix.log:1.0.1:jar:provided</include>
-                                                <include>org.apache.felix:org.apache.felix.main:4.2.1:jar:provided</include>
-                                                <include>org.apache.httpcomponents:httpclient:4.3.6:jar:provided</include>
-                                                <include>org.apache.httpcomponents:httpcore:4.3.3:jar:provided</include>
-                                                <include>org.eclipse.jetty:jetty-http:9.4.6.v20170531:jar:provided</include>
-                                                <include>org.eclipse.jetty:jetty-io:9.4.6.v20170531:jar:provided</include>
-                                                <include>org.eclipse.jetty:jetty-util:9.4.6.v20170531:jar:provided</include>
-                                                <include>org.glassfish.hk2.external:aopalliance-repackaged:2.5.0-b05:jar:provided</include>
-                                                <include>org.glassfish.hk2.external:javax.inject:2.5.0-b05:jar:provided</include>
-                                                <include>org.glassfish.hk2:hk2-api:2.5.0-b05:jar:provided</include>
-                                                <include>org.glassfish.hk2:hk2-locator:2.5.0-b05:jar:provided</include>
-                                                <include>org.glassfish.hk2:hk2-utils:2.5.0-b05:jar:provided</include>
-                                                <include>org.glassfish.hk2:osgi-resource-locator:1.0.1:jar:provided</include>
-                                                <include>org.glassfish.jersey.bundles.repackaged:jersey-guava:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.containers:jersey-container-servlet-core:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.containers:jersey-container-servlet:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.core:jersey-client:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.core:jersey-common:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.core:jersey-server:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.ext:jersey-entity-filtering:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.ext:jersey-proxy-client:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.media:jersey-media-jaxb:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.media:jersey-media-json-jackson:2.23.2:jar:provided</include>
-                                                <include>org.glassfish.jersey.media:jersey-media-multipart:2.23.2:jar:provided</include>
-                                                <include>org.javassist:javassist:3.20.0-GA:jar:provided</include>
-                                                <include>org.json:json:20090211:jar:provided</include>
-                                                <include>org.jvnet.mimepull:mimepull:1.9.6:jar:provided</include>
-                                                <include>org.scala-lang.modules:scala-parser-combinators_2.11:1.0.1:jar:provided</include>
-                                                <include>org.slf4j:jcl-over-slf4j:1.7.5:jar:provided</include>
-                                                <include>org.slf4j:log4j-over-slf4j:1.7.5:jar:provided</include>
-                                                <include>org.slf4j:slf4j-api:1.7.5:jar:provided</include>
-                                                <include>org.slf4j:slf4j-jdk14:1.7.5:jar:provided</include>
-                                                <include>xml-apis:xml-apis:1.4.01:jar:provided</include>
+                                                <include>aopalliance:aopalliance:[1.0]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.core:jackson-annotations:[${jackson2.version}]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.core:jackson-core:[${jackson2.version}]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.core:jackson-databind:[${jackson2.version}]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8:[${jackson2.version}]:jar:provided</include>
+
+                                                <!-- Use version range for jax deps, because jersey and junit affect the versions. -->
+                                                <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:[2.5.4, ${jackson2.version}]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:[2.5.4, ${jackson2.version}]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:[2.5.4, ${jackson2.version}]:jar:provided</include>
+
+                                                <include>com.google.code.findbugs:annotations:[1.3.9]:jar:provided</include>
+                                                <include>com.google.code.findbugs:jsr305:[1.3.9]:jar:provided</include>
+                                                <include>com.google.guava:guava:[18.0]:jar:provided</include>
+                                                <include>com.google.inject.extensions:guice-assistedinject:[3.0]:jar:provided</include>
+                                                <include>com.google.inject.extensions:guice-multibindings:[3.0]:jar:provided</include>
+                                                <include>com.google.inject:guice:[3.0]:jar:provided:no_aop</include>
+                                                <include>commons-codec:commons-codec:[1.4]:jar:provided</include>
+                                                <include>commons-daemon:commons-daemon:[1.0.3]:jar:provided</include>
+                                                <include>commons-logging:commons-logging:[1.1.1]:jar:provided</include>
+                                                <include>javax.annotation:javax.annotation-api:[1.2]:jar:provided</include>
+                                                <include>javax.inject:javax.inject:[1]:jar:provided</include>
+                                                <include>javax.servlet:javax.servlet-api:[3.1.0]:jar:provided</include>
+                                                <include>javax.validation:validation-api:[1.1.0.Final]:jar:provided</include>
+                                                <include>javax.ws.rs:javax.ws.rs-api:[${javax.ws.rs-api.version}]:jar:provided</include>
+                                                <include>net.jcip:jcip-annotations:[1.0]:jar:provided</include>
+                                                <include>net.jpountz.lz4:lz4:[1.3.0]:jar:provided</include>
+                                                <include>org.apache.felix:org.apache.felix.framework:[4.2.1]:jar:provided</include>
+                                                <include>org.apache.felix:org.apache.felix.log:[1.0.1]:jar:provided</include>
+                                                <include>org.apache.felix:org.apache.felix.main:[4.2.1]:jar:provided</include>
+                                                <include>org.apache.httpcomponents:httpclient:[4.3.6]:jar:provided</include>
+                                                <include>org.apache.httpcomponents:httpcore:[4.3.3]:jar:provided</include>
+                                                <include>org.eclipse.jetty:jetty-http:[${jetty.version}]:jar:provided</include>
+                                                <include>org.eclipse.jetty:jetty-io:[${jetty.version}]:jar:provided</include>
+                                                <include>org.eclipse.jetty:jetty-util:[${jetty.version}]:jar:provided</include>
+                                                <include>org.glassfish.hk2.external:aopalliance-repackaged:[2.5.0-b05]:jar:provided</include>
+                                                <include>org.glassfish.hk2.external:javax.inject:[2.5.0-b05]:jar:provided</include>
+                                                <include>org.glassfish.hk2:hk2-api:[2.5.0-b05]:jar:provided</include>
+                                                <include>org.glassfish.hk2:hk2-locator:[2.5.0-b05]:jar:provided</include>
+                                                <include>org.glassfish.hk2:hk2-utils:[2.5.0-b05]:jar:provided</include>
+                                                <include>org.glassfish.hk2:osgi-resource-locator:[1.0.1]:jar:provided</include>
+                                                <include>org.glassfish.jersey.bundles.repackaged:jersey-guava:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.containers:jersey-container-servlet-core:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.containers:jersey-container-servlet:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.core:jersey-client:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.core:jersey-common:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.core:jersey-server:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.ext:jersey-entity-filtering:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.ext:jersey-proxy-client:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.media:jersey-media-jaxb:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.media:jersey-media-json-jackson:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.glassfish.jersey.media:jersey-media-multipart:[${jersey2.version}]:jar:provided</include>
+                                                <include>org.javassist:javassist:[3.20.0-GA]:jar:provided</include>
+                                                <include>org.json:json:[20090211]:jar:provided</include>
+                                                <include>org.jvnet.mimepull:mimepull:[1.9.6]:jar:provided</include>
+                                                <include>org.scala-lang.modules:scala-parser-combinators_2.11:[1.0.1]:jar:provided</include>
+                                                <include>org.slf4j:jcl-over-slf4j:[1.7.5]:jar:provided</include>
+                                                <include>org.slf4j:log4j-over-slf4j:[1.7.5]:jar:provided</include>
+                                                <include>org.slf4j:slf4j-api:[1.7.5]:jar:provided</include>
+                                                <include>org.slf4j:slf4j-jdk14:[1.7.5]:jar:provided</include>
+                                                <include>xml-apis:xml-apis:[1.4.01]:jar:provided</include>
                                             </includes>
                                         </bannedDependencies>
                                     </rules>


### PR DESCRIPTION
+ Use vespa parent to get dependency version properties.
+ Add junit as test dep for a more realistic setup, plus it
  actually affects the versions of provided deps.