### PR TITLE
Add wantedDocumentCount parameter to Document V1 visiting API

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandler.java
@@ -8,11 +8,11 @@ import java.util.Optional;
 /**
  * Abstract the backend stuff for the REST API, such as retrieving or updating documents.
  *
- * @author dybis
+ * @author Haakon Dybdahl
  */
 public interface OperationHandler {
 
-    class VisitResult{
+    class VisitResult {
 
         public final Optional<String> token;
         public final String documentsAsJsonList;
@@ -23,7 +23,19 @@ public interface OperationHandler {
         }
     }
 
-    VisitResult visit(RestUri restUri, String documentSelection,  Optional<String> cluster, Optional<String> continuation) throws RestApiException;
+    class VisitOptions {
+        public final Optional<String> cluster;
+        public final Optional<String> continuation;
+        public final Optional<Integer> wantedDocumentCount;
+
+        public VisitOptions(Optional<String> cluster, Optional<String> continuation, Optional<Integer> wantedDocumentCount) {
+            this.cluster = cluster;
+            this.continuation = continuation;
+            this.wantedDocumentCount = wantedDocumentCount;
+        }
+    }
+
+    VisitResult visit(RestUri restUri, String documentSelection, VisitOptions options) throws RestApiException;
 
     void put(RestUri restUri, VespaXMLFeedReader.Operation data, Optional<String> route) throws RestApiException;
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
@@ -20,7 +20,7 @@ public class MockedOperationHandler implements OperationHandler {
     @Override
     public VisitResult visit(RestUri restUri, String documentSelection, VisitOptions options) throws RestApiException {
         return new VisitResult(Optional.of("token"), "List of json docs, cont token "
-                + options.continuation.map(a->a).orElse("not set") + ", doc selection: '"
+                + options.continuation.orElse("not set") + ", doc selection: '"
                 + documentSelection + "'"
                 + options.wantedDocumentCount.map(n -> String.format(", min docs returned: %d", n)).orElse(""));
     }

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
@@ -18,9 +18,11 @@ public class MockedOperationHandler implements OperationHandler {
     int deleteCount = 0;
 
     @Override
-    public VisitResult visit(RestUri restUri, String documentSelection, Optional<String> cluster, Optional<String> continuation) throws RestApiException {
-        return new VisitResult(Optional.of("token"), "List of json docs, cont token " + continuation.map(a->a).orElse("not set") + ", doc selection: '"
-                + documentSelection + "'");
+    public VisitResult visit(RestUri restUri, String documentSelection, VisitOptions options) throws RestApiException {
+        return new VisitResult(Optional.of("token"), "List of json docs, cont token "
+                + options.continuation.map(a->a).orElse("not set") + ", doc selection: '"
+                + documentSelection + "'"
+                + options.wantedDocumentCount.map(n -> String.format(", min docs returned: %d", n)).orElse(""));
     }
 
     @Override

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
@@ -270,6 +270,7 @@ public class RestApiTest {
         assertThat(rest, containsString(visit_response_part3));
     }
 
+    // TODO why is this a limitation?
     String visit_test_bad_uri = "/document/v1/namespace/document-type/group/abc?continuation=abc&selection=foo";
     String visit_test_bad_response = "Visiting does not support setting value for group/value in combination with expression";
 
@@ -292,6 +293,22 @@ public class RestApiTest {
         HttpGet get = new HttpGet(request.getUri());
         String rest = doRest(get);
         assertThat(rest, containsString(visit_test_response_selection_rewrite));
+    }
+
+    @Test
+    public void wanted_document_count_returned_parameter_is_propagated() throws IOException {
+        Request request = new Request(String.format("http://localhost:%s/document/v1/namespace/document-type/docid/?wantedDocumentCount=321", getFirstListenPort()));
+        HttpGet get = new HttpGet(request.getUri());
+        String rest = doRest(get);
+        assertThat(rest, containsString("min docs returned: 321"));
+    }
+
+    @Test
+    public void wanted_document_count_parameter_returns_error_response() throws IOException {
+        Request request = new Request(String.format("http://localhost:%s/document/v1/namespace/document-type/docid/?wantedDocumentCount=aardvark", getFirstListenPort()));
+        HttpGet get = new HttpGet(request.getUri());
+        String rest = doRest(get);
+        assertThat(rest, containsString("Invalid 'wantedDocumentCount' value. Expected integer"));
     }
 
     private String doRest(HttpRequestBase request) throws IOException {


### PR DESCRIPTION
@freva please review

Visiting will continue until the provided number of documents has
been returned, or the session times out.
Parameter is bounded by an implementation defined maximum.
Remove old visit() interface method, as it should not have been covered
by an ExportPackage and therefore no one should have managed to
actually use it externally.

This fixes #3394