### PR TITLE
exposes sentinel metrics

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -30,9 +30,21 @@ public class VespaMetricSet {
         metrics.addAll(getQrserverMetrics());
         metrics.addAll(getContainerMetrics());
         metrics.addAll(getConfigServerMetrics());
+        metrics.addAll(getSentinelMetrics());
         metrics.addAll(getOtherMetrics());
 
         return Collections.unmodifiableSet(metrics);
+    }
+
+    private static Set<Metric> getSentinelMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+
+        metrics.add(new Metric("sentinel.restarts.count"));
+
+        metrics.add(new Metric("sentinel.running.count"));
+        metrics.add(new Metric("sentinel.running.last"));
+
+        return metrics;
     }
 
     private static Set<Metric> getOtherMetrics() {


### PR DESCRIPTION
* how many times sentinel restarted a service
* how many services the sentinel has running currently

@gjoranv, we need to expose some of the sentinel metrics. Is this enough or do I need to do something else?

