### PR TITLE
Upgrade docker-java

### DIFF
--- a/docker-api/pom.xml
+++ b/docker-api/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>3.0.8</version>
+            <version>3.0.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -419,7 +419,7 @@ public class DockerImpl implements Docker {
     @Override
     public void buildImage(File dockerfile, DockerImage image) {
         try {
-            dockerClient.buildImageCmd(dockerfile).withTag(image.asString())
+            dockerClient.buildImageCmd(dockerfile).withTags(Collections.singleton(image.asString()))
                     .exec(new BuildImageResultCallback()).awaitImageId();
         } catch (RuntimeException e) {
             numberOfDockerDaemonFails.add();


### PR DESCRIPTION
Upgrade `docker-java` to `3.0.13`: Fixes annoying `NullPointerException` when build a docker image (for sys.test) with docker version > 17.05.