### PR TITLE
Remove unnecessary expensive cleanup

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/FileDistribution.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/FileDistribution.java
@@ -18,6 +18,7 @@ public interface FileDistribution {
 
     void sendDeployedFiles(String hostName, Set<FileReference> fileReferences);
     void reloadDeployFileDistributor();
+    // TODO: Remove when 6.150 is the oldest version used
     void limitSendingOfDeployedFilesTo(Collection<String> hostNames);
     void removeDeploymentsThatHaveDifferentApplicationId(Collection<String> targetHostnames);
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributor.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributor.java
@@ -102,7 +102,6 @@ public class FileDistributor {
             }
         }
         dbHandler.sendDeployedFiles(fileSourceHost, allFilesToSend());
-        dbHandler.limitSendingOfDeployedFilesTo(union(getTargetHostnames(), fileSourceHost));
         dbHandler.removeDeploymentsThatHaveDifferentApplicationId(getTargetHostnames());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
@@ -134,7 +134,6 @@ public class SessionPreparerTest extends TestWithCurator {
     public void require_that_application_is_prepared() throws Exception {
         preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(), new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().sendDeployedFilesCalled, is(2));
-        assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().limitSendingOfDeployedFilesToCalled, is(2));
         // Should be called only once no matter how many model versions are built
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().reloadDeployFileDistributorCalled, is(1));
         assertTrue(configCurator.exists(sessionsPath.append(ConfigCurator.USERAPP_ZK_SUBPATH).append("services.xml").getAbsolute()));


### PR DESCRIPTION
* Remove step that is very expensive, since it iterates over all hosts
  in the system.  Cleanup is done by
  removeDeploymentsThatHaveDifferentApplicationId() anyway