### PR TITLE
Revert "Upgrade surefire to 2.20.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -910,7 +910,7 @@
     	<doclint>all</doclint>
         <scala.major-version>2.11</scala.major-version>
         <scala.version>${scala.major-version}.4</scala.version>
-        <surefire.version>2.20.1</surefire.version>
+        <surefire.version>2.19.1</surefire.version> <!-- NOTE bjorncs 15.06.2017: Version 2.20 has OoM issues -->
     </properties>
 
     <modules>


### PR DESCRIPTION
Reverts vespa-engine/vespa#3631

Seems to leak into production builds, which fail due to tests not being run