### PR TITLE
Use plain CentOS base when building Vespa rpm.

### DIFF
--- a/docker/build-vespa.sh
+++ b/docker/build-vespa.sh
@@ -11,7 +11,7 @@ DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 cd $DIR
 
 VESPA_VERSION=$1
-DOCKER_IMAGE="vespaengine/vespa-dev:latest"
+DOCKER_IMAGE="centos:latest"
 
 docker pull ${DOCKER_IMAGE}
 docker run --rm -v $(pwd)/..:/vespa --entrypoint /vespa/docker/build/build-vespa-internal.sh "$DOCKER_IMAGE" "$VESPA_VERSION" "$(id -u)" "$(id -g)"

--- a/docker/build/build-vespa-internal.sh
+++ b/docker/build/build-vespa-internal.sh
@@ -13,6 +13,12 @@ CALLER_GID=$3
 
 cd /vespa
 ./dist.sh ${VESPA_VERSION}
+
+yum -y install epel-release
+yum -y install centos-release-scl
+yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo
+
+yum-builddep -y ~/rpmbuild/SPECS/vespa-${VESPA_VERSION}.spec
 rpmbuild -bb ~/rpmbuild/SPECS/vespa-${VESPA_VERSION}.spec
 chown ${CALLER_UID}:${CALLER_GID} ~/rpmbuild/RPMS/x86_64/*.rpm
 mv ~/rpmbuild/RPMS/x86_64/*.rpm /vespa/docker 


### PR DESCRIPTION
@bjorncs 

Need this to test build the RPM for a given Vespa version. Don't want to be dependent upon what was in the vespa-dev image.