### PR TITLE
Use vespa version from active application if not supplied

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -330,7 +330,12 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         LocalSession session = getLocalSession(tenant, sessionId);
         ApplicationId appId = params.getApplicationId();
         Optional<ApplicationSet> currentActiveApplicationSet = getCurrentActiveApplicationSet(tenant, appId);
-        return session.prepare(logger, params, currentActiveApplicationSet, tenant.getPath(), clock.instant());
+        Optional<Version> currentActiveVespaVersion = Optional.empty();
+        if (currentActiveApplicationSet.isPresent()) {
+            currentActiveVespaVersion = Optional.of(getExistingSession(tenant, appId).getVespaVersion());
+        }
+        return session.prepare(logger, params, currentActiveApplicationSet, currentActiveVespaVersion,
+                               tenant.getPath(), clock.instant());
     }
 
     private List<ApplicationId> listApplicationIds(Tenant tenant) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -111,6 +111,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                                                    .vespaVersion(version.toString())
                                                    .build(),
                         Optional.empty(),
+                        Optional.empty(),
                         tenantPath,
                         clock.instant());
         this.prepared = true;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
@@ -61,12 +61,14 @@ public class LocalSession extends Session implements Comparable<LocalSession> {
 
     public ConfigChangeActions prepare(DeployLogger logger, 
                                        PrepareParams params, 
-                                       Optional<ApplicationSet> currentActiveApplicationSet, 
+                                       Optional<ApplicationSet> currentActiveApplicationSet,
+                                       Optional<Version> currentActiveVespaVersion,
                                        Path tenantPath,
                                        Instant now) {
         Curator.CompletionWaiter waiter = zooKeeperClient.createPrepareWaiter();
         ConfigChangeActions actions = sessionPreparer.prepare(sessionContext, logger, params,
-                                                              currentActiveApplicationSet, tenantPath, now);
+                                                              currentActiveApplicationSet, currentActiveVespaVersion,
+                                                              tenantPath, now);
         setPrepared();
         waiter.awaitCompletion(params.getTimeoutBudget().timeLeft());
         return actions;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -140,9 +140,14 @@ public class DeployTester {
         PrepareParams.Builder paramsBuilder = new PrepareParams.Builder().applicationId(id);
         if (vespaVersion != null)
             paramsBuilder.vespaVersion(vespaVersion);
+        LocalSession activeSession = tenant.getLocalSessionRepo().getActiveSession(id);
+        Optional<com.yahoo.component.Version> currentActiveVespaVersion = Optional.empty();
+        if (activeSession != null)
+            currentActiveVespaVersion = Optional.of(activeSession.getVespaVersion());
         session.prepare(new SilentDeployLogger(),
                         paramsBuilder.build(),
                         Optional.empty(),
+                        currentActiveVespaVersion,
                         tenant.getPath(),
                         now);
         session.createActivateTransaction().commit();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
@@ -104,7 +104,10 @@ public class SessionHandlerTest {
         }
 
         @Override
-        public ConfigChangeActions prepare(DeployLogger logger, PrepareParams params, Optional<ApplicationSet> application, Path tenantPath, Instant now) {
+        public ConfigChangeActions prepare(DeployLogger logger, PrepareParams params,
+                                           Optional<ApplicationSet> applicationSet,
+                                           Optional<com.yahoo.component.Version> currentActiveVespaVersion,
+                                           Path tenantPath, Instant now) {
             status = Session.Status.PREPARE;
             if (doVerboseLogging) {
                 logger.log(LogLevel.DEBUG, "debuglog");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.config.server.http.v2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.yahoo.cloud.config.ConfigserverConfig;
+import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ServiceInfo;
@@ -408,7 +409,8 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
         @Override
         public ConfigChangeActions prepare(DeployLogger logger,
                                            PrepareParams params,
-                                           Optional<ApplicationSet> application,
+                                           Optional<ApplicationSet> applicationSet,
+                                           Optional<Version> currentActiveVespaVersion,
                                            Path tenantPath,
                                            Instant now) {
             throw exception;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
@@ -173,7 +173,7 @@ public class LocalSessionTest {
     }
 
     private void doPrepare(LocalSession session, PrepareParams params, Instant now) {
-        session.prepare(getLogger(false), params, Optional.empty(), tenantPath, now);
+        session.prepare(getLogger(false), params, Optional.empty(), Optional.empty(), tenantPath, now);
     }
 
     DeployHandlerLogger getLogger(boolean verbose) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionTest.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.session;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.config.server.application.ApplicationSet;
@@ -18,14 +19,18 @@ import java.util.Optional;
 public class SessionTest {
 
     public static class MockSessionPreparer extends SessionPreparer {
-        public boolean isPrepared = false;
+        boolean isPrepared = false;
 
         public MockSessionPreparer() {
-            super(null, null, null, null, null, null, new MockCurator(), null);
+            super(null, null, null, null,
+                  null, null, new MockCurator(), null);
         }
 
         @Override
-        public ConfigChangeActions prepare(SessionContext context, DeployLogger logger, PrepareParams params, Optional<ApplicationSet> currentActiveApplicationSet, Path tenantPath, Instant now) {
+        public ConfigChangeActions prepare(SessionContext context, DeployLogger logger, PrepareParams params,
+                                           Optional<ApplicationSet> currentActiveApplicationSet,
+                                           Optional<Version> currentVespaVersion,
+                                           Path tenantPath, Instant now) {
             isPrepared = true;
             return new ConfigChangeActions(new ArrayList<>());
         }


### PR DESCRIPTION
* If preparing a deployment and no vespa version is given in request parameter
  use the vespa version from the active application if one exists AND running
  on hosted vespa, else use current vespa version.