### PR TITLE
Revert "Use vespa version from active application if not supplied"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -330,12 +330,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         LocalSession session = getLocalSession(tenant, sessionId);
         ApplicationId appId = params.getApplicationId();
         Optional<ApplicationSet> currentActiveApplicationSet = getCurrentActiveApplicationSet(tenant, appId);
-        Optional<Version> currentActiveVespaVersion = Optional.empty();
-        if (currentActiveApplicationSet.isPresent()) {
-            currentActiveVespaVersion = Optional.of(getExistingSession(tenant, appId).getVespaVersion());
-        }
-        return session.prepare(logger, params, currentActiveApplicationSet, currentActiveVespaVersion,
-                               tenant.getPath(), clock.instant());
+        return session.prepare(logger, params, currentActiveApplicationSet, tenant.getPath(), clock.instant());
     }
 
     private List<ApplicationId> listApplicationIds(Tenant tenant) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -111,7 +111,6 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                                                    .vespaVersion(version.toString())
                                                    .build(),
                         Optional.empty(),
-                        Optional.empty(),
                         tenantPath,
                         clock.instant());
         this.prepared = true;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
@@ -61,14 +61,12 @@ public class LocalSession extends Session implements Comparable<LocalSession> {
 
     public ConfigChangeActions prepare(DeployLogger logger, 
                                        PrepareParams params, 
-                                       Optional<ApplicationSet> currentActiveApplicationSet,
-                                       Optional<Version> currentActiveVespaVersion,
+                                       Optional<ApplicationSet> currentActiveApplicationSet, 
                                        Path tenantPath,
                                        Instant now) {
         Curator.CompletionWaiter waiter = zooKeeperClient.createPrepareWaiter();
         ConfigChangeActions actions = sessionPreparer.prepare(sessionContext, logger, params,
-                                                              currentActiveApplicationSet, currentActiveVespaVersion,
-                                                              tenantPath, now);
+                                                              currentActiveApplicationSet, tenantPath, now);
         setPrepared();
         waiter.awaitCompletion(params.getTimeoutBudget().timeLeft());
         return actions;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -87,11 +87,9 @@ public class SessionPreparer {
      * @return the config change actions that must be done to handle the activation of the models prepared.
      */
     public ConfigChangeActions prepare(SessionContext context, DeployLogger logger, PrepareParams params,
-                                       Optional<ApplicationSet> currentActiveApplicationSet,
-                                       Optional<com.yahoo.component.Version> currentActiveVespaVersion, Path tenantPath,
+                                       Optional<ApplicationSet> currentActiveApplicationSet, Path tenantPath, 
                                        Instant now) {
-        Preparation preparation = new Preparation(context, logger, params, currentActiveApplicationSet,
-                                                  currentActiveVespaVersion, tenantPath);
+        Preparation preparation = new Preparation(context, logger, params, currentActiveApplicationSet, tenantPath);
         preparation.preprocess();
         try {
             AllocatedHosts allocatedHosts = preparation.buildModels(now);
@@ -136,9 +134,7 @@ public class SessionPreparer {
         private final PreparedModelsBuilder preparedModelsBuilder;
 
         Preparation(SessionContext context, DeployLogger logger, PrepareParams params,
-                    Optional<ApplicationSet> currentActiveApplicationSet,
-                    Optional<com.yahoo.component.Version> currentActiveVespaVersion,
-                    Path tenantPath) {
+                    Optional<ApplicationSet> currentActiveApplicationSet, Path tenantPath) {
             this.context = context;
             this.logger = logger;
             this.params = params;
@@ -146,7 +142,7 @@ public class SessionPreparer {
             this.tenantPath = tenantPath;
 
             this.applicationId = params.getApplicationId();
-            this.vespaVersion = wantedVespaVersion(params, currentActiveVespaVersion, configserverConfig.hostedVespa());
+            this.vespaVersion = params.vespaVersion().orElse(Vtag.currentVersion);
             this.rotations = new Rotations(curator, tenantPath);
             this.rotationsSet = getRotations(params.rotations());
             this.properties = new ModelContextImpl.Properties(params.getApplicationId(),
@@ -165,17 +161,6 @@ public class SessionPreparer {
                                                                    params,
                                                                    currentActiveApplicationSet,
                                                                    properties);
-        }
-
-        private com.yahoo.component.Version wantedVespaVersion(PrepareParams params,
-                                                               Optional<com.yahoo.component.Version> currentActiveVespaVersion,
-                                                               boolean hostedVespa) {
-            if (params.vespaVersion().isPresent())
-                return params.vespaVersion().get();
-            else if (hostedVespa)
-                return currentActiveVespaVersion.orElse(Vtag.currentVersion);
-            else
-                return Vtag.currentVersion;
         }
 
         void checkTimeout(String step) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -140,14 +140,9 @@ public class DeployTester {
         PrepareParams.Builder paramsBuilder = new PrepareParams.Builder().applicationId(id);
         if (vespaVersion != null)
             paramsBuilder.vespaVersion(vespaVersion);
-        LocalSession activeSession = tenant.getLocalSessionRepo().getActiveSession(id);
-        Optional<com.yahoo.component.Version> currentActiveVespaVersion = Optional.empty();
-        if (activeSession != null)
-            currentActiveVespaVersion = Optional.of(activeSession.getVespaVersion());
         session.prepare(new SilentDeployLogger(),
                         paramsBuilder.build(),
                         Optional.empty(),
-                        currentActiveVespaVersion,
                         tenant.getPath(),
                         now);
         session.createActivateTransaction().commit();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -103,21 +102,6 @@ public class HostedDeployTest {
                 // success
             }
         }
-    }
-
-    // If on hosted vespa and no version is given, the version for the current active application should be used
-    // This might be the case for manual/emergency deployments not coming from controller
-    @Test
-    public void deployWithoutVersionShouldUseActiveVersionOnHostedVespa() throws InterruptedException, IOException {
-        DeployTester tester = new DeployTester("src/test/apps/hosted/", createConfigserverConfig());
-        String vespaVersion = "4.5.6";
-        ApplicationId initialApplicationId = tester.deployApp("myApp", vespaVersion, Instant.now());
-        long initialSessionId = tester.tenant().getApplicationRepo().getSessionIdForApplication(initialApplicationId);
-
-        ApplicationId applicationId = tester.deployApp("myApp", Instant.now()); // no version
-        long sessionId = tester.tenant().getApplicationRepo().getSessionIdForApplication(applicationId);
-        assertNotEquals(initialSessionId, sessionId);
-        assertEquals(vespaVersion, tester.tenant().getLocalSessionRepo().getSession(sessionId).getVespaVersion().toFullString());
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
@@ -104,10 +104,7 @@ public class SessionHandlerTest {
         }
 
         @Override
-        public ConfigChangeActions prepare(DeployLogger logger, PrepareParams params,
-                                           Optional<ApplicationSet> applicationSet,
-                                           Optional<com.yahoo.component.Version> currentActiveVespaVersion,
-                                           Path tenantPath, Instant now) {
+        public ConfigChangeActions prepare(DeployLogger logger, PrepareParams params, Optional<ApplicationSet> application, Path tenantPath, Instant now) {
             status = Session.Status.PREPARE;
             if (doVerboseLogging) {
                 logger.log(LogLevel.DEBUG, "debuglog");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.config.server.http.v2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.yahoo.cloud.config.ConfigserverConfig;
-import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ServiceInfo;
@@ -409,8 +408,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
         @Override
         public ConfigChangeActions prepare(DeployLogger logger,
                                            PrepareParams params,
-                                           Optional<ApplicationSet> applicationSet,
-                                           Optional<Version> currentActiveVespaVersion,
+                                           Optional<ApplicationSet> application,
                                            Path tenantPath,
                                            Instant now) {
             throw exception;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
@@ -173,7 +173,7 @@ public class LocalSessionTest {
     }
 
     private void doPrepare(LocalSession session, PrepareParams params, Instant now) {
-        session.prepare(getLogger(false), params, Optional.empty(), Optional.empty(), tenantPath, now);
+        session.prepare(getLogger(false), params, Optional.empty(), tenantPath, now);
     }
 
     DeployHandlerLogger getLogger(boolean verbose) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
@@ -21,7 +21,6 @@ import com.yahoo.vespa.config.server.*;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.config.server.application.MemoryTenantApplications;
 import com.yahoo.vespa.config.server.application.PermanentApplicationPackage;
-import com.yahoo.vespa.config.server.configchange.ConfigChangeActions;
 import com.yahoo.vespa.config.server.configchange.MockRestartAction;
 import com.yahoo.vespa.config.server.configchange.RestartActions;
 import com.yahoo.vespa.config.server.deploy.DeployHandlerLogger;
@@ -101,24 +100,31 @@ public class SessionPreparerTest extends TestWithCurator {
 
     @Test(expected = InvalidApplicationException.class)
     public void require_that_application_validation_exception_is_not_caught() throws IOException, SAXException {
-        prepare(invalidTestApp, new PrepareParams.Builder().build());
+        FilesApplicationPackage app = getApplicationPackage(invalidTestApp);
+        preparer.prepare(getContext(app), getLogger(), new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
     }
 
     @Test
     public void require_that_application_validation_exception_is_ignored_if_forced() throws IOException, SAXException {
-        prepare(invalidTestApp,
-                new PrepareParams.Builder().ignoreValidationErrors(true).timeoutBudget(TimeoutBudgetTest.day()).build());
+        FilesApplicationPackage app = getApplicationPackage(invalidTestApp);
+        preparer.prepare(getContext(app), getLogger(),
+                         new PrepareParams.Builder().ignoreValidationErrors(true).timeoutBudget(TimeoutBudgetTest.day()).build(),
+                         Optional.empty(), tenantPath, Instant.now());
     }
 
     @Test
     public void require_that_zookeeper_is_not_written_to_if_dryrun() throws IOException {
-        prepare(testApp, new PrepareParams.Builder().dryRun(true).timeoutBudget(TimeoutBudgetTest.day()).build());
+        preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(),
+                         new PrepareParams.Builder().dryRun(true).timeoutBudget(TimeoutBudgetTest.day()).build(),
+                         Optional.empty(), tenantPath, Instant.now());
         assertFalse(configCurator.exists(sessionsPath.append(ConfigCurator.USERAPP_ZK_SUBPATH).append("services.xml").getAbsolute()));
     }
 
     @Test
     public void require_that_filedistribution_is_ignored_on_dryrun() throws IOException {
-        prepare(testApp, new PrepareParams.Builder().dryRun(true).timeoutBudget(TimeoutBudgetTest.day()).build());
+        preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(),
+                         new PrepareParams.Builder().dryRun(true).timeoutBudget(TimeoutBudgetTest.day()).build(),
+                         Optional.empty(), tenantPath, Instant.now());
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().sendDeployedFilesCalled, is(0));
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().limitSendingOfDeployedFilesToCalled, is(0));
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().reloadDeployFileDistributorCalled, is(0));
@@ -126,7 +132,7 @@ public class SessionPreparerTest extends TestWithCurator {
 
     @Test
     public void require_that_application_is_prepared() throws Exception {
-        prepare(testApp, new PrepareParams.Builder().build());
+        preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(), new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().sendDeployedFilesCalled, is(2));
         // Should be called only once no matter how many model versions are built
         assertThat(fileDistributionFactory.mockFileDistributionProvider.getMockFileDBHandler().reloadDeployFileDistributorCalled, is(1));
@@ -139,7 +145,7 @@ public class SessionPreparerTest extends TestWithCurator {
                 new TestModelFactory(Version.fromIntValues(1, 2, 3)),
                 new FailingModelFactory(Version.fromIntValues(3, 2, 1), new IllegalArgumentException("BOOHOO"))));
         preparer = createPreparer(modelFactoryRegistry, HostProvisionerProvider.empty());
-        prepare(testApp, new PrepareParams.Builder().build());
+        preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(), new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
     }
 
     @Test(expected = InvalidApplicationException.class)
@@ -148,14 +154,14 @@ public class SessionPreparerTest extends TestWithCurator {
                 new TestModelFactory(Version.fromIntValues(3, 2, 3)),
                 new FailingModelFactory(Version.fromIntValues(1, 2, 1), new IllegalArgumentException("BOOHOO"))));
         preparer = createPreparer(modelFactoryRegistry, HostProvisionerProvider.empty());
-        prepare(testApp, new PrepareParams.Builder().build());
+        preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(), new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
     }
 
     @Test(expected = InvalidApplicationException.class)
     public void require_exception_for_overlapping_host() throws IOException {
         SessionContext ctx = getContext(getApplicationPackage(testApp));
         ((HostRegistry<ApplicationId>)ctx.getHostValidator()).update(applicationId("foo"), Collections.singletonList("mytesthost"));
-        prepare(new PrepareParams.Builder().build(), new BaseDeployLogger(), ctx);
+        preparer.prepare(ctx, new BaseDeployLogger(), new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
     }
     
     @Test
@@ -167,7 +173,7 @@ public class SessionPreparerTest extends TestWithCurator {
             System.out.println(level + ": "+message);
             if (level.equals(LogLevel.WARNING) && message.contains("The host mytesthost is already in use")) logged.append("ok");
         };
-        prepare(testApp, new PrepareParams.Builder().build(), logger);
+        preparer.prepare(ctx, logger, new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now());
         assertEquals(logged.toString(), "");
     }
 
@@ -178,7 +184,7 @@ public class SessionPreparerTest extends TestWithCurator {
                                .tenant(tenant)
                                .applicationName("foo").instanceName("quux").build();
         PrepareParams params = new PrepareParams.Builder().applicationId(origId).build();
-        prepare(testApp, params);
+        preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(), params, Optional.empty(), tenantPath, Instant.now());
         SessionZooKeeperClient zkc = new SessionZooKeeperClient(curator, sessionsPath);
         assertTrue(configCurator.exists(sessionsPath.append(SessionZooKeeperClient.APPLICATION_ID_PATH).getAbsolute()));
         assertThat(zkc.readApplicationId(), is(origId));
@@ -193,8 +199,10 @@ public class SessionPreparerTest extends TestWithCurator {
                 new ConfigChangeActionsModelFactory(Version.fromIntValues(1, 2, 4),
                         new MockRestartAction("other change", Arrays.asList(service)))));
         preparer = createPreparer(modelFactoryRegistry, HostProvisionerProvider.empty());
-        List<RestartActions.Entry> actions = prepare(testApp, new PrepareParams.Builder().build())
-                .getRestartActions().getEntries();
+        List<RestartActions.Entry> actions =
+                preparer.prepare(getContext(getApplicationPackage(testApp)), getLogger(),
+                                 new PrepareParams.Builder().build(), Optional.empty(), tenantPath, Instant.now())
+                        .getRestartActions().getEntries();
         assertThat(actions.size(), is(1));
         assertThat(actions.get(0).getMessages(), equalTo(ImmutableSet.of("change", "other change")));
     }
@@ -209,7 +217,7 @@ public class SessionPreparerTest extends TestWithCurator {
         final ApplicationId applicationId = applicationId("test");
         PrepareParams params = new PrepareParams.Builder().applicationId(applicationId).rotations(rotations).build();
         File app = new File("src/test/resources/deploy/app");
-        prepare(app, params);
+        preparer.prepare(getContext(getApplicationPackage(app)), getLogger(), params, Optional.empty(), tenantPath, Instant.now());
         assertThat(readRotationsFromZK(applicationId), contains(new Rotation(rotations)));
     }
 
@@ -225,7 +233,7 @@ public class SessionPreparerTest extends TestWithCurator {
         new Rotations(curator, tenantPath).writeRotationsToZooKeeper(applicationId, Collections.singleton(new Rotation(rotations)));
         final PrepareParams params = new PrepareParams.Builder().applicationId(applicationId).build();
         final File app = new File("src/test/resources/deploy/app");
-        prepare(app, params);
+        preparer.prepare(getContext(getApplicationPackage(app)), getLogger(), params, Optional.empty(), tenantPath, Instant.now());
 
         // check that the rotation from zookeeper were used
         final ModelContext modelContext = modelFactory.getModelContext();
@@ -234,19 +242,6 @@ public class SessionPreparerTest extends TestWithCurator {
 
         // Check that the persisted value is still the same
         assertThat(readRotationsFromZK(applicationId), contains(new Rotation(rotations)));
-    }
-
-    private ConfigChangeActions prepare(File app, PrepareParams params) throws IOException {
-        return prepare(app, params, getLogger());
-    }
-
-    private ConfigChangeActions prepare(File app, PrepareParams params, DeployLogger logger) throws IOException {
-        return prepare(params, logger, getContext(getApplicationPackage(app)));
-    }
-
-    private ConfigChangeActions prepare(PrepareParams params, DeployLogger logger, SessionContext sessionContext) throws IOException {
-        return preparer.prepare(sessionContext, logger, params, Optional.empty(),
-                                Optional.empty(), tenantPath, Instant.now());
     }
 
     private SessionContext getContext(FilesApplicationPackage app) throws IOException {
@@ -259,8 +254,12 @@ public class SessionPreparerTest extends TestWithCurator {
         return FilesApplicationPackage.fromFile(appDir);
     }
 
-    private DeployHandlerLogger getLogger() {
-        return new DeployHandlerLogger(new Slime().get(), false,
+    DeployHandlerLogger getLogger() {
+        return getLogger(false);
+    }
+
+    DeployHandlerLogger getLogger(boolean verbose) {
+        return new DeployHandlerLogger(new Slime().get(), verbose,
                                        new ApplicationId.Builder().tenant("testtenant").applicationName("testapp").build());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionTest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.session;
 
-import com.yahoo.component.Version;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.config.server.application.ApplicationSet;
@@ -19,18 +18,14 @@ import java.util.Optional;
 public class SessionTest {
 
     public static class MockSessionPreparer extends SessionPreparer {
-        boolean isPrepared = false;
+        public boolean isPrepared = false;
 
         public MockSessionPreparer() {
-            super(null, null, null, null,
-                  null, null, new MockCurator(), null);
+            super(null, null, null, null, null, null, new MockCurator(), null);
         }
 
         @Override
-        public ConfigChangeActions prepare(SessionContext context, DeployLogger logger, PrepareParams params,
-                                           Optional<ApplicationSet> currentActiveApplicationSet,
-                                           Optional<Version> currentVespaVersion,
-                                           Path tenantPath, Instant now) {
+        public ConfigChangeActions prepare(SessionContext context, DeployLogger logger, PrepareParams params, Optional<ApplicationSet> currentActiveApplicationSet, Path tenantPath, Instant now) {
             isPrepared = true;
             return new ConfigChangeActions(new ArrayList<>());
         }


### PR DESCRIPTION
Reverts vespa-engine/vespa#3653

Didn't work when deploying zone application (where we don't supply version)