### PR TITLE
Increase max heap size for Maven

### DIFF
--- a/travis/travis-build-java.sh
+++ b/travis/travis-build-java.sh
@@ -6,7 +6,7 @@ SOURCE_DIR=/source
 NUM_THREADS=4
 
 cd "${SOURCE_DIR}"
-export MAVEN_OPTS="-Xms128m -Xmx512m"
+export MAVEN_OPTS="-Xms128m -Xmx1g"
 source /etc/profile.d/devtoolset-6.sh || true
 sh ./bootstrap.sh java
 mvn install -nsu -B -T ${NUM_THREADS} -V # Should ideally split out test phase, but some unit tests fails on 'mvn test'


### PR DESCRIPTION
Some build jobs are now failing because Maven runs out of memory