### PR TITLE
Add back SslKeyStoreFactoryProvider as a temporary workaround

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -220,6 +220,7 @@ public final class ContainerCluster
         addSimpleComponent(com.yahoo.concurrent.classlock.ClassLocking.class);
         addSimpleComponent("com.yahoo.jdisc.http.filter.SecurityFilterInvoker");
         addSimpleComponent(SIMPLE_LINGUISTICS_PROVIDER);
+        addSimpleComponent("com.yahoo.container.jdisc.SslKeyStoreFactoryProvider");
         addSimpleComponent("com.yahoo.container.jdisc.SecretStoreProvider");
         addSimpleComponent("com.yahoo.container.jdisc.CertificateStoreProvider");
         addSimpleComponent("com.yahoo.container.jdisc.metric.MetricConsumerProviderProvider");

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SslKeyStoreFactoryProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SslKeyStoreFactoryProvider.java
@@ -1,0 +1,41 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.container.jdisc;
+
+import com.yahoo.container.di.componentgraph.Provider;
+import com.yahoo.jdisc.http.ssl.ReaderForPath;
+import com.yahoo.jdisc.http.ssl.SslKeyStore;
+import com.yahoo.jdisc.http.ssl.SslKeyStoreFactory;
+
+/**
+ * An SSL key store provider which provides a factory which throws exception on
+ * invocation  as no SSL key store is currently provided by default.
+ * The purpose of this is to provide a ssl store factory for injection in the case where
+ * no secret store component is provided.
+ *
+ * @author bratseth
+ */
+public class SslKeyStoreFactoryProvider implements Provider<SslKeyStoreFactory> {
+
+    private static final ThrowingSslKeyStoreFactory instance = new ThrowingSslKeyStoreFactory();
+
+    @Override
+    public SslKeyStoreFactory get() { return instance; }
+
+    @Override
+    public void deconstruct() { }
+
+    private static final class ThrowingSslKeyStoreFactory implements SslKeyStoreFactory {
+
+        @Override
+        public SslKeyStore createKeyStore(ReaderForPath certificateFile, ReaderForPath keyFile) {
+            throw new UnsupportedOperationException("A SSL key store factory component is not available");
+        }
+
+        @Override
+        public SslKeyStore createTrustStore(ReaderForPath certificateFile) {
+            throw new UnsupportedOperationException("A SSL key store factory component is not available");
+        }
+
+    }
+
+}

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/SslKeyStoreFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/SslKeyStoreFactory.java
@@ -1,0 +1,15 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.jdisc.http.ssl;
+
+/**
+ * A factory for SSL key stores.
+ *
+ * @author bratseth
+ */
+public interface SslKeyStoreFactory {
+
+    SslKeyStore createKeyStore(ReaderForPath certificateFile, ReaderForPath keyFile);
+
+    SslKeyStore createTrustStore(ReaderForPath certificateFile);
+
+}


### PR DESCRIPTION
Some applications use unsafe config features
that breaks when removing a component from the config-model.


FYI @hmusum 