### PR TITLE
- Let the commitExecutor and the sessionExecutor be different.

### DIFF
--- a/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
@@ -193,7 +193,6 @@ Domain::triggerSyncNow()
     MonitorGuard guard(_syncMonitor);
     if (!_pendingSync) {
         _pendingSync = true;
-        _commitExecutor.sync();
         DomainPart::SP dp(_parts.rbegin()->second);
         _sessionExecutor.execute(Sync::UP(new Sync(_syncMonitor, dp, _pendingSync)));
     }

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
@@ -93,6 +93,7 @@ TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, con
       _baseDir(baseDir),
       _domainPartSize(domainPartSize),
       _defaultCrcType(defaultCrcType),
+      _commitExecutor(maxThreads, 128*1024),
       _sessionExecutor(maxThreads, 128*1024),
       _threadPool(8192, 1),
       _supervisor(std::make_unique<FRT_Supervisor>()),
@@ -109,7 +110,7 @@ TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, con
                 domainDir >> domainName;
                 if ( ! domainName.empty()) {
                     try {
-                        auto domain = std::make_shared<Domain>(domainName, dir(), _sessionExecutor, _sessionExecutor,
+                        auto domain = std::make_shared<Domain>(domainName, dir(), _commitExecutor, _sessionExecutor,
                                                                _domainPartSize, _defaultCrcType,_fileHeaderContext);
                         _domains[domain->name()] = domain;
                     } catch (const std::exception & e) {
@@ -344,7 +345,7 @@ void TransLogServer::createDomain(FRT_RPCRequest *req)
     Domain::SP domain(findDomain(domainName));
     if ( !domain ) {
         try {
-            domain = std::make_shared<Domain>(domainName, dir(), _sessionExecutor, _sessionExecutor,
+            domain = std::make_shared<Domain>(domainName, dir(), _commitExecutor, _sessionExecutor,
                                               _domainPartSize, _defaultCrcType, _fileHeaderContext);
             {
                 Guard domainGuard(_lock);

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.h
@@ -82,6 +82,7 @@ private:
     vespalib::string                    _baseDir;
     const uint64_t                      _domainPartSize;
     const DomainPart::Crc               _defaultCrcType;
+    vespalib::ThreadStackExecutor       _commitExecutor;
     vespalib::ThreadStackExecutor       _sessionExecutor;
     FastOS_ThreadPool                   _threadPool;
     std::unique_ptr<FRT_Supervisor>     _supervisor;


### PR DESCRIPTION
- No need to sync commitExecutor.
@toregge PR