### PR TITLE
The first argument to fastMatch() should be the tensor with fewest cells.

### DIFF
--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor_match.cpp
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor_match.cpp
@@ -112,7 +112,12 @@ SparseTensorMatch::SparseTensorMatch(const TensorImplType &lhs,
 {
     if ((lhs.type().dimensions().size() == rhs.type().dimensions().size()) &&
         (lhs.type().dimensions().size() == _builder.type().dimensions().size())) {
-        fastMatch(lhs, rhs);
+        // Ensure that first tensor to fastMatch has fewest cells.
+        if (lhs.cells().size() <= rhs.cells().size()) {
+            fastMatch(lhs, rhs);
+        } else {
+            fastMatch(rhs, lhs);
+        }
     } else {
         slowMatch(lhs, rhs);
     }


### PR DESCRIPTION
@geirst, please review
@bratseth, FYI