### PR TITLE
Config-retired should not override explicit Down or Maintenance states

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
@@ -258,7 +258,11 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
 
     /** Returns the wanted state of this node - which can either be set by a user or configured */
     public NodeState getWantedState() {
-        if (configuredRetired) return new NodeState(node.getType(), State.RETIRED);
+        NodeState retiredState = new NodeState(node.getType(), State.RETIRED);
+        // Don't let configure retired state override explicitly set Down and Maintenance.
+        if (configuredRetired && wantedState.above(retiredState)) {
+            return retiredState;
+        }
         return wantedState;
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
@@ -12,8 +12,10 @@ import com.yahoo.vespa.clustercontroller.core.listeners.NodeStateOrHostInfoChang
 import com.yahoo.vespa.clustercontroller.utils.util.NoMetricReporter;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static org.mockito.Mockito.mock;
@@ -160,6 +162,14 @@ class ClusterFixture {
 
     void enableTransientMaintenanceModeOnDown(final int transitionTimeMs) {
         this.params.transitionTimes(transitionTimeMs);
+    }
+
+    ClusterFixture markNodeAsConfigRetired(int nodeIndex) {
+        Set<ConfiguredNode> configuredNodes = new HashSet<>(cluster.getConfiguredNodes().values());
+        configuredNodes.remove(new ConfiguredNode(nodeIndex, false));
+        configuredNodes.add(new ConfiguredNode(nodeIndex, true));
+        cluster.setNodes(configuredNodes);
+        return this;
     }
 
     AnnotatedClusterState annotatedGeneratedClusterState() {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeInfoTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeInfoTest.java
@@ -6,6 +6,7 @@ import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vdslib.state.State;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -75,6 +76,34 @@ public class NodeInfoTest {
         final NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 1));
         nodeInfo.setPrematureCrashCount(1);
         assertFalse(nodeInfo.recentlyObservedUnstableDuringInit());
+    }
+
+    @Test
+    public void down_wanted_state_overrides_config_retired_state() {
+        ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
+                .markNodeAsConfigRetired(1)
+                .proposeStorageNodeWantedState(1, State.DOWN);
+
+        NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 1));
+        assertEquals(State.DOWN, nodeInfo.getWantedState().getState());
+    }
+
+    @Test
+    public void maintenance_wanted_state_overrides_config_retired_state() {
+        ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
+                .markNodeAsConfigRetired(1)
+                .proposeStorageNodeWantedState(1, State.MAINTENANCE);
+
+        NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 1));
+        assertEquals(State.MAINTENANCE, nodeInfo.getWantedState().getState());
+    }
+
+    @Test
+    public void retired_state_overrides_default_up_wanted_state() {
+        final ClusterFixture fixture = ClusterFixture.forFlatCluster(3).markNodeAsConfigRetired(1);
+
+        NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 1));
+        assertEquals(State.RETIRED, nodeInfo.getWantedState().getState());
     }
 
 }


### PR DESCRIPTION
@bratseth @hakonhall please review.

Previously, a config-retired node marked as Down by the Orchestrator
would remain as Retired in the cluster state until the node was
actually taken down entirely.