### PR TITLE
Bratseth/only consider prod applications

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
@@ -8,6 +8,7 @@ import com.yahoo.component.Vtag;
 import com.yahoo.vespa.hosted.controller.api.integration.github.GitSha;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.application.ApplicationList;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
@@ -132,7 +133,7 @@ public class VersionStatus {
             versionMap.put(infrastructureVersion, DeploymentStatistics.empty(infrastructureVersion));
         }
 
-        for (Application application : applications) {
+        for (Application application : ApplicationList.from(applications).notPullRequest().asList()) {
             DeploymentJobs jobs = application.deploymentJobs();
 
             // Note that each version deployed on this application exists

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
@@ -49,8 +49,8 @@ public class VespaVersion implements Comparable<VespaVersion> {
                                                           .notFailing();
         ApplicationList failingOnThis = ApplicationList.from(statistics.failing(), controller.applications());
         ApplicationList all = ApplicationList.from(controller.applications().asList())
-                .hasDeployment()
-                .notPullRequest();
+                                             .hasDeployment()
+                                             .notPullRequest();
 
         // 'broken' if any Canary fails
         if  ( ! failingOnThis.with(UpgradePolicy.canary).isEmpty())

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/SearchColumnPolicy.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/SearchColumnPolicy.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  * to all recipients receives more than "maxbadparts" out-of-service replies,
  * according to (2.a) above.</p>
  *
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  */
 public class SearchColumnPolicy implements DocumentProtocolRoutingPolicy {
 


### PR DESCRIPTION
@mpolden please review

There is some discrepancy between the list of applications we actually consider when listing versions and computing confidence, and my expectations/what we should do:
The last one should have confidence: high by now, and we shouldn't show versions with no deployments (unless when the infradstructure is upgraded and no applications).

Not sure if it's caused by not filtering out PR's, but it's not wrong.