### PR TITLE
Use priority queue for external client operations

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -572,19 +572,61 @@ Distributor::workWasDone()
     return !_tickResult.waitWanted();
 }
 
-void
-Distributor::startExternalOperations()
-{
-    for (uint32_t i=0; i<_fetchedMessages.size(); ++i) {
-        MBUS_TRACE(_fetchedMessages[i]->getTrace(), 9,
-                   "Distributor: Grabbed from queue to be processed.");
-        if (!handleMessage(_fetchedMessages[i])) {
-            MBUS_TRACE(_fetchedMessages[i]->getTrace(), 9,
-                       "Distributor: Not handling it. Sending further down.");
-            sendDown(_fetchedMessages[i]);
+namespace {
+
+bool is_client_request(const api::StorageMessage& msg) noexcept {
+    // Despite having been converted to StorageAPI messages, the following
+    // set of messages are never sent to the distributor by other processes
+    // than clients.
+    switch (msg.getType().getId()) {
+    case api::MessageType::GET_ID:
+    case api::MessageType::PUT_ID:
+    case api::MessageType::REMOVE_ID:
+    case api::MessageType::VISITOR_CREATE_ID:
+    case api::MessageType::VISITOR_DESTROY_ID:
+    case api::MessageType::MULTIOPERATION_ID: // Deprecated
+    case api::MessageType::GETBUCKETLIST_ID:
+    case api::MessageType::STATBUCKET_ID:
+    case api::MessageType::UPDATE_ID:
+    case api::MessageType::REMOVELOCATION_ID:
+    case api::MessageType::BATCHPUTREMOVE_ID: // Deprecated
+    case api::MessageType::BATCHDOCUMENTUPDATE_ID: // Deprecated
+        return true;
+    default:
+        return false;
+    }
+}
+
+}
+
+void Distributor::handle_or_propagate_message(const std::shared_ptr<api::StorageMessage>& msg) {
+    if (!handleMessage(msg)) {
+        MBUS_TRACE(msg->getTrace(), 9, "Distributor: Not handling it. Sending further down.");
+        sendDown(msg);
+    }
+}
+
+void Distributor::startExternalOperations() {
+    for (auto& msg : _fetchedMessages) {
+        if (is_client_request(*msg)) {
+            MBUS_TRACE(msg->getTrace(), 9, "Distributor: adding to client request priority queue");
+            _client_request_priority_queue.emplace(std::move(msg));
+        } else {
+            MBUS_TRACE(msg->getTrace(), 9, "Distributor: Grabbed from queue to be processed.");
+            handle_or_propagate_message(msg);
         }
     }
-    if (!_fetchedMessages.empty()) {
+
+    const bool start_single_client_request = !_client_request_priority_queue.empty();
+    if (start_single_client_request) {
+        auto& msg = _client_request_priority_queue.top();
+        MBUS_TRACE(msg->getTrace(), 9, "Distributor: Grabbed from "
+                   "client request priority queue to be processed.");
+        handle_or_propagate_message(msg); // TODO move() once we've move-enabled our message chains
+        _client_request_priority_queue.pop();
+    }
+
+    if (!_fetchedMessages.empty() || start_single_client_request) {
         signalWorkWasDone();
     }
     _fetchedMessages.clear();

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -23,6 +23,7 @@
 #include <vespa/config/config.h>
 #include <vespa/vespalib/util/sync.h>
 #include <unordered_map>
+#include <queue>
 
 namespace storage {
 
@@ -191,6 +192,7 @@ private:
     bool isMaintenanceReply(const api::StorageReply& reply) const;
 
     void handleStatusRequests();
+    void handle_or_propagate_message(const std::shared_ptr<api::StorageMessage>& msg);
     void startExternalOperations();
 
     /**
@@ -252,8 +254,20 @@ private:
     mutable std::shared_ptr<lib::Distribution> _distribution;
     std::shared_ptr<lib::Distribution> _nextDistribution;
 
-    typedef std::vector<std::shared_ptr<api::StorageMessage> > MessageQueue;
+    using MessageQueue = std::vector<std::shared_ptr<api::StorageMessage>>;
+    struct IndirectHigherPriority {
+        template <typename Lhs, typename Rhs>
+        bool operator()(const Lhs& lhs, const Rhs& rhs) const noexcept {
+            return lhs->getPriority() > rhs->getPriority();
+        }
+    };
+    using ClientRequestPriorityQueue = std::priority_queue<
+            std::shared_ptr<api::StorageMessage>,
+            std::vector<std::shared_ptr<api::StorageMessage>>,
+            IndirectHigherPriority
+    >;
     MessageQueue _messageQueue;
+    ClientRequestPriorityQueue _client_request_priority_queue;
     MessageQueue _fetchedMessages;
     framework::TickingThreadPool& _threadPool;
     vespalib::Monitor _statusMonitor;


### PR DESCRIPTION
@baldersheim please review
@hakonhall FYI

This introduces a priority queue for client operations on the distributor. This comes at the added cost of a couple more mutex acquire/release cycles per client request, as these are no longer started as part of a batch. Internal perf tests will tell us if this matters in practice. 

Internal operations and replies and handled in FIFO order as before.