### PR TITLE
Decouple deployment metrics from the metricservice

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -334,9 +334,10 @@ public class ApplicationController {
             Deployment previousDeployment = application.deployments().get(zone);
             Deployment newDeployment = previousDeployment;
             if (previousDeployment == null) {
-                newDeployment = new Deployment(zone, revision, version, clock.instant(), new HashMap<>(), new HashMap<>());
+                newDeployment = new Deployment(zone, revision, version, clock.instant());
             } else {
-                newDeployment = new Deployment(zone, revision, version, clock.instant(), previousDeployment.clusterUtils(), previousDeployment.clusterInfo());
+                newDeployment = new Deployment(zone, revision, version, clock.instant(),
+                        previousDeployment.clusterUtils(), previousDeployment.clusterInfo(), previousDeployment.metrics());
             }
 
             application = application.with(newDeployment);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -331,14 +331,10 @@ public class ApplicationController {
                                                applicationPackage.zippedContent());
             preparedApplication.activate();
 
-            Deployment previousDeployment = application.deployments().get(zone);
-            Deployment newDeployment = previousDeployment;
-            if (previousDeployment == null) {
-                newDeployment = new Deployment(zone, revision, version, clock.instant());
-            } else {
-                newDeployment = new Deployment(zone, revision, version, clock.instant(),
+            // Use info from previous deployments is available
+            Deployment previousDeployment = application.deployments().getOrDefault(zone, new Deployment(zone, revision, version, clock.instant()));
+            Deployment newDeployment = new Deployment(zone, revision, version, clock.instant(),
                         previousDeployment.clusterUtils(), previousDeployment.clusterInfo(), previousDeployment.metrics());
-            }
 
             application = application.with(newDeployment);
             store(application, lock);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Deployment.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Deployment.java
@@ -14,6 +14,7 @@ import java.util.Objects;
  * A deployment of an application in a particular zone.
  * 
  * @author bratseth
+ * @author smorgrav
  */
 public class Deployment {
 
@@ -23,24 +24,28 @@ public class Deployment {
     private final Instant deployTime;
     private final Map<Id, ClusterUtilization> clusterUtils;
     private final Map<Id, ClusterInfo> clusterInfo;
+    private final DeploymentMetrics metrics;
 
     public Deployment(Zone zone, ApplicationRevision revision, Version version, Instant deployTime) {
-        this(zone, revision, version, deployTime, new HashMap<>(), new HashMap<>());
+        this(zone, revision, version, deployTime, new HashMap<>(), new HashMap<>(), new DeploymentMetrics());
     }
 
-    public Deployment(Zone zone, ApplicationRevision revision, Version version, Instant deployTime, Map<Id, ClusterUtilization> clusterUtils, Map<Id, ClusterInfo> clusterInfo) {
+    public Deployment(Zone zone, ApplicationRevision revision, Version version, Instant deployTime,
+                      Map<Id, ClusterUtilization> clusterUtils, Map<Id, ClusterInfo> clusterInfo, DeploymentMetrics metrics) {
         Objects.requireNonNull(zone, "zone cannot be null");
         Objects.requireNonNull(revision, "revision cannot be null");
         Objects.requireNonNull(version, "version cannot be null");
         Objects.requireNonNull(deployTime, "deployTime cannot be null");
         Objects.requireNonNull(clusterUtils, "clusterUtils cannot be null");
         Objects.requireNonNull(clusterInfo, "clusterInfo cannot be null");
+        Objects.requireNonNull(clusterInfo, "deployment metrics cannot be null");
         this.zone = zone;
         this.revision = revision;
         this.version = version;
         this.deployTime = deployTime;
         this.clusterUtils = clusterUtils;
         this.clusterInfo = clusterInfo;
+        this.metrics = metrics;
     }
 
     /** Returns the zone this was deployed to */
@@ -64,11 +69,20 @@ public class Deployment {
     }
 
     public Deployment withClusterUtils(Map<Id, ClusterUtilization> clusterUtilization) {
-        return new Deployment(zone, revision, version, deployTime, clusterUtilization, clusterInfo);
+        return new Deployment(zone, revision, version, deployTime, clusterUtilization, clusterInfo, metrics);
     }
 
     public Deployment withClusterInfo(Map<Id, ClusterInfo> newClusterInfo) {
-        return new Deployment(zone, revision, version, deployTime, clusterUtils, newClusterInfo);
+        return new Deployment(zone, revision, version, deployTime, clusterUtils, newClusterInfo, metrics);
+    }
+
+    public Deployment withMetrics(DeploymentMetrics metrics) {
+        return new Deployment(zone, revision, version, deployTime, clusterUtils, clusterInfo, metrics);
+    }
+
+    /** @return Key metrics for the deployment (application level) like QPS and document count */
+    public DeploymentMetrics metrics() {
+        return metrics;
     }
 
     /**

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentMetrics.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentMetrics.java
@@ -1,0 +1,50 @@
+package com.yahoo.vespa.hosted.controller.application;// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+/**
+ * @author smorgrav
+ */
+public class DeploymentMetrics {
+
+    private final double queriesPerSecond;
+    private final double writesPerSecond;
+    private final double documentCount;
+    private final double queryLatencyMillis;
+    private final double writeLatencyMills;
+
+    DeploymentMetrics() {
+        this.queriesPerSecond = 0;
+        this.writesPerSecond = 0;
+        this.documentCount = 0;
+        this.queryLatencyMillis = 0;
+        this.writeLatencyMills = 0;
+    }
+
+    public DeploymentMetrics(double queriesPerSecond, double writesPerSecond, double documentCount,
+                      double queryLatencyMillis, double writeLatencyMills) {
+        this.queriesPerSecond = queriesPerSecond;
+        this.writesPerSecond = writesPerSecond;
+        this.documentCount = documentCount;
+        this.queryLatencyMillis = queryLatencyMillis;
+        this.writeLatencyMills = writeLatencyMills;
+    }
+
+    public double queriesPerSecond() {
+        return queriesPerSecond;
+    }
+
+    public double writesPerSecond() {
+        return writesPerSecond;
+    }
+
+    public double documentCount() {
+        return documentCount;
+    }
+
+    public double queryLatencyMillis() {
+        return queryLatencyMillis;
+    }
+
+    public double writeLatencyMillis() {
+        return writeLatencyMills;
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -35,6 +35,7 @@ public class ControllerMaintenance extends AbstractComponent {
     private final BlockedChangeDeployer blockedChangeDeployer;
     private final ClusterInfoMaintainer clusterInfoMaintainer;
     private final ClusterUtilizationMaintainer clusterUtilizationMaintainer;
+    private final DeploymentMetricsMaintainer deploymentMetricsMaintainer;
 
     @SuppressWarnings("unused") // instantiated by Dependency Injection
     public ControllerMaintenance(MaintainerConfig maintainerConfig, Controller controller, CuratorDb curator,
@@ -54,6 +55,7 @@ public class ControllerMaintenance extends AbstractComponent {
         blockedChangeDeployer = new BlockedChangeDeployer(controller, maintenanceInterval, jobControl);
         clusterInfoMaintainer = new ClusterInfoMaintainer(controller, Duration.ofHours(2), jobControl);
         clusterUtilizationMaintainer = new ClusterUtilizationMaintainer(controller, Duration.ofHours(2), jobControl);
+        deploymentMetricsMaintainer = new DeploymentMetricsMaintainer(controller, Duration.ofMinutes(10), jobControl);
     }
 
     public Upgrader upgrader() { return upgrader; }
@@ -74,6 +76,7 @@ public class ControllerMaintenance extends AbstractComponent {
         blockedChangeDeployer.deconstruct();
         clusterUtilizationMaintainer.deconstruct();
         clusterInfoMaintainer.deconstruct();
+        deploymentMetricsMaintainer.deconstruct();
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
@@ -1,0 +1,43 @@
+package com.yahoo.vespa.hosted.controller.maintenance;// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+import com.yahoo.vespa.curator.Lock;
+import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.api.integration.MetricsService;
+import com.yahoo.vespa.hosted.controller.application.Deployment;
+import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
+
+import java.time.Duration;
+
+/**
+ * Retrieve deployment metrics like qps and document count from the metric service and
+ * update the applications with this info.
+ *
+ * @author smorgrav
+ */
+public class DeploymentMetricsMaintainer extends Maintainer {
+
+    DeploymentMetricsMaintainer(Controller controller, Duration duration, JobControl jobControl) {
+        super(controller, duration, jobControl);
+    }
+
+    @Override
+    protected void maintain() {
+
+        for (Application application : controller().applications().asList()) {
+            try (Lock lock = controller().applications().lock(application.id())) {
+                for (Deployment deployment : application.deployments().values()) {
+
+                    MetricsService.DeploymentMetrics metrics = controller().metricsService()
+                            .getDeploymentMetrics(application.id(), deployment.zone());
+
+                    DeploymentMetrics appMetrics = new DeploymentMetrics(metrics.queriesPerSecond(), metrics.writesPerSecond(),
+                            metrics.documentCount(), metrics.queryLatencyMillis(), metrics.writeLatencyMillis());
+
+                    Application app = application.with(deployment.withMetrics(appMetrics));
+                    controller().applications().store(app, lock);
+                }
+            }
+        }
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -22,6 +22,7 @@ import com.yahoo.vespa.hosted.controller.application.ClusterUtilization;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobError;
+import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.application.SourceRevision;
 
@@ -95,6 +96,14 @@ public class ApplicationSerializer {
     private final String clusterUtilsDiskField = "disk";
     private final String clusterUtilsDiskBusyField = "diskbusy";
 
+    // Deployment metrics fields
+    private final String deploymentMetricsField = "metrics";
+    private final String deploymentMetricsQPSField = "queriesPerSecond";
+    private final String deploymentMetricsWPSField = "writesPerSecond";
+    private final String deploymentMetricsDocsField = "documentCount";
+    private final String deploymentMetricsQueryLatencyField = "queryLatencyMillis";
+    private final String deploymentMetricsWriteLatencyField = "writeLatencyMillis";
+
     
     // ------------------ Serialization
     
@@ -123,6 +132,16 @@ public class ApplicationSerializer {
         toSlime(deployment.revision(), object.setObject(applicationPackageRevisionField));
         clusterInfoToSlime(deployment.clusterInfo(), object);
         clusterUtilsToSlime(deployment.clusterUtils(), object);
+        metricsToSlime(deployment.metrics(), object);
+    }
+
+    private void metricsToSlime(DeploymentMetrics metrics, Cursor object) {
+        Cursor root = object.setObject(deploymentMetricsField);
+        root.setDouble(deploymentMetricsQPSField, metrics.queriesPerSecond());
+        root.setDouble(deploymentMetricsWPSField, metrics.writesPerSecond());
+        root.setDouble(deploymentMetricsDocsField, metrics.documentCount());
+        root.setDouble(deploymentMetricsQueryLatencyField, metrics.queryLatencyMillis());
+        root.setDouble(deploymentMetricsWriteLatencyField, metrics.writeLatencyMillis());
     }
 
     private void clusterInfoToSlime(Map<ClusterSpec.Id, ClusterInfo> clusters, Cursor object) {
@@ -246,7 +265,20 @@ public class ApplicationSerializer {
                               Version.fromString(deploymentObject.field(versionField).asString()),
                               Instant.ofEpochMilli(deploymentObject.field(deployTimeField).asLong()),
                 clusterUtilsMapFromSlime(deploymentObject.field(clusterUtilsField)),
-                clusterInfoMapFromSlime(deploymentObject.field(clusterInfoField)));
+                clusterInfoMapFromSlime(deploymentObject.field(clusterInfoField)),
+                deploymentMetricsFromSlime(deploymentObject.field(deploymentMetricsField)));
+    }
+
+    private DeploymentMetrics deploymentMetricsFromSlime(Inspector object) {
+
+        double queriesPerSecond = object.field(deploymentMetricsQPSField).asDouble();
+        double writesPerSecond = object.field(deploymentMetricsWPSField).asDouble();
+        double documentCount = object.field(deploymentMetricsDocsField).asDouble();
+        double queryLatencyMillis = object.field(deploymentMetricsQueryLatencyField).asDouble();
+        double writeLatencyMills = object.field(deploymentMetricsWriteLatencyField).asDouble();
+
+        return new DeploymentMetrics(queriesPerSecond, writesPerSecond,
+                documentCount, queryLatencyMillis, writeLatencyMills);
     }
 
     private Map<ClusterSpec.Id, ClusterInfo> clusterInfoMapFromSlime(Inspector object) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -62,8 +62,9 @@ import com.yahoo.vespa.hosted.controller.application.Change;
 import com.yahoo.vespa.hosted.controller.application.ClusterCost;
 import com.yahoo.vespa.hosted.controller.application.ClusterUtilization;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
-import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.DeploymentCost;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
+import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.application.SourceRevision;
 import com.yahoo.vespa.hosted.controller.restapi.ErrorResponse;
@@ -433,20 +434,13 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         toSlime(appCost, costObject);
 
         // Metrics
-        com.yahoo.config.provision.ApplicationId applicationId = com.yahoo.config.provision.ApplicationId.from(tenantName, applicationName, instanceName);
-        Zone zoneId = new Zone(Environment.from(environment), RegionName.from(region));
-        try {
-            MetricsService.DeploymentMetrics metrics = controller.metricsService().getDeploymentMetrics(applicationId, zoneId);
-            Cursor metricsObject = response.setObject("metrics");
-            metricsObject.setDouble("queriesPerSecond", metrics.queriesPerSecond());
-            metricsObject.setDouble("writesPerSecond", metrics.writesPerSecond());
-            metricsObject.setDouble("documentCount", metrics.documentCount());
-            metricsObject.setDouble("queryLatencyMillis", metrics.queryLatencyMillis());
-            metricsObject.setDouble("writeLatencyMillis", metrics.writeLatencyMillis());
-        }
-        catch (RuntimeException e) {
-            log.log(Level.WARNING, "Failed getting Yamas metrics", Exceptions.toMessageString(e));
-        }
+        DeploymentMetrics metrics = deployment.metrics();
+        Cursor metricsObject = response.setObject("metrics");
+        metricsObject.setDouble("queriesPerSecond", metrics.queriesPerSecond());
+        metricsObject.setDouble("writesPerSecond", metrics.writesPerSecond());
+        metricsObject.setDouble("documentCount", metrics.documentCount());
+        metricsObject.setDouble("queryLatencyMillis", metrics.queryLatencyMillis());
+        metricsObject.setDouble("writeLatencyMillis", metrics.writeLatencyMillis());
 
         return new SlimeJsonResponse(slime);
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
@@ -1,0 +1,41 @@
+package com.yahoo.vespa.hosted.controller.maintenance;
+
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.vespa.hosted.controller.ControllerTester;
+import com.yahoo.vespa.hosted.controller.application.Deployment;
+import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+
+/**
+ * @author smorgrav
+ */
+public class DeploymentMetricsMaintainerTest {
+
+    @Test
+    public void maintain() {
+        ControllerTester tester = new ControllerTester();
+        ApplicationId app = tester.createAndDeploy("tenant1", "domain1", "app1", Environment.dev, 123).id();
+
+        // Pre condition: no metric info on the deployment
+        Deployment deployment = tester.controller().applications().get(app).get().deployments().values().stream().findAny().get();
+        Assert.assertEquals(0, deployment.metrics().documentCount(), Double.MIN_VALUE);
+
+        DeploymentMetricsMaintainer maintainer = new DeploymentMetricsMaintainer(tester.controller(), Duration.ofMinutes(10), new JobControl(new MockCuratorDb()));
+        maintainer.maintain();
+
+        // Post condition:
+        deployment = tester.controller().applications().get(app).get().deployments().values().stream().findAny().get();
+        Assert.assertEquals(1, deployment.metrics().queriesPerSecond(), Double.MIN_VALUE);
+        Assert.assertEquals(2, deployment.metrics().writesPerSecond(), Double.MIN_VALUE);
+        Assert.assertEquals(3, deployment.metrics().documentCount(), Double.MIN_VALUE);
+        Assert.assertEquals(4, deployment.metrics().queryLatencyMillis(), Double.MIN_VALUE);
+        Assert.assertEquals(5, deployment.metrics().writeLatencyMillis(), Double.MIN_VALUE);
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -20,6 +20,7 @@ import com.yahoo.vespa.hosted.controller.application.ClusterUtilization;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobError;
+import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.application.SourceRevision;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class ApplicationSerializerTest {
         ApplicationRevision revision2 = ApplicationRevision.from("appHash2", new SourceRevision("repo1", "branch1", "commit1"));
         deployments.add(new Deployment(zone1, revision1, Version.fromString("1.2.3"), Instant.ofEpochMilli(3))); // One deployment without cluster info and utils
         deployments.add(new Deployment(zone2, revision2, Version.fromString("1.2.3"), Instant.ofEpochMilli(5),
-                createClusterUtils(3, 0.2), createClusterInfo(3, 4)));
+                createClusterUtils(3, 0.2), createClusterInfo(3, 4),new DeploymentMetrics(2,3,4,5,6)));
 
         Optional<Long> projectId = Optional.of(123L);
         List<JobStatus> statusList = new ArrayList<>();
@@ -122,6 +123,13 @@ public class ApplicationSerializerTest {
         assertEquals(ClusterSpec.Type.content, serialized.deployments().get(zone2).clusterInfo().get(ClusterSpec.Id.from("id2")).getClusterType());
         assertEquals("flavor2", serialized.deployments().get(zone2).clusterInfo().get(ClusterSpec.Id.from("id2")).getFlavor());
         assertEquals(4, serialized.deployments().get(zone2).clusterInfo().get(ClusterSpec.Id.from("id2")).getHostnames().size());
+
+        // Test metrics
+        assertEquals(2, serialized.deployments().get(zone2).metrics().queriesPerSecond(), Double.MIN_VALUE);
+        assertEquals(3, serialized.deployments().get(zone2).metrics().writesPerSecond(), Double.MIN_VALUE);
+        assertEquals(4, serialized.deployments().get(zone2).metrics().documentCount(), Double.MIN_VALUE);
+        assertEquals(5, serialized.deployments().get(zone2).metrics().queryLatencyMillis(), Double.MIN_VALUE);
+        assertEquals(6, serialized.deployments().get(zone2).metrics().writeLatencyMillis(), Double.MIN_VALUE);
 
         { // test more deployment serialization cases
             Application original2 = original.withDeploying(Optional.of(Change.ApplicationChange.of(ApplicationRevision.from("hash1"))));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/responses/maintenance.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/responses/maintenance.json
@@ -4,16 +4,28 @@
       "name": "DelayedDeployer"
     },
     {
-      "name": "ClusterUtilizationMaintainer"
-    },
-    {
-      "name":"BlockedChangeDeployer"
+      "name": "BlockedChangeDeployer"
     },
     {
       "name": "Upgrader"
     },
     {
       "name": "FailureRedeployer"
+    },
+    {
+      "name": "VersionStatusUpdater"
+    },
+    {
+      "name": "DeploymentIssueReporter"
+    },
+    {
+      "name": "DeploymentMetricsMaintainer"
+    },
+    {
+      "name": "OutstandingChangeDeployer"
+    },
+    {
+      "name": "ClusterUtilizationMaintainer"
     },
     {
       "name": "ClusterInfoMaintainer"
@@ -23,15 +35,6 @@
     },
     {
       "name": "MetricsReporter"
-    },
-    {
-      "name": "VersionStatusUpdater"
-    },
-    {
-      "name": "DeploymentIssueReporter"
-    },
-    {
-      "name": "OutstandingChangeDeployer"
     }
   ],
   "inactive": [


### PR DESCRIPTION
This is to avoid external calls to the metric providers when asking for deployment info.

With this change the deployment info is self-contained and can be returned without any (potentially) external calls.