### PR TITLE
Abort priority-queued requests on distributor shutdown

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -187,11 +187,11 @@ private:
     };
 
     void setNodeStateUp();
-
     bool handleMessage(const std::shared_ptr<api::StorageMessage>& msg);
     bool isMaintenanceReply(const api::StorageReply& reply) const;
 
     void handleStatusRequests();
+    void send_shutdown_abort_reply(const std::shared_ptr<api::StorageMessage>&);
     void handle_or_propagate_message(const std::shared_ptr<api::StorageMessage>& msg);
     void startExternalOperations();
 


### PR DESCRIPTION
@baldersheim please review, fixes race on shutdown where a freed mbus context is attempted used.