### PR TITLE
Adjust API for storage messages: Replace virtual getBucketId() method…

### DIFF
--- a/storage/src/vespa/storage/common/bucketmessages.h
+++ b/storage/src/vespa/storage/common/bucketmessages.h
@@ -3,7 +3,7 @@
 
 #include <vespa/persistence/spi/persistenceprovider.h>
 #include <vespa/storageapi/message/internal.h>
-#include <vespa/document/bucket/bucketid.h>
+#include <vespa/document/bucket/bucket.h>
 #include <vespa/storageapi/buckets/bucketinfo.h>
 #include <vector>
 #include <set>
@@ -78,7 +78,7 @@ public:
     ReadBucketInfo(const document::BucketId& bucketId);
     ~ReadBucketInfo();
 
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     bool hasSingleBucketId() const override { return true; }
 
     std::unique_ptr<api::StorageReply> makeReply() override;
@@ -102,7 +102,7 @@ public:
     ReadBucketInfoReply(const ReadBucketInfo& cmd);
     ~ReadBucketInfoReply();
 
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     bool hasSingleBucketId() const override { return true; }
 
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
@@ -133,7 +133,7 @@ public:
     ~RepairBucketCommand();
 
     bool hasSingleBucketId() const override { return true; }
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucket); }
 
     uint16_t getDisk() const { return _disk; }
     bool verifyBody() const { return _verifyBody; }
@@ -166,7 +166,7 @@ public:
 
     RepairBucketReply(const RepairBucketCommand& cmd, const api::BucketInfo& bucketInfo = api::BucketInfo());
     ~RepairBucketReply();
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucket); }
     bool hasSingleBucketId() const override { return true; }
 
     const api::BucketInfo& getBucketInfo() const { return _bucketInfo; }
@@ -199,7 +199,7 @@ public:
     BucketDiskMoveCommand(const document::BucketId& bucket, uint16_t srcDisk, uint16_t dstDisk);
     ~BucketDiskMoveCommand();
 
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucket); }
     bool hasSingleBucketId() const override { return true; }
 
     uint16_t getSrcDisk() const { return _srcDisk; }
@@ -234,7 +234,7 @@ public:
                         uint32_t destinationFileSize = 0);
     ~BucketDiskMoveReply();
 
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucket); }
     bool hasSingleBucketId() const override { return true; }
 
     const api::BucketInfo& getBucketInfo() const { return _bucketInfo; }
@@ -270,7 +270,7 @@ public:
     InternalBucketJoinCommand(const document::BucketId& bucket, uint16_t keepOnDisk, uint16_t joinFromDisk);
     ~InternalBucketJoinCommand();
 
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucket); }
     bool hasSingleBucketId() const override { return true; }
 
     uint16_t getDiskOfInstanceToKeep() const { return _keepOnDisk; }
@@ -296,7 +296,7 @@ public:
                             const api::BucketInfo& info = api::BucketInfo());
     ~InternalBucketJoinReply();
 
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucket); }
     bool hasSingleBucketId() const override { return true; }
 
     const api::BucketInfo& getBucketInfo() const { return _bucketInfo; }

--- a/storage/src/vespa/storage/persistence/diskmoveoperationhandler.cpp
+++ b/storage/src/vespa/storage/persistence/diskmoveoperationhandler.cpp
@@ -22,7 +22,7 @@ DiskMoveOperationHandler::handleBucketDiskMove(BucketDiskMoveCommand& cmd,
                                        _env._metrics.movedBuckets,
                                        _env._component.getClock()));
 
-    document::BucketId bucket(cmd.getBucketId());
+    document::Bucket bucket(cmd.getBucket());
     uint32_t targetDisk(cmd.getDstDisk());
     uint32_t deviceIndex(_env._partition);
 
@@ -45,8 +45,8 @@ DiskMoveOperationHandler::handleBucketDiskMove(BucketDiskMoveCommand& cmd,
         bucket.toString().c_str(),
         deviceIndex, targetDisk);
 
-    spi::Bucket from(document::Bucket(document::BucketSpace::placeHolder(), bucket), spi::PartitionId(deviceIndex));
-    spi::Bucket to(document::Bucket(document::BucketSpace::placeHolder(), bucket), spi::PartitionId(targetDisk));
+    spi::Bucket from(bucket, spi::PartitionId(deviceIndex));
+    spi::Bucket to(bucket, spi::PartitionId(targetDisk));
 
     spi::Result result(
             _provider.move(from, spi::PartitionId(targetDisk), context));
@@ -66,13 +66,13 @@ DiskMoveOperationHandler::handleBucketDiskMove(BucketDiskMoveCommand& cmd,
         // is executed. moving queue should move delete command to correct disk
         StorBucketDatabase::WrappedEntry entry(
                 _env.getBucketDatabase().get(
-                    bucket, "FileStorThread::onBucketDiskMove",
+                    bucket.getBucketId(), "FileStorThread::onBucketDiskMove",
                     StorBucketDatabase::LOCK_IF_NONEXISTING_AND_NOT_CREATING));
 
         // Move queued operations in bucket to new thread. Hold bucket lock
         // while doing it, so filestor manager can't put in other operations
         // first, such that operations change order.
-        _env._fileStorHandler.remapQueueAfterDiskMove(bucket, deviceIndex, targetDisk);
+        _env._fileStorHandler.remapQueueAfterDiskMove(bucket.getBucketId(), deviceIndex, targetDisk);
 
         if (entry.exist()) {
             entry->setBucketInfo(bInfo);

--- a/storage/src/vespa/storage/persistence/mergehandler.cpp
+++ b/storage/src/vespa/storage/persistence/mergehandler.cpp
@@ -955,8 +955,8 @@ MergeHandler::handleMergeBucket(api::MergeBucketCommand& cmd,
                                        _env._metrics.mergeBuckets,
                                        _env._component.getClock()));
 
-    const document::BucketId& id(cmd.getBucketId());
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(), id), spi::PartitionId(_env._partition));
+    spi::Bucket bucket(cmd.getBucket(), spi::PartitionId(_env._partition));
+    const document::BucketId id(bucket.getBucketId());
     LOG(debug, "MergeBucket(%s) with max timestamp %" PRIu64 ".",
         bucket.toString().c_str(), cmd.getMaxTimestamp());
 
@@ -1181,8 +1181,8 @@ MergeHandler::handleGetBucketDiff(api::GetBucketDiffCommand& cmd,
     MessageTracker::UP tracker(new MessageTracker(
                                        _env._metrics.getBucketDiff,
                                        _env._component.getClock()));
-    const document::BucketId& id(cmd.getBucketId());
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(), id), spi::PartitionId(_env._partition));
+    spi::Bucket bucket(cmd.getBucket(), spi::PartitionId(_env._partition));
+    const document::BucketId id(bucket.getBucketId());
     LOG(debug, "GetBucketDiff(%s)", bucket.toString().c_str());
     checkResult(_spi.createBucket(bucket, context), bucket, "create bucket");
 
@@ -1304,8 +1304,8 @@ MergeHandler::handleGetBucketDiffReply(api::GetBucketDiffReply& reply,
                                        MessageSender& sender)
 {
     ++_env._metrics.getBucketDiffReply;
-    document::BucketId id(reply.getBucketId());
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(), id), spi::PartitionId(_env._partition));
+    spi::Bucket bucket(reply.getBucket(), spi::PartitionId(_env._partition));
+    document::BucketId id(bucket.getBucketId());
     LOG(debug, "GetBucketDiffReply(%s)", bucket.toString().c_str());
 
     if (!_env._fileStorHandler.isMerging(id)) {
@@ -1388,8 +1388,8 @@ MergeHandler::handleApplyBucketDiff(api::ApplyBucketDiffCommand& cmd,
                                        _env._metrics.applyBucketDiff,
                                        _env._component.getClock()));
 
-    const document::BucketId& id(cmd.getBucketId());
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(), id), spi::PartitionId(_env._partition));
+    spi::Bucket bucket(cmd.getBucket(), spi::PartitionId(_env._partition));
+    const document::BucketId id(bucket.getBucketId());
     LOG(debug, "%s", cmd.toString().c_str());
 
     if (_env._fileStorHandler.isMerging(id)) {
@@ -1484,8 +1484,8 @@ MergeHandler::handleApplyBucketDiffReply(api::ApplyBucketDiffReply& reply,
                                          MessageSender& sender)
 {
     ++_env._metrics.applyBucketDiffReply;
-    document::BucketId id(reply.getBucketId());
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(), id), spi::PartitionId(_env._partition));
+    spi::Bucket bucket(reply.getBucket(), spi::PartitionId(_env._partition));
+    document::BucketId id(bucket.getBucketId());
     std::vector<api::ApplyBucketDiffCommand::Entry>& diff(reply.getDiff());
     LOG(debug, "%s", reply.toString().c_str());
 

--- a/storage/src/vespa/storage/persistence/messages.h
+++ b/storage/src/vespa/storage/persistence/messages.h
@@ -32,7 +32,7 @@ public:
 
     std::unique_ptr<api::StorageReply> makeReply() override;
 
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     bool hasSingleBucketId() const override { return true; }
 
     spi::IteratorId getIteratorId() const { return _iteratorId; }
@@ -64,9 +64,7 @@ public:
     ~GetIterReply();
 
     bool hasSingleBucketId() const override { return true; }
-    document::BucketId getBucketId() const override {
-        return _bucketId;
-    }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
 
     const std::vector<spi::DocEntry::UP>& getEntries() const {
         return _entries;
@@ -101,7 +99,7 @@ public:
                           spi::IncludedVersions includedVersions);
     ~CreateIteratorCommand();
     bool hasSingleBucketId() const override { return true; }
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     const spi::Selection& getSelection() const { return _selection; }
     spi::IncludedVersions getIncludedVersions() const { return _includedVersions; }
     const std::string& getFields() const { return _fieldSet; }
@@ -131,7 +129,7 @@ public:
     ~CreateIteratorReply();
 
     bool hasSingleBucketId() const override { return true; }
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
 
     spi::IteratorId getIteratorId() const { return _iteratorId; }
 
@@ -181,9 +179,7 @@ public:
     RecheckBucketInfoCommand(const document::BucketId& bucketId);
     ~RecheckBucketInfoCommand();
 
-    document::BucketId getBucketId() const override {
-        return _bucketId;
-    }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
 
     std::unique_ptr<api::StorageReply> makeReply() override;
 
@@ -201,9 +197,7 @@ public:
     RecheckBucketInfoReply(const RecheckBucketInfoCommand& cmd);
     ~RecheckBucketInfoReply();
 
-    document::BucketId getBucketId() const override {
-        return _bucketId;
-    }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
 
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 };

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -231,7 +231,7 @@ PersistenceThread::handleRepairBucket(RepairBucketCommand& cmd)
         (cmd.verifyBody() ? "Verifying body" : "Not verifying body"));
     api::BucketInfo before = _env.getBucketInfo(cmd.getBucketId());
     spi::Result result =
-        _spi.maintain(spi::Bucket(document::Bucket(document::BucketSpace::placeHolder(), cmd.getBucketId()),
+        _spi.maintain(spi::Bucket(cmd.getBucket(),
                                   spi::PartitionId(_env._partition)),
                       cmd.verifyBody() ?
                       spi::HIGH : spi::LOW);

--- a/storage/src/vespa/storage/persistence/processallhandler.cpp
+++ b/storage/src/vespa/storage/persistence/processallhandler.cpp
@@ -87,9 +87,7 @@ ProcessAllHandler::handleRemoveLocation(api::RemoveLocationCommand& cmd,
         cmd.getBucketId().toString().c_str(),
         cmd.getDocumentSelection().c_str());
 
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(),
-                                        cmd.getBucketId()),
-                       spi::PartitionId(_env._partition));
+    spi::Bucket bucket(cmd.getBucket(), spi::PartitionId(_env._partition));
     UnrevertableRemoveEntryProcessor processor(_spi, bucket, context);
     BucketProcessor::iterateAll(_spi,
                                 bucket,
@@ -118,8 +116,7 @@ ProcessAllHandler::handleStatBucket(api::StatBucketCommand& cmd,
     ost << "Persistence bucket " << cmd.getBucketId()
         << ", partition " << _env._partition << "\n";
 
-    spi::Bucket bucket(document::Bucket(document::BucketSpace::placeHolder(), cmd.getBucketId()),
-                       spi::PartitionId(_env._partition));
+    spi::Bucket bucket(cmd.getBucket(), spi::PartitionId(_env._partition));
     StatEntryProcessor processor(ost);
     BucketProcessor::iterateAll(_spi,
                bucket,

--- a/storageapi/src/vespa/storageapi/message/batch.h
+++ b/storageapi/src/vespa/storageapi/message/batch.h
@@ -159,9 +159,9 @@ public:
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 
     /**
-       Returns a bucket id suitable for routing this message.
+       Returns a bucket suitable for routing this message.
     */
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     bool hasSingleBucketId() const override { return true; }
 
     DECLARE_STORAGECOMMAND(BatchDocumentUpdateCommand, onBatchDocumentUpdate)

--- a/storageapi/src/vespa/storageapi/message/datagram.h
+++ b/storageapi/src/vespa/storageapi/message/datagram.h
@@ -34,7 +34,7 @@ public:
         { assert(_docBlock.getBufferSize() > 0); return _docBlock; }
     void setDocumentBlock(vdslib::DocumentList& block) { _docBlock = block; }
 
-    document::BucketId getBucketId() const override { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     bool hasSingleBucketId() const override { return true; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     bool keepTimeStamps() const { return _keepTimeStamps; }
@@ -119,7 +119,7 @@ private:
     std::vector<Entry> _documents;
 public:
     DocumentListCommand(const document::BucketId& bid);
-    const document::BucketId& getBucketId() { return _bucketId; }
+    document::Bucket getBucket() const override { return getPlaceHolderBucket(_bucketId); }
     std::vector<Entry>& getDocuments() { return _documents; }
     const std::vector<Entry>& getDocuments() const { return _documents; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;

--- a/storageapi/src/vespa/storageapi/messageapi/bucketcommand.cpp
+++ b/storageapi/src/vespa/storageapi/messageapi/bucketcommand.cpp
@@ -3,14 +3,35 @@
 #include "bucketcommand.h"
 #include <ostream>
 
+using document::Bucket;
+using document::BucketId;
+using document::BucketSpace;
+
 namespace storage {
 namespace api {
+
+BucketCommand::BucketCommand(const MessageType& type, const BucketId& id)
+    : StorageCommand(type),
+      _bucket(BucketSpace::placeHolder(), id),
+      _originalBucket()
+{
+}
+
+void
+BucketCommand::remapBucketId(const BucketId& bucket)
+{
+    if (_originalBucket.getRawId() == 0) {
+        _originalBucket = _bucket.getBucketId();
+    }
+    Bucket newBucket(_bucket.getBucketSpace(), bucket);
+    _bucket = newBucket;
+}
 
 void
 BucketCommand::print(std::ostream& out,
                      bool verbose, const std::string& indent) const
 {
-    out << "BucketCommand(" << _bucket;
+    out << "BucketCommand(" << _bucket.getBucketId();
     if (hasBeenRemapped()) {
         out << " <- " << _originalBucket;
     }

--- a/storageapi/src/vespa/storageapi/messageapi/bucketcommand.h
+++ b/storageapi/src/vespa/storageapi/messageapi/bucketcommand.h
@@ -9,27 +9,22 @@
 #pragma once
 
 #include "storagecommand.h"
+#include <vespa/document/bucket/bucket.h>
 
 namespace storage::api {
 
 class BucketCommand : public StorageCommand {
-    document::BucketId _bucket;
+    document::Bucket   _bucket;
     document::BucketId _originalBucket;
 
 protected:
-    BucketCommand(const MessageType& type, const document::BucketId& id)
-        : StorageCommand(type), _bucket(id), _originalBucket()
-    {}
+    BucketCommand(const MessageType& type, const document::BucketId& id);
 
 public:
     DECLARE_POINTER_TYPEDEFS(BucketCommand);
 
-    void remapBucketId(const document::BucketId& bucket) {
-        if (_originalBucket.getRawId() == 0) _originalBucket = _bucket;
-        _bucket = bucket;
-    }
-
-    document::BucketId getBucketId() const override { return _bucket; }
+    void remapBucketId(const document::BucketId& bucket);
+    document::Bucket getBucket() const override { return _bucket; }
     bool hasBeenRemapped() const { return (_originalBucket.getRawId() != 0); }
     const document::BucketId& getOriginalBucketId() const { return _originalBucket; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;

--- a/storageapi/src/vespa/storageapi/messageapi/bucketreply.cpp
+++ b/storageapi/src/vespa/storageapi/messageapi/bucketreply.cpp
@@ -4,22 +4,34 @@
 #include "bucketcommand.h"
 #include <ostream>
 
+using document::Bucket;
+using document::BucketId;
+
 namespace storage {
 namespace api {
 
 BucketReply::BucketReply(const BucketCommand& cmd,
                          const ReturnCode& code)
     : StorageReply(cmd, code),
-      _bucket(cmd.getBucketId()),
+      _bucket(cmd.getBucket()),
       _originalBucket(cmd.getOriginalBucketId())
 {
+}
+
+void
+BucketReply::remapBucketId(const BucketId& bucket) {
+    if (_originalBucket.getRawId() == 0) {
+        _originalBucket = _bucket.getBucketId();
+    }
+    Bucket newBucket(_bucket.getBucketSpace(), bucket);
+    _bucket = newBucket;
 }
 
 void
 BucketReply::print(std::ostream& out, bool verbose,
                    const std::string& indent) const
 {
-    out << "BucketReply(" << _bucket;
+    out << "BucketReply(" << _bucket.getBucketId();
     if (hasBeenRemapped()) {
         out << " <- " << _originalBucket;
     }

--- a/storageapi/src/vespa/storageapi/messageapi/bucketreply.h
+++ b/storageapi/src/vespa/storageapi/messageapi/bucketreply.h
@@ -16,7 +16,7 @@ namespace api {
 class BucketCommand;
 
 class BucketReply : public StorageReply {
-    document::BucketId _bucket;
+    document::Bucket _bucket;
     document::BucketId _originalBucket;
 
 protected:
@@ -26,7 +26,7 @@ protected:
 public:
     DECLARE_POINTER_TYPEDEFS(BucketReply);
 
-    document::BucketId getBucketId() const override { return _bucket; }
+    document::Bucket getBucket() const override { return _bucket; }
     virtual bool hasSingleBucketId() const override { return true; }
 
     bool hasBeenRemapped() const { return (_originalBucket.getRawId() != 0); }
@@ -34,10 +34,7 @@ public:
         { return _originalBucket; }
 
     /** The deserialization code need access to set the remapping. */
-    void remapBucketId(const document::BucketId& bucket) {
-        if (_originalBucket.getRawId() == 0) _originalBucket = _bucket;
-        _bucket = bucket;
-    }
+    void remapBucketId(const document::BucketId& bucket);
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 };
 

--- a/storageapi/src/vespa/storageapi/messageapi/storagemessage.h
+++ b/storageapi/src/vespa/storageapi/messageapi/storagemessage.h
@@ -17,7 +17,7 @@
 #include <vespa/messagebus/routing/route.h>
 #include <vespa/messagebus/trace.h>
 #include <vespa/vdslib/state/nodetype.h>
-#include <vespa/document/bucket/bucketid.h>
+#include <vespa/document/bucket/bucket.h>
 #include <vespa/vespalib/util/printable.h>
 #include <map>
 
@@ -350,6 +350,8 @@ protected:
     StorageMessage(const MessageType& code, Id id);
     StorageMessage(const StorageMessage&, Id id);
 
+    static document::Bucket getPlaceHolderBucket(document::BucketId bucketId)  { return document::Bucket(document::BucketSpace::placeHolder(), bucketId); }
+    static document::Bucket getDummyBucket() { return getPlaceHolderBucket(document::BucketId()); }
 public:
     virtual ~StorageMessage();
 
@@ -420,7 +422,8 @@ public:
      */
     virtual vespalib::string getSummary() const;
 
-    virtual document::BucketId getBucketId() const { return document::BucketId(); }
+    virtual document::Bucket getBucket() const { return getDummyBucket(); }
+    document::BucketId getBucketId() const { return getBucket().getBucketId(); }
     virtual bool hasSingleBucketId() const { return false; }
 };
 


### PR DESCRIPTION
… with

virtual getBucket() method that also contains bucket space.

Adjust BucketCommand/BucketReply intermediate storage message classes to use
document::Bucket members instead of document::BucketId.

@vekterli, please review
@geirst, FYI