### PR TITLE
Use packaging 'jar'

### DIFF
--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -14,7 +14,7 @@
   </parent>
   <artifactId>container-test</artifactId>
   <version>6-SNAPSHOT</version>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
.. so that users don't have to explicitly declare dependency type.