### PR TITLE
Find reserved names when loading class

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/ReservedMacroNames.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/ReservedMacroNames.java
@@ -1,5 +1,6 @@
 package com.yahoo.searchdefinition.processing;
 
+import com.google.common.collect.ImmutableSet;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.searchdefinition.RankProfile;
 import com.yahoo.searchdefinition.RankProfileRegistry;
@@ -39,12 +40,12 @@ public class ReservedMacroNames extends Processor {
         }
     }
 
-    private static Set<String> getReservedNames() {
-        Set<String> names = new HashSet<>();
+    private static ImmutableSet<String> getReservedNames() {
+        ImmutableSet.Builder<String> names = ImmutableSet.builder();
         for (String token : RankingExpressionParserConstants.tokenImage) {
             String tokenWithoutQuotes = token.substring(1, token.length()-1);
             names.add(tokenWithoutQuotes);
         }
-        return names;
+        return names.build();
     }
 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/ReservedMacroNames.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/ReservedMacroNames.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
  * @author lesters
  */
 public class ReservedMacroNames extends Processor {
+    private static Set<String> reservedNames = getReservedNames();
 
     public ReservedMacroNames(Search search, DeployLogger deployLogger, RankProfileRegistry rankProfileRegistry, QueryProfiles queryProfiles) {
         super(search, deployLogger, rankProfileRegistry, queryProfiles);
@@ -25,7 +26,6 @@ public class ReservedMacroNames extends Processor {
 
     @Override
     public void process() {
-        Set<String> reservedNames = getReservedNames();
         for (RankProfile rp : rankProfileRegistry.allRankProfiles()) {
             for (String macroName : rp.getMacros().keySet()) {
                 if (reservedNames.contains(macroName)) {
@@ -39,7 +39,7 @@ public class ReservedMacroNames extends Processor {
         }
     }
 
-    private Set<String> getReservedNames() {
+    private static Set<String> getReservedNames() {
         Set<String> names = new HashSet<>();
         for (String token : RankingExpressionParserConstants.tokenImage) {
             String tokenWithoutQuotes = token.substring(1, token.length()-1);


### PR DESCRIPTION
We got a (small) performance hit (when deploying) when starting to use ReservedMacroNames, not sure if this change will help much, but let's see.