### PR TITLE
Arnej/add uptime metric for sentinel

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -40,6 +40,7 @@ public class VespaMetricSet {
         Set<Metric> metrics = new LinkedHashSet<>();
 
         metrics.add(new Metric("sentinel.restarts.count"));
+        metrics.add(new Metric("sentinel.uptime.last", "sentinel.uptime"));
 
         metrics.add(new Metric("sentinel.running.count"));
         metrics.add(new Metric("sentinel.running.last"));

--- a/configd/src/apps/sentinel/metrics.cpp
+++ b/configd/src/apps/sentinel/metrics.cpp
@@ -8,7 +8,7 @@ namespace config {
 namespace sentinel {
 
 StartMetrics::StartMetrics()
-    : currentlyRunningServices(0), totalRestartsCounter(0), totalRestartsLastPeriod(0),
+    : currentlyRunningServices(0), totalRestartsCounter(0), totalRestartsLastPeriod(1),
       lastLoggedTime(0),
       totalRestartsLastSnapshot(0),
       snapshotStart(0),


### PR DESCRIPTION
@hakonhall please review and merge
this ensures the "sentinel.restarts.count" metric will have a bump at sentinel restart,
and also adds a "sentinel.uptime" metric that may make it easier to see disparity between nodes when graphed.
@ldalves FYI