### PR TITLE
Revert "Use the existing sync method."

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
@@ -577,7 +577,9 @@ performPruneRemovedDocuments(PruneRemovedDocumentsOperation &pruneOp)
 {
     const LidVectorContext::SP lids_to_remove = pruneOp.getLidsToRemove();
     if (lids_to_remove && lids_to_remove->getNumLids() != 0) {
-        storeOperationSync(pruneOp);
+        vespalib::Gate gate;
+        storeOperation(pruneOp, std::make_shared<search::GateCallback>(gate));
+        gate.await();
         _activeFeedView->handlePruneRemovedDocuments(pruneOp);
     }
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#3795
system test failure