### PR TITLE
Configure ccache through cli interface

### DIFF
--- a/travis/cpp-prelude.sh
+++ b/travis/cpp-prelude.sh
@@ -2,6 +2,6 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 set -e
 
-export CCACHE_MAXSIZE="1250M"
-export CCACHE_COMPRESS=1
+ccache --max-size=1250M
+ccache --set-config=compression=true
 ccache --print-config


### PR DESCRIPTION
It looks like the Travis-CI VM contains some configuration in its .ccache
directory that overrides whatever we configures through ccache
environment variables.