### PR TITLE
Use config definitions from a configured directory

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -13,6 +13,7 @@ zookeeperserver[].port int default=2181
 zookeeper.barrierTimeout long default=120
 configModelPluginDir[] string
 configServerDBDir string default="var/db/vespa/config_server/serverdb/"
+configDefinitionsDir string default="share/vespa/configdefinitions/"
 maxgetconfigclients int default=1000000
 maxoutputbuffersize int default=65536
 # in seconds

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerDB.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerDB.java
@@ -28,7 +28,7 @@ public class ConfigServerDB {
     public ConfigServerDB(ConfigserverConfig configserverConfig) {
         this.configserverConfig = configserverConfig;
         this.serverDB = new File(Defaults.getDefaults().underVespaHome(configserverConfig.configServerDBDir()));
-        create();
+        createDirectory(serverdefs());
         try {
             initialize(configserverConfig.configModelPluginDir());
         } catch (IllegalArgumentException e) {
@@ -38,25 +38,18 @@ public class ConfigServerDB {
         }
     }
 
-    public static ConfigServerDB createTestConfigServerDb(String dir) {
-        return new ConfigServerDB(new ConfigserverConfig(new ConfigserverConfig.Builder().configServerDBDir(dir)));
+    public static ConfigServerDB createTestConfigServerDb(String dbDir, String definitionsDir) {
+        return new ConfigServerDB(new ConfigserverConfig(new ConfigserverConfig.Builder()
+                                                                 .configServerDBDir(dbDir)
+                                                                 .configDefinitionsDir(definitionsDir)));
     }
 
-    public File classes() { return new File(serverDB, "classes"); }
-    public File vespaapps() { return new File(serverDB, "vespaapps"); }
+    // The config definitions shipped with Vespa
+    public File classes() { return new File(Defaults.getDefaults().underVespaHome(configserverConfig.configDefinitionsDir()));}
+
     public File serverdefs() { return new File(serverDB, "serverdefs"); }
 
-
-    /**
-     * Creates all the config server db's dirs that are global.
-     */
-    public void create() {
-        cr(classes());
-        cr(vespaapps());
-        cr(serverdefs());
-    }
-
-    public static void cr(File d) {
+    public static void createDirectory(File d) {
         if (d.exists()) {
             if (!d.isDirectory()) {
                 throw new IllegalArgumentException(d.getAbsolutePath() + " exists, but isn't a directory.");

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/TenantFileSystemDirs.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/TenantFileSystemDirs.java
@@ -22,7 +22,7 @@ public class TenantFileSystemDirs {
     public TenantFileSystemDirs(File dir, TenantName tenant) {
         this.serverDB = dir;
         this.tenant = tenant;
-        ConfigServerDB.cr(path());
+        ConfigServerDB.createDirectory(path());
     }
 
     public static TenantFileSystemDirs createTestDirs(TenantName tenantName) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerDBTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerDBTest.java
@@ -18,18 +18,20 @@ import static org.junit.Assert.assertThat;
  */
 public class ConfigServerDBTest {
     private ConfigServerDB serverDB;
-    private File tempDir;
+    private File dbDir;
+    private File definitionsDir;
 
     @Before
     public void setup() {
-        tempDir = Files.createTempDir();
-        serverDB = ConfigServerDB.createTestConfigServerDb(tempDir.getAbsolutePath());
+        dbDir = Files.createTempDir();
+        definitionsDir = Files.createTempDir();
+        serverDB = ConfigServerDB.createTestConfigServerDb(dbDir.getAbsolutePath(), definitionsDir.getAbsolutePath());
     }
 
-    private ConfigServerDB createInitializer() throws IOException {
+    private void createInitializer() throws IOException {
         File existingDef = new File(serverDB.classes(), "test.def");
         IOUtils.writeFile(existingDef, "hello", false);
-        return ConfigServerDB.createTestConfigServerDb(tempDir.getAbsolutePath());
+        ConfigServerDB.createTestConfigServerDb(dbDir.getAbsolutePath(), definitionsDir.getAbsolutePath());
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/InjectedGlobalComponentRegistryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/InjectedGlobalComponentRegistryTest.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.config.server.application.PermanentApplicationPackage;
 import com.yahoo.vespa.config.server.host.ConfigRequestHostLivenessTracker;
 import com.yahoo.vespa.config.server.host.HostRegistries;
 import com.yahoo.vespa.config.server.http.SessionHandlerTest;
-import com.yahoo.vespa.config.server.http.v2.SessionActiveHandlerTest;
 import com.yahoo.vespa.config.server.modelfactory.ModelFactoryRegistry;
 import com.yahoo.vespa.config.server.monitoring.Metrics;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
@@ -36,7 +35,6 @@ import static org.junit.Assert.assertTrue;
 public class InjectedGlobalComponentRegistryTest {
 
     private Curator curator;
-    private ConfigCurator configCurator;
     private Metrics metrics;
     private ConfigServerDB serverDB;
     private SessionPreparer sessionPreparer;
@@ -48,16 +46,18 @@ public class InjectedGlobalComponentRegistryTest {
     private HostRegistries hostRegistries;
     private GlobalComponentRegistry globalComponentRegistry;
     private ModelFactoryRegistry modelFactoryRegistry;
-    private HostProvisionerProvider hostProvisionerProvider;
     private Zone zone;
 
     @Before
     public void setupRegistry() {
         curator = new MockCurator();
-        configCurator = ConfigCurator.create(curator);
+        ConfigCurator configCurator = ConfigCurator.create(curator);
         metrics = Metrics.createTestMetrics();
         modelFactoryRegistry = new ModelFactoryRegistry(Collections.singletonList(new VespaModelFactory(new NullConfigModelRegistry())));
-        configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder().configServerDBDir(Files.createTempDir().getAbsolutePath()));
+        configserverConfig = new ConfigserverConfig(
+                new ConfigserverConfig.Builder()
+                        .configServerDBDir(Files.createTempDir().getAbsolutePath())
+                        .configDefinitionsDir(Files.createTempDir().getAbsolutePath()));
         serverDB = new ConfigServerDB(configserverConfig);
         sessionPreparer = new SessionTest.MockSessionPreparer();
         rpcServer = new RpcServer(configserverConfig, null, Metrics.createTestMetrics(), 
@@ -66,7 +66,7 @@ public class InjectedGlobalComponentRegistryTest {
         defRepo = new StaticConfigDefinitionRepo();
         permanentApplicationPackage = new PermanentApplicationPackage(configserverConfig);
         hostRegistries = new HostRegistries();
-        hostProvisionerProvider = HostProvisionerProvider.withProvisioner(new SessionHandlerTest.MockProvisioner());
+        HostProvisionerProvider hostProvisionerProvider = HostProvisionerProvider.withProvisioner(new SessionHandlerTest.MockProvisioner());
         zone = Zone.defaultZone();
         globalComponentRegistry = new InjectedGlobalComponentRegistry(curator, configCurator, metrics, modelFactoryRegistry, serverDB, sessionPreparer, rpcServer, configserverConfig, generationCounter, defRepo, permanentApplicationPackage, hostRegistries, hostProvisionerProvider, zone);
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
@@ -89,9 +89,10 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
         private Curator curator = new MockCurator();
         private Optional<ConfigCurator> configCurator = Optional.empty();
         private Metrics metrics = Metrics.createTestMetrics();
+        private String configserverTempDir = Files.createTempDir().getAbsolutePath();
         private ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder()
-                                                                                       .configServerDBDir(Files.createTempDir()
-                                                                                                               .getAbsolutePath()));
+                                                                                       .configServerDBDir(configserverTempDir)
+                                                                                       .configDefinitionsDir(configserverTempDir));
         private ConfigDefinitionRepo defRepo = new StaticConfigDefinitionRepo();
         private TenantRequestHandlerTest.MockReloadListener reloadListener = new TenantRequestHandlerTest.MockReloadListener();
         private MockTenantListener tenantListener = new MockTenantListener();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -71,7 +71,9 @@ public class DeployTester {
     public DeployTester(String appPath, List<ModelFactory> modelFactories) {
         this(appPath, modelFactories, new ConfigserverConfig(new ConfigserverConfig.Builder()
                                                                      .configServerDBDir(Files.createTempDir()
-                                                                                             .getAbsolutePath())),
+                                                                                             .getAbsolutePath())
+                                                                     .configDefinitionsDir(Files.createTempDir()
+                                                                                                .getAbsolutePath())),
              Clock.systemUTC());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -126,9 +126,10 @@ public class HostedDeployTest {
     }
 
     private static ConfigserverConfig createConfigserverConfig() {
+        String tempDir = Files.createTempDir().getAbsolutePath();
         return new ConfigserverConfig(new ConfigserverConfig.Builder()
-                                              .configServerDBDir(Files.createTempDir()
-                                                                      .getAbsolutePath())
+                                              .configServerDBDir(tempDir)
+                                              .configDefinitionsDir(tempDir)
                                               .dockerRegistry(dockerRegistry)
                                               .dockerVespaBaseImage(dockerVespaBaseImage)
                                               .hostedVespa(true)

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/RedeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/RedeployTest.java
@@ -72,6 +72,8 @@ public class RedeployTest {
         ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder()
                                                                                .configServerDBDir(Files.createTempDir()
                                                                                                        .getAbsolutePath())
+                                                                               .configDefinitionsDir(Files.createTempDir()
+                                                                                                          .getAbsolutePath())
                                                                                .sessionLifetime(60));
         DeployTester tester = new DeployTester("src/test/apps/app", configserverConfig, clock);
         tester.deployApp("myapp", Instant.now()); // session 2 (numbering starts at 2)


### PR DESCRIPTION
* By default use config definitions from share/vespa/configdefinitions
* Remove creation of classes/ (not needed) and vespaapps/ (not used)
* This is a preparation for moving .def files to share/vespa/configdefinitions
  (today that is a symlink to var/db/vespa/config_server/serverdb/classes)

@aressem FYI