### PR TITLE
Do not require that fields in a field set must be part of the documen…

### DIFF
--- a/document/src/vespa/document/datatype/documenttype.cpp
+++ b/document/src/vespa/document/datatype/documenttype.cpp
@@ -75,17 +75,6 @@ DocumentType::~DocumentType()
 DocumentType &
 DocumentType::addFieldSet(const vespalib::string & name, const FieldSet::Fields & fields)
 {
-    for (FieldSet::Fields::const_iterator it(fields.begin()), mt(fields.end()); it != mt; it++) {
-        if ( ! _fields->hasField(*it) ) {
-            FieldPath fieldPath;
-            try {
-                _fields->buildFieldPath(fieldPath, *it);
-            } catch (FieldNotFoundException & e) {
-                throw IllegalArgumentException("Fieldset '" + name + "': No field with name '" + *it +
-                                               "' in document type '" + getName() + "'.", VESPA_STRLOC);
-            }
-        }
-    }
     _fieldSets[name] = FieldSet(name, fields);
     return *this;
 }


### PR DESCRIPTION
…t type.

Imported fields (from parent/referenced document types) are not part of the document type,
but can be part of field sets for search purposes.

@baldersheim or @vekterli please review