### PR TITLE
Revert "Move config server defs and make sure VESPA_USER owns var/."

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -539,9 +539,9 @@ endfunction()
 
 function(install_config_definition)
     if(ARGC GREATER 1)
-        install(FILES ${ARGV0} RENAME ${ARGV1} DESTINATION  share/vespa/configdefinitions)
+        install(FILES ${ARGV0} RENAME ${ARGV1} DESTINATION var/db/vespa/config_server/serverdb/classes)
     else()
-        install(FILES ${ARGV0} DESTINATION  share/vespa/configdefinitions)
+        install(FILES ${ARGV0} DESTINATION var/db/vespa/config_server/serverdb/classes)
     endif()
 endfunction()
 

--- a/vespabase/src/rhel-prestart.sh
+++ b/vespabase/src/rhel-prestart.sh
@@ -84,7 +84,6 @@ fixdir   root        wheel 1777  var/run
 fixdir ${VESPA_USER} wheel 1777  var/crash
 fixdir ${VESPA_USER} wheel 1777  logs/vespa
 fixdir ${VESPA_USER} wheel 1777  tmp/vespa
-fixdir ${VESPA_USER} wheel  755  var
 fixdir ${VESPA_USER} wheel  755  libexec/vespa/plugins/qrs
 fixdir ${VESPA_USER} wheel  755  logs/vespa/configserver
 fixdir ${VESPA_USER} wheel  755  logs/vespa/qrs


### PR DESCRIPTION
Reverts vespa-engine/vespa#3820

Seems like some modues (document at least) assume def files are still in var/db/vespa/config_server/serverdb/classes