### PR TITLE
Disallow parallel triggering

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -239,7 +239,7 @@ public class DeploymentSpec {
         }
     }
 
-    /** A delpoyment step */
+    /** A deployment step */
     public abstract static class Step {
         
         /** Returns whether this step deploys to the given region */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentOrder.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentOrder.java
@@ -47,8 +47,9 @@ public class DeploymentOrder {
     }
 
     /** Returns a list of jobs to trigger after the given job */
+    // TODO: This does too much - should just tell us the order, as advertised
     public List<JobType> nextAfter(JobType job, Application application) {
-        if (!application.deploying().isPresent()) { // Change was cancelled
+        if ( ! application.deploying().isPresent()) { // Change was cancelled
             return Collections.emptyList();
         }
 
@@ -71,7 +72,7 @@ public class DeploymentOrder {
             return Collections.emptyList();
         }
 
-        // Postpone if step hasn't completed all it's jobs for this change
+        // Postpone if step hasn't completed all its jobs for this change
         if (!completedSuccessfully(currentStep.get(), application.deploying().get(), application)) {
             return Collections.emptyList();
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -137,7 +137,7 @@ public class ControllerTest {
 
         // system and staging test job - succeeding
         applications.notifyJobCompletion(mockReport(app1, component, true));
-        tester.deployAndNotify(app1, applicationPackage, true, systemTest);
+        tester.deployAndNotify(app1, applicationPackage, true, false, systemTest);
         assertStatus(JobStatus.initial(systemTest)
                               .withTriggering(version1, revision, false, tester.clock().instant())
                               .withCompletion(Optional.empty(), tester.clock().instant(), tester.controller()), app1.id(), tester.controller());
@@ -435,7 +435,7 @@ public class ControllerTest {
         // out of capacity retry mechanism
         tester.clock().advance(Duration.ofMinutes(15));
         tester.notifyJobCompletion(component, app1, true);
-        tester.deployAndNotify(app1, applicationPackage, true, systemTest);
+        tester.deployAndNotify(app1, applicationPackage, true, false, systemTest);
         tester.deploy(stagingTest, app1, applicationPackage);
         assertEquals(1, buildSystem.takeJobsToRun().size());
         tester.notifyJobCompletion(stagingTest, app1, Optional.of(JobError.outOfCapacity));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -269,6 +269,7 @@ public class DeploymentTriggerTest {
         BlockedChangeDeployer blockedChangeDeployer = new BlockedChangeDeployer(tester.controller(),
                                                                                 Duration.ofHours(1),
                                                                                 new JobControl(tester.controllerTester().curator()));
+
         Version version = Version.fromString("5.0");
         tester.updateVersionStatus(version);
 
@@ -276,10 +277,14 @@ public class DeploymentTriggerTest {
                 .upgradePolicy("canary")
                 // Block revision changes on tuesday in hours 18 and 19
                 .blockChange(true, false, "tue", "18-19", "UTC")
-                .region("us-west-1");
+                .region("us-west-1")
+                .region("us-central-1")
+                .region("us-east-3");
 
         Application app = tester.createAndDeploy("app1", 1, applicationPackageBuilder.build());
 
+        
+        
         tester.clock().advance(Duration.ofHours(1)); // --------------- Enter block window: 18:30
         
         blockedChangeDeployer.run();


### PR DESCRIPTION
- Disallow parallel triggering
- Let triggerReadyJobs look at all jobs
- Refuse to trigger an upgrade if a newer upgrade has started in the meantime (due to block + timeout)
- More upgrade+block scenario tests

@mpolden please review