### PR TITLE
Make SlobrokMonitorManager a component

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -43,6 +43,7 @@
     <preprocess:include file='config-models.xml' required='false' />
     <preprocess:include file='node-repository.xml' required='false' />
     <preprocess:include file='hosted-vespa/routing-status.xml' required='false' />
+    <component id="com.yahoo.vespa.service.monitor.SlobrokMonitorManagerImpl" bundle="orchestrator" />
     <component id="com.yahoo.vespa.service.monitor.ServiceMonitorImpl" bundle="orchestrator" />
     <component id="com.yahoo.vespa.orchestrator.ServiceMonitorInstanceLookupService" bundle="orchestrator" />
     <component id="com.yahoo.vespa.orchestrator.status.ZookeeperStatusService" bundle="orchestrator" />

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -187,7 +187,7 @@ public class NodeFailer extends Maintainer {
      */
     private List<Node> determineActiveNodeDownStatus() {
         List<Node> downNodes = new ArrayList<>();
-        for (ApplicationInstance application : serviceMonitor.queryStatusOfAllApplicationInstances().values()) {
+        for (ApplicationInstance application : serviceMonitor.getAllApplicationInstances().values()) {
             for (ServiceCluster cluster : application.serviceClusters()) {
                 for (ServiceInstance service : cluster.serviceInstances()) {
                     Optional<Node> node = nodeRepository().getNode(service.hostName().s(), Node.State.active);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ServiceMonitorStub.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ServiceMonitorStub.java
@@ -67,7 +67,7 @@ public class ServiceMonitorStub implements ServiceMonitor {
     }
 
     @Override
-    public Map<ApplicationInstanceReference, ApplicationInstance> queryStatusOfAllApplicationInstances() {
+    public Map<ApplicationInstanceReference, ApplicationInstance> getAllApplicationInstances() {
         // Convert apps information to the response payload to return
         Map<ApplicationInstanceReference, ApplicationInstance> status = new HashMap<>();
         for (Map.Entry<ApplicationId, MockDeployer.ApplicationContext> app : apps.entrySet()) {

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/ServiceMonitorInstanceLookupService.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/ServiceMonitorInstanceLookupService.java
@@ -30,14 +30,14 @@ public class ServiceMonitorInstanceLookupService implements InstanceLookupServic
     @Override
     public Optional<ApplicationInstance> findInstanceById(ApplicationInstanceReference applicationInstanceReference) {
         Map<ApplicationInstanceReference, ApplicationInstance> instanceMap
-                = serviceMonitor.queryStatusOfAllApplicationInstances();
+                = serviceMonitor.getAllApplicationInstances();
         return Optional.ofNullable(instanceMap.get(applicationInstanceReference));
     }
 
     @Override
     public Optional<ApplicationInstance> findInstanceByHost(HostName hostName) {
         Map<ApplicationInstanceReference, ApplicationInstance> instanceMap 
-                = serviceMonitor.queryStatusOfAllApplicationInstances();
+                = serviceMonitor.getAllApplicationInstances();
         List<ApplicationInstance> applicationInstancesUsingHost = instanceMap.entrySet().stream()
                 .filter(entry -> applicationInstanceUsesHost(entry.getValue(), hostName))
                 .map(Map.Entry::getValue)
@@ -55,7 +55,7 @@ public class ServiceMonitorInstanceLookupService implements InstanceLookupServic
 
     @Override
     public Set<ApplicationInstanceReference> knownInstances() {
-        return serviceMonitor.queryStatusOfAllApplicationInstances().keySet();
+        return serviceMonitor.getAllApplicationInstances().keySet();
     }
 
     private static boolean applicationInstanceUsesHost(ApplicationInstance applicationInstance,

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/ServiceMonitor.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/ServiceMonitor.java
@@ -18,6 +18,6 @@ public interface ServiceMonitor {
      * Returns the current liveness status (up, down or unknown) of all instances
      * of all services of all clusters of all applications in a zone.
      */
-    Map<ApplicationInstanceReference, ApplicationInstance> queryStatusOfAllApplicationInstances();
+    Map<ApplicationInstanceReference, ApplicationInstance> getAllApplicationInstances();
 
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/ServiceMonitorImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/ServiceMonitorImpl.java
@@ -23,12 +23,12 @@ public class ServiceMonitorImpl implements ServiceMonitor {
 
     private final Zone zone;
     private final List<String> configServerHosts;
-    private final SlobrokMonitorManager slobrokMonitorManager = new SlobrokMonitorManager();
     private final ServiceModelCache serviceModelCache;
 
     @Inject
     public ServiceMonitorImpl(SuperModelProvider superModelProvider,
                               ConfigserverConfig configserverConfig,
+                              SlobrokMonitorManagerImpl slobrokMonitorManager,
                               Metric metric,
                               Timer timer) {
         this.zone = superModelProvider.getZone();
@@ -58,8 +58,7 @@ public class ServiceMonitorImpl implements ServiceMonitor {
     }
 
     @Override
-    public Map<ApplicationInstanceReference,
-            ApplicationInstance> queryStatusOfAllApplicationInstances() {
+    public Map<ApplicationInstanceReference, ApplicationInstance> getAllApplicationInstances() {
         return serviceModelCache.get().getAllApplicationInstances();
     }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SlobrokMonitor.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SlobrokMonitor.java
@@ -12,30 +12,31 @@ import com.yahoo.jrt.slobrok.api.Mirror;
 import com.yahoo.jrt.slobrok.api.SlobrokList;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * Class to manage Slobrok
  */
-public class SlobrokMonitor2 implements AutoCloseable {
+public class SlobrokMonitor implements AutoCloseable {
     public static final String SLOBROK_SERVICE_TYPE = "slobrok";
     public static final String SLOBROK_RPC_PORT_TAG = "rpc";
 
     private final SlobrokList slobrokList;
     private final Mirror mirror;
 
-    SlobrokMonitor2() {
+    SlobrokMonitor() {
         this(new SlobrokList());
     }
 
     // Package-private for testing.
-    SlobrokMonitor2(SlobrokList slobrokList, Mirror mirror) {
+    SlobrokMonitor(SlobrokList slobrokList, Mirror mirror) {
         this.slobrokList = slobrokList;
         this.mirror = mirror;
     }
 
-    private SlobrokMonitor2(SlobrokList slobrokList) {
+    private SlobrokMonitor(SlobrokList slobrokList) {
         this(slobrokList, new Mirror(new Supervisor(new Transport()), slobrokList));
     }
 
@@ -65,9 +66,12 @@ public class SlobrokMonitor2 implements AutoCloseable {
         return slobrokSpecs;
     }
 
+    List<Mirror.Entry> lookup(String pattern) {
+        return Arrays.asList(mirror.lookup(pattern));
+    }
+
     @Override
     public void close() {
-        // TODO: Make sure registeredInSlobrok returns DOWN from now on (concurrently)
         mirror.shutdown();
     }
 

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SlobrokMonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SlobrokMonitorManager.java
@@ -1,115 +1,25 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.service.monitor;
 
-import com.yahoo.config.model.api.ApplicationInfo;
-import com.yahoo.config.model.api.SuperModel;
-import com.yahoo.config.model.api.SuperModelListener;
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.log.LogLevel;
+import com.yahoo.jrt.slobrok.api.Mirror;
 import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 
-import java.util.HashMap;
-import java.util.Optional;
-import java.util.function.Supplier;
-import java.util.logging.Logger;
+import java.util.List;
 
-public class SlobrokMonitorManager implements SuperModelListener {
-    private static final Logger logger =
-            Logger.getLogger(SlobrokMonitorManager.class.getName());
-
-    private final Supplier<SlobrokMonitor2> slobrokMonitorFactory;
-
-    private final Object monitor = new Object();
-    private final HashMap<ApplicationId, SlobrokMonitor2> slobrokMonitors = new HashMap<>();
-
-    SlobrokMonitorManager() {
-        this(() -> new SlobrokMonitor2());
-    }
-
-    SlobrokMonitorManager(Supplier<SlobrokMonitor2> slobrokMonitorFactory) {
-        this.slobrokMonitorFactory = slobrokMonitorFactory;
-    }
-
-    @Override
-    public void applicationActivated(SuperModel superModel, ApplicationInfo application) {
-        synchronized (monitor) {
-            SlobrokMonitor2 slobrokMonitor = slobrokMonitors.computeIfAbsent(
-                    application.getApplicationId(),
-                    id -> slobrokMonitorFactory.get());
-            slobrokMonitor.updateSlobrokList(application);
-        }
-    }
-
-    @Override
-    public void applicationRemoved(SuperModel superModel, ApplicationId id) {
-        synchronized (monitor) {
-            SlobrokMonitor2 slobrokMonitor = slobrokMonitors.remove(id);
-            if (slobrokMonitor == null) {
-                logger.log(LogLevel.WARNING, "Removed application " + id +
-                        ", but it was never registered");
-            } else {
-                slobrokMonitor.close();
-            }
-        }
-    }
-
-    ServiceStatus getStatus(ApplicationId applicationId,
-			    ServiceType serviceType,
-			    ConfigId configId) {
-        Optional<String> slobrokServiceName = findSlobrokServiceName(serviceType, configId);
-        if (slobrokServiceName.isPresent()) {
-            synchronized (monitor) {
-                SlobrokMonitor2 slobrokMonitor = slobrokMonitors.get(applicationId);
-                if (slobrokMonitor != null &&
-                        slobrokMonitor.registeredInSlobrok(slobrokServiceName.get())) {
-                    return ServiceStatus.UP;
-                } else {
-                    return ServiceStatus.DOWN;
-                }
-            }
-        } else {
-            return ServiceStatus.NOT_CHECKED;
-        }
-    }
+public interface SlobrokMonitorManager {
+    /**
+     * Get all Slobrok entries that has a name matching pattern as described in
+     * Mirror::lookup.
+     */
+    List<Mirror.Entry> lookup(ApplicationId application, String pattern);
 
     /**
-     * Get the Slobrok service name of the service, or empty if the service
-     * is not registered with Slobrok.
+     * Query the ServiceMonitorStatus of a particular service.
      */
-    Optional<String> findSlobrokServiceName(ServiceType serviceType, ConfigId configId) {
-        switch (serviceType.s()) {
-            case "adminserver":
-            case "config-sentinel":
-            case "configproxy":
-            case "configserver":
-            case "filedistributorservice":
-            case "logd":
-            case "logserver":
-            case "metricsproxy":
-            case "slobrok":
-            case "transactionlogserver":
-                return Optional.empty();
-
-            case "topleveldispatch":
-                return Optional.of(configId.s());
-
-            case "qrserver":
-            case "container":
-            case "docprocservice":
-            case "container-clustercontroller":
-                return Optional.of("vespa/service/" + configId.s());
-
-            case "searchnode": //TODO: handle only as storagenode instead of both as searchnode/storagenode
-                return Optional.of(configId.s() + "/realtimecontroller");
-            case "distributor":
-            case "storagenode":
-                return Optional.of("storage/cluster." + configId.s());
-            default:
-                logger.log(LogLevel.DEBUG, "Unknown service type " + serviceType.s() +
-                        " with config id " + configId.s());
-                return Optional.empty();
-        }
-    }
+    ServiceStatus getStatus(ApplicationId applicationId,
+                            ServiceType serviceType,
+                            ConfigId configId);
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SlobrokMonitorManagerImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SlobrokMonitorManagerImpl.java
@@ -1,0 +1,130 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.monitor;
+
+import com.yahoo.config.model.api.ApplicationInfo;
+import com.yahoo.config.model.api.SuperModel;
+import com.yahoo.config.model.api.SuperModelListener;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.jrt.slobrok.api.Mirror;
+import com.yahoo.log.LogLevel;
+import com.yahoo.vespa.applicationmodel.ConfigId;
+import com.yahoo.vespa.applicationmodel.ServiceStatus;
+import com.yahoo.vespa.applicationmodel.ServiceType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+public class SlobrokMonitorManagerImpl implements SuperModelListener, SlobrokMonitorManager {
+    private static final Logger logger =
+            Logger.getLogger(SlobrokMonitorManagerImpl.class.getName());
+
+    private final Supplier<SlobrokMonitor> slobrokMonitorFactory;
+
+    private final Object monitor = new Object();
+    private final HashMap<ApplicationId, SlobrokMonitor> slobrokMonitors = new HashMap<>();
+
+    SlobrokMonitorManagerImpl() {
+        this(() -> new SlobrokMonitor());
+    }
+
+    SlobrokMonitorManagerImpl(Supplier<SlobrokMonitor> slobrokMonitorFactory) {
+        this.slobrokMonitorFactory = slobrokMonitorFactory;
+    }
+
+    @Override
+    public void applicationActivated(SuperModel superModel, ApplicationInfo application) {
+        synchronized (monitor) {
+            SlobrokMonitor slobrokMonitor = slobrokMonitors.computeIfAbsent(
+                    application.getApplicationId(),
+                    id -> slobrokMonitorFactory.get());
+            slobrokMonitor.updateSlobrokList(application);
+        }
+    }
+
+    @Override
+    public void applicationRemoved(SuperModel superModel, ApplicationId id) {
+        synchronized (monitor) {
+            SlobrokMonitor slobrokMonitor = slobrokMonitors.remove(id);
+            if (slobrokMonitor == null) {
+                logger.log(LogLevel.WARNING, "Removed application " + id +
+                        ", but it was never registered");
+            } else {
+                slobrokMonitor.close();
+            }
+        }
+    }
+
+    @Override
+    public List<Mirror.Entry> lookup(ApplicationId id, String pattern) {
+        synchronized (monitor) {
+            SlobrokMonitor slobrokMonitor = slobrokMonitors.get(id);
+            if (slobrokMonitor == null) {
+                throw new IllegalArgumentException("Slobrok manager has no knowledge of application " + id);
+            } else {
+                return slobrokMonitor.lookup(pattern);
+            }
+        }
+    }
+
+    @Override
+    public ServiceStatus getStatus(ApplicationId applicationId,
+                                   ServiceType serviceType,
+                                   ConfigId configId) {
+        Optional<String> slobrokServiceName = findSlobrokServiceName(serviceType, configId);
+        if (slobrokServiceName.isPresent()) {
+            synchronized (monitor) {
+                SlobrokMonitor slobrokMonitor = slobrokMonitors.get(applicationId);
+                if (slobrokMonitor != null &&
+                        slobrokMonitor.registeredInSlobrok(slobrokServiceName.get())) {
+                    return ServiceStatus.UP;
+                } else {
+                    return ServiceStatus.DOWN;
+                }
+            }
+        } else {
+            return ServiceStatus.NOT_CHECKED;
+        }
+    }
+
+    /**
+     * Get the Slobrok service name of the service, or empty if the service
+     * is not registered with Slobrok.
+     */
+    Optional<String> findSlobrokServiceName(ServiceType serviceType, ConfigId configId) {
+        switch (serviceType.s()) {
+            case "adminserver":
+            case "config-sentinel":
+            case "configproxy":
+            case "configserver":
+            case "filedistributorservice":
+            case "logd":
+            case "logserver":
+            case "metricsproxy":
+            case "slobrok":
+            case "transactionlogserver":
+                return Optional.empty();
+
+            case "topleveldispatch":
+                return Optional.of(configId.s());
+
+            case "qrserver":
+            case "container":
+            case "docprocservice":
+            case "container-clustercontroller":
+                return Optional.of("vespa/service/" + configId.s());
+
+            case "searchnode": //TODO: handle only as storagenode instead of both as searchnode/storagenode
+                return Optional.of(configId.s() + "/realtimecontroller");
+            case "distributor":
+            case "storagenode":
+                return Optional.of("storage/cluster." + configId.s());
+            default:
+                logger.log(LogLevel.DEBUG, "Unknown service type " + serviceType.s() +
+                        " with config id " + configId.s());
+                return Optional.empty();
+        }
+    }
+}

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SuperModelListenerImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/SuperModelListenerImpl.java
@@ -25,10 +25,10 @@ public class SuperModelListenerImpl implements SuperModelListener, Supplier<Serv
     // superModel and slobrokMonitorManager are always updated together
     // and atomically using this monitor.
     private final Object monitor = new Object();
-    private final SlobrokMonitorManager slobrokMonitorManager;
+    private final SlobrokMonitorManagerImpl slobrokMonitorManager;
     private SuperModel superModel;
 
-    SuperModelListenerImpl(SlobrokMonitorManager slobrokMonitorManager,
+    SuperModelListenerImpl(SlobrokMonitorManagerImpl slobrokMonitorManager,
                            ServiceMonitorMetrics metrics,
                            ModelGenerator modelGenerator,
                            Zone zone,

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/ExampleModel.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/ExampleModel.java
@@ -27,7 +27,7 @@ public class ExampleModel {
 
     static final String CLUSTER_ID = "cluster-id";
     static final String SERVICE_NAME = "service-name";
-    static final String SERVICE_TYPE = SlobrokMonitor2.SLOBROK_SERVICE_TYPE;
+    static final String SERVICE_TYPE = SlobrokMonitor.SLOBROK_SERVICE_TYPE;
     static final String CONFIG_ID = "configid/1";
     static final String TENANT = "tenant";
     static final String APPLICATION_NAME = "application";
@@ -39,7 +39,7 @@ public class ExampleModel {
         ApplicationInfo applicationInfo = ExampleModel
                 .createApplication(TENANT, APPLICATION_NAME)
                 .addServiceCluster(CLUSTER_ID, SERVICE_NAME, SERVICE_TYPE, hosts)
-                .addPort(rpcPort, "footag", SlobrokMonitor2.SLOBROK_RPC_PORT_TAG)
+                .addPort(rpcPort, "footag", SlobrokMonitor.SLOBROK_RPC_PORT_TAG)
                 .addPort(rpcPort + 1, "bartag")
                 .then()
                 .build();

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/ModelGeneratorTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/ModelGeneratorTest.java
@@ -42,7 +42,7 @@ public class ModelGeneratorTest {
         List<String> configServerHosts = Stream.of("cfg1", "cfg2", "cfg3")
                 .collect(Collectors.toList());
 
-        SlobrokMonitorManager slobrokMonitorManager = mock(SlobrokMonitorManager.class);
+        SlobrokMonitorManagerImpl slobrokMonitorManager = mock(SlobrokMonitorManagerImpl.class);
         when(slobrokMonitorManager.getStatus(any(), any(), any()))
                 .thenReturn(ServiceStatus.UP);
 
@@ -86,7 +86,7 @@ public class ModelGeneratorTest {
 
         List<String> configServerHosts = Collections.emptyList();
 
-        SlobrokMonitorManager slobrokMonitorManager = mock(SlobrokMonitorManager.class);
+        SlobrokMonitorManagerImpl slobrokMonitorManager = mock(SlobrokMonitorManagerImpl.class);
         when(slobrokMonitorManager.getStatus(any(), any(), any()))
                 .thenReturn(ServiceStatus.UP);
 

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/SlobrokMonitorManagerImplImplTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/SlobrokMonitorManagerImplImplTest.java
@@ -19,14 +19,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SlobrokMonitorManagerTest {
+public class SlobrokMonitorManagerImplImplTest {
     // IntelliJ complains if parametrized type is specified, Maven complains if not specified.
     @SuppressWarnings("unchecked")
-    private final Supplier<SlobrokMonitor2> slobrokMonitorFactory = mock(Supplier.class);
+    private final Supplier<SlobrokMonitor> slobrokMonitorFactory = mock(Supplier.class);
 
-    private final SlobrokMonitorManager slobrokMonitorManager =
-            new SlobrokMonitorManager(slobrokMonitorFactory);
-    private final SlobrokMonitor2 slobrokMonitor = mock(SlobrokMonitor2.class);
+    private final SlobrokMonitorManagerImpl slobrokMonitorManager =
+            new SlobrokMonitorManagerImpl(slobrokMonitorFactory);
+    private final SlobrokMonitor slobrokMonitor = mock(SlobrokMonitor.class);
     private final SuperModel superModel = mock(SuperModel.class);
     private final ApplicationInfo application = mock(ApplicationInfo.class);
 

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/SlobrokMonitorTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/SlobrokMonitorTest.java
@@ -8,10 +8,10 @@ import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
 
-public class SlobrokMonitor2Test {
+public class SlobrokMonitorTest {
     private final SlobrokList slobrokList = mock(SlobrokList.class);
     private final Mirror mirror = mock(Mirror.class);
-    private SlobrokMonitor2 slobrokMonitor = new SlobrokMonitor2(slobrokList, mirror);
+    private SlobrokMonitor slobrokMonitor = new SlobrokMonitor(slobrokList, mirror);
 
     @Test
     public void testUpdateSlobrokList() {

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/SuperModelListenerImplTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/SuperModelListenerImplTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 public class SuperModelListenerImplTest {
     @Test
     public void sanityCheck() {
-        SlobrokMonitorManager slobrokMonitorManager = mock(SlobrokMonitorManager.class);
+        SlobrokMonitorManagerImpl slobrokMonitorManager = mock(SlobrokMonitorManagerImpl.class);
         ServiceMonitorMetrics metrics = mock(ServiceMonitorMetrics.class);
         ModelGenerator modelGenerator = mock(ModelGenerator.class);
         Zone zone = mock(Zone.class);


### PR DESCRIPTION
To get insights into the Slobrok data used by the service monitor, it would be
useful to expose SlobrokMonitorManager. For instance it could provide a list of
name/spec pairs of services that are up (added as ServiceMonitorManager::lookup
in this PR).

The first step towards this is making SlobrokMonitorManager a component.