### PR TITLE
Move tenant application repo out of local session repo

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/Tenant.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/Tenant.java
@@ -1,10 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.tenant;
 
-import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.TenantName;
-import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.config.server.ReloadHandler;
 import com.yahoo.vespa.config.server.RequestHandler;
@@ -14,9 +11,6 @@ import com.yahoo.vespa.config.server.session.LocalSessionRepo;
 import com.yahoo.vespa.config.server.session.RemoteSessionRepo;
 import com.yahoo.vespa.config.server.session.SessionFactory;
 import com.yahoo.vespa.curator.Curator;
-
-import java.time.Duration;
-import java.util.logging.Logger;
 
 /**
  * Contains all tenant-level components for a single tenant, dealing with editing sessions and
@@ -28,7 +22,6 @@ import java.util.logging.Logger;
  */
 public class Tenant implements TenantHandlerProvider {
 
-    private static final Logger log = Logger.getLogger(Tenant.class.getName());
     public static final String SESSIONS = "sessions";
     public static final String APPLICATIONS = "applications";
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantBuilder.java
@@ -117,8 +117,7 @@ public class TenantBuilder {
 
 	private void createLocalSessionRepo() {
         if (localSessionRepo == null) {
-            localSessionRepo = new LocalSessionRepo(tenantFileSystemDirs, localSessionLoader, applicationRepo,
-                                                    componentRegistry.getClock(), componentRegistry.getConfigserverConfig().sessionLifetime());
+            localSessionRepo = new LocalSessionRepo(tenantFileSystemDirs, localSessionLoader, componentRegistry.getClock(), componentRegistry.getConfigserverConfig().sessionLifetime());
         }
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -57,10 +57,10 @@ import java.util.Optional;
  */
 public class DeployTester {
 
-    private final Curator curator;
     private final Clock clock;
     private final Tenants tenants;
     private final File testApp;
+    private final ApplicationRepository applicationRepository;
 
     private ApplicationId id;
 
@@ -97,7 +97,7 @@ public class DeployTester {
 
     public DeployTester(String appPath, List<ModelFactory> modelFactories, ConfigserverConfig configserverConfig, Clock clock) {
         Metrics metrics = Metrics.createTestMetrics();
-        this.curator = new MockCurator();
+        Curator curator = new MockCurator();
         this.clock = clock;
         TestComponentRegistry componentRegistry = createComponentRegistry(curator, metrics, modelFactories,
                                                                           configserverConfig, clock);
@@ -108,6 +108,10 @@ public class DeployTester {
         catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
+        applicationRepository = new ApplicationRepository(tenants,
+                                                          createHostProvisioner(),
+                                                          curator,
+                                                          clock);
     }
 
     public Tenant tenant() { return tenants.defaultTenant(); }
@@ -137,7 +141,7 @@ public class DeployTester {
      */
     public ApplicationId deployApp(String appName, String vespaVersion, Instant now)  {
         Tenant tenant = tenant();
-        LocalSession session = tenant.getSessionFactory().createSession(testApp, appName, new TimeoutBudget(Clock.systemUTC(), Duration.ofSeconds(60)));
+        LocalSession session = tenant.getSessionFactory().createSession(testApp, appName, new TimeoutBudget(clock, Duration.ofSeconds(60)));
         ApplicationId id = ApplicationId.from(tenant.getName(), ApplicationName.from(appName), InstanceName.defaultName());
         PrepareParams.Builder paramsBuilder = new PrepareParams.Builder().applicationId(id);
         if (vespaVersion != null)
@@ -167,11 +171,11 @@ public class DeployTester {
     }
 
     public Optional<com.yahoo.config.provision.Deployment> redeployFromLocalActive(ApplicationId id) {
-        ApplicationRepository applicationRepository = new ApplicationRepository(tenants,
-                                                                                createHostProvisioner(),
-                                                                                curator,
-                                                                                clock);
         return applicationRepository.deployFromLocalActive(id, Duration.ofSeconds(60));
+    }
+
+    public ApplicationRepository applicationRepository() {
+        return applicationRepository;
     }
 
     private Provisioner createHostProvisioner() {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/RedeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/RedeployTest.java
@@ -44,11 +44,11 @@ public class RedeployTest {
         Optional<com.yahoo.config.provision.Deployment> deployment = tester.redeployFromLocalActive();
 
         assertTrue(deployment.isPresent());
-        long activeSessionIdBefore = tester.tenant().getLocalSessionRepo().getActiveSession(tester.applicationId()).getSessionId();
+        long activeSessionIdBefore = tester.applicationRepository().getActiveSession(tester.applicationId()).getSessionId();
         assertEquals(tester.applicationId(), tester.tenant().getLocalSessionRepo().getSession(activeSessionIdBefore).getApplicationId());
         deployment.get().prepare();
         deployment.get().activate();
-        long activeSessionIdAfter =  tester.tenant().getLocalSessionRepo().getActiveSession(tester.applicationId()).getSessionId();
+        long activeSessionIdAfter =  tester.applicationRepository().getActiveSession(tester.applicationId()).getSessionId();
         assertEquals(activeSessionIdAfter, activeSessionIdBefore + 1);
         assertEquals(tester.applicationId(), tester.tenant().getLocalSessionRepo().getSession(activeSessionIdAfter).getApplicationId());
     }
@@ -83,7 +83,7 @@ public class RedeployTest {
 
         assertTrue(deployment2.isPresent());
         deployment2.get().activate(); // session 3
-        long activeSessionId = tester.tenant().getLocalSessionRepo().getActiveSession(tester.applicationId()).getSessionId();
+        long activeSessionId = tester.tenant().getApplicationRepo().getSessionIdForApplication(tester.applicationId());
 
         clock.advance(Duration.ofSeconds(10));
         Optional<com.yahoo.config.provision.Deployment> deployment3 = tester.redeployFromLocalActive();
@@ -93,7 +93,7 @@ public class RedeployTest {
         LocalSession deployment3session = ((Deployment) deployment3.get()).session();
         assertNotEquals(activeSessionId, deployment3session);
         // No change to active session id
-        assertEquals(activeSessionId, tester.tenant().getLocalSessionRepo().getActiveSession(tester.applicationId()).getSessionId());
+        assertEquals(activeSessionId, tester.tenant().getApplicationRepo().getSessionIdForApplication(tester.applicationId()));
         assertEquals(3, tester.tenant().getLocalSessionRepo().listSessions().size());
 
         clock.advance(Duration.ofHours(1)); // longer than session lifetime
@@ -105,6 +105,7 @@ public class RedeployTest {
 
         // Both session 2 (deactivated) and session 4 (never activated) should have been removed
         final Collection<LocalSession> sessions = tester.tenant().getLocalSessionRepo().listSessions();
+        System.out.println(sessions);
         assertEquals(2, sessions.size());
         final Set<Long> sessionIds = sessions.stream().map(Session::getSessionId).collect(Collectors.toSet());
         assertTrue(sessionIds.contains(3L));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
@@ -93,7 +93,7 @@ public class SessionActiveHandlerTest extends SessionHandlerTest {
         applicationRepo = new MemoryTenantApplications();
         curator = new MockCurator();
         configCurator = ConfigCurator.create(curator);
-        localRepo = new LocalSessionRepo(applicationRepo, Clock.systemUTC());
+        localRepo = new LocalSessionRepo(Clock.systemUTC());
         pathPrefix = "/application/v2/tenant/" + tenant + "/session/";
         pathProvider = new PathProvider(Path.createRoot());
         hostProvisioner = new MockProvisioner();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
@@ -59,7 +59,7 @@ public class SessionCreateHandlerTest extends SessionHandlerTest {
     @Before
     public void setupRepo() throws Exception {
         applicationRepo = new MemoryTenantApplications();
-        localSessionRepo = new LocalSessionRepo(applicationRepo, Clock.systemUTC());
+        localSessionRepo = new LocalSessionRepo(Clock.systemUTC());
         pathPrefix = "/application/v2/tenant/" + tenant + "/session/";
         createdMessage = " for tenant '" + tenant + "' created.\"";
         tenantMessage = ",\"tenant\":\"test\"";

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -77,7 +77,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     public void setupRepo() throws Exception {
         applicationRepo = new MemoryTenantApplications();
         curator = new MockCurator();
-        localRepo = new LocalSessionRepo(applicationRepo, Clock.systemUTC());
+        localRepo = new LocalSessionRepo(Clock.systemUTC());
         pathPrefix = "/application/v2/tenant/" + tenant + "/session/";
         preparedMessage = " for tenant '" + tenant + "' prepared.\"";
         tenantMessage = ",\"tenant\":\"" + tenant + "\"";
@@ -238,8 +238,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     @Test
     public void require_that_preparing_with_multiple_tenants_work() throws Exception {
         // Need different repos for 'default' tenant as opposed to the 'test' tenant
-        TenantApplications applicationRepoDefault = new MemoryTenantApplications();
-        LocalSessionRepo localRepoDefault = new LocalSessionRepo(applicationRepoDefault, Clock.systemUTC());
+        LocalSessionRepo localRepoDefault = new LocalSessionRepo(Clock.systemUTC());
         final TenantName tenantName = TenantName.defaultName();
         addTenant(tenantName, localRepoDefault, new RemoteSessionRepo(), new MockSessionFactory());
         addTestTenant();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/TestTenantBuilder.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/TestTenantBuilder.java
@@ -35,7 +35,7 @@ public class TestTenantBuilder {
         MemoryTenantApplications applicationRepo = new MemoryTenantApplications();
         TenantBuilder builder = TenantBuilder.create(componentRegistry, tenantName, Path.createRoot().append(tenantName.value()))
                 .withSessionFactory(new SessionCreateHandlerTest.MockSessionFactory())
-                .withLocalSessionRepo(new LocalSessionRepo(applicationRepo, componentRegistry.getClock()))
+                .withLocalSessionRepo(new LocalSessionRepo(componentRegistry.getClock()))
                 .withRemoteSessionRepo(new RemoteSessionRepo())
                 .withApplicationRepo(applicationRepo);
         tenantMap.put(tenantName, builder);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionRepoTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionRepoTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -57,7 +58,7 @@ public class LocalSessionRepoTest extends TestWithCurator {
                 new MemoryTenantApplications(),
                 tenantFileSystemDirs, new HostRegistry<>(),
                 tenantName);
-        repo = new LocalSessionRepo(tenantFileSystemDirs, loader, new MemoryTenantApplications(), clock, 5);
+        repo = new LocalSessionRepo(tenantFileSystemDirs, loader, clock, 5);
     }
 
     @Test


### PR DESCRIPTION
* Cleanup by moving getActiveSession() to ApplicationRepository,
  untangles dependencies a bit and simplifies code