### PR TITLE
We can now remove the workaround that was not working as we require g…

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -431,15 +431,6 @@ function(vespa_workaround_gcc_bug_67055 SOURCE_FILE)
     endif()
 endfunction()
 
-function(vespa_workaround_set_gcc_march_skylake_avx512_if_supported SOURCE_FILE)
-    if(CMAKE_COMPILER_IS_GNUCC)
-        execute_process(COMMAND ${CMAKE_CPP_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-        if (GCC_VERSION VERSION_GREATER "5.2")
-            set_source_files_properties(${SOURCE_FILE} PROPERTIES COMPILE_FLAGS -march=skylake-avx512)
-        endif()
-    endif()
-endfunction()
-
 macro(__initialize_module)
     # Set a couple of useful variables for this module
     set(MODULE_ROOT ${CMAKE_CURRENT_BINARY_DIR})

--- a/vespalib/src/vespa/vespalib/hwaccelrated/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/hwaccelrated/CMakeLists.txt
@@ -11,4 +11,4 @@ vespa_add_library(vespalib_vespalib_hwaccelrated OBJECT
 )
 set_source_files_properties(avx.cpp PROPERTIES COMPILE_FLAGS -march=sandybridge)
 set_source_files_properties(avx2.cpp PROPERTIES COMPILE_FLAGS -march=haswell)
-vespa_workaround_set_gcc_march_skylake_avx512_if_supported(avx512.cpp)
+set_source_files_properties(avx512.cpp PROPERTIES COMPILE_FLAGS -march=skylake-avx512)


### PR DESCRIPTION
…cc 6 and c++1z everywhere.
@lesters PR