### PR TITLE
Don't cache ZMS client instance

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -26,7 +26,6 @@ import com.yahoo.vespa.hosted.controller.api.integration.routing.RotationStatus;
 import com.yahoo.vespa.hosted.controller.api.integration.routing.RoutingGenerator;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 import com.yahoo.vespa.hosted.controller.athenz.AthenzClientFactory;
-import com.yahoo.vespa.hosted.controller.athenz.ZmsClient;
 import com.yahoo.vespa.hosted.controller.persistence.ControllerDb;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
 import com.yahoo.vespa.hosted.controller.versions.VersionStatus;
@@ -73,7 +72,7 @@ public class Controller extends AbstractComponent {
     private final ConfigServerClient configServerClient;
     private final MetricsService metricsService;
     private final Chef chefClient;
-    private final ZmsClient zmsClient;
+    private final AthenzClientFactory athenzClientFactory;
 
     /**
      * Creates a controller 
@@ -127,7 +126,7 @@ public class Controller extends AbstractComponent {
         this.metricsService = metricsService;
         this.chefClient = chefClient;
         this.clock = clock;
-        this.zmsClient = athenzClientFactory.createZmsClientWithServicePrincipal();
+        this.athenzClientFactory = athenzClientFactory;
 
         applicationController = new ApplicationController(this, db, curator, rotationRepository, athenzClientFactory,
                                                           nameService, configServerClient, routingGenerator, clock);
@@ -141,7 +140,7 @@ public class Controller extends AbstractComponent {
     public ApplicationController applications() { return applicationController; }
 
     public List<AthenzDomain> getDomainList(String prefix) {
-        return zmsClient.getDomainList(prefix);
+        return athenzClientFactory.createZmsClientWithServicePrincipal().getDomainList(prefix);
     }
 
     /**


### PR DESCRIPTION
Caching the client will eventually result in the client having an
expired principal token. All requests to ZMS will then fail.