### PR TITLE
remove old reduce/map/apply tensor API

### DIFF
--- a/eval/src/tests/eval/function_speed/function_speed_test.cpp
+++ b/eval/src/tests/eval/function_speed/function_speed_test.cpp
@@ -5,9 +5,11 @@
 #include <vespa/vespalib/util/benchmark_timer.h>
 #include <vespa/eval/eval/interpreted_function.h>
 #include <vespa/vespalib/util/benchmark_timer.h>
+#include <vespa/eval/tensor/default_tensor_engine.h>
 
 using namespace vespalib::eval;
 using vespalib::BenchmarkTimer;
+using vespalib::tensor::DefaultTensorEngine;
 
 double budget = 0.25;
 
@@ -38,12 +40,14 @@ double big_gcc_function(double p, double o, double q, double f, double w) {
 struct Fixture {
     Function function;
     InterpretedFunction interpreted;
+    InterpretedFunction interpreted_simple;
     CompiledFunction separate;
     CompiledFunction array;
     CompiledFunction lazy;
     Fixture(const vespalib::string &expr)
         : function(Function::parse(expr)),
-          interpreted(SimpleTensorEngine::ref(), function, NodeTypes()),
+          interpreted(DefaultTensorEngine::ref(), function, NodeTypes()),
+          interpreted_simple(SimpleTensorEngine::ref(), function, NodeTypes()),
           separate(function, PassParams::SEPARATE),
           array(function, PassParams::ARRAY),
           lazy(function, PassParams::LAZY) {}
@@ -74,12 +78,16 @@ TEST("measure small function eval/jit/gcc speed") {
 
     double interpret_time = fixture.interpreted.estimate_cost_us(test_params, budget);
     fprintf(stderr, "interpret: %g us\n", interpret_time);
+    double interpret_simple_time = fixture.interpreted_simple.estimate_cost_us(test_params, budget);
+    fprintf(stderr, "interpret (simple): %g us\n", interpret_simple_time);
     double jit_time = estimate_cost_us(test_params, fixture.separate.get_function<5>());
     fprintf(stderr, "jit compiled: %g us\n", jit_time);
     double gcc_time = estimate_cost_us(test_params, fun);
     fprintf(stderr, "gcc compiled: %g us\n", gcc_time);
+    double simple_vs_default_speed = (1.0/interpret_simple_time)/(1.0/interpret_time);
     double jit_vs_interpret_speed = (1.0/jit_time)/(1.0/interpret_time);
     double gcc_vs_jit_speed = (1.0/gcc_time)/(1.0/jit_time);
+    fprintf(stderr, "simple vs default interpret speed: %g\n", simple_vs_default_speed);
     fprintf(stderr, "jit speed compared to interpret: %g\n", jit_vs_interpret_speed);
     fprintf(stderr, "gcc speed compared to jit: %g\n", gcc_vs_jit_speed);
 
@@ -104,12 +112,16 @@ TEST("measure big function eval/jit/gcc speed") {
 
     double interpret_time = fixture.interpreted.estimate_cost_us(test_params, budget);
     fprintf(stderr, "interpret: %g us\n", interpret_time);
+    double interpret_simple_time = fixture.interpreted_simple.estimate_cost_us(test_params, budget);
+    fprintf(stderr, "interpret (simple): %g us\n", interpret_time);
     double jit_time = estimate_cost_us(test_params, fixture.separate.get_function<5>());
     fprintf(stderr, "jit compiled: %g us\n", jit_time);
     double gcc_time = estimate_cost_us(test_params, fun);
     fprintf(stderr, "gcc compiled: %g us\n", gcc_time);
+    double simple_vs_default_speed = (1.0/interpret_simple_time)/(1.0/interpret_time);
     double jit_vs_interpret_speed = (1.0/jit_time)/(1.0/interpret_time);
     double gcc_vs_jit_speed = (1.0/gcc_time)/(1.0/jit_time);
+    fprintf(stderr, "simple vs default interpret speed: %g\n", simple_vs_default_speed);
     fprintf(stderr, "jit speed compared to interpret: %g\n", jit_vs_interpret_speed);
     fprintf(stderr, "gcc speed compared to jit: %g\n", gcc_vs_jit_speed);
 

--- a/eval/src/tests/eval/simple_tensor/simple_tensor_test.cpp
+++ b/eval/src/tests/eval/simple_tensor/simple_tensor_test.cpp
@@ -94,7 +94,7 @@ TEST("require that simple tensors can have their values negated") {
     auto result = tensor->map([](double a){ return -a; });
     EXPECT_EQUAL(*expect, *result);
     Stash stash;
-    const Value &result2 = SimpleTensorEngine::ref().map(operation::Neg(), *tensor, stash);
+    const Value &result2 = SimpleTensorEngine::ref().map(TensorValue(*tensor), operation::Neg::f, stash);
     EXPECT_EQUAL(*expect, unwrap(result2));    
 }
 
@@ -119,7 +119,7 @@ TEST("require that simple tensors can be multiplied with each other") {
     auto result = SimpleTensor::join(*lhs, *rhs, [](double a, double b){ return (a * b); });
     EXPECT_EQUAL(*expect, *result);
     Stash stash;
-    const Value &result2 = SimpleTensorEngine::ref().apply(operation::Mul(), *lhs, *rhs, stash);
+    const Value &result2 = SimpleTensorEngine::ref().join(TensorValue(*lhs), TensorValue(*rhs), operation::Mul::f, stash);
     EXPECT_EQUAL(*expect, unwrap(result2));
 }
 
@@ -150,10 +150,10 @@ TEST("require that simple tensors support dimension reduction") {
     EXPECT_EQUAL(*expect_sum_y, *result_sum_y);
     EXPECT_EQUAL(*expect_sum_x, *result_sum_x);
     EXPECT_EQUAL(*expect_sum_all, *result_sum_all);
-    const Value &result_sum_y_2 = SimpleTensorEngine::ref().reduce(*tensor, operation::Add(), {"y"}, stash);
-    const Value &result_sum_x_2 = SimpleTensorEngine::ref().reduce(*tensor, operation::Add(), {"x"}, stash);
-    const Value &result_sum_all_2 = SimpleTensorEngine::ref().reduce(*tensor, operation::Add(), {"x", "y"}, stash); 
-    const Value &result_sum_all_3 = SimpleTensorEngine::ref().reduce(*tensor, operation::Add(), {}, stash);
+    const Value &result_sum_y_2 = SimpleTensorEngine::ref().reduce(TensorValue(*tensor), Aggr::SUM, {"y"}, stash);
+    const Value &result_sum_x_2 = SimpleTensorEngine::ref().reduce(TensorValue(*tensor), Aggr::SUM, {"x"}, stash);
+    const Value &result_sum_all_2 = SimpleTensorEngine::ref().reduce(TensorValue(*tensor), Aggr::SUM, {"x", "y"}, stash); 
+    const Value &result_sum_all_3 = SimpleTensorEngine::ref().reduce(TensorValue(*tensor), Aggr::SUM, {}, stash);
     EXPECT_EQUAL(*expect_sum_y, unwrap(result_sum_y_2));
     EXPECT_EQUAL(*expect_sum_x, unwrap(result_sum_x_2));
     EXPECT_TRUE(result_sum_all_2.is_double());

--- a/eval/src/vespa/eval/eval/simple_tensor_engine.h
+++ b/eval/src/vespa/eval/eval/simple_tensor_engine.h
@@ -25,9 +25,6 @@ public:
     TensorSpec to_spec(const Tensor &tensor) const override;
 
     std::unique_ptr<Tensor> create(const TensorSpec &spec) const override;
-    const Value &reduce(const Tensor &tensor, const BinaryOperation &op, const std::vector<vespalib::string> &dimensions, Stash &stash) const override;
-    const Value &map(const UnaryOperation &op, const Tensor &a, Stash &stash) const override;
-    const Value &apply(const BinaryOperation &op, const Tensor &a, const Tensor &b, Stash &stash) const override;
 
     void encode(const Value &value, nbostream &output, Stash &stash) const override;
     const Value &decode(nbostream &input, Stash &stash) const override;

--- a/eval/src/vespa/eval/eval/tensor_engine.h
+++ b/eval/src/vespa/eval/eval/tensor_engine.h
@@ -20,8 +20,6 @@ namespace eval {
 class Value;
 class Tensor;
 class TensorSpec;
-struct UnaryOperation;
-struct BinaryOperation;
 
 /**
  * Top-level API for a tensor implementation. All Tensor operations
@@ -40,8 +38,6 @@ struct TensorEngine
     using Value = eval::Value;
     using map_fun_t = double (*)(double);
     using join_fun_t = double (*)(double, double);
-    using BinaryOperation = eval::BinaryOperation;
-    using UnaryOperation = eval::UnaryOperation;
     using Aggr = eval::Aggr;
 
     virtual ValueType type_of(const Tensor &tensor) const = 0;
@@ -52,9 +48,6 @@ struct TensorEngine
     virtual TensorFunction::UP compile(tensor_function::Node_UP expr) const { return std::move(expr); }
 
     virtual std::unique_ptr<Tensor> create(const TensorSpec &spec) const = 0;
-    virtual const Value &reduce(const Tensor &tensor, const BinaryOperation &op, const std::vector<vespalib::string> &dimensions, Stash &stash) const = 0;
-    virtual const Value &map(const UnaryOperation &op, const Tensor &a, Stash &stash) const = 0;
-    virtual const Value &apply(const BinaryOperation &op, const Tensor &a, const Tensor &b, Stash &stash) const = 0;
 
     // havardpe: new API, WIP
     virtual void encode(const Value &value, nbostream &output, Stash &stash) const = 0;

--- a/eval/src/vespa/eval/eval/value.cpp
+++ b/eval/src/vespa/eval/eval/value.cpp
@@ -7,40 +7,12 @@
 namespace vespalib {
 namespace eval {
 
-const Value &
-Value::apply(const UnaryOperation &, Stash &stash) const
-{
-    return stash.create<ErrorValue>();
-}
-
-const Value &
-Value::apply(const BinaryOperation &, const Value &, Stash &stash) const
-{
-    return stash.create<ErrorValue>();
-}
-
 ErrorValue ErrorValue::instance;
 
 bool
 TensorValue::equal(const Value &rhs) const
 {
     return (rhs.is_tensor() && _tensor->engine().equal(*_tensor, *rhs.as_tensor()));
-}
-
-const Value &
-TensorValue::apply(const UnaryOperation &op, Stash &stash) const
-{
-    return _tensor->engine().map(op, *_tensor, stash);
-}
-
-const Value &
-TensorValue::apply(const BinaryOperation &op, const Value &rhs, Stash &stash) const
-{
-    const Tensor *other = rhs.as_tensor();
-    if ((other == nullptr) || (&other->engine() != &_tensor->engine())) {
-        return stash.create<ErrorValue>();
-    }
-    return _tensor->engine().apply(op, *_tensor, *other, stash);
 }
 
 ValueType

--- a/eval/src/vespa/eval/eval/value.h
+++ b/eval/src/vespa/eval/eval/value.h
@@ -15,12 +15,8 @@ class Tensor;
 
 constexpr double error_value = 31212.0;
 
-struct UnaryOperation;
-struct BinaryOperation;
-
 /**
- * An abstract Value. Calculation using abstract values should be done
- * using the perform function on the appropriate Operation.
+ * An abstract Value.
  **/
 struct Value {
     typedef std::unique_ptr<Value> UP;
@@ -32,8 +28,6 @@ struct Value {
     virtual bool as_bool() const { return false; }
     virtual const Tensor *as_tensor() const { return nullptr; }
     virtual bool equal(const Value &rhs) const = 0;
-    virtual const Value &apply(const UnaryOperation &op, Stash &stash) const;
-    virtual const Value &apply(const BinaryOperation &op, const Value &rhs, Stash &stash) const;
     virtual ValueType type() const = 0;
     virtual ~Value() {}
 };
@@ -72,8 +66,6 @@ public:
     bool is_tensor() const override { return true; }
     const Tensor *as_tensor() const override { return _tensor; }
     bool equal(const Value &rhs) const override;
-    const Value &apply(const UnaryOperation &op, Stash &stash) const override;
-    const Value &apply(const BinaryOperation &op, const Value &rhs, Stash &stash) const override;
     ValueType type() const override;
 };
 

--- a/eval/src/vespa/eval/tensor/default_tensor_engine.h
+++ b/eval/src/vespa/eval/tensor/default_tensor_engine.h
@@ -27,9 +27,6 @@ public:
     virtual eval::TensorFunction::UP compile(eval::tensor_function::Node_UP expr) const override;
 
     std::unique_ptr<Tensor> create(const TensorSpec &spec) const override;
-    const Value &reduce(const Tensor &tensor, const BinaryOperation &op, const std::vector<vespalib::string> &dimensions, Stash &stash) const override;
-    const Value &map(const UnaryOperation &op, const Tensor &a, Stash &stash) const override;
-    const Value &apply(const BinaryOperation &op, const Tensor &a, const Tensor &b, Stash &stash) const override;
 
     void encode(const Value &value, nbostream &output, Stash &stash) const override;
     const Value &decode(nbostream &input, Stash &stash) const override;


### PR DESCRIPTION
remove Operation::perform and Value::apply; invoke TensorEngine
map/join directly instead

remove no-longer-needed operation proxy classes using thread-local
storage

add fast-path evaluation of double-only map/join in SimpleTensorEngine
to avoid creating tensors when doing interpreted constant folding
during LLVM compilation

enable inlining of multiply join operation in
DefaultTensorEngine::join

@arnej27959 please review