### PR TITLE
Bjorncs/remove deprecated authorization

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/ErrorResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/ErrorResponse.java
@@ -11,6 +11,7 @@ import static com.yahoo.jdisc.Response.Status.FORBIDDEN;
 import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
 import static com.yahoo.jdisc.Response.Status.METHOD_NOT_ALLOWED;
 import static com.yahoo.jdisc.Response.Status.NOT_FOUND;
+import static com.yahoo.jdisc.Response.Status.UNAUTHORIZED;
 
 /**
  * A HTTP JSON response containing an error code and a message
@@ -24,7 +25,8 @@ public class ErrorResponse extends SlimeJsonResponse {
         BAD_REQUEST,
         FORBIDDEN,
         METHOD_NOT_ALLOWED,
-        INTERNAL_SERVER_ERROR
+        INTERNAL_SERVER_ERROR,
+        UNAUTHORIZED
     }
 
     public ErrorResponse(int statusCode, String errorType, String message) {
@@ -53,6 +55,10 @@ public class ErrorResponse extends SlimeJsonResponse {
 
     public static ErrorResponse forbidden(String message) {
         return new ErrorResponse(FORBIDDEN, errorCodes.FORBIDDEN.name(), message);
+    }
+
+    public static ErrorResponse unauthorized(String message) {
+        return new ErrorResponse(UNAUTHORIZED, errorCodes.UNAUTHORIZED.name(), message);
     }
 
     public static ErrorResponse methodNotAllowed(String message) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -67,7 +67,6 @@ import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.application.SourceRevision;
 import com.yahoo.vespa.hosted.controller.athenz.AthenzClientFactory;
-import com.yahoo.vespa.hosted.controller.athenz.AthenzPrincipal;
 import com.yahoo.vespa.hosted.controller.athenz.NToken;
 import com.yahoo.vespa.hosted.controller.athenz.ZmsException;
 import com.yahoo.vespa.hosted.controller.restapi.ErrorResponse;
@@ -780,25 +779,8 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         DeployAuthorizer deployAuthorizer = new DeployAuthorizer(controller.zoneRegistry(), athenzClientFactory);
         Tenant tenant = controller.tenants().tenant(new TenantId(tenantName)).orElseThrow(() -> new NotExistsException(new TenantId(tenantName)));
         Principal principal = authorizer.getPrincipal(request);
-        if (principal instanceof AthenzPrincipal) {
-            deployAuthorizer.throwIfUnauthorizedForDeploy(principal,
-                                                          Environment.from(environment),
-                                                          tenant,
-                                                          applicationId);
-        } else { // In case of host-based principal
-            // TODO What about other user type principals like Bouncer?
-            log.log(LogLevel.WARNING,
-                    "Using deprecated DeployAuthorizer.throwIfUnauthorizedForDeploy. Principal=" + principal);
-            UserId userId = new UserId(principal.getName());
-            deployAuthorizer.throwIfUnauthorizedForDeploy(
-                    Environment.from(environment),
-                    userId,
-                    tenant,
-                    applicationId,
-                    optional("screwdriverBuildJob", deployOptions).map(ScrewdriverId::new));
-        }
+        deployAuthorizer.throwIfUnauthorizedForDeploy(principal, Environment.from(environment), tenant, applicationId);
 
-        
         // TODO: get rid of the json object
         DeployOptions deployOptionsJsonClass = new DeployOptions(screwdriverBuildJobFromSlime(deployOptions.field("screwdriverBuildJob")),
                                                                  optional("vespaVersion", deployOptions).map(Version::new),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -81,6 +81,7 @@ import com.yahoo.yolean.Exceptions;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -138,6 +139,9 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         }
         catch (ForbiddenException e) {
             return ErrorResponse.forbidden(Exceptions.toMessageString(e));
+        }
+        catch (NotAuthorizedException e) {
+            return ErrorResponse.unauthorized(Exceptions.toMessageString(e));
         }
         catch (NotExistsException e) {
             return ErrorResponse.notFoundError(Exceptions.toMessageString(e));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/DeployAuthorizer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/DeployAuthorizer.java
@@ -39,10 +39,12 @@ public class DeployAuthorizer {
                                              Environment environment,
                                              Tenant tenant,
                                              ApplicationId applicationId) {
-        if (!environmentRequiresAuthorization(environment))  return;
+        if (!environmentRequiresAuthorization(environment)) {
+            return;
+        }
 
         if (principal == null) {
-            throw loggedUnauthorizedException("Principal '%s' is not authenticated.", principal.getName());
+            throw loggedUnauthorizedException("Principal not authenticated!");
         }
 
         if (!(principal instanceof AthenzPrincipal)) {
@@ -54,20 +56,22 @@ public class DeployAuthorizer {
         AthenzPrincipal athenzPrincipal = (AthenzPrincipal) principal;
         AthenzDomain principalDomain = athenzPrincipal.getDomain();
 
-        if (!principalDomain.equals(AthenzUtils.SCREWDRIVER_DOMAIN))
+        if (!principalDomain.equals(AthenzUtils.SCREWDRIVER_DOMAIN)) {
             throw loggedForbiddenException(
                     "Principal '%s' is not a Screwdriver principal. Excepted principal with Athenz domain '%s', got '%s'.",
                     principal.getName(), AthenzUtils.SCREWDRIVER_DOMAIN.id(), principalDomain.id());
+        }
 
         // NOTE: no fine-grained deploy authorization for non-Athenz tenants
         if (tenant.isAthensTenant()) {
             AthenzDomain tenantDomain = tenant.getAthensDomain().get();
-            if ( ! hasDeployAccessToAthenzApplication(athenzPrincipal, tenantDomain, applicationId))
+            if (!hasDeployAccessToAthenzApplication(athenzPrincipal, tenantDomain, applicationId)) {
                 throw loggedForbiddenException(
                         "Screwdriver principal '%1$s' does not have deploy access to '%2$s'. " +
                         "Either the application has not been created at " + zoneRegistry.getDashboardUri() + " or " +
                         "'%1$s' is not added to the application's deployer role in Athenz domain '%3$s'.",
                         athenzPrincipal.toYRN(), applicationId, tenantDomain.id());
+            }
         }
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/DeployAuthorizer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/DeployAuthorizer.java
@@ -5,23 +5,19 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.vespa.hosted.controller.api.Tenant;
 import com.yahoo.vespa.hosted.controller.api.identifiers.AthenzDomain;
-import com.yahoo.vespa.hosted.controller.api.identifiers.ScrewdriverId;
-import com.yahoo.vespa.hosted.controller.api.identifiers.UserId;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 import com.yahoo.vespa.hosted.controller.athenz.ApplicationAction;
 import com.yahoo.vespa.hosted.controller.athenz.AthenzClientFactory;
 import com.yahoo.vespa.hosted.controller.athenz.AthenzPrincipal;
 import com.yahoo.vespa.hosted.controller.athenz.AthenzUtils;
 import com.yahoo.vespa.hosted.controller.athenz.ZmsException;
-import com.yahoo.vespa.hosted.controller.restapi.filter.UnauthenticatedUserPrincipal;
 
 import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 import java.security.Principal;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.hosted.controller.restapi.application.Authorizer.environmentRequiresAuthorization;
-import static com.yahoo.vespa.hosted.controller.restapi.application.Authorizer.isScrewdriverPrincipal;
 
 /**
  * @author bjorncs
@@ -43,36 +39,36 @@ public class DeployAuthorizer {
                                              Environment environment,
                                              Tenant tenant,
                                              ApplicationId applicationId) {
-        if (athenzCredentialsRequired(environment, tenant, applicationId, principal))
-            checkAthenzCredentials(principal, tenant, applicationId);
-    }
+        if (!environmentRequiresAuthorization(environment))  return;
 
-    // TODO: inline when deployment via ssh is removed
-    private boolean athenzCredentialsRequired(Environment environment, Tenant tenant, ApplicationId applicationId, Principal principal) {
-        if (!environmentRequiresAuthorization(environment))  return false;
+        if (principal == null) {
+            throw loggedUnauthorizedException("Principal '%s' is not authenticated.", principal.getName());
+        }
 
-        if (! isScrewdriverPrincipal(principal))
+        if (!(principal instanceof AthenzPrincipal)) {
+            throw loggedUnauthorizedException(
+                    "Principal '%s' of type '%s' is not an Athenz principal, which is required for production deployments.",
+                    principal.getName(), principal.getClass().getSimpleName());
+        }
+
+        AthenzPrincipal athenzPrincipal = (AthenzPrincipal) principal;
+        AthenzDomain principalDomain = athenzPrincipal.getDomain();
+
+        if (!principalDomain.equals(AthenzUtils.SCREWDRIVER_DOMAIN))
             throw loggedForbiddenException(
-                    "Principal '%s' is not a screwdriver principal, and does not have deploy access to application '%s'",
-                    principal.getName(), applicationId.toShortString());
+                    "Principal '%s' is not a Screwdriver principal. Excepted principal with Athenz domain '%s', got '%s'.",
+                    principal.getName(), AthenzUtils.SCREWDRIVER_DOMAIN.id(), principalDomain.id());
 
-        return tenant.isAthensTenant();
-    }
-
-
-    // TODO: inline when deployment via ssh is removed
-    private void checkAthenzCredentials(Principal principal, Tenant tenant, ApplicationId applicationId) {
-        AthenzDomain domain = tenant.getAthensDomain().get();
-        if (! (principal instanceof AthenzPrincipal))
-            throw loggedForbiddenException("Principal '%s' is not authenticated.", principal.getName());
-
-        AthenzPrincipal athensPrincipal = (AthenzPrincipal)principal;
-        if ( ! hasDeployAccessToAthenzApplication(athensPrincipal, domain, applicationId))
-            throw loggedForbiddenException(
-                    "Screwdriver principal '%1$s' does not have deploy access to '%2$s'. " +
-                    "Either the application has not been created at " + zoneRegistry.getDashboardUri() + " or " +
-                    "'%1$s' is not added to the application's deployer role in Athens domain '%3$s'.",
-                    athensPrincipal, applicationId, tenant.getAthensDomain().get());
+        // NOTE: no fine-grained deploy authorization for non-Athenz tenants
+        if (tenant.isAthensTenant()) {
+            AthenzDomain tenantDomain = tenant.getAthensDomain().get();
+            if ( ! hasDeployAccessToAthenzApplication(athenzPrincipal, tenantDomain, applicationId))
+                throw loggedForbiddenException(
+                        "Screwdriver principal '%1$s' does not have deploy access to '%2$s'. " +
+                        "Either the application has not been created at " + zoneRegistry.getDashboardUri() + " or " +
+                        "'%1$s' is not added to the application's deployer role in Athenz domain '%3$s'.",
+                        athenzPrincipal.toYRN(), applicationId, tenantDomain.id());
+        }
     }
 
     private static ForbiddenException loggedForbiddenException(String message, Object... args) {
@@ -81,23 +77,10 @@ public class DeployAuthorizer {
         return new ForbiddenException(formattedMessage);
     }
 
-    /**
-     * @deprecated Only usable for ssh. Use the method that takes Principal instead of UserId and screwdriverId.
-     */
-    @Deprecated
-    public void throwIfUnauthorizedForDeploy(Environment environment,
-                                             UserId userId,
-                                             Tenant tenant,
-                                             ApplicationId applicationId,
-                                             Optional<ScrewdriverId> optionalScrewdriverId) {
-        Principal principal = new UnauthenticatedUserPrincipal(userId.id());
-
-        if (athenzCredentialsRequired(environment, tenant, applicationId, principal)) {
-            ScrewdriverId screwdriverId = optionalScrewdriverId.orElseThrow(
-                    () -> loggedForbiddenException("Screwdriver id must be provided when deploying from Screwdriver."));
-            principal = AthenzUtils.createPrincipal(screwdriverId);
-            checkAthenzCredentials(principal, tenant, applicationId);
-        }
+    private static NotAuthorizedException loggedUnauthorizedException(String message, Object... args) {
+        String formattedMessage = String.format(message, args);
+        log.info(formattedMessage);
+        return new NotAuthorizedException(formattedMessage);
     }
 
     private boolean hasDeployAccessToAthenzApplication(AthenzPrincipal principal, AthenzDomain domain, ApplicationId applicationId) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -577,7 +577,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                       entity,
                                       Request.Method.POST,
                                       athenzUserDomain, "mytenant"),
-                              "{\"error-code\":\"FORBIDDEN\",\"message\":\"Principal 'mytenant' is not a screwdriver principal, and does not have deploy access to application 'tenant1.application1'\"}", 
+                              "{\"error-code\":\"FORBIDDEN\",\"message\":\"Principal 'mytenant' is not a Screwdriver principal. Excepted principal with Athenz domain 'cd.screwdriver.project', got 'domain1'.\"}",
                               403);
 
         // Deleting an application for an Athens domain the user is not admin for is disallowed


### PR DESCRIPTION
This PR removes some of the old deployment authorization logic and replaces it with a simplified set of rules.  Please give extra attention to the updated `DeployAuthorizer.throwIfUnauthorizedForDeploy` method.