### PR TITLE
Use std::mutex instead of FastOS_Mutex in slobrok and vespalog modules.

### DIFF
--- a/slobrok/src/tests/oldapi/mirror.cpp
+++ b/slobrok/src/tests/oldapi/mirror.cpp
@@ -54,14 +54,13 @@ MirrorOld::SpecList
 MirrorOld::lookup(const std::string & pattern) const
 {
     SpecList ret;
-    _lock.Lock();
+    std::lock_guard<std::mutex> guard(_lock);
     SpecList::const_iterator end = _specs.end();
     for (SpecList::const_iterator it = _specs.begin(); it != end; ++it) {
         if (match(it->first.c_str(), pattern.c_str())) {
             ret.push_back(*it);
         }
     }
-    _lock.Unlock();
     return ret;    
 }
 
@@ -119,10 +118,11 @@ MirrorOld::PerformTask()
                                                std::string(s[idx]._str)));
             }
 
-            _lock.Lock();
-            std::swap(specs, _specs);
-            _updates.add();
-            _lock.Unlock();
+            {
+                std::lock_guard<std::mutex> guard(_lock);
+                std::swap(specs, _specs);
+                _updates.add();
+            }
             _specsGen.setFromInt(answer[2]._intval32);
         }
         _backOff.reset();

--- a/slobrok/src/tests/oldapi/mirror.h
+++ b/slobrok/src/tests/oldapi/mirror.h
@@ -111,7 +111,7 @@ private:
     void RequestDone(FRT_RPCRequest *req) override;
 
     FRT_Supervisor          &_orb;
-    mutable FastOS_Mutex     _lock;
+    mutable std::mutex       _lock;
     bool                     _reqDone;
     SpecList                 _specs;
     vespalib::GenCnt         _specsGen;

--- a/slobrok/src/vespa/slobrok/sbregister.h
+++ b/slobrok/src/vespa/slobrok/sbregister.h
@@ -84,7 +84,7 @@ private:
 
     FRT_Supervisor          &_orb;
     RPCHooks                 _hooks;
-    FastOS_Mutex             _lock;
+    std::mutex               _lock;
     bool                     _reqDone;
     bool                     _busy;
     SlobrokList              _slobrokSpecs;


### PR DESCRIPTION
@arnej27959, please review.
