### PR TITLE
Log when a cluster state version is published

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -134,6 +134,7 @@ public class SystemStateBroadcaster {
         if (systemState == null) return false;
 
         if (!systemState.isOfficial()) {
+            log.log(LogLevel.INFO, String.format("Publishing cluster state version %d", systemState.getVersion()));
             systemState.setOfficial(true);
         }
 


### PR DESCRIPTION
@hakonhall please review

Makes it much easier to reason about which state transitions have been
made visible in the cluster, and which ones have just been internal
state transitions in the controller.