### PR TITLE
Validate configserver directories structure

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerDB.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerDB.java
@@ -26,6 +26,9 @@ public class ConfigServerDB {
     private final ConfigserverConfig configserverConfig;
 
     public ConfigServerDB(ConfigserverConfig configserverConfig) {
+        if (configserverConfig.configDefinitionsDir().equals(configserverConfig.configServerDBDir()))
+            throw new IllegalArgumentException("configDefinitionsDir and configServerDBDir cannot be equal ('" +
+                    configserverConfig.configDefinitionsDir() + "')");
         this.configserverConfig = configserverConfig;
         this.serverDB = new File(Defaults.getDefaults().underVespaHome(configserverConfig.configServerDBDir()));
         createDirectory(serverdefs());
@@ -63,7 +66,7 @@ public class ConfigServerDB {
 
     private void initialize(List<String> pluginDirectories) throws IOException {
         IOUtils.recursiveDeleteDir(serverdefs());
-        IOUtils.copyDirectory(classes(), serverdefs());
+        IOUtils.copyDirectory(classes(), serverdefs(), 1);
         ConfigDefinitionDir configDefinitionDir = new ConfigDefinitionDir(serverdefs());
         ArrayList<Bundle> bundles = new ArrayList<>();
         for (String pluginDirectory : pluginDirectories) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
@@ -89,10 +89,10 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
         private Curator curator = new MockCurator();
         private Optional<ConfigCurator> configCurator = Optional.empty();
         private Metrics metrics = Metrics.createTestMetrics();
-        private String configserverTempDir = Files.createTempDir().getAbsolutePath();
-        private ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder()
-                                                                                       .configServerDBDir(configserverTempDir)
-                                                                                       .configDefinitionsDir(configserverTempDir));
+        private ConfigserverConfig configserverConfig = new ConfigserverConfig(
+                new ConfigserverConfig.Builder()
+                        .configServerDBDir(Files.createTempDir().getAbsolutePath())
+                        .configDefinitionsDir(Files.createTempDir().getAbsolutePath()));
         private ConfigDefinitionRepo defRepo = new StaticConfigDefinitionRepo();
         private TenantRequestHandlerTest.MockReloadListener reloadListener = new TenantRequestHandlerTest.MockReloadListener();
         private MockTenantListener tenantListener = new MockTenantListener();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/PermanentApplicationPackageTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/PermanentApplicationPackageTest.java
@@ -19,7 +19,8 @@ import static org.junit.Assert.assertTrue;
 public class PermanentApplicationPackageTest {
     @Test
     public void testNonexistingApplication() {
-        PermanentApplicationPackage permanentApplicationPackage = new PermanentApplicationPackage(new ConfigserverConfig(new ConfigserverConfig.Builder().applicationDirectory("_no_such_dir")));
+        PermanentApplicationPackage permanentApplicationPackage = new PermanentApplicationPackage(
+                new ConfigserverConfig(new ConfigserverConfig.Builder().applicationDirectory("_no_such_dir")));
         assertFalse(permanentApplicationPackage.applicationPackage().isPresent());
     }
 
@@ -29,7 +30,8 @@ public class PermanentApplicationPackageTest {
     @Test
     public void testExistingApplication() throws IOException {
         File tmpDir = folder.newFolder();
-        PermanentApplicationPackage permanentApplicationPackage = new PermanentApplicationPackage(new ConfigserverConfig(new ConfigserverConfig.Builder().applicationDirectory(tmpDir.getAbsolutePath())));
+        PermanentApplicationPackage permanentApplicationPackage = new PermanentApplicationPackage(
+                new ConfigserverConfig(new ConfigserverConfig.Builder().applicationDirectory(tmpDir.getAbsolutePath())));
         assertTrue(permanentApplicationPackage.applicationPackage().isPresent());
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -126,10 +126,9 @@ public class HostedDeployTest {
     }
 
     private static ConfigserverConfig createConfigserverConfig() {
-        String tempDir = Files.createTempDir().getAbsolutePath();
         return new ConfigserverConfig(new ConfigserverConfig.Builder()
-                                              .configServerDBDir(tempDir)
-                                              .configDefinitionsDir(tempDir)
+                                              .configServerDBDir(Files.createTempDir().getAbsolutePath())
+                                              .configDefinitionsDir(Files.createTempDir().getAbsolutePath())
                                               .dockerRegistry(dockerRegistry)
                                               .dockerVespaBaseImage(dockerVespaBaseImage)
                                               .hostedVespa(true)


### PR DESCRIPTION
* Require different paths for config definitions dir and serverdefs dir
  and throw exception if not
* Recurse only one level when copying files from config definitions dir
  to serverdefs dir