### PR TITLE
Athenz now uses "user" as principal domain and "home" as personal domain

### DIFF
--- a/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/identifiers/IdentifierTest.java
+++ b/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/identifiers/IdentifierTest.java
@@ -119,12 +119,12 @@ public class IdentifierTest {
 
     @Test
     public void athenz_parent_domain_is_without_name_suffix() {
-        assertEquals(new AthenzDomain("yby.john"), new AthenzDomain("yby.john.myapp").getParent());
+        assertEquals(new AthenzDomain("home.john"), new AthenzDomain("home.john.myapp").getParent());
     }
 
     @Test
     public void athenz_domain_name_is_last_suffix() {
-        assertEquals("myapp", new AthenzDomain("yby.john.myapp").getNameSuffix());
+        assertEquals("myapp", new AthenzDomain("home.john.myapp").getNameSuffix());
     }
 
     @Test

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/AthenzUtils.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/AthenzUtils.java
@@ -12,8 +12,7 @@ public class AthenzUtils {
 
     private AthenzUtils() {}
 
-    // TODO Change to "user" as primary user principal domain. Also support "yby" for a limited time as per recent Athenz changes
-    public static final AthenzDomain USER_PRINCIPAL_DOMAIN = new AthenzDomain("yby");
+    public static final AthenzDomain USER_PRINCIPAL_DOMAIN = new AthenzDomain("user");
     public static final AthenzDomain SCREWDRIVER_DOMAIN = new AthenzDomain("cd.screwdriver.project");
     public static final AthenzService ZMS_ATHENZ_SERVICE = new AthenzService("sys.auth", "zms");
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzClientFactoryImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzClientFactoryImpl.java
@@ -20,6 +20,8 @@ import com.yahoo.vespa.hosted.controller.athenz.config.AthenzConfig;
 import java.security.PrivateKey;
 import java.util.concurrent.TimeUnit;
 
+import static com.yahoo.vespa.hosted.controller.athenz.AthenzUtils.USER_PRINCIPAL_DOMAIN;
+
 /**
  * @author bjorncs
  */
@@ -63,7 +65,7 @@ public class AthenzClientFactoryImpl implements AthenzClientFactory {
                 config.domain() + "." + service.name(), service.publicKeyId(), getServicePrivateKey());
 
         Principal dualPrincipal = SimplePrincipal.create(
-                "yby", signedToken.getName(), signedToken.getSignedToken(), athenzPrincipalAuthority);
+                USER_PRINCIPAL_DOMAIN.id(), signedToken.getName(), signedToken.getSignedToken(), athenzPrincipalAuthority);
         return new ZmsClientImpl(new ZMSClient(config.zmsUrl(), dualPrincipal), config);
 
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/athenz/filter/NTokenValidatorTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/athenz/filter/NTokenValidatorTest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.athenz.filter;
 
-import com.yahoo.vespa.hosted.controller.api.identifiers.AthenzDomain;
 import com.yahoo.vespa.hosted.controller.api.identifiers.UserId;
 import com.yahoo.vespa.hosted.controller.athenz.AthenzPrincipal;
 import com.yahoo.vespa.hosted.controller.athenz.InvalidTokenException;
@@ -16,6 +15,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
 import static com.yahoo.vespa.hosted.controller.athenz.AthenzUtils.ZMS_ATHENZ_SERVICE;
+import static com.yahoo.vespa.hosted.controller.athenz.AthenzUtils.createPrincipal;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -25,7 +25,7 @@ public class NTokenValidatorTest {
 
     private static final KeyPair TRUSTED_KEY = AthenzTestUtils.generateRsaKeypair();
     private static final KeyPair UNKNOWN_KEY = AthenzTestUtils.generateRsaKeypair();
-    private static final AthenzPrincipal PRINCIPAL = new AthenzPrincipal(new AthenzDomain("yby"), new UserId("user"));
+    private static final AthenzPrincipal PRINCIPAL = createPrincipal(new UserId("myuser"));
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -35,7 +35,7 @@ public class NTokenValidatorTest {
         NTokenValidator validator = new NTokenValidator(createKeystore());
         NToken token = createNToken(PRINCIPAL, System.currentTimeMillis(), TRUSTED_KEY, "0");
         AthenzPrincipal principal = validator.validate(token);
-        assertEquals("yby.user", principal.toYRN());
+        assertEquals("user.myuser", principal.toYRN());
     }
 
     @Test


### PR DESCRIPTION
Note: There is no need to support the old _yby_ domain as Athenz has already successfully migrated to _user_ and _home_ respectively. The previous _yby_ domain is handled by Athenz services for a limited time (ZMS/ZTS currently rewrites operations on _yby_ to _user_/_home_).