### PR TITLE
Add reserved name validation for document type names

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ReservedDocumentTypeNameValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ReservedDocumentTypeNameValidator.java
@@ -1,0 +1,42 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.content;
+
+import com.yahoo.documentmodel.NewDocumentType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ReservedDocumentTypeNameValidator {
+
+    public static final List<String> ORDERED_RESERVED_NAMES = Collections.unmodifiableList(
+            Arrays.asList("and", "false", "id", "not", "null", "or", "true"));
+    public static final Set<String> RESERVED_NAMES = Collections.unmodifiableSet(new HashSet<>(ORDERED_RESERVED_NAMES));
+
+    public void validate(Map<String, NewDocumentType> documentDefinitions) {
+        List<String> conflictingNames = documentDefinitions.keySet().stream()
+                .filter(this::isReservedName)
+                .collect(Collectors.toList());
+        if (!conflictingNames.isEmpty()) {
+            throw new IllegalArgumentException(makeReservedNameMessage(conflictingNames));
+        }
+    }
+
+    private boolean isReservedName(String name) {
+        return RESERVED_NAMES.contains(name.toLowerCase());
+    }
+
+    private static String asQuotedListString(List<String> list) {
+        return list.stream().map(s -> String.format("'%s'", s)).collect(Collectors.joining(", "));
+    }
+
+    private static String makeReservedNameMessage(List<String> conflictingNames) {
+        return String.format("The following document types conflict with reserved keyword names: %s. Reserved keywords are %s",
+                asQuotedListString(conflictingNames), asQuotedListString(ORDERED_RESERVED_NAMES));
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -617,6 +617,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
                 throw new IllegalArgumentException("In indexed content cluster '" + search.getClusterName() + "': Using multi-level dispatch setup is not supported when using hierarchical distribution.");
             }
         }
+        new ReservedDocumentTypeNameValidator().validate(documentDefinitions);
         new GlobalDistributionValidator().validate(documentDefinitions, globallyDistributedDocuments, redundancy);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ReservedDocumentTypeNameValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ReservedDocumentTypeNameValidatorTest.java
@@ -1,0 +1,57 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.content;
+
+import com.yahoo.documentmodel.NewDocumentType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ReservedDocumentTypeNameValidatorTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static Map<String, NewDocumentType> asDocTypeMapping(List<String> typeNames) {
+        return typeNames.stream().collect(Collectors.toMap(Function.identity(), n -> new NewDocumentType(new NewDocumentType.Name(n))));
+    }
+
+    @Test
+    public void exception_thrown_on_reserved_names() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The following document types conflict with reserved keyword names: " +
+                "'and', 'false', 'id', 'not', 'null', 'or', 'true'. " +
+                "Reserved keywords are 'and', 'false', 'id', 'not', 'null', 'or', 'true'");
+
+        // Ensure ordering is consistent for testing
+        Map<String, NewDocumentType> orderedDocTypes = new TreeMap<>(asDocTypeMapping(ReservedDocumentTypeNameValidator.ORDERED_RESERVED_NAMES));
+
+        ReservedDocumentTypeNameValidator validator = new ReservedDocumentTypeNameValidator();
+        validator.validate(orderedDocTypes);
+    }
+
+    @Test
+    public void exception_is_not_thrown_on_unreserved_name() {
+        ReservedDocumentTypeNameValidator validator = new ReservedDocumentTypeNameValidator();
+        validator.validate(asDocTypeMapping(Collections.singletonList("foo")));
+    }
+
+    @Test
+    public void validation_is_case_insensitive() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The following document types conflict with reserved keyword names: " +
+                "'NULL', 'True', 'anD'.");
+
+        ReservedDocumentTypeNameValidator validator = new ReservedDocumentTypeNameValidator();
+        Map<String, NewDocumentType> orderedDocTypes = new TreeMap<>(asDocTypeMapping(Arrays.asList("NULL", "True", "anD")));
+        validator.validate(orderedDocTypes);
+    }
+
+}


### PR DESCRIPTION
@bratseth please review

Reserved names are those that cause ambiguity with the selection
language used for routing documents into clusters and evaluating
GC expressions.