### PR TITLE
Various minor fixes to bootstrap scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can also setup CentOS 7 natively and install the following build dependencie
 ### Build Java modules
 
     export MAVEN_OPTS="-Xms128m -Xmx512m"
+    source /opt/rh/rh-maven33/enable
     bash bootstrap.sh java
     mvn -T <num-threads> install
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ You can also setup CentOS 7 natively and install the following build dependencie
 ### Build Java modules
 
     export MAVEN_OPTS="-Xms128m -Xmx512m"
-    sh bootstrap.sh java
+    bash bootstrap.sh java
     mvn -T <num-threads> install
 
 ### Build C++ modules
 Replace `<build-dir>` with the name of the directory in which you'd like to build Vespa.
 Replace `<source-dir>` with the directory in which you've cloned/unpacked the source tree.
 
-    sh bootstrap-cpp.sh <source-dir> <build-dir>
+    bash bootstrap-cpp.sh <source-dir> <build-dir>
     cd <build-dir>
     make -j <num-threads>
     ctest3 -j <num-threads>

--- a/bootstrap-cpp.sh
+++ b/bootstrap-cpp.sh
@@ -5,9 +5,10 @@ usage() {
     echo "Usage: $0 <source-dir> <build-dir>" >&2
 }
 
+# Parse arguments
 if [ $# -eq 2 ]; then
-    SOURCE_DIR=$(realpath $1)
-    BUILD_DIR=$(realpath $2)
+    SOURCE_DIR="$1"
+    BUILD_DIR="$2"
 elif [[ $# -eq 1 && ( "$1" = "-h" || "$1" = "--help" )]]; then
     usage
     exit 0
@@ -17,10 +18,23 @@ else
     exit 1
 fi
 
-mkdir -p "${BUILD_DIR}"
+# Check the source directory
+if [ ! -d "$SOURCE_DIR" ] ; then
+    echo "Source dir $SOURCE_DIR not found" >&2
+    exit 1
+fi
+SOURCE_DIR=$(realpath "${SOURCE_DIR}")
 
+# Check (and possibly create) the build directory
+mkdir -p "${BUILD_DIR}" || {
+    echo "Failed to create build directory" >&2
+    exit 1
+}
+BUILD_DIR=$(realpath "${BUILD_DIR}")
+
+# Build it
 source /opt/rh/devtoolset-6/enable || true
 cd "${SOURCE_DIR}"
-sh ./bootstrap.sh full
+bash ./bootstrap.sh full
 cd "${BUILD_DIR}"
-sh ${SOURCE_DIR}/bootstrap-cmake.sh ${SOURCE_DIR}
+bash ${SOURCE_DIR}/bootstrap-cmake.sh "${SOURCE_DIR}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,8 @@ usage() {
     echo "Usage: $0 [full | java | default]" >&2
 }
 
+source /opt/rh/rh-maven33/enable
+
 if [ $# -eq 0 ]; then
     # Build minimal set of java modules required to run cmake
     MODE=default


### PR DESCRIPTION
Updates to the bootstrap script to handle cases where the source or destination directory does not exist or contain spaces. Also, use "bash" explicitly for systems where "sh" is not equivalent to "bash" (probably rare, but they do exist).
Before the Java build the Maven 3.3 from /opt/rh/rh-maven33 must be enabled. If not the build will either fail because no mvn is in $PATH or the wrong Maven version may be used.

Changes were required in order to build on a vanilla CentOS 7.