### PR TITLE
Handle null superModel in service-monitor

### DIFF
--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/internal/SuperModelListenerImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/internal/SuperModelListenerImpl.java
@@ -25,7 +25,7 @@ public class SuperModelListenerImpl implements SuperModelListener, Supplier<Serv
     // and atomically using this monitor.
     private final Object monitor = new Object();
     private final SlobrokMonitorManagerImpl slobrokMonitorManager;
-    private SuperModel superModel;
+    private SuperModel superModel = new SuperModel();
 
     SuperModelListenerImpl(SlobrokMonitorManagerImpl slobrokMonitorManager,
                            ServiceMonitorMetrics metrics,

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/internal/SuperModelListenerImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/internal/SuperModelListenerImpl.java
@@ -25,7 +25,7 @@ public class SuperModelListenerImpl implements SuperModelListener, Supplier<Serv
     // and atomically using this monitor.
     private final Object monitor = new Object();
     private final SlobrokMonitorManagerImpl slobrokMonitorManager;
-    private SuperModel superModel = new SuperModel();
+    private SuperModel superModel;
 
     SuperModelListenerImpl(SlobrokMonitorManagerImpl slobrokMonitorManager,
                            ServiceMonitorMetrics metrics,
@@ -44,10 +44,9 @@ public class SuperModelListenerImpl implements SuperModelListener, Supplier<Serv
             // This snapshot() call needs to be within the synchronized block,
             // since applicationActivated()/applicationRemoved() may be called
             // asynchronously even before snapshot() returns.
-            SuperModel snapshot = superModelProvider.snapshot(this);
-
-            snapshot.getAllApplicationInfos().stream().forEach(application ->
-                    applicationActivated(snapshot, application));
+            this.superModel = superModelProvider.snapshot(this);
+            superModel.getAllApplicationInfos().stream().forEach(application ->
+                    slobrokMonitorManager.applicationActivated(superModel, application));
         }
     }
 


### PR DESCRIPTION
Once controller components are merged into configserver-app, the controller
configserver will no longer have any applications deployed.

However, the configserver runs
com.yahoo.vespa.hosted.provision.maintenance.MetricsReporter by default, which
interacts with service monitor.

MetricsReporter throws a NPE on every run when no applications have ever been
activated.