### PR TITLE
Pass distributor bucket space and document bucket to state checker context.

### DIFF
--- a/storage/src/tests/distributor/statecheckerstest.cpp
+++ b/storage/src/tests/distributor/statecheckerstest.cpp
@@ -134,17 +134,17 @@ struct StateCheckersTest : public CppUnit::TestFixture,
         std::ostringstream ost;
 
         c.siblingBucket = getIdealStateManager().getDistributorComponent()
-                          .getSibling(c.bucket.getBucketId());
+                          .getSibling(c.getBucketId());
 
         std::vector<BucketDatabase::Entry> entries;
-        getBucketDatabase().getAll(c.bucket.getBucketId(), entries);
+        getBucketDatabase().getAll(c.getBucketId(), entries);
         c.siblingEntry = getBucketDatabase().get(c.siblingBucket);
 
         c.entries = entries;
         for (uint32_t j = 0; j < entries.size(); ++j) {
             // Run checking only on this bucketid, but include all buckets
             // owned by it or owners of it, so we can detect inconsistent split.
-            if (entries[j].getBucketId() == c.bucket.getBucketId()) {
+            if (entries[j].getBucketId() == c.getBucketId()) {
                 c.entry = entries[j];
 
                 StateChecker::Result result(checker.check(c));

--- a/storage/src/tests/distributor/statecheckerstest.cpp
+++ b/storage/src/tests/distributor/statecheckerstest.cpp
@@ -13,6 +13,7 @@
 #include <vespa/storage/distributor/operations/idealstate/setbucketstateoperation.h>
 #include <vespa/storage/distributor/operations/idealstate/splitoperation.h>
 #include <vespa/storage/distributor/maintenance/node_maintenance_stats_tracker.h>
+#include <vespa/storage/distributor/distributor_bucket_space_repo.h>
 #include <vespa/storageapi/message/stat.h>
 #include <vespa/storage/storageutil/utils.h>
 #include <tests/distributor/distributortestutil.h>
@@ -20,8 +21,12 @@
 #include <vespa/storageapi/message/state.h>
 #include <vespa/config-stor-distribution.h>
 #include <vespa/storage/distributor/distributor.h>
+#include <vespa/document/test/make_bucket_space.h>
+#include <vespa/document/test/make_document_bucket.h>
 
 using namespace std::literals::string_literals;
+using document::test::makeBucketSpace;
+using document::test::makeDocumentBucket;
 
 namespace storage {
 namespace distributor {
@@ -105,8 +110,9 @@ struct StateCheckersTest : public CppUnit::TestFixture,
     void assertCurrentIdealState(const document::BucketId& bucket,
                                  const std::vector<uint16_t> expected)
     {
+        auto &distributorBucketSpace(getIdealStateManager().getBucketSpaceRepo().get(makeBucketSpace()));
         std::vector<uint16_t> idealNodes(
-                getIdealStateManager().getDistributorComponent()
+                distributorBucketSpace
                 .getDistribution().getIdealStorageNodes(
                         getIdealStateManager().getDistributorComponent()
                                 .getClusterState(),
@@ -128,17 +134,17 @@ struct StateCheckersTest : public CppUnit::TestFixture,
         std::ostringstream ost;
 
         c.siblingBucket = getIdealStateManager().getDistributorComponent()
-                .getSibling(c.bucketId);
+                          .getSibling(c.bucket.getBucketId());
 
         std::vector<BucketDatabase::Entry> entries;
-        getBucketDatabase().getAll(c.bucketId, entries);
+        getBucketDatabase().getAll(c.bucket.getBucketId(), entries);
         c.siblingEntry = getBucketDatabase().get(c.siblingBucket);
 
         c.entries = entries;
         for (uint32_t j = 0; j < entries.size(); ++j) {
             // Run checking only on this bucketid, but include all buckets
             // owned by it or owners of it, so we can detect inconsistent split.
-            if (entries[j].getBucketId() == c.bucketId) {
+            if (entries[j].getBucketId() == c.bucket.getBucketId()) {
                 c.entry = entries[j];
 
                 StateChecker::Result result(checker.check(c));
@@ -263,7 +269,7 @@ struct StateCheckersTest : public CppUnit::TestFixture,
                 lib::ClusterState(params._clusterState));
         NodeMaintenanceStatsTracker statsTracker;
         StateChecker::Context c(
-                getExternalOperationHandler(), statsTracker, bid);
+                getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
         std::string result =  testStateChecker(
                 checker, c, false, *params._blockerMessage,
                 params._includeMessagePriority,
@@ -361,7 +367,7 @@ std::string StateCheckersTest::testSplit(uint32_t splitCount,
 
     SplitBucketStateChecker checker;
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     getConfig().setSplitSize(splitSize);
     getConfig().setSplitCount(splitCount);
     getConfig().setMinimalBucketSplit(minSplitBits);
@@ -465,7 +471,7 @@ StateCheckersTest::testInconsistentSplit(const document::BucketId& bid,
 {
     SplitInconsistentStateChecker checker;
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     return testStateChecker(checker, c, true,
                             PendingMessage(), includePriority);
 }
@@ -533,7 +539,7 @@ StateCheckersTest::testJoin(uint32_t joinCount,
     getConfig().setMinimalBucketSplit(minSplitBits);
 
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     return testStateChecker(checker, c, true, blocker, includePriority);
 }
 
@@ -789,7 +795,7 @@ StateCheckersTest::testSynchronizeAndMove(const std::string& bucketInfo,
 
     _distributor->enableClusterState(lib::ClusterState(clusterState));
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     return testStateChecker(checker, c, false, blocker, includePriority);
 }
 
@@ -984,7 +990,7 @@ StateCheckersTest::testDeleteExtraCopies(
     }
     DeleteExtraCopiesStateChecker checker;
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     return testStateChecker(checker, c, false, blocker, includePriority);
 }
 
@@ -995,8 +1001,9 @@ StateCheckersTest::testDeleteExtraCopies()
     setupDistributor(2, 100, "distributor:1 storage:4");
 
     {
+        auto &distributorBucketSpace(getIdealStateManager().getBucketSpaceRepo().get(makeBucketSpace()));
         std::vector<uint16_t> idealNodes(
-                getIdealStateManager().getDistributorComponent()
+                distributorBucketSpace
                 .getDistribution().getIdealStorageNodes(
                         getIdealStateManager().getDistributorComponent().getClusterState(),
                         document::BucketId(17, 0),
@@ -1133,7 +1140,7 @@ std::string StateCheckersTest::testBucketState(
 
     BucketStateStateChecker checker;
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     return testStateChecker(checker, c, false, PendingMessage(),
                             includePriority);
 }
@@ -1332,7 +1339,7 @@ std::string StateCheckersTest::testBucketStatePerGroup(
 
     BucketStateStateChecker checker;
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, bid);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket(bid));
     return testStateChecker(checker, c, false, PendingMessage(),
                             includePriority);
 }
@@ -1474,8 +1481,8 @@ std::string StateCheckersTest::testGarbageCollection(
     getConfig().setGarbageCollection("music", checkInterval);
     getConfig().setLastGarbageCollectionChangeTime(lastChangeTime);
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker,
-            e.getBucketId());
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker,
+                            makeDocumentBucket(e.getBucketId()));
     getClock().setAbsoluteTimeInSeconds(nowTimestamp);
     return testStateChecker(checker, c, false, PendingMessage(),
                             includePriority, includeSchedulingPri);
@@ -1561,8 +1568,8 @@ StateCheckersTest::gcInhibitedWhenIdealNodeInMaintenance()
     getConfig().setGarbageCollection("music", 3600);
     getConfig().setLastGarbageCollectionChangeTime(0);
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker,
-                            bucket);
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker,
+                            makeDocumentBucket(bucket));
     getClock().setAbsoluteTimeInSeconds(4000);
     // Would normally (in a non-maintenance case) trigger GC due to having
     // overshot the GC check cycle.
@@ -1727,7 +1734,7 @@ StateCheckersTest::contextPopulatesIdealStateContainers()
     setupDistributor(2, 100, "distributor:1 storage:4");
 
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(getExternalOperationHandler(), statsTracker, {17, 0});
+    StateChecker::Context c(getExternalOperationHandler(), getDistributorBucketSpace(), statsTracker, makeDocumentBucket({17, 0}));
 
     CPPUNIT_ASSERT_EQUAL((std::vector<uint16_t>{1, 3}), c.idealState);
     CPPUNIT_ASSERT_EQUAL(size_t(2), c.unorderedIdealState.size());
@@ -1772,7 +1779,7 @@ public:
     // NOTE: resets the bucket database!
     void runFor(const document::BucketId& bid) {
         Checker checker;
-        StateChecker::Context c(_fixture.getExternalOperationHandler(), _statsTracker, bid);
+        StateChecker::Context c(_fixture.getExternalOperationHandler(), _fixture.getDistributorBucketSpace(), _statsTracker, makeDocumentBucket(bid));
         _result = _fixture.testStateChecker(
                 checker, c, false, StateCheckersTest::PendingMessage(), false);
     }

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -527,7 +527,7 @@ Distributor::checkBucketForSplit(document::BucketSpace bucketSpace,
     }
 
     Operation::SP operation =
-        _idealStateManager.generateInterceptingSplit(e, priority);
+        _idealStateManager.generateInterceptingSplit(bucketSpace, e, priority);
 
     if (operation.get()) {
         _maintenanceOperationOwner.start(operation, priority);

--- a/storage/src/vespa/storage/distributor/idealstatemanager.cpp
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.cpp
@@ -77,7 +77,7 @@ IdealStateManager::iAmUp() const
 void
 IdealStateManager::fillParentAndChildBuckets(StateChecker::Context& c) const
 {
-    c.db.getAll(c.bucket.getBucketId(), c.entries);
+    c.db.getAll(c.getBucketId(), c.entries);
     if (c.entries.empty()) {
         LOG(spam,
             "Did not find bucket %s in bucket database",
@@ -95,7 +95,7 @@ IdealStateManager::getEntryForPrimaryBucket(StateChecker::Context& c) const
 {
     for (uint32_t j = 0; j < c.entries.size(); ++j) {
         BucketDatabase::Entry& e = c.entries[j];
-        if (e.getBucketId() == c.bucket.getBucketId()) {
+        if (e.getBucketId() == c.getBucketId()) {
             return &e;
         }
     }

--- a/storage/src/vespa/storage/distributor/idealstatemanager.cpp
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.cpp
@@ -10,10 +10,12 @@
 #include <vespa/storageapi/message/multioperation.h>
 #include <vespa/storage/common/bucketmessages.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
+#include "distributor_bucket_space_repo.h"
 
 #include <vespa/log/log.h>
 LOG_SETUP(".distributor.operation.queue");
 
+using document::BucketSpace;
 using storage::lib::Node;
 using storage::lib::NodeType;
 
@@ -28,7 +30,8 @@ IdealStateManager::IdealStateManager(
         bool manageActiveBucketCopies)
     : HtmlStatusReporter("idealstateman", "Ideal state manager"),
       _metrics(new IdealStateMetricSet),
-      _distributorComponent(owner, bucketSpaceRepo, bucketSpace, compReg, "Ideal state manager")
+      _distributorComponent(owner, bucketSpaceRepo, bucketSpace, compReg, "Ideal state manager"),
+      _bucketSpaceRepo(bucketSpaceRepo)
 {
     _distributorComponent.registerStatusPage(*this);
     _distributorComponent.registerMetric(*_metrics);
@@ -74,17 +77,17 @@ IdealStateManager::iAmUp() const
 void
 IdealStateManager::fillParentAndChildBuckets(StateChecker::Context& c) const
 {
-    _distributorComponent.getBucketDatabase().getAll(c.bucketId, c.entries);
+    c.db.getAll(c.bucket.getBucketId(), c.entries);
     if (c.entries.empty()) {
         LOG(spam,
             "Did not find bucket %s in bucket database",
-            c.bucketId.toString().c_str());
+            c.bucket.toString().c_str());
     }
 }
 void
 IdealStateManager::fillSiblingBucket(StateChecker::Context& c) const
 {
-    c.siblingEntry = _distributorComponent.getBucketDatabase().get(c.siblingBucket);
+    c.siblingEntry = c.db.get(c.siblingBucket);
 }
 
 BucketDatabase::Entry*
@@ -92,7 +95,7 @@ IdealStateManager::getEntryForPrimaryBucket(StateChecker::Context& c) const
 {
     for (uint32_t j = 0; j < c.entries.size(); ++j) {
         BucketDatabase::Entry& e = c.entries[j];
-        if (e.getBucketId() == c.bucketId) {
+        if (e.getBucketId() == c.bucket.getBucketId()) {
             return &e;
         }
     }
@@ -143,7 +146,8 @@ IdealStateManager::generateHighestPriority(
         const document::Bucket &bucket,
         NodeMaintenanceStatsTracker& statsTracker) const
 {
-    StateChecker::Context c(_distributorComponent, statsTracker, bucket.getBucketId());
+    auto &distributorBucketSpace(_bucketSpaceRepo.get(bucket.getBucketSpace()));
+    StateChecker::Context c(_distributorComponent, distributorBucketSpace, statsTracker, bucket);
     fillParentAndChildBuckets(c);
     fillSiblingBucket(c);
 
@@ -172,11 +176,14 @@ IdealStateManager::prioritize(
 }
 
 IdealStateOperation::SP
-IdealStateManager::generateInterceptingSplit(const BucketDatabase::Entry& e,
+IdealStateManager::generateInterceptingSplit(BucketSpace bucketSpace,
+                                             const BucketDatabase::Entry& e,
                                              api::StorageMessage::Priority pri)
 {
     NodeMaintenanceStatsTracker statsTracker;
-    StateChecker::Context c(_distributorComponent, statsTracker, e.getBucketId());
+    document::Bucket bucket(bucketSpace, e.getBucketId());
+    auto &distributorBucketSpace(_bucketSpaceRepo.get(bucket.getBucketSpace()));
+    StateChecker::Context c(_distributorComponent, distributorBucketSpace, statsTracker, bucket);
     if (e.valid()) {
         c.entry = e;
 
@@ -210,7 +217,8 @@ std::vector<MaintenanceOperation::SP>
 IdealStateManager::generateAll(const document::Bucket &bucket,
                                NodeMaintenanceStatsTracker& statsTracker) const
 {
-    StateChecker::Context c(_distributorComponent, statsTracker, bucket.getBucketId());
+    auto &distributorBucketSpace(_bucketSpaceRepo.get(bucket.getBucketSpace()));
+    StateChecker::Context c(_distributorComponent, distributorBucketSpace, statsTracker, bucket);
     fillParentAndChildBuckets(c);
     fillSiblingBucket(c);
     BucketDatabase::Entry* e(getEntryForPrimaryBucket(c));
@@ -233,7 +241,7 @@ IdealStateManager::generateAll(const document::Bucket &bucket,
 
 void
 IdealStateManager::getBucketStatus(
-        document::BucketSpace bucketSpace,
+        BucketSpace bucketSpace,
         const BucketDatabase::Entry& entry,
         NodeMaintenanceStatsTracker& statsTracker,
         std::ostream& out) const
@@ -265,8 +273,10 @@ IdealStateManager::getBucketStatus(
 void
 IdealStateManager::getBucketStatus(std::ostream& out) const
 {
-     StatusBucketVisitor proc(*this, document::BucketSpace::placeHolder(), out);
-     _distributorComponent.getBucketDatabase().forEach(proc);
+    BucketSpace bucketSpace(BucketSpace::placeHolder());
+    StatusBucketVisitor proc(*this, bucketSpace, out);
+    auto &distributorBucketSpace(_bucketSpaceRepo.get(bucketSpace));
+    distributorBucketSpace.getBucketDatabase().forEach(proc);
 }
 
 } // distributor

--- a/storage/src/vespa/storage/distributor/idealstatemanager.h
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.h
@@ -68,6 +68,7 @@ public:
      * with higher priority than the given one.
      */
     IdealStateOperation::SP generateInterceptingSplit(
+            document::BucketSpace bucketSpace,
             const BucketDatabase::Entry& e,
             api::StorageMessage::Priority pri);
 
@@ -85,6 +86,8 @@ public:
         return _distributorComponent; }
     StorageComponent::LoadTypeSetSP getLoadTypes() {
         return _distributorComponent.getLoadTypes(); }
+    DistributorBucketSpaceRepo &getBucketSpaceRepo() { return _bucketSpaceRepo; }
+    const DistributorBucketSpaceRepo &getBucketSpaceRepo() const { return _bucketSpaceRepo; }
 
 private:
     void fillParentAndChildBuckets(StateChecker::Context& c) const;
@@ -112,6 +115,7 @@ private:
     SplitBucketStateChecker* _splitBucketStateChecker;
 
     DistributorBucketSpaceComponent _distributorComponent;
+    DistributorBucketSpaceRepo     &_bucketSpaceRepo;
 
     std::vector<IdealStateOperation::SP> generateOperationsForBucket(
             StateChecker::Context& c) const;
@@ -140,7 +144,6 @@ private:
                          const BucketDatabase::Entry& entry,
                          NodeMaintenanceStatsTracker& statsTracker,
                          std::ostream& out) const;
-
 };
 
 } // distributor

--- a/storage/src/vespa/storage/distributor/statechecker.h
+++ b/storage/src/vespa/storage/distributor/statechecker.h
@@ -19,6 +19,7 @@ class DistributorConfiguration;
 namespace distributor {
 
 class DistributorComponent;
+class DistributorBucketSpace;
 class NodeMaintenanceStatsTracker;
 
 /**
@@ -45,15 +46,16 @@ public:
     struct Context
     {
         Context(const DistributorComponent&,
+                const DistributorBucketSpace &distributorBucketSpace,
                 NodeMaintenanceStatsTracker&,
-                const document::BucketId& bid);
+                const document::Bucket &bucket_);
         ~Context();
         Context(const Context &) = delete;
         Context & operator =(const Context &) = delete;
 
 
         // Per bucket
-        document::BucketId bucketId;
+        document::Bucket   bucket;
         document::BucketId siblingBucket;
 
         BucketDatabase::Entry entry;
@@ -82,7 +84,7 @@ public:
             return siblingEntry;
         }
 
-        document::Bucket getBucket() const { return document::Bucket(document::BucketSpace::placeHolder(), bucketId); }
+        document::Bucket getBucket() const { return bucket; }
 
         std::string toString() const;
     };

--- a/storage/src/vespa/storage/distributor/statechecker.h
+++ b/storage/src/vespa/storage/distributor/statechecker.h
@@ -85,6 +85,7 @@ public:
         }
 
         document::Bucket getBucket() const { return bucket; }
+        document::BucketId getBucketId() const { return bucket.getBucketId(); }
 
         std::string toString() const;
     };

--- a/storage/src/vespa/storage/distributor/statecheckers.cpp
+++ b/storage/src/vespa/storage/distributor/statecheckers.cpp
@@ -32,7 +32,7 @@ SplitBucketStateChecker::validForSplit(StateChecker::Context& c)
     }
 
     // Can't split anymore if we already used 58 bits.
-    if (c.bucket.getBucketId().getUsedBits() >= 58) {
+    if (c.getBucketId().getUsedBits() >= 58) {
         return false;
     }
 
@@ -145,7 +145,7 @@ SplitBucketStateChecker::check(StateChecker::Context& c) {
     }
 
     // Always split it if it has less used bits than the minimum.
-    if (c.bucket.getBucketId().getUsedBits() < c.distributorConfig.getMinimalBucketSplit()) {
+    if (c.getBucketId().getUsedBits() < c.distributorConfig.getMinimalBucketSplit()) {
         return generateMinimumBucketSplitOperation(c);
     }
     return Result::noMaintenanceNeeded();
@@ -258,8 +258,8 @@ JoinBucketsStateChecker::siblingsAreInSync(const Context& context) const
 bool
 JoinBucketsStateChecker::singleBucketJoinIsConsistent(const Context& c) const
 {
-    document::BucketId joinTarget(c.bucket.getBucketId().getUsedBits() - 1,
-                                  c.bucket.getBucketId().getRawId());
+    document::BucketId joinTarget(c.getBucketId().getUsedBits() - 1,
+                                  c.getBucketId().getRawId());
     // If there are 2 children under the potential join target bucket, joining
     // would cause the bucket tree to become inconsistent. The reason for this
     // being that "moving" a bucket one bit up in the tree (and into
@@ -321,14 +321,14 @@ JoinBucketsStateChecker::shouldJoin(const Context& c) const
         return false;
     }
 
-    if (bucketAtDistributionBitLimit(c.bucket.getBucketId(), c)) {
+    if (bucketAtDistributionBitLimit(c.getBucketId(), c)) {
         LOG(spam,
             "Not joining bucket %s because it is below the min split "
             "count (config: %u, cluster state: %u, bucket has: %u)",
             c.bucket.toString().c_str(),
             c.distributorConfig.getMinimalBucketSplit(),
             c.systemState.getDistributionBitCount(),
-            c.bucket.getBucketId().getUsedBits());
+            c.getBucketId().getUsedBits());
         return false;
     }
 
@@ -337,7 +337,7 @@ JoinBucketsStateChecker::shouldJoin(const Context& c) const
     }
 
     if (c.getSiblingEntry().valid()) {
-        if (!isFirstSibling(c.bucket.getBucketId())) {
+        if (!isFirstSibling(c.getBucketId())) {
             LOG(spam,
                 "Not joining bucket %s because it is the second sibling of "
                 "%s and not the first",
@@ -427,8 +427,8 @@ JoinBucketsStateChecker::computeJoinBucket(const Context& c) const
 {
     // Always decrease by at least 1 bit, as we could not get here unless this
     // were a valid outcome.
-    unsigned int level = c.bucket.getBucketId().getUsedBits() - 1;
-    document::BucketId target(level, c.bucket.getBucketId().getRawId());
+    unsigned int level = c.getBucketId().getUsedBits() - 1;
+    document::BucketId target(level, c.getBucketId().getRawId());
 
     // Push bucket up the tree as long as it gets no siblings. This means
     // joins involving 2 source buckets will currently only be decreased by 1
@@ -436,7 +436,7 @@ JoinBucketsStateChecker::computeJoinBucket(const Context& c) const
     // be decreased by multiple bits. We may want to optimize joins for cases
     // with 2 source buckets in the future.
     while (true) {
-        document::BucketId candidate(level, c.bucket.getBucketId().getRawId());
+        document::BucketId candidate(level, c.getBucketId().getRawId());
         if (bucketHasMultipleChildren(candidate, c)
             || !legalBucketSplitLevel(candidate, c))
         {
@@ -458,15 +458,15 @@ JoinBucketsStateChecker::check(StateChecker::Context& c)
     }
     
     document::Bucket joinedBucket(computeJoinBucket(c));
-    assert(joinedBucket.getBucketId().getUsedBits() < c.bucket.getBucketId().getUsedBits());
+    assert(joinedBucket.getBucketId().getUsedBits() < c.getBucketId().getUsedBits());
 
     std::vector<document::BucketId> sourceBuckets;
     if (c.getSiblingEntry().valid()) {
         sourceBuckets.push_back(c.siblingBucket);
     } else {
-        sourceBuckets.push_back(c.bucket.getBucketId());
+        sourceBuckets.push_back(c.getBucketId());
     }
-    sourceBuckets.push_back(c.bucket.getBucketId());
+    sourceBuckets.push_back(c.getBucketId());
     IdealStateOperation::UP op(new JoinOperation(
             c.component.getClusterName(),
             BucketAndNodes(joinedBucket, c.entry->getNodes()),
@@ -568,7 +568,7 @@ SplitInconsistentStateChecker::check(StateChecker::Context& c)
         return Result::noMaintenanceNeeded();
     }
 
-    if (!isLeastSplitBucket(c.bucket.getBucketId(), c.entries)) {
+    if (!isLeastSplitBucket(c.getBucketId(), c.entries)) {
         return Result::noMaintenanceNeeded();
     }
     
@@ -581,7 +581,7 @@ SplitInconsistentStateChecker::check(StateChecker::Context& c)
 
     op->setPriority(c.distributorConfig.getMaintenancePriorities()
                     .splitInconsistentBucket);
-    op->setDetailedReason(getReason(c.bucket.getBucketId(), c.entries));
+    op->setDetailedReason(getReason(c.getBucketId(), c.entries));
     return Result::createStoredResult(std::move(op), MaintenancePriority::HIGH);
 }
 
@@ -1119,7 +1119,7 @@ GarbageCollectionStateChecker::needsGarbageCollection(const Context& c) const
     std::chrono::seconds currentTime(
             c.component.getClock().getTimeInSeconds().getTime());
 
-    return c.gcTimeCalculator.shouldGc(c.bucket.getBucketId(), currentTime, lastRunAt);
+    return c.gcTimeCalculator.shouldGc(c.getBucketId(), currentTime, lastRunAt);
 }
 
 StateChecker::Result

--- a/storage/src/vespa/storage/distributor/statecheckers.cpp
+++ b/storage/src/vespa/storage/distributor/statecheckers.cpp
@@ -27,12 +27,12 @@ SplitBucketStateChecker::validForSplit(StateChecker::Context& c)
     if (c.entry->getNodeCount() == 0) {
         LOG(spam,
             "Can't split bucket %s, since it has no copies",
-            c.bucketId.toString().c_str());
+            c.bucket.toString().c_str());
         return false;
     }
 
     // Can't split anymore if we already used 58 bits.
-    if (c.bucketId.getUsedBits() >= 58) {
+    if (c.bucket.getBucketId().getUsedBits() >= 58) {
         return false;
     }
 
@@ -145,7 +145,7 @@ SplitBucketStateChecker::check(StateChecker::Context& c) {
     }
 
     // Always split it if it has less used bits than the minimum.
-    if (c.bucketId.getUsedBits() < c.distributorConfig.getMinimalBucketSplit()) {
+    if (c.bucket.getBucketId().getUsedBits() < c.distributorConfig.getMinimalBucketSplit()) {
         return generateMinimumBucketSplitOperation(c);
     }
     return Result::noMaintenanceNeeded();
@@ -217,7 +217,7 @@ JoinBucketsStateChecker::siblingsAreInSync(const Context& context) const
         LOG(spam,
             "Not joining bucket %s because sibling bucket %s had different "
             "node count",
-            context.bucketId.toString().c_str(),
+            context.bucket.toString().c_str(),
             context.siblingBucket.toString().c_str());
         return false;
     }
@@ -238,7 +238,7 @@ JoinBucketsStateChecker::siblingsAreInSync(const Context& context) const
             "does not have the same node set, or inconsistent joins cannot be "
             "performed either due to config or because replicas were not in "
             "their ideal location",
-            context.bucketId.toString().c_str(),
+            context.bucket.toString().c_str(),
             context.siblingBucket.toString().c_str());
         return false;
     }
@@ -247,7 +247,7 @@ JoinBucketsStateChecker::siblingsAreInSync(const Context& context) const
         LOG(spam,
             "Not joining bucket %s because it or %s is out of sync "
             "and syncing it may cause it to become too large",
-            context.bucketId.toString().c_str(),
+            context.bucket.toString().c_str(),
             context.siblingBucket.toString().c_str());
         return false;
     }
@@ -258,8 +258,8 @@ JoinBucketsStateChecker::siblingsAreInSync(const Context& context) const
 bool
 JoinBucketsStateChecker::singleBucketJoinIsConsistent(const Context& c) const
 {
-    document::BucketId joinTarget(c.bucketId.getUsedBits() - 1,
-                                  c.bucketId.getRawId());
+    document::BucketId joinTarget(c.bucket.getBucketId().getUsedBits() - 1,
+                                  c.bucket.getBucketId().getRawId());
     // If there are 2 children under the potential join target bucket, joining
     // would cause the bucket tree to become inconsistent. The reason for this
     // being that "moving" a bucket one bit up in the tree (and into
@@ -305,30 +305,30 @@ JoinBucketsStateChecker::shouldJoin(const Context& c) const
 {
     if (c.entry->getNodeCount() == 0) {
         LOG(spam, "Not joining bucket %s because it has no nodes",
-            c.bucketId.toString().c_str());
+            c.bucket.toString().c_str());
         return false;
     }
 
     if (contextBucketHasTooManyReplicas(c)) {
         LOG(spam, "Not joining %s because it has too high replication level",
-            c.bucketId.toString().c_str());
+            c.bucket.toString().c_str());
         return false;
     }
 
     if (c.distributorConfig.getJoinSize() == 0 && c.distributorConfig.getJoinCount() == 0) {
         LOG(spam, "Not joining bucket %s because join is disabled",
-            c.bucketId.toString().c_str());
+            c.bucket.toString().c_str());
         return false;
     }
 
-    if (bucketAtDistributionBitLimit(c.bucketId, c)) {
+    if (bucketAtDistributionBitLimit(c.bucket.getBucketId(), c)) {
         LOG(spam,
             "Not joining bucket %s because it is below the min split "
             "count (config: %u, cluster state: %u, bucket has: %u)",
-            c.bucketId.toString().c_str(),
+            c.bucket.toString().c_str(),
             c.distributorConfig.getMinimalBucketSplit(),
             c.systemState.getDistributionBitCount(),
-            c.bucketId.getUsedBits());
+            c.bucket.getBucketId().getUsedBits());
         return false;
     }
 
@@ -337,11 +337,11 @@ JoinBucketsStateChecker::shouldJoin(const Context& c) const
     }
 
     if (c.getSiblingEntry().valid()) {
-        if (!isFirstSibling(c.bucketId)) {
+        if (!isFirstSibling(c.bucket.getBucketId())) {
             LOG(spam,
                 "Not joining bucket %s because it is the second sibling of "
                 "%s and not the first",
-                c.bucketId.toString().c_str(),
+                c.bucket.toString().c_str(),
                 c.siblingBucket.toString().c_str());
             return false;
         }
@@ -427,8 +427,8 @@ JoinBucketsStateChecker::computeJoinBucket(const Context& c) const
 {
     // Always decrease by at least 1 bit, as we could not get here unless this
     // were a valid outcome.
-    unsigned int level = c.bucketId.getUsedBits() - 1;
-    document::BucketId target(level, c.bucketId.getRawId());
+    unsigned int level = c.bucket.getBucketId().getUsedBits() - 1;
+    document::BucketId target(level, c.bucket.getBucketId().getRawId());
 
     // Push bucket up the tree as long as it gets no siblings. This means
     // joins involving 2 source buckets will currently only be decreased by 1
@@ -436,7 +436,7 @@ JoinBucketsStateChecker::computeJoinBucket(const Context& c) const
     // be decreased by multiple bits. We may want to optimize joins for cases
     // with 2 source buckets in the future.
     while (true) {
-        document::BucketId candidate(level, c.bucketId.getRawId());
+        document::BucketId candidate(level, c.bucket.getBucketId().getRawId());
         if (bucketHasMultipleChildren(candidate, c)
             || !legalBucketSplitLevel(candidate, c))
         {
@@ -458,15 +458,15 @@ JoinBucketsStateChecker::check(StateChecker::Context& c)
     }
     
     document::Bucket joinedBucket(computeJoinBucket(c));
-    assert(joinedBucket.getBucketId().getUsedBits() < c.bucketId.getUsedBits());
+    assert(joinedBucket.getBucketId().getUsedBits() < c.bucket.getBucketId().getUsedBits());
 
     std::vector<document::BucketId> sourceBuckets;
     if (c.getSiblingEntry().valid()) {
         sourceBuckets.push_back(c.siblingBucket);
     } else {
-        sourceBuckets.push_back(c.bucketId);
+        sourceBuckets.push_back(c.bucket.getBucketId());
     }
-    sourceBuckets.push_back(c.bucketId);
+    sourceBuckets.push_back(c.bucket.getBucketId());
     IdealStateOperation::UP op(new JoinOperation(
             c.component.getClusterName(),
             BucketAndNodes(joinedBucket, c.entry->getNodes()),
@@ -568,7 +568,7 @@ SplitInconsistentStateChecker::check(StateChecker::Context& c)
         return Result::noMaintenanceNeeded();
     }
 
-    if (!isLeastSplitBucket(c.bucketId, c.entries)) {
+    if (!isLeastSplitBucket(c.bucket.getBucketId(), c.entries)) {
         return Result::noMaintenanceNeeded();
     }
     
@@ -581,7 +581,7 @@ SplitInconsistentStateChecker::check(StateChecker::Context& c)
 
     op->setPriority(c.distributorConfig.getMaintenancePriorities()
                     .splitInconsistentBucket);
-    op->setDetailedReason(getReason(c.bucketId, c.entries));
+    op->setDetailedReason(getReason(c.bucket.getBucketId(), c.entries));
     return Result::createStoredResult(std::move(op), MaintenancePriority::HIGH);
 }
 
@@ -856,7 +856,7 @@ SynchronizeAndMoveStateChecker::check(StateChecker::Context& c)
     } else {
         LOG(spam, "Bucket %s: No need for merge, as bucket is in consistent state "
             "(or inconsistent buckets are empty) %s",
-            c.bucketId.toString().c_str(),
+            c.bucket.toString().c_str(),
             c.entry->toString().c_str());
         return Result::noMaintenanceNeeded();
     }
@@ -1119,7 +1119,7 @@ GarbageCollectionStateChecker::needsGarbageCollection(const Context& c) const
     std::chrono::seconds currentTime(
             c.component.getClock().getTimeInSeconds().getTime());
 
-    return c.gcTimeCalculator.shouldGc(c.bucketId, currentTime, lastRunAt);
+    return c.gcTimeCalculator.shouldGc(c.bucket.getBucketId(), currentTime, lastRunAt);
 }
 
 StateChecker::Result


### PR DESCRIPTION
This allows state checker to select proper bucket data base and distribution
and extends some state checker log messgages to contain bucket space.

@geirst, @vekterli: please review
