### PR TITLE
Fix is-upgrading condition

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
@@ -68,7 +68,10 @@ public class JobList {
 
     /** Returns the subset of jobs which are current upgrading */
     public JobList upgrading() { // TODO: Centralise and standardise reasoning about upgrades and revisions.
-        return filter(job -> job.lastSuccess().isPresent() && job.lastSuccess().get().version().isBefore(job.lastTriggered().get().version()));
+        return filter(job ->      job.lastSuccess().isPresent()
+                             &&   job.lastTriggered().isPresent()
+                             && ! job.lastTriggered().get().at().isBefore(job.lastCompleted().get().at())
+                             &&   job.lastSuccess().get().version().isBefore(job.lastTriggered().get().version()));
     }
 
     /** Returns the subset of jobs which are currently running, according to the given timeout */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiHandler.java
@@ -181,8 +181,7 @@ public class DeploymentApiHandler extends LoggingRequestHandler {
     /** The last triggered upgrade to this version, for this application */
     private Optional<JobStatus> lastDeployingTo(Version version, Application application) {
         return JobList.from(application)
-                .running(controller.applications().deploymentTrigger().jobTimeoutLimit())
-                .lastTriggered().upgrade()
+                .upgrading()
                 .asList().stream()
                 .max(comparing(job -> job.lastTriggered().get().at()));
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
@@ -165,7 +165,6 @@ public class VersionStatus {
 
             // Deploying versions
             JobList.from(application)
-                    .running(jobTimeoutLimit)
                     .upgrading()
                     .mapToList(job -> job.lastTriggered().get().version())
                     .forEach(version -> versionMap.put(version, versionMap.getOrDefault(version, DeploymentStatistics.empty(version)).withDeploying(application.id())));


### PR DESCRIPTION
@mpolden please merge. 

This is a proper check for isRunning, so the filter for currently upgrading jobs is correct. 

Implementing this change for all JobRuns is a pain, but I'll do it bit by bit. 