### PR TITLE
Geirst/reapply commit attributes once when handling delete bucket operations

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -309,12 +309,6 @@ TEST_F("require that attribute writer handles remove", Fixture)
 {
     AttributeVector::SP a1 = f.addAttribute("a1");
     AttributeVector::SP a2 = f.addAttribute("a2");
-    Schema s;
-    s.addAttributeField(Schema::AttributeField("a1", schema::DataType::INT32, CollectionType::SINGLE));
-    s.addAttributeField(Schema::AttributeField("a2", schema::DataType::INT32, CollectionType::SINGLE));
-
-    DocBuilder idb(s);
-
     fillAttribute(a1, 1, 10, 1);
     fillAttribute(a2, 1, 20, 1);
 


### PR DESCRIPTION
@toregge please review
This re-applies https://github.com/vespa-engine/vespa/pull/4024 with fix in RemoveTask::run().