### PR TITLE
Remove configserver-app magic include

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ConfigServerContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ConfigServerContainerModelBuilder.java
@@ -1,17 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.xml;
 
-import com.yahoo.config.application.Xml;
-import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.ConfigModelContext;
-import com.yahoo.path.Path;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.configserver.ConfigserverCluster;
 import com.yahoo.vespa.model.container.configserver.option.CloudConfigOptions;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-
-import java.util.List;
 
 /**
  * Builds the config model for the standalone config server.
@@ -21,34 +15,18 @@ import java.util.List;
 public class ConfigServerContainerModelBuilder extends ContainerModelBuilder {
 
     private final CloudConfigOptions options;
-    private final static String HOSTED_VESPA_INCLUDE_DIR = "hosted-vespa";
 
     public ConfigServerContainerModelBuilder(CloudConfigOptions options) {
         super(true, Networking.enable);
         this.options = options;
     }
 
-
     @Override
     public void doBuild(ContainerModel model, Element spec, ConfigModelContext modelContext) {
-        ApplicationPackage app = modelContext.getDeployState().getApplicationPackage();
-        if ( ! app.getFiles(Path.fromString(HOSTED_VESPA_INCLUDE_DIR), ".xml").isEmpty()) {
-            app.validateIncludeDir(HOSTED_VESPA_INCLUDE_DIR);
-            List<Element> configModelElements = Xml.allElemsFromPath(app, HOSTED_VESPA_INCLUDE_DIR);
-            mergeInto(spec, configModelElements);
-        }
-
-        ConfigserverCluster cluster = new ConfigserverCluster(modelContext.getParentProducer(), "configserver", options);
+        ConfigserverCluster cluster = new ConfigserverCluster(modelContext.getParentProducer(), "configserver",
+                                                              options);
         super.doBuild(model, spec, modelContext.withParent(cluster));
         cluster.setContainerCluster(model.getCluster());
     }
 
-    private void mergeInto(Element destination, List<Element> configModelElements) {
-        for (Element jdiscElement: configModelElements) {
-            for (Node child = jdiscElement.getFirstChild();  child != null; child = child.getNextSibling()) {
-                Node copiedNode = destination.getOwnerDocument().importNode(child, true);
-                destination.appendChild(copiedNode);
-            }
-        }
-    }
 }

--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -44,6 +44,7 @@
     <preprocess:include file='config-models.xml' required='false' />
     <preprocess:include file='node-repository.xml' required='false' />
     <preprocess:include file='hosted-vespa/routing-status.xml' required='false' />
+    <preprocess:include file='hosted-vespa/scoreboard.xml' required='false' />
     <preprocess:include file='controller/container.xml' required='false' />
     <component id="com.yahoo.vespa.service.monitor.internal.SlobrokMonitorManagerImpl" bundle="service-monitor" />
     <component id="com.yahoo.vespa.service.monitor.internal.ServiceMonitorImpl" bundle="service-monitor" />


### PR DESCRIPTION
Looked at some production config servers. Only `scoreboard.xml` seemed to be
included implicitly.