### PR TITLE
Bratseth/inplace flavor migration

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Flavor.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Flavor.java
@@ -76,6 +76,9 @@ public class Flavor {
     }
 
     public Type getType() { return type; }
+    
+    /** Convenience, returns getType() == Type.DOCKER_CONTAINER */
+    public boolean isDocker() { return type == Type.DOCKER_CONTAINER; }
 
     /** The free capacity we would like to preserve for this flavor */
     public int getIdealHeadroom() {
@@ -130,6 +133,14 @@ public class Flavor {
     /** Irreversibly freezes the content of this */
     public void freeze() {
         replacesFlavors = ImmutableList.copyOf(replacesFlavors);
+    }
+    
+    /** Returns whether this flavor has at least as much as each hardware resource as the given flavor */
+    public boolean isLargerThan(Flavor other) {
+        return this.minCpuCores >= other.minCpuCores &&
+               this.minDiskAvailableGb >= other.minDiskAvailableGb &&
+               this.minMainMemoryAvailableGb >= other.minMainMemoryAvailableGb &&
+               this.fastDisk || ! other.fastDisk;
     }
 
     @Override

--- a/config-provisioning/src/main/resources/configdefinitions/flavors.def
+++ b/config-provisioning/src/main/resources/configdefinitions/flavors.def
@@ -25,7 +25,7 @@ flavor[].cost int default=0
 # for some historical reason. These nodes are assigned to applications by exact match and ignoring cost.
 flavor[].stock bool default=true
 
-# The type of node (e.g. bare metal, docker..).
+# The type of node: BARE_METAL, VIRTUAL_MACHINE or DOCKER_CONTAINER
 flavor[].environment string default="undefined"
 
 # The minimum number of CPU cores available.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -97,10 +97,10 @@ class Activator {
         List<Node> updated = new ArrayList<>();
         for (Node node : nodes) {
             HostSpec hostSpec = getHost(node.hostname(), hosts);
-            node = hostSpec.membership().get().retired()
-                    ? node.retire(clock.instant())
-                    : node.unretire();
+            node = hostSpec.membership().get().retired() ? node.retire(clock.instant()) : node.unretire();
             node = node.with(node.allocation().get().with(hostSpec.membership().get()));
+            if (hostSpec.flavor().isPresent()) // Docker nodes may change flavor
+                node = node.with(hostSpec.flavor().get());
             updated.add(node);
         }
         return updated;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -49,7 +49,7 @@ class GroupPreparer {
                               List<Node> surplusActiveNodes, MutableInteger highestIndex, int nofSpares, BiConsumer<List<Node>, String> debugRecorder) {
         try (Mutex lock = nodeRepository.lock(application)) {
 
-            // Use new, ready nodes. Lock ready pool to ensure that nodes are not grabbed by others.
+            // Lock ready pool to ensure that ready nodes are not simultaneously grabbed by others
             try (Mutex readyLock = nodeRepository.lockUnallocated()) {
 
                 // Create a prioritized set of nodes

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -90,15 +90,15 @@ class NodeAllocation {
 
                 // conditions on which we want to retire nodes that were allocated previously
                 if ( offeredNodeHasParentHostnameAlreadyAccepted(this.nodes, offered)) wantToRetireNode = true;
-                if ( !hasCompatibleFlavor(offered)) wantToRetireNode = true;
+                if ( ! hasCompatibleFlavor(offered)) wantToRetireNode = true;
                 if ( offered.flavor().isRetired()) wantToRetireNode = true;
                 if ( offered.status().wantToRetire()) wantToRetireNode = true;
 
-                if ((!saturated() && hasCompatibleFlavor(offered)) || acceptToRetire(offered) ) {
+                if (( ! saturated() && hasCompatibleFlavor(offered)) || acceptToRetire(offered) ) {
                     accepted.add(acceptNode(offeredPriority, wantToRetireNode));
                 }
             }
-            else if (! saturated() && hasCompatibleFlavor(offered)) {
+            else if ( ! saturated() && hasCompatibleFlavor(offered)) {
                 if ( offeredNodeHasParentHostnameAlreadyAccepted(this.nodes, offered)) {
                     ++rejectedWithClashingParentHost;
                     continue;
@@ -232,6 +232,12 @@ class NodeAllocation {
                     if (++surplus == 0) break;
                 }
             }
+        }
+        
+        // Update flavor of allocated docker nodes as we can change it in place
+        for (PrioritizableNode node : nodes) {
+            if (node.node.allocation().isPresent())
+                node.node = requestedNodes.assignRequestedFlavor(node.node);
         }
 
         return nodes.stream().map(n -> n.node).collect(Collectors.toList());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
@@ -67,10 +67,12 @@ public interface NodeSpec {
             this.requestedFlavor = flavor;
         }
 
+        // TODO: Remove usage of this
         public Flavor getFlavor() {
             return requestedFlavor;
         }
 
+        // TODO: Remove usage of this
         public int getCount()  { return count; }
 
         @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
@@ -79,7 +79,6 @@ public interface NodeSpec {
         @Override
         public boolean isCompatible(Flavor flavor) { 
             if (flavor.satisfies(requestedFlavor)) return true;
-
             return requestedFlavorCanBeAchievedByResizing(flavor);
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
@@ -178,8 +178,8 @@ public class AclProvisioningTest {
         // Populate repo
         List<Node> dockerHostNodes = tester.makeReadyNodes(2, "default", NodeType.host);
         Node dockerHostNodeUnderTest = dockerHostNodes.get(0);
-        List<Node> dockerNodes = tester.makeReadyDockerNodes(5, "docker1",
-                dockerHostNodeUnderTest.hostname());
+        List<Node> dockerNodes = tester.makeReadyDockerNodes(5, "dockerSmall",
+                                                             dockerHostNodeUnderTest.hostname());
 
         List<NodeAcl> acls = tester.nodeRepository().getNodeAcls(dockerHostNodeUnderTest, true);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DockerProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DockerProvisioningTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class DockerProvisioningTest {
 
-    private static final String dockerFlavor = "docker1";
+    private static final String dockerFlavor = "dockerSmall";
 
     @Test
     public void docker_application_deployment() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -94,7 +94,8 @@ public class ProvisioningTester implements AutoCloseable {
         FlavorConfigBuilder b = new FlavorConfigBuilder();
         b.addFlavor("default", 2., 4., 100, Flavor.Type.BARE_METAL).cost(3);
         b.addFlavor("small", 1., 2., 50, Flavor.Type.BARE_METAL).cost(2);
-        b.addFlavor("docker1", 1., 1., 10, Flavor.Type.DOCKER_CONTAINER).cost(1);
+        b.addFlavor("dockerSmall", 1., 1., 10, Flavor.Type.DOCKER_CONTAINER).cost(1);
+        b.addFlavor("dockerLarge", 2., 1., 20, Flavor.Type.DOCKER_CONTAINER).cost(3);
         b.addFlavor("v-4-8-100", 4., 8., 100, Flavor.Type.VIRTUAL_MACHINE).cost(4);
         b.addFlavor("old-large1", 2., 4., 100, Flavor.Type.BARE_METAL).cost(6);
         b.addFlavor("old-large2", 2., 5., 100, Flavor.Type.BARE_METAL).cost(14);


### PR DESCRIPTION
@smorgrav please review

I think you knows this code best now.

The getFlavor and getCount methods you added to NodeSpecification and are using with cast breaks the API in such a way that proxies (specified with type) can not be docker ... we need to fix that but I just added some TODO's now as I don't want it in the same release as this.

@kraune FYI