### PR TITLE
Check all distributor nodes that go down instead of only the first one.

### DIFF
--- a/storage/src/vespa/storage/distributor/pendingclusterstate.cpp
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.cpp
@@ -252,8 +252,10 @@ PendingClusterState::distributorChanged(
         const lib::State& nw(newState.getNodeState(node).getState());
 
         if (nodeWasUpButNowIsDown(old, nw)) {
-            return (nodeInSameGroupAsSelf(i)
-                    || nodeNeedsOwnershipTransferFromGroupDown(i, newState));
+            if (nodeInSameGroupAsSelf(i) ||
+                nodeNeedsOwnershipTransferFromGroupDown(i, newState)) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
@geirst, @vekterli: please review