### PR TITLE
Jvenstad/deployment cleanup 3

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -172,12 +172,6 @@ public class Application {
         return "application '" + id + "'";
     }
 
-    /** Returns true if there is no current change to deploy - i.e deploying is empty or completely deployed */
-    public boolean deployingCompleted() { 
-        if ( ! deploying.isPresent()) return true;
-        return deploymentJobs().isDeployed(deploying.get()); 
-    }
-
     /** Returns true if there is a current change which is blocked from being deployed to production at this instant */
     public boolean deployingBlocked(Instant instant) {
         if ( ! deploying.isPresent()) return false;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -322,7 +322,6 @@ public class ApplicationController {
                     application = application.with(application.deploymentJobs()
                                                            .withTriggering(jobType.get(),
                                                                            application.deploying(),
-                                                                           triggering.id(),
                                                                            version,
                                                                            Optional.of(revision),
                                                                            triggering.reason(),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -204,7 +204,7 @@ public class Controller extends AbstractComponent {
     }
 
     // TODO: Model the response properly
-    // TODO: What is this
+    // TODO: What is this -- I believe it fetches, and purges, errors from some log server
     public JsonNode grabLog(DeploymentId deploymentId) {
         return configServerClient.grabLog(deploymentId);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
@@ -61,13 +61,11 @@ public class LockedApplication extends Application {
                                                      deploying(), hasOutstandingChange()), lock);
     }
 
-    // TODO: runId is always -1. Don't pass it, and pretend it's there.
-    public LockedApplication withJobTriggering(long runId, DeploymentJobs.JobType type, Optional<Change> change,
+    public LockedApplication withJobTriggering(DeploymentJobs.JobType type, Optional<Change> change,
                                                String reason, Instant triggerTime, Controller controller) {
         return new LockedApplication(new Application(id(), deploymentSpec(), validationOverrides(), deployments(),
                                                      deploymentJobs().withTriggering(type,
                                                                                      change,
-                                                                                     runId,
                                                                                      determineTriggerVersion(type, controller),
                                                                                      determineTriggerRevision(type, controller),
                                                                                      reason,

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
@@ -119,8 +119,8 @@ public class ApplicationList {
     }
 
     /** Returns the subset of applications which started failing after the given instant */
-    public ApplicationList startedFailingAfter(Instant instant) {
-        return listOf(list.stream().filter(application -> application.deploymentJobs().failingSince().isAfter(instant)));
+    public ApplicationList startedFailingOnVersionAfter(Version version, Instant instant) {
+        return listOf(list.stream().filter(application -> JobList.from(application).firstFailing().on(version).firstFailing().after(instant).anyMatch()));
     }
 
     /** Returns the subset of applications which has the given upgrade policy */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -68,7 +68,6 @@ public class DeploymentJobs {
 
     public DeploymentJobs withTriggering(JobType jobType,
                                          Optional<Change> change,
-                                         long runId,
                                          Version version,
                                          Optional<ApplicationRevision> revision,
                                          String reason,
@@ -76,8 +75,7 @@ public class DeploymentJobs {
         Map<JobType, JobStatus> status = new LinkedHashMap<>(this.status);
         status.compute(jobType, (type, job) -> {
             if (job == null) job = JobStatus.initial(jobType);
-            return job.withTriggering(runId,
-                                      version,
+            return job.withTriggering( version,
                                       revision,
                                       change.isPresent() && change.get() instanceof Change.VersionChange,
                                       reason,

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -133,30 +133,12 @@ public class DeploymentJobs {
         return true; // other environments do not have any preconditions
     }
 
-    // TODO: This is wrong -- JobStatuses which are not yet run are ignored here.
-    /** Returns whether the given change has been deployed completely */
-    public boolean isDeployed(Change change) {
-        return status.values().stream()
-                .filter(status -> status.type().isProduction())
-                .allMatch(status -> isSuccessful(change, status.type()));
-    }
-
     /** Returns whether job has completed successfully */
     public boolean isSuccessful(Change change, JobType jobType) {
         return Optional.ofNullable(jobStatus().get(jobType))
                 .flatMap(JobStatus::lastSuccess)
                 .filter(status -> status.lastCompletedWas(change))
                 .isPresent();
-    }
-
-    // TODO: This should be replaced by more precise firstFailing.at -- both uses of this are wrong.
-    /** Returns the oldest failingSince time of the jobs of this, or null if none are failing */
-    public Instant failingSince() {
-        return JobList.from(jobStatus().values())
-                .failing()
-                .mapToList(job -> job.firstFailing().get().at())
-                .stream()
-                .min(Comparator.naturalOrder()).orElse(null);
     }
 
     /**

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -133,6 +133,7 @@ public class DeploymentJobs {
         return true; // other environments do not have any preconditions
     }
 
+    // TODO: This is wrong -- JobStatuses which are not yet run are ignored here.
     /** Returns whether the given change has been deployed completely */
     public boolean isDeployed(Change change) {
         return status.values().stream()
@@ -147,7 +148,8 @@ public class DeploymentJobs {
                 .filter(status -> status.lastCompletedWas(change))
                 .isPresent();
     }
-    
+
+    // TODO: This should be replaced by more precise firstFailing.at -- both uses of this are wrong.
     /** Returns the oldest failingSince time of the jobs of this, or null if none are failing */
     public Instant failingSince() {
         return JobList.from(jobStatus().values())

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
@@ -55,9 +55,9 @@ public class JobStatus {
         return new JobStatus(type, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()); 
     }
 
-    public JobStatus withTriggering(long runId, Version version, Optional<ApplicationRevision> revision,
+    public JobStatus withTriggering(Version version, Optional<ApplicationRevision> revision,
                                     boolean upgrade, String reason, Instant triggerTime) {
-        return new JobStatus(type, jobError, Optional.of(new JobRun(runId, version, revision, upgrade, reason, triggerTime)),
+        return new JobStatus(type, jobError, Optional.of(new JobRun(-1, version, revision, upgrade, reason, triggerTime)),
                              lastCompleted, firstFailing, lastSuccess);
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentOrder.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentOrder.java
@@ -93,18 +93,6 @@ public class DeploymentOrder {
         return job == JobType.component;
     }
 
-    /** Returns whether the given job is last in a deployment */
-    public boolean isLast(JobType job, Application application) {
-        List<DeploymentSpec.Step> deploymentSteps = deploymentSteps(application);
-        if (deploymentSteps.isEmpty()) { // Deployment spec not yet available
-            return false;
-        }
-        DeploymentSpec.Step lastStep = deploymentSteps.get(deploymentSteps.size() - 1);
-        Optional<DeploymentSpec.Step> step = fromJob(job, application);
-        // Step may not exist for all jobs, e.g. component
-        return step.map(s -> s.equals(lastStep)).orElse(false);
-    }
-
     /** Returns jobs for given deployment spec, in the order they are declared */
     public List<JobType> jobsFrom(DeploymentSpec deploymentSpec) {
         return deploymentSpec.steps().stream()

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentOrder.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentOrder.java
@@ -108,7 +108,6 @@ public class DeploymentOrder {
                 .collect(collectingAndThen(toList(), Collections::unmodifiableList));
     }
 
-    // TODO: These sorts should throw when not all items to sort are listed.
     /** Returns deployments sorted according to declared zones */
     public List<Deployment> sortBy(List<DeploymentSpec.DeclaredZone> zones, Collection<Deployment> deployments) {
         List<Zone> productionZones = zones.stream()

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -22,6 +22,7 @@ import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType;
 import com.yahoo.vespa.hosted.controller.application.JobList;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
+import org.apache.zookeeper.Op;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Responsible for scheduling deployment jobs in a build system and keeping
@@ -77,6 +79,7 @@ public class DeploymentTrigger {
      * @param report information about the job that just completed
      */
     public void triggerFromCompletion(JobReport report) {
+        log.info("Got notified about completion of " + report.jobType() + " + for " + report.applicationId() + " with outcome " + (report.success() ? "success" : "failure"));
         try (Lock lock = applications().lock(report.applicationId())) {
             LockedApplication application = applications().require(report.applicationId(), lock);
             application = application.withJobCompletion(report, clock.instant(), controller);
@@ -95,8 +98,7 @@ public class DeploymentTrigger {
                         return;
                     }
                 }
-                // TODO: Should rather fix deployingCompleted() (let it check that all declared zones have the change).
-                else if (order.isLast(report.jobType(), application) && application.deployingCompleted()) {
+                else if (deploymentComplete(application)) {
                     // change completed
                     application = application.withDeploying(Optional.empty());
                 }
@@ -115,6 +117,14 @@ public class DeploymentTrigger {
 
             applications().store(application);
         }
+    }
+
+    /** Returns whether all production zones listed in deployment spec last were successful on the currently deploying change. */
+    private boolean deploymentComplete(LockedApplication application) {
+        if ( ! application.deploying().isPresent()) return true;
+        return order.jobsFrom(application.deploymentSpec()).stream()
+                .filter(JobType::isProduction)
+                .allMatch(jobType -> application.deploymentJobs().isSuccessful(application.deploying().get(), jobType));
     }
 
     /**
@@ -477,7 +487,6 @@ public class DeploymentTrigger {
         if ( ! application.deploying().isPresent()) return true;
         if ( application.deploying().get() instanceof Change.ApplicationChange) return true; // more changes are ok
 
-        // TODO: Don't these two below allow concurrent App and Version changes?
         if ( application.deploymentJobs().hasFailures()) return true; // allow changes to fix upgrade problems
         if ( application.isBlocked(clock.instant())) return true; // allow testing changes while upgrade blocked (debatable)
         // Otherwise, the application is currently upgrading, without failures, and we should wait with the revision.

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -22,7 +22,6 @@ import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType;
 import com.yahoo.vespa.hosted.controller.application.JobList;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
-import org.apache.zookeeper.Op;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -33,7 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for scheduling deployment jobs in a build system and keeping
@@ -79,7 +77,6 @@ public class DeploymentTrigger {
      * @param report information about the job that just completed
      */
     public void triggerFromCompletion(JobReport report) {
-        log.info("Got notified about completion of " + report.jobType() + " + for " + report.applicationId() + " with outcome " + (report.success() ? "success" : "failure"));
         try (Lock lock = applications().lock(report.applicationId())) {
             LockedApplication application = applications().require(report.applicationId(), lock);
             application = application.withJobCompletion(report, clock.instant(), controller);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -385,7 +385,7 @@ public class ApplicationSerializer {
 
     private Optional<JobStatus.JobRun> jobRunFromSlime(Inspector object) {
         if ( ! object.valid()) return Optional.empty();
-        return Optional.of(new JobStatus.JobRun(optionalLong(object.field(jobRunIdField)).orElse(-1L), // TODO: Make non-optional after November 2017
+        return Optional.of(new JobStatus.JobRun(optionalLong(object.field(jobRunIdField)).orElse(-1L), // TODO: Make non-optional after November 2017 -- what about lastTriggered?
                                                 new Version(object.field(versionField).asString()),
                                                 applicationRevisionFromSlime(object.field(revisionField)),
                                                 object.field(upgradeField).asBool(),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
@@ -147,8 +147,6 @@ public class VespaVersion implements Comparable<VespaVersion> {
                                                        ApplicationList productionOnThis,
                                                        Instant releasedAt,
                                                        CuratorDb curator) {
-        // TODO: This is wrong: a non-canary could fail a job for the previous version and then fail again here;
-        // it would then not be listed, because the old failure was from before upgrade. Use JobList filters instead.
         ApplicationList failingNonCanaries = failingOnThis.without(UpgradePolicy.canary).startedFailingOnVersionAfter(version, releasedAt);
         ApplicationList productionNonCanaries = productionOnThis.without(UpgradePolicy.canary);
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
@@ -146,6 +146,8 @@ public class VespaVersion implements Comparable<VespaVersion> {
                                                        ApplicationList productionOnThis,
                                                        Instant releasedAt,
                                                        CuratorDb curator) {
+        // TODO: This is wrong: a non-canary could fail a job for the previous version and then fail again here;
+        // it would then not be listed, because the old failure was from before upgrade. Use JobList filters instead.
         ApplicationList failingNonCanaries = failingOnThis.without(UpgradePolicy.canary).startedFailingAfter(releasedAt);
         ApplicationList productionNonCanaries = productionOnThis.without(UpgradePolicy.canary);
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
@@ -58,7 +58,7 @@ public class VespaVersion implements Comparable<VespaVersion> {
             return Confidence.broken;
 
         // 'broken' if 4 non-canary was broken by this, and that is at least 10% of all
-        if (nonCanaryApplicationsBroken(failingOnThis, productionOnThis, releasedAt, controller.curator()))
+        if (nonCanaryApplicationsBroken(statistics.version(), failingOnThis, productionOnThis, releasedAt, controller.curator()))
             return Confidence.broken;
 
         // 'low' unless all canary applications are upgraded
@@ -142,13 +142,14 @@ public class VespaVersion implements Comparable<VespaVersion> {
 
     }
 
-    private static boolean nonCanaryApplicationsBroken(ApplicationList failingOnThis,
+    private static boolean nonCanaryApplicationsBroken(Version version,
+                                                       ApplicationList failingOnThis,
                                                        ApplicationList productionOnThis,
                                                        Instant releasedAt,
                                                        CuratorDb curator) {
         // TODO: This is wrong: a non-canary could fail a job for the previous version and then fail again here;
         // it would then not be listed, because the old failure was from before upgrade. Use JobList filters instead.
-        ApplicationList failingNonCanaries = failingOnThis.without(UpgradePolicy.canary).startedFailingAfter(releasedAt);
+        ApplicationList failingNonCanaries = failingOnThis.without(UpgradePolicy.canary).startedFailingOnVersionAfter(version, releasedAt);
         ApplicationList productionNonCanaries = productionOnThis.without(UpgradePolicy.canary);
 
         if (productionNonCanaries.size() + failingNonCanaries.size() == 0 || curator.readIgnoreConfidence()) return false;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -31,7 +31,6 @@ import com.yahoo.vespa.hosted.controller.application.Change;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobError;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType;
-import com.yahoo.vespa.hosted.controller.application.JobList;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.athenz.NToken;
 import com.yahoo.vespa.hosted.controller.athenz.mock.AthenzDbMock;
@@ -78,6 +77,12 @@ public class ControllerTest {
     private static final ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
             .environment(Environment.prod)
             .region("corp-us-east-1")
+            .build();
+
+    private static final ApplicationPackage applicationPackage2 = new ApplicationPackageBuilder()
+            .environment(Environment.prod)
+            .region("corp-us-east-1")
+            .region("us-west-1")
             .build();
 
     @Test
@@ -448,12 +453,13 @@ public class ControllerTest {
         tester.notifyJobCompletion(stagingTest, app1, Optional.of(JobError.outOfCapacity));
         assertTrue("No jobs queued", buildSystem.jobs().isEmpty());
 
-        // app2 and app3: New change triggers staging-test jobs
+        // app2 and app3: New change triggers system-test jobs
+        // Provide a changed application package, too, or the deployment is a no-op.
         tester.notifyJobCompletion(component, app2, true);
-        tester.deployAndNotify(app2, applicationPackage, true, systemTest);
+        tester.deployAndNotify(app2, applicationPackage2, true, systemTest);
 
         tester.notifyJobCompletion(component, app3, true);
-        tester.deployAndNotify(app3, applicationPackage, true, systemTest);
+        tester.deployAndNotify(app3, applicationPackage2, true, systemTest);
 
         assertEquals(2, buildSystem.jobs().size());
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -109,12 +109,12 @@ public class ControllerTest {
         Optional<ApplicationRevision> revision = ((Change.ApplicationChange)tester.controller().applications().require(app1.id()).deploying().get()).revision();
         assertTrue("Revision has been set during deployment", revision.isPresent());
         assertStatus(JobStatus.initial(stagingTest)
-                              .withTriggering(-1, version1, revision, false, "", tester.clock().instant().minus(Duration.ofMillis(1)))
+                              .withTriggering(version1, revision, false, "", tester.clock().instant().minus(Duration.ofMillis(1)))
                               .withCompletion(42, Optional.empty(), tester.clock().instant(), tester.controller()), app1.id(), tester.controller());
 
         // Causes first deployment job to be triggered
         assertStatus(JobStatus.initial(productionCorpUsEast1)
-                              .withTriggering(-1, version1, revision, false, "", tester.clock().instant()), app1.id(), tester.controller());
+                              .withTriggering(version1, revision, false, "", tester.clock().instant()), app1.id(), tester.controller());
         tester.clock().advance(Duration.ofSeconds(1));
 
         // production job (failing)
@@ -122,9 +122,9 @@ public class ControllerTest {
         assertEquals(4, applications.require(app1.id()).deploymentJobs().jobStatus().size());
 
         JobStatus expectedJobStatus = JobStatus.initial(productionCorpUsEast1)
-                                               .withTriggering(-1, version1, revision, false, "", tester.clock().instant()) // Triggered first without revision info
+                                               .withTriggering(version1, revision, false, "", tester.clock().instant()) // Triggered first without revision info
                                                .withCompletion(42, Optional.of(JobError.unknown), tester.clock().instant(), tester.controller())
-                                               .withTriggering(-1, version1, revision, false, "", tester.clock().instant()); // Re-triggering (due to failure) has revision info
+                                               .withTriggering(version1, revision, false, "", tester.clock().instant()); // Re-triggering (due to failure) has revision info
 
         assertStatus(expectedJobStatus, app1.id(), tester.controller());
 
@@ -147,20 +147,20 @@ public class ControllerTest {
         tester.notifyJobCompletion(component, app1, true);
         tester.deployAndNotify(app1, applicationPackage, true, false, systemTest);
         assertStatus(JobStatus.initial(systemTest)
-                              .withTriggering(-1, version1, revision, false, "", tester.clock().instant().minus(Duration.ofMillis(1)))
+                              .withTriggering(version1, revision, false, "", tester.clock().instant().minus(Duration.ofMillis(1)))
                               .withCompletion(42, Optional.empty(), tester.clock().instant(), tester.controller()), app1.id(), tester.controller());
         tester.deployAndNotify(app1, applicationPackage, true, stagingTest);
 
         // production job succeeding now
         tester.deployAndNotify(app1, applicationPackage, true, productionCorpUsEast1);
         expectedJobStatus = expectedJobStatus
-                .withTriggering(-1, version1, revision, false, "", tester.clock().instant().minus(Duration.ofMillis(1)))
+                .withTriggering(version1, revision, false, "", tester.clock().instant().minus(Duration.ofMillis(1)))
                 .withCompletion(42, Optional.empty(), tester.clock().instant(), tester.controller());
         assertStatus(expectedJobStatus, app1.id(), tester.controller());
 
         // causes triggering of next production job
         assertStatus(JobStatus.initial(productionUsEast3)
-                              .withTriggering(-1, version1, revision, false, "", tester.clock().instant()),
+                              .withTriggering(version1, revision, false, "", tester.clock().instant()),
                      app1.id(), tester.controller());
         tester.deployAndNotify(app1, applicationPackage, true, productionUsEast3);
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentIssueReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentIssueReporterTest.java
@@ -135,9 +135,7 @@ public class DeploymentIssueReporterTest {
 
         // app3 now has a new failure past max failure age; see that a new issue is filed.
         tester.notifyJobCompletion(component, app3, true);
-        tester.deployAndNotify(app3, applicationPackage, true, systemTest);
-        tester.deployAndNotify(app3, applicationPackage, true, stagingTest);
-        tester.deployAndNotify(app3, applicationPackage, false, productionCorpUsEast1);
+        tester.deployAndNotify(app3, applicationPackage, false, systemTest);
         tester.clock().advance(maxInactivity.plus(maxFailureAge));
 
         reporter.maintain();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
@@ -149,10 +149,6 @@ public class UpgraderTest {
         // Deploy application change
         tester.deployCompletely("default0");
 
-        // Let maintainer trigger version change, and deploy it, too
-        tester.upgrader().maintain();
-        tester.deployCompletely("default0");
-
         tester.updateVersionStatus(version);
         assertEquals(VespaVersion.Confidence.high, tester.controller().versionStatus().systemVersion().get().confidence());
         tester.upgrader().maintain();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
@@ -95,7 +95,10 @@ public class UpgraderTest {
         assertEquals("New system version: Should upgrade Canaries", 2, tester.buildSystem().jobs().size());
         tester.completeUpgradeWithError(canary0, version, "canary", DeploymentJobs.JobType.stagingTest);
         assertEquals("Other Canary was cancelled", 2, tester.buildSystem().jobs().size());
-        // TODO: Cancelled?
+        // TODO: Cancelled would mean it was triggerd, removed from the build system, but never reported in.
+        //       Thus, the expected number of jobs should be 1, above: the retrying canary0.
+        //       Further, canary1 should be retried after the timeout period of 12 hours, but verifying this is
+        //       not possible when jobs are consumed form the build system on notification, rather than on deploy.
 
         tester.updateVersionStatus(version);
         assertEquals(VespaVersion.Confidence.broken, tester.controller().versionStatus().systemVersion().get().confidence());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -105,7 +105,6 @@ public class ApplicationSerializerTest {
                      serialized.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.systemTest));
         assertEquals(  original.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.stagingTest),
                      serialized.deploymentJobs().jobStatus().get(DeploymentJobs.JobType.stagingTest));
-        assertEquals(original.deploymentJobs().failingSince(), serialized.deploymentJobs().failingSince());
 
         assertEquals(original.hasOutstandingChange(), serialized.hasOutstandingChange());
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -69,10 +69,10 @@ public class ApplicationSerializerTest {
         List<JobStatus> statusList = new ArrayList<>();
 
         statusList.add(JobStatus.initial(DeploymentJobs.JobType.systemTest)
-                                .withTriggering(37, Version.fromString("5.6.7"), Optional.empty(), true, "Test", Instant.ofEpochMilli(7))
+                                .withTriggering(Version.fromString("5.6.7"), Optional.empty(), true, "Test", Instant.ofEpochMilli(7))
                                 .withCompletion(30, Optional.empty(), Instant.ofEpochMilli(8), tester.controller()));
         statusList.add(JobStatus.initial(DeploymentJobs.JobType.stagingTest)
-                                .withTriggering(12, Version.fromString("5.6.6"), Optional.empty(), true, "Test 2", Instant.ofEpochMilli(5))
+                                .withTriggering(Version.fromString("5.6.6"), Optional.empty(), true, "Test 2", Instant.ofEpochMilli(5))
                                 .withCompletion(11, Optional.of(JobError.unknown), Instant.ofEpochMilli(6), tester.controller()));
 
         DeploymentJobs deploymentJobs = new DeploymentJobs(projectId, statusList, Optional.empty());


### PR DESCRIPTION
@mpolden please review. 

I slightly modified the condition for a deployment being complete, by not requiring any of the terminal jobs to trigger the check; rather, the new check is whether the deploying() change has been deployed, successfully, to all production zones listed in the deployment spec. 

The old implementation was bugged, and would be wrong if the last step for an application was a parallel one, where some jobs hadn't yet finished when the last listed job did, and where this was the first pass through the pipeline. Then, some JobTypes would not be in jobStatus(), and would be exempt from the isSuccessful(change, jobType) check. 

I also slightly modified the condition for immediate retry of an application to be per job failure, rather than per application failure, i.e., the new condition allows immediate retry if the failing _job_ just started failing, rather than if the job just started failing, and was the only failing job for the given _application_. I think the new one is better. 