### PR TITLE
Revert "Avoid changing API before all clients handle it"

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostResource.java
@@ -68,13 +68,11 @@ public class HostResource implements HostApi {
                             serviceInstance.serviceStatus().name()))
                     .collect(Collectors.toList());
 
-            // TODO: Use applicationUri.toString() and hostServices once nobody is using <6.164
-            // TODO: Enable testing again in HostResourceTest.getHost_works
             return new GetHostResponse(
                     host.getHostName().s(),
                     host.getHostStatus().name(),
-                    null,
-                    null);
+                    applicationUri.toString(),
+                    hostServices);
         } catch (HostNameNotFoundException e) {
             log.log(LogLevel.INFO, "Host not found: " + hostName);
             throw new NotFoundException(e);

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
@@ -48,7 +48,6 @@ import static com.yahoo.vespa.orchestrator.TestUtil.makeServiceClusterSet;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.Fail.fail;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -358,17 +357,13 @@ public class HostResourceTest {
                 Collections.singletonList(serviceInstance));
         when(orchestrator.getHost(hostName)).thenReturn(host);
         GetHostResponse response = hostResource.getHost(hostName.s());
+        assertEquals("https://foo.com/bar", response.applicationUrl());
         assertEquals("hostname", response.hostname());
         assertEquals("ALLOWED_TO_BE_DOWN", response.state());
-
-        // See TODO in HostResource:
-        // assertEquals("https://foo.com/bar", response.applicationUrl());
-        // assertEquals(1, response.services().size());
-        // assertEquals("clusterId", response.services().get(0).clusterId);
-        // assertEquals("configId", response.services().get(0).configId);
-        // assertEquals("UP", response.services().get(0).serviceStatus);
-        // assertEquals("serviceType", response.services().get(0).serviceType);
-        assertNull(response.applicationUrl());
-        assertNull(response.services());
+        assertEquals(1, response.services().size());
+        assertEquals("clusterId", response.services().get(0).clusterId);
+        assertEquals("configId", response.services().get(0).configId);
+        assertEquals("UP", response.services().get(0).serviceStatus);
+        assertEquals("serviceType", response.services().get(0).serviceType);
     }
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#3966

All nodes have upgraded to beyond 6.164.