### PR TITLE
Increase number of threads

### DIFF
--- a/travis/travis-build-full.sh
+++ b/travis/travis-build-full.sh
@@ -3,7 +3,7 @@
 set -e
 
 export SOURCE_DIR=/source
-export NUM_THREADS=4
+export NUM_THREADS=6
 export MALLOC_ARENA_MAX=1
 export MAVEN_OPTS="-Xms128m -Xmx2g"
 source /etc/profile.d/devtoolset-6.sh || true


### PR DESCRIPTION
It seems like we are now using the premium VMs based on the elapsed time of the latest builds.

Let's start with 6 threads. We can increase to 8 later on to benchmark the difference.