### PR TITLE
Register receiveFile with the client supervisor

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
@@ -59,17 +59,8 @@ public class FileDistributionRpcServer {
                                      .methodDesc("set which file references to download")
                                      .paramDesc(0, "file references", "file reference to download")
                                      .returnDesc(0, "ret", "0 if success, 1 otherwise"));
-        supervisor.addMethod(new Method("filedistribution.receiveFile", "ssxlis", "i", // TODO Temporary method to get started with testing
-                                        this, "receiveFile")
-                                     .methodDesc("receive file reference content")
-                                     .paramDesc(0, "file references", "file reference to download")
-                                     .paramDesc(1, "filename", "filename")
-                                     .paramDesc(2, "content", "array of bytes")
-                                     .paramDesc(3, "hash", "xx64hash of the file content")
-                                     .paramDesc(4, "errorcode", "Error code. 0 if none")
-                                     .paramDesc(5, "error-description", "Error description.")
-                                     .returnDesc(0, "ret", "0 if success, 1 otherwise"));
     }
+
 
     //---------------- RPC methods ------------------------------------
     // TODO: Duplicate of code in FileAcquirereImpl. Find out where to put it. What about C++ code using this RPC call?
@@ -132,24 +123,5 @@ public class FileDistributionRpcServer {
         req.returnValues().add(new Int32Value(0));
     }
 
-    @SuppressWarnings({"UnusedDeclaration"})
-    public final void receiveFile(Request req) {
-        FileReference fileReference = new FileReference(req.parameters().get(0).asString());
-        String filename = req.parameters().get(1).asString();
-        byte[] content = req.parameters().get(2).asData();
-        long xxhash = req.parameters().get(3).asInt64();
-        int errorCode = req.parameters().get(4).asInt32();
-        String errorDescription = req.parameters().get(5).asString();
 
-        if (errorCode == 0) {
-            // TODO: Remove when system test works
-            log.log(LogLevel.INFO, "Receiving file reference '" + fileReference.value() + "'");
-            downloader.receiveFile(fileReference, filename, content);
-            req.returnValues().add(new Int32Value(0));
-        } else {
-            log.log(LogLevel.WARNING, "Receiving file reference '" + fileReference.value() + "' failed: " + errorDescription);
-            req.returnValues().add(new Int32Value(1));
-            // TODO: Add error description return value here too?
-        }
-    }
 }

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileReceiver.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileReceiver.java
@@ -1,0 +1,87 @@
+//  Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.config.proxy.filedistribution;
+
+import com.yahoo.config.FileReference;
+import com.yahoo.jrt.Int32Value;
+import com.yahoo.jrt.Method;
+import com.yahoo.jrt.Request;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.log.LogLevel;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.logging.Logger;
+
+public class FileReceiver {
+
+    private final static Logger log = Logger.getLogger(FileReceiver.class.getName());
+
+    private final Supervisor supervisor;
+    private final FileReferenceDownloader downloader;
+    private final File downloadDirectory;
+
+    public FileReceiver(Supervisor supervisor, FileReferenceDownloader downloader, File downloadDirectory) {
+        this.supervisor = supervisor;
+        this.downloader = downloader;
+        this.downloadDirectory = downloadDirectory;
+        registerMethods();
+    }
+
+    private void registerMethods() {
+        supervisor.addMethod(receiveFileMethod(this));
+    }
+
+    // Defined here so that it can be added to supervisor used by client (server will use same connection when calling
+    // receiveFile after getting a serveFile method call). handler needs to implement receiveFile method
+    private Method receiveFileMethod(Object handler) {
+        return new Method("filedistribution.receiveFile", "ssxlis", "i", // TODO Temporary method to get started with testing
+                          handler, "receiveFile")
+                .methodDesc("receive file reference content")
+                .paramDesc(0, "file references", "file reference to download")
+                .paramDesc(1, "filename", "filename")
+                .paramDesc(2, "content", "array of bytes")
+                .paramDesc(3, "hash", "xx64hash of the file content")
+                .paramDesc(4, "errorcode", "Error code. 0 if none")
+                .paramDesc(5, "error-description", "Error description.")
+                .returnDesc(0, "ret", "0 if success, 1 otherwise");
+    }
+
+    @SuppressWarnings({"UnusedDeclaration"})
+    public final void receiveFile(Request req) {
+        FileReference fileReference = new FileReference(req.parameters().get(0).asString());
+        String filename = req.parameters().get(1).asString();
+        byte[] content = req.parameters().get(2).asData();
+        long xxhash = req.parameters().get(3).asInt64();
+        int errorCode = req.parameters().get(4).asInt32();
+        String errorDescription = req.parameters().get(5).asString();
+
+        if (errorCode == 0) {
+            // TODO: Remove when system test works
+            log.log(LogLevel.INFO, "Receiving file reference '" + fileReference.value() + "'");
+            receiveFile(fileReference, filename, content);
+            req.returnValues().add(new Int32Value(0));
+        } else {
+            log.log(LogLevel.WARNING, "Receiving file reference '" + fileReference.value() + "' failed: " + errorDescription);
+            req.returnValues().add(new Int32Value(1));
+            // TODO: Add error description return value here too?
+        }
+    }
+
+    void receiveFile(FileReference fileReference, String filename, byte[] content) {
+        File fileReferenceDir = new File(downloadDirectory, fileReference.value());
+        try {
+            Files.createDirectories(fileReferenceDir.toPath());
+            File file = new File(fileReferenceDir, filename);
+            log.log(LogLevel.INFO, "Writing data to " + file.getAbsolutePath());
+            Files.write(file.toPath(), content);
+            downloader.completedDownloading(fileReference, file);
+        } catch (IOException e) {
+            log.log(LogLevel.ERROR, "Failed writing file: " + e.getMessage());
+            throw new RuntimeException("Failed writing file: ", e);
+        }
+    }
+
+
+}

--- a/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
@@ -3,6 +3,7 @@ package com.yahoo.config.subscription.impl;
 
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.RequestWaiter;
+import com.yahoo.jrt.Supervisor;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.Connection;
 import com.yahoo.vespa.config.ConnectionPool;
@@ -94,6 +95,11 @@ public class MockConnection implements ConnectionPool, com.yahoo.vespa.config.Co
     @Override
     public int getSize() {
         return numSpecs;
+    }
+
+    @Override
+    public Supervisor getSupervisor() {
+        return null;
     }
 
     public int getNumberOfRequests() {

--- a/config/src/main/java/com/yahoo/vespa/config/ConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConnectionPool.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config;
 
+import com.yahoo.jrt.Supervisor;
+
 /**
  * @author hmusum
  */
@@ -15,4 +17,6 @@ public interface ConnectionPool {
     Connection setNewCurrentConnection();
 
     int getSize();
+
+    Supervisor getSupervisor();
 }

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
  * @author hmusum
  */
 public class JRTConnectionPool implements ConnectionPool {
+
     private static final Logger log = Logger.getLogger(JRTConnectionPool.class.getName());
 
     private final Supervisor supervisor = new Supervisor(new Transport());
@@ -148,6 +149,11 @@ public class JRTConnectionPool implements ConnectionPool {
         synchronized (connections) {
             return connections.size();
         }
+    }
+
+    @Override
+    public Supervisor getSupervisor() {
+        return supervisor;
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/ApplicationFileManager.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/ApplicationFileManager.java
@@ -15,9 +15,7 @@ public class ApplicationFileManager implements AddFileInterface {
 
     @Override
     public FileReference addFile(String relativePath, FileReference reference) {
-        // TODO Wire in when verified in system test
-        // return master.addFile(new File(applicationDir, relativePath), reference);
-        return reference;
+        return master.addFile(new File(applicationDir, relativePath), reference);
     }
 
     @Override


### PR DESCRIPTION
Since the server will use the same connection to call receiveFile
after the client have called serveFile we need to register the RPC
method using the same supervisor as the client uses.
Also some preparations for making the code more reusable for others.