### PR TITLE
Lesters/tensor conformance

### DIFF
--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
@@ -122,6 +122,7 @@ public class TensorValue extends Value {
             case max: return value.max(argument);
             case atan2: return value.atan2(argument);
             case pow: return value.pow(argument);
+            case fmod: return value.fmod(argument);
             default: throw new UnsupportedOperationException("Cannot combine two tensors using " + function);
         }
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
@@ -103,6 +103,7 @@ public class TensorValue extends Value {
             case SMALLEREQUAL: return value.smallerOrEqual(argument);
             case EQUAL: return value.equal(argument);
             case NOTEQUAL: return value.notEqual(argument);
+            case APPROX_EQUAL: return value.approxEqual(argument);
             default: throw new UnsupportedOperationException("Tensors cannot be compared with " + operator);
         }
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
@@ -121,6 +121,7 @@ public class TensorValue extends Value {
             case min: return value.min(argument);
             case max: return value.max(argument);
             case atan2: return value.atan2(argument);
+            case pow: return value.pow(argument);
             default: throw new UnsupportedOperationException("Cannot combine two tensors using " + function);
         }
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
@@ -123,6 +123,7 @@ public class TensorValue extends Value {
             case atan2: return value.atan2(argument);
             case pow: return value.pow(argument);
             case fmod: return value.fmod(argument);
+            case ldexp: return value.ldexp(argument);
             default: throw new UnsupportedOperationException("Cannot combine two tensors using " + function);
         }
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/Function.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/Function.java
@@ -39,7 +39,7 @@ public enum Function implements Serializable {
 
     atan2(2)  { public double evaluate(double x, double y) { return atan2(x,y); } },
     fmod(2)   { public double evaluate(double x, double y) { return x % y; } },
-    ldexp(2)  { public double evaluate(double x, double y) { return x*pow(2,y); } },
+    ldexp(2)  { public double evaluate(double x, double y) { return x*pow(2,(int)y); } },
     max(2)    { public double evaluate(double x, double y) { return max(x,y); } },
     min(2)    { public double evaluate(double x, double y) { return min(x,y); } },
     pow(2)    { public double evaluate(double x, double y) { return pow(x,y); } };

--- a/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
@@ -171,6 +171,7 @@ public interface Tensor {
     default Tensor max(Tensor argument) { return join(argument, (a, b) -> (a > b ? a : b )); }
     default Tensor min(Tensor argument) { return join(argument, (a, b) -> (a < b ? a : b )); }
     default Tensor atan2(Tensor argument) { return join(argument, Math::atan2); }
+    default Tensor pow(Tensor argument) { return join(argument, Math::pow); }
     default Tensor larger(Tensor argument) { return join(argument, (a, b) -> ( a > b ? 1.0 : 0.0)); }
     default Tensor largerOrEqual(Tensor argument) { return join(argument, (a, b) -> ( a >= b ? 1.0 : 0.0)); }
     default Tensor smaller(Tensor argument) { return join(argument, (a, b) -> ( a < b ? 1.0 : 0.0)); }

--- a/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
@@ -172,6 +172,7 @@ public interface Tensor {
     default Tensor min(Tensor argument) { return join(argument, (a, b) -> (a < b ? a : b )); }
     default Tensor atan2(Tensor argument) { return join(argument, Math::atan2); }
     default Tensor pow(Tensor argument) { return join(argument, Math::pow); }
+    default Tensor fmod(Tensor argument) { return join(argument, (a, b) -> ( a % b )); }
     default Tensor larger(Tensor argument) { return join(argument, (a, b) -> ( a > b ? 1.0 : 0.0)); }
     default Tensor largerOrEqual(Tensor argument) { return join(argument, (a, b) -> ( a >= b ? 1.0 : 0.0)); }
     default Tensor smaller(Tensor argument) { return join(argument, (a, b) -> ( a < b ? 1.0 : 0.0)); }

--- a/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
@@ -173,6 +173,7 @@ public interface Tensor {
     default Tensor atan2(Tensor argument) { return join(argument, Math::atan2); }
     default Tensor pow(Tensor argument) { return join(argument, Math::pow); }
     default Tensor fmod(Tensor argument) { return join(argument, (a, b) -> ( a % b )); }
+    default Tensor ldexp(Tensor argument) { return join(argument, (a, b) -> ( a * Math.pow(2.0, (int)b) )); }
     default Tensor larger(Tensor argument) { return join(argument, (a, b) -> ( a > b ? 1.0 : 0.0)); }
     default Tensor largerOrEqual(Tensor argument) { return join(argument, (a, b) -> ( a >= b ? 1.0 : 0.0)); }
     default Tensor smaller(Tensor argument) { return join(argument, (a, b) -> ( a < b ? 1.0 : 0.0)); }


### PR DESCRIPTION
@bratseth Please review.

One thing of note: the Java implementation of `ldexp` was `x*pow(2,y)`. In C++, this goes to the library call `std::ldexp(double,int)`, e.g. an implicit call to int for the second argument. This is what caused some disagreement in the conformance test. I've added a cast to int in Java to do the same. An alternative solution would be to change the C++ side to use the same expression as above, as `pow` accepts doubles. Or perhaps deprecate this function as it seems of limited use to me.