### PR TITLE
Revert "Treat loadbalancer address as string and pass through"

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -10,6 +10,7 @@ import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.Zone;
 
 import java.io.File;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -41,7 +42,7 @@ public interface ModelContext {
         boolean multitenant();
         ApplicationId applicationId();
         List<ConfigServerSpec> configServerSpecs();
-        String loadBalancerAddress();
+        URI loadBalancerAddress();
         boolean hostedVespa();
         Zone zone();
         Set<Rotation> rotations();

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployProperties.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Version;
 import com.yahoo.config.provision.Zone;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +21,7 @@ public class DeployProperties {
     private final boolean multitenant;
     private final ApplicationId applicationId;
     private final List<ConfigServerSpec> serverSpecs = new ArrayList<>();
-    private final String loadBalancerAddress;
+    private final URI loadBalancerAddress;
     private final boolean hostedVespa;
     private final Version vespaVersion;
     private final Zone zone;
@@ -28,7 +29,7 @@ public class DeployProperties {
     private DeployProperties(boolean multitenant,
                              ApplicationId applicationId,
                              List<ConfigServerSpec> configServerSpecs,
-                             String loadBalancerAddress,
+                             URI loadBalancerAddress,
                              boolean hostedVespa,
                              Version vespaVersion,
                              Zone zone) {
@@ -54,7 +55,7 @@ public class DeployProperties {
         return serverSpecs;
     }
 
-    public String loadBalancerAddress() {
+    public URI loadBalancerAddress() {
         return loadBalancerAddress;
     }
 
@@ -74,7 +75,7 @@ public class DeployProperties {
         private ApplicationId applicationId = ApplicationId.defaultId();
         private boolean multitenant = false;
         private List<ConfigServerSpec> configServerSpecs = new ArrayList<>();
-        private String loadBalancerAddress;
+        private URI loadBalancerAddress;
         private boolean hostedVespa = false;
         private Version vespaVersion = Version.fromIntValues(1, 0, 0);
         private Zone zone = Zone.defaultZone();
@@ -94,7 +95,7 @@ public class DeployProperties {
             return this;
         }
 
-        public Builder loadBalancerAddress(String loadBalancerAddress) {
+        public Builder loadBalancerAddress(URI loadBalancerAddress) {
             this.loadBalancerAddress = loadBalancerAddress;
             return this;
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Identity.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Identity.java
@@ -5,6 +5,9 @@ import com.yahoo.container.core.identity.IdentityConfig;
 import com.yahoo.container.jdisc.athenz.impl.AthenzIdentityProviderImpl;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
 
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * @author mortent
  */
@@ -13,9 +16,9 @@ public class Identity extends SimpleComponent implements IdentityConfig.Producer
 
     private final String domain;
     private final String service;
-    private final String loadBalancerAddress;
+    private final URI loadBalancerAddress;
 
-    public Identity(String domain, String service, String loadBalancerAddress) {
+    public Identity(String domain, String service, URI loadBalancerAddress) {
         super(CLASS);
         this.domain = domain;
         this.service = service;
@@ -26,8 +29,13 @@ public class Identity extends SimpleComponent implements IdentityConfig.Producer
     public void getConfig(IdentityConfig.Builder builder) {
         builder.domain(domain);
         builder.service(service);
+        // Load balancer address might not have been set
         // Current interpretation of loadbalancer address is: hostname.
         // Config should be renamed or send the uri
-        builder.loadBalancerAddress(loadBalancerAddress);
+        builder.loadBalancerAddress(
+                Optional.ofNullable(loadBalancerAddress)
+                .map(URI::getHost)
+                .orElse("")
+        );
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -7,7 +7,6 @@ import com.yahoo.config.application.Xml;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelContext;
-import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.application.provider.IncludeDirs;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
@@ -58,6 +57,7 @@ import com.yahoo.vespa.model.content.StorageGroup;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -166,10 +166,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
         // Athenz copper argos
         // NOTE: Must be done after addNodes()
-        addIdentity(spec,
-                    cluster,
-                    context.getDeployState().getProperties().configServerSpecs(),
-                    context.getDeployState().getProperties().loadBalancerAddress());
+        addIdentity(spec, cluster, context.getDeployState().getProperties().loadBalancerAddress());
 
         //TODO: overview handler, see DomQrserverClusterBuilder
     }
@@ -697,22 +694,13 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
     }
 
-    private void addIdentity(Element element, ContainerCluster cluster, List<ConfigServerSpec> configServerSpecs, String loadBalancerAddress) {
+    private void addIdentity(Element element, ContainerCluster cluster, URI loadBalancerAddress) {
         Element identityElement = XML.getChild(element, "identity");
         if(identityElement != null) {
             String domain = XML.getValue(XML.getChild(identityElement, "domain"));
             String service = XML.getValue(XML.getChild(identityElement, "service"));
 
-            // Set lbaddress, or use first hostname if not specified.
-            String lbAddress = Optional.ofNullable(loadBalancerAddress)
-                    .orElseGet(
-                            () -> configServerSpecs.stream()
-                                    .findFirst()
-                                    .map(ConfigServerSpec::getHostName)
-                                    .orElse("unknown") // Currently unable to test this, hence the unknown
-                    );
-
-            Identity identity = new Identity(domain.trim(), service.trim(), lbAddress);
+            Identity identity = new Identity(domain.trim(), service.trim(), loadBalancerAddress);
             cluster.addComponent(identity);
 
             cluster.getContainers().forEach(container -> {

--- a/config-model/src/test/java/com/yahoo/config/model/MockModelContext.java
+++ b/config-model/src/test/java/com/yahoo/config/model/MockModelContext.java
@@ -2,15 +2,11 @@
 package com.yahoo.config.model;
 
 import com.yahoo.component.Version;
+import com.yahoo.config.model.api.*;
 import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.application.api.FileRegistry;
-import com.yahoo.config.model.api.ConfigDefinitionRepo;
-import com.yahoo.config.model.api.ConfigServerSpec;
-import com.yahoo.config.model.api.HostProvisioner;
-import com.yahoo.config.model.api.Model;
-import com.yahoo.config.model.api.ModelContext;
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
 import com.yahoo.config.model.application.provider.StaticConfigDefinitionRepo;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -18,6 +14,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.Zone;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -99,7 +96,7 @@ public class MockModelContext implements ModelContext {
             }
 
             @Override
-            public String loadBalancerAddress() {
+            public URI loadBalancerAddress() {
                 return null;
             }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/VespaModelFactoryTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/VespaModelFactoryTest.java
@@ -27,6 +27,7 @@ import com.yahoo.config.provision.Zone;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -195,7 +196,7 @@ public class VespaModelFactoryTest {
                     }
 
                     @Override
-                    public String loadBalancerAddress() {
+                    public URI loadBalancerAddress() {
                         return null;
                     }
                 };

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -2,19 +2,16 @@
 package com.yahoo.vespa.config.server.deploy;
 
 import com.yahoo.component.Version;
+import com.yahoo.config.model.api.*;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.application.api.FileRegistry;
-import com.yahoo.config.model.api.ConfigDefinitionRepo;
-import com.yahoo.config.model.api.ConfigServerSpec;
-import com.yahoo.config.model.api.HostProvisioner;
-import com.yahoo.config.model.api.Model;
-import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.Zone;
 
 import java.io.File;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -136,7 +133,7 @@ public class ModelContextImpl implements ModelContext {
         private final ApplicationId applicationId;
         private final boolean multitenant;
         private final List<ConfigServerSpec> configServerSpecs;
-        private final String loadBalancerAddress;
+        private final URI loadBalancerAddress;
         private final boolean hostedVespa;
         private final Zone zone;
         private final Set<Rotation> rotations;
@@ -144,7 +141,7 @@ public class ModelContextImpl implements ModelContext {
         public Properties(ApplicationId applicationId,
                           boolean multitenant,
                           List<ConfigServerSpec> configServerSpecs,
-                          String loadBalancerAddress,
+                          URI loadBalancerAddress,
                           boolean hostedVespa,
                           Zone zone,
                           Set<Rotation> rotations) {
@@ -173,7 +170,7 @@ public class ModelContextImpl implements ModelContext {
         }
 
         @Override
-        public String loadBalancerAddress() {
+        public URI loadBalancerAddress() {
             return loadBalancerAddress;
         }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -6,10 +6,10 @@ import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.ModelFactory;
-import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationLockException;
 import com.yahoo.config.provision.OutOfCapacityException;
+import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.Version;
 import com.yahoo.config.provision.Zone;
@@ -19,6 +19,7 @@ import com.yahoo.vespa.config.server.deploy.ModelContextImpl;
 import com.yahoo.vespa.config.server.http.UnknownVespaVersionException;
 import com.yahoo.vespa.config.server.provision.StaticProvisioner;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -173,7 +174,7 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
         return new ModelContextImpl.Properties(applicationId,
                                                configserverConfig.multitenant(),
                                                ConfigServerSpec.fromConfig(configserverConfig),
-                                               configserverConfig.loadBalancerAddress(),
+                                               URI.create(configserverConfig.loadBalancerAddress()),
                                                configserverConfig.hostedVespa(),
                                                zone,
                                                rotations);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -35,6 +35,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -151,7 +152,7 @@ public class SessionPreparer {
             this.properties = new ModelContextImpl.Properties(params.getApplicationId(),
                                                               configserverConfig.multitenant(),
                                                               ConfigServerSpec.fromConfig(configserverConfig),
-                                                              configserverConfig.loadBalancerAddress(),
+                                                              URI.create(configserverConfig.loadBalancerAddress()),
                                                               configserverConfig.hostedVespa(),
                                                               zone,
                                                               rotationsSet);


### PR DESCRIPTION
Reverts vespa-engine/vespa#4120

config-model API cannot be changed when there are still old models using it (then you get java.lang.NoSuchMethodError: com.yahoo.config.model.api.ModelContext$Properties.loadBalancerAddress()Ljava/net/URI;)

Please review after the fact