### PR TITLE
Certificate refresher

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzInstanceProviderService.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzInstanceProviderService.java
@@ -114,7 +114,7 @@ public class AthenzInstanceProviderService extends AbstractComponent {
         ServletHandler handler = new ServletHandler();
 
         CertificateSignerServlet certificateSignerServlet = new CertificateSignerServlet(certificateSigner);
-        handler.addServletWithMapping(new ServletHolder(certificateSignerServlet), "/sign");
+        handler.addServletWithMapping(new ServletHolder(certificateSignerServlet), config.apiPath() + "/sign");
 
         InstanceConfirmationServlet instanceConfirmationServlet = new InstanceConfirmationServlet(instanceValidator);
         handler.addServletWithMapping(new ServletHolder(instanceConfirmationServlet), config.apiPath() + "/instance");

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzInstanceProviderService.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzInstanceProviderService.java
@@ -114,7 +114,7 @@ public class AthenzInstanceProviderService extends AbstractComponent {
         ServletHandler handler = new ServletHandler();
 
         CertificateSignerServlet certificateSignerServlet = new CertificateSignerServlet(certificateSigner);
-        handler.addServletWithMapping(new ServletHolder(certificateSignerServlet), config.apiPath() + "/sign");
+        handler.addServletWithMapping(new ServletHolder(certificateSignerServlet), "/sign");
 
         InstanceConfirmationServlet instanceConfirmationServlet = new InstanceConfirmationServlet(instanceValidator);
         handler.addServletWithMapping(new ServletHolder(instanceConfirmationServlet), config.apiPath() + "/instance");

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSigner.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSigner.java
@@ -55,8 +55,8 @@ public class CertificateSigner {
     private static final List<ASN1ObjectIdentifier> ILLEGAL_EXTENSIONS = ImmutableList.of(
             Extension.basicConstraints, Extension.subjectAlternativeName);
 
-    private final JcaX509CertificateConverter certificateConverter = new JcaX509CertificateConverter();
-    private final Provider provider = new BouncyCastleProvider();
+    public static final JcaX509CertificateConverter CERTIFICATE_CONVERTER = new JcaX509CertificateConverter()
+            .setProvider(new BouncyCastleProvider());
 
     private final PrivateKey caPrivateKey;
     private final X500Name issuer;
@@ -98,9 +98,7 @@ public class CertificateSigner {
 
             ContentSigner caSigner = new JcaContentSignerBuilder(SIGNER_ALGORITHM).build(caPrivateKey);
 
-            return certificateConverter
-                    .setProvider(provider)
-                    .getCertificate(caBuilder.build(caSigner));
+            return CERTIFICATE_CONVERTER.getCertificate(caBuilder.build(caSigner));
         } catch (Exception ex) {
             log.log(LogLevel.ERROR, "Failed to generate X509 Certificate", ex);
             throw new RuntimeException("Failed to generate X509 Certificate");

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSigner.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSigner.java
@@ -15,17 +15,13 @@ import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 
 import java.math.BigInteger;
 import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
 import java.time.Duration;
@@ -89,9 +85,8 @@ public class CertificateSigner {
         Date notAfter = Date.from(clock.instant().plus(CERTIFICATE_EXPIRATION));
 
         try {
-            PublicKey publicKey = new JcaPKCS10CertificationRequest(certReq).getPublicKey();
-            X509v3CertificateBuilder caBuilder = new JcaX509v3CertificateBuilder(
-                    issuer, BigInteger.valueOf(clock.millis()), notBefore, notAfter, certReq.getSubject(), publicKey)
+            X509v3CertificateBuilder caBuilder = new X509v3CertificateBuilder(issuer, BigInteger.valueOf(clock.millis()),
+                    notBefore, notAfter, certReq.getSubject(), certReq.getSubjectPublicKeyInfo())
 
                     // Set Basic Constraints to false
                     .addExtension(Extension.basicConstraints, true, new BasicConstraints(false));

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/model/CertificateSerializedPayload.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/model/CertificateSerializedPayload.java
@@ -4,15 +4,24 @@ package com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.CertificateSigner;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.util.io.pem.PemObject;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 /**
@@ -26,7 +35,8 @@ public class CertificateSerializedPayload {
     public final X509Certificate certificate;
 
     @JsonCreator
-    public CertificateSerializedPayload(@JsonProperty("certificate") X509Certificate certificate) {
+    public CertificateSerializedPayload(@JsonProperty("certificate") @JsonDeserialize(using = CertificateDeserializer.class)
+                                                    X509Certificate certificate) {
         this.certificate = certificate;
     }
 
@@ -52,7 +62,7 @@ public class CertificateSerializedPayload {
                 '}';
     }
 
-    public static class CertificateSerializer extends JsonSerializer<X509Certificate> {
+    private static class CertificateSerializer extends JsonSerializer<X509Certificate> {
         @Override
         public void serialize(
                 X509Certificate certificate, JsonGenerator gen, SerializerProvider serializers) throws IOException {
@@ -62,6 +72,19 @@ public class CertificateSerializedPayload {
                 gen.writeString(stringWriter.toString());
             } catch (CertificateEncodingException e) {
                 throw new RuntimeException("Failed to encode X509Certificate", e);
+            }
+        }
+    }
+
+    private static class CertificateDeserializer extends JsonDeserializer<X509Certificate> {
+        @Override
+        public X509Certificate deserialize(
+                JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+            try (PEMParser pemParser = new PEMParser(new StringReader(jsonParser.getValueAsString()))) {
+                Object pemObject = pemParser.readObject();
+                return CertificateSigner.CERTIFICATE_CONVERTER.getCertificate((X509CertificateHolder) pemObject);
+            } catch (CertificateException e) {
+                throw new IllegalArgumentException("Unable to convert certificate", e);
             }
         }
     }

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/model/CsrSerializedPayload.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/model/CsrSerializedPayload.java
@@ -3,15 +3,22 @@ package com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.util.io.pem.PemObject;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * Contains PEM formatted Certificate Signing Request (CSR)
@@ -20,7 +27,8 @@ import java.io.StringReader;
  */
 public class CsrSerializedPayload {
 
-    @JsonProperty("csr") public final PKCS10CertificationRequest csr;
+    @JsonProperty("csr") @JsonSerialize(using = CertificateRequestSerializer.class)
+    public final PKCS10CertificationRequest csr;
 
     @JsonCreator
     public CsrSerializedPayload(@JsonProperty("csr") @JsonDeserialize(using = CertificateRequestDeserializer.class)
@@ -50,7 +58,19 @@ public class CsrSerializedPayload {
                 '}';
     }
 
-    public static class CertificateRequestDeserializer extends JsonDeserializer<PKCS10CertificationRequest> {
+    private static class CertificateRequestSerializer extends JsonSerializer<PKCS10CertificationRequest> {
+        @Override
+        public void serialize(
+                PKCS10CertificationRequest csr, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            try (StringWriter stringWriter = new StringWriter(); JcaPEMWriter pemWriter = new JcaPEMWriter(stringWriter)) {
+                pemWriter.writeObject(new PemObject("CERTIFICATE REQUEST", csr.getEncoded()));
+                pemWriter.flush();
+                gen.writeString(stringWriter.toString());
+            }
+        }
+    }
+
+    private static class CertificateRequestDeserializer extends JsonDeserializer<PKCS10CertificationRequest> {
         @Override
         public PKCS10CertificationRequest deserialize(
                 JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {

--- a/node-maintainer/pom.xml
+++ b/node-maintainer/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
+            <artifactId>athenz-identity-provider-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
             <artifactId>config</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -55,6 +60,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>testutil</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/certificate/CertificateAuthorityClient.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/certificate/CertificateAuthorityClient.java
@@ -1,0 +1,88 @@
+package com.yahoo.vespa.hosted.node.certificate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.model.CertificateSerializedPayload;
+import com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.model.CsrSerializedPayload;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.security.cert.X509Certificate;
+
+/**
+ * Sends Certificate Signing Requests to config server
+ *
+ * @author freva
+ */
+class CertificateAuthorityClient {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final String caServerPath;
+    private final CloseableHttpClient client;
+
+    CertificateAuthorityClient(String caServerHostname) {
+        this.caServerPath = "https://" + caServerHostname + ":8443/sign";
+
+        // Trust all certificates
+        SSLConnectionSocketFactory sslSocketFactory;
+        try {
+            sslSocketFactory = new SSLConnectionSocketFactory(
+                    new SSLContextBuilder().loadTrustMaterial(null, (arg0, arg1) -> true).build(),
+                    SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        this.client = HttpClientBuilder.create()
+                .setUserAgent("Node-Maintainer CA client")
+                .setSSLSocketFactory(sslSocketFactory)
+                .disableAutomaticRetries()
+                .build();
+    }
+
+    X509Certificate signCsr(PKCS10CertificationRequest csr) {
+        CsrSerializedPayload csrSerialized = new CsrSerializedPayload(csr);
+        CertificateSerializedPayload certificateSerialized = sendCsr(csrSerialized);
+        return certificateSerialized.certificate;
+    }
+
+    private CertificateSerializedPayload sendCsr(CsrSerializedPayload csrSerialized) {
+        try {
+            String csrJson = mapper.writeValueAsString(csrSerialized);
+            InputStream certificateResponseStream = postJson(caServerPath, csrJson);
+            return mapper.readValue(certificateResponseStream, CertificateSerializedPayload.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize CSR/deserialize certificate", e);
+        }
+    }
+
+    private InputStream postJson(String path, String json) {
+        HttpPost request = new HttpPost(path);
+        request.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        try {
+            request.setEntity(new StringEntity(json));
+            HttpResponse response = client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode != 200) {
+                throw new RuntimeException("CA responded with HTTP-" + statusCode + ", expected HTTP-200");
+            }
+            return response.getEntity().getContent();
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to encode request content", e);
+        } catch (IOException e) {
+            throw new RuntimeException("Error executing request", e);
+        }
+    }
+}

--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/certificate/CertificateRefresher.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/certificate/CertificateRefresher.java
@@ -1,0 +1,110 @@
+package com.yahoo.vespa.hosted.node.certificate;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Clock;
+
+/**
+ * Refreshes certificate that is used by nodes to authenticate themselves to the config server
+ *
+ * @author freva
+ */
+class CertificateRefresher {
+
+    static final String SIGNER_ALGORITHM = "SHA256withRSA";
+    private static final String KEY_STORE_INSTANCE = "PKCS12";
+    private static final String KEY_STORE_ALIAS = "alias";
+    private static final char[] KEY_STORE_PASSWORD = new char[0];
+
+    private final CertificateAuthorityClient caClient;
+    private final Clock clock;
+
+    CertificateRefresher(CertificateAuthorityClient caClient, Clock clock) {
+        this.caClient = caClient;
+        this.clock = clock;
+    }
+
+    CertificateRefresher(CertificateAuthorityClient caClient) {
+        this(caClient, Clock.systemUTC());
+    }
+
+    void refreshCertificate(Path pathToKeyStore, String commonName)
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, OperatorCreationException {
+        if (! shouldRefreshCertificate(pathToKeyStore)) return;
+
+        KeyPair keyPair = generateKeyPair();
+        PKCS10CertificationRequest csr = generateCsr(keyPair, commonName);
+        X509Certificate certificate = caClient.signCsr(csr);
+
+        storeCertificate(pathToKeyStore, keyPair, certificate);
+    }
+
+    private void storeCertificate(Path pathToKeyStore, KeyPair keyPair, X509Certificate certificate)
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        pathToKeyStore.getParent().toFile().mkdirs();
+        X509Certificate[] certificateChain = {certificate};
+
+        try (FileOutputStream fos = new FileOutputStream(pathToKeyStore.toFile())) {
+            KeyStore keyStore = KeyStore.getInstance(KEY_STORE_INSTANCE);
+            keyStore.load(null, null);
+            keyStore.setKeyEntry(KEY_STORE_ALIAS, keyPair.getPrivate(), KEY_STORE_PASSWORD, certificateChain);
+            keyStore.store(fos, KEY_STORE_PASSWORD);
+            fos.flush();
+        }
+    }
+
+    private boolean shouldRefreshCertificate(Path pathToKeyStore)
+            throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
+        try {
+            X509Certificate cert = readCertificate(pathToKeyStore);
+            long notBefore = cert.getNotBefore().getTime();
+            long notAfter = cert.getNotAfter().getTime();
+            long thirdOfLifetime = (notAfter - notBefore) / 3;
+
+            return notBefore + thirdOfLifetime < clock.millis();
+        } catch (FileNotFoundException e) {
+            return true;
+        }
+    }
+
+    static X509Certificate readCertificate(Path pathToKeyStore)
+            throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException {
+        try (FileInputStream fis = new FileInputStream(pathToKeyStore.toFile())) {
+            KeyStore keyStore = KeyStore.getInstance(KEY_STORE_INSTANCE);
+            keyStore.load(fis, KEY_STORE_PASSWORD);
+
+            return (X509Certificate) keyStore.getCertificate(KEY_STORE_ALIAS);
+        }
+    }
+
+    static KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator rsa = KeyPairGenerator.getInstance("RSA");
+        rsa.initialize(2048);
+        return rsa.genKeyPair();
+    }
+
+    private static PKCS10CertificationRequest generateCsr(KeyPair keyPair, String commonName)
+            throws NoSuchAlgorithmException, OperatorCreationException {
+        ContentSigner signer = new JcaContentSignerBuilder(SIGNER_ALGORITHM).build(keyPair.getPrivate());
+
+        return new JcaPKCS10CertificationRequestBuilder(new X500Name("CN=" + commonName), keyPair.getPublic())
+                .build(signer);
+    }
+}

--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/certificate/Main.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/certificate/Main.java
@@ -1,0 +1,23 @@
+package com.yahoo.vespa.hosted.node.certificate;
+
+import com.yahoo.net.HostName;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author freva
+ */
+public class Main {
+
+
+    public static void main(String[] args) throws Exception {
+        final String caServerHostname = args[0];
+        final Path keyStorePath = Paths.get(args[1]);
+
+        CertificateAuthorityClient caClient = new CertificateAuthorityClient(caServerHostname);
+        CertificateRefresher certificateRefresher = new CertificateRefresher(caClient);
+
+        certificateRefresher.refreshCertificate(keyStorePath, HostName.getLocalhost());
+    }
+}

--- a/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/certificate/CertificateRefresherTest.java
+++ b/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/certificate/CertificateRefresherTest.java
@@ -1,0 +1,89 @@
+package com.yahoo.vespa.hosted.node.certificate;
+
+import com.yahoo.test.ManualClock;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.math.BigInteger;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author freva
+ */
+public class CertificateRefresherTest {
+
+    private final ManualClock clock = new ManualClock();
+    private final String commonName = "CertificateRefresherTest";
+    private final Duration certificateExpiration = Duration.ofDays(5);
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void write_new_certificate() throws Exception {
+        X509Certificate firstCertificate = makeCertificate(1);
+        X509Certificate secondCertificate = makeCertificate(2);
+        CertificateAuthorityClient caClient = mock(CertificateAuthorityClient.class);
+        when(caClient.signCsr(any())).thenReturn(firstCertificate, secondCertificate);
+
+        Path keyStorePath = tempFolder.getRoot().toPath().resolve("some/path/keystore.p12");
+        CertificateRefresher certificateRefresher = new CertificateRefresher(caClient, clock);
+
+        certificateRefresher.refreshCertificate(keyStorePath, commonName);
+        assertEquals(firstCertificate, CertificateRefresher.readCertificate(keyStorePath));
+
+        // Calling it again before a third of certificate lifetime has passed has no effect
+        certificateRefresher.refreshCertificate(keyStorePath, commonName);
+        assertEquals(firstCertificate, CertificateRefresher.readCertificate(keyStorePath));
+
+        // After a third of the expiration time passes, we should refresh the certificate
+        clock.advance(certificateExpiration.dividedBy(3).plusSeconds(1));
+        certificateRefresher.refreshCertificate(keyStorePath, commonName);
+        assertEquals(secondCertificate, CertificateRefresher.readCertificate(keyStorePath));
+
+        verify(caClient, times(2)).signCsr(any());
+    }
+
+    private X509Certificate makeCertificate(int serial)
+            throws CertificateException, InvalidKeyException, SignatureException, NoSuchAlgorithmException, NoSuchProviderException {
+        try {
+            KeyPair keyPair = CertificateRefresher.generateKeyPair();
+            X500Name subject = new X500Name("CN=" + commonName);
+            Date notBefore = Date.from(clock.instant());
+            Date notAfter = Date.from(clock.instant().plus(certificateExpiration));
+
+            JcaX509v3CertificateBuilder certGen = new JcaX509v3CertificateBuilder(subject,
+                    BigInteger.valueOf(serial), notBefore, notAfter, subject, keyPair.getPublic());
+            ContentSigner sigGen = new JcaContentSignerBuilder(CertificateRefresher.SIGNER_ALGORITHM)
+                    .build(keyPair.getPrivate());
+            return new JcaX509CertificateConverter()
+                    .setProvider(new BouncyCastleProvider())
+                    .getCertificate(certGen.build(sigGen));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
In `CertificateAuthorityClient` I had to use dummy `TrustStrategy` as the nodes don't have(?) the root certificate that signed config server's certificate. I also had use `ALLOW_ALL_HOSTNAME_VERIFIER` since config server's certificate does not contain its hostname. Not sure if that should be commented in the source since this is mostly due to internal implementation.