### PR TITLE
Java tensors: support unequal size when concatenating

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
@@ -134,9 +134,7 @@ public class Concat extends PrimitiveTensorFunction {
             if (currentDimension.equals(concatDimension))
                 concatSizes.set(i, aSize + bSize);
             else if (aSize != 0 && bSize != 0 && aSize!=bSize )
-                throw new IllegalArgumentException("Dimension " + currentDimension + " must be of the same size when " +
-                                                   "concatenating " + a.type() + " and " + b.type() + " along dimension " + 
-                                                   concatDimension + ", but was " + aSize + " and " + bSize);
+                concatSizes.set(i, Math.min(aSize, bSize));
             else
                 concatSizes.set(i, Math.max(aSize, bSize));
         }

--- a/vespajlib/src/test/java/com/yahoo/tensor/functions/ConcatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/functions/ConcatTestCase.java
@@ -43,12 +43,7 @@ public class ConcatTestCase {
         Tensor a = Tensor.from("tensor(x[]):{ {x:0}:1, {x:1}:2 }");
         Tensor b = Tensor.from("tensor(x[]):{ {x:0}:4, {x:1}:5, {x:2}:6 }");
         assertEquals(Tensor.from("tensor(x[5]):{ {x:0}:1, {x:1}:2, {x:2}:4, {x:3}:5, {x:4}:6 }"), a.concat(b, "x"));
-        try {
-            a.concat(b, "y");
-            fail("Expected exception");
-        } catch (IllegalArgumentException expected) {
-            // success
-        }
+        assertEquals(Tensor.from("tensor(x[2],y[2]):{ {x:0,y:0}:1, {x:1,y:0}:2, {x:0,y:1}:4, {x:1,y:1}:5 }"), a.concat(b, "y"));
     }
 
     @Test


### PR DESCRIPTION
@bratseth Please review.

As far as I can see this is correct, however there might be some assumption I am not aware of in the code that is violated. Please check.

With this, all 1226 conformance tests now pass.