### PR TITLE
Flip internal priorities of GC and move-only merge

### DIFF
--- a/storage/src/tests/distributor/statecheckerstest.cpp
+++ b/storage/src/tests/distributor/statecheckerstest.cpp
@@ -826,7 +826,7 @@ StateCheckersTest::testSynchronizeAndMove()
     runAndVerify<SynchronizeAndMoveStateChecker>(
         CheckerParams()
             .expect("[Moving bucket to ideal node 3] "
-                    "(scheduling pri VERY_LOW)")
+                    "(scheduling pri LOW)")
             .bucketInfo("0=1,1=1,2=1")
             .clusterState("distributor:1 storage:4")
             .includeSchedulingPriority(true));
@@ -843,7 +843,7 @@ StateCheckersTest::testSynchronizeAndMove()
         CheckerParams()
             .expect("[Moving bucket to ideal node 1]"
                     "[Moving bucket to ideal node 3] (pri 165) "
-                    "(scheduling pri VERY_LOW)")
+                    "(scheduling pri LOW)")
             .clusterState("distributor:1 storage:5")
             .bucketInfo("0=1,4=1,5=1")
             .includeMessagePriority(true)
@@ -1540,7 +1540,7 @@ StateCheckersTest::testGarbageCollection()
 void StateCheckersTest::gc_ops_are_prioritized_with_low_priority_category() {
     CPPUNIT_ASSERT_EQUAL(
             std::string("[Needs garbage collection: Last check at 3, current time 4000, "
-                        "configured interval 300] (scheduling pri LOW)"),
+                        "configured interval 300] (scheduling pri VERY_LOW)"),
             testGarbageCollection(3, 4000, 300, 1, false, true));
 }
 

--- a/storage/src/vespa/storage/distributor/statecheckers.cpp
+++ b/storage/src/vespa/storage/distributor/statecheckers.cpp
@@ -849,7 +849,7 @@ SynchronizeAndMoveStateChecker::check(StateChecker::Context& c)
         op->setPriority(result.priority());
         op->setDetailedReason(result.reason());
         MaintenancePriority::Priority schedPri(
-                result.needsMoveOnly() ? MaintenancePriority::VERY_LOW
+                result.needsMoveOnly() ? MaintenancePriority::LOW
                                        : MaintenancePriority::MEDIUM);
 
         return Result::createStoredResult(std::move(op), schedPri);
@@ -1142,7 +1142,7 @@ GarbageCollectionStateChecker::check(Context& c)
         op->setPriority(c.distributorConfig.getMaintenancePriorities()
                         .garbageCollection);
         op->setDetailedReason(reason.c_str());
-        return Result::createStoredResult(std::move(op), MaintenancePriority::LOW);
+        return Result::createStoredResult(std::move(op), MaintenancePriority::VERY_LOW);
     } else {
         return Result::noMaintenanceNeeded();
     }


### PR DESCRIPTION
@hakonhall please review. See issue #4165 for context.

Having GC be higher priority than move-only merges meant that slow GC
could effectively inhibit node retirement. Furthermore, move-only merges
are finite while GC happens indefinitely, so it makes sense to give merging
higher priority overall.

This fixes #4165