### PR TITLE
Don't depend on filedistribution

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -276,11 +276,6 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>filedistribution</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
       <artifactId>searchsummary</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
No need to depend on filedistribution anymore, config defs are now in configdefinitions module