### PR TITLE
Fix handling of missing fields in Java document selection matching

### DIFF
--- a/document/src/main/java/com/yahoo/document/select/ResultList.java
+++ b/document/src/main/java/com/yahoo/document/select/ResultList.java
@@ -60,6 +60,10 @@ public class ResultList {
         return results;
     }
 
+    public static ResultList fromBoolean(boolean result) {
+        return new ResultList(result ? Result.TRUE : Result.FALSE);
+    }
+
     public Result toResult() {
         if (results.isEmpty()) {
             return Result.FALSE;

--- a/document/src/main/java/com/yahoo/document/select/rule/ArithmeticNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/ArithmeticNode.java
@@ -50,7 +50,7 @@ public class ArithmeticNode implements ExpressionNode {
             Object val = item.node.evaluate(context);
 
             if (val == null) {
-                throw new IllegalStateException("Null value found!");
+                throw new IllegalArgumentException("Can not perform arithmetic on null value (referencing missing field?)");
             }
 
             if (val instanceof AttributeNode.VariableValueList) {

--- a/document/src/main/java/com/yahoo/document/select/rule/AttributeNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/AttributeNode.java
@@ -127,12 +127,14 @@ public class AttributeNode implements ExpressionNode {
             FieldPath fieldPath = doc.getDataType().buildFieldPath(fieldPth);
             IteratorHandler handler = new IteratorHandler();
             doc.iterateNested(fieldPath, 0, handler);
+            if (handler.values.isEmpty()) {
+                return null;
+            }
             return handler.values;
         } else if (value instanceof DocumentUpdate) {
             return Result.INVALID;
         }
         return Result.FALSE;
-        //throw new IllegalStateException("Attributes are only available for document types for value '" + value + "'. Looking for " + fieldPth);
     }
 
     private static Object evaluateFunction(String function, Object value) {

--- a/document/src/main/java/com/yahoo/document/select/rule/ComparisonNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/ComparisonNode.java
@@ -215,8 +215,8 @@ public class ComparisonNode implements ExpressionNode {
     public Object evaluate(Context context) {
         Object oLeft = lhs.evaluate(context);
         Object oRight = rhs.evaluate(context);
-        if (oLeft == null && oRight == null) {
-            return new ResultList(Result.TRUE);
+        if (oLeft == null || oRight == null) {
+            return evaluateWithAtLeastOneNullSide(oLeft, oRight);
         }
         if (oLeft == Result.INVALID || oRight == Result.INVALID) {
             return new ResultList(Result.INVALID);
@@ -235,6 +235,23 @@ public class ComparisonNode implements ExpressionNode {
             return evaluateListAndSingle((AttributeNode.VariableValueList)oRight, oLeft);
         }
         return new ResultList(evaluateBool(oLeft, oRight));
+    }
+
+    /**
+     * Evaluates a binary comparison where one or both operands are null.
+     * Boolean outcomes are only defined for (in)equality relations, all others
+     * return Result.INVALID.
+     *
+     * Precondition: lhs AND/OR rhs is null.
+     */
+    private ResultList evaluateWithAtLeastOneNullSide(Object lhs, Object rhs) {
+        if (operator.equals("==") || operator.equals("=")) { // Glob (=) operator falls back to equality for non-strings
+            return ResultList.fromBoolean(lhs == rhs);
+        } else if (operator.equals("!=")) {
+            return ResultList.fromBoolean(lhs != rhs);
+        } else {
+            return new ResultList(Result.INVALID);
+        }
     }
 
     public ResultList evaluateListsTrue(AttributeNode.VariableValueList lhs, AttributeNode.VariableValueList rhs) {


### PR DESCRIPTION
@bratseth @baldersheim please review

Now matches C++ implementation by returning a null value when attempting
to match a missing field rather than returning an empty result list.
Altered handling of null comparisons; they should now have the expected
semantics.