### PR TITLE
Return status code 500 and print stack trace if NullPointerException …

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -17,6 +17,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.lang.SettableOptional;
 import com.yahoo.vespa.config.server.ConfigServerSpec;
 import com.yahoo.vespa.config.server.deploy.ModelContextImpl;
+import com.yahoo.vespa.config.server.http.InternalServerException;
 import com.yahoo.vespa.config.server.http.UnknownVespaVersionException;
 import com.yahoo.vespa.config.server.provision.StaticProvisioner;
 
@@ -97,7 +98,12 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
             catch (RuntimeException e) {
                 boolean isOldestMajor = i == majorVersions.size() - 1;
                 if (isOldestMajor) {
-                    throw new IllegalArgumentException(applicationId + ": Error loading model", e);
+                    if (e instanceof NullPointerException) {
+                        e.printStackTrace();
+                        throw new InternalServerException(applicationId + ": Error loading model", e);
+                    } else {
+                        throw new IllegalArgumentException(applicationId + ": Error loading model", e);
+                    }
                 } else {
                     log.log(Level.INFO, applicationId + ": Skipping major version " + majorVersions.get(i), e);
                 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -15,6 +15,7 @@ import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.Version;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.lang.SettableOptional;
+import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.server.ConfigServerSpec;
 import com.yahoo.vespa.config.server.deploy.ModelContextImpl;
 import com.yahoo.vespa.config.server.http.InternalServerException;
@@ -99,7 +100,7 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
                 boolean isOldestMajor = i == majorVersions.size() - 1;
                 if (isOldestMajor) {
                     if (e instanceof NullPointerException) {
-                        e.printStackTrace();
+                        log.log(LogLevel.WARNING, "Unexpected error when building model ", e);
                         throw new InternalServerException(applicationId + ": Error loading model", e);
                     } else {
                         throw new IllegalArgumentException(applicationId + ": Error loading model", e);


### PR DESCRIPTION
…is thrown

When building a model, return 500 (as opposed to 400 now) and print stack trace
when a NullPointerException is thrown