### PR TITLE
Add support for downloading from another config server

### DIFF
--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -126,6 +126,11 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>filedistribution</artifactId>
+      <version>6-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>filedistributionmanager</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -4,7 +4,10 @@ package com.yahoo.vespa.config.server.filedistribution;
 import com.google.inject.Inject;
 import com.yahoo.config.FileReference;
 import com.yahoo.config.model.api.FileDistribution;
+import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.io.IOUtils;
+import com.yahoo.vespa.config.JRTConnectionPool;
+import com.yahoo.vespa.filedistribution.FileDownloader;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +19,7 @@ public class FileServer {
     private static final Logger log = Logger.getLogger(FileServer.class.getName());
     private final FileDirectory root;
     private final ExecutorService executor;
+    private final FileDownloader downloader = new FileDownloader(new JRTConnectionPool(ConfigSourceSet.createDefault()));
 
     public static class ReplayStatus {
         private final int code;
@@ -85,5 +89,9 @@ public class FileServer {
                 new ReplayStatus(success ? 0 : 1, success ? "OK" : errorDescription));
         // TODO remove once verified in system tests.
         log.info("Done serving reference '" + reference.toString() + "' with file '" + file.getAbsolutePath() + "'");
+    }
+
+    public void download(FileReference fileReference) {
+        downloader.getFile(fileReference);
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
@@ -21,7 +21,6 @@ import com.yahoo.jrt.StringValue;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Target;
 import com.yahoo.jrt.Transport;
-import com.yahoo.jrt.Value;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ErrorCode;
 import com.yahoo.vespa.config.JRTMethods;
@@ -249,7 +248,6 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
         }
 
         for (int i = 0; i < responsesSent; i++) {
-
             try {
                 completionService.take();
             } catch (InterruptedException e) {
@@ -469,6 +467,8 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
                     : FileApiErrorCodes.NOT_FOUND;
             if (result == FileApiErrorCodes.OK) {
                 fileServer.startFileServing(fileReference, new FileReceiver(request.target()));
+            } else {
+                fileServer.download(new FileReference(fileReference));
             }
         } catch (IllegalArgumentException e) {
             result = FileApiErrorCodes.NOT_FOUND;


### PR DESCRIPTION
If a request for a file reference cannot be fulfilled, ask another
config server for the file.
Handle connection errors when downloading files.