### PR TITLE
Use content bucket space for bucket mover runs

### DIFF
--- a/storage/src/vespa/storage/bucketmover/bucketmover.h
+++ b/storage/src/vespa/storage/bucketmover/bucketmover.h
@@ -83,6 +83,7 @@ private:
     void run(framework::ThreadHandle&) override;
     bool onInternalReply(const std::shared_ptr<api::InternalReply>&) override;
     void storageDistributionChanged() override;
+    lib::Distribution::DiskDistribution currentDiskDistribution() const;
 
     framework::SecondTime calculateWaitTimeOfNextRun() const;
 

--- a/storage/src/vespa/storage/bucketmover/move.cpp
+++ b/storage/src/vespa/storage/bucketmover/move.cpp
@@ -9,13 +9,13 @@ namespace bucketmover {
 Move::Move()
     : _sourceDisk(0),
       _targetDisk(0),
-      _bucket(0),
+      _bucket(document::BucketSpace::placeHolder(), document::BucketId(0)),
       _totalDocSize(0),
       _priority(255)
 {
 }
 
-Move::Move(uint16_t source, uint16_t target, const document::BucketId& bucket,
+Move::Move(uint16_t source, uint16_t target, const document::Bucket& bucket,
            uint32_t totalDocSize)
     : _sourceDisk(source),
       _targetDisk(target),

--- a/storage/src/vespa/storage/bucketmover/move.h
+++ b/storage/src/vespa/storage/bucketmover/move.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <vespa/document/bucket/bucketid.h>
+#include <vespa/document/bucket/bucket.h>
 #include <vespa/vespalib/util/printable.h>
 
 namespace storage {
@@ -17,22 +17,22 @@ namespace bucketmover {
 class Move : public vespalib::Printable {
     uint16_t _sourceDisk;
     uint16_t _targetDisk;
-    document::BucketId _bucket;
+    document::Bucket _bucket;
     uint32_t _totalDocSize;
     uint8_t _priority;
 
 public:
     Move();
-    Move(uint16_t source, uint16_t target, const document::BucketId& bucket,
+    Move(uint16_t source, uint16_t target, const document::Bucket& bucket,
          uint32_t totalDocSize);
 
     /** False if invalid move. (Empty constructor) Indicates end of run. */
-    bool isDefined() const { return (_bucket.getRawId() != 0); }
+    bool isDefined() const { return (_bucket.getBucketId().getRawId() != 0); }
 
     // Only valid to call if move is defined
     uint16_t getSourceDisk() const { return _sourceDisk; }
     uint16_t getTargetDisk() const { return _targetDisk; }
-    const document::BucketId& getBucketId() const { return _bucket; }
+    const document::Bucket& getBucket() const { return _bucket; }
     uint8_t getPriority() const { return _priority; }
     uint32_t getTotalDocSize() const { return _totalDocSize; }
 

--- a/storage/src/vespa/storage/bucketmover/run.cpp
+++ b/storage/src/vespa/storage/bucketmover/run.cpp
@@ -114,7 +114,7 @@ Run::getNextMove()
         }
 
         // Cache more entries
-        BucketIterator it(document::BucketSpace::placeHolder(), *_distribution,
+        BucketIterator it(_bucketSpace.bucketSpace(), *_distribution,
                           _nodeState, _nodeIndex, _statistics, _entries);
         _bucketSpace.bucketDatabase().all(it, "bucketmover::Run", _statistics._lastBucketVisited.toKey());
         if (it._bucketsVisited == 0) {

--- a/storage/src/vespa/storage/bucketmover/run.h
+++ b/storage/src/vespa/storage/bucketmover/run.h
@@ -18,6 +18,7 @@
 
 #include "move.h"
 #include "runstatistics.h"
+#include <vespa/storage/common/content_bucket_space.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/nodestate.h>
 #include <list>
@@ -33,8 +34,8 @@ class Clock;
 namespace bucketmover {
 
 class Run : public document::Printable {
-    StorBucketDatabase& _bucketDatabase;
-    lib::Distribution::SP _distribution;
+    ContentBucketSpace& _bucketSpace;
+    std::shared_ptr<const lib::Distribution> _distribution;
     lib::NodeState _nodeState;
     uint16_t _nodeIndex;
     uint32_t _maxEntriesToKeep;
@@ -48,8 +49,7 @@ class Run : public document::Printable {
 public:
     Run(const Run &) = delete;
     Run & operator = (const Run &) = delete;
-    Run(StorBucketDatabase&,
-        lib::Distribution::SP,
+    Run(ContentBucketSpace& bucketSpace,
         const lib::NodeState&,
         uint16_t nodeIndex,
         framework::Clock&);
@@ -77,12 +77,6 @@ public:
      *         The whole database have been iterated through.
      */
     Move getNextMove();
-
-    /**
-     * Run through the database not doing any moves. Useful to do a run only
-     * to gather statistics of current state.
-     */
-    void depleteMoves();
 
     void moveOk(Move& move);
     void moveFailedBucketNotFound(Move& move);

--- a/storage/src/vespa/storage/bucketmover/runstatistics.cpp
+++ b/storage/src/vespa/storage/bucketmover/runstatistics.cpp
@@ -39,7 +39,7 @@ RunStatistics::RunStatistics(DiskDistribution d, framework::Clock& clock,
                              const lib::NodeState& ns)
     : _clock(&clock),
       _distribution(d),
-      _lastBucketProcessed(0),
+      _lastBucketProcessed(),
       _lastBucketVisited(0),
       _diskData(ns.getDiskCount(), DiskData(ns.getDiskCount())),
       _startTime(_clock->getTimeInSeconds()),
@@ -149,13 +149,14 @@ RunStatistics::getWronglyPlacedRatio() const
     return static_cast<double>(wrong) / total;
 }
 
+// FIXME does not cover multiple spaces (but only used for printing)
 double
 RunStatistics::getProgress() const
 {
     if (_endTime.isSet()) return 1.0;
     double result = 0;
     double weight = 0.5;
-    uint64_t key = _lastBucketProcessed.toKey();
+    uint64_t key = _lastBucketProcessed.getBucketId().toKey();
     for (uint16_t i=0; i<64; ++i) {
         uint64_t flag = uint64_t(1) << (63 - i);
         if ((key & flag) == flag) {

--- a/storage/src/vespa/storage/bucketmover/runstatistics.h
+++ b/storage/src/vespa/storage/bucketmover/runstatistics.h
@@ -38,7 +38,7 @@
 
 #include <vespa/vdslib/state/nodestate.h>
 #include <vespa/vdslib/distribution/distribution.h>
-#include <vespa/document/bucket/bucketid.h>
+#include <vespa/document/bucket/bucket.h>
 #include <vespa/vespalib/util/printable.h>
 #include <vespa/storageframework/generic/clock/time.h>
 
@@ -76,7 +76,7 @@ struct RunStatistics : public document::Printable {
 
     framework::Clock* _clock;
     DiskDistribution _distribution;
-    document::BucketId _lastBucketProcessed;
+    document::Bucket _lastBucketProcessed;
     document::BucketId _lastBucketVisited; // Invalid bucket for starting point
     std::vector<DiskData> _diskData;
     framework::SecondTime _startTime;

--- a/storage/src/vespa/storage/common/content_bucket_space.cpp
+++ b/storage/src/vespa/storage/common/content_bucket_space.cpp
@@ -4,8 +4,9 @@
 
 namespace storage {
 
-ContentBucketSpace::ContentBucketSpace()
-    : _bucketDatabase(),
+ContentBucketSpace::ContentBucketSpace(document::BucketSpace bucketSpace)
+    : _bucketSpace(bucketSpace),
+      _bucketDatabase(),
       _lock(),
       _distribution()
 {

--- a/storage/src/vespa/storage/common/content_bucket_space.h
+++ b/storage/src/vespa/storage/common/content_bucket_space.h
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <vespa/document/bucket/bucketspace.h>
 #include <vespa/storage/bucketdb/storbucketdb.h>
 #include <mutex>
 
@@ -13,13 +14,16 @@ namespace lib { class Distribution; }
  */
 class ContentBucketSpace {
 private:
+    document::BucketSpace _bucketSpace;
     StorBucketDatabase _bucketDatabase;
     mutable std::mutex _lock;
     std::shared_ptr<const lib::Distribution> _distribution;
 
 public:
     using UP = std::unique_ptr<ContentBucketSpace>;
-    ContentBucketSpace();
+    ContentBucketSpace(document::BucketSpace bucketSpace);
+
+    document::BucketSpace bucketSpace() const noexcept { return _bucketSpace; }
     StorBucketDatabase &bucketDatabase() { return _bucketDatabase; }
     void setDistribution(std::shared_ptr<const lib::Distribution> distribution);
     std::shared_ptr<const lib::Distribution> getDistribution() const;

--- a/storage/src/vespa/storage/common/content_bucket_space_repo.cpp
+++ b/storage/src/vespa/storage/common/content_bucket_space_repo.cpp
@@ -9,7 +9,7 @@ namespace storage {
 ContentBucketSpaceRepo::ContentBucketSpaceRepo()
     : _map()
 {
-    _map.emplace(BucketSpace::placeHolder(), std::make_unique<ContentBucketSpace>());
+    _map.emplace(BucketSpace::placeHolder(), std::make_unique<ContentBucketSpace>(BucketSpace::placeHolder()));
 }
 
 ContentBucketSpace &


### PR DESCRIPTION
@geirst @toregge please review

Primarily moving code to emitting proper Buckets and using the bucket space interfaces rather than passing DBs and component distribution directly. + misc cleanup of old code.

Note that `BucketMover` will still only move buckets in the "default" bucket space. But now easier to change this later if needed.

Also added a `bucketSpace()` accessor to `ContentBucketSpace` so that you can get to its `document::BucketSpace` when you only have an instance but not the key from which it was looked up.