### PR TITLE
Don't inject config instances into jax-rs resources

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSignerResource.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSignerResource.java
@@ -2,14 +2,10 @@
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca;
 
 import com.google.inject.Inject;
-import com.yahoo.config.provision.Zone;
 import com.yahoo.container.jaxrs.annotation.Component;
 import com.yahoo.log.LogLevel;
-import com.yahoo.net.HostName;
 import com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.model.CertificateSerializedPayload;
 import com.yahoo.vespa.hosted.athenz.instanceproviderservice.ca.model.CsrSerializedPayload;
-import com.yahoo.vespa.hosted.athenz.instanceproviderservice.config.AthenzProviderServiceConfig;
-import com.yahoo.vespa.hosted.athenz.instanceproviderservice.KeyProvider;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,8 +19,6 @@ import javax.ws.rs.core.MediaType;
 import java.security.cert.X509Certificate;
 import java.util.logging.Logger;
 
-import static com.yahoo.vespa.hosted.athenz.instanceproviderservice.impl.Utils.getZoneConfig;
-
 /**
  * @author bjorncs
  * @author freva
@@ -37,11 +31,8 @@ public class CertificateSignerResource {
     private final CertificateSigner certificateSigner;
 
     @Inject
-    public CertificateSignerResource(@Component AthenzProviderServiceConfig config,
-                                     @Component Zone zone,
-                                     @Component KeyProvider keyProvider) {
-        AthenzProviderServiceConfig.Zones zoneConfig = getZoneConfig(config, zone);
-        this.certificateSigner = new CertificateSigner(keyProvider, zoneConfig, HostName.getLocalhost());
+    public CertificateSignerResource(@Component CertificateSigner certificateSigner) {
+        this.certificateSigner = certificateSigner;
     }
 
     @POST

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGenerator.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGenerator.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.identitydocument;
 
+import com.google.inject.Inject;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.hosted.athenz.instanceproviderservice.KeyProvider;
 import com.yahoo.vespa.hosted.athenz.instanceproviderservice.config.AthenzProviderServiceConfig;
@@ -28,8 +29,12 @@ public class IdentityDocumentGenerator {
     private final String providerDomain;
     private final int signingSecretVersion;
 
-    public IdentityDocumentGenerator(AthenzProviderServiceConfig config, AthenzProviderServiceConfig.Zones zoneConfig,
-                                     NodeRepository nodeRepository, Zone zone, KeyProvider keyProvider) {
+    @Inject
+    public IdentityDocumentGenerator(AthenzProviderServiceConfig config,
+                                     NodeRepository nodeRepository,
+                                     Zone zone,
+                                     KeyProvider keyProvider) {
+        AthenzProviderServiceConfig.Zones zoneConfig = Utils.getZoneConfig(config, zone);
         this.nodeRepository = nodeRepository;
         this.zone = zone;
         this.keyProvider = keyProvider;

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentResource.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentResource.java
@@ -2,12 +2,8 @@
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.identitydocument;
 
 import com.google.inject.Inject;
-import com.yahoo.config.provision.Zone;
 import com.yahoo.container.jaxrs.annotation.Component;
 import com.yahoo.log.LogLevel;
-import com.yahoo.vespa.hosted.athenz.instanceproviderservice.KeyProvider;
-import com.yahoo.vespa.hosted.athenz.instanceproviderservice.config.AthenzProviderServiceConfig;
-import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
@@ -17,8 +13,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.logging.Logger;
-
-import static com.yahoo.vespa.hosted.athenz.instanceproviderservice.impl.Utils.getZoneConfig;
 
 /**
  * @author bjorncs
@@ -31,13 +25,8 @@ public class IdentityDocumentResource {
     private final IdentityDocumentGenerator identityDocumentGenerator;
 
     @Inject
-    public IdentityDocumentResource(@Component AthenzProviderServiceConfig config,
-                                    @Component Zone zone,
-                                    @Component NodeRepository nodeRepository,
-                                    @Component KeyProvider keyProvider) {
-        AthenzProviderServiceConfig.Zones zoneConfig = getZoneConfig(config, zone);
-        this.identityDocumentGenerator =
-                new IdentityDocumentGenerator(config, zoneConfig, nodeRepository, zone, keyProvider);
+    public IdentityDocumentResource(@Component IdentityDocumentGenerator identityDocumentGenerator) {
+        this.identityDocumentGenerator = identityDocumentGenerator;
     }
 
     @GET

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceConfirmationResource.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceConfirmationResource.java
@@ -2,10 +2,8 @@
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.instanceconfirmation;
 
 import com.google.inject.Inject;
-import com.yahoo.config.model.api.SuperModelProvider;
 import com.yahoo.container.jaxrs.annotation.Component;
 import com.yahoo.log.LogLevel;
-import com.yahoo.vespa.hosted.athenz.instanceproviderservice.KeyProvider;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
@@ -26,9 +24,8 @@ public class InstanceConfirmationResource {
     private final InstanceValidator instanceValidator;
 
     @Inject
-    public InstanceConfirmationResource(@Component KeyProvider keyProvider,
-                                        @Component SuperModelProvider superModelProvider) {
-        this.instanceValidator = new InstanceValidator(keyProvider, superModelProvider);
+    public InstanceConfirmationResource(@Component InstanceValidator instanceValidator) {
+        this.instanceValidator = instanceValidator;
     }
 
     @POST

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceValidator.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceValidator.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.instanceconfirmation;
 
+import com.google.inject.Inject;
 import com.yahoo.config.model.api.ApplicationInfo;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.model.api.SuperModelProvider;
@@ -33,6 +34,7 @@ public class InstanceValidator {
     private final KeyProvider keyProvider;
     private final SuperModelProvider superModelProvider;
 
+    @Inject
     public InstanceValidator(KeyProvider keyProvider, SuperModelProvider superModelProvider) {
         this.keyProvider = keyProvider;
         this.superModelProvider = superModelProvider;

--- a/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGeneratorTest.java
+++ b/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGeneratorTest.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.Optional;
 
 import static com.yahoo.vespa.hosted.athenz.instanceproviderservice.TestUtils.getAthenzProviderConfig;
-import static com.yahoo.vespa.hosted.athenz.instanceproviderservice.impl.Utils.getZoneConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -65,12 +64,8 @@ public class IdentityDocumentGeneratorTest {
 
         String dnsSuffix = "vespa.dns.suffix";
         AthenzProviderServiceConfig config = getAthenzProviderConfig("domain", "service", dnsSuffix, ZONE);
-        IdentityDocumentGenerator identityDocumentGenerator = new IdentityDocumentGenerator(
-                config,
-                getZoneConfig(config, ZONE),
-                nodeRepository,
-                ZONE,
-                keyProvider);
+        IdentityDocumentGenerator identityDocumentGenerator =
+                new IdentityDocumentGenerator(config, nodeRepository, ZONE, keyProvider);
         SignedIdentityDocument signedIdentityDocument = identityDocumentGenerator.generateSignedIdentityDocument(hostname);
 
         // Verify attributes


### PR DESCRIPTION
Injection of config instances is not suppored for jax-rs resources.
All dependencies of resources must be components.

FYI @tokle 