### PR TITLE
Ignore logd in vespa-config-status

### DIFF
--- a/configutil/src/lib/configstatus.cpp
+++ b/configutil/src/lib/configstatus.cpp
@@ -165,7 +165,8 @@ ConfigStatus::action()
                     if (!upToDate) {
                         if (svc.type == "searchnode" ||
                             svc.type == "filedistributorservice" ||
-                            svc.type == "topleveldispatch")
+                            svc.type == "topleveldispatch" ||
+                            svc.type == "logd")
                         {
                             std::cerr << "[generation not up-to-date ignored]" << std::endl;
                         } else {


### PR DESCRIPTION
Seems like logd does not do live reconfig, it just started having a
state port, so it was never checked before. Ignore logd for now.