### PR TITLE
Import /zone/v2

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutor.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutor.java
@@ -1,0 +1,14 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import com.yahoo.container.jdisc.HttpResponse;
+
+/**
+ * Executes call against config servers and handles discovery requests. Rest URIs in the response are
+ * rewritten.
+ *
+ * @author Haakon Dybdahl
+ */
+public interface ConfigServerRestExecutor {
+    HttpResponse handle(ProxyRequest proxyRequest) throws ProxyException;
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -1,0 +1,236 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.io.IOUtils;
+import com.yahoo.jdisc.http.HttpRequest.Method;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
+import org.apache.http.Header;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * @author Haakon Dybdahl
+ */
+@SuppressWarnings("unused") // Injected
+public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
+
+    private static final Duration PROXY_REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final ZoneRegistry zoneRegistry;
+
+    public ConfigServerRestExecutorImpl(ZoneRegistry zoneRegistry) {
+        this.zoneRegistry = zoneRegistry;
+    }
+
+    @Override
+    public ProxyResponse handle(ProxyRequest proxyRequest) throws ProxyException {
+        if (proxyRequest.isDiscoveryRequest()) {
+            return createDiscoveryResponse(proxyRequest);
+        }
+
+        Environment environment = Environment.from(proxyRequest.getEnvironment());
+        RegionName region = RegionName.from(proxyRequest.getRegion());
+
+        // Make a local copy of the list as we want to manipulate it in case of ping problems.
+        final List<URI> allServers = new ArrayList<>(zoneRegistry.getConfigServerUris(environment, region));
+
+        StringBuilder errorBuilder = new StringBuilder();
+        if (queueFirstServerIfDown(allServers)) {
+            errorBuilder.append("Change ordering due to failed ping.");
+        }
+        for (URI uri : allServers) {
+            Optional<ProxyResponse> proxyResponse = proxyCall(uri, proxyRequest, errorBuilder);
+            if (proxyResponse.isPresent()) {
+                return proxyResponse.get();
+            }
+        }
+        // TODO Add logging, for now, experimental and we want to not add more noise.
+        throw new ProxyException(ErrorResponse.internalServerError("Failed talking to config servers: "
+                + errorBuilder.toString()));
+    }
+
+    private static class DiscoveryResponseStructure {
+        public List<String> uris = new ArrayList<>();
+    }
+
+    private ProxyResponse createDiscoveryResponse(ProxyRequest proxyRequest) {
+        ObjectMapper mapper = new ObjectMapper();
+        DiscoveryResponseStructure responseStructure = new DiscoveryResponseStructure();
+
+        List<Zone> zones = zoneRegistry.zones();
+        for (Zone zone : zones) {
+            if (!"".equals(proxyRequest.getEnvironment()) &&
+                !proxyRequest.getEnvironment().equals(zone.environment().value())) {
+                continue;
+            }
+            responseStructure.uris.add(proxyRequest.getScheme() + "://" + proxyRequest.getControllerPrefix() +
+                                       zone.environment().name() + "/" + zone.region().value());
+        }
+        JsonNode node = mapper.valueToTree(responseStructure);
+        return new ProxyResponse(proxyRequest, node.toString(), 200, Optional.empty(), "application/json");
+    }
+
+    private String removeFirstSlashIfAny(String url) {
+        if (url.startsWith("/")) {
+            return url.substring(1);
+        }
+        return url;
+    }
+
+    private Optional<ProxyResponse> proxyCall(URI uri, ProxyRequest proxyRequest, StringBuilder errorBuilder)
+            throws ProxyException {
+        String fullUri = uri.toString() + removeFirstSlashIfAny(proxyRequest.getConfigServerRequest());
+        final HttpRequestBase requestBase = createHttpBaseRequest(
+                proxyRequest.getMethod(), fullUri, proxyRequest.getData());
+        // Empty list of headers to copy for now, add headers when needed, or rewrite logic.
+        copyHeaders(proxyRequest.getHeaders(), requestBase, new HashSet<>());
+
+        RequestConfig config = RequestConfig.custom()
+                                            .setConnectTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
+                                            .setConnectionRequestTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
+                                            .setSocketTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis()).build();
+        try (
+                CloseableHttpClient client = createHttpClient(config);
+                CloseableHttpResponse response = client.execute(requestBase);
+        ) {
+            if (response.getStatusLine().getStatusCode() / 100 == 5) {
+                errorBuilder.append("Talking to server ").append(uri.getHost());
+                errorBuilder.append(", got ").append(response.getStatusLine().getStatusCode()).append(" ")
+                            .append(streamToString(response.getEntity().getContent())).append("\n");
+                return Optional.empty();
+            }
+            final Header contentHeader = response.getLastHeader("Content-Type");
+            final String contentType;
+            if (contentHeader != null && contentHeader.getValue() != null && ! contentHeader.getValue().isEmpty()) {
+                contentType = contentHeader.getValue().replace("; charset=UTF-8","");
+            } else {
+                contentType = "application/json";
+            }
+            return Optional.of(new ProxyResponse(
+                    proxyRequest,
+                    streamToString(response.getEntity().getContent()),
+                    response.getStatusLine().getStatusCode(),
+                    Optional.of(uri),
+                    contentType));
+
+            // Send response back
+        } catch (IOException|RuntimeException e) {
+            errorBuilder.append("Talking to server ").append(uri.getHost());
+            errorBuilder.append(" got exception ").append(e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private HttpRequestBase createHttpBaseRequest(String method, String uri, InputStream data) throws ProxyException {
+        Method enumMethod =  Method.valueOf(method);
+        switch (enumMethod) {
+            case GET:
+                return new HttpGet(uri);
+            case POST:
+                HttpPost post = new HttpPost(uri);
+                if (data != null) {
+                    post.setEntity(new InputStreamEntity(data));
+                }
+                return post;
+            case PUT:
+                HttpPut put = new HttpPut(uri);
+                if (data != null) {
+                    put.setEntity(new InputStreamEntity(data));
+                }
+                return put;
+            case DELETE:
+                return new HttpDelete(uri);
+            default:
+                throw new ProxyException(ErrorResponse.methodNotAllowed("Will not proxy such calls."));
+        }
+    }
+
+    private void copyHeaders(Map<String, List<String>> headers, HttpRequestBase toRequest, Set<String> headersToCopy) {
+        for (Map.Entry<String, List<String>> headerEntry : headers.entrySet()) {
+            for (String value : headerEntry.getValue()) {
+                if (headersToCopy.contains(value)) {
+                    toRequest.addHeader(headerEntry.getKey(), value);
+                }
+            }
+        }
+    }
+
+    public static String streamToString(final InputStream inputStream) throws IOException {
+        final StringBuilder out = new StringBuilder();
+        while (true) {
+            byte[] bytesFromStream = IOUtils.readBytes(inputStream, 1024);
+            if (bytesFromStream.length == 0) {
+                return out.toString();
+            }
+            out.append(new String(bytesFromStream, StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * During upgrade, one server can be down, this is normal. Therefor we do a quick ping on the first server,
+     * if it is not responding, we try the other servers first. False positive/negatives are not critical,
+     * but will increase latency to some extent.
+     */
+    private boolean queueFirstServerIfDown(List<URI> allServers) {
+        if (allServers.size() < 2) {
+            return false;
+        }
+        URI uri = allServers.get(0);
+        HttpGet httpget = new HttpGet(uri);
+
+        int timeout = 500;
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(timeout)
+                .setConnectionRequestTimeout(timeout)
+                .setSocketTimeout(timeout).build();
+        try (
+                CloseableHttpClient client = createHttpClient(config);
+                CloseableHttpResponse response = client.execute(httpget);
+
+        ) {
+            if (response.getStatusLine().getStatusCode() == 200) {
+                return false;
+            }
+
+        } catch (IOException e) {
+            // We ignore this, if server is restarting this might happen.
+        }
+        // Some error happened, move this server to the back. The other servers should be running.
+        allServers.remove(0);
+        allServers.add(uri);
+        return true;
+    }
+
+    private static CloseableHttpClient createHttpClient(RequestConfig config) {
+        return HttpClientBuilder.create()
+                .setUserAgent("config-server-client")
+                .setDefaultRequestConfig(config)
+                .build();
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -14,6 +14,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -165,6 +166,12 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
                 return put;
             case DELETE:
                 return new HttpDelete(uri);
+            case PATCH:
+                HttpPatch patch = new HttpPatch(uri);
+                if (data != null) {
+                    patch.setEntity(new InputStreamEntity(data));
+                }
+                return patch;
             default:
                 throw new ProxyException(ErrorResponse.methodNotAllowed("Will not proxy such calls."));
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ErrorResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ErrorResponse.java
@@ -1,0 +1,66 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.JsonFormat;
+import com.yahoo.slime.Slime;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.yahoo.jdisc.Response.Status.BAD_REQUEST;
+import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
+import static com.yahoo.jdisc.Response.Status.METHOD_NOT_ALLOWED;
+import static com.yahoo.jdisc.Response.Status.NOT_FOUND;
+
+/**
+ * Class for generating error responses.
+ *
+ * @author Haakon Dybdahl
+ */
+public class ErrorResponse extends HttpResponse {
+
+    private final Slime slime = new Slime();
+    public final String message;
+
+    public ErrorResponse(int code, String errorType, String message) {
+        super(code);
+        this.message = message;
+        Cursor root = slime.setObject();
+        root.setString("error-code", errorType);
+        root.setString("message", message);
+    }
+
+    public enum errorCodes {
+        NOT_FOUND,
+        BAD_REQUEST,
+        METHOD_NOT_ALLOWED,
+        INTERNAL_SERVER_ERROR,
+
+    }
+
+    public static ErrorResponse notFoundError(String message) {
+        return new ErrorResponse(NOT_FOUND, errorCodes.NOT_FOUND.name(), message);
+    }
+
+    public static ErrorResponse internalServerError(String message) {
+        return new ErrorResponse(INTERNAL_SERVER_ERROR, errorCodes.INTERNAL_SERVER_ERROR.name(), message);
+    }
+
+    public static ErrorResponse badRequest(String message) {
+        return new ErrorResponse(BAD_REQUEST, errorCodes.BAD_REQUEST.name(), message);
+    }
+
+    public static ErrorResponse methodNotAllowed(String message) {
+        return new ErrorResponse(METHOD_NOT_ALLOWED, errorCodes.METHOD_NOT_ALLOWED.name(), message);
+    }
+
+    @Override
+    public void render(OutputStream stream) throws IOException {
+        new JsonFormat(true).encode(stream, slime);
+    }
+
+    @Override
+    public String getContentType() { return "application/json"; }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyException.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyException.java
@@ -1,0 +1,16 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+/**
+ * Exceptions related to proxying calls to config servers.
+ *
+ * @author Haakon Dybdahl
+ */
+public class ProxyException extends Exception {
+    public final ErrorResponse errorResponse;
+
+    public ProxyException(ErrorResponse errorResponse) {
+        super(errorResponse.message);
+        this.errorResponse = errorResponse;
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
@@ -1,0 +1,119 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import com.yahoo.container.jdisc.HttpRequest;
+import com.yahoo.net.HostName;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Keeping information about the calls that are being proxied.
+ * A request is of form /zone/v2/[environment]/[region]/[config-server-path]
+ *
+ * @author Haakon Dybdahl
+ */
+public class ProxyRequest {
+
+    private final String environment;
+    private final String region;
+    private final String configServerRequest;
+    private final InputStream requestData;
+    private final Map<String, List<String>> headers;
+    private final String method;
+    private final String controllerPrefix;
+    private final String scheme;
+
+    /**
+     * The constructor calls exception if the request is invalid.
+     *
+     * @param request the request from the jdisc framework.
+     * @param pathPrefix the path prefix of the proxy.
+     * @throws ProxyException on errors
+     */
+    public ProxyRequest(HttpRequest request, String pathPrefix) throws ProxyException, IOException {
+        this(request.getUri(), request.getJDiscRequest().headers(), request.getData(), request.getMethod().name(),
+             pathPrefix);
+    }
+
+    ProxyRequest(URI requestUri, Map<String, List<String>> headers, InputStream body, String method,
+                 String pathPrefix) throws ProxyException, IOException {
+        if (requestUri == null) {
+            throw new ProxyException(ErrorResponse.badRequest("Request not set."));
+        }
+        final String path = URLDecoder.decode(requestUri.getPath(),"UTF-8");
+        if (! path.startsWith(pathPrefix)) {
+            // This has to be caused by wrong mapping of path in services.xml.
+            throw new ProxyException(ErrorResponse.notFoundError("Request not starting with " + pathPrefix));
+        }
+        final String uriNoPrefix = path.replaceFirst(pathPrefix, "")
+                + (requestUri.getRawQuery() == null ? "" : "?" + requestUri.getRawQuery());
+
+        final String[] parts = uriNoPrefix.split("/");
+
+        this.environment = parts.length > 0 ? parts[0] : "";
+        this.region = parts.length > 1 ? parts[1] : "";
+        this.configServerRequest = parts.length > 2 ? uriNoPrefix.replace(environment + "/" + region, "") : "";
+        this.requestData = body;
+        this.headers = headers;
+        this.method = method;
+
+        String hostPort = headers.containsKey("host")
+                ? headers.get("host").get(0)
+                : HostName.getLocalhost() + ":" + requestUri.getPort();
+        StringBuilder prefix = new StringBuilder(hostPort + pathPrefix);
+        if (! environment.isEmpty()) {
+            prefix.append(environment).append("/").append(region);
+        }
+
+        this.controllerPrefix = prefix.toString();
+        this.scheme = requestUri.getScheme();
+    }
+
+    /**
+     * A discovery query lists environments and regions.
+     */
+    public boolean isDiscoveryRequest() {
+        return region.isEmpty();
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public String getConfigServerRequest() {
+        return configServerRequest;
+    }
+
+    public InputStream getData() {
+        return requestData;
+    }
+
+    @Override
+    public String toString() {
+        return "[ region: " + region + " env: " + environment + " request: " + configServerRequest + "]";
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getControllerPrefix() {
+        return controllerPrefix;
+    }
+
+    public String getScheme() { return scheme; }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponse.java
@@ -1,0 +1,64 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import com.yahoo.container.jdisc.HttpResponse;
+import org.apache.http.client.utils.URIBuilder;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Response class that also rewrites URL from config server.
+ *
+ * @author Haakon Dybdahl
+ */
+public class ProxyResponse  extends HttpResponse {
+
+    private final String bodyResponseRewritten;
+    private final String contentType;
+
+    public ProxyResponse(
+            ProxyRequest controllerRequest,
+            String bodyResponse,
+            int statusResponse,
+            Optional<URI> configServer,
+            String contentType) {
+        super(statusResponse);
+        this.contentType = contentType;
+
+        if (! configServer.isPresent() || controllerRequest.getControllerPrefix().isEmpty()) {
+            bodyResponseRewritten = bodyResponse;
+            return;
+        }
+
+        final String configServerPrefix;
+        final String controllerRequestPrefix;
+        try {
+            configServerPrefix = new URIBuilder()
+                    .setScheme(configServer.get().getScheme())
+                    .setHost(configServer.get().getHost())
+                    .setPort(configServer.get().getPort())
+                    .build().toString();
+            controllerRequestPrefix = new URIBuilder()
+                    .setScheme(controllerRequest.getScheme())
+                    // controller prefix is more than host, so it is a bit hackish, but verified by tests.
+                    .setHost(controllerRequest.getControllerPrefix())
+                    .build().toString();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        bodyResponseRewritten = bodyResponse.replace(configServerPrefix, controllerRequestPrefix);
+    }
+
+    @Override
+    public void render(OutputStream stream) throws IOException {
+        stream.write(bodyResponseRewritten.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String getContentType() { return contentType; }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/package-info.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/package-info.java
@@ -1,0 +1,8 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.vespa.hosted.controller.proxy;
+
+/**
+ * @author Haakon Dybdahl
+ */
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/Path.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/Path.java
@@ -76,8 +76,8 @@ public class Path {
             StringBuilder rest = new StringBuilder();
             for (int i = specElements.length; i < this.elements.length; i++)
                 rest.append(elements[i]).append("/");
-            if ( ! pathString.endsWith("/"))
-                rest.setLength(rest.length() -1);
+            if ( ! pathString.endsWith("/") && rest.length() > 0)
+                rest.setLength(rest.length() - 1);
             this.rest = rest.toString();
         }
         

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiHandler.java
@@ -115,16 +115,17 @@ public class ZoneApiHandler extends LoggingRequestHandler {
         Slime slime = new Slime();
         Cursor root = slime.setObject();
         root.setString("name", region.value());
-        root.setString("url", request.getUri().resolve("region").resolve(region.value()).toString());
+        root.setString("url", request.getUri()
+                                     .resolve("/zone/v2/environment/")
+                                     .resolve(environment.value() + "/")
+                                     .resolve("region/")
+                                     .resolve(region.value())
+                                     .toString());
         return new SlimeJsonResponse(slime);
     }
 
     private HttpResponse notFound(Path path) {
         return ErrorResponse.notFoundError("Nothing at " + path);
-    }
-
-    private static String url(HttpRequest request, String path) {
-        return request.getUri().resolve(path).toString();
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
@@ -1,0 +1,116 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.restapi.zone.v2;
+
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.container.jdisc.HttpRequest;
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.logging.AccessLog;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Slime;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
+import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
+import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
+import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
+import com.yahoo.vespa.hosted.controller.restapi.ErrorResponse;
+import com.yahoo.vespa.hosted.controller.restapi.Path;
+import com.yahoo.vespa.hosted.controller.restapi.SlimeJsonResponse;
+import com.yahoo.yolean.Exceptions;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
+
+/**
+ * REST API for proxying requests to config servers in a given zone (version 2).
+ *
+ * This API does something completely different from /zone/v1, but such is the world.
+ *
+ * @author mpolden
+ */
+@SuppressWarnings("unused")
+public class ZoneApiHandler extends LoggingRequestHandler {
+
+    private final ZoneRegistry zoneRegistry;
+    private final ConfigServerRestExecutor proxy;
+
+    public ZoneApiHandler(Executor executor, AccessLog accessLog, ZoneRegistry zoneRegistry,
+                          ConfigServerRestExecutor proxy) {
+        super(executor, accessLog);
+        this.zoneRegistry = zoneRegistry;
+        this.proxy = proxy;
+    }
+
+    @Override
+    public HttpResponse handle(HttpRequest request) {
+        try {
+            switch (request.getMethod()) {
+                case GET:
+                    return get(request);
+                case POST:
+                case PUT:
+                case DELETE:
+                case PATCH:
+                    return proxy(request);
+                default:
+                    return ErrorResponse.methodNotAllowed("Method '" + request.getMethod() + "' is unsupported");
+            }
+        } catch (IllegalArgumentException e) {
+            return ErrorResponse.badRequest(Exceptions.toMessageString(e));
+        } catch (RuntimeException e) {
+            log.log(Level.WARNING, "Unexpected error handling '" + request.getUri() + "'", e);
+            return ErrorResponse.internalServerError(Exceptions.toMessageString(e));
+        }
+    }
+
+    private HttpResponse get(HttpRequest request) {
+        Path path = new Path(request.getUri().getPath());
+        if (path.matches("/zone/v2")) {
+            return root(request);
+        }
+        return proxy(request);
+    }
+
+    private HttpResponse proxy(HttpRequest request) {
+        Path path = new Path(request.getUri().getPath());
+        if (!path.matches("/zone/v2/{environment}/{region}/{*}")) {
+            return notFound(path);
+        }
+        Environment environment = Environment.from(path.get("environment"));
+        RegionName region = RegionName.from(path.get("region"));
+        Optional<Zone> zone = zoneRegistry.getZone(environment, region);
+        if (!zone.isPresent()) {
+            throw new IllegalArgumentException("No such zone: " + environment.value() + "." + region.value());
+        }
+        try {
+            return proxy.handle(new ProxyRequest(request, "/zone/v2/"));
+        } catch (ProxyException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpResponse root(HttpRequest request) {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+        Cursor uris = root.setArray("uris");
+        zoneRegistry.zones().forEach(zone -> uris.addString(request.getUri()
+                                                               .resolve("/zone/v2/")
+                                                               .resolve(zone.environment().value() + "/")
+                                                               .resolve(zone.region().value())
+                                                               .toString()));
+        Cursor zones = root.setArray("zones");
+        zoneRegistry.zones().forEach(zone -> {
+            Cursor object = zones.addObject();
+            object.setString("environment", zone.environment().value());
+            object.setString("region", zone.region().value());
+        });
+        return new SlimeJsonResponse(slime);
+    }
+
+    private HttpResponse notFound(Path path) {
+        return ErrorResponse.notFoundError("Nothing at " + path);
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/package-info.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+/**
+ * @author mpolden
+ */
+package com.yahoo.vespa.hosted.controller.restapi.zone.v2;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ConfigServerProxyMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ConfigServerProxyMock.java
@@ -1,0 +1,43 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller;
+
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
+import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
+import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
+import com.yahoo.vespa.hosted.controller.restapi.StringResponse;
+
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Scanner;
+
+/**
+ * @author mpolden
+ */
+public class ConfigServerProxyMock extends AbstractComponent implements ConfigServerRestExecutor {
+
+    private volatile ProxyRequest lastReceived = null;
+    private volatile String requestBody = null;
+
+    @Override
+    public HttpResponse handle(ProxyRequest proxyRequest) throws ProxyException {
+        lastReceived = proxyRequest;
+        // Copy request body as the input stream is drained once the request completes
+        requestBody = asString(proxyRequest.getData());
+        return new StringResponse("ok");
+    }
+
+    public Optional<ProxyRequest> lastReceived() {
+        return Optional.ofNullable(lastReceived);
+    }
+
+    public Optional<String> lastRequestBody() {
+        return Optional.ofNullable(requestBody);
+    }
+
+    private static String asString(InputStream inputStream) {
+        Scanner scanner = new Scanner(inputStream).useDelimiter("\\A");
+        return scanner.hasNext() ? scanner.next() : "";
+    }
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
@@ -1,0 +1,83 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Haakon Dybdahl
+ */
+public class ProxyRequestTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testEmpty() throws Exception {
+        exception.expectMessage("Request not set.");
+        testRequest(null, "/zone/v2/");
+    }
+
+    @Test
+    public void testBadUri() throws Exception {
+        exception.expectMessage("Request not starting with /zone/v2/");
+        testRequest(URI.create("http://foo"), "/zone/v2/");
+    }
+
+    @Test
+    public void testConfigRequestEmpty() throws Exception {
+        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo/bar"), "/zone/v2/");
+        assertEquals("foo", proxyRequest.getEnvironment());
+        assertEquals("bar", proxyRequest.getRegion());
+        assertFalse(proxyRequest.isDiscoveryRequest());
+        assertTrue(proxyRequest.getConfigServerRequest().isEmpty());
+
+    }
+
+    @Test
+    public void testDiscoveryRequest() throws Exception {
+        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo"), "/zone/v2/");
+        assertEquals("foo", proxyRequest.getEnvironment());
+        assertTrue(proxyRequest.isDiscoveryRequest());
+
+    }
+
+    @Test
+    public void testProxyRequest() throws Exception {
+        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo/bar/bla/bla/v1/something"),
+                                                "/zone/v2/");
+        assertEquals("foo", proxyRequest.getEnvironment());
+        assertEquals("/bla/bla/v1/something", proxyRequest.getConfigServerRequest());
+    }
+
+    @Test
+    public void testProxyRequestWithParameters() throws Exception {
+        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo/bar/something?p=v&q=y"),
+                                                "/zone/v2/");
+        assertEquals("foo", proxyRequest.getEnvironment());
+        assertEquals("/something?p=v&q=y", proxyRequest.getConfigServerRequest());
+    }
+
+    private static ProxyRequest testRequest(URI url, String pathPrefix) throws IOException, ProxyException {
+        return new ProxyRequest(url, headers("controller:49152"), null, "GET", pathPrefix);
+    }
+
+    private static Map<String, List<String>> headers(String hostPort) {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("host", Collections.singletonList(hostPort));
+        return Collections.unmodifiableMap(headers);
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
@@ -1,0 +1,69 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Haakon Dybdahl
+ */
+public class ProxyResponseTest {
+
+    @Test
+    public void testRewriteUrl() throws Exception {
+        String controllerPrefix = "/zone/v2/";
+        URI configServer = URI.create("http://configserver:1234");
+        ProxyRequest request = new ProxyRequest(URI.create("http://foo/zone/v2/env/region/configserver"),
+                                                headers("controller:49152"), null, "GET",
+                                                controllerPrefix);
+        ProxyResponse proxyResponse = new ProxyResponse(
+                request,
+                "response link is http://configserver:1234/bla/bla/",
+                200,
+                Optional.of(configServer),
+                "application/json");
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        proxyResponse.render(outputStream);
+        String document = new String(outputStream.toByteArray(),"UTF-8");
+        assertEquals("response link is http://controller:49152/zone/v2/env/region/bla/bla/", document);
+    }
+
+    @Test
+    public void testRewriteSecureUrl() throws Exception {
+        String controllerPrefix = "/zone/v2/";
+        URI configServer = URI.create("http://configserver:1234");
+        ProxyRequest request = new ProxyRequest(URI.create("https://foo/zone/v2/env/region/configserver"),
+                                                headers("controller:49152"), null, "GET",
+                                                controllerPrefix);
+        ProxyResponse proxyResponse = new ProxyResponse(
+                request,
+                "response link is http://configserver:1234/bla/bla/",
+                200,
+                Optional.of(configServer),
+                "application/json");
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        proxyResponse.render(outputStream);
+        String document = new String(outputStream.toByteArray(),"UTF-8");
+        assertEquals("response link is https://controller:49152/zone/v2/env/region/bla/bla/", document);
+    }
+
+    private static Map<String, List<String>> headers(String hostPort) {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("host", Collections.singletonList(hostPort));
+        return Collections.unmodifiableMap(headers);
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
@@ -48,6 +48,7 @@ public class ControllerContainerTest {
             "  <component id='com.yahoo.vespa.hosted.controller.ConfigServerClientMock'/>" +
             "  <component id='com.yahoo.vespa.hosted.controller.ZoneRegistryMock'/>" +
             "  <component id='com.yahoo.vespa.hosted.controller.Controller'/>" +
+            "  <component id='com.yahoo.vespa.hosted.controller.ConfigServerProxyMock'/>" +
             "  <component id='com.yahoo.vespa.hosted.controller.integration.MockMetricsService'/>" +
             "  <component id='com.yahoo.vespa.hosted.controller.maintenance.ControllerMaintenance'/>" +
             "  <component id='com.yahoo.vespa.hosted.controller.maintenance.JobControl'/>" +
@@ -73,6 +74,10 @@ public class ControllerContainerTest {
             "  <handler id='com.yahoo.vespa.hosted.controller.restapi.zone.v1.ZoneApiHandler'>" +
             "    <binding>http://*/zone/v1</binding>" +
             "    <binding>http://*/zone/v1/*</binding>" +
+            "  </handler>" +
+            "  <handler id='com.yahoo.vespa.hosted.controller.restapi.zone.v2.ZoneApiHandler'>" +
+            "    <binding>http://*/zone/v2</binding>" +
+            "    <binding>http://*/zone/v2/*</binding>" +
             "  </handler>" +
             "</jdisc>";
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/default-for-region.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/default-for-region.json
@@ -1,4 +1,4 @@
 {
   "name": "us-north-2",
-  "url": "http://localhost:8080/zone/v1/environment/dev/us-north-2"
+  "url": "http://localhost:8080/zone/v2/environment/dev/region/us-north-2"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/no-default-region.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/no-default-region.json
@@ -1,0 +1,4 @@
+{
+  "error-code": "BAD_REQUEST",
+  "message": "No default region for environment: prod"
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiTest.java
@@ -1,0 +1,117 @@
+package com.yahoo.vespa.hosted.controller.restapi.zone.v2;
+
+import com.yahoo.application.container.handler.Request;
+import com.yahoo.application.container.handler.Request.Method;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.text.Utf8;
+import com.yahoo.vespa.hosted.controller.ConfigServerProxyMock;
+import com.yahoo.vespa.hosted.controller.ZoneRegistryMock;
+import com.yahoo.vespa.hosted.controller.restapi.ContainerControllerTester;
+import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author mpolden
+ */
+public class ZoneApiTest extends ControllerContainerTest {
+
+    private static final String responseFiles = "src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/";
+    private static final List<Zone> zones = Arrays.asList(
+            new Zone(Environment.prod, RegionName.from("us-north-1")),
+            new Zone(Environment.dev, RegionName.from("us-north-2")),
+            new Zone(Environment.test, RegionName.from("us-north-3")),
+            new Zone(Environment.staging, RegionName.from("us-north-4"))
+    );
+
+    private ContainerControllerTester tester;
+    private ConfigServerProxyMock proxy;
+
+    @Before
+    public void before() {
+        ZoneRegistryMock zoneRegistry = (ZoneRegistryMock) container.components()
+                                                                    .getComponent(ZoneRegistryMock.class.getName());
+        zoneRegistry.setDefaultRegionForEnvironment(Environment.dev, RegionName.from("us-north-2"))
+                    .setZones(zones);
+        this.tester = new ContainerControllerTester(container, responseFiles);
+        this.proxy = (ConfigServerProxyMock) container.components().getComponent(ConfigServerProxyMock.class.getName());
+    }
+
+    @Test
+    public void test_requests() throws Exception {
+        // GET /zone/v2
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2"),
+                                                new File("root.json"));
+
+        // GET /zone/v2/prod/us-north-1
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/prod/us-north-1"),
+                                                "ok");
+        assertEquals("prod", proxy.lastReceived().get().getEnvironment());
+        assertEquals("us-north-1", proxy.lastReceived().get().getRegion());
+        assertEquals("", proxy.lastReceived().get().getConfigServerRequest());
+        assertEquals("GET", proxy.lastReceived().get().getMethod());
+
+        // GET /zone/v2/nodes/v2/node/?recursive=true
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/node/?recursive=true"),
+                                                "ok");
+
+        assertEquals("prod", proxy.lastReceived().get().getEnvironment());
+        assertEquals("us-north-1", proxy.lastReceived().get().getRegion());
+        assertEquals("/nodes/v2/node/?recursive=true", proxy.lastReceived().get().getConfigServerRequest());
+        assertEquals("GET", proxy.lastReceived().get().getMethod());
+
+        // POST /zone/v2/dev/us-north-2/nodes/v2/command/restart?hostname=node1
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/dev/us-north-2/nodes/v2/command/restart?hostname=node1",
+                                                            new byte[0], Method.POST),
+                                                "ok");
+        assertEquals("dev", proxy.lastReceived().get().getEnvironment());
+        assertEquals("us-north-2", proxy.lastReceived().get().getRegion());
+        assertEquals("/nodes/v2/command/restart?hostname=node1", proxy.lastReceived().get().getConfigServerRequest());
+        assertEquals("POST", proxy.lastReceived().get().getMethod());
+
+        // PUT /zone/v2/prod/us-north-1/nodes/v2/state/dirty/node1
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/state/dirty/node1",
+                                                            new byte[0], Method.PUT), "ok");
+        assertEquals("prod", proxy.lastReceived().get().getEnvironment());
+        assertEquals("us-north-1", proxy.lastReceived().get().getRegion());
+        assertEquals("/nodes/v2/state/dirty/node1", proxy.lastReceived().get().getConfigServerRequest());
+        assertEquals("PUT", proxy.lastReceived().get().getMethod());
+
+        // DELETE /zone/v2/prod/us-north-1/nodes/v2/node/node1
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/node/node1",
+                                                            new byte[0], Method.DELETE), "ok");
+        assertEquals("prod", proxy.lastReceived().get().getEnvironment());
+        assertEquals("us-north-1", proxy.lastReceived().get().getRegion());
+        assertEquals("/nodes/v2/node/node1", proxy.lastReceived().get().getConfigServerRequest());
+        assertEquals("DELETE", proxy.lastReceived().get().getMethod());
+
+        // PATCH /zone/v2/prod/us-north-1/nodes/v2/node/node1
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/node/node1",
+                                                            Utf8.toBytes("{\"currentRestartGeneration\": 1}"),
+                                                            Method.PATCH), "ok");
+        assertEquals("prod", proxy.lastReceived().get().getEnvironment());
+        assertEquals("us-north-1", proxy.lastReceived().get().getRegion());
+        assertEquals("/nodes/v2/node/node1", proxy.lastReceived().get().getConfigServerRequest());
+        assertEquals("PATCH", proxy.lastReceived().get().getMethod());
+        assertEquals("{\"currentRestartGeneration\": 1}", proxy.lastRequestBody().get());
+    }
+
+    @Test
+    public void test_invalid_requests() throws Exception {
+        // GET /zone/v2/prod/us-north-34/nodes/v2
+        tester.containerTester().assertResponse(new Request("http://localhost:8080/zone/v2/prod/us-north-42/nodes/v2",
+                                                            new byte[0], Method.POST),
+                                                new File("unknown-zone.json"), 400);
+        assertFalse(proxy.lastReceived().isPresent());
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/root.json
@@ -1,0 +1,26 @@
+{
+  "uris": [
+    "http://localhost:8080/zone/v2/prod/us-north-1",
+    "http://localhost:8080/zone/v2/dev/us-north-2",
+    "http://localhost:8080/zone/v2/test/us-north-3",
+    "http://localhost:8080/zone/v2/staging/us-north-4"
+  ],
+  "zones": [
+    {
+      "environment": "prod",
+      "region": "us-north-1"
+    },
+    {
+      "environment": "dev",
+      "region": "us-north-2"
+    },
+    {
+      "environment": "test",
+      "region": "us-north-3"
+    },
+    {
+      "environment": "staging",
+      "region": "us-north-4"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/unknown-zone.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/unknown-zone.json
@@ -1,0 +1,4 @@
+{
+  "error-code": "BAD_REQUEST",
+  "message": "No such zone: prod.us-north-42"
+}


### PR DESCRIPTION
The last commit is the most interesting one. Second to last is just a code import from internal repo, the package could use a cleanup, but decided to not do that right now.

This rewrite solves several outstanding issues:
* Proxy of root, e.g `/zone/v2/prod/us-north-1`. Now proxied to config server root.
* Adds PATCH support. Old implementation already had `POST`, `PUT` and `DELETE` and allowing `PATCH` was easy enough.
* Poor handling of exceptions and invalid requests in both `/zone/v1` and `/zone/v2`
* More controller things open sourced 🎉 
* -1 Maven module 🎉 

Will update `services.xml` to use these handlers when CD becomes less red.

FYI @bjorncs @tokle @frodelu 