### PR TITLE
Handle activaRotation property not being set

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/model/LbServicesProducer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/model/LbServicesProducer.java
@@ -75,7 +75,7 @@ public class LbServicesProducer implements LbServicesConfig.Producer {
                             serviceInfo.getServiceType().equals("qrserver")).
                     findAny();
             if (container.isPresent()) {
-                activeRotation |= Boolean.valueOf(container.get().getProperty("activeRotation").get());
+                activeRotation |= Boolean.valueOf(container.get().getProperty("activeRotation").orElse("false"));
             }
         }
         return activeRotation;


### PR DESCRIPTION
Note that it might not be set in older config models too, so
this will handle that case also