### PR TITLE
Implement chained download of file references

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -2,24 +2,33 @@
 package com.yahoo.vespa.config.server.filedistribution;
 
 import com.google.inject.Inject;
+import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.FileReference;
 import com.yahoo.config.model.api.FileDistribution;
 import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.io.IOUtils;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.jrt.Transport;
+import com.yahoo.net.HostName;
+import com.yahoo.vespa.config.Connection;
+import com.yahoo.vespa.config.ConnectionPool;
 import com.yahoo.vespa.config.JRTConnectionPool;
+import com.yahoo.vespa.config.server.ConfigServerSpec;
 import com.yahoo.vespa.filedistribution.FileDownloader;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class FileServer {
     private static final Logger log = Logger.getLogger(FileServer.class.getName());
     private final FileDirectory root;
     private final ExecutorService executor;
-    private final FileDownloader downloader = new FileDownloader(new JRTConnectionPool(ConfigSourceSet.createDefault()));
+    private final FileDownloader downloader;
 
     public static class ReplayStatus {
         private final int code;
@@ -38,18 +47,21 @@ public class FileServer {
     }
 
     @Inject
-    public FileServer() {
-        this(FileDistribution.getDefaultFileDBPath());
+    public FileServer(ConfigserverConfig configserverConfig) {
+        this(createConnectionPool(configserverConfig), FileDistribution.getDefaultFileDBPath());
     }
 
+    // For testing only
     public FileServer(File rootDir) {
-        this(rootDir, Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+        this(new EmptyConnectionPool(), rootDir);
     }
 
-    public FileServer(File rootDir, ExecutorService executor) {
+    private FileServer(ConnectionPool connectionPool, File rootDir) {
+        this.downloader = new FileDownloader(connectionPool);
         this.root = new FileDirectory(rootDir);
-        this.executor = executor;
+        this.executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
     }
+
     public boolean hasFile(String fileName) {
         return hasFile(new FileReference(fileName));
     }
@@ -93,5 +105,41 @@ public class FileServer {
 
     public void download(FileReference fileReference) {
         downloader.getFile(fileReference);
+    }
+
+    public FileDownloader downloader() {
+        return downloader;
+    }
+
+    // Connection pool with all config servers except this one (might be an empty pool if there is only one config server)
+    private static ConnectionPool createConnectionPool(ConfigserverConfig configserverConfig) {
+        List<String> configServers = ConfigServerSpec.fromConfig(configserverConfig)
+                .stream()
+                .filter(spec -> !spec.getHostName().equals(HostName.getLocalhost()))
+                .map(spec -> "tcp/" + spec.getHostName() + ":" + spec.getConfigServerPort())
+                .collect(Collectors.toList());
+
+        return configServers.size() > 0 ? new JRTConnectionPool(new ConfigSourceSet(configServers)) : new EmptyConnectionPool();
+    }
+
+    private static class EmptyConnectionPool implements ConnectionPool {
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void setError(Connection connection, int i) {}
+
+        @Override
+        public Connection getCurrent() { return null; }
+
+        @Override
+        public Connection setNewCurrentConnection() { return null; }
+
+        @Override
+        public int getSize() { return 0; }
+
+        @Override
+        public Supervisor getSupervisor() { return new Supervisor(new Transport()); }
     }
 }

--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -34,6 +34,7 @@
     <component id="com.yahoo.config.provision.Zone" bundle="config-provisioning" />
     <component id="com.yahoo.vespa.config.server.application.ApplicationConvergenceChecker" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.application.HttpProxy" bundle="configserver" />
+    <component id="com.yahoo.vespa.config.server.filedistribution.FileServer" bundle="configserver" />
 
     <component id="com.yahoo.vespa.serviceview.ConfigServerLocation" bundle="configserver" />
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -146,8 +146,7 @@ public class FileDownloader {
         fileReferenceDownloader.addToDownloadQueue(fileReferenceDownload);
     }
 
-    Set<FileReference> queuedDownloads() {
-        return fileReferenceDownloader.queuedDownloads();
+    public FileReferenceDownloader fileReferenceDownloader() {
+        return fileReferenceDownloader;
     }
-
 }


### PR DESCRIPTION
* A config server will download from another one (if possible) if it
  does not have the file itself.
* Set error in connection pool when request fails
* Use an empty connection pool if only one server