### PR TITLE
Fix url fields in /zone/v1

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiHandler.java
@@ -79,9 +79,8 @@ public class ZoneApiHandler extends LoggingRequestHandler {
         environments.forEach(environment -> {
             Cursor object = root.addObject();
             object.setString("name", environment.value());
-            // Returning /zone/v2 is a bit strange, but that's what the original Jersey implementation did
             object.setString("url", request.getUri()
-                                           .resolve("/zone/v2/environment/")
+                                           .resolve("/zone/v1/environment/")
                                            .resolve(environment.value())
                                            .toString());
         });
@@ -97,12 +96,7 @@ public class ZoneApiHandler extends LoggingRequestHandler {
         zones.forEach(zone -> {
             Cursor object = root.addObject();
             object.setString("name", zone.region().value());
-            object.setString("url", request.getUri()
-                                           .resolve("/zone/v2/environment/")
-                                           .resolve(environment.value() + "/")
-                                           .resolve("region/")
-                                           .resolve(zone.region().value())
-                                           .toString());
+            object.setString("url", request.getUri().toString());
         });
         return new SlimeJsonResponse(slime);
     }
@@ -115,12 +109,7 @@ public class ZoneApiHandler extends LoggingRequestHandler {
         Slime slime = new Slime();
         Cursor root = slime.setObject();
         root.setString("name", region.value());
-        root.setString("url", request.getUri()
-                                     .resolve("/zone/v2/environment/")
-                                     .resolve(environment.value() + "/")
-                                     .resolve("region/")
-                                     .resolve(region.value())
-                                     .toString());
+        root.setString("url", request.getUri().toString());
         return new SlimeJsonResponse(slime);
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/default-for-region.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/default-for-region.json
@@ -1,4 +1,4 @@
 {
   "name": "us-north-2",
-  "url": "http://localhost:8080/zone/v2/environment/dev/region/us-north-2"
+  "url": "http://localhost:8080/zone/v1/environment/dev/default"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/prod.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/prod.json
@@ -1,6 +1,6 @@
 [
   {
     "name": "us-north-1",
-    "url": "http://localhost:8080/zone/v2/environment/prod/region/us-north-1"
+    "url": "http://localhost:8080/zone/v1/environment/prod"
   }
 ]

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/root.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "dev",
-    "url": "http://localhost:8080/zone/v2/environment/dev"
+    "url": "http://localhost:8080/zone/v1/environment/dev"
   },
   {
     "name": "prod",
-    "url": "http://localhost:8080/zone/v2/environment/prod"
+    "url": "http://localhost:8080/zone/v1/environment/prod"
   },
   {
     "name": "staging",
-    "url": "http://localhost:8080/zone/v2/environment/staging"
+    "url": "http://localhost:8080/zone/v1/environment/staging"
   },
   {
     "name": "test",
-    "url": "http://localhost:8080/zone/v2/environment/test"
+    "url": "http://localhost:8080/zone/v1/environment/test"
   }
 ]


### PR DESCRIPTION
Returning /zone/v2 URLs seems to have been a bug in the original implementation
as it returned invalid /zone/v2 URLs.