### PR TITLE
Freva/docker container kernel usage

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/SystemMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/SystemMetrics.java
@@ -11,6 +11,7 @@ import java.util.Set;
 @SuppressWarnings("UnusedDeclaration") // Used by model amenders
 public class SystemMetrics {
     public static final String CPU_UTIL = "cpu.util";
+    public static final String CPU_SYS_UTIL = "cpu.sys.util";
     public static final String DISK_LIMIT = "disk.limit";
     public static final String DISK_USED = "disk.used";
     public static final String DISK_UTIL = "disk.util";
@@ -23,6 +24,7 @@ public class SystemMetrics {
     private static MetricSet createSystemMetricSet() {
         Set<Metric> dockerNodeMetrics =
                 ImmutableSet.of(new Metric(CPU_UTIL),
+                                new Metric(CPU_SYS_UTIL),
                                 new Metric(DISK_LIMIT),
                                 new Metric(DISK_USED),
                                 new Metric(DISK_UTIL),

--- a/node-admin/src/test/resources/docker.stats.json
+++ b/node-admin/src/test/resources/docker.stats.json
@@ -36,7 +36,7 @@
         44567860460,
         39049895962
       ],
-      "usage_in_kernelmode":44050000000,
+      "usage_in_kernelmode":44106083850,
       "usage_in_usermode":158950000000
     },
     "system_cpu_usage":5876882680000000,

--- a/node-admin/src/test/resources/expected.container.system.metrics.txt
+++ b/node-admin/src/test/resources/expected.container.system.metrics.txt
@@ -11,6 +11,7 @@ s:
         "mem.limit": 4294967296,
         "mem.used": 1073741824,
         "disk.used": 39625000000,
+        "cpu.sys.util": 3.402,
         "disk.util": 15.85,
         "cpu.util": 5.4,
         "mem.util": 25.0,


### PR DESCRIPTION
Adds `vespa.node.cpu.sys.util` metric which reports % of allocated CPU time container spent in kernel mode.

FYI: @ldalves 