### PR TITLE
Add setting for turning off file distributor

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/ConfigModelContext.java
+++ b/config-model/src/main/java/com/yahoo/config/model/ConfigModelContext.java
@@ -5,17 +5,14 @@ import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
-import org.w3c.dom.Element;
 
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
  * This class contains a context that is passed to a model builder, and can be used to retrieve the application package,
  * logger etc.
  *
- * @author lulf
- * @since 5.1
+ * @author Ulf Lilleengen
  */
 public final class ConfigModelContext {
 

--- a/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
+++ b/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
@@ -75,7 +75,11 @@ public class AdminModel extends ConfigModel {
         public void doBuild(AdminModel model, Element adminElement, ConfigModelContext modelContext) {
             AbstractConfigProducer parent = modelContext.getParentProducer();
             DeployProperties properties = modelContext.getDeployState().getProperties();
-            DomAdminV2Builder domBuilder = new DomAdminV2Builder(modelContext.getApplicationType(), modelContext.getDeployState().getFileRegistry(), properties.multitenant(), properties.configServerSpecs());
+            DomAdminV2Builder domBuilder = new DomAdminV2Builder(modelContext.getApplicationType(),
+                                                                 modelContext.getDeployState().getFileRegistry(),
+                                                                 properties.multitenant(),
+                                                                 properties.configServerSpecs(),
+                                                                 modelContext.getDeployState().disableFiledistributor());
             model.admin = domBuilder.build(parent, adminElement);
             // TODO: Is required since other models depend on admin.
             if (parent instanceof ApplicationConfigProducerRoot) {
@@ -101,7 +105,11 @@ public class AdminModel extends ConfigModel {
         public void doBuild(AdminModel model, Element adminElement, ConfigModelContext modelContext) {
             AbstractConfigProducer parent = modelContext.getParentProducer();
             DeployProperties properties = modelContext.getDeployState().getProperties();
-            DomAdminV4Builder domBuilder = new DomAdminV4Builder(modelContext, properties.multitenant(), properties.configServerSpecs(), model.getContainerModels());
+            DomAdminV4Builder domBuilder = new DomAdminV4Builder(modelContext,
+                                                                 properties.multitenant(),
+                                                                 properties.configServerSpecs(),
+                                                                 model.getContainerModels(),
+                                                                 modelContext.getDeployState().disableFiledistributor());
             model.admin = domBuilder.build(parent, adminElement);
             // TODO: Is required since other models depend on admin.
             if (parent instanceof ApplicationConfigProducerRoot) {

--- a/config-model/src/main/java/com/yahoo/config/model/test/MockRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/MockRoot.java
@@ -11,6 +11,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.ConfigProducer;
 import com.yahoo.vespa.model.HostSystem;
@@ -147,7 +148,8 @@ public class MockRoot extends AbstractConfigProducerRoot {
 
         try {
             Document doc = XmlHelper.getDocumentBuilder().parse(new InputSource(new StringReader(servicesXml)));
-            setAdmin(new DomAdminV2Builder(ConfigModelContext.ApplicationType.DEFAULT, deployState.getFileRegistry(), false, new ArrayList<>()).
+            setAdmin(new DomAdminV2Builder(ConfigModelContext.ApplicationType.DEFAULT, deployState.getFileRegistry(),
+                                           false, new ArrayList<>(), deployState.disableFiledistributor()).
                     build(this, XML.getChildren(doc.getDocumentElement(), "admin").get(0)));
         } catch (SAXException | IOException e) {
             throw new RuntimeException(e);

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
@@ -37,16 +37,19 @@ public abstract class DomAdminBuilderBase extends VespaDomBuilder.DomConfigProdu
     private final ApplicationType applicationType;
     private final List<ConfigServerSpec> configServerSpecs;
     private final FileRegistry fileRegistry;
+    private final boolean disableFiledistributor;
     protected final boolean multitenant;
 
-    public DomAdminBuilderBase(ApplicationType applicationType, FileRegistry fileRegistry, boolean multitenant, List<ConfigServerSpec> configServerSpecs) {
+    DomAdminBuilderBase(ApplicationType applicationType, FileRegistry fileRegistry, boolean multitenant,
+                        List<ConfigServerSpec> configServerSpecs, boolean disableFiledistributor) {
         this.applicationType = applicationType;
         this.fileRegistry = fileRegistry;
         this.multitenant = multitenant;
         this.configServerSpecs = configServerSpecs;
+        this.disableFiledistributor = disableFiledistributor;
     }
 
-    protected List<Configserver> getConfigServersFromSpec(AbstractConfigProducer parent) {
+    List<Configserver> getConfigServersFromSpec(AbstractConfigProducer parent) {
         List<Configserver> configservers = new ArrayList<>();
         for (ConfigServerSpec spec : configServerSpecs) {
             HostSystem hostSystem = parent.getHostSystem();
@@ -76,7 +79,9 @@ public abstract class DomAdminBuilderBase extends VespaDomBuilder.DomConfigProdu
 
         new ModelConfigProvider(admin);
 
-        FileDistributionOptions fileDistributionOptions = new DomFileDistributionOptionsBuilder().build(XML.getChild(adminElement, "filedistribution"));
+        FileDistributionOptions fileDistributionOptions = FileDistributionOptions.defaultOptions();
+        fileDistributionOptions.disabled(disableFiledistributor);
+        fileDistributionOptions = new DomFileDistributionOptionsBuilder(fileDistributionOptions).build(XML.getChild(adminElement, "filedistribution"));
         admin.setFileDistribution(new FileDistributionConfigProducer.Builder(fileDistributionOptions).build(parent, fileRegistry));
         return admin;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom;
 
+import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
@@ -18,7 +19,6 @@ import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder.DomConfigProducerBu
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.xml.ContainerModelBuilder;
-import com.yahoo.config.application.api.FileRegistry;
 import org.w3c.dom.Element;
 
 import java.util.List;
@@ -37,8 +37,9 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
     public DomAdminV2Builder(ConfigModelContext.ApplicationType applicationType,
                              FileRegistry fileRegistry,
                              boolean multitenant,
-                             List<ConfigServerSpec> configServerSpecs) {
-        super(applicationType, fileRegistry, multitenant, configServerSpecs);
+                             List<ConfigServerSpec> configServerSpecs,
+                             boolean disableFiledistributor) {
+        super(applicationType, fileRegistry, multitenant, configServerSpecs, disableFiledistributor);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
@@ -30,8 +30,10 @@ public class DomAdminV4Builder extends DomAdminBuilderBase {
     private final Collection<ContainerModel> containerModels;
     private final ConfigModelContext context;
 
-    public DomAdminV4Builder(ConfigModelContext context, boolean multitenant, List<ConfigServerSpec> configServerSpecs, Collection<ContainerModel> containerModels) {
-        super(context.getApplicationType(), context.getDeployState().getFileRegistry(), multitenant, configServerSpecs);
+    public DomAdminV4Builder(ConfigModelContext context, boolean multitenant, List<ConfigServerSpec> configServerSpecs,
+                             Collection<ContainerModel> containerModels, boolean disableFiledistributor) {
+        super(context.getApplicationType(), context.getDeployState().getFileRegistry(), multitenant,
+              configServerSpecs, disableFiledistributor);
         this.containerModels = containerModels;
         this.context = context;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomFileDistributionOptionsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomFileDistributionOptionsBuilder.java
@@ -15,6 +15,11 @@ import java.util.Optional;
  * @author hmusum
  */
 public class DomFileDistributionOptionsBuilder {
+    private final FileDistributionOptions fileDistributionOptions;
+
+    public DomFileDistributionOptionsBuilder(FileDistributionOptions fileDistributionOptions) {
+        this.fileDistributionOptions = fileDistributionOptions;
+    }
 
     private static void throwExceptionForElementInFileDistribution(String subElement, String reason) {
         throw new RuntimeException("In element '" + subElement + "' contained in 'filedistribution': " + reason);
@@ -34,15 +39,14 @@ public class DomFileDistributionOptionsBuilder {
     }
 
     public FileDistributionOptions build(Element fileDistributionElement) {
-        FileDistributionOptions options = FileDistributionOptions.defaultOptions();
         if (fileDistributionElement != null) {
-            getAmount("uploadbitrate", fileDistributionElement).ifPresent(options::uploadBitRate);
-            getAmount("downloadbitrate", fileDistributionElement).ifPresent(options::downloadBitRate);
+            getAmount("uploadbitrate", fileDistributionElement).ifPresent(fileDistributionOptions::uploadBitRate);
+            getAmount("downloadbitrate", fileDistributionElement).ifPresent(fileDistributionOptions::downloadBitRate);
             Element disable = XML.getChild(fileDistributionElement, "disabled");
             if (disable != null) {
-                options.disabled(Boolean.valueOf(XML.getValue(disable)));
+                fileDistributionOptions.disabled(Boolean.valueOf(XML.getValue(disable)));
             }
         }
-        return options;
+        return fileDistributionOptions;
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -144,6 +144,9 @@ public class ConfigserverCluster extends AbstractConfigProducer
         if (options.loadBalancerAddress().isPresent()) {
             builder.loadBalancerAddress(options.loadBalancerAddress().get());
         }
+        if (options.disableFiledistributor().isPresent()) {
+            builder.disableFiledistributor(options.disableFiledistributor().get());
+        }
     }
 
     private String[] getConfigModelPluginDirs() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/CloudConfigOptions.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/CloudConfigOptions.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.configserver.option;
 import java.util.Optional;
 
 /**
- * @author tonytv
+ * @author Tony Vaagenes
  */
 public interface CloudConfigOptions {
 
@@ -44,4 +44,5 @@ public interface CloudConfigOptions {
     Optional<String> dockerRegistry();
     Optional<String> dockerVespaBaseImage();
     Optional<String> loadBalancerAddress();
+    Optional<Boolean> disableFiledistributor();
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2BuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2BuilderTest.java
@@ -207,7 +207,10 @@ public class DomAdminV2BuilderTest extends DomBuilderTest {
     }
 
     private Admin buildAdmin(Element xml, boolean multitenant, List<ConfigServerSpec> configServerSpecs) {
-        final DomAdminV2Builder domAdminBuilder = new DomAdminV2Builder(ConfigModelContext.ApplicationType.DEFAULT, root.getDeployState().getFileRegistry(), multitenant, configServerSpecs);
+        final DomAdminV2Builder domAdminBuilder =
+                new DomAdminV2Builder(ConfigModelContext.ApplicationType.DEFAULT,
+                                      root.getDeployState().getFileRegistry(), multitenant,
+                                      configServerSpecs, root.getDeployState().disableFiledistributor());
         Admin admin = domAdminBuilder.build(root, xml);
         admin.addPerHostServices(root.getHostSystem().getHosts(), new DeployProperties.Builder().build());
         return admin;

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
@@ -6,8 +6,7 @@ import com.yahoo.vespa.model.container.configserver.option.CloudConfigOptions;
 import java.util.Optional;
 
 /**
- * @author lulf
- * @since 5.
+ * @author Ulf Lilleengen
  */
 public class TestOptions implements CloudConfigOptions {
     private Optional<Integer> rpcPort = Optional.empty();
@@ -20,6 +19,7 @@ public class TestOptions implements CloudConfigOptions {
     private Optional<Boolean> useVespaVersionInRequest = Optional.empty();
     private Optional<Boolean> hostedVespa = Optional.empty();
     private Optional<Integer> numParallelTenantLoaders = Optional.empty();
+    private Optional<Boolean> disableFiledistributor = Optional.empty();
 
     @Override
     public Optional<Integer> rpcPort() {
@@ -117,6 +117,9 @@ public class TestOptions implements CloudConfigOptions {
 
     @Override
     public Optional<String> loadBalancerAddress() { return Optional.empty(); }
+
+    @Override
+    public Optional<Boolean> disableFiledistributor() { return disableFiledistributor; }
 
     public TestOptions numParallelTenantLoaders(int numLoaders) {
         this.numParallelTenantLoaders = Optional.of(numLoaders);

--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -1,5 +1,6 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 namespace=cloud.config
+
 rpcport int default=19070
 httpport int default=19071
 numthreads int default=16
@@ -44,3 +45,6 @@ dockerVespaBaseImage string default=""
 
 # Athenz config
 loadBalancerAddress string default=""
+
+# File distributions
+disableFiledistributor bool default=false

--- a/configserver/src/main/sh/start-filedistribution
+++ b/configserver/src/main/sh/start-filedistribution
@@ -63,7 +63,7 @@ ROOT=${VESPA_HOME%/}
 VESPA_CONFIG_ID="dir:${ROOT}/conf/filedistributor"
 export VESPA_CONFIG_ID
 
-if [ "$multitenant" = "true" ]; then
+if [ "$multitenant" = "true" -a "$disable_filedistributor" = "false" ]; then
     foo=`${ROOT}/libexec/vespa/vespa-config.pl -mkfiledistributorconfig`
     PIDFILE_FILEDISTRIBUTOR=var/run/filedistributor.pid
     LOGFILE="${ROOT}/logs/vespa/vespa.log"

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/RpcTester.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/RpcTester.java
@@ -1,0 +1,98 @@
+//  Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.filedistribution;
+
+import com.yahoo.config.FileReference;
+import com.yahoo.io.IOUtils;
+import com.yahoo.jrt.DataValue;
+import com.yahoo.jrt.Int32Value;
+import com.yahoo.jrt.Int64Value;
+import com.yahoo.jrt.Request;
+import com.yahoo.jrt.Spec;
+import com.yahoo.jrt.StringValue;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.jrt.Target;
+import com.yahoo.jrt.Transport;
+import com.yahoo.log.LogLevel;
+import net.jpountz.xxhash.XXHash64;
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.logging.Logger;
+
+public class RpcTester {
+
+    private static final Logger log = Logger.getLogger(RpcTester.class.getName());
+
+    private final Target target;
+
+    private RpcTester(Target target) {
+        this.target = target;
+    }
+
+    private void call(String fileReference, String filename, byte[] blob) {
+        new FileReceiver(target).receive(new FileReference(fileReference), filename, blob);
+    }
+
+    public static void main(String[] args) {
+        //String fileReference = args[0];
+        String fileReference = "59f93f445438c9db7ccbf1629f583c2aa004a68b";
+        String filename = "com.yahoo.vespatest.ExtraHitSearcher-1.0.0-deploy.jar";
+        File file = new File(String.format("/tmp/%s/%s", fileReference, filename));
+        byte[] blob = null;
+
+        try {
+            blob = IOUtils.readFileBytes(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        log.log(LogLevel.INFO, "Read blob from " + file.getAbsolutePath());
+
+
+        Supervisor supervisor = new Supervisor(new Transport());
+
+        Spec spec = new Spec("tcp/localhost:19090");
+        log.log(LogLevel.INFO, "Connecting to " + spec);
+        Target target = supervisor.connect(spec);
+        if (! target.isValid()) {
+            log.log(LogLevel.INFO, "Could not connect");
+            System.exit(1);
+        } else {
+            log.log(LogLevel.INFO, "Connected to " + spec);
+        }
+
+        new RpcTester(target).call(fileReference, filename, blob);
+    }
+
+    class FileReceiver {
+
+        Target target;
+
+        FileReceiver(Target target) {
+            this.target = target;
+        }
+
+        void receive(FileReference reference, String filename, byte[] content) {
+
+            log.log(LogLevel.INFO, "Preparing receive call for " + reference.value() + " and file " + filename);
+
+            XXHash64 hasher = XXHashFactory.fastestInstance().hash64();
+            Request fileBlob = new Request("filedistribution.receiveFile");
+
+            log.log(LogLevel.INFO, "Calling " + fileBlob.methodName() + " with target " + target);
+
+            fileBlob.parameters().add(new StringValue(reference.value()));
+            fileBlob.parameters().add(new StringValue(filename));
+            fileBlob.parameters().add(new DataValue(content));
+            fileBlob.parameters().add(new Int64Value(hasher.hash(ByteBuffer.wrap(content), 0)));
+            fileBlob.parameters().add(new Int32Value(0));
+            fileBlob.parameters().add(new StringValue("OK"));
+            log.log(LogLevel.INFO, "Doing invokeSync");
+            target.invokeSync(fileBlob, 5);
+            log.log(LogLevel.INFO, "Done with invokeSync");
+        }
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -139,7 +139,7 @@ public class StorageMaintainer {
         Process duCommand = new ProcessBuilder().command(command).start();
         if (!duCommand.waitFor(60, TimeUnit.SECONDS)) {
             duCommand.destroy();
-            throw new RuntimeException("Disk usage command timedout, aborting.");
+            throw new RuntimeException("Disk usage command timed out, aborting.");
         }
         String output = IOUtils.readAll(new InputStreamReader(duCommand.getInputStream()));
         String[] results = output.split("\t");

--- a/standalone-container/src/main/scala/com/yahoo/container/standalone/CloudConfigYinstVariables.scala
+++ b/standalone-container/src/main/scala/com/yahoo/container/standalone/CloudConfigYinstVariables.scala
@@ -10,8 +10,8 @@ import scala.language.implicitConversions
 import scala.util.Try
 
 /**
- * @author tonytv
- */
+  * @author Tony Vaagenes
+  */
 class CloudConfigYinstVariables extends CloudConfigOptions {
   import CloudConfigYinstVariables._
 
@@ -39,6 +39,7 @@ class CloudConfigYinstVariables extends CloudConfigOptions {
   override val dockerRegistry = optionalYinstVar[java.lang.String]("docker_registry")
   override val dockerVespaBaseImage = optionalYinstVar[java.lang.String]("docker_vespa_base_image")
   override val loadBalancerAddress = optionalYinstVar[java.lang.String]("load_balancer_address")
+  override val disableFiledistributor = optionalYinstVar[java.lang.Boolean]("disable_filedistributor")
 }
 
 object CloudConfigYinstVariables {


### PR DESCRIPTION
If set, will not start file distributor on config server host and on
tenant nodes, will instead use config proxy and file distribution will
be done with RPC calls between config proxy and config server