### PR TITLE
Do not create system tenants in constructor. Do not put into map of t…

### DIFF
--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -23,6 +23,7 @@ import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.ProvisionLogger;
 import com.yahoo.config.provision.Provisioner;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Version;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.config.server.ApplicationRepository;
@@ -56,6 +57,8 @@ import java.util.Optional;
  * @author bratseth
  */
 public class DeployTester {
+
+    private static final TenantName tenantName = TenantName.from("deploytester");
 
     private final Clock clock;
     private final Tenants tenants;
@@ -95,6 +98,7 @@ public class DeployTester {
         try {
             this.testApp = new File(appPath);
             this.tenants = new Tenants(componentRegistry, Collections.emptySet());
+            tenants.addTenant(tenantName);
         }
         catch (Exception e) {
             throw new IllegalArgumentException(e);
@@ -103,7 +107,7 @@ public class DeployTester {
     }
 
     public Tenant tenant() {
-        return tenants.defaultTenant();
+        return tenants.getTenant(tenantName);
     }
     
     /** Create a model factory for the version of this source*/

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/RedeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/RedeployTest.java
@@ -7,7 +7,6 @@ import com.yahoo.config.model.api.ModelFactory;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.InstanceName;
-import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Version;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.config.server.session.LocalSession;
@@ -60,7 +59,7 @@ public class RedeployTest {
         modelFactories.add(DeployTester.createModelFactory(Clock.systemUTC()));
         modelFactories.add(DeployTester.createFailingModelFactory(Version.fromIntValues(1, 0, 0)));
         DeployTester tester = new DeployTester("ignored/app/path", modelFactories);
-        ApplicationId id = ApplicationId.from(TenantName.from("default"),
+        ApplicationId id = ApplicationId.from(tester.tenant().getName(),
                                               ApplicationName.from("default"),
                                               InstanceName.from("default"));
         assertFalse(tester.redeployFromLocalActive(id).isPresent());


### PR DESCRIPTION
…enants unless absent

After these changes I am not able to reproduce failing unit tests anymore.