### PR TITLE
Do not setup a service for filedistributor when it is disabled

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/ConfigProxy.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/ConfigProxy.java
@@ -16,6 +16,8 @@ package com.yahoo.vespa.model;
  */
 public class ConfigProxy extends AbstractService {
 
+    public final static int BASEPORT = 19090;
+
     /**
      * Creates a new ConfigProxy instance.
      *
@@ -31,7 +33,7 @@ public class ConfigProxy extends AbstractService {
     /**
      * Returns the desired base port for this service.
      */
-    public int getWantedPort() { return 19090; }
+    public int getWantedPort() { return BASEPORT; }
 
     /**
      * The desired base port is the only allowed base port.

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -14,6 +14,8 @@ import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.admin.monitoring.Monitoring;
 import com.yahoo.vespa.model.admin.monitoring.builder.Metrics;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.filedistribution.DummyFileDistributionConfigProducer;
+import com.yahoo.vespa.model.filedistribution.FileDistributionConfigProvider;
 import com.yahoo.vespa.model.filedistribution.FileDistributionConfigProducer;
 import com.yahoo.vespa.model.filedistribution.FileDistributor;
 import com.yahoo.vespa.model.filedistribution.FileDistributorService;
@@ -213,11 +215,25 @@ public class Admin extends AbstractConfigProducer implements Serializable {
                                        fileDistributor.fileSourceHost() + "'. Hostsystem=" + getHostSystem());
         }
 
-        FileDistributorService fds = new FileDistributorService(fileDistribution, host.getHost().getHostName(),
-            fileDistribution.getFileDistributor(), fileDistribution.getOptions(), host == deployHost);
-        fds.setHostResource(host);
-        fds.initService();
-        fileDistribution.addFileDistributionService(host.getHost(), fds);
+        FileDistributionConfigProvider configProvider =
+                new FileDistributionConfigProvider(fileDistributor,
+                                                   fileDistribution.getOptions(),
+                                                   host == deployHost,
+                                                   host.getHost());
+        if (fileDistribution.getOptions().disableFiledistributor()) {
+            DummyFileDistributionConfigProducer dummyFileDistributionConfigProducer =
+                    new DummyFileDistributionConfigProducer(fileDistribution,
+                                                            host.getHost().getHostName(),
+                                                            configProvider);
+            fileDistribution.addFileDistributionConfigProducer(host.getHost(), dummyFileDistributionConfigProducer);
+        } else {
+            FileDistributorService fds = new FileDistributorService(fileDistribution,
+                                                                    host.getHost().getHostName(),
+                                                                    configProvider);
+            fds.setHostResource(host);
+            fds.initService();
+            fileDistribution.addFileDistributionConfigProducer(host.getHost(), fds);
+        }
     }
 
     private boolean deployHostIsMissing(HostResource deployHost) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -330,7 +330,7 @@ public class Container extends AbstractService implements
 
         FileDistributionConfigProducer fileDistribution = getRoot().getFileDistributionConfigProducer();
         if (fileDistribution != null) {
-            builder.configid(fileDistribution.getFileDistributorService(getHost()).getConfigId());
+            builder.configid(fileDistribution.getConfigProducer(getHost()).getConfigId());
         }
         return builder;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/DummyFileDistributionConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/DummyFileDistributionConfigProducer.java
@@ -5,55 +5,24 @@ import com.yahoo.cloud.config.filedistribution.FiledistributorConfig;
 import com.yahoo.cloud.config.filedistribution.FiledistributorrpcConfig;
 import com.yahoo.cloud.config.filedistribution.FilereferencesConfig;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
-import com.yahoo.vespa.model.AbstractService;
 
 /**
- * @author Tony Vaagenes
- *
- * Config is produced by {@link FileDistributionConfigProvider}
+ * @author hmusum
+ * <p>
+ * Dummy file distribution config producer, needed for serving file distribution config when there is no FiledistributorService.
  */
-public class FileDistributorService extends AbstractService implements
+public class DummyFileDistributionConfigProducer extends AbstractConfigProducer implements
         FiledistributorConfig.Producer,
         FiledistributorrpcConfig.Producer,
         FilereferencesConfig.Producer {
 
-    final static int BASEPORT = 19092;
-
     private final FileDistributionConfigProvider configProvider;
 
-    public FileDistributorService(AbstractConfigProducer parent, String hostname, FileDistributionConfigProvider configProvider) {
+    public DummyFileDistributionConfigProducer(AbstractConfigProducer parent,
+                                               String hostname,
+                                               FileDistributionConfigProvider configProvider) {
         super(parent, hostname);
         this.configProvider = configProvider;
-        portsMeta.on(0).tag("rpc");
-        portsMeta.on(1).tag("torrent");
-        portsMeta.on(2).tag("http").tag("state");
-        setProp("clustertype", "filedistribution");
-        setProp("clustername", "admin");
-    }
-
-    @Override
-    public String getStartupCommand() {
-        return "exec $ROOT/sbin/vespa-filedistributor" + " --configid " + getConfigId();
-    }
-
-    @Override
-    public boolean getAutostartFlag() {
-        return true;
-    }
-
-    @Override
-    public boolean getAutorestartFlag() {
-        return true;
-    }
-
-    @Override
-    public int getPortCount() {
-        return 3;
-    }
-
-    @Override
-    public int getWantedPort() {
-        return BASEPORT;
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProducer.java
@@ -10,11 +10,13 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 /**
- * @author tonytv
+ * @author hmusum
+ * <p>
+ * File distribution config producer, delegates getting config to {@link DummyFileDistributionConfigProducer} (one per host)
  */
 public class FileDistributionConfigProducer extends AbstractConfigProducer {
 
-    private final Map<Host, FileDistributorService> fileDistributorServices = new IdentityHashMap<>();
+    private final Map<Host, AbstractConfigProducer> fileDistributionConfigProducers = new IdentityHashMap<>();
     private final FileDistributor fileDistributor;
     private final FileDistributionOptions options;
 
@@ -22,14 +24,6 @@ public class FileDistributionConfigProducer extends AbstractConfigProducer {
         super(parent, "filedistribution");
         this.fileDistributor = fileDistributor;
         this.options = options;
-    }
-
-    public FileDistributorService getFileDistributorService(Host host) {
-        FileDistributorService service = fileDistributorServices.get(host);
-        if (service == null) {
-            throw new IllegalStateException("No file distribution service for host " + host);
-        }
-        return service;
     }
 
     public FileDistributor getFileDistributor() {
@@ -40,8 +34,8 @@ public class FileDistributionConfigProducer extends AbstractConfigProducer {
         return options;
     }
 
-    public void addFileDistributionService(Host host, FileDistributorService fds) {
-        fileDistributorServices.put(host, fds);
+    public void addFileDistributionConfigProducer(Host host, AbstractConfigProducer fileDistributionConfigProducer) {
+        fileDistributionConfigProducers.put(host, fileDistributionConfigProducer);
     }
 
     public static class Builder {
@@ -56,6 +50,10 @@ public class FileDistributionConfigProducer extends AbstractConfigProducer {
             FileDistributor fileDistributor = new FileDistributor(fileRegistry);
             return new FileDistributionConfigProducer(ancestor, fileDistributor, options);
         }
+    }
+
+    public AbstractConfigProducer getConfigProducer(Host host) {
+        return fileDistributionConfigProducers.get(host);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProvider.java
@@ -1,0 +1,59 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.filedistribution;
+
+import com.yahoo.cloud.config.filedistribution.FiledistributorConfig;
+import com.yahoo.cloud.config.filedistribution.FiledistributorrpcConfig;
+import com.yahoo.cloud.config.filedistribution.FilereferencesConfig;
+import com.yahoo.config.FileReference;
+import com.yahoo.config.model.api.FileDistribution;
+import com.yahoo.vespa.model.ConfigProxy;
+import com.yahoo.vespa.model.Host;
+import com.yahoo.vespa.model.admin.FileDistributionOptions;
+
+import java.util.Collection;
+
+public class FileDistributionConfigProvider {
+
+    private final FileDistributor fileDistributor;
+    private final FileDistributionOptions fileDistributionOptions;
+    private final boolean sendAllFiles;
+    private final Host host;
+
+    public FileDistributionConfigProvider(FileDistributor fileDistributor,
+                                          FileDistributionOptions fileDistributionOptions,
+                                          boolean sendAllFiles,
+                                          Host host) {
+        this.fileDistributor = fileDistributor;
+        this.fileDistributionOptions = fileDistributionOptions;
+        this.sendAllFiles = sendAllFiles;
+        this.host = host;
+    }
+
+    public void getConfig(FiledistributorConfig.Builder builder) {
+        fileDistributionOptions.getConfig(builder);
+        builder.torrentport(FileDistributorService.BASEPORT + 1);
+        builder.stateport(FileDistributorService.BASEPORT + 2);
+        builder.hostname(host.getHostName());
+        builder.filedbpath(FileDistribution.getDefaultFileDBPath().toString());
+    }
+
+    public void getConfig(FiledistributorrpcConfig.Builder builder) {
+        // If disabled config proxy should act as file distributor, so use config proxy port
+        int port = (fileDistributionOptions.disableFiledistributor()) ? ConfigProxy.BASEPORT : FileDistributorService.BASEPORT;
+        builder.connectionspec("tcp/" + host.getHostName() + ":" + port);
+    }
+
+    public void getConfig(FilereferencesConfig.Builder builder) {
+        for (FileReference reference : getFileReferences()) {
+            builder.filereferences(reference.value());
+        }
+    }
+
+    private Collection<FileReference> getFileReferences() {
+        if (sendAllFiles) {
+            return fileDistributor.allFilesToSend();
+        } else {
+            return fileDistributor.filesToSendToHost(host);
+        }
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.model.admin.monitoring.Monitoring;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.content.ContentNode;
+import com.yahoo.vespa.model.filedistribution.DummyFileDistributionConfigProducer;
 import com.yahoo.vespa.model.filedistribution.FileDistributionConfigProducer;
 import com.yahoo.vespa.model.filedistribution.FileDistributorService;
 import org.w3c.dom.Element;
@@ -228,10 +229,12 @@ public class SearchNode extends AbstractService implements
     public void getConfig(FiledistributorrpcConfig.Builder builder) {
         FileDistributionConfigProducer fileDistribution = getRoot().getFileDistributionConfigProducer();
         if (fileDistribution != null) {
-            FileDistributorService fds = fileDistribution.getFileDistributorService(getHost());
-            if (fds != null) {
-                fds.getConfig(builder);
-            }
+            AbstractConfigProducer configProducer = fileDistribution.getConfigProducer(getHost());
+            // TODO: Hack, will be fixed when FileDistributorService is gone
+            if (configProducer instanceof DummyFileDistributionConfigProducer)
+                ((DummyFileDistributionConfigProducer) configProducer).getConfig(builder);
+            else
+                ((FileDistributorService) configProducer).getConfig(builder);
         }
     }
 


### PR DESCRIPTION
Some workarounds needed to still file distribution config even when such a
serice is not set up (can be simplified a lot when file distributor is removed
for good)