### PR TITLE
Make GetBucketListMessage destructor explicit

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/messages/getbucketlistmessage.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/messages/getbucketlistmessage.cpp
@@ -13,6 +13,8 @@ GetBucketListMessage::GetBucketListMessage(const document::BucketId &bucketId) :
 {
 }
 
+GetBucketListMessage::~GetBucketListMessage() = default;
+
 DocumentReply::UP
 GetBucketListMessage::doCreateReply() const
 {

--- a/documentapi/src/vespa/documentapi/messagebus/messages/getbucketlistmessage.h
+++ b/documentapi/src/vespa/documentapi/messagebus/messages/getbucketlistmessage.h
@@ -24,6 +24,8 @@ public:
      */
     GetBucketListMessage(const document::BucketId &bucketId);
 
+    ~GetBucketListMessage();
+
     /**
      * Returns the bucket whose list to retrieve.
      *


### PR DESCRIPTION
Avoids inlining size warnings when compiling with debug flags