### PR TITLE
Use correct attribute for x509 cert chain

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
@@ -116,7 +116,7 @@ public class AccessLogRequestLog extends AbstractLifeCycle implements RequestLog
         if (principal != null) {
             accessLogEntry.setUserPrincipal(principal);
         }
-        X509Certificate[] clientCert = (X509Certificate[]) request.getAttribute(ServletRequest.JDISC_REQUEST_X509CERT);
+        X509Certificate[] clientCert = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
         if (clientCert != null && clientCert.length > 0) {
             accessLogEntry.setSslPrincipal(clientCert[0].getSubjectX500Principal());
         }


### PR DESCRIPTION
The JDisc attribute will not return the cert chain here as the JDisc
attributes are not back-propagated to the underlying Servlet request.
The fix is to use the corresponding Servlet attribute.