### PR TITLE
Use curator lock when assigning rotation

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -39,6 +39,8 @@ public class CuratorDb {
 
     private static final Path root = Path.fromString("/controller/v1");
 
+    private static final Path lockRoot = root.append("locks");
+
     private static final Duration defaultLockTimeout = Duration.ofMinutes(5);
 
     private final StringSetSerializer stringSetSerializer = new StringSetSerializer();
@@ -67,6 +69,10 @@ public class CuratorDb {
         return lock(lockPath(id), timeout);
     }
 
+    public Lock lockRotations() {
+        return lock(lockRoot.append("rotations"), defaultLockTimeout);
+    }
+
     /** Create a reentrant lock */
     private Lock lock(Path path, Duration timeout) {
         Lock lock = locks.computeIfAbsent(path, (pathArg) -> new Lock(pathArg.getAbsolute(), curator));
@@ -75,18 +81,18 @@ public class CuratorDb {
     }
 
     public Lock lockInactiveJobs() {
-        return lock(root.append("locks").append("inactiveJobsLock"), defaultLockTimeout);
+        return lock(lockRoot.append("inactiveJobsLock"), defaultLockTimeout);
     }
 
     public Lock lockJobQueues() {
-        return lock(root.append("locks").append("jobQueuesLock"), defaultLockTimeout);
+        return lock(lockRoot.append("jobQueuesLock"), defaultLockTimeout);
     }
 
     public Lock lockMaintenanceJob(String jobName) {
         // Use a short timeout such that if maintenance jobs are started at about the same time on different nodes
         // and the maintenance job takes a long time to complete, only one of the nodes will run the job
         // in each maintenance interval
-        return lock(root.append("locks").append("maintenanceJobLocks").append(jobName), Duration.ofSeconds(1));
+        return lock(lockRoot.append("maintenanceJobLocks").append(jobName), Duration.ofSeconds(1));
     }
 
     public Lock lockProvisionState(String provisionStateId) {
@@ -94,11 +100,11 @@ public class CuratorDb {
     }
 
     public Lock lockVespaServerPool() {
-        return lock(root.append("locks").append("vespaServerPoolLock"), Duration.ofSeconds(1));
+        return lock(lockRoot.append("vespaServerPoolLock"), Duration.ofSeconds(1));
     }
 
     public Lock lockOpenStackServerPool() {
-        return lock(root.append("locks").append("openStackServerPoolLock"), Duration.ofSeconds(1));
+        return lock(lockRoot.append("openStackServerPoolLock"), Duration.ofSeconds(1));
     }
 
     // -------------- Read and write --------------------------------------------------
@@ -223,14 +229,14 @@ public class CuratorDb {
     // -------------- Paths --------------------------------------------------
 
     private Path lockPath(TenantId tenant) {
-        Path lockPath = root.append("locks")
+        Path lockPath = lockRoot
                 .append(tenant.id());
         curator.create(lockPath);
         return lockPath;
     }
 
     private Path lockPath(ApplicationId application) {
-        Path lockPath = root.append("locks")
+        Path lockPath = lockRoot
                 .append(application.tenant().value())
                 .append(application.application().value())
                 .append(application.instance().value());
@@ -239,7 +245,7 @@ public class CuratorDb {
     }
 
     private Path lockPath(String provisionId) {
-        Path lockPath = root.append("locks")
+        Path lockPath = lockRoot
                 .append(provisionStatePath())
                 .append(provisionId);
         curator.create(lockPath);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/rotation/RotationLock.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/rotation/RotationLock.java
@@ -1,0 +1,25 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.rotation;
+
+import com.yahoo.vespa.curator.Lock;
+
+import java.util.Objects;
+
+/**
+ * A lock for the rotation repository. This is a type-safe wrapper for a curator lock.
+ *
+ * @author mpolden
+ */
+public class RotationLock implements AutoCloseable {
+
+    private final Lock lock;
+
+    RotationLock(Lock lock) {
+        this.lock = Objects.requireNonNull(lock, "lock cannot be null");
+    }
+
+    @Override
+    public void close() {
+        lock.close();
+    }
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ConfigServerProxyMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ConfigServerProxyMock.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.controller;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
-import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
 import com.yahoo.vespa.hosted.controller.restapi.StringResponse;
 
@@ -21,7 +20,7 @@ public class ConfigServerProxyMock extends AbstractComponent implements ConfigSe
     private volatile String requestBody = null;
 
     @Override
-    public HttpResponse handle(ProxyRequest proxyRequest) throws ProxyException {
+    public HttpResponse handle(ProxyRequest proxyRequest) {
         lastReceived = proxyRequest;
         // Copy request body as the input stream is drained once the request completes
         requestBody = asString(proxyRequest.getData());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializerTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 public class VersionStatusSerializerTest {
 
     @Test
-    public void testSerialization() throws Exception {
+    public void testSerialization() {
         List<VespaVersion> vespaVersions = new ArrayList<>();
         DeploymentStatistics statistics = new DeploymentStatistics(
                 Version.fromString("5.0"),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerControllerTester.java
@@ -45,18 +45,16 @@ import java.util.Optional;
 public class ContainerControllerTester {
 
     private final ContainerTester containerTester;
-    private final Controller controller;
     private final Upgrader upgrader;
 
     public ContainerControllerTester(JDisc container, String responseFilePath) {
         containerTester = new ContainerTester(container, responseFilePath);
-        controller = (Controller)container.components().getComponent("com.yahoo.vespa.hosted.controller.Controller");
         CuratorDb curatorDb = new MockCuratorDb();
         curatorDb.writeUpgradesPerMinute(100);
-        upgrader = new Upgrader(controller, Duration.ofDays(1), new JobControl(curatorDb), curatorDb);
+        upgrader = new Upgrader(controller(), Duration.ofDays(1), new JobControl(curatorDb), curatorDb);
     }
 
-    public Controller controller() { return controller; }
+    public Controller controller() { return containerTester.controller(); }
 
     public Upgrader upgrader() { return upgrader; }
 
@@ -70,18 +68,18 @@ public class ContainerControllerTester {
 
     public Application createApplication(String athensDomain, String tenant, String application) {
         AthenzDomain domain1 = addTenantAthenzDomain(athensDomain, "mytenant");
-        controller.tenants().addTenant(Tenant.createAthensTenant(new TenantId(tenant), domain1,
+        controller().tenants().addTenant(Tenant.createAthensTenant(new TenantId(tenant), domain1,
                                                                  new Property("property1"),
                                                                  Optional.of(new PropertyId("1234"))),
                                        Optional.of(TestIdentities.userNToken));
         ApplicationId app = ApplicationId.from(tenant, application, "default");
-        return controller.applications().createApplication(app, Optional.of(TestIdentities.userNToken));
+        return controller().applications().createApplication(app, Optional.of(TestIdentities.userNToken));
     }
 
     public Application deploy(Application application, ApplicationPackage applicationPackage, Zone zone, long projectId) {
         ScrewdriverId app1ScrewdriverId = new ScrewdriverId(String.valueOf(projectId));
         GitRevision app1RevisionId = new GitRevision(new GitRepository("repo"), new GitBranch("master"), new GitCommit("commit1"));
-        controller.applications().deployApplication(application.id(),
+        controller().applications().deployApplication(application.id(),
                                                     zone,
                                                     applicationPackage,
                                                     new DeployOptions(Optional.of(new ScrewdriverBuildJob(app1ScrewdriverId, app1RevisionId)), Optional.empty(), false, false));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerTester.java
@@ -43,14 +43,16 @@ public class ContainerTester {
     
     public JDisc container() { return container; }
 
+    public Controller controller() {
+        return (Controller) container.components().getComponent(Controller.class.getName());
+    }
+
     public void updateSystemVersion() {
-        Controller controller = (Controller)container.components().getComponent("com.yahoo.vespa.hosted.controller.Controller");
-        controller.updateVersionStatus(VersionStatus.compute(controller));
+        controller().updateVersionStatus(VersionStatus.compute(controller()));
     }
 
     public void updateSystemVersion(Version version) {
-        Controller controller = (Controller)container.components().getComponent("com.yahoo.vespa.hosted.controller.Controller");
-        controller.updateVersionStatus(VersionStatus.compute(controller, version));
+        controller().updateVersionStatus(VersionStatus.compute(controller(), version));
     }
 
     public void assertResponse(Supplier<Request> request, File responseFile) throws IOException {


### PR DESCRIPTION
With multi controller deployments can happen on any controller, so lock must be
taken cluster-wide when assigning rotation.

Last commit is the interesting one.