### PR TITLE
Disallow ID strings with empty user/group values

### DIFF
--- a/document/src/main/java/com/yahoo/document/idstring/IdIdString.java
+++ b/document/src/main/java/com/yahoo/document/idstring/IdIdString.java
@@ -62,6 +62,9 @@ public class IdIdString extends IdString {
                     if (hasSetLocation) {
                         throw new IllegalArgumentException("Illegal key combination in " + keyValues);
                     }
+                    if (value.isEmpty()) {
+                        throw new IllegalArgumentException("ID location value for 'n=' key is empty");
+                    }
                     location = Long.parseLong(value);
                     hasSetLocation = true;
                     hasNumber = true;
@@ -69,6 +72,9 @@ public class IdIdString extends IdString {
                 case "g":
                     if (hasSetLocation) {
                         throw new IllegalArgumentException("Illegal key combination in " + keyValues);
+                    }
+                    if (value.isEmpty()) {
+                        throw new IllegalArgumentException("ID location value for 'g=' key is empty");
                     }
                     location = makeLocation(value);
                     hasSetLocation = true;


### PR DESCRIPTION
@baldersheim please review

It does not make sense to have an empty value for these, as the value plays
an explicit part of the document's distribution properties.