### PR TITLE
Error should also exit JDisc container

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/StandaloneMain.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/StandaloneMain.java
@@ -47,7 +47,7 @@ public class StandaloneMain {
             loader.destroy();
             System.out.println("debug\tStopped ok.");
             System.exit(0);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             System.out.print("debug\tUnexpected: ");
             e.printStackTrace();
             log.log(Level.SEVERE, "Unexpected: ", e);


### PR DESCRIPTION
Ensure JVM exits when we fail to construct component graph. The following exception left the JVM in a zombie state: the main thread exited but some non-daemon thread didn't exit and kept the JVM alive. (@tokle looked into which thread it was and found it was FelixDispatchQueue in this case)

```
[2017-12-08 08:04:42.018] WARNING : container        Container.com.yahoo.container.di.Container
	Failed to set up first component graph. Exiting within 60 seconds.
	exception=
	java.lang.NoClassDefFoundError: com/yahoo/athenz/auth/Authority
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
	at java.lang.Class.getConstructors(Class.java:1651)
	at com.yahoo.container.di.componentgraph.core.ComponentNode$.com$yahoo$container$di$componentgraph$core$ComponentNode$$bestConstructor(ComponentNode.scala:178)
	at com.yahoo.container.di.componentgraph.core.ComponentNode.<init>(ComponentNode.scala:35)
	at com.yahoo.container.di.Container$$anonfun$addNodes$2.apply(Container.scala:208)
	at com.yahoo.container.di.Container$$anonfun$addNodes$2.apply(Container.scala:200)
	at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:778)
	at scala.collection.Iterator$class.foreach(Iterator.scala:743)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1195)
	at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:777)
	at com.yahoo.container.di.Container.addNodes(Container.scala:200)
	at com.yahoo.container.di.Container.createComponentsGraph(Container.scala:189)
	at com.yahoo.container.di.Container.createNewGraph(Container.scala:130)
	at com.yahoo.container.di.Container.runOnce(Container.scala:58)
	at com.yahoo.container.core.config.HandlersConfigurerDi.runOnceAndEnsureRegistryHackRun(HandlersConfigurerDi.java:142)
	at com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:89)
	at com.yahoo.container.jdisc.ConfiguredApplication.configureComponents(ConfiguredApplication.java:246)
	at com.yahoo.container.jdisc.ConfiguredApplication.start(ConfiguredApplication.java:125)
	at com.yahoo.jdisc.core.ApplicationLoader.start(ApplicationLoader.java:154)
	at com.yahoo.jdisc.core.StandaloneMain.run(StandaloneMain.java:41)
	at com.yahoo.jdisc.core.StandaloneMain.main(StandaloneMain.java:34)
	Caused by: java.lang.ClassNotFoundException: com.yahoo.athenz.auth.Authority not found by vespa-secret-provider [71]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1532)
	at org.apache.felix.framework.BundleWiringImpl.access$400(BundleWiringImpl.java:75)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1955)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 24 more
```

And more generally, ensure JVM exits when an Error reaches main.