### PR TITLE
Fix off-by-one error when getting hostname from request

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -184,8 +184,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
     }
 
     private Node nodeFromRequest(HttpRequest request) {
-        String path = request.getUri().getPath();
-        String hostname = path.substring(path.lastIndexOf("/"));
+        String hostname = lastElement(request.getUri().getPath());
 
         return nodeRepository.getNode(hostname).orElseThrow(() ->
                 new NotFoundException("No node found with hostname " + hostname));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -455,6 +455,11 @@ public class RestApiTest {
                                    Request.Method.PATCH),
                        "{\"message\":\"Updated host4.yahoo.com\"}");
 
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/doesnotexist.yahoo.com",
+                                   Utf8.toBytes("{\"currentRestartGeneration\": 1}"),
+                                   Request.Method.PATCH),
+                       404, "{\"error-code\":\"NOT_FOUND\",\"message\":\"No node found with hostname doesnotexist.yahoo.com\"}");
+
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host5.yahoo.com",
                                    Utf8.toBytes("{\"currentRestartGeneration\": 1}"),
                                    Request.Method.PATCH),


### PR DESCRIPTION
The / would be included in hostname, which just happened to work because
code further down handled getting //hostname in requests