### PR TITLE
Revert "Use chunked transfer in file distribution by default"

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -48,4 +48,4 @@ loadBalancerAddress string default=""
 
 # File distribution
 disableFiledistributor bool default=false
-usechunkedtransfer bool default=true
+usechunkedtransfer bool default=false


### PR DESCRIPTION
Reverts vespa-engine/vespa#4405

CD did not converge, seems related to this change. From  log:
[2017-12-11 17:56:07.643] INFO    : configproxy      configproxy.com.yahoo.vespa.filedistribution.FileReferenceDownloader       Found file reference 'a025f0e8de56e4f6d735a5b605f05e5e20542429' available a
t tcp/cfg1.dev.cd-us-central-1.vespahosted.ne1.yahoo.com:19070
[2017-12-11 17:56:07.644] INFO    : configproxy      configproxy.com.yahoo.vespa.filedistribution.FileReceiver  Received method call 'filedistribution.receiveFileMeta' with parameters : a025f0e8de56e4f6d
735a5b605f05e5e20542429,docker-api-6.184.14-bundle.jar4583825590585539330.inprogress,file,0
[2017-12-11 17:56:07.646] INFO    : configproxy      configproxy.com.yahoo.vespa.filedistribution.FileReceiver  Received method call 'filedistribution.receiveFileEof' with parameters : a025f0e8de56e4f6d7
35a5b605f05e5e20542429,9,-1205034819632174695,0,OK
[2017-12-11 17:56:07.646] INFO    : configproxy      configproxy.com.yahoo.vespa.filedistribution.FileReceiver  File moved from /home/y/var/db/vespa/filedistribution/a025f0e8de56e4f6d735a5b605f05e5e20542
429/docker-api-6.184.14-bundle.jar4583825590585539330.inprogress642740449205534008.inprogress to /home/y/var/db/vespa/filedistribution/a025f0e8de56e4f6d735a5b605f05e5e20542429/docker-api-6.184.14-bundle.
jar4583825590585539330.inprogress
[2017-12-11 17:56:07.646] INFO    : configproxy      configproxy.com.yahoo.vespa.filedistribution.FileDistributionRpcServer     File reference 'a025f0e8de56e4f6d735a5b605f05e5e20542429' available at /hom
e/y/var/db/vespa/filedistribution/a025f0e8de56e4f6d735a5b605f05e5e20542429/docker-api-6.184.14-bundle.jar4583825590585539330.inprogress
[2017-12-11 17:56:07.647] INFO    : configproxy      configproxy.com.yahoo.vespa.filedistribution.FileReceiver  Received method call 'filedistribution.receiveFileMeta' with parameters : a025f0e8de56e4f6d
735a5b605f05e5e20542429,docker-api-6.184.14-bundle.jar4583825590585539330.inprogress,file,0
[2017-12-11 17:56:07.713] WARNING : container        Container.com.yahoo.container.di.Container Failed to set up new component graph. Retaining previous component generation.\nexception=\njava.lang.Runti
meException: Could not install bundle 'file 'a025f0e8de56e4f6d735a5b605f05e5e20542429'
