### PR TITLE
Bjorncs/athenz ssl context

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/AthenzIdentityCertificate.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/AthenzIdentityCertificate.java
@@ -1,0 +1,27 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.athenz;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * @author bjorncs
+ */
+public class AthenzIdentityCertificate {
+
+    private final X509Certificate certificate;
+    private final PrivateKey privateKey;
+
+    public AthenzIdentityCertificate(X509Certificate certificate, PrivateKey privateKey) {
+        this.certificate = certificate;
+        this.privateKey = privateKey;
+    }
+
+    public X509Certificate getCertificate() {
+        return certificate;
+    }
+
+    public PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/AthenzRoleCertificate.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/AthenzRoleCertificate.java
@@ -1,0 +1,27 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.athenz;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * @author bjorncs
+ */
+public class AthenzRoleCertificate {
+
+    private final X509Certificate certificate;
+    private final PrivateKey privateKey;
+
+    public AthenzRoleCertificate(X509Certificate certificate, PrivateKey privateKey) {
+        this.certificate = certificate;
+        this.privateKey = privateKey;
+    }
+
+    public X509Certificate getCertificate() {
+        return certificate;
+    }
+
+    public PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/AthenzSslContextProvider.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/AthenzSslContextProvider.java
@@ -1,0 +1,14 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.athenz;
+
+import com.google.inject.Provider;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Provides a {@link SSLContext} for use in controller clients communicating with Athenz TLS secured services.
+ * It is configured with a keystore containing the Athenz service certificate and a trust store with the Athenz CA certificates.
+ *
+ * @author bjorncs
+ */
+public interface AthenzSslContextProvider extends Provider<SSLContext> {}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/ZtsClient.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/athenz/ZtsClient.java
@@ -12,4 +12,8 @@ public interface ZtsClient {
 
     List<AthenzDomain> getTenantDomainsForUser(AthenzIdentity principal);
 
+    AthenzIdentityCertificate getIdentityCertificate();
+
+    AthenzRoleCertificate getRoleCertificate(AthenzDomain roleDomain, String roleName);
+
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzClientFactoryImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzClientFactoryImpl.java
@@ -51,7 +51,7 @@ public class AthenzClientFactoryImpl implements AthenzClientFactory {
      */
     @Override
     public ZtsClient createZtsClientWithServicePrincipal() {
-        return new ZtsClientImpl(new ZTSClient(config.ztsUrl(), createServicePrincipal()), config);
+        return new ZtsClientImpl(new ZTSClient(config.ztsUrl(), createServicePrincipal()), getServicePrivateKey(), config);
     }
 
     /**

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzClientFactoryImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzClientFactoryImpl.java
@@ -18,7 +18,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.security.KeyService;
 import com.yahoo.vespa.hosted.controller.athenz.config.AthenzConfig;
 
 import java.security.PrivateKey;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzUtils.USER_PRINCIPAL_DOMAIN;
 
@@ -75,8 +75,12 @@ public class AthenzClientFactoryImpl implements AthenzClientFactory {
         // TODO bjorncs: Cache principal token
         SimpleServiceIdentityProvider identityProvider =
                 new SimpleServiceIdentityProvider(
-                        athenzPrincipalAuthority, config.domain(), service.name(),
-                        getServicePrivateKey(), service.publicKeyId(), /*tokenTimeout*/TimeUnit.HOURS.toSeconds(1));
+                        athenzPrincipalAuthority,
+                        config.domain(),
+                        service.name(),
+                        getServicePrivateKey(),
+                        service.publicKeyId(),
+                        Duration.ofMinutes(service.credentialsExpiryMinutes()).getSeconds());
         return identityProvider.getIdentity(config.domain(), service.name());
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzSslContextProviderImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzSslContextProviderImpl.java
@@ -1,0 +1,86 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.athenz.impl;
+
+import com.google.inject.Inject;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzClientFactory;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzIdentityCertificate;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzSslContextProvider;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.ZtsClient;
+import com.yahoo.vespa.hosted.controller.athenz.config.AthenzConfig;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+
+/**
+ * @author bjorncs
+ */
+public class AthenzSslContextProviderImpl implements AthenzSslContextProvider {
+
+    private final AthenzClientFactory clientFactory;
+    private final AthenzConfig config;
+
+    @Inject
+    public AthenzSslContextProviderImpl(AthenzClientFactory clientFactory, AthenzConfig config) {
+        this.clientFactory = clientFactory;
+        this.config = config;
+    }
+
+    @Override
+    public SSLContext get() {
+        return createSslContext();
+    }
+
+    private SSLContext createSslContext() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            sslContext.init(createKeyManagersWithServiceCertificate(clientFactory.createZtsClientWithServicePrincipal()),
+                            createTrustManagersWithAthenzCa(config),
+                            null);
+            return sslContext;
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static KeyManager[] createKeyManagersWithServiceCertificate(ZtsClient ztsClient) {
+        try {
+            AthenzIdentityCertificate identityCertificate = ztsClient.getIdentityCertificate();
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+            keyStore.setKeyEntry("athenz-controller-key",
+                                 identityCertificate.getPrivateKey(),
+                                 new char[0],
+                                 new Certificate[]{identityCertificate.getCertificate()});
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("X509");
+            keyManagerFactory.init(keyStore, new char[0]);
+            return keyManagerFactory.getKeyManagers();
+        } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static TrustManager[] createTrustManagersWithAthenzCa(AthenzConfig config) {
+        try {
+            KeyStore trustStore = KeyStore.getInstance("JKS");
+            try (FileInputStream in = new FileInputStream(config.athenzCaTrustStore())) {
+                trustStore.load(in, "changeit".toCharArray());
+            }
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("X509");
+            trustManagerFactory.init(trustStore);
+            return trustManagerFactory.getTrustManagers();
+        } catch (CertificateException | IOException | KeyStoreException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/ZtsClientImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/ZtsClientImpl.java
@@ -32,18 +32,19 @@ import static java.util.stream.Collectors.toList;
 public class ZtsClientImpl implements ZtsClient {
 
     private static final Logger log = Logger.getLogger(ZtsClientImpl.class.getName());
-    private static final Duration CERTIFICATE_EXPIRY = Duration.ofHours(1);
 
     private final ZTSClient ztsClient;
     private final AthenzService service;
     private final PrivateKey privateKey;
     private final String certificateDnsDomain;
+    private final Duration certExpiry;
 
     public ZtsClientImpl(ZTSClient ztsClient, PrivateKey privateKey, AthenzConfig config) {
         this.ztsClient = ztsClient;
         this.service = new AthenzService(config.domain(), config.service().name());
         this.privateKey = privateKey;
         this.certificateDnsDomain = config.certDnsDomain();
+        this.certExpiry = Duration.ofMinutes(config.service().credentialsExpiryMinutes());
     }
 
     @Override
@@ -71,7 +72,7 @@ public class ZtsClientImpl implements ZtsClient {
                             service.getName(),
                             privateKey,
                             certificateDnsDomain,
-                            (int) CERTIFICATE_EXPIRY.getSeconds());
+                            (int) certExpiry.getSeconds());
             X509Certificate certificate = Crypto.loadX509Certificate(
                     ztsClient.postInstanceRefreshRequest(service.getDomain().id(), service.getName(), req)
                             .getCertificate());
@@ -93,7 +94,7 @@ public class ZtsClientImpl implements ZtsClient {
                             roleName,
                             privateKey,
                             certificateDnsDomain,
-                            (int)CERTIFICATE_EXPIRY.getSeconds());
+                            (int)certExpiry.getSeconds());
             X509Certificate roleCertificate = Crypto.loadX509Certificate(
                     ztsClient.postRoleCertificateRequest(roleDomain.id(), roleName, req)
                             .getToken());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/ZtsClientImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/ZtsClientImpl.java
@@ -1,18 +1,27 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.athenz.impl;
 
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.zts.InstanceRefreshRequest;
+import com.yahoo.athenz.zts.RoleCertificateRequest;
 import com.yahoo.athenz.zts.TenantDomains;
 import com.yahoo.athenz.zts.ZTSClient;
 import com.yahoo.athenz.zts.ZTSClientException;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.controller.api.identifiers.AthenzDomain;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzIdentity;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzIdentityCertificate;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzRoleCertificate;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzService;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.ZtsClient;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.ZtsException;
 import com.yahoo.vespa.hosted.controller.athenz.config.AthenzConfig;
 
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import static java.util.stream.Collectors.toList;
@@ -23,27 +32,80 @@ import static java.util.stream.Collectors.toList;
 public class ZtsClientImpl implements ZtsClient {
 
     private static final Logger log = Logger.getLogger(ZtsClientImpl.class.getName());
+    private static final Duration CERTIFICATE_EXPIRY = Duration.ofHours(1);
 
     private final ZTSClient ztsClient;
     private final AthenzService service;
+    private final PrivateKey privateKey;
+    private final String certificateDnsDomain;
 
-    public ZtsClientImpl(ZTSClient ztsClient, AthenzConfig config) {
+    public ZtsClientImpl(ZTSClient ztsClient, PrivateKey privateKey, AthenzConfig config) {
         this.ztsClient = ztsClient;
         this.service = new AthenzService(config.domain(), config.service().name());
+        this.privateKey = privateKey;
+        this.certificateDnsDomain = config.certDnsDomain();
     }
 
     @Override
     public List<AthenzDomain> getTenantDomainsForUser(AthenzIdentity identity) {
-        log.log(LogLevel.DEBUG, String.format(
-                "getTenantDomains(domain=%s, identity=%s, rolename=admin, service=%s)",
-                service.getDomain().id(), identity.getFullName(), service.getFullName()));
-        try {
+        return getOrThrow(() -> {
+            log.log(LogLevel.DEBUG, String.format(
+                    "getTenantDomains(domain=%s, identity=%s, rolename=admin, service=%s)",
+                    service.getDomain().id(), identity.getFullName(), service.getFullName()));
             TenantDomains domains = ztsClient.getTenantDomains(
                     service.getDomain().id(), identity.getFullName(), "admin", service.getName());
             return domains.getTenantDomainNames().stream()
                     .map(AthenzDomain::new)
                     .collect(toList());
+        });
+    }
+
+    @Override
+    public AthenzIdentityCertificate getIdentityCertificate() {
+        return getOrThrow(() -> {
+            log.log(LogLevel.DEBUG,
+                    String.format("postInstanceRefreshRequest(service=%s)", service.getFullName()));
+            InstanceRefreshRequest req =
+                    ZTSClient.generateInstanceRefreshRequest(
+                            service.getDomain().id(),
+                            service.getName(),
+                            privateKey,
+                            certificateDnsDomain,
+                            (int) CERTIFICATE_EXPIRY.getSeconds());
+            X509Certificate certificate = Crypto.loadX509Certificate(
+                    ztsClient.postInstanceRefreshRequest(service.getDomain().id(), service.getName(), req)
+                            .getCertificate());
+            return new AthenzIdentityCertificate(certificate, privateKey);
+        });
+    }
+
+    @Override
+    public AthenzRoleCertificate getRoleCertificate(AthenzDomain roleDomain, String roleName) {
+        return getOrThrow(() -> {
+            log.log(LogLevel.DEBUG,
+                    String.format("postRoleCertificateRequest(service=%s, roleDomain=%s, roleName=%s)",
+                                  service.getFullName(), roleDomain.id(), roleName));
+            RoleCertificateRequest req =
+                    ZTSClient.generateRoleCertificateRequest(
+                            service.getDomain().id(),
+                            service.getName(),
+                            roleDomain.id(),
+                            roleName,
+                            privateKey,
+                            certificateDnsDomain,
+                            (int)CERTIFICATE_EXPIRY.getSeconds());
+            X509Certificate roleCertificate = Crypto.loadX509Certificate(
+                    ztsClient.postRoleCertificateRequest(roleDomain.id(), roleName, req)
+                            .getToken());
+            return new AthenzRoleCertificate(roleCertificate, privateKey);
+        });
+    }
+
+    private static <T> T getOrThrow(Supplier<T> wrappedCode) {
+        try {
+            return wrappedCode.get();
         } catch (ZTSClientException e) {
+            log.warning("Error from Athenz: " + e.getMessage());
             throw new ZtsException(e.getCode(), e);
         }
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/mock/ZtsClientMock.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/mock/ZtsClientMock.java
@@ -1,10 +1,21 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.athenz.mock;
 
+import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.vespa.hosted.controller.api.identifiers.AthenzDomain;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzIdentity;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzIdentityCertificate;
+import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzRoleCertificate;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.ZtsClient;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,4 +42,44 @@ public class ZtsClientMock implements ZtsClient {
                 .map(domain -> domain.name)
                 .collect(toList());
     }
+
+    @Override
+    public AthenzIdentityCertificate getIdentityCertificate() {
+        log.log(Level.INFO, "getIdentityCertificate()");
+        try {
+            KeyPair keyPair = createKeyPair();
+            String subject = "CN=controller";
+            return new AthenzIdentityCertificate(createCertificate(keyPair, subject), keyPair.getPrivate());
+        } catch (NoSuchAlgorithmException | OperatorCreationException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public AthenzRoleCertificate getRoleCertificate(AthenzDomain roleDomain, String roleName) {
+        log.log(Level.INFO,
+                String.format("getRoleCertificate(roleDomain=%s, roleName=%s)", roleDomain.id(), roleDomain));
+        try {
+            KeyPair keyPair = createKeyPair();
+            String subject = String.format("CN=%s:role.%s", roleDomain.id(), roleName);
+            return new AthenzRoleCertificate(createCertificate(keyPair, subject), keyPair.getPrivate());
+        } catch (NoSuchAlgorithmException | OperatorCreationException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static X509Certificate createCertificate(KeyPair keyPair, String subject) throws
+            OperatorCreationException, IOException {
+        PKCS10CertificationRequest csr =
+                Crypto.getPKCS10CertRequest(
+                        Crypto.generateX509CSR(keyPair.getPrivate(), subject, null));
+        return Crypto.generateX509Certificate(csr, keyPair.getPrivate(), new X500Name(subject), 3600, false);
+    }
+
+    private static KeyPair createKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(512);
+        return keyGen.genKeyPair();
+    }
+
 }

--- a/controller-server/src/main/resources/configdefinitions/athenz.def
+++ b/controller-server/src/main/resources/configdefinitions/athenz.def
@@ -31,3 +31,6 @@ service.privateKeyVersion       int
 
 # Name of Athenz service private key secret
 service.privateKeySecretName    string
+
+# Expiry of service principal token and certificate
+service.credentialsExpiryMinutes int   default=43200  # 30 days

--- a/controller-server/src/main/resources/configdefinitions/athenz.def
+++ b/controller-server/src/main/resources/configdefinitions/athenz.def
@@ -17,6 +17,9 @@ domain                          string
 userAuthenticationPassThruAttribute  string
 # TODO Remove once migrated to Okta
 
+# Certificate DNS domain
+certDnsDomain                   string
+
 # Athenz service name for controller identity
 service.name                    string
 

--- a/controller-server/src/main/resources/configdefinitions/athenz.def
+++ b/controller-server/src/main/resources/configdefinitions/athenz.def
@@ -17,6 +17,9 @@ domain                          string
 userAuthenticationPassThruAttribute  string
 # TODO Remove once migrated to Okta
 
+# Path to Athenz CA JKS trust store
+athenzCaTrustStore              string
+
 # Certificate DNS domain
 certDnsDomain                   string
 


### PR DESCRIPTION
Take two. I fixed the bug causing the controller to die. `AthenzSslContextProviderImpl` is now taking an `AthenzClientFactory` instead of `ZtsClient`.