### PR TITLE
Revert "Use RTMLocking"

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -187,7 +187,6 @@ exec_jsvc () {
     exec $numactlcmd $envcmd $jsvc_binary_name \
         -Dconfig.id="${VESPA_CONFIG_ID}" \
         -XX:+PreserveFramePointer \
-        -XX:+UseRTMLocking \
         ${jsvc_opts} \
         ${memory_options} \
         ${jvm_gcopts} \
@@ -261,7 +260,6 @@ maybe_use_jsvc
 exec $numactlcmd $envcmd java \
         -Dconfig.id="${VESPA_CONFIG_ID}" \
         -XX:+PreserveFramePointer \
-        -XX:+UseRTMLocking \
         ${memory_options} \
         ${jvm_gcopts} \
         -XX:MaxJavaStackTraceDepth=-1 \


### PR DESCRIPTION
Reverts vespa-engine/vespa#4420

Container does not come up, fails with this in the log:

Error occurred during initialization of VM
RTM instructions are not available on this CPU

(this was  taken from a system test running on systest51.head.factory.vespa.corp.gq1.yahoo.com)