### PR TITLE
Change type of timeout in SyncSession from TemporalAmount to Duration

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/SyncParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/SyncParameters.java
@@ -1,17 +1,17 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.documentapi;
 
-import java.time.temporal.TemporalAmount;
+import java.time.Duration;
 import java.util.Optional;
 
 /**
  * Parameters for creating a synchronous session
  *
  * @author bjorncs
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  */
 public class SyncParameters extends Parameters {
-    private final TemporalAmount defaultTimeout;
+    private final Duration defaultTimeout;
 
     /**
      * @deprecated Use {@link Builder} instead.
@@ -22,21 +22,21 @@ public class SyncParameters extends Parameters {
         this(null);
     }
 
-    private SyncParameters(TemporalAmount defaultTimeout) {
+    private SyncParameters(Duration defaultTimeout) {
         this.defaultTimeout = defaultTimeout;
     }
 
-    public Optional<TemporalAmount> defaultTimeout() {
+    public Optional<Duration> defaultTimeout() {
         return Optional.ofNullable(defaultTimeout);
     }
 
     public static class Builder {
-        private TemporalAmount defaultTimeout;
+        private Duration defaultTimeout;
 
         /**
          * Set default timeout for all messagebus operations.
          */
-        public void setDefaultTimeout(TemporalAmount defaultTimeout) {
+        public void setDefaultTimeout(Duration defaultTimeout) {
             this.defaultTimeout = defaultTimeout;
         }
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/SyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/SyncSession.java
@@ -8,13 +8,13 @@ import com.yahoo.document.DocumentRemove;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 
-import java.time.temporal.TemporalAmount;
+import java.time.Duration;
 
 /**
  * <p>A session for synchronous access to a document repository. This class
  * provides simple document access where throughput is not a concern.</p>
  *
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  * @author bjorncs
  */
 public interface SyncSession extends Session {
@@ -71,7 +71,7 @@ public interface SyncSession extends Session {
      * @throws DocumentAccessException on any messagebus error, including timeout ({@link com.yahoo.messagebus.ErrorCode#TIMEOUT}).
      */
     // TODO Vespa 7: Remove default implementation. Consider removing get() overloads without timeout.
-    default Document get(DocumentId id, TemporalAmount timeout) {
+    default Document get(DocumentId id, Duration timeout) {
         return get(id);
     }
 
@@ -88,8 +88,7 @@ public interface SyncSession extends Session {
      * @throws DocumentAccessException on any messagebus error, including timeout ({@link com.yahoo.messagebus.ErrorCode#TIMEOUT}).
      */
     // TODO Vespa 7: Remove default implementation. Consider removing get() overloads without timeout.
-    default Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority priority,
-                         TemporalAmount timeout) {
+    default Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority priority, Duration timeout) {
         return get(id, fieldSet, priority);
     }
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
@@ -25,19 +25,18 @@ import com.yahoo.messagebus.MessageBus;
 import com.yahoo.messagebus.Reply;
 import com.yahoo.messagebus.ReplyHandler;
 
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAmount;
+import java.time.Duration;
 
 /**
  * An implementation of the SyncSession interface running over message bus.
  *
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  * @author bjorncs
  */
 public class MessageBusSyncSession implements MessageBusSession, SyncSession, ReplyHandler {
 
     private final MessageBusAsyncSession session;
-    private final TemporalAmount defaultTimeout;
+    private final Duration defaultTimeout;
 
     /**
      * Creates a new sync session running on message bus logic.
@@ -87,9 +86,9 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
         return syncSend(msg, defaultTimeout);
     }
 
-    private Reply syncSend(Message msg, TemporalAmount timeout) {
+    private Reply syncSend(Message msg, Duration timeout) {
         if (timeout != null) {
-            msg.setTimeRemaining(timeout.get(ChronoUnit.MILLIS));
+            msg.setTimeRemaining(timeout.toMillis());
         }
         try {
             RequestMonitor monitor = new RequestMonitor();
@@ -135,13 +134,12 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
     }
 
     @Override
-    public Document get(DocumentId id, TemporalAmount timeout) {
+    public Document get(DocumentId id, Duration timeout) {
         return get(id, "[all]", DocumentProtocol.Priority.NORMAL_1, timeout);
     }
 
     @Override
-    public Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority pri,
-                        TemporalAmount timeout) {
+    public Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority pri, Duration timeout) {
         GetDocumentMessage msg = new GetDocumentMessage(id, fieldSet);
         msg.setPriority(pri);
 


### PR DESCRIPTION
TemporalAmount does not expose any API for retrieving the amount in
milliseconds (get(ChronoUnit.MILLIS) throws exception).
The Javadoc on TemporalAmount also states that the type is
a framework-level interface that should not be widely used in
application code.

FYI @vekterli 