### PR TITLE
EofException is always wrapped in CompletionException

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -34,6 +35,7 @@ import static com.yahoo.jdisc.http.server.jetty.Exceptions.throwUnchecked;
 
 /**
  * @author Simon Thoresen Hult
+ * @author bjorncs
  */
 class HttpRequestDispatch {
 
@@ -123,10 +125,10 @@ class HttpRequestDispatch {
             boolean reportedError = false;
 
             if (error != null) {
-                if (error instanceof EofException) {
+                if (error instanceof CompletionException && error.getCause() instanceof EofException) {
                     log.log(Level.FINE,
-                            "Network connection was unexpectedly terminated: " + parent.servletRequest.getRequestURI(),
-                            error);
+                            error,
+                            () -> "Network connection was unexpectedly terminated: " + parent.servletRequest.getRequestURI());
                 } else if (!(error instanceof OverloadException || error instanceof BindingNotFoundException)) {
                     log.log(Level.WARNING, "Request failed: " + parent.servletRequest.getRequestURI(), error);
                 }


### PR DESCRIPTION
Also change logging to use Supplier<String> to avoid unnecessary String
instantiations.