### PR TITLE
Make Flex and Bison outputs explicit in CMakeLists.txt

### DIFF
--- a/document/src/vespa/document/select/CMakeLists.txt
+++ b/document/src/vespa/document/select/CMakeLists.txt
@@ -1,10 +1,14 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-find_package(BISON REQUIRED)
-find_package(FLEX REQUIRED)
+find_package(BISON REQUIRED 3.0)
+find_package(FLEX REQUIRED 2.5)
 
-BISON_TARGET(DocSelParser grammar/parser.yy ${CMAKE_CURRENT_BINARY_DIR}/parser.cxx)
-FLEX_TARGET(DocSelLexer grammar/lexer.ll ${CMAKE_CURRENT_BINARY_DIR}/lexer.cxx)
+BISON_TARGET(DocSelParser grammar/parser.yy
+             ${CMAKE_CURRENT_BINARY_DIR}/parser.cxx
+             DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/parser.hxx)
+FLEX_TARGET(DocSelLexer grammar/lexer.ll
+            ${CMAKE_CURRENT_BINARY_DIR}/lexer.cxx
+            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/lexer.hxx)
 
 ADD_FLEX_BISON_DEPENDENCY(DocSelLexer DocSelParser)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/document/src/vespa/document/select/grammar/lexer.ll
+++ b/document/src/vespa/document/select/grammar/lexer.ll
@@ -1,9 +1,5 @@
  /* Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. */
 
- /* We use the .*xx-suffix to denote a build-time generated file */
-%option outfile="lexer.cxx"
-%option header-file="lexer.hxx"
-
 %option c++
  /* Uncomment to enable debug tracing of parsing */
  /* %option debug */

--- a/document/src/vespa/document/select/grammar/parser.yy
+++ b/document/src/vespa/document/select/grammar/parser.yy
@@ -1,8 +1,5 @@
  /* Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. */
 
-%output "parser.cxx"
-%defines "parser.hxx"
-
  /* Skeleton implementation included as part of the generated source. Note: _not_ covered by the GPL. */
 %skeleton "lalr1.cc"
 


### PR DESCRIPTION
@baldersheim please review
@aressem FYI

Stating outputs in lexer and parser grammar files messes up the output
directory and always places the outputs in the current working directory.

This fixes #4435