### PR TITLE
Fix per doc-id race with multiple document updates against same document

### DIFF
--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
@@ -177,10 +177,14 @@ public class OperationProcessor {
             docSendInfoByOperationId.remove(endpointResult.getOperationId());
 
             String documentId = documentSendInfo.getDocument().getDocumentId();
-            inflightDocumentIds.remove(documentId);
-
+            /**
+             * If we got a pending operation against this document
+             * dont't remove it from inflightDocuments and send blocked document operation
+             */
             List<Document> blockedDocuments = blockedDocumentsByDocumentId.get(documentId);
-            if (! blockedDocuments.isEmpty()) {
+            if (blockedDocuments.isEmpty()) {
+                inflightDocumentIds.remove(documentId);
+            } else {
                 sendToClusters(blockedDocuments.remove(0));
             }
             return result;


### PR DESCRIPTION
These events would trigger this issue. 

 1  PUT foo x=10 is sent and in-flight operations is updated 
 2  UPDATE foo x=12  is sent but before the ack of PUT in $1 and is hence blocked as in-flight contains the document id  
 3  The ack for $1 arrives and foo is removed from inflight, operation $2 is sent but not tracked as in-flight
 4  UPDATE foo x=5 arrives before operation $2 is acked and since in flight is not tracked for operation $2 this operation is not blocked and sent directly leading to a race condition. 