### PR TITLE
Use a prime based hash instead.

### DIFF
--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor.cpp
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor.cpp
@@ -190,7 +190,4 @@ SparseTensor::reduce(join_fun_t op,
 
 }
 
-// VESPALIB_HASH_MAP_INSTANTIATE(vespalib::tensor::SparseTensorAddressRef, double);
-
-VESPALIB_HASH_MAP_INSTANTIATE_H_E_M(vespalib::tensor::SparseTensorAddressRef, double, vespalib::hash<vespalib::tensor::SparseTensorAddressRef>,
-        std::equal_to<vespalib::tensor::SparseTensorAddressRef>, vespalib::hashtable_base::and_modulator);
+VESPALIB_HASH_MAP_INSTANTIATE(vespalib::tensor::SparseTensorAddressRef, double);

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor.h
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor.h
@@ -21,8 +21,7 @@ namespace vespalib::tensor {
 class SparseTensor : public Tensor
 {
 public:
-    using Cells = hash_map<SparseTensorAddressRef, double, hash<SparseTensorAddressRef>,
-            std::equal_to<SparseTensorAddressRef>, hashtable_base::and_modulator>;
+    using Cells = hash_map<SparseTensorAddressRef, double>;
 
     static constexpr size_t STASH_CHUNK_SIZE = 16384u;
 


### PR DESCRIPTION
@geirst PR
This cancels the effect of  #4495 