### PR TITLE
Use longs for dimensions lengths in all API's

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationPackage.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationPackage.java
@@ -3,11 +3,10 @@ package com.yahoo.config.application.api;
 
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.Version;
-import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provision.ZoneId;
-import com.yahoo.path.Path;
 import com.yahoo.io.IOUtils;
 import com.yahoo.io.reader.NamedReader;
+import com.yahoo.path.Path;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import org.w3c.dom.Element;
@@ -15,8 +14,17 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -229,9 +237,9 @@ public interface ApplicationPackage {
         throw new UnsupportedOperationException("This application package cannot write its metadata");
     }
 
-    /** 
-     * Returns the single host allocation info of this, or an empty map if no allocation is available 
-     * 
+    /**
+     * Returns the single host allocation info of this, or an empty map if no allocation is available
+     *
      * @deprecated please use #getAllocatedHosts
      */
     // TODO: Remove on Vespa 7

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationPackage.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationPackage.java
@@ -3,6 +3,7 @@ package com.yahoo.config.application.api;
 
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.Version;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provision.ZoneId;
 import com.yahoo.io.IOUtils;
 import com.yahoo.io.reader.NamedReader;

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/ValidateSortingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/ValidateSortingSearcher.java
@@ -25,7 +25,7 @@ import static com.yahoo.prelude.querytransform.NormalizingSearcher.ACCENT_REMOVA
  * Check sorting specification makes sense to the search cluster before
  * passing it on to the backend.
  *
- * @author  <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 @Before(PhaseNames.BACKEND)
 @After(ACCENT_REMOVAL)
@@ -118,6 +118,7 @@ public class ValidateSortingSearcher extends Searcher {
         for (Sorting.FieldOrder f : l) {
             String name = f.getFieldName();
             if ("[rank]".equals(name) || "[docid]".equals(name)) {
+                // built-in constants - ok
             } else if (names.containsKey(name)) {
                 AttributesConfig.Attribute attrConfig = names.get(name);
                 if (attrConfig != null) {
@@ -166,18 +167,13 @@ public class ValidateSortingSearcher extends Searcher {
                             locale = "en_US";
                         }
 
-                        // getLogger().info("locale = " + locale + " attrConfig.sortlocale.value() = " + attrConfig.sortlocale.value() + " query.getLanguage() = " + query.getModel().getLanguage());
-                        // getLogger().info("locale = " + locale);
-
                         Sorting.UcaSorter.Strength strength = sorter.getStrength();
                         if (sorter.getStrength() == Sorting.UcaSorter.Strength.UNDEFINED) {
                             strength = config2Strength(attrConfig.sortstrength());
                         }
                         if ((sorter.getStrength() == Sorting.UcaSorter.Strength.UNDEFINED) || (sorter.getLocale() == null) || sorter.getLocale().isEmpty()) {
-                            // getLogger().info("locale = " + locale + " strength = " + strength.toString());
                             sorter.setLocale(locale, strength);
                         }
-                        //getLogger().info("locale = " + locale + " strength = " + strength.toString() + "decompose = " + sorter.getDecomposition());
                     }
                 } else {
                     return ErrorMessage.createInvalidQueryParameter("The cluster " + getClusterName() + " has attribute config for field: " + name);

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TensorConverter.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TensorConverter.java
@@ -26,7 +26,7 @@ public class TensorConverter {
         int dimensionIndex = 0;
         for (long dimensionSize : shape) {
             if (dimensionSize == 0) dimensionSize = 1; // TensorFlow ...
-            b.indexed("d" + (dimensionIndex++), (int) dimensionSize);
+            b.indexed("d" + (dimensionIndex++), dimensionSize);
         }
         return b.build();
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/GeneratorLambdaFunctionNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/GeneratorLambdaFunctionNode.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression.rule;
 
-import com.google.common.collect.ImmutableList;
 import com.yahoo.searchlib.rankingexpression.evaluation.Context;
 import com.yahoo.searchlib.rankingexpression.evaluation.MapContext;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
@@ -10,7 +9,6 @@ import com.yahoo.tensor.TensorType;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
-import java.util.function.*;
 
 /**
  * A tensor generating function, whose arguments are determined by a tensor type
@@ -57,14 +55,14 @@ public class GeneratorLambdaFunctionNode extends CompositeNode {
     /**
      * Returns this as an operator which converts a list of integers into a double
      */
-    public IntegerListToDoubleLambda asIntegerListToDoubleOperator() {
-        return new IntegerListToDoubleLambda();
+    public LongListToDoubleLambda asLongListToDoubleOperator() {
+        return new LongListToDoubleLambda();
     }
 
-    private class IntegerListToDoubleLambda implements java.util.function.Function<List<Integer>, Double> {
+    private class LongListToDoubleLambda implements java.util.function.Function<List<Long>, Double> {
 
         @Override
-        public Double apply(List<Integer> arguments) {
+        public Double apply(List<Long> arguments) {
             MapContext context = new MapContext();
             for (int i = 0; i < type.dimensions().size(); i++)
                 context.put(type.dimensions().get(i).name(), arguments.get(i));

--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -467,7 +467,7 @@ ExpressionNode tensorGenerate() :
 }
 {
     <TENSOR> type = tensorTypeArgument() <LBRACE> generator = expression() <RBRACE>
-    { return new TensorFunctionNode(new Generate(type, new GeneratorLambdaFunctionNode(type, generator).asIntegerListToDoubleOperator())); }
+    { return new TensorFunctionNode(new Generate(type, new GeneratorLambdaFunctionNode(type, generator).asLongListToDoubleOperator())); }
 }
 
 ExpressionNode tensorRange() :

--- a/vespajlib/src/main/java/com/yahoo/tensor/DimensionSizes.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/DimensionSizes.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 @Beta
 public final class DimensionSizes {
 
-    private final int[] sizes;
+    private final long[] sizes;
 
     private DimensionSizes(Builder builder) {
         this.sizes = builder.sizes;
@@ -25,15 +25,15 @@ public final class DimensionSizes {
      *
      * @throws IndexOutOfBoundsException if the index is larger than the number of dimensions in this tensor minus one
      */
-    public int size(int dimensionIndex) { return sizes[dimensionIndex]; }
+    public long size(int dimensionIndex) { return sizes[dimensionIndex]; }
 
     /** Returns the number of dimensions this provides the size of */
     public int dimensions() { return sizes.length; }
 
     /** Returns the product of the sizes of this */
-    public int totalSize() {
-        int productSize = 1;
-        for (int dimensionSize : sizes )
+    public long totalSize() {
+        long productSize = 1;
+        for (long dimensionSize : sizes )
             productSize *= dimensionSize;
         return productSize;
     }
@@ -54,13 +54,13 @@ public final class DimensionSizes {
      */
     public final static class Builder {
 
-        private int[] sizes;
+        private long[] sizes;
 
         public Builder(int dimensions) {
-            this.sizes = new int[dimensions];
+            this.sizes = new long[dimensions];
         }
 
-        public Builder set(int dimensionIndex, int size) {
+        public Builder set(int dimensionIndex, long size) {
             sizes[dimensionIndex] = size;
             return this;
         }
@@ -70,7 +70,7 @@ public final class DimensionSizes {
          *
          * @throws IndexOutOfBoundsException if the index is larger than the number of dimensions in this tensor minus one
          */
-        public int size(int dimensionIndex) { return sizes[dimensionIndex]; }
+        public long size(int dimensionIndex) { return sizes[dimensionIndex]; }
 
         /** Returns the number of dimensions this provides the size of */
         public int dimensions() { return sizes.length; }

--- a/vespajlib/src/main/java/com/yahoo/tensor/MappedTensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/MappedTensor.java
@@ -29,7 +29,7 @@ public class MappedTensor implements Tensor {
     public TensorType type() { return type; }
 
     @Override
-    public int size() { return cells.size(); }
+    public long size() { return cells.size(); }
 
     @Override
     public double get(TensorAddress address) { return cells.getOrDefault(address, Double.NaN); }
@@ -80,7 +80,7 @@ public class MappedTensor implements Tensor {
         }
 
         @Override
-        public Builder cell(double value, int... labels) {
+        public Builder cell(double value, long... labels) {
             cells.put(TensorAddress.of(labels), value);
             return this;
         }

--- a/vespajlib/src/main/java/com/yahoo/tensor/PartialAddress.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/PartialAddress.java
@@ -6,11 +6,11 @@ import com.google.common.annotations.Beta;
 /**
  * An address to a subset of a tensors' cells, specifying a label for some but not necessarily all of the tensors
  * dimensions.
- * 
+ *
  * @author bratseth
  */
-// Implementation notes: 
-// - These are created in inner (though not inner-most) loops so they are implemented with minimal allocation. 
+// Implementation notes:
+// - These are created in inner (though not inner-most) loops so they are implemented with minimal allocation.
 //   We also avoid non-essential error checking.
 // - We can add support for string labels later without breaking the API
 @Beta
@@ -19,7 +19,7 @@ public class PartialAddress {
     // Two arrays which contains corresponding dimension=label pairs.
     // The sizes of these are always equal.
     private final String[] dimensionNames;
-    private final int[] labels;
+    private final long[] labels;
 
     private PartialAddress(Builder builder) {
         this.dimensionNames = builder.dimensionNames;
@@ -27,36 +27,36 @@ public class PartialAddress {
         builder.dimensionNames = null; // invalidate builder to safely take over array ownership
         builder.labels = null;
     }
-    
+
     /** Returns the int label of this dimension, or -1 if no label is specified for it */
-    int intLabel(String dimensionName) {
+    long numericLabel(String dimensionName) {
         for (int i = 0; i < dimensionNames.length; i++)
             if (dimensionNames[i].equals(dimensionName))
                 return labels[i];
         return -1;
     }
-    
+
     public static class Builder {
 
         private String[] dimensionNames;
-        private int[] labels;
+        private long[] labels;
         private int index = 0;
-        
+
         public Builder(int size) {
             dimensionNames = new String[size];
-            labels = new int[size];
+            labels = new long[size];
         }
-        
-        public void add(String dimensionName, int label) {
+
+        public void add(String dimensionName, long label) {
             dimensionNames[index] = dimensionName;
             labels[index] = label;
             index++;
         }
-        
+
         public PartialAddress build() {
             return new PartialAddress(this);
         }
-        
+
     }
-    
+
 }

--- a/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
@@ -59,7 +59,7 @@ public interface Tensor {
     default boolean isEmpty() { return size() == 0; }
 
     /** Returns the number of cells in this */
-    int size();
+    long size();
 
     /** Returns the value of a cell, or NaN if this cell does not exist/have no value */
     double get(TensorAddress address);
@@ -124,7 +124,7 @@ public interface Tensor {
         return new Rename(new ConstantTensor(this), fromDimensions, toDimensions).evaluate();
     }
 
-    static Tensor generate(TensorType type, Function<List<Integer>, Double> valueSupplier) {
+    static Tensor generate(TensorType type, Function<List<Long>, Double> valueSupplier) {
         return new Generate(type, valueSupplier).evaluate();
     }
 
@@ -333,7 +333,7 @@ public interface Tensor {
          * This is for optimizations mapping between tensors where this is possible without creating a
          * TensorAddress.
          */
-        int getDirectIndex() { return -1; }
+        long getDirectIndex() { return -1; }
 
         @Override
         public Double getValue() { return value; }
@@ -396,7 +396,7 @@ public interface Tensor {
         Builder cell(TensorAddress address, double value);
 
         /** Add a cell */
-        Builder cell(double value, int ... labels);
+        Builder cell(double value, long ... labels);
 
         /**
          * Add a cell
@@ -425,7 +425,7 @@ public interface Tensor {
                 return this;
             }
 
-            public CellBuilder label(String dimension, int label) {
+            public CellBuilder label(String dimension, long label) {
                 return label(dimension, String.valueOf(label));
             }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorAddress.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorAddress.java
@@ -2,16 +2,10 @@
 package com.yahoo.tensor;
 
 import com.google.common.annotations.Beta;
-import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * An immutable address to a tensor cell. This simply supplies a value to each dimension
@@ -26,8 +20,8 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
         return new StringTensorAddress(labels);
     }
 
-    public static TensorAddress of(int ... labels) {
-        return new IntTensorAddress(labels);
+    public static TensorAddress of(long ... labels) {
+        return new NumericTensorAddress(labels);
     }
 
     /** Returns the number of labels in this */
@@ -41,14 +35,14 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
     public abstract String label(int i);
 
     /**
-     * Returns the i'th label in this as an int.
-     * Prefer this if you know that this is an integer address, but not otherwise.
+     * Returns the i'th label in this as a long.
+     * Prefer this if you know that this is a numeric address, but not otherwise.
      *
      * @throws IllegalArgumentException if there is no label at this index
      */
-    public abstract int intLabel(int i);
+    public abstract long numericLabel(int i);
 
-    public abstract TensorAddress withLabel(int labelIndex, int label);
+    public abstract TensorAddress withLabel(int labelIndex, long label);
 
     public final boolean isEmpty() { return size() == 0; }
 
@@ -110,17 +104,17 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
         public String label(int i) { return labels[i]; }
 
         @Override
-        public int intLabel(int i) {
+        public long numericLabel(int i) {
             try {
-                return Integer.parseInt(labels[i]);
+                return Long.parseLong(labels[i]);
             }
             catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Expected an int label in " + this + " at position " + i);
+                throw new IllegalArgumentException("Expected a long label in " + this + " at position " + i);
             }
         }
 
         @Override
-        public TensorAddress withLabel(int index, int label) {
+        public TensorAddress withLabel(int index, long label) {
             String[] labels = Arrays.copyOf(this.labels, this.labels.length);
             labels[index] = String.valueOf(label);
             return new StringTensorAddress(labels);
@@ -133,11 +127,11 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
 
     }
 
-    private static final class IntTensorAddress extends TensorAddress {
+    private static final class NumericTensorAddress extends TensorAddress {
 
-        private final int[] labels;
+        private final long[] labels;
 
-        private IntTensorAddress(int[] labels) {
+        private NumericTensorAddress(long[] labels) {
             this.labels = Arrays.copyOf(labels, labels.length);
         }
 
@@ -148,13 +142,13 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
         public String label(int i) { return String.valueOf(labels[i]); }
 
         @Override
-        public int intLabel(int i) { return labels[i]; }
+        public long numericLabel(int i) { return labels[i]; }
 
         @Override
-        public TensorAddress withLabel(int index, int label) {
-            int[] labels = Arrays.copyOf(this.labels, this.labels.length);
+        public TensorAddress withLabel(int index, long label) {
+            long[] labels = Arrays.copyOf(this.labels, this.labels.length);
             labels[index] = label;
-            return new IntTensorAddress(labels);
+            return new NumericTensorAddress(labels);
         }
 
         @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
@@ -139,7 +139,7 @@ public class TensorType {
         public final String name() { return name; }
 
         /** Returns the size of this dimension if it is bound, empty otherwise */
-        public abstract Optional<Integer> size();
+        public abstract Optional<Long> size();
 
         public abstract Type type();
 
@@ -189,7 +189,7 @@ public class TensorType {
             return this.name.compareTo(other.name);
         }
 
-        public static Dimension indexed(String name, int size) {
+        public static Dimension indexed(String name, long size) {
             return new IndexedBoundDimension(name, size);
         }
 
@@ -197,17 +197,19 @@ public class TensorType {
 
     public static class IndexedBoundDimension extends TensorType.Dimension {
 
-        private final Integer size;
+        private final Long size;
 
-        private IndexedBoundDimension(String name, int size) {
+        private IndexedBoundDimension(String name, long size) {
             super(name);
             if (size < 1)
                 throw new IllegalArgumentException("Size of bound dimension '" + name + "' must be at least 1");
+            if (size > Integer.MAX_VALUE)
+                throw new IllegalArgumentException("Size of bound dimension '" + name + "' cannot be larger than " + Integer.MAX_VALUE);
             this.size = size;
         }
 
         @Override
-        public Optional<Integer> size() { return Optional.of(size); }
+        public Optional<Long> size() { return Optional.of(size); }
 
         @Override
         public Type type() { return Type.indexedBound; }
@@ -248,7 +250,7 @@ public class TensorType {
         }
 
         @Override
-        public Optional<Integer> size() { return Optional.empty(); }
+        public Optional<Long> size() { return Optional.empty(); }
 
         @Override
         public Type type() { return Type.indexedUnbound; }
@@ -269,7 +271,7 @@ public class TensorType {
         }
 
         @Override
-        public Optional<Integer> size() { return Optional.empty(); }
+        public Optional<Long> size() { return Optional.empty(); }
 
         @Override
         public Type type() { return Type.mapped; }
@@ -357,7 +359,7 @@ public class TensorType {
          *
          * @throws IllegalArgumentException if the dimension is already present
          */
-        public Builder indexed(String name, int size) { return add(new IndexedBoundDimension(name, size)); }
+        public Builder indexed(String name, long size) { return add(new IndexedBoundDimension(name, size)); }
 
         /**
          * Adds an unbound indexed dimension to this

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
@@ -67,7 +67,7 @@ public class Concat extends PrimitiveTensorFunction {
         DimensionSizes concatSize = concatSize(concatType, aIndexed, bIndexed, dimension);
 
         Tensor.Builder builder = Tensor.Builder.of(concatType, concatSize);
-        int aDimensionLength = aIndexed.type().indexOfDimension(dimension).map(d -> aIndexed.dimensionSizes().size(d)).orElseThrow(RuntimeException::new);
+        long aDimensionLength = aIndexed.type().indexOfDimension(dimension).map(d -> aIndexed.dimensionSizes().size(d)).orElseThrow(RuntimeException::new);
         int[] aToIndexes = mapIndexes(a.type(), concatType);
         int[] bToIndexes = mapIndexes(b.type(), concatType);
         concatenateTo(aIndexed, bIndexed, aDimensionLength, concatType, aToIndexes, bToIndexes, builder);
@@ -75,7 +75,7 @@ public class Concat extends PrimitiveTensorFunction {
         return builder.build();
     }
 
-    private void concatenateTo(IndexedTensor a, IndexedTensor b, int offset, TensorType concatType,
+    private void concatenateTo(IndexedTensor a, IndexedTensor b, long offset, TensorType concatType,
                                int[] aToIndexes, int[] bToIndexes, Tensor.Builder builder) {
         Set<String> otherADimensions = a.type().dimensionNames().stream().filter(d -> !d.equals(dimension)).collect(Collectors.toSet());
         for (Iterator<IndexedTensor.SubspaceIterator> ia = a.subspaceIterator(otherADimensions); ia.hasNext();) {
@@ -129,8 +129,8 @@ public class Concat extends PrimitiveTensorFunction {
         DimensionSizes.Builder concatSizes = new DimensionSizes.Builder(concatType.dimensions().size());
         for (int i = 0; i < concatSizes.dimensions(); i++) {
             String currentDimension = concatType.dimensions().get(i).name();
-            int aSize = a.type().indexOfDimension(currentDimension).map(d -> a.dimensionSizes().size(d)).orElse(0);
-            int bSize = b.type().indexOfDimension(currentDimension).map(d -> b.dimensionSizes().size(d)).orElse(0);
+            long aSize = a.type().indexOfDimension(currentDimension).map(d -> a.dimensionSizes().size(d)).orElse(0L);
+            long bSize = b.type().indexOfDimension(currentDimension).map(d -> b.dimensionSizes().size(d)).orElse(0L);
             if (currentDimension.equals(concatDimension))
                 concatSizes.set(i, aSize + bSize);
             else if (aSize != 0 && bSize != 0 && aSize!=bSize )
@@ -148,8 +148,8 @@ public class Concat extends PrimitiveTensorFunction {
      *         (in some other dimension than the concat dimension)
      */
     private TensorAddress combineAddresses(TensorAddress a, int[] aToIndexes, TensorAddress b, int[] bToIndexes,
-                                           TensorType concatType, int concatOffset, String concatDimension) {
-        int[] combinedLabels = new int[concatType.dimensions().size()];
+                                           TensorType concatType, long concatOffset, String concatDimension) {
+        long[] combinedLabels = new long[concatType.dimensions().size()];
         Arrays.fill(combinedLabels, -1);
         int concatDimensionIndex = concatType.indexOfDimension(concatDimension).get();
         mapContent(a, combinedLabels, aToIndexes, concatDimensionIndex, concatOffset); // note: This sets a nonsensical value in the concat dimension
@@ -179,15 +179,15 @@ public class Concat extends PrimitiveTensorFunction {
      * @return true if the mapping was successful, false if one of the destination positions was
      *         occupied by a different value
      */
-    private boolean mapContent(TensorAddress from, int[] to, int[] indexMap, int concatDimension, int concatOffset) {
+    private boolean mapContent(TensorAddress from, long[] to, int[] indexMap, int concatDimension, long concatOffset) {
         for (int i = 0; i < from.size(); i++) {
             int toIndex = indexMap[i];
             if (concatDimension == toIndex) {
-                to[toIndex] = from.intLabel(i) + concatOffset;
+                to[toIndex] = from.numericLabel(i) + concatOffset;
             }
             else {
-                if (to[toIndex] != -1 && to[toIndex] != from.intLabel(i)) return false;
-                to[toIndex] = from.intLabel(i);
+                if (to[toIndex] != -1 && to[toIndex] != from.numericLabel(i)) return false;
+                to[toIndex] = from.numericLabel(i);
             }
         }
         return true;

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Diag.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Diag.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 public class Diag extends CompositeTensorFunction {
 
     private final TensorType type;
-    private final Function<List<Integer>, Double> diagFunction;
+    private final Function<List<Long>, Double> diagFunction;
 
     public Diag(TensorType type) {
         this.type = type;

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Generate.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Generate.java
@@ -22,17 +22,17 @@ import java.util.function.Function;
 public class Generate extends PrimitiveTensorFunction {
 
     private final TensorType type;
-    private final Function<List<Integer>, Double> generator;
+    private final Function<List<Long>, Double> generator;
 
     /**
      * Creates a generated tensor
      *
      * @param type the type of the tensor
-     * @param generator the function generating values from a list of ints specifying the indexes of the
+     * @param generator the function generating values from a list of numbers specifying the indexes of the
      *                  tensor cell which will receive the value
      * @throws IllegalArgumentException if any of the tensor dimensions are not indexed bound
      */
-    public Generate(TensorType type, Function<List<Integer>, Double> generator) {
+    public Generate(TensorType type, Function<List<Long>, Double> generator) {
         Objects.requireNonNull(type, "The argument tensor type cannot be null");
         Objects.requireNonNull(generator, "The argument function cannot be null");
         validateType(type);

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Join.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Join.java
@@ -56,8 +56,8 @@ public class Join extends PrimitiveTensorFunction {
                 if (aDim.name().equals(bDim.name())) { // include
                     if (aDim.isIndexed() && bDim.isIndexed()) {
                         if (aDim.size().isPresent() || bDim.size().isPresent())
-                            typeBuilder.indexed(aDim.name(), Math.min(aDim.size().orElse(Integer.MAX_VALUE),
-                                                                      bDim.size().orElse(Integer.MAX_VALUE)));
+                            typeBuilder.indexed(aDim.name(), Math.min(aDim.size().orElse(Long.MAX_VALUE),
+                                                                      bDim.size().orElse(Long.MAX_VALUE)));
                         else
                             typeBuilder.indexed(aDim.name());
                     }
@@ -118,11 +118,11 @@ public class Join extends PrimitiveTensorFunction {
     }
 
     private Tensor indexedVectorJoin(IndexedTensor a, IndexedTensor b, TensorType type) {
-        int joinedLength = Math.min(a.dimensionSizes().size(0), b.dimensionSizes().size(0));
+        long joinedRank = Math.min(a.dimensionSizes().size(0), b.dimensionSizes().size(0));
         Iterator<Double> aIterator = a.valueIterator();
         Iterator<Double> bIterator = b.valueIterator();
-        IndexedTensor.Builder builder = IndexedTensor.Builder.of(type, new DimensionSizes.Builder(1).set(0, joinedLength).build());
-        for (int i = 0; i < joinedLength; i++)
+        IndexedTensor.Builder builder = IndexedTensor.Builder.of(type, new DimensionSizes.Builder(1).set(0, joinedRank).build());
+        for (int i = 0; i < joinedRank; i++)
             builder.cell(combinator.applyAsDouble(aIterator.next(), bIterator.next()), i);
         return builder.build();
     }
@@ -169,10 +169,10 @@ public class Join extends PrimitiveTensorFunction {
         return builder.build();
     }
 
-    private void joinSubspaces(Iterator<Double> subspace, int subspaceSize,
-                               Iterator<Tensor.Cell> superspace, int superspaceSize,
+    private void joinSubspaces(Iterator<Double> subspace, long subspaceSize,
+                               Iterator<Tensor.Cell> superspace, long superspaceSize,
                                boolean reversedArgumentOrder, IndexedTensor.Builder builder) {
-        int joinedLength = Math.min(subspaceSize, superspaceSize);
+        long joinedLength = Math.min(subspaceSize, superspaceSize);
         if (reversedArgumentOrder) {
             for (int i = 0; i < joinedLength; i++) {
                 Tensor.Cell supercell = superspace.next();
@@ -281,7 +281,7 @@ public class Join extends PrimitiveTensorFunction {
         PartialAddress.Builder builder = new PartialAddress.Builder(retainDimensions.size());
         for (int i = 0; i < addressType.dimensions().size(); i++)
             if (retainDimensions.contains(addressType.dimensions().get(i).name()))
-                builder.add(addressType.dimensions().get(i).name(), address.intLabel(i));
+                builder.add(addressType.dimensions().get(i).name(), address.numericLabel(i));
         return builder.build();
     }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Range.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Range.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 public class Range extends CompositeTensorFunction {
 
     private final TensorType type;
-    private final Function<List<Integer>, Double> rangeFunction;
+    private final Function<List<Long>, Double> rangeFunction;
 
     public Range(TensorType type) {
         this.type = type;

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/ScalarFunctions.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/ScalarFunctions.java
@@ -14,8 +14,8 @@ import java.util.stream.Collectors;
 /**
  * Factory of scalar Java functions.
  * The purpose of this is to embellish anonymous functions with a runtime type
- * such that they can be inspected and will return a parseable toString.
- * 
+ * such that they can be inspected and will return a parsable toString.
+ *
  * @author bratseth
  */
 @Beta
@@ -31,9 +31,9 @@ public class ScalarFunctions {
     public static DoubleUnaryOperator sqrt() { return new Sqrt(); }
     public static DoubleUnaryOperator square() { return new Square(); }
 
-    public static Function<List<Integer>, Double> random() { return new Random(); }
-    public static Function<List<Integer>, Double> equal(List<String> argumentNames) { return new EqualElements(argumentNames); }
-    public static Function<List<Integer>, Double> sum(List<String> argumentNames) { return new SumElements(argumentNames); }
+    public static Function<List<Long>, Double> random() { return new Random(); }
+    public static Function<List<Long>, Double> equal(List<String> argumentNames) { return new EqualElements(argumentNames); }
+    public static Function<List<Long>, Double> sum(List<String> argumentNames) { return new SumElements(argumentNames); }
 
     // Binary operators -----------------------------------------------------------------------------
 
@@ -60,7 +60,7 @@ public class ScalarFunctions {
 
     public static class Multiply implements DoubleBinaryOperator {
         @Override
-        public double applyAsDouble(double left, double right) { return left * right; }        
+        public double applyAsDouble(double left, double right) { return left * right; }
         @Override
         public String toString() { return "f(a,b)(a * b)"; }
     }
@@ -100,26 +100,26 @@ public class ScalarFunctions {
 
     // Variable-length operators -----------------------------------------------------------------------------
 
-    public static class EqualElements implements Function<List<Integer>, Double> {        
-        private final ImmutableList<String> argumentNames;        
+    public static class EqualElements implements Function<List<Long>, Double> {
+        private final ImmutableList<String> argumentNames;
         private EqualElements(List<String> argumentNames) {
             this.argumentNames = ImmutableList.copyOf(argumentNames);
         }
 
         @Override
-        public Double apply(List<Integer> values) {
+        public Double apply(List<Long> values) {
             if (values.isEmpty()) return 1.0;
-            for (Integer value : values)
+            for (Long value : values)
                 if ( ! value.equals(values.get(0)))
                     return 0.0;
             return 1.0;
         }
         @Override
-        public String toString() { 
+        public String toString() {
             if (argumentNames.size() == 0) return "1";
             if (argumentNames.size() == 1) return "1";
             if (argumentNames.size() == 2) return argumentNames.get(0) + "==" + argumentNames.get(1);
-            
+
             StringBuilder b = new StringBuilder();
             for (int i = 0; i < argumentNames.size() -1; i++) {
                 b.append("(").append(argumentNames.get(i)).append("==").append(argumentNames.get(i+1)).append(")");
@@ -130,25 +130,25 @@ public class ScalarFunctions {
         }
     }
 
-    public static class Random implements Function<List<Integer>, Double> {
+    public static class Random implements Function<List<Long>, Double> {
         @Override
-        public Double apply(List<Integer> values) {
+        public Double apply(List<Long> values) {
             return ThreadLocalRandom.current().nextDouble();
         }
         @Override
         public String toString() { return "random"; }
     }
 
-    public static class SumElements implements Function<List<Integer>, Double> {
+    public static class SumElements implements Function<List<Long>, Double> {
         private final ImmutableList<String> argumentNames;
         private SumElements(List<String> argumentNames) {
             this.argumentNames = ImmutableList.copyOf(argumentNames);
         }
 
         @Override
-        public Double apply(List<Integer> values) {
-            int sum = 0;
-            for (Integer value : values)
+        public Double apply(List<Long> values) {
+            long sum = 0;
+            for (Long value : values)
                 sum += value;
             return (double)sum;
         }

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/DenseBinaryFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/DenseBinaryFormat.java
@@ -36,7 +36,7 @@ public class DenseBinaryFormat implements BinaryFormat {
         buffer.putInt1_4Bytes(tensor.type().dimensions().size());
         for (int i = 0; i < tensor.type().dimensions().size(); i++) {
             buffer.putUtf8String(tensor.type().dimensions().get(i).name());
-            buffer.putInt1_4Bytes(tensor.dimensionSizes().size(i));
+            buffer.putInt1_4Bytes((int)tensor.dimensionSizes().size(i)); // XXX: Size truncation
         }
     }
 
@@ -71,7 +71,7 @@ public class DenseBinaryFormat implements BinaryFormat {
         int dimensionCount = buffer.getInt1_4Bytes();
         TensorType.Builder builder = new TensorType.Builder();
         for (int i = 0; i < dimensionCount; i++)
-            builder.indexed(buffer.getUtf8String(), buffer.getInt1_4Bytes());
+            builder.indexed(buffer.getUtf8String(), buffer.getInt1_4Bytes()); // XXX: Size truncation
         return builder.build();
     }
 
@@ -84,7 +84,7 @@ public class DenseBinaryFormat implements BinaryFormat {
     }
 
     private void decodeCells(DimensionSizes sizes, GrowableByteBuffer buffer, IndexedTensor.BoundBuilder builder) {
-        for (int i = 0; i < sizes.totalSize(); i++)
+        for (long i = 0; i < sizes.totalSize(); i++)
             builder.cellByDirectIndex(i, buffer.getDouble());
     }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/SparseBinaryFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/SparseBinaryFormat.java
@@ -3,13 +3,14 @@ package com.yahoo.tensor.serialization;
 
 import com.google.common.annotations.Beta;
 import com.yahoo.io.GrowableByteBuffer;
-import com.yahoo.tensor.MappedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
-import com.yahoo.text.Utf8;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Implementation of a sparse binary format for a tensor on the form:
@@ -39,7 +40,7 @@ class SparseBinaryFormat implements BinaryFormat {
     }
 
     private void encodeCells(GrowableByteBuffer buffer, Tensor tensor) {
-        buffer.putInt1_4Bytes(tensor.size());
+        buffer.putInt1_4Bytes((int)tensor.size()); // XXX: Size truncation
         for (Iterator<Tensor.Cell> i = tensor.cellIterator(); i.hasNext(); ) {
             Map.Entry<TensorAddress, Double> cell = i.next();
             encodeAddress(buffer, cell.getKey());
@@ -79,8 +80,8 @@ class SparseBinaryFormat implements BinaryFormat {
     }
 
     private void decodeCells(GrowableByteBuffer buffer, Tensor.Builder builder, TensorType type) {
-        int numCells = buffer.getInt1_4Bytes();
-        for (int i = 0; i < numCells; ++i) {
+        long numCells = buffer.getInt1_4Bytes(); // XXX: Size truncation
+        for (long i = 0; i < numCells; ++i) {
             Tensor.Builder.CellBuilder cellBuilder = builder.cell();
             decodeAddress(buffer, cellBuilder, type);
             cellBuilder.value(buffer.getDouble());

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorTestCase.java
@@ -4,7 +4,6 @@ package com.yahoo.tensor;
 import com.google.common.collect.ImmutableList;
 import com.yahoo.tensor.evaluation.MapEvaluationContext;
 import com.yahoo.tensor.evaluation.VariableTensor;
-import com.yahoo.tensor.functions.Argmax;
 import com.yahoo.tensor.functions.ConstantTensor;
 import com.yahoo.tensor.functions.Join;
 import com.yahoo.tensor.functions.Reduce;
@@ -12,14 +11,12 @@ import com.yahoo.tensor.functions.TensorFunction;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
 import static com.yahoo.tensor.TensorType.Dimension.Type;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -99,7 +96,7 @@ public class TensorTestCase {
                                                                                                ImmutableList.of("y", "x")));
         assertEquals(Tensor.from("{ {x:0,y:0}:0, {x:0,y:1}:0, {x:1,y:0}:0, {x:1,y:1}:1, {x:2,y:0}:0, {x:2,y:1}:2, }"),
                      Tensor.generate(new TensorType.Builder().indexed("x", 3).indexed("y", 2).build(),
-                                     (List<Integer> indexes) -> (double)indexes.get(0)*indexes.get(1)));
+                                     (List<Long> indexes) -> (double)indexes.get(0)*indexes.get(1)));
         assertEquals(Tensor.from("{ {x:0,y:0,z:0}:0, {x:0,y:1,z:0}:1, {x:1,y:0,z:0}:1, {x:1,y:1,z:0}:2, {x:2,y:0,z:0}:2, {x:2,y:1,z:0}:3, "+
                                  "  {x:0,y:0,z:1}:1, {x:0,y:1,z:1}:2, {x:1,y:0,z:1}:2, {x:1,y:1,z:1}:3, {x:2,y:0,z:1}:3, {x:2,y:1,z:1}:4 }"),
                      Tensor.range(new TensorType.Builder().indexed("x", 3).indexed("y", 2).indexed("z", 2).build()));


### PR DESCRIPTION
This is to be able to support tensor dimensions with more than 2B elements in the future
without API change.