### PR TITLE
an entry with no nodes cannot be used

### DIFF
--- a/storage/src/vespa/storage/distributor/idealstatemanager.cpp
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.cpp
@@ -95,7 +95,7 @@ IdealStateManager::getEntryForPrimaryBucket(StateChecker::Context& c) const
 {
     for (uint32_t j = 0; j < c.entries.size(); ++j) {
         BucketDatabase::Entry& e = c.entries[j];
-        if (e.getBucketId() == c.getBucketId()) {
+        if (e.getBucketId() == c.getBucketId() && ! e->getNodes().empty()) {
             return &e;
         }
     }


### PR DESCRIPTION
@baldersheim  please review and merge
@vekterli we also need to figure out why there are some entries with no nodes, is this caused by move to multiple bucket spaces?