### PR TITLE
Allow localhost zk affinity

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -27,6 +27,7 @@ payloadCompressionType enum { UNCOMPRESSED, LZ4 } default=LZ4
 serverId string default="localhost"
 hostedVespa bool default=false
 numParallelTenantLoaders int default=4
+zookeeperLocalhostAffinity bool default=false
 
 # Zone information
 environment string default="prod"

--- a/vespajlib/src/main/java/com/yahoo/net/HostName.java
+++ b/vespajlib/src/main/java/com/yahoo/net/HostName.java
@@ -27,7 +27,7 @@ public class HostName {
 
     private static final Logger logger = Logger.getLogger(HostName.class.getName());
 
-    private static String cachedHostName = null;
+    private static String preferredHostName = null;
 
     /**
      * Return a public and fully qualified hostname for localhost that resolves to an IP address on
@@ -38,14 +38,14 @@ public class HostName {
      * @throws RuntimeException if accessing the network or the 'hostname' command fails
      */
     public static synchronized String getLocalhost() {
-        if (cachedHostName == null) {
+        if (preferredHostName == null) {
             try {
-                cachedHostName = getPreferredHostName();
+                preferredHostName = getPreferredHostName();
             } catch (Exception e) {
                 throw new RuntimeException("Failed to find a preferred hostname", e);
             }
         }
-        return cachedHostName;
+        return preferredHostName;
     }
 
     private static String getPreferredHostName() throws Exception {
@@ -178,4 +178,7 @@ public class HostName {
         }
     }
 
+    public static void setHostNameForTestingOnly(String hostName) {
+        preferredHostName = hostName;
+    }
 }


### PR DESCRIPTION
This allows the config server's Curator component to use a connectSpec that
only specifies the localhost zk server.