### PR TITLE
only start node admin once

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
@@ -48,7 +48,6 @@ public class NodeAdminMain implements AutoCloseable {
         this.docker = docker;
         this.metricReceiver = metricReceiver;
         this.classLocking = classLocking;
-        start();
     }
 
     @Override


### PR DESCRIPTION
This is not actually a problem right now, since the second
NodeAdminStateUpdater will try to take an exclusive lock to ensure only one
NASU runs. It will just hang forever.