### PR TITLE
Revert "only start node admin once"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
@@ -48,6 +48,7 @@ public class NodeAdminMain implements AutoCloseable {
         this.docker = docker;
         this.metricReceiver = metricReceiver;
         this.classLocking = classLocking;
+        start();
     }
 
     @Override


### PR DESCRIPTION
Reverts vespa-engine/vespa#4517

I need to revert this and the the node-admin refactoring because there's some odd OSGi issue with docker-api.