### PR TITLE
Revert "Log at JDisc process start and stop"

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/StandaloneMain.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/StandaloneMain.java
@@ -37,23 +37,20 @@ public class StandaloneMain {
     void run(String bundleLocation) {
         try {
             System.out.println("debug\tInitializing application without privileges.");
-            log.log(Level.INFO, "JDisc starting with bundle location " + bundleLocation);
             loader.init(bundleLocation, false);
             loader.start();
             setupSigTermHandler();
             waitForShutdown();
             System.out.println("debug\tTrying to shutdown in a controlled manner.");
-            log.log(Level.INFO, "JDisc shutting down");
             loader.stop();
             System.out.println("debug\tTrying to clean up in a controlled manner.");
             loader.destroy();
             System.out.println("debug\tStopped ok.");
-            log.log(Level.INFO, "JDisc exiting");
             System.exit(0);
         } catch (Throwable e) {
             System.out.print("debug\tUnexpected: ");
             e.printStackTrace();
-            log.log(Level.SEVERE, "JDisc exiting: Throwable caught: ", e);
+            log.log(Level.SEVERE, "Unexpected: ", e);
             System.exit(6);
         }
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#4518

this broke system tests, you'll need to use system.out.println like the other logging from this location.