### PR TITLE
Add org.apache.httpcomponents httpcore for mvn install

### DIFF
--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -144,6 +144,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <scope>compile</scope>

--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <scope>test</scope>
     </dependency>

--- a/node-maintainer/pom.xml
+++ b/node-maintainer/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>


### PR DESCRIPTION
Hi,
    when i mvn install in my mac 10.13.2,it can not compile,so i add httpcore in these poms which can not compile, resolve it.