### PR TITLE
use new LoggingRequestHandler constructor

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpGetConfigHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpGetConfigHandler.java
@@ -23,14 +23,14 @@ import java.util.concurrent.Executor;
 public class HttpGetConfigHandler extends HttpHandler {
     private final RequestHandler requestHandler;
 
-    public HttpGetConfigHandler(Executor executor, RequestHandler requestHandler, AccessLog accessLog) {
-        super(executor, accessLog);
+    public HttpGetConfigHandler(HttpHandler.Context ctx, RequestHandler requestHandler) {
+        super(ctx);
         this.requestHandler = requestHandler;
     }
 
     @Inject
-    public HttpGetConfigHandler(Executor executor, Tenants tenants, AccessLog accesslog) {
-        this(executor, tenants.defaultTenant().getRequestHandler(), accesslog);
+    public HttpGetConfigHandler(HttpHandler.Context ctx, Tenants tenants) {
+        this(ctx, tenants.defaultTenant().getRequestHandler());
     }
     
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http;
 
+import com.google.inject.Inject;
+
 import com.yahoo.config.provision.ApplicationLockException;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
@@ -25,8 +27,8 @@ import java.util.concurrent.Executor;
  */
 public class HttpHandler extends LoggingRequestHandler {
 
-    public HttpHandler(Executor executor, AccessLog accessLog) {
-        super(executor, accessLog);
+    public HttpHandler(HttpHandler.Context ctx) {
+        super(ctx);
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpListConfigsHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpListConfigsHandler.java
@@ -32,12 +32,12 @@ public class HttpListConfigsHandler extends HttpHandler {
     private final RequestHandler requestHandler;
 
     @Inject
-    public HttpListConfigsHandler(Executor executor, AccessLog accessLog, Tenants tenants) {
-        this(executor, accessLog, tenants.defaultTenant().getRequestHandler());
+    public HttpListConfigsHandler(HttpHandler.Context ctx, Tenants tenants) {
+        this(ctx, tenants.defaultTenant().getRequestHandler());
     }
 
-    public HttpListConfigsHandler(Executor executor, AccessLog accessLog, RequestHandler requestHandler) {
-        super(executor, accessLog);
+    public HttpListConfigsHandler(HttpHandler.Context ctx, RequestHandler requestHandler) {
+        super(ctx);
         this.requestHandler = requestHandler;
     }
     

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpListNamedConfigsHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpListNamedConfigsHandler.java
@@ -25,14 +25,16 @@ import java.util.concurrent.Executor;
 public class HttpListNamedConfigsHandler extends HttpHandler {
     private final RequestHandler requestHandler;
 
-    public HttpListNamedConfigsHandler(Executor executor, RequestHandler requestHandler, AccessLog accessLog) {
-        super(executor, accessLog);
+    public HttpListNamedConfigsHandler(HttpHandler.Context ctx,
+                                       RequestHandler requestHandler) {
+        super(ctx);
         this.requestHandler = requestHandler;
     }
 
     @Inject
-    public HttpListNamedConfigsHandler(Executor executor, Tenants tenants, AccessLog accessLog) {
-        this(executor, tenants.defaultTenant().getRequestHandler(), accessLog);
+    public HttpListNamedConfigsHandler(HttpHandler.Context ctx,
+                                       Tenants tenants) {
+        this(ctx, tenants.defaultTenant().getRequestHandler());
     }
     
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/SessionHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/SessionHandler.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http;
 
+import com.google.inject.Inject;
+
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.logging.AccessLog;
@@ -27,8 +29,9 @@ public class SessionHandler extends HttpHandler {
 
     protected final ApplicationRepository applicationRepository;
 
-    public SessionHandler(Executor executor, AccessLog accessLog, ApplicationRepository applicationRepository) {
-        super(executor, accessLog);
+    public SessionHandler(HttpHandler.Context ctx, ApplicationRepository applicationRepository)
+    {
+        super(ctx);
         this.applicationRepository = applicationRepository;
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http.v2;
 
+import com.google.inject.Inject;
+
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
@@ -37,11 +39,11 @@ public class ApplicationHandler extends HttpHandler {
     private final Zone zone;
     private final ApplicationRepository applicationRepository;
 
-    public ApplicationHandler(Executor executor,
-                              AccessLog accessLog,
+    @Inject
+    public ApplicationHandler(HttpHandler.Context ctx,
                               Zone zone,
                               ApplicationRepository applicationRepository) {
-        super(executor, accessLog);
+        super(ctx);
         this.zone = zone;
         this.applicationRepository = applicationRepository;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HostHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HostHandler.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http.v2;
 
+import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
@@ -28,8 +29,10 @@ public class HostHandler extends HttpHandler {
     final HostRegistries hostRegistries;
     private final Zone zone;
 
-    public HostHandler(Executor executor, AccessLog accessLog, GlobalComponentRegistry globalComponentRegistry) {
-        super(executor, accessLog);
+    @Inject
+    public HostHandler(HttpHandler.Context ctx,
+                       GlobalComponentRegistry globalComponentRegistry) {
+        super(ctx);
         this.hostRegistries = globalComponentRegistry.getHostRegistries();
         this.zone = globalComponentRegistry.getZone();
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HttpGetConfigHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HttpGetConfigHandler.java
@@ -27,8 +27,10 @@ public class HttpGetConfigHandler extends HttpHandler {
     private final Tenants tenants;
 
     @Inject
-    public HttpGetConfigHandler(Executor executor, AccessLog accesslog, Tenants tenants) {
-        super(executor, accesslog);
+    public HttpGetConfigHandler(HttpHandler.Context ctx,
+                                Tenants tenants)
+    {
+        super(ctx);
         this.tenants = tenants;
     }
     

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HttpListConfigsHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HttpListConfigsHandler.java
@@ -34,8 +34,10 @@ public class HttpListConfigsHandler extends HttpHandler {
     private final Zone zone;
     
     @Inject
-    public HttpListConfigsHandler(Executor executor, AccessLog accesslog, Tenants tenants, Zone zone) {
-        super(executor, accesslog);
+    public HttpListConfigsHandler(HttpHandler.Context ctx,
+                                  Tenants tenants, Zone zone)
+    {
+        super(ctx);
         this.tenants = tenants;
         this.zone = zone;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HttpListNamedConfigsHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/HttpListNamedConfigsHandler.java
@@ -29,8 +29,10 @@ public class HttpListNamedConfigsHandler extends HttpHandler {
     private final Zone zone;
     
     @Inject
-    public HttpListNamedConfigsHandler(Executor executor, AccessLog accesslog, Tenants tenants, Zone zone) {
-        super(executor, accesslog);
+    public HttpListNamedConfigsHandler(HttpHandler.Context ctx,
+                                       Tenants tenants, Zone zone)
+    {
+        super(ctx);
         this.tenants = tenants;
         this.zone = zone;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandler.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http.v2;
 
+import com.google.inject.Inject;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.yahoo.config.provision.TenantName;
@@ -29,8 +30,11 @@ import java.util.concurrent.Executor;
 public class ListApplicationsHandler extends HttpHandler {
     private final Tenants tenants;
     private final Zone zone;
-    public ListApplicationsHandler(Executor executor, AccessLog accessLog, Tenants tenants, Zone zone) {
-        super(executor, accessLog);
+
+    @Inject
+    public ListApplicationsHandler(HttpHandler.Context ctx,
+                                   Tenants tenants, Zone zone) {
+        super(ctx);
         this.tenants = tenants;
         this.zone = zone;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandler.java
@@ -33,12 +33,11 @@ public class SessionActiveHandler extends SessionHandler {
     private final Zone zone;
 
     @Inject
-    public SessionActiveHandler(Executor executor,
-                                AccessLog accessLog,
+    public SessionActiveHandler(SessionHandler.Context ctx,
+                                ApplicationRepository applicationRepository,
                                 Tenants tenants,
-                                Zone zone,
-                                ApplicationRepository applicationRepository) {
-        super(executor, accessLog, applicationRepository);
+                                Zone zone) {
+        super(ctx, applicationRepository);
         this.tenants = tenants;
         this.zone = zone;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionContentHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionContentHandler.java
@@ -28,11 +28,11 @@ public class SessionContentHandler extends SessionHandler {
     private final ContentHandler contentHandler = new ContentHandler();
 
     @Inject
-    public SessionContentHandler(Executor executor,
-                                 AccessLog accessLog,
-                                 Tenants tenants,
-                                 ApplicationRepository applicationRepository) {
-        super(executor, accessLog, applicationRepository);
+    public SessionContentHandler(SessionHandler.Context ctx,
+                                 ApplicationRepository applicationRepository,
+                                 Tenants tenants)
+    {
+        super(ctx, applicationRepository);
         this.tenants = tenants;
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandler.java
@@ -49,12 +49,11 @@ public class SessionCreateHandler extends SessionHandler {
     private final Duration zookeeperBarrierTimeout;
 
     @Inject
-    public SessionCreateHandler(Executor executor,
-                                AccessLog accessLog,
+    public SessionCreateHandler(SessionHandler.Context ctx,
+                                ApplicationRepository applicationRepository,
                                 Tenants tenants,
-                                ConfigserverConfig configserverConfig,
-                                ApplicationRepository applicationRepository) {
-        super(executor, accessLog, applicationRepository);
+                                ConfigserverConfig configserverConfig) {
+        super(ctx, applicationRepository);
         this.tenants = tenants;
         this.zookeeperBarrierTimeout = Duration.ofSeconds(configserverConfig.zookeeper().barrierTimeout());
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandler.java
@@ -41,12 +41,11 @@ public class SessionPrepareHandler extends SessionHandler {
     private final Duration zookeeperBarrierTimeout;
 
     @Inject
-    public SessionPrepareHandler(Executor executor,
-                                 AccessLog accessLog,
+    public SessionPrepareHandler(SessionHandler.Context ctx,
+                                 ApplicationRepository applicationRepository,
                                  Tenants tenants,
-                                 ConfigserverConfig configserverConfig,
-                                 ApplicationRepository applicationRepository) {
-        super(executor, accessLog, applicationRepository);
+                                 ConfigserverConfig configserverConfig) {
+        super(ctx, applicationRepository);
         this.tenants = tenants;
         this.zookeeperBarrierTimeout = Duration.ofSeconds(configserverConfig.zookeeper().barrierTimeout());
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/TenantHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/TenantHandler.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.config.server.http.v2;
 
 import java.util.List;
 import java.util.concurrent.Executor;
+import com.google.inject.Inject;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
@@ -29,8 +30,10 @@ public class TenantHandler extends HttpHandler {
     private static final String TENANT_NAME_REGEXP = "[\\w-]+";
     private final Tenants tenants;
 
-    public TenantHandler(Executor executor, AccessLog accessLog, Tenants tenants) {
-        super(executor, accessLog);
+    @Inject
+    public TenantHandler(HttpHandler.Context ctx,
+                         Tenants tenants) {
+        super(ctx);
         this.tenants = tenants;
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpGetConfigHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpGetConfigHandlerTest.java
@@ -44,13 +44,9 @@ public class HttpGetConfigHandlerTest {
         mockRequestHandler.setAllConfigs(new HashSet<ConfigKey<?>>() {{ 
             add(new ConfigKey<>("bar", "myid", "foo"));
             }} );
-        handler = new HttpGetConfigHandler(new Executor() {
-            @SuppressWarnings("NullableProblems")
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        }, mockRequestHandler, AccessLog.voidAccessLog());
+        handler = new HttpGetConfigHandler(
+                HttpGetConfigHandler.testOnlyContext(),
+                mockRequestHandler);
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpHandlerTest.java
@@ -25,7 +25,7 @@ public class HttpHandlerTest {
     @Test
     public void testResponse() throws IOException {
         final String message = "failed";
-        HttpHandler httpHandler = new HttpTestHandler(Executors.newSingleThreadExecutor(), AccessLog.voidAccessLog(), new InvalidApplicationException(message));
+        HttpHandler httpHandler = new HttpTestHandler(new InvalidApplicationException(message));
         HttpResponse response = httpHandler.handle(HttpRequest.createTestRequest("foo", com.yahoo.jdisc.http.HttpRequest.Method.GET));
         assertThat(response.getStatus(), is(Response.Status.BAD_REQUEST));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -38,8 +38,8 @@ public class HttpHandlerTest {
 
     private static class HttpTestHandler extends HttpHandler {
         private RuntimeException exception;
-        public HttpTestHandler(Executor executor, AccessLog accessLog, RuntimeException exception) {
-            super(executor, accessLog);
+        public HttpTestHandler(RuntimeException exception) {
+            super(HttpHandler.testOnlyContext());
             this.exception = exception;
         }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpListConfigsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpListConfigsHandlerTest.java
@@ -37,18 +37,9 @@ public class HttpListConfigsHandlerTest {
         mockRequestHandler.setAllConfigs(new HashSet<ConfigKey<?>>() {{ 
             add(new ConfigKey<>("bar", "conf/id/", "foo"));
             }} );
-        handler = new HttpListConfigsHandler(new Executor() {
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        }, AccessLog.voidAccessLog(), mockRequestHandler);
-        namedHandler = new HttpListNamedConfigsHandler(new Executor() {
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        }, mockRequestHandler, AccessLog.voidAccessLog());
+        HttpListConfigsHandler.Context ctx = HttpListConfigsHandler.testOnlyContext();
+        handler = new HttpListConfigsHandler(ctx, mockRequestHandler);
+        namedHandler = new HttpListNamedConfigsHandler(ctx, mockRequestHandler);
     }
     
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionExampleHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionExampleHandlerTest.java
@@ -54,7 +54,7 @@ public class SessionExampleHandlerTest {
     public static class SessionExampleHandler extends ThreadedHttpRequestHandler {
 
         public SessionExampleHandler(Executor executor) {
-            super(executor);
+            super(executor, null);
         }
 
         @Override

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationContentHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationContentHandlerTest.java
@@ -52,8 +52,7 @@ public class ApplicationContentHandlerTest extends ContentHandlerTestBase {
         testTenantBuilder.tenants().get(tenant2).getLocalSessionRepo().addSession(new MockSession(3l, FilesApplicationPackage.fromFile(new File("src/test/apps/content2"))));
         testTenantBuilder.tenants().get(tenant1).getApplicationRepo().createPutApplicationTransaction(idTenant1, 2l).commit();
         testTenantBuilder.tenants().get(tenant2).getApplicationRepo().createPutApplicationTransaction(idTenant2, 3l).commit();
-        handler = new ApplicationHandler(Runnable::run,
-                                         AccessLog.voidAccessLog(),
+        handler = new ApplicationHandler(ApplicationHandler.testOnlyContext(),
                                          Zone.defaultZone(),
                                          new ApplicationRepository(testTenantBuilder.createTenants(),
                                                                    new MockProvisioner(),

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -96,7 +96,8 @@ public class ApplicationHandlerTest {
                 mockHttpProxy,
                 new MockLogServerLogGrabber());
         listApplicationsHandler = new ListApplicationsHandler(
-                Runnable::run, AccessLog.voidAccessLog(), tenants, Zone.defaultZone());
+                ListApplicationsHandler.testOnlyContext(),
+                tenants, Zone.defaultZone());
     }
 
     private ApplicationHandler createMockApplicationHandler(
@@ -105,8 +106,7 @@ public class ApplicationHandlerTest {
             HttpProxy httpProxy,
             LogServerLogGrabber logServerLogGrabber) {
         return new ApplicationHandler(
-                Runnable::run,
-                AccessLog.voidAccessLog(),
+                ApplicationHandler.testOnlyContext(),
                 Zone.defaultZone(),
                 new ApplicationRepository(tenants,
                                           HostProvisionerProvider.withProvisioner(provisioner),
@@ -118,8 +118,7 @@ public class ApplicationHandlerTest {
 
     private ApplicationHandler createApplicationHandler(Tenants tenants) {
         return new ApplicationHandler(
-                Runnable::run,
-                AccessLog.voidAccessLog(),
+                ApplicationHandler.testOnlyContext(),
                 Zone.defaultZone(),
                 new ApplicationRepository(tenants,
                                           HostProvisionerProvider.withProvisioner(provisioner),

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HostHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HostHandlerTest.java
@@ -52,9 +52,9 @@ public class HostHandlerTest {
         hostRegistries = testComponentRegistry.getHostRegistries();
         hostRegistries.createApplicationHostRegistry(mytenant).update(ApplicationId.from(mytenant, ApplicationName.defaultName(), InstanceName.defaultName()), Collections.singletonList(hostname));
         hostRegistries.getTenantHostRegistry().update(mytenant, Collections.singletonList(hostname));
-        hostHandler = new HostHandler(command -> {
-            command.run();
-        }, AccessLog.voidAccessLog(), testComponentRegistry);
+        hostHandler = new HostHandler(
+                HostHandler.testOnlyContext(),
+                testComponentRegistry);
         return hostHandler;
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpGetConfigHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpGetConfigHandlerTest.java
@@ -49,9 +49,9 @@ public class HttpGetConfigHandlerTest {
         TestTenantBuilder tb = new TestTenantBuilder();
         tb.createTenant(tenant).withRequestHandler(mockRequestHandler).build();
         Tenants tenants = tb.createTenants();        
-        handler = new HttpGetConfigHandler(command -> {
-            command.run();
-        }, AccessLog.voidAccessLog(), tenants);
+        handler = new HttpGetConfigHandler(
+                HttpGetConfigHandler.testOnlyContext(),
+                tenants);
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpListConfigsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpListConfigsHandlerTest.java
@@ -45,12 +45,12 @@ public class HttpListConfigsHandlerTest {
         TestTenantBuilder tb = new TestTenantBuilder();
         tb.createTenant(TenantName.from("mytenant")).withRequestHandler(mockRequestHandler).build();
         Tenants tenants = tb.createTenants();
-        handler = new HttpListConfigsHandler(command -> {
-            command.run();
-        }, AccessLog.voidAccessLog(), tenants, Zone.defaultZone());
-        namedHandler = new HttpListNamedConfigsHandler(command -> {
-            command.run();
-        }, AccessLog.voidAccessLog(), tenants, Zone.defaultZone());
+        handler = new HttpListConfigsHandler(
+                HttpListConfigsHandler.testOnlyContext(),
+                tenants, Zone.defaultZone());
+        namedHandler = new HttpListNamedConfigsHandler(
+                HttpListConfigsHandler.testOnlyContext(),
+                tenants, Zone.defaultZone());
     }
     
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandlerTest.java
@@ -39,10 +39,10 @@ public class ListApplicationsHandlerTest {
         applicationRepo = testBuilder.tenants().get(mytenant).getApplicationRepo();
         applicationRepo2 = testBuilder.tenants().get(foobar).getApplicationRepo();
         Tenants tenants = testBuilder.createTenants();
-        handler = new ListApplicationsHandler(Runnable::run,
-                                              AccessLog.voidAccessLog(),
-                                              tenants,
-                                              new Zone(Environment.dev, RegionName.from("us-east")));
+        handler = new ListApplicationsHandler(
+                ListApplicationsHandler.testOnlyContext(),
+                tenants,
+                new Zone(Environment.dev, RegionName.from("us-east")));
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
@@ -373,13 +373,12 @@ public class SessionActiveHandlerTest extends SessionHandlerTest {
                 .withApplicationRepo(applicationRepo)
                 .build();
         return new SessionActiveHandler(
-                Runnable::run,
-                AccessLog.voidAccessLog(),
-                testTenantBuilder.createTenants(),
-                Zone.defaultZone(),
+                SessionActiveHandler.testOnlyContext(),
                 new ApplicationRepository(testTenantBuilder.createTenants(),
                                           hostProvisioner,
-                                          Clock.systemUTC()));
+                                          Clock.systemUTC()),
+                testTenantBuilder.createTenants(),
+                Zone.defaultZone());
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionContentHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionContentHandlerTest.java
@@ -161,15 +161,11 @@ public class SessionContentHandlerTest extends ContentHandlerTestBase {
     private SessionContentHandler createHandler() throws Exception {
         TestTenantBuilder testTenantBuilder = new TestTenantBuilder();
         testTenantBuilder.createTenant(tenant).getLocalSessionRepo().addSession(new MockSession(1l, FilesApplicationPackage.fromFile(createTestApp())));
-        return new SessionContentHandler(new Executor() {
-            @SuppressWarnings("NullableProblems")
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        }, AccessLog.voidAccessLog(), testTenantBuilder.createTenants(),
-                                         new ApplicationRepository(testTenantBuilder.createTenants(),
-                                                                   new SessionHandlerTest.MockProvisioner(),
-                                                                   Clock.systemUTC()));
+        return new SessionContentHandler(
+                SessionContentHandler.testOnlyContext(),
+                new ApplicationRepository(testTenantBuilder.createTenants(),
+                                          new SessionHandlerTest.MockProvisioner(),
+                                          Clock.systemUTC()),
+                testTenantBuilder.createTenants());
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
@@ -243,10 +243,13 @@ public class SessionCreateHandlerTest extends SessionHandlerTest {
     private SessionCreateHandler createHandler(Tenants tenants) throws Exception {
         TestTenantBuilder testTenantBuilder = new TestTenantBuilder();
         final ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder());
-        return new SessionCreateHandler(Runnable::run, AccessLog.voidAccessLog(), tenants, configserverConfig,
-                                        new ApplicationRepository(testTenantBuilder.createTenants(),
-                                                                  new SessionHandlerTest.MockProvisioner(),
-                                                                  Clock.systemUTC()));
+        return new SessionCreateHandler(
+                SessionCreateHandler.testOnlyContext(),
+                new ApplicationRepository(testTenantBuilder.createTenants(),
+                                          new SessionHandlerTest.MockProvisioner(),
+                                          Clock.systemUTC()),
+                tenants, configserverConfig);
+
     }
 
     private HttpRequest post() throws FileNotFoundException {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -383,10 +383,13 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
 
     private SessionHandler createHandler(TestTenantBuilder builder) {
         final ConfigserverConfig configserverConfig = new ConfigserverConfig(new ConfigserverConfig.Builder());
-        return new SessionPrepareHandler(Runnable::run, AccessLog.voidAccessLog(), builder.createTenants(), configserverConfig,
-                                         new ApplicationRepository(builder.createTenants(),
-                                                                   new MockProvisioner(),
-                                                                   Clock.systemUTC()));
+        return new SessionPrepareHandler(
+                SessionPrepareHandler.testOnlyContext(),
+                new ApplicationRepository(builder.createTenants(),
+                                          new MockProvisioner(),
+                                          Clock.systemUTC()),
+                builder.createTenants(), configserverConfig);
+
     }
 
     private TestTenantBuilder addTenant(TenantName tenantName,

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/TenantHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/TenantHandlerTest.java
@@ -27,7 +27,9 @@ public class TenantHandlerTest extends TenantTest {
 
     @Before
     public void setup() throws Exception {
-        handler = new TenantHandler(testExecutor(), null, tenants);
+        handler = new TenantHandler(
+                TenantHandler.testOnlyContext(),
+                tenants);
     }
 
     @Test


### PR DESCRIPTION
@gjoranv or @hmusum please review and merge

this is to get the the jdisc Metric injected into the Handler superclass, but uses
LoggingRequestHandler.Context to avoid every handler subclass having to inject
all the superclass requirements separately.