### PR TITLE
Always set document type repo during deserialization

### DIFF
--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -85,6 +85,7 @@ void VespaDocumentDeserializer::readDocument(Document &value) {
         Document newDoc(*type, value.getId(), true);
         value.swap(newDoc);
     }
+    value.setRepo(_repo.getDocumentTypeRepo());
 
     FixedTypeRepo repo(_repo.getDocumentTypeRepo(), value.getType());
     VarScope<FixedTypeRepo> repo_scope(_repo, repo);


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

Avoids edge case where repo is not set after deserializing
an empty document.