### PR TITLE
Workaround for Jetty truststore without password

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -94,7 +94,7 @@ public class ConnectorFactory {
     private SslConnectionFactory newSslConnectionFactory() {
         Ssl sslConfig = connectorConfig.ssl();
 
-        SslContextFactory factory = new SslContextFactory();
+        SslContextFactory factory = new JDiscSslContextFactory();
 
         sslKeyStoreConfigurator.configure(new DefaultSslKeyStoreContext(factory));
         sslTrustStoreConfigurator.configure(new DefaultSslTrustStoreContext(factory));

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscSslContextFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscSslContextFactory.java
@@ -1,0 +1,34 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.jdisc.http.server.jetty;
+
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.security.CertificateUtils;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import java.security.KeyStore;
+import java.util.Objects;
+
+/**
+ * @author bjorncs
+ */
+class JDiscSslContextFactory extends SslContextFactory {
+
+    private String trustStorePassword;
+
+    @Override
+    public void setTrustStorePassword(String password) {
+        super.setTrustStorePassword(password);
+        this.trustStorePassword = password;
+    }
+
+
+    // Overriden to stop Jetty from using the keystore password if no truststore password is specified.
+    @Override
+    protected KeyStore loadTrustStore(Resource resource) throws Exception {
+        return CertificateUtils.getKeyStore(
+                resource != null ? resource : getKeyStoreResource(),
+                Objects.toString(getTrustStoreType(), getKeyStoreType()),
+                Objects.toString(getTrustStoreProvider(), getKeyStoreProvider()),
+                trustStorePassword);
+    }
+}

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscSslContextFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscSslContextFactory.java
@@ -9,6 +9,8 @@ import java.security.KeyStore;
 import java.util.Objects;
 
 /**
+ * A modified {@link SslContextFactory} that allows passwordless truststore in combination with password protected keystore.
+ *
  * @author bjorncs
  */
 class JDiscSslContextFactory extends SslContextFactory {


### PR DESCRIPTION
Jetty no longer allows truststore without password. If not password is
specified, the truststore password defaults to the keystore password.
The Jetty change broke JDisc applications using keystore with password
in combination with truststore without password.