### PR TITLE
Use baseline CentOS 7 box for Vagrant development

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -21,7 +21,6 @@ Vagrant.configure("2") do |config|
   
   # Install required and nice-to-have packages
   config.vm.provision "shell", inline: <<-SHELL
-    yum update -y
     yum -y groupinstall "GNOME Desktop" "Graphical Administration Tools"
     systemctl set-default graphical.target
     yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,7 +4,7 @@
 # For a complete reference, please see the online documentation at https://docs.vagrantup.com.
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "boxcutter/centos7-desktop"
+  config.vm.box = "centos/7"
 
   config.ssh.forward_agent = true
 
@@ -21,6 +21,9 @@ Vagrant.configure("2") do |config|
   
   # Install required and nice-to-have packages
   config.vm.provision "shell", inline: <<-SHELL
+    yum update -y
+    yum -y groupinstall "GNOME Desktop" "Graphical Administration Tools"
+    systemctl set-default graphical.target
     yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo
     yum -y install epel-release
     yum -y install centos-release-scl
@@ -37,7 +40,8 @@ Vagrant.configure("2") do |config|
     echo -e "* soft nproc 409600\n* hard nproc 409600" > /etc/security/limits.d/99-nproc.conf
     echo -e "* soft nofile 262144\n* hard nofile 262144" > /etc/security/limits.d/99-nofile.conf
     echo -e "fs.inotify.max_user_watches = 524288" > /etc/sysctl.d/clion.conf
-    wget -q -O - https://download.jetbrains.com/cpp/CLion-2017.2.3.tar.gz | tar -C /opt -zx
-    ln -sf /opt/clion-2017.2.3/bin/clion.sh /usr/bin/clion
+    wget -q -O - https://download.jetbrains.com/cpp/CLion-2017.3.tar.gz | tar -C /opt -zx
+    ln -sf /opt/clion-2017.3/bin/clion.sh /usr/bin/clion
+    /sbin/reboot now
   SHELL
 end


### PR DESCRIPTION
Now sets up desktop environment explicitly, which adds some time to
the setup phase, but no longer requires any third-party boxes.

A reboot is automatically performed at the end of the provisioning phase,
which is required for the desktop environment to kick in.

Also update CLion version.