### PR TITLE
For now Copr expect the release number so we should provide it.

### DIFF
--- a/dist/.tito/tito.props
+++ b/dist/.tito/tito.props
@@ -1,6 +1,6 @@
 [buildconfig]
 builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
-tag_format = {component}-{version}
+tag_format = {component}-{version}-{release}
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)


### PR DESCRIPTION
@bjorncs 

tito got updated on standard EPEL repo, so until Copr updates we need to supply the release number in the tag.