### PR TITLE
Don't connect reference attribute to referenced document type while replaying transaction log.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.h
@@ -32,6 +32,7 @@ private:
     const document::DocumentType &_prevThisDocType;
     MonitoredRefCount              &_refCount;
     search::ISequencedTaskExecutor &_attributeFieldWriter;
+    bool                            _useReferences;
     std::map<vespalib::string, std::unique_ptr<GidToLidChangeRegistrator>> _registrators;
 
     GidToLidChangeRegistrator &getRegistrator(const vespalib::string &docTypeName);
@@ -49,7 +50,8 @@ public:
                                 const ImportedFieldsConfig &importedFieldsCfg,
                                 const document::DocumentType &prevThisDocType,
                                 MonitoredRefCount &refCount,
-                                search::ISequencedTaskExecutor &attributeFieldWriter);
+                                search::ISequencedTaskExecutor &attributeFieldWriter,
+                                bool useReferencdes);
     ~DocumentDBReferenceResolver();
 
     virtual std::unique_ptr<ImportedAttributesRepo> resolve(const search::IAttributeManager &newAttrMgr,

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.h
@@ -51,7 +51,7 @@ public:
                                 const document::DocumentType &prevThisDocType,
                                 MonitoredRefCount &refCount,
                                 search::ISequencedTaskExecutor &attributeFieldWriter,
-                                bool useReferencdes);
+                                bool useReferences);
     ~DocumentDBReferenceResolver();
 
     virtual std::unique_ptr<ImportedAttributesRepo> resolve(const search::IAttributeManager &newAttrMgr,


### PR DESCRIPTION
Problem reported in issue #4564.

@geirst, @baldersheim: please review.