### PR TITLE
Balder/alternative dense tensor apply accounted

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -24,7 +24,7 @@ set(C_WARN_OPTS "-Winline -Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wc
 set(CXX_SPECIFIC_WARN_OPTS "-Wsuggest-override -Wnon-virtual-dtor -Wformat-security")
 
 # C and C++ compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Og -fno-omit-frame-pointer ${C_WARN_OPTS} -fPIC ${VESPA_CXX_ABI_FLAGS} -DBOOST_DISABLE_ASSERTS ${VESPA_CPU_ARCH_FLAGS} -mtune=intel ${EXTRA_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 -fno-omit-frame-pointer ${C_WARN_OPTS} -fPIC ${VESPA_CXX_ABI_FLAGS} -DBOOST_DISABLE_ASSERTS ${VESPA_CPU_ARCH_FLAGS} -mtune=intel ${EXTRA_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} ${CXX_SPECIFIC_WARN_OPTS} -std=c++1z -fvisibility-inlines-hidden -fdiagnostics-color=auto ${EXTRA_CXX_FLAGS}")
 
 # Linker flags

--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -24,7 +24,7 @@ set(C_WARN_OPTS "-Winline -Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wc
 set(CXX_SPECIFIC_WARN_OPTS "-Wsuggest-override -Wnon-virtual-dtor -Wformat-security")
 
 # C and C++ compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3 -fno-omit-frame-pointer ${C_WARN_OPTS} -fPIC ${VESPA_CXX_ABI_FLAGS} -DBOOST_DISABLE_ASSERTS ${VESPA_CPU_ARCH_FLAGS} -mtune=intel ${EXTRA_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Og -fno-omit-frame-pointer ${C_WARN_OPTS} -fPIC ${VESPA_CXX_ABI_FLAGS} -DBOOST_DISABLE_ASSERTS ${VESPA_CPU_ARCH_FLAGS} -mtune=intel ${EXTRA_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} ${CXX_SPECIFIC_WARN_OPTS} -std=c++1z -fvisibility-inlines-hidden -fdiagnostics-color=auto ${EXTRA_CXX_FLAGS}")
 
 # Linker flags

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
@@ -73,21 +73,16 @@ DenseTensorAddressCombiner::combineDimensions(const eval::ValueType &lhs,
 
 
 CommonDenseTensorCellsIterator::CommonDenseTensorCellsIterator(const Mapping & common,
+                                                               const Mapping & right,
                                                                const eval::ValueType &type_in,
                                                                CellsRef cells)
     : _type(type_in),
       _cells(cells),
       _address(type_in.dimensions().size(), 0),
       _common(common),
-      _mutable(_address.size()),
+      _mutable(right),
       _accumulatedSize(_address.size())
 {
-    for (uint32_t i(0); i < _address.size(); i++) {
-        _mutable[i] = i;
-    }
-    for (auto cur = _common.rbegin(); cur != _common.rend(); cur++) {
-        _mutable.erase(_mutable.begin() + cur->second);
-    }
     size_t multiplier = 1;
     for (int32_t i(_address.size() - 1); i >= 0; i--) {
         _accumulatedSize[i] = multiplier;

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
@@ -11,7 +11,10 @@ DenseTensorAddressCombiner::~DenseTensorAddressCombiner() { }
 DenseTensorAddressCombiner::DenseTensorAddressCombiner(const eval::ValueType &lhs,
                                                        const eval::ValueType &rhs)
     : _ops(),
-      _combinedAddress()
+      _combinedAddress(),
+      _left(),
+      _commonRight(),
+      _right()
 {
     auto rhsItr = rhs.dimensions().cbegin();
     auto rhsItrEnd = rhs.dimensions().cend();

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
@@ -80,7 +80,7 @@ CommonDenseTensorCellsIterator::CommonDenseTensorCellsIterator(const Mapping & c
       _cells(cells),
       _address(type_in.dimensions().size(), 0),
       _common(common),
-      _mutable(right),
+      _right(right),
       _accumulatedSize(_address.size())
 {
     size_t multiplier = 1;

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
@@ -71,4 +71,29 @@ DenseTensorAddressCombiner::combineDimensions(const eval::ValueType &lhs,
             eval::ValueType::tensor_type(std::move(result)));
 }
 
+
+CommonDenseTensorCellsIterator::CommonDenseTensorCellsIterator(const Mapping & common,
+                                                               const eval::ValueType &type_in,
+                                                               CellsRef cells)
+    : _type(type_in),
+      _cells(cells),
+      _address(type_in.dimensions().size(), 0),
+      _common(common),
+      _mutable(_address.size()),
+      _accumulatedSize(_address.size())
+{
+    for (uint32_t i(0); i < _address.size(); i++) {
+        _mutable[i] = i;
+    }
+    for (auto cur = _common.rbegin(); cur != _common.rend(); cur++) {
+        _mutable.erase(_mutable.begin() + cur->second);
+    }
+    size_t multiplier = 1;
+    for (int32_t i(_address.size() - 1); i >= 0; i--) {
+        _accumulatedSize[i] = multiplier;
+        multiplier *= type_in.dimensions()[i].size;
+    }
+}
+CommonDenseTensorCellsIterator::~CommonDenseTensorCellsIterator() = default;
+
 }

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
@@ -10,36 +10,33 @@ DenseTensorAddressCombiner::~DenseTensorAddressCombiner() { }
 
 DenseTensorAddressCombiner::DenseTensorAddressCombiner(const eval::ValueType &lhs,
                                                        const eval::ValueType &rhs)
-    : _ops(),
-      _combinedAddress(),
+    : _combinedAddress(),
       _left(),
       _commonRight(),
       _right()
 {
     auto rhsItr = rhs.dimensions().cbegin();
     auto rhsItrEnd = rhs.dimensions().cend();
+    uint32_t numDimensions(0);
     for (const auto &lhsDim : lhs.dimensions()) {
         while ((rhsItr != rhsItrEnd) && (rhsItr->name < lhsDim.name)) {
-            _right.emplace_back(_ops.size(), rhsItr-rhs.dimensions().cbegin());
-            _ops.push_back(AddressOp::RHS);
+            _right.emplace_back(numDimensions++, rhsItr-rhs.dimensions().cbegin());
             ++rhsItr;
         }
         if ((rhsItr != rhsItrEnd) && (rhsItr->name == lhsDim.name)) {
-            _left.emplace_back(_ops.size(), _left.size());
-            _commonRight.emplace_back(_ops.size(), rhsItr-rhs.dimensions().cbegin());
-            _ops.push_back(AddressOp::BOTH);
+            _left.emplace_back(numDimensions, _left.size());
+            _commonRight.emplace_back(numDimensions, rhsItr-rhs.dimensions().cbegin());
+            ++numDimensions;
             ++rhsItr;
         } else {
-            _left.emplace_back(_ops.size(), _left.size());
-            _ops.push_back(AddressOp::LHS);
+            _left.emplace_back(numDimensions++, _left.size());
         }
     }
     while (rhsItr != rhsItrEnd) {
-        _right.emplace_back(_ops.size(), rhsItr-rhs.dimensions().cbegin());
-        _ops.push_back(AddressOp::RHS);
+        _right.emplace_back(numDimensions++, rhsItr-rhs.dimensions().cbegin());
         ++rhsItr;
     }
-    _combinedAddress.resize(_ops.size());
+    _combinedAddress.resize(numDimensions);
 }
 
 eval::ValueType

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.cpp
@@ -17,17 +17,22 @@ DenseTensorAddressCombiner::DenseTensorAddressCombiner(const eval::ValueType &lh
     auto rhsItrEnd = rhs.dimensions().cend();
     for (const auto &lhsDim : lhs.dimensions()) {
         while ((rhsItr != rhsItrEnd) && (rhsItr->name < lhsDim.name)) {
+            _right.emplace_back(_ops.size(), rhsItr-rhs.dimensions().cbegin());
             _ops.push_back(AddressOp::RHS);
             ++rhsItr;
         }
         if ((rhsItr != rhsItrEnd) && (rhsItr->name == lhsDim.name)) {
+            _left.emplace_back(_ops.size(), _left.size());
+            _commonRight.emplace_back(_ops.size(), rhsItr-rhs.dimensions().cbegin());
             _ops.push_back(AddressOp::BOTH);
             ++rhsItr;
         } else {
+            _left.emplace_back(_ops.size(), _left.size());
             _ops.push_back(AddressOp::LHS);
         }
     }
     while (rhsItr != rhsItrEnd) {
+        _right.emplace_back(_ops.size(), rhsItr-rhs.dimensions().cbegin());
         _ops.push_back(AddressOp::RHS);
         ++rhsItr;
     }

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
@@ -64,7 +64,7 @@ private:
     CellsRef               _cells;
     Address                _address;
     const Mapping         &_common;
-    const Mapping         &_mutable;
+    const Mapping         &_right;
     std::vector<size_t>    _accumulatedSize;
 
     double cell(size_t cellIdx) const { return _cells[cellIdx]; }
@@ -81,12 +81,12 @@ public:
     ~CommonDenseTensorCellsIterator();
     template <typename Func>
     void for_each(Address & combined, Func && func) const {
-        const int32_t lastDimension = _mutable.size() - 1;
+        const int32_t lastDimension = _right.size() - 1;
         int32_t curDimension = lastDimension;
         size_t cellIdx = index(_address);
         while (curDimension >= 0) {
-            const uint32_t rdim = _mutable[curDimension].second;
-            const uint32_t cdim = _mutable[curDimension].first;
+            const uint32_t rdim = _right[curDimension].second;
+            const uint32_t cdim = _right[curDimension].first;
             size_type & cindex = combined[cdim];
             if (curDimension == lastDimension) {
                 for (cindex = 0; cindex < _type.dimensions()[rdim].size; cindex++) {

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
@@ -127,31 +127,30 @@ public:
                                    const eval::ValueType &type_in, CellsRef cells);
     ~CommonDenseTensorCellsIterator();
     template <typename Func>
-    void for_each(Address & combined, Func && func) {
+    void for_each(Address & combined, Func && func) const {
         const int32_t lastDimension = _mutable.size() - 1;
         int32_t curDimension = lastDimension;
         size_t cellIdx = index(_address);
         while (curDimension >= 0) {
             const uint32_t rdim = _mutable[curDimension].second;
             const uint32_t cdim = _mutable[curDimension].first;
-            size_type & rindex = _address[rdim];
             size_type & cindex = combined[cdim];
             if (curDimension == lastDimension) {
-                for (rindex = 0, cindex = 0; rindex < _type.dimensions()[rdim].size; rindex++, cindex++) {
+                for (cindex = 0; cindex < _type.dimensions()[rdim].size; cindex++) {
                     func(combined, cell(cellIdx));
                     cellIdx += _accumulatedSize[rdim];
                 }
-                rindex = 0; cindex = 0;
+                cindex = 0;
                 cellIdx -= _accumulatedSize[rdim] * _type.dimensions()[rdim].size;
                 curDimension--;
             } else {
-                if (rindex < _type.dimensions()[rdim].size) {
-                    rindex++; cindex++;
+                if (cindex < _type.dimensions()[rdim].size) {
+                    cindex++;
                     cellIdx += _accumulatedSize[rdim];
                     curDimension++;
                 } else {
                     cellIdx -= _accumulatedSize[rdim] * _type.dimensions()[rdim].size;
-                    rindex = 0; cindex = 0;
+                    cindex = 0;
                     curDimension--;
                 }
             }

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
@@ -111,7 +111,9 @@ public:
     }
     bool updateCommon(const Address & combined) {
         for (const auto & m : _common) {
-            if (combined[m.first] >= _type.dimensions()[m.second].size) return false;
+            if (combined[m.first] >= _type.dimensions()[m.second].size) {
+                return false;
+            }
             _address[m.second] = combined[m.first];
         }
         return true;

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
@@ -66,31 +66,6 @@ public:
     const Address &address() const { return _combinedAddress; }
     Address &address() { return _combinedAddress; }
 
-    bool combine(const Address & lhs, const Address & rhs) {
-        uint32_t index(0);
-        AddressReader lhsReader(lhs);
-        AddressReader rhsReader(rhs);
-        for (const auto &op : _ops) {
-            switch (op) {
-                case AddressOp::LHS:
-                    _combinedAddress[index] = lhsReader.nextLabel();
-                    break;
-                case AddressOp::RHS:
-                    _combinedAddress[index] = rhsReader.nextLabel();
-                    break;
-                case AddressOp::BOTH:
-                    Address::value_type lhsLabel = lhsReader.nextLabel();
-                    Address::value_type rhsLabel = rhsReader.nextLabel();
-                    if (lhsLabel != rhsLabel) {
-                        return false;
-                    }
-                    _combinedAddress[index] = lhsLabel;
-            }
-            index++;
-        }
-        return true;
-    }
-
     static eval::ValueType combineDimensions(const eval::ValueType &lhs, const eval::ValueType &rhs);
 };
 

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
@@ -60,6 +60,8 @@ public:
 
     const Mapping & commonRight() const { return _commonRight; }
 
+    bool hasAnyRightOnlyDimensions() const { return ! _right.empty(); }
+
     const Address &address() const { return _combinedAddress; }
 
     bool combine(const Address & lhs, const Address & rhs) {
@@ -123,10 +125,6 @@ public:
     ~CommonDenseTensorCellsIterator();
     template <typename Func>
     void for_each(Func && func) {
-        if (_mutable.empty()) {
-            func(_address, cell(index(_address)));
-            return;
-        }
         const int32_t lastDimension = _mutable.size() - 1;
         int32_t curDimension = lastDimension;
         size_t cellIdx = index(_address);
@@ -160,6 +158,9 @@ public:
             _address[m.second] = combined[m.first];
         }
         return true;
+    }
+    double cell() const {
+        return cell(index(_address));
     }
 
     const eval::ValueType &fast_type() const { return _type; }

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_address_combiner.h
@@ -18,25 +18,11 @@ namespace vespalib::tensor {
 class DenseTensorAddressCombiner
 {
 public:
-    using Address = DenseTensorCellsIterator::Address;
     using Mapping = std::vector<std::pair<uint32_t, uint32_t>>;
 
 private:
-    enum class AddressOp { LHS, RHS, BOTH };
+    using Address = DenseTensorCellsIterator::Address;
 
-    using CellsIterator = DenseTensorCellsIterator;
-
-    class AddressReader
-    {
-    private:
-        const Address &_address;
-        uint32_t       _idx;
-    public:
-        AddressReader(const Address &address) : _address(address), _idx(0) {}
-        Address::value_type nextLabel() { return _address[_idx++]; }
-    };
-
-    std::vector<AddressOp> _ops;
     Address                _combinedAddress;
     Mapping                _left;
     Mapping                _commonRight;
@@ -50,14 +36,6 @@ public:
     DenseTensorAddressCombiner(const eval::ValueType &lhs, const eval::ValueType &rhs);
     ~DenseTensorAddressCombiner();
     void updateLeftAndCommon(const Address & addr) { update(addr, _left); }
-    void updateRight(const Address & addr) { update(addr, _right); }
-    bool hasCommonWithRight(const Address & addr) const {
-        for (const auto & m : _commonRight) {
-            if (_combinedAddress[m.first] != addr[m.second]) return false;
-        }
-        return true;
-    }
-
     const Mapping & getCommonRight() const { return _commonRight; }
     const Mapping & getRight() const { return _right; }
 

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
@@ -15,9 +15,10 @@ apply(const DenseTensorView &lhs, const DenseTensorView &rhs, Function &&func)
     DenseTensorAddressCombiner combiner(lhs.fast_type(), rhs.fast_type());
     DirectDenseTensorBuilder builder(DenseTensorAddressCombiner::combineDimensions(lhs.fast_type(), rhs.fast_type()));
     for (DenseTensorCellsIterator lhsItr = lhs.cellsIterator(); lhsItr.valid(); lhsItr.next()) {
+        combiner.updateLeftAndCommon(lhsItr.address());
         for (DenseTensorCellsIterator rhsItr = rhs.cellsIterator(); rhsItr.valid(); rhsItr.next()) {
-            bool combineSuccess = combiner.combine(lhsItr, rhsItr);
-            if (combineSuccess) {
+            if (combiner.hasCommonWithRight(rhsItr.address())) {
+                combiner.updateRight(rhsItr.address());
                 builder.insertCell(combiner.address(), func(lhsItr.cell(), rhsItr.cell()));
             }
         }

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
@@ -11,6 +11,11 @@ namespace vespalib::tensor::dense {
 template <typename Function>
 std::unique_ptr<Tensor>
 apply(DenseTensorAddressCombiner & combiner, DirectDenseTensorBuilder & builder,
+      CommonDenseTensorCellsIterator & rhsIter, const DenseTensorView &lhs, Function &&func) __attribute__((noinline));
+
+template <typename Function>
+std::unique_ptr<Tensor>
+apply(DenseTensorAddressCombiner & combiner, DirectDenseTensorBuilder & builder,
       CommonDenseTensorCellsIterator & rhsIter, const DenseTensorView &lhs, Function &&func)
 {
     for (DenseTensorCellsIterator lhsItr = lhs.cellsIterator(); lhsItr.valid(); lhsItr.next()) {
@@ -23,6 +28,13 @@ apply(DenseTensorAddressCombiner & combiner, DirectDenseTensorBuilder & builder,
     }
     return builder.build();
 }
+
+
+template <typename Function>
+std::unique_ptr<Tensor>
+apply_no_rightonly_dimensions(DenseTensorAddressCombiner & combiner, DirectDenseTensorBuilder & builder,
+                              CommonDenseTensorCellsIterator & rhsIter,
+                              const DenseTensorView &lhs, Function &&func)  __attribute__((noinline));
 
 template <typename Function>
 std::unique_ptr<Tensor>

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
@@ -16,9 +16,8 @@ apply(DenseTensorAddressCombiner & combiner, DirectDenseTensorBuilder & builder,
     for (DenseTensorCellsIterator lhsItr = lhs.cellsIterator(); lhsItr.valid(); lhsItr.next()) {
         combiner.updateLeftAndCommon(lhsItr.address());
         if (rhsIter.updateCommon(combiner.address())) {
-            rhsIter.for_each([&combiner, &func, &builder, &lhsItr](const DenseTensorCellsIterator::Address & right, double rhsCell) {
-                combiner.updateRight(right);
-                builder.insertCell(combiner.address(), func(lhsItr.cell(), rhsCell));
+            rhsIter.for_each(combiner.address(), [&combiner, &func, &builder, &lhsItr](const DenseTensorCellsIterator::Address & combined, double rhsCell) {
+                builder.insertCell(combined, func(lhsItr.cell(), rhsCell));
             });
         }
     }
@@ -46,7 +45,7 @@ apply(const DenseTensorView &lhs, const DenseTensorView &rhs, Function &&func)
 {
     DenseTensorAddressCombiner combiner(lhs.fast_type(), rhs.fast_type());
     DirectDenseTensorBuilder builder(DenseTensorAddressCombiner::combineDimensions(lhs.fast_type(), rhs.fast_type()));
-    CommonDenseTensorCellsIterator rhsIter(combiner.commonRight(), rhs.fast_type(), rhs.cellsRef());
+    CommonDenseTensorCellsIterator rhsIter(combiner.getCommonRight(), combiner.getRight(), rhs.fast_type(), rhs.cellsRef());
     if (combiner.hasAnyRightOnlyDimensions()) {
         return apply(combiner, builder, rhsIter, lhs, std::move(func));
     } else {

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_apply.hpp
@@ -21,7 +21,7 @@ apply(DenseTensorAddressCombiner & combiner, DirectDenseTensorBuilder & builder,
     for (DenseTensorCellsIterator lhsItr = lhs.cellsIterator(); lhsItr.valid(); lhsItr.next()) {
         combiner.updateLeftAndCommon(lhsItr.address());
         if (rhsIter.updateCommon(combiner.address())) {
-            rhsIter.for_each(combiner.address(), [&combiner, &func, &builder, &lhsItr](const DenseTensorCellsIterator::Address & combined, double rhsCell) {
+            rhsIter.for_each(combiner.address(), [&func, &builder, &lhsItr](const DenseTensorCellsIterator::Address & combined, double rhsCell) {
                 builder.insertCell(combined, func(lhsItr.cell(), rhsCell));
             });
         }

--- a/eval/src/vespa/eval/tensor/dense/direct_dense_tensor_builder.h
+++ b/eval/src/vespa/eval/tensor/dense/direct_dense_tensor_builder.h
@@ -31,7 +31,10 @@ public:
     DirectDenseTensorBuilder(const eval::ValueType &type_in);
     ~DirectDenseTensorBuilder();
     void insertCell(const Address &address, double cellValue) {
-        _cells[calculateCellAddress(address, _type)] = cellValue;
+        insertCell(calculateCellAddress(address, _type), cellValue);
+    }
+    void insertCell(size_t index, double cellValue) {
+        _cells[index] = cellValue;
     }
     Tensor::UP build();
 };


### PR DESCRIPTION
@havardpe This contains all the minor code fixes from #4537 and a merge back to a single combiner. Iteration is the same. It is just a merge of the 2 classes. I will merge it now to get performance number while I change to iterate common dimensions first.