### PR TITLE
Revert "Delegate to other components if specified"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminConfig.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminConfig.java
@@ -7,18 +7,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.logging.Logger;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NodeAdminConfig {
+    private static final Logger logger = Logger.getLogger(NodeAdminConfig.class.getName());
     private static final ObjectMapper mapper = new ObjectMapper();
-
-    /**
-     * A list of components to enable instead of the default.
-     */
-    @JsonProperty("components")
-    public List<String> components = new ArrayList<>();
 
     public enum Mode {
         aws_tenant,

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
@@ -1,21 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.nodeadmin;
 
-import com.yahoo.component.ComponentId;
-import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.concurrent.classlock.ClassLocking;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
-import com.yahoo.vespa.hosted.node.admin.component.AdminComponent;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * NodeAdminMain is the main component of the node admin JDisc application:
@@ -27,73 +19,52 @@ import java.util.stream.Collectors;
  *    be fatal: the node admin may not have installed and started the docker daemon.
  */
 public class NodeAdminMain implements AutoCloseable {
-    private static final Logger logger = Logger.getLogger(NodeAdminMain.class.getName());
-
-    private final ComponentRegistry<AdminComponent> adminRegistry;
     private final Docker docker;
     private final MetricReceiverWrapper metricReceiver;
     private final ClassLocking classLocking;
 
-    private List<AdminComponent> enabledComponents = new ArrayList<>();
-
     private Optional<DockerAdminComponent> dockerAdmin = Optional.empty();
 
-    public NodeAdminMain(ComponentRegistry<AdminComponent> adminRegistry,
-                         Docker docker,
+    public NodeAdminMain(Docker docker,
                          MetricReceiverWrapper metricReceiver,
                          ClassLocking classLocking) {
-        this.adminRegistry = adminRegistry;
         this.docker = docker;
         this.metricReceiver = metricReceiver;
         this.classLocking = classLocking;
     }
 
-    public static NodeAdminConfig getConfig() {
-        String path = Defaults.getDefaults().underVespaHome("conf/node-admin.json");
-        return NodeAdminConfig.fromFile(new File(path));
-    }
-
-    public void start() {
-        NodeAdminConfig config = getConfig();
-
-        if (config.components.isEmpty()) {
-            enable(new DockerAdminComponent(config, docker, metricReceiver, classLocking));
-        } else {
-            logger.log(LogLevel.INFO, () -> {
-                String registeredComponentsList = adminRegistry
-                        .allComponentsById().keySet().stream()
-                        .map(ComponentId::stringValue)
-                        .collect(Collectors.joining(", "));
-
-                String requestedComponentsList = config.components.stream()
-                        .collect(Collectors.joining(", "));
-
-                return String.format(
-                        "Components registered = '%s', enabled = '%s'",
-                        registeredComponentsList,
-                        requestedComponentsList);
-            });
-
-            for (String componentSpecificationString : config.components) {
-                enable(adminRegistry.getComponent(componentSpecificationString));
-            }
-        }
-    }
-
-    private void enable(AdminComponent component) {
-        component.enable();
-        enabledComponents.add(component);
-    }
-
     @Override
     public void close() {
-        int i = enabledComponents.size();
-        while (i --> 0) {
-            enabledComponents.remove(i).disable();
-        }
+        dockerAdmin.ifPresent(DockerAdminComponent::disable);
     }
 
     public NodeAdminStateUpdater getNodeAdminStateUpdater() {
         return dockerAdmin.get().getNodeAdminStateUpdater();
+    }
+
+    public void start() {
+        String staticConfigPath = Defaults.getDefaults().underVespaHome("conf/node-admin.json");
+        NodeAdminConfig config = NodeAdminConfig.fromFile(new File(staticConfigPath));
+
+        switch (config.mode) {
+            case aws_tenant:
+            case tenant:
+                dockerAdmin = Optional.of(new DockerAdminComponent(
+                        config,
+                        docker,
+                        metricReceiver,
+                        classLocking));
+                dockerAdmin.get().enable();
+                return;
+            case config_server_host:
+                // TODO:
+                //  - install and start docker daemon
+                //  - Read config that specifies which containers to start how
+                //  - use thin static backends for node repo and orchestrator
+                //  - Start node admin state updater.
+                return;
+        }
+
+        throw new IllegalStateException("Unknown bootstrap mode: " + config.mode.name());
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/NodeAdminProvider.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/NodeAdminProvider.java
@@ -2,12 +2,10 @@
 package com.yahoo.vespa.hosted.node.admin.provider;
 
 import com.google.inject.Inject;
-import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.concurrent.classlock.ClassLocking;
 import com.yahoo.container.di.componentgraph.Provider;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
-import com.yahoo.vespa.hosted.node.admin.component.AdminComponent;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminMain;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
 
@@ -15,11 +13,10 @@ public class NodeAdminProvider implements Provider<NodeAdminStateUpdater> {
     private final NodeAdminMain nodeAdminMain;
 
     @Inject
-    public NodeAdminProvider(ComponentRegistry<AdminComponent> adminRegistry,
-                             Docker docker,
+    public NodeAdminProvider(Docker docker,
                              MetricReceiverWrapper metricReceiver,
                              ClassLocking classLocking) {
-        nodeAdminMain = new NodeAdminMain(adminRegistry, docker, metricReceiver, classLocking);
+        nodeAdminMain = new NodeAdminMain(docker, metricReceiver, classLocking);
         nodeAdminMain.start();
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#4592

Container does not start, fails with `[2018-01-10 06:41:18.457] WARNING : container        stderr	java.util.NoSuchElementException: No value present
[2018-01-10 06:41:18.457] WARNING : container        stderr	\tat java.util.Optional.get(Optional.java:135)
[2018-01-10 06:41:18.457] WARNING : container        stderr	\tat com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminMain.getNodeAdminStateUpdater(NodeAdminMain.java:97)`
  