### PR TITLE
Revert "Prefer zookeeper server on localhost for CD"

### DIFF
--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -77,7 +77,7 @@ public class Curator implements AutoCloseable {
 
             String spec = String.format("%s:%d", server.hostname(), server.port());
 
-            if ((config.zookeeperLocalhostAffinity() || config.system().equals("cd")) && server.hostname().equals(thisServer)) {
+            if (config.zookeeperLocalhostAffinity() && server.hostname().equals(thisServer)) {
                 // Only connect to localhost server if possible, to save network traffic
                 // and balance load.
                 return spec;


### PR DESCRIPTION
Reverts vespa-engine/vespa#4610

Failed with `com.yahoo.container.di.componentgraph.core.ComponentNode$ComponentConstructorException: Error constructing 'com.yahoo.vespa.config.server.SuperModelManager'
        Caused by: java.lang.RuntimeException: Unable to get value
        at com.yahoo.vespa.curator.recipes.CuratorCounter.get(CuratorCounter.java:76)
        at com.yahoo.vespa.config.server.SuperModelGenerationCounter.get(SuperModelGenerationCounter.java:40)
....`

@aressem FYI