### PR TITLE
Use invalid bucket space in default document::Bucket constructor.

### DIFF
--- a/document/src/vespa/document/bucket/bucket.cpp
+++ b/document/src/vespa/document/bucket/bucket.cpp
@@ -6,7 +6,7 @@
 namespace document {
 
 Bucket::Bucket() noexcept
-    : _bucketSpace(BucketSpace::placeHolder()),
+    : _bucketSpace(BucketSpace::invalid()),
       _bucketId()
 {
 }


### PR DESCRIPTION
@geirst, @vekterli: please review
