### PR TITLE
Add dependency management for scala-library.

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -336,6 +336,13 @@
                 <version>${mimepull.version}</version>
             </dependency>
             <dependency>
+                <!-- NOT provided from Jdisc runtime, but any project that has unit tests based on
+                     the 'application' framework MUST use our version. -->
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${scala.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
@@ -422,6 +429,7 @@
         <guava.version>18.0</guava.version>
         <guice.version>3.0</guice.version>
         <jetty.version>9.4.8.v20171121</jetty.version>
+        <scala.version>2.11.4</scala.version>  <!-- When updating this, the scala.major-version in parent must also be updated! -->
         <slf4j.version>1.7.5</slf4j.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -617,11 +617,6 @@
                 <version>4.3.0</version>
             </dependency>
             <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.scala-lang.modules</groupId>
                 <artifactId>scala-parser-combinators_${scala.major-version}</artifactId>
                 <version>1.0.1</version>
@@ -710,8 +705,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.hide>true</test.hide>
     	<doclint>all</doclint>
-        <scala.major-version>2.11</scala.major-version>
-        <scala.version>${scala.major-version}.4</scala.version>
+        <scala.major-version>2.11</scala.major-version> <!-- TODO: factorylib magic for maven cache bootstrapping prevents moving this to container-dep-versions. -->
         <surefire.version>2.19.1</surefire.version> <!-- NOTE bjorncs 15.06.2017: Version 2.20 has OoM issues -->
     </properties>
 


### PR DESCRIPTION
- All users with 'application' based unit tests must use the
  version of scala-library that vespa is built with.