### PR TITLE
Use invalid bucket space in default storage::spi::Bucket constructor.

### DIFF
--- a/persistence/src/vespa/persistence/spi/bucket.h
+++ b/persistence/src/vespa/persistence/spi/bucket.h
@@ -25,7 +25,7 @@ class Bucket {
     PartitionId _partition;
 
 public:
-    Bucket() : _bucket(document::BucketSpace::placeHolder(), document::BucketId(0)), _partition(0) {}
+    Bucket() : _bucket(document::BucketSpace::invalid(), document::BucketId(0)), _partition(0) {}
     Bucket(const document::Bucket& b, PartitionId p)
         : _bucket(b), _partition(p) {}
 


### PR DESCRIPTION
@vekterli, please review
@geirst, FYI