### PR TITLE
Use ContentSigner with BouncyCastle provider

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSigner.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ca/CertificateSigner.java
@@ -103,7 +103,9 @@ public class CertificateSigner {
                     // Set Basic Constraints to false
                     .addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
 
-            ContentSigner caSigner = new JcaContentSignerBuilder(SIGNER_ALGORITHM).build(caPrivateKey);
+            ContentSigner caSigner = new JcaContentSignerBuilder(SIGNER_ALGORITHM)
+                    .setProvider(provider)
+                    .build(caPrivateKey);
 
             return certificateConverter
                     .setProvider(provider)


### PR DESCRIPTION
As we use _BouncyCastle provider_ for the `JcaX509CertificateConverter` instance, we should probably use _BouncyCastle_ for `ContentSigner` as well.