### PR TITLE
Run spec verifier with args

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -311,7 +311,7 @@ public class StorageMaintainer {
      * @throws RuntimeException if exit code != 0
      */
     public String getHardwareDivergence(ContainerNodeSpec nodeSpec) {
-        List<String> argumnets = new ArrayList<>(Arrays.asList("specification",
+        List<String> arguments = new ArrayList<>(Arrays.asList("specification",
                 "--disk", Double.toString(nodeSpec.minDiskAvailableGb),
                 "--memory", Double.toString(nodeSpec.minMainMemoryAvailableGb),
                 "--cpu_cores", Double.toString(nodeSpec.minCpuCores),
@@ -319,11 +319,11 @@ public class StorageMaintainer {
                 "--ips", String.join(",", nodeSpec.ipAddresses)));
 
         if (nodeSpec.hardwareDivergence.isPresent()) {
-            argumnets.add("--divergence");
-            argumnets.add(nodeSpec.hardwareDivergence.get());
+            arguments.add("--divergence");
+            arguments.add(nodeSpec.hardwareDivergence.get());
         }
 
-        return executeMaintainer("com.yahoo.vespa.hosted.node.verification.Main", argumnets.toArray(new String[0]));
+        return executeMaintainer("com.yahoo.vespa.hosted.node.verification.Main", arguments.toArray(new String[0]));
     }
 
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -21,7 +21,6 @@ import com.yahoo.vespa.hosted.node.admin.util.SecretAgentScheduleMaker;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -37,7 +36,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
@@ -308,20 +306,33 @@ public class StorageMaintainer {
 
     /**
      * Runs node-maintainer's SpecVerifier and returns its output
+     * @param nodeSpec Node specification containing the excepted values we want to verify against
+     * @return new combined hardware divergence
      * @throws RuntimeException if exit code != 0
      */
-    public String getHardwareDivergence() {
-        String configServers = environment.getConfigServerUris().stream()
-                .map(URI::getHost)
-                .collect(Collectors.joining(","));
-        return executeMaintainer("com.yahoo.vespa.hosted.node.verification.spec.SpecVerifier", configServers);
+    public String getHardwareDivergence(ContainerNodeSpec nodeSpec) {
+        List<String> argumnets = new ArrayList<>(Arrays.asList("specification",
+                "--disk", Double.toString(nodeSpec.minDiskAvailableGb),
+                "--memory", Double.toString(nodeSpec.minMainMemoryAvailableGb),
+                "--cpu_cores", Double.toString(nodeSpec.minCpuCores),
+                "--is_ssd", Boolean.toString(nodeSpec.fastDisk),
+                "--ips", String.join(",", nodeSpec.ipAddresses)));
+
+        if (nodeSpec.hardwareDivergence.isPresent()) {
+            argumnets.add("--divergence");
+            argumnets.add(nodeSpec.hardwareDivergence.get());
+        }
+
+        return executeMaintainer("com.yahoo.vespa.hosted.node.verification.Main", argumnets.toArray(new String[0]));
     }
 
 
     private String executeMaintainer(String mainClass, String... args) {
         String[] command = Stream.concat(
-                Stream.of("sudo", "VESPA_HOME=" + getDefaults().vespaHome(),
-                        getDefaults().underVespaHome("libexec/vespa/node-admin/maintenance.sh"), mainClass),
+                Stream.of("sudo",
+                        "VESPA_HOME=" + getDefaults().vespaHome(),
+                        getDefaults().underVespaHome("libexec/vespa/node-admin/maintenance.sh"),
+                        mainClass),
                 Stream.of(args))
                 .toArray(String[]::new);
 
@@ -334,7 +345,7 @@ public class StorageMaintainer {
                         String.format("Maintainer failed to execute command: %s, Exit code: %d, Stdout/stderr: %s",
                                 Arrays.toString(command), result.getFirst(), result.getSecond()));
             }
-            return result.getSecond();
+            return result.getSecond().trim();
         } catch (IOException e) {
             throw new RuntimeException("Failed to execute maintainer", e);
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/NodeRepositoryImpl.java
@@ -134,7 +134,10 @@ public class NodeRepositoryImpl implements NodeRepository {
                 Optional.ofNullable(node.currentRestartGeneration),
                 node.minCpuCores,
                 node.minMainMemoryAvailableGb,
-                node.minDiskAvailableGb);
+                node.minDiskAvailableGb,
+                node.fastDisk,
+                node.ipAddresses,
+                Optional.ofNullable(node.hardwareDivergence));
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/bindings/GetNodesResponse.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/noderepository/bindings/GetNodesResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class represents a response from the /nodes/v2/node/ API. It is designed to be
@@ -43,6 +44,9 @@ public class GetNodesResponse {
         public final Double minCpuCores;
         public final Double minMainMemoryAvailableGb;
         public final Double minDiskAvailableGb;
+        public final Boolean fastDisk;
+        public final Set<String> ipAddresses;
+        public final String hardwareDivergence;
 
         @JsonCreator
         public Node(@JsonProperty("id") String hostname,
@@ -62,7 +66,10 @@ public class GetNodesResponse {
                     @JsonProperty("currentRebootGeneration") Long currentRebootGeneration,
                     @JsonProperty("minCpuCores") Double minCpuCores,
                     @JsonProperty("minMainMemoryAvailableGb") Double minMainMemoryAvailableGb,
-                    @JsonProperty("minDiskAvailableGb") Double minDiskAvailableGb) {
+                    @JsonProperty("minDiskAvailableGb") Double minDiskAvailableGb,
+                    @JsonProperty("fastDisk") Boolean fastDisk,
+                    @JsonProperty("ipAddresses") Set<String> ipAddresses,
+                    @JsonProperty("hardwareDivergence") String hardwareDivergence) {
             this.hostname = hostname;
             this.wantedDockerImage = wantedDockerImage;
             this.currentDockerImage = currentDockerImage;
@@ -81,6 +88,9 @@ public class GetNodesResponse {
             this.minCpuCores = minCpuCores;
             this.minMainMemoryAvailableGb = minMainMemoryAvailableGb;
             this.minDiskAvailableGb = minDiskAvailableGb;
+            this.fastDisk = fastDisk;
+            this.ipAddresses = ipAddresses;
+            this.hardwareDivergence = hardwareDivergence;
         }
 
         public String toString() {


### PR DESCRIPTION
This PR updates how we call `node-maintainer` to run the spec verifier.
Since #4694 spec verifier will no longer call node-repo and instead take all the required values as command line arguments.