### PR TITLE
Add builder helper for SSLContext in vespa-athenz

### DIFF
--- a/controller-api/pom.xml
+++ b/controller-api/pom.xml
@@ -70,19 +70,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Required for AthenzIdentityVerifierTest -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-
     </dependencies>
 
     <build>

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzSslContextProviderImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/athenz/impl/AthenzSslContextProviderImpl.java
@@ -2,26 +2,13 @@
 package com.yahoo.vespa.hosted.controller.athenz.impl;
 
 import com.google.inject.Inject;
+import com.yahoo.vespa.athenz.tls.AthenzSslContextBuilder;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzClientFactory;
-import com.yahoo.vespa.athenz.api.AthenzIdentityCertificate;
 import com.yahoo.vespa.hosted.controller.api.integration.athenz.AthenzSslContextProvider;
-import com.yahoo.vespa.hosted.controller.api.integration.athenz.ZtsClient;
 import com.yahoo.vespa.hosted.controller.athenz.config.AthenzConfig;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
+import java.io.File;
 
 /**
  * @author bjorncs
@@ -39,49 +26,9 @@ public class AthenzSslContextProviderImpl implements AthenzSslContextProvider {
 
     @Override
     public SSLContext get() {
-        return createSslContext();
-    }
-
-    private SSLContext createSslContext() {
-        try {
-            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
-            sslContext.init(createKeyManagersWithServiceCertificate(clientFactory.createZtsClientWithServicePrincipal()),
-                            createTrustManagersWithAthenzCa(config),
-                            null);
-            return sslContext;
-        } catch (NoSuchAlgorithmException | KeyManagementException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static KeyManager[] createKeyManagersWithServiceCertificate(ZtsClient ztsClient) {
-        try {
-            AthenzIdentityCertificate identityCertificate = ztsClient.getIdentityCertificate();
-            KeyStore keyStore = KeyStore.getInstance("JKS");
-            keyStore.load(null);
-            keyStore.setKeyEntry("athenz-controller-key",
-                                 identityCertificate.getPrivateKey(),
-                                 new char[0],
-                                 new Certificate[]{identityCertificate.getCertificate()});
-            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(keyStore, new char[0]);
-            return keyManagerFactory.getKeyManagers();
-        } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException | CertificateException | IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static TrustManager[] createTrustManagersWithAthenzCa(AthenzConfig config) {
-        try {
-            KeyStore trustStore = KeyStore.getInstance("JKS");
-            try (FileInputStream in = new FileInputStream(config.athenzCaTrustStore())) {
-                trustStore.load(in, "changeit".toCharArray());
-            }
-            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            trustManagerFactory.init(trustStore);
-            return trustManagerFactory.getTrustManagers();
-        } catch (CertificateException | IOException | KeyStoreException | NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        return new AthenzSslContextBuilder()
+                .withTrustStore(new File(config.athenzCaTrustStore()), "JKS")
+                .withIdentityCertificate(clientFactory.createZtsClientWithServicePrincipal().getIdentityCertificate())
+                .build();
     }
 }

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/tls/AthenzSslContextBuilder.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/tls/AthenzSslContextBuilder.java
@@ -1,0 +1,125 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.athenz.tls;
+
+import com.yahoo.vespa.athenz.api.AthenzIdentityCertificate;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+
+/**
+ * @author bjorncs
+ */
+public class AthenzSslContextBuilder {
+
+    private KeyStoreSupplier trustStoreSupplier;
+    private KeyStoreSupplier keyStoreSupplier;
+    private char[] keyStorePassword;
+
+    public AthenzSslContextBuilder() {}
+
+    public AthenzSslContextBuilder withTrustStore(File file, String trustStoreType) {
+        this.trustStoreSupplier = () -> loadKeyStoreFromFile(file, null, trustStoreType);
+        return this;
+    }
+
+    public AthenzSslContextBuilder withTrustStore(KeyStore trustStore) {
+        this.trustStoreSupplier = () -> trustStore;
+        return this;
+    }
+
+    public AthenzSslContextBuilder withIdentityCertificate(AthenzIdentityCertificate certificate) {
+        char[] pwd = new char[0];
+        this.keyStoreSupplier = () -> {
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+            keyStore.load(null);
+            keyStore.setKeyEntry(
+                    "athenz-identity", certificate.getPrivateKey(), pwd, new Certificate[]{certificate.getCertificate()});
+            return keyStore;
+        };
+        this.keyStorePassword = pwd;
+        return this;
+    }
+
+    public AthenzSslContextBuilder withKeyStore(KeyStore keyStore, char[] password) {
+        this.keyStoreSupplier = () -> keyStore;
+        this.keyStorePassword = password;
+        return this;
+    }
+
+    public AthenzSslContextBuilder withKeyStore(File file, char[] password, String keyStoreType) {
+        this.keyStoreSupplier = () -> loadKeyStoreFromFile(file, password, keyStoreType);
+        this.keyStorePassword = password;
+        return this;
+    }
+
+    public SSLContext build() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            TrustManager[] trustManagers =
+                    trustStoreSupplier != null ? createTrustManagers(trustStoreSupplier) : getDefaultTrustManagers();
+            KeyManager[] keyManagers =
+                    keyStoreSupplier != null ? createKeyManagers(keyStoreSupplier, keyStorePassword) : getDefaultKeyManagers();
+            sslContext.init(keyManagers, trustManagers, null);
+            return sslContext;
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static TrustManager[] createTrustManagers(KeyStoreSupplier trustStoreSupplier)
+            throws GeneralSecurityException, IOException {
+        TrustManagerFactory trustManagerFactory = getTrustManagerFactory();
+        trustManagerFactory.init(trustStoreSupplier.get());
+        return trustManagerFactory.getTrustManagers();
+    }
+
+    private static KeyManager[] createKeyManagers(KeyStoreSupplier keyStoreSupplier, char[] password)
+            throws GeneralSecurityException, IOException {
+        KeyManagerFactory keyManagerFactory = getKeyManagerFactory();
+        keyManagerFactory.init(keyStoreSupplier.get(), password);
+        return keyManagerFactory.getKeyManagers();
+    }
+
+    private static KeyManager[] getDefaultKeyManagers() throws NoSuchAlgorithmException {
+        return getKeyManagerFactory().getKeyManagers();
+    }
+
+    private static TrustManager[] getDefaultTrustManagers() throws NoSuchAlgorithmException {
+        return getTrustManagerFactory().getTrustManagers();
+    }
+
+    private static KeyManagerFactory getKeyManagerFactory() throws NoSuchAlgorithmException {
+        return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    }
+
+    private static TrustManagerFactory getTrustManagerFactory() throws NoSuchAlgorithmException {
+        return TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    }
+
+    private static KeyStore loadKeyStoreFromFile(File file, char[] password, String keyStoreType)
+            throws IOException, GeneralSecurityException{
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        try (FileInputStream in = new FileInputStream(file)) {
+            keyStore.load(in, password);
+        }
+        return keyStore;
+    }
+
+    private interface KeyStoreSupplier {
+        KeyStore get() throws IOException, GeneralSecurityException;
+    }
+
+}

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/tls/package-info.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/tls/package-info.java
@@ -1,0 +1,9 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+/**
+ * @author bjorncs
+ */
+
+@ExportPackage
+package com.yahoo.vespa.athenz.tls;
+
+import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
Use new builder in AthenzSslContextProviderImpl

Added missing `package-info.java` file compared to previous PR.