### PR TITLE
Use protobuf 3.4.0 by default

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -312,7 +312,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 import java.util.jar.JarInputStream;
 
 /**
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen Hult</a>
+ * @author Simon Thoresen Hult
  */
 public class ExportPackages {
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -403,7 +403,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>2.4.1</version>
+                <version>3.4.0</version>
             </dependency>
             <dependency>
                 <groupId>com.googlecode.jmockit</groupId>

--- a/searchlib/pom.xml
+++ b/searchlib/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>


### PR DESCRIPTION
I left the Hadoop stuff on 2.5.0 - do you know if that uses that particular version for some special reason or can I change that to 3.4.0 as well?