### PR TITLE
Revert "don't allow nodes with spec divergence to go to dirty"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -391,9 +391,8 @@ public class NodeRepository extends AbstractComponent {
         Node nodeToDirty = getNode(hostname, Node.State.provisioned, Node.State.failed, Node.State.parked).orElseThrow(() ->
                 new IllegalArgumentException("Could not deallocate " + hostname + ": No such node in the provisioned, failed or parked state"));
 
-        if (nodeToDirty.status().hardwareFailureDescription().isPresent() || nodeToDirty.status().hardwareDivergence().isPresent())
-            throw new IllegalArgumentException("Could not deallocate " + hostname + ": It has a hardware failure/spec divergence");
-
+        if (nodeToDirty.status().hardwareFailureDescription().isPresent())
+            throw new IllegalArgumentException("Could not deallocate " + hostname + ": It has a hardware failure");
         return setDirty(nodeToDirty);
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -282,7 +282,7 @@ public class RestApiTest {
                 "{\"message\":\"Moved host12.yahoo.com to failed\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/dirty/host12.yahoo.com",
                 new byte[0], Request.Method.PUT), 400,
-                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Could not deallocate host12.yahoo.com: It has a hardware failure/spec divergence\"}");
+                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Could not deallocate host12.yahoo.com: It has a hardware failure\"}");
     }
 
     @Test


### PR DESCRIPTION
Reverts #3896 (See VESPA-11059). Assuming we still want the check for HW failure there?