### PR TITLE
Log warning when aborting operation due to clock skew

### DIFF
--- a/storage/src/tests/storageserver/bouncertest.cpp
+++ b/storage/src/tests/storageserver/bouncertest.cpp
@@ -5,6 +5,7 @@
 #include <vespa/storageapi/message/state.h>
 #include <vespa/storageapi/message/stat.h>
 #include <vespa/storage/storageserver/bouncer.h>
+#include <vespa/storage/storageserver/bouncer_metrics.h>
 #include <tests/common/teststorageapp.h>
 #include <tests/common/testhelper.h>
 #include <tests/common/dummystoragelink.h>
@@ -122,6 +123,7 @@ BouncerTest::createDummyFeedMessage(api::Timestamp timestamp,
 void
 BouncerTest::testFutureTimestamp()
 {
+    CPPUNIT_ASSERT_EQUAL(uint64_t(0), _manager->metrics().clock_skew_aborts.getValue());
 
     // Fail when future timestamps (more than 5 seconds) are received.
     {
@@ -134,6 +136,7 @@ BouncerTest::testFutureTimestamp()
                              getResult().getResult());
         _upper->reset();
     }
+    CPPUNIT_ASSERT_EQUAL(uint64_t(1), _manager->metrics().clock_skew_aborts.getValue());
 
     // Verify that 1 second clock skew is OK
     {
@@ -151,7 +154,7 @@ BouncerTest::testFutureTimestamp()
         CPPUNIT_ASSERT_EQUAL(1, (int)_lower->getNumCommands());
     }
 
-
+    CPPUNIT_ASSERT_EQUAL(uint64_t(1), _manager->metrics().clock_skew_aborts.getValue());
 }
 
 void

--- a/storage/src/vespa/storage/storageserver/CMakeLists.txt
+++ b/storage/src/vespa/storage/storageserver/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(storage_storageserver
     SOURCES
     bouncer.cpp
+    bouncer_metrics.cpp
     bucketintegritychecker.cpp
     changedbucketownershiphandler.cpp
     communicationmanager.cpp

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -23,6 +23,8 @@ namespace config { class ConfigUri; }
 
 namespace storage {
 
+class BouncerMetrics;
+
 class Bouncer : public StorageLink,
                 private StateListener,
                 private config::IFetcherCallback<vespa::config::content::core::StorBouncerConfig>
@@ -33,16 +35,18 @@ class Bouncer : public StorageLink,
     lib::NodeState _nodeState;
     const lib::State* _clusterState;
     config::ConfigFetcher _configFetcher;
+    std::unique_ptr<BouncerMetrics> _metrics;
 
 public:
-    explicit Bouncer(StorageComponentRegister& compReg,
-                     const config::ConfigUri & configUri);
-    ~Bouncer();
+    Bouncer(StorageComponentRegister& compReg, const config::ConfigUri & configUri);
+    ~Bouncer() override;
 
     void print(std::ostream& out, bool verbose,
                const std::string& indent) const override;
 
     void configure(std::unique_ptr<vespa::config::content::core::StorBouncerConfig> config) override;
+
+    const BouncerMetrics& metrics() const noexcept;
 
 private:
     void validateConfig(

--- a/storage/src/vespa/storage/storageserver/bouncer_metrics.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer_metrics.cpp
@@ -1,0 +1,16 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "bouncer_metrics.h"
+
+namespace storage {
+
+BouncerMetrics::BouncerMetrics()
+    : MetricSet("bouncer", "", "Metrics for Bouncer component", nullptr),
+      clock_skew_aborts("clock_skew_aborts", "", "Number of client operations that were aborted due to "
+                        "clock skew between sender and receiver exceeding acceptable range", this)
+{
+}
+
+BouncerMetrics::~BouncerMetrics() = default;
+
+}

--- a/storage/src/vespa/storage/storageserver/bouncer_metrics.h
+++ b/storage/src/vespa/storage/storageserver/bouncer_metrics.h
@@ -1,0 +1,16 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/metrics/metrics.h>
+
+namespace storage {
+
+struct BouncerMetrics : metrics::MetricSet {
+    metrics::LongCountMetric clock_skew_aborts;
+
+    BouncerMetrics();
+    ~BouncerMetrics() override;
+};
+
+}


### PR DESCRIPTION
@geirst please review
@yngveaasheim FYI

Improves visibility into clock/NTP-related problems. Logs distributor
index to make it easier to identify the skewing node(s).

Logs are throttled to prevent log spam. This might cause us to miss
some bad nodes if multiple distributors send skewed timestamps, but
at least we'll be aware of it happening in the cluster.