### PR TITLE
Use NodeAdminBaseConfig

### DIFF
--- a/node-admin/src/main/application/services.xml
+++ b/node-admin/src/main/application/services.xml
@@ -15,11 +15,6 @@
       <isRunningLocally>false</isRunningLocally>
     </config>
 
-    <config name="vespa.hosted.node.admin.node-admin">
-      <isRunningLocally>false</isRunningLocally>
-      <restartOnDeploy>true</restartOnDeploy>
-    </config>
-
     <nodes type="host"/>
 
     <preprocess:include file="variant.xml" required="false"/>

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/DockerAdminComponent.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/DockerAdminComponent.java
@@ -6,6 +6,7 @@ import com.yahoo.net.HostName;
 import com.yahoo.system.ProcessExecuter;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
+import com.yahoo.vespa.hosted.node.admin.ConfigServerConfig;
 import com.yahoo.vespa.hosted.node.admin.component.AdminComponent;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
@@ -32,6 +33,7 @@ public class DockerAdminComponent implements AdminComponent {
     private static final Duration NODE_AGENT_SCAN_INTERVAL = Duration.ofSeconds(30);
     private static final Duration NODE_ADMIN_CONVERGE_STATE_INTERVAL = Duration.ofSeconds(30);
 
+    private final ConfigServerConfig configServerConfig;
     private final NodeAdminConfig config;
     private final Docker docker;
     private final MetricReceiverWrapper metricReceiver;
@@ -41,10 +43,12 @@ public class DockerAdminComponent implements AdminComponent {
 
     private Optional<NodeAdminStateUpdater> nodeAdminStateUpdater = Optional.empty();
 
-    public DockerAdminComponent(NodeAdminConfig config,
+    public DockerAdminComponent(ConfigServerConfig configServerConfig,
+                                NodeAdminConfig config,
                                 Docker docker,
                                 MetricReceiverWrapper metricReceiver,
                                 ClassLocking classLocking) {
+        this.configServerConfig = configServerConfig;
         this.config = config;
         this.docker = docker;
         this.metricReceiver = metricReceiver;
@@ -57,7 +61,7 @@ public class DockerAdminComponent implements AdminComponent {
             return;
         }
 
-        Environment environment = new Environment();
+        Environment environment = new Environment(configServerConfig);
         requestExecutor = ConfigServerHttpRequestExecutor.create(
                 environment.getConfigServerUris(), environment.getKeyStoreOptions(), environment.getTrustStoreOptions());
         NodeRepository nodeRepository = new NodeRepositoryImpl(requestExecutor);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminMain.java
@@ -8,6 +8,7 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
+import com.yahoo.vespa.hosted.node.admin.ConfigServerConfig;
 import com.yahoo.vespa.hosted.node.admin.component.AdminComponent;
 
 import java.io.File;
@@ -30,6 +31,7 @@ public class NodeAdminMain implements AutoCloseable {
     private static final Logger logger = Logger.getLogger(NodeAdminMain.class.getName());
 
     private final ComponentRegistry<AdminComponent> adminRegistry;
+    private final ConfigServerConfig configServerConfig;
     private final Docker docker;
     private final MetricReceiverWrapper metricReceiver;
     private final ClassLocking classLocking;
@@ -39,10 +41,12 @@ public class NodeAdminMain implements AutoCloseable {
     private Optional<DockerAdminComponent> dockerAdmin = Optional.empty();
 
     public NodeAdminMain(ComponentRegistry<AdminComponent> adminRegistry,
+                         ConfigServerConfig configServerConfig,
                          Docker docker,
                          MetricReceiverWrapper metricReceiver,
                          ClassLocking classLocking) {
         this.adminRegistry = adminRegistry;
+        this.configServerConfig = configServerConfig;
         this.docker = docker;
         this.metricReceiver = metricReceiver;
         this.classLocking = classLocking;
@@ -58,7 +62,7 @@ public class NodeAdminMain implements AutoCloseable {
 
         if (config.components.isEmpty()) {
             dockerAdmin = Optional.of(new DockerAdminComponent(
-                    config, docker, metricReceiver, classLocking));
+                    configServerConfig, config, docker, metricReceiver, classLocking));
             enable(dockerAdmin.get());
         } else {
             logger.log(LogLevel.INFO, () -> {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/NodeAdminProvider.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/NodeAdminProvider.java
@@ -10,16 +10,18 @@ import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.component.AdminComponent;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminMain;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
+import com.yahoo.vespa.hosted.node.admin.ConfigServerConfig;
 
 public class NodeAdminProvider implements Provider<NodeAdminStateUpdater> {
     private final NodeAdminMain nodeAdminMain;
 
     @Inject
     public NodeAdminProvider(ComponentRegistry<AdminComponent> adminRegistry,
+                             ConfigServerConfig configServerConfig,
                              Docker docker,
                              MetricReceiverWrapper metricReceiver,
                              ClassLocking classLocking) {
-        nodeAdminMain = new NodeAdminMain(adminRegistry, docker, metricReceiver, classLocking);
+        nodeAdminMain = new NodeAdminMain(adminRegistry, configServerConfig, docker, metricReceiver, classLocking);
         nodeAdminMain.start();
     }
 

--- a/node-admin/src/main/resources/configdefinitions/config-server.def
+++ b/node-admin/src/main/resources/configdefinitions/config-server.def
@@ -1,0 +1,20 @@
+# Copyright 2018 Yahoo Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+namespace=vespa.hosted.node.admin
+
+hosts[]                      string
+port                         int                         default=8080 range=[1,65535]
+scheme                       string                      default="http"
+
+# Optional options used to authenticate config server
+athenzDomain                 string                      default=""
+serviceName                  string                      default=""
+
+# Optional options about key store to use when communicating with config server
+keyStoreConfig.path          string                      default=""      # Path to keystore
+keyStoreConfig.type          enum { JKS, PEM, PKCS12 }   default=JKS
+keyStoreConfig.password      string                      default=""
+
+# Optional options about trust store to use to authenticate config server
+trustStoreConfig.path        string                      default=""
+trustStoreConfig.type        enum { JKS, PEM, PKCS12 }   default=JKS
+trustStoreConfig.password    string                      default=""


### PR DESCRIPTION
Logstash nodes will still come from environment, but from what I understand, this is going away soon anyway?
Other than that, Environment only used to store some resolvers, so maybe it can be removed entirely