### PR TITLE
Remove transaction commit in mock provisioner that should never have …

### DIFF
--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
@@ -38,7 +38,6 @@ import java.util.Optional;
  * Base class for session handler tests
  *
  * @author hmusum
- * @since 5.1.14
  */
 public class SessionHandlerTest {
 
@@ -233,7 +232,6 @@ public class SessionHandlerTest {
 
         @Override
         public void activate(NestedTransaction transaction, ApplicationId application, Collection<HostSpec> hosts) {
-            transaction.commit();
             activated = true;
             lastApplicationId = application;
             lastHosts = hosts;

--- a/vespajlib/src/main/java/com/yahoo/transaction/NestedTransaction.java
+++ b/vespajlib/src/main/java/com/yahoo/transaction/NestedTransaction.java
@@ -88,6 +88,11 @@ public final class NestedTransaction implements AutoCloseable {
             transaction.transaction.close();
     }
 
+    @Override
+    public String toString() {
+        return String.join(",", transactions.stream().map(Object::toString).collect(Collectors.toList()));
+    }
+
     private List<Transaction> organizeTransactions(List<ConstrainedTransaction> transactions) {
         return orderTransactions(combineTransactions(transactions), findOrderingConstraints(transactions));
     }
@@ -173,6 +178,11 @@ public final class NestedTransaction implements AutoCloseable {
 
         /** Returns transaction types which should commit after this */
         public Class<? extends Transaction>[] before() { return before; }
+
+        @Override
+        public String toString() {
+            return transaction.toString();
+        }
 
     }
 

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorTransaction.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorTransaction.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.curator.Curator;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Transaction implementation against ZooKeeper.
@@ -63,6 +64,11 @@ public class CuratorTransaction extends AbstractTransaction {
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    @Override
+    public String toString() {
+        return String.join(",", operations().stream().map(operation -> operation.toString()).collect(Collectors.toList()));
     }
 
 }


### PR DESCRIPTION
…been there. Led to transaction being committed twice in a realistic test scenario.

Related to this: Should it be allowed to commit a transaction twice? Should that be the caller's responsibility or should the second one throw if that happens?