### PR TITLE
Use a non-transient error code for clock skew rejections

### DIFF
--- a/storage/src/tests/storageserver/bouncertest.cpp
+++ b/storage/src/tests/storageserver/bouncertest.cpp
@@ -131,7 +131,7 @@ BouncerTest::testFutureTimestamp()
 
         CPPUNIT_ASSERT_EQUAL(1, (int)_upper->getNumReplies());
         CPPUNIT_ASSERT_EQUAL(0, (int)_upper->getNumCommands());
-        CPPUNIT_ASSERT_EQUAL(api::ReturnCode::ABORTED,
+        CPPUNIT_ASSERT_EQUAL(api::ReturnCode::REJECTED,
                              static_cast<api::RemoveReply&>(*_upper->getReply(0)).
                              getResult().getResult());
         _upper->reset();

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -57,8 +57,8 @@ private:
     void abortCommandForUnavailableNode(api::StorageMessage&,
                                         const lib::State&);
 
-    void abortCommandWithTooHighClockSkew(api::StorageMessage& msg,
-                                          int maxClockSkewInSeconds);
+    void rejectCommandWithTooHighClockSkew(api::StorageMessage& msg,
+                                           int maxClockSkewInSeconds);
 
     void abortCommandDueToClusterDown(api::StorageMessage&);
 


### PR DESCRIPTION
@baldersheim please review
@yngveaasheim FYI

Using REJECTED instead of ABORTED fails the message all the way out to the
caller immediately instead of hiding the (likely not automatically fixed)
problems behind retries and timeouts.