### PR TITLE
Mark all document types as belonging to the default bucket spaces as …

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -722,7 +722,8 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
         for (NewDocumentType docType : getDocumentDefinitions().values()) {
             BucketspacesConfig.Documenttype.Builder docTypeBuilder = new BucketspacesConfig.Documenttype.Builder();
             docTypeBuilder.name(docType.getName());
-            String bucketSpace = (isGloballyDistributed(docType) ? GLOBAL_BUCKET_SPACE : DEFAULT_BUCKET_SPACE);
+            String bucketSpace = ((enableMultipleBucketSpaces && isGloballyDistributed(docType))
+                    ? GLOBAL_BUCKET_SPACE : DEFAULT_BUCKET_SPACE);
             docTypeBuilder.bucketspace(bucketSpace);
             builder.documenttype(docTypeBuilder);
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSearchClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSearchClusterTest.java
@@ -144,9 +144,11 @@ public class ContentSearchClusterTest {
     }
 
     @Test
-    public void require_that_bucket_spaces_config_is_produced_for_content_cluster() throws Exception {
+    public void require_that_all_document_types_belong_to_default_bucket_space_by_default() throws Exception {
         BucketspacesConfig config = getBucketspacesConfig(createClusterWithGlobalType());
-        assertBucketspacesConfigWithTwoDocumentTypes(config);
+        assertEquals(2, config.documenttype().size());
+        assertDocumentType("global", "default", config.documenttype(0));
+        assertDocumentType("regular", "default", config.documenttype(1));
         // Safeguard against flipping the switch
         assertFalse(config.enable_multiple_bucket_spaces());
     }
@@ -154,14 +156,10 @@ public class ContentSearchClusterTest {
     @Test
     public void require_that_multiple_bucket_spaces_can_be_enabled() throws Exception {
         BucketspacesConfig config = getBucketspacesConfig(createClusterWithMultipleBucketSpacesEnabled());
-        assertBucketspacesConfigWithTwoDocumentTypes(config);
-        assertTrue(config.enable_multiple_bucket_spaces());
-    }
-
-    private static void assertBucketspacesConfigWithTwoDocumentTypes(BucketspacesConfig config) {
         assertEquals(2, config.documenttype().size());
         assertDocumentType("global", "global", config.documenttype(0));
         assertDocumentType("regular", "default", config.documenttype(1));
+        assertTrue(config.enable_multiple_bucket_spaces());
     }
 
 }


### PR DESCRIPTION
…default.

This ensures that upcoming changes to document API clients will work as
expected when multiple bucket spaces is NOT enabled.

@vekterli and @toregge please review