### PR TITLE
Log and increment failure metrics on concurrent mutation aborts

### DIFF
--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -64,7 +64,8 @@ private:
             PersistenceOperationMetricSet& persistenceMetrics);
     std::shared_ptr<api::StorageMessage> makeConcurrentMutationRejectionReply(
             api::StorageCommand& cmd,
-            const document::DocumentId& docId) const;
+            const document::DocumentId& docId,
+            PersistenceOperationMetricSet& persistenceMetrics) const;
     bool allowMutation(const SequencingHandle& handle) const;
 
     DistributorMetricSet& getMetrics() { return getDistributor().getMetrics(); }

--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.cpp
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.cpp
@@ -26,7 +26,9 @@ PersistenceFailuresMetricSet::PersistenceFailuresMetricSet(MetricSet* owner)
       inconsistent_bucket("inconsistent_bucket", "",
                           "The number of operations failed due to buckets "
                           "being in an inconsistent state or not found", this),
-      notfound("notfound", "", "The number of operations that failed because the document did not exist", this)
+      notfound("notfound", "", "The number of operations that failed because the document did not exist", this),
+      concurrent_mutations("concurrent_mutations", "", "The number of operations that were transiently failed due "
+                           "to a mutating operation already being in progress for its document ID", this)
 {
     sum.addMetricToSum(notready);
     sum.addMetricToSum(notconnected);
@@ -38,7 +40,8 @@ PersistenceFailuresMetricSet::PersistenceFailuresMetricSet(MetricSet* owner)
     sum.addMetricToSum(inconsistent_bucket);
     sum.addMetricToSum(notfound);
 }
-PersistenceFailuresMetricSet::~PersistenceFailuresMetricSet() { }
+
+PersistenceFailuresMetricSet::~PersistenceFailuresMetricSet() = default;
 
 MetricSet *
 PersistenceFailuresMetricSet::clone(std::vector<Metric::UP>& ownerList, CopyType copyType,

--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
@@ -14,7 +14,7 @@ class ReturnCode;
 class PersistenceFailuresMetricSet : public metrics::MetricSet
 {
 public:
-    PersistenceFailuresMetricSet(metrics::MetricSet* owner);
+    explicit PersistenceFailuresMetricSet(metrics::MetricSet* owner);
     ~PersistenceFailuresMetricSet();
 
     metrics::SumMetric<metrics::LongCountMetric> sum;
@@ -27,6 +27,7 @@ public:
     metrics::LongCountMetric busy;
     metrics::LongCountMetric inconsistent_bucket;
     metrics::LongCountMetric notfound;
+    metrics::LongCountMetric concurrent_mutations;
 
     MetricSet * clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
                       metrics::MetricSet* owner, bool includeUnused) const override;


### PR DESCRIPTION
@geirst @toregge please review.

Greatly increases visibility for edge cases where multiple clients are
sending many potentially conflicting operations to the same document set.