### PR TITLE
Remove synchronization, it leads to deadlocks

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ActivateLock.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ActivateLock.java
@@ -23,7 +23,7 @@ public class ActivateLock {
         this.curatorLock = new CuratorLock(curator, rootPath.append(ACTIVATE_LOCK_NAME).getAbsolute());
     }
 
-    public synchronized boolean acquire(TimeoutBudget timeoutBudget, boolean ignoreLockError) {
+    public boolean acquire(TimeoutBudget timeoutBudget, boolean ignoreLockError) {
         try {
             return curatorLock.tryLock(timeoutBudget.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
         } catch (Exception e) {
@@ -34,7 +34,7 @@ public class ActivateLock {
         }
     }
 
-    public synchronized void release() {
+    public void release() {
         if (curatorLock.hasLock()) {
             curatorLock.unlock();
         }


### PR DESCRIPTION
Example:
Thread A gets the lock in acquire(), does not hold the monitor anymore..
Thread B calls acquire() and waits for the lock (while holding the monitor)
Thead A wants to call release(), but cannot do that because thread B is
holding the monitor. Deadlock until timeout for thread A, at which time
thread B holds the monitor again and continues