### PR TITLE
Revert "Balder/compute summary cache automatically in backend"

### DIFF
--- a/searchcore/src/apps/tests/persistenceconformance_test.cpp
+++ b/searchcore/src/apps/tests/persistenceconformance_test.cpp
@@ -183,7 +183,7 @@ public:
                                                   std::make_shared<ProtonConfig>(),
                                                   std::make_shared<FiledistributorrpcConfig>(),
                                                   std::make_shared<BucketspacesConfig>(),
-                                                  tuneFileDocDB, HwInfo()));
+                                                  tuneFileDocDB));
         mgr.forwardConfig(b);
         mgr.nextGeneration(0);
         return DocumentDB::SP(

--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -208,7 +208,7 @@ public:
                                                    std::make_shared<ProtonConfig>(),
                                                    std::make_shared<FiledistributorrpcConfig>(),
                                                    std::make_shared<BucketspacesConfig>(),
-                                                   _tuneFileDocumentDB, _hwInfo);
+                                                   _tuneFileDocumentDB);
         _configMgr.forwardConfig(b);
         _configMgr.nextGeneration(0);
         if (! FastOS_File::MakeDirectory((std::string("tmpdb/") + docTypeName).c_str())) { abort(); }

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -284,7 +284,7 @@ struct MyConfigSnapshot
                                  std::make_shared<ProtonConfig>(),
                                  std::make_shared<FiledistributorrpcConfig>(),
                                  std::make_shared<BucketspacesConfig>(),
-                                 tuneFileDocumentDB, HwInfo());
+                                 tuneFileDocumentDB);
         config::DirSpec spec(cfgDir);
         DocumentDBConfigHelper mgr(spec, "searchdocument");
         mgr.forwardConfig(_bootstrap);

--- a/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
@@ -99,7 +99,7 @@ Fixture::Fixture()
                               std::make_shared<ProtonConfig>(),
                               std::make_shared<FiledistributorrpcConfig>(),
                               std::make_shared<BucketspacesConfig>(),
-                              tuneFileDocumentDB, HwInfo()));
+                              tuneFileDocumentDB));
     mgr.forwardConfig(b);
     mgr.nextGeneration(0);
     _db.reset(new DocumentDB(".", mgr.getConfig(), "tcp/localhost:9014", _queryLimiter, _clock, DocTypeName("typea"),

--- a/searchcore/src/tests/proton/documentdb/fileconfigmanager/fileconfigmanager_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/fileconfigmanager/fileconfigmanager_test.cpp
@@ -40,12 +40,13 @@ makeBaseConfigSnapshot()
 
     DBCM dbcm(spec, "test");
     DocumenttypesConfigSP dtcfg(config::ConfigGetter<DocumenttypesConfig>::getConfig("", spec).release());
-    BootstrapConfig::SP b(new BootstrapConfig(1, dtcfg,
+    BootstrapConfig::SP b(new BootstrapConfig(1,
+                                              dtcfg,
                                               DocumentTypeRepo::SP(new DocumentTypeRepo(*dtcfg)),
                                               std::make_shared<ProtonConfig>(),
                                               std::make_shared<FiledistributorrpcConfig>(),
                                               std::make_shared<BucketspacesConfig>(),
-                                              std::make_shared<TuneFileDocumentDB>(), HwInfo()));
+                                              std::make_shared<TuneFileDocumentDB>()));
     dbcm.forwardConfig(b);
     dbcm.nextGeneration(0);
     DocumentDBConfig::SP snap = dbcm.getConfig();

--- a/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
+++ b/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
@@ -14,12 +14,12 @@
 #include <vespa/searchcore/proton/server/proton_config_fetcher.h>
 #include <vespa/searchcore/proton/server/proton_config_snapshot.h>
 #include <vespa/searchcore/proton/server/i_proton_configurer.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchsummary/config/config-juniperrc.h>
 #include <vespa/searchcore/config/config-ranking-constants.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/varholder.h>
 #include <vespa/config-bucketspaces.h>
+#include <mutex>
 
 using namespace config;
 using namespace proton;
@@ -146,15 +146,14 @@ struct ConfigTestFixture {
                 documenttypesBuilder == bootstrapConfig->getDocumenttypesConfig());
     }
 
-    BootstrapConfig::SP getBootstrapConfig(int64_t generation, const HwInfo & hwInfo) const {
+    BootstrapConfig::SP getBootstrapConfig(int64_t generation) const {
         return BootstrapConfig::SP(new BootstrapConfig(generation,
-                                                       std::make_shared<DocumenttypesConfig>(documenttypesBuilder),
-                                                       std::make_shared<DocumentTypeRepo>(documenttypesBuilder),
-                                                       std::make_shared<ProtonConfig>(protonBuilder),
+                                                       BootstrapConfig::DocumenttypesConfigSP(new DocumenttypesConfig(documenttypesBuilder)),
+                                                       DocumentTypeRepo::SP(new DocumentTypeRepo(documenttypesBuilder)),
+                                                       BootstrapConfig::ProtonConfigSP(new ProtonConfig(protonBuilder)),
                                                        std::make_shared<FiledistributorrpcConfig>(),
                                                        std::make_shared<BucketspacesConfig>(bucketspacesBuilder),
-                                                       std::make_shared<TuneFileDocumentDB>(),
-                                                       hwInfo));
+                                                       std::make_shared<TuneFileDocumentDB>()));
     }
 
     void reload() { context->reload(); }
@@ -233,18 +232,12 @@ TEST_FFF("require that bootstrap config manager updates config", ConfigTestFixtu
 }
 
 DocumentDBConfig::SP
-getDocumentDBConfig(ConfigTestFixture &f, DocumentDBConfigManager &mgr, const HwInfo & hwInfo)
-{
-    ConfigRetriever retriever(mgr.createConfigKeySet(), f.context);
-    mgr.forwardConfig(f.getBootstrapConfig(1, hwInfo));
-    mgr.update(retriever.getBootstrapConfigs()); // Cheating, but we only need the configs
-    return mgr.getConfig();
-}
-
-DocumentDBConfig::SP
 getDocumentDBConfig(ConfigTestFixture &f, DocumentDBConfigManager &mgr)
 {
-    return getDocumentDBConfig(f, mgr, HwInfo());
+    ConfigRetriever retriever(mgr.createConfigKeySet(), f.context);
+    mgr.forwardConfig(f.getBootstrapConfig(1));
+    mgr.update(retriever.getBootstrapConfigs()); // Cheating, but we only need the configs
+    return mgr.getConfig();
 }
 
 TEST_FF("require that documentdb config manager subscribes for config",
@@ -356,40 +349,6 @@ TEST_FF("require that prune removed documents interval can be set based on age",
     f1.addDocType("test");
     auto config = getDocumentDBConfig(f1, f2);
     EXPECT_EQUAL(20, config->getMaintenanceConfigSP()->getPruneRemovedDocumentsConfig().getInterval());
-}
-
-TEST_FF("require that docstore config computes cachesize automatically if unset",
-        ConfigTestFixture("test"),
-        DocumentDBConfigManager(f1.configId + "/test", "test"))
-{
-    HwInfo hwInfo(HwInfo::Disk(1, false, false), HwInfo::Memory(1000000), HwInfo::Cpu(1));
-    f1.addDocType("test");
-    f1.protonBuilder.summary.cache.maxbytes = 2000;
-    auto config = getDocumentDBConfig(f1, f2, hwInfo);
-    EXPECT_EQUAL(2000ul, config->getStoreConfig().getMaxCacheBytes());
-
-    f1.protonBuilder.summary.cache.maxbytes = -7;
-    config = getDocumentDBConfig(f1, f2, hwInfo);
-    EXPECT_EQUAL(70000ul, config->getStoreConfig().getMaxCacheBytes());
-
-    f1.protonBuilder.summary.cache.maxbytes = -700;
-    config = getDocumentDBConfig(f1, f2, hwInfo);
-    EXPECT_EQUAL(500000ul, config->getStoreConfig().getMaxCacheBytes());
-}
-
-TEST("test HwInfo equality") {
-    EXPECT_TRUE(HwInfo::Cpu(1) == HwInfo::Cpu(1));
-    EXPECT_FALSE(HwInfo::Cpu(1) == HwInfo::Cpu(2));
-    EXPECT_TRUE(HwInfo::Memory(1) == HwInfo::Memory(1));
-    EXPECT_FALSE(HwInfo::Memory(1) == HwInfo::Memory(2));
-    EXPECT_TRUE(HwInfo::Disk(1, false, false) == HwInfo::Disk(1, false,false));
-    EXPECT_FALSE(HwInfo::Disk(1, false, false) == HwInfo::Disk(1, false,true));
-    EXPECT_FALSE(HwInfo::Disk(1, false, false) == HwInfo::Disk(1, true,false));
-    EXPECT_FALSE(HwInfo::Disk(1, false, false) == HwInfo::Disk(2, false,false));
-    EXPECT_TRUE(HwInfo(HwInfo::Disk(1, false, false), 1ul, 1ul) == HwInfo(HwInfo::Disk(1, false,false), 1ul, 1ul));
-    EXPECT_FALSE(HwInfo(HwInfo::Disk(1, false, false), 1ul, 1ul) == HwInfo(HwInfo::Disk(1, false,false), 1ul, 2ul));
-    EXPECT_FALSE(HwInfo(HwInfo::Disk(1, false, false), 1ul, 1ul) == HwInfo(HwInfo::Disk(1, false,false), 2ul, 1ul));
-    EXPECT_FALSE(HwInfo(HwInfo::Disk(1, false, false), 1ul, 1ul) == HwInfo(HwInfo::Disk(2, false,false), 1ul, 1ul));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
+++ b/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
@@ -171,7 +171,7 @@ struct ConfigFixture {
                                                        BootstrapConfig::ProtonConfigSP(new ProtonConfig(_protonBuilder)),
                                                        std::make_shared<FiledistributorrpcConfig>(),
                                                        std::make_shared<BucketspacesConfig>(_bucketspacesBuilder),
-                                                       std::make_shared<TuneFileDocumentDB>(), HwInfo()));
+                                                       std::make_shared<TuneFileDocumentDB>()));
     }
 
     std::shared_ptr<ProtonConfigSnapshot> getConfigSnapshot()

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -2,7 +2,7 @@
 namespace=vespa.config.search.core
 
 ## Base directory. The default is ignored as it is assigned by the model
-basedir       string default="." restart
+basedir       string default="tmp" restart
 
 ## specifies the port number for the persistent internal transport
 ## protocol provided for a multi-level dispatch system.
@@ -210,9 +210,7 @@ grow.numdocs int default=10000 restart
 grow.multivalueallocfactor double default=0.2 restart
 
 ## Control cache size in bytes.
-## Postive numbers are absolute in bytes.
-## Negative numbers are a percentage of memory.
-summary.cache.maxbytes long default=-5
+summary.cache.maxbytes long default=0
 
 ## Include visits in the cache, if the visitoperation allows it.
 ## This will enable another separate cache of summary.cache.maxbytes size.

--- a/searchcore/src/vespa/searchcore/proton/common/hw_info.h
+++ b/searchcore/src/vespa/searchcore/proton/common/hw_info.h
@@ -23,9 +23,6 @@ public:
         uint64_t sizeBytes() const { return _sizeBytes; }
         bool slow() const { return _slow; }
         bool shared() const { return _shared; }
-        bool operator == (const Disk & rhs) const {
-            return (_sizeBytes == rhs._sizeBytes) && (_slow == rhs._slow) && (_shared == rhs._shared);
-        }
     };
 
     class Memory {
@@ -34,7 +31,6 @@ public:
     public:
         Memory(uint64_t sizeBytes_) : _sizeBytes(sizeBytes_) {}
         uint64_t sizeBytes() const { return _sizeBytes; }
-        bool operator == (const Memory & rhs) const { return _sizeBytes == rhs._sizeBytes; }
     };
 
     class Cpu {
@@ -43,7 +39,6 @@ public:
     public:
         Cpu(uint32_t cores_) : _cores(cores_) {}
         uint32_t cores() const { return _cores; }
-        bool operator == (const Cpu & rhs) const { return _cores == rhs._cores; }
     };
 
 private:
@@ -71,9 +66,6 @@ public:
     const Disk &disk() const { return _disk; }
     const Memory &memory() const { return _memory; }
     const Cpu &cpu() const { return _cpu; }
-    bool operator == (const HwInfo & rhs) const {
-        return (_cpu == rhs._cpu) && (_disk == rhs._disk) && (_memory == rhs._memory);
-    }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.cpp
@@ -29,30 +29,29 @@ BootstrapConfig::BootstrapConfig(
                const ProtonConfigSP &protonConfig,
                const FiledistributorrpcConfigSP &filedistRpcConfSP,
                const BucketspacesConfigSP &bucketspaces,
-               const search::TuneFileDocumentDB::SP &tuneFileDocumentDB,
-               const HwInfo & hwInfo)
+               const search::TuneFileDocumentDB::SP &tuneFileDocumentDB)
     : _documenttypes(documenttypes),
       _repo(repo),
       _proton(protonConfig),
       _fileDistributorRpc(filedistRpcConfSP),
       _bucketspaces(bucketspaces),
       _tuneFileDocumentDB(tuneFileDocumentDB),
-      _hwInfo(hwInfo),
       _generation(generation)
 { }
 
-BootstrapConfig::~BootstrapConfig() = default;
+BootstrapConfig::~BootstrapConfig() { }
 
 bool
 BootstrapConfig::operator==(const BootstrapConfig &rhs) const
 {
-    return equals<DocumenttypesConfig>(_documenttypes.get(), rhs._documenttypes.get()) &&
+    return equals<DocumenttypesConfig>(_documenttypes.get(),
+                                       rhs._documenttypes.get()) &&
         _repo.get() == rhs._repo.get() &&
         equals<ProtonConfig>(_proton.get(), rhs._proton.get()) &&
         equals<FiledistributorrpcConfig>(_fileDistributorRpc.get(), rhs._fileDistributorRpc.get()) &&
         equals<BucketspacesConfig>(_bucketspaces.get(), rhs._bucketspaces.get()) &&
-        equals<TuneFileDocumentDB>(_tuneFileDocumentDB.get(), rhs._tuneFileDocumentDB.get()) &&
-        (_hwInfo == rhs._hwInfo);
+        equals<TuneFileDocumentDB>(_tuneFileDocumentDB.get(),
+                                   rhs._tuneFileDocumentDB.get());
 }
 
 
@@ -61,5 +60,6 @@ BootstrapConfig::valid() const
 {
     return _documenttypes && _repo && _proton && _fileDistributorRpc && _bucketspaces && _tuneFileDocumentDB;
 }
+
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include "documentdbconfig.h"
-#include <vespa/searchcore/proton/common/hw_info.h>
-#include <vespa/searchcore/config/config-proton.h>
 #include <vespa/document/config/config-documenttypes.h>
 #include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/searchcore/config/config-proton.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
+#include <vespa/config/retriever/configkeyset.h>
 #include <vespa/config/retriever/configsnapshot.h>
 #include <vespa/fileacquirer/config-filedistributorrpc.h>
 
@@ -37,7 +37,6 @@ private:
     FiledistributorrpcConfigSP     _fileDistributorRpc;
     BucketspacesConfigSP           _bucketspaces;
     search::TuneFileDocumentDB::SP _tuneFileDocumentDB;
-    HwInfo                         _hwInfo;
     int64_t                        _generation;
 
 public:
@@ -47,21 +46,37 @@ public:
                     const ProtonConfigSP &protonConfig,
                     const FiledistributorrpcConfigSP &filedistRpcConfSP,
                     const BucketspacesConfigSP &bucketspaces,
-                    const search::TuneFileDocumentDB::SP &_tuneFileDocumentDB,
-                    const HwInfo & hwInfo);
+                    const search::TuneFileDocumentDB::SP &
+                    _tuneFileDocumentDB);
     ~BootstrapConfig();
 
-    const document::DocumenttypesConfig &getDocumenttypesConfig() const { return *_documenttypes; }
-    const FiledistributorrpcConfig &getFiledistributorrpcConfig() const { return *_fileDistributorRpc; }
-    const FiledistributorrpcConfigSP &getFiledistributorrpcConfigSP() const { return _fileDistributorRpc; }
-    const DocumenttypesConfigSP &getDocumenttypesConfigSP() const { return _documenttypes; }
-    const document::DocumentTypeRepo::SP &getDocumentTypeRepoSP() const { return _repo; }
-    const vespa::config::search::core::ProtonConfig &getProtonConfig() const { return *_proton; }
-    const ProtonConfigSP &getProtonConfigSP() const { return _proton; }
+    const document::DocumenttypesConfig &
+    getDocumenttypesConfig() const { return *_documenttypes; }
+
+    const cloud::config::filedistribution::FiledistributorrpcConfig &
+    getFiledistributorrpcConfig() const { return *_fileDistributorRpc; }
+
+    const FiledistributorrpcConfigSP &
+    getFiledistributorrpcConfigSP() const { return _fileDistributorRpc; }
+
+    const DocumenttypesConfigSP &
+    getDocumenttypesConfigSP() const { return _documenttypes; }
+
+    const document::DocumentTypeRepo::SP &
+    getDocumentTypeRepoSP() const { return _repo; }
+
+    const vespa::config::search::core::ProtonConfig &
+    getProtonConfig() const { return *_proton; }
+
+    const ProtonConfigSP &
+    getProtonConfigSP() const { return _proton; }
+
     const BucketspacesConfigSP &getBucketspacesConfigSP() const { return _bucketspaces; }
-    const search::TuneFileDocumentDB::SP &getTuneFileDocumentDBSP() const { return _tuneFileDocumentDB; }
+
+    const search::TuneFileDocumentDB::SP &
+    getTuneFileDocumentDBSP() const { return _tuneFileDocumentDB; }
+
     int64_t getGeneration() const { return _generation; }
-    const HwInfo & getHwInfo() const { return _hwInfo; }
 
     /**
      * Shared pointers are checked for identity, not equality.
@@ -71,3 +86,4 @@ public:
 };
 
 } // namespace proton
+

--- a/searchcore/src/vespa/searchcore/proton/server/bootstrapconfigmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/server/bootstrapconfigmanager.h
@@ -20,7 +20,12 @@ public:
     ~BootstrapConfigManager();
     const config::ConfigKeySet createConfigKeySet() const;
 
-    std::shared_ptr<BootstrapConfig> getConfig() const;
+    std::shared_ptr<BootstrapConfig>
+    getConfig() const
+    {
+        std::lock_guard<std::mutex> lock(_pendingConfigMutex);
+        return _pendingConfigSnapshot;
+    }
     void update(const config::ConfigSnapshot & snapshot);
 
 private:

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.h
@@ -2,14 +2,14 @@
 
 #pragma once
 
-#include "documentdbconfig.h"
+#include <vespa/vespalib/stllike/string.h>
 #include <vespa/config/config.h>
+#include "documentdbconfig.h"
 #include <mutex>
 
 namespace proton {
 
 class BootstrapConfig;
-
 /**
  * This class manages the subscription for documentdb configs.
  */

--- a/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
@@ -2,7 +2,6 @@
 
 #include "fileconfigmanager.h"
 #include "bootstrapconfig.h"
-#include <vespa/searchcore/proton/common/hw_info_sampler.h>
 #include <vespa/config/print/fileconfigwriter.h>
 #include <vespa/config/print/fileconfigsnapshotreader.h>
 #include <vespa/config/print/fileconfigsnapshotwriter.h>
@@ -12,7 +11,9 @@
 #include <vespa/config-summarymap.h>
 #include <vespa/config-rank-profiles.h>
 #include <vespa/searchsummary/config/config-juniperrc.h>
+#include <vespa/fastos/file.h>
 #include <vespa/config/helper/configgetter.hpp>
+#include <fstream>
 #include <sstream>
 #include <fcntl.h>
 
@@ -359,16 +360,8 @@ FileConfigManager::loadConfig(const DocumentDBConfig &currentSnapshot,
      * of default values here instead of the current values from the config
      * server.
      */
-    const ProtonConfig &protonConfig = *_protonConfig;
-    const auto &hwDiskCfg = protonConfig.hwinfo.disk;
-    const auto &hwMemoryCfg = protonConfig.hwinfo.memory;
-    const auto &hwCpuCfg = protonConfig.hwinfo.cpu;
-    HwInfoSampler::Config samplerCfg(hwDiskCfg.size, hwDiskCfg.writespeed, hwDiskCfg.slowwritespeedlimit,
-                                     hwDiskCfg.samplewritesize, hwDiskCfg.shared, hwMemoryCfg.size, hwCpuCfg.cores);
-    HwInfoSampler sampler(protonConfig.basedir, samplerCfg);
     auto bootstrap = std::make_shared<BootstrapConfig>(1, docTypesCfg, repo, _protonConfig, filedistRpcConf,
-                                                       bucketspaces,currentSnapshot.getTuneFileDocumentDBSP(),
-                                                       sampler.hwInfo());
+                                                       bucketspaces,currentSnapshot.getTuneFileDocumentDBSP());
     dbc.forwardConfig(bootstrap);
     dbc.nextGeneration(0);
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -12,6 +12,7 @@
 #include "proton_configurer.h"
 #include "rpc_hooks.h"
 #include "bootstrapconfig.h"
+#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/flushengine/flushengine.h>
 #include <vespa/searchcore/proton/matchengine/matchengine.h>
 #include <vespa/searchcore/proton/matching/querylimiter.h>
@@ -37,6 +38,7 @@
 namespace proton {
 
 class DiskMemUsageSampler;
+class HwInfoSampler;
 class IDocumentDBReferenceRegistry;
 
 class Proton : public IProtonConfigurerOwner,
@@ -122,6 +124,8 @@ private:
     bool                            _initStarted;
     bool                            _initComplete;
     bool                            _initDocumentDbsInSequence;
+    HwInfo                          _hwInfo;
+    std::unique_ptr<HwInfoSampler>  _hwInfoSampler;
     std::shared_ptr<IDocumentDBReferenceRegistry> _documentDBReferenceRegistry;
 
     IDocumentDBConfigOwner *

--- a/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.cpp
@@ -65,7 +65,8 @@ ProtonConfigFetcher::pruneManagerMap(const BootstrapConfig::SP & config)
         if (_dbManagerMap.find(docTypeName) != _dbManagerMap.end()) {
             mgr = _dbManagerMap[docTypeName];
         } else {
-            mgr = std::make_shared<DocumentDBConfigManager>(ddb.configid, docTypeName.getName());
+            mgr = DocumentDBConfigManager::SP(new DocumentDBConfigManager
+                    (ddb.configid, docTypeName.getName()));
         }
         set.add(mgr->createConfigKeySet());
         newMap[docTypeName] = mgr;

--- a/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.h
@@ -52,9 +52,9 @@ private:
     using TimePoint = std::chrono::time_point<Clock>;
     using OldDocumentTypeRepo = std::pair<TimePoint, std::shared_ptr<document::DocumentTypeRepo>>;
 
-    BootstrapConfigManager  _bootstrapConfigManager;
+    BootstrapConfigManager _bootstrapConfigManager;
     config::ConfigRetriever _retriever;
-    IProtonConfigurer     & _owner;
+    IProtonConfigurer & _owner;
 
     mutable std::mutex _mutex; // Protects maps
     using lock_guard = std::lock_guard<std::mutex>;
@@ -71,4 +71,6 @@ private:
     void rememberDocumentTypeRepo(std::shared_ptr<document::DocumentTypeRepo> repo);
 };
 
+
 } // namespace proton
+


### PR DESCRIPTION
Reverts vespa-engine/vespa#4814

Lots of core dumps in system tests