### PR TITLE
Do not allocate to retiring hosts

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -178,6 +178,7 @@ public class NodePrioritizer {
         for (Node node : allNodes) {
             if (node.type() != NodeType.host) continue;
             if (node.state() != Node.State.active) continue;
+            if (node.status().wantToRetire()) continue;
 
             boolean hostHasCapacityForWantedFlavor = capacity.hasCapacity(node, wantedResourceCapacity);
             boolean conflictingCluster = list.childNodes(node).owner(appId).asList().stream()


### PR DESCRIPTION
In order to make it possible to safely retire an entire docker host, we need to ensure three things:
1) All children on the host are also retired (#4878)
2) Docker host is deactivated (moved to inactive) **after** all the children have finished retiring, this way `node-admin` will be able to clean up the child containers before it is stopped (#4930)
3) While this is going on, no new nodes are allocated to this host (#4883)

I think this is what's needed to ensure 3)?