### PR TITLE
Skip DNS lookup that is not used

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/DiscFilterRequest.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/DiscFilterRequest.java
@@ -96,7 +96,7 @@ public abstract class DiscFilterRequest {
         return localAddress.getAddress().getHostAddress();
     }
 
-    protected InetSocketAddress localAddress() {
+    private InetSocketAddress localAddress() {
         int port = parent.getUri().getPort();
         if (port < 0)
             port  = 0;


### PR DESCRIPTION
Look up the local address on demand only.
Since this field was (errounously) made protected,
this is strictly an API change, however I could not find any use
of the field in any known repo using Vespa.

cc @baldersheim 