### PR TITLE
Report config server cert expiry metrics

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzSslTrustStoreConfigurator.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzSslTrustStoreConfigurator.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.Provider;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -39,6 +40,7 @@ import java.util.logging.Logger;
 public class AthenzSslTrustStoreConfigurator implements SslTrustStoreConfigurator {
 
     private static final Logger log = Logger.getLogger(AthenzSslTrustStoreConfigurator.class.getName());
+    private static final String CERTIFICATE_ALIAS = "cfgselfsigned";
 
     private static final Provider provider = new BouncyCastleProvider();
     private final KeyStore trustStore;
@@ -56,6 +58,11 @@ public class AthenzSslTrustStoreConfigurator implements SslTrustStoreConfigurato
         log.log(LogLevel.INFO, "Configured JDisc trust store with self-signed certificate");
     }
 
+    Instant getTrustStoreExpiry() throws KeyStoreException {
+        X509Certificate certificate = (X509Certificate) trustStore.getCertificate(CERTIFICATE_ALIAS);
+        return certificate.getNotAfter().toInstant();
+    }
+
     private static KeyStore createTrustStore(KeyProvider keyProvider,
                                              ConfigserverConfig configserverConfig,
                                              AthenzProviderServiceConfig athenzProviderServiceConfig) {
@@ -67,7 +74,7 @@ public class AthenzSslTrustStoreConfigurator implements SslTrustStoreConfigurato
             try (FileInputStream in = new FileInputStream(athenzProviderServiceConfig.athenzCaTrustStore())) {
                 trustStore.load(in, "changeit".toCharArray());
             }
-            trustStore.setCertificateEntry("cfgselfsigned", selfSignedCertificate);
+            trustStore.setCertificateEntry(CERTIFICATE_ALIAS, selfSignedCertificate);
             return trustStore;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/CertificateExpiryMetricUpdater.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/CertificateExpiryMetricUpdater.java
@@ -1,0 +1,75 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.athenz.instanceproviderservice;
+
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.jdisc.Metric;
+
+import com.google.inject.Inject;
+
+import java.security.KeyStoreException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author freva
+ */
+public class CertificateExpiryMetricUpdater extends AbstractComponent {
+
+    private static final Duration METRIC_REFRESH_PERIOD = Duration.ofMinutes(5);
+    private static final String NODE_CA_CERT_METRIC_NAME = "node-ca-cert.expiry.seconds";
+    private static final String ATHENZ_CONFIGSERVER_CERT_METRIC_NAME = "athenz-configserver-cert.expiry.seconds";
+
+    private final Logger logger = Logger.getLogger(CertificateExpiryMetricUpdater.class.getName());
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final Metric metric;
+    private final AthenzSslKeyStoreConfigurator keyStoreConfigurator;
+    private final AthenzSslTrustStoreConfigurator trustStoreConfigurator;
+
+    @Inject
+    public CertificateExpiryMetricUpdater(Metric metric,
+                                          AthenzSslKeyStoreConfigurator keyStoreConfigurator,
+                                          AthenzSslTrustStoreConfigurator trustStoreConfigurator) {
+        this.metric = metric;
+        this.keyStoreConfigurator = keyStoreConfigurator;
+        this.trustStoreConfigurator = trustStoreConfigurator;
+
+
+        scheduler.scheduleAtFixedRate(this::updateMetrics,
+                30/*initial delay*/,
+                METRIC_REFRESH_PERIOD.getSeconds(),
+                TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void deconstruct() {
+        try {
+            scheduler.shutdownNow();
+            scheduler.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to shutdown certificate expiry metrics updater on time", e);
+        }
+    }
+
+    private void updateMetrics() {
+        Instant now = Instant.now();
+
+        try {
+            Duration keyStoreExpiry = Duration.between(now, keyStoreConfigurator.getKeyStoreExpiry());
+            metric.set(ATHENZ_CONFIGSERVER_CERT_METRIC_NAME, keyStoreExpiry.getSeconds(), null);
+        } catch (KeyStoreException e) {
+            logger.log(Level.WARNING, "Failed to update key store expiry metric", e);
+        }
+
+        try {
+            Duration trustStoreExpiry = Duration.between(now, trustStoreConfigurator.getTrustStoreExpiry());
+            metric.set(NODE_CA_CERT_METRIC_NAME, trustStoreExpiry.getSeconds(), null);
+        } catch (KeyStoreException e) {
+            logger.log(Level.WARNING, "Failed to update trust store expiry metric", e);
+        }
+    }
+}


### PR DESCRIPTION
Adds metrics
* **configserver** . **node-ca-cert.expiry.seconds** to be the remaining lifetime in seconds of the self-signed certificate used to sign node certificates.
* **configserver** . **athenz-configserver-cert.expiry.seconds** to be remaining lifetime in seconds of the key store certificate.

The **configserver** application name for these metrics needs to be mapped to **vespa.tls** in Yamas backend since I don't think there is a way to specify application name for the injected `Metric`.