### PR TITLE
Amend program output parse exceptions with command and output snippet

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/ChildProcessException.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/ChildProcessException.java
@@ -26,13 +26,26 @@ public abstract class ChildProcessException extends RuntimeException {
      * @param possiblyHugeOutput The output of the command
      */
     protected ChildProcessException(String problem, String commandLine, String possiblyHugeOutput) {
-        super(makeSnippet(
+        super(makeSnippet(problem, commandLine, possiblyHugeOutput));
+    }
+
+    protected ChildProcessException(RuntimeException cause,
+                                    String problem,
+                                    String commandLine,
+                                    String possiblyHugeOutput) {
+        super(makeSnippet(problem, commandLine, possiblyHugeOutput), cause);
+    }
+
+    private static String makeSnippet(String problem,
+                               String commandLine,
+                               String possiblyHugeOutput) {
+        return makeSnippet(
                 problem,
                 commandLine,
                 possiblyHugeOutput,
                 MAX_OUTPUT_PREFIX,
                 MAX_OUTPUT_SUFFIX,
-                MAX_OUTPUT_SLACK));
+                MAX_OUTPUT_SLACK);
     }
 
     // Package-private instead of private for testing.

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/CommandLine.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/CommandLine.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -66,9 +67,14 @@ public class CommandLine {
     public CommandLine add(String... arguments) { return add(Arrays.asList(arguments)); }
 
     /** Add arguments to the command. The first argument in the first call to add() is the program. */
-    public CommandLine add(List<String> arguments) {
+    public CommandLine add(Collection<String> arguments) {
         this.arguments.addAll(arguments);
         return this;
+    }
+
+    /** Add arguments by splitting arguments by space. */
+    public CommandLine addTokens(String arguments) {
+        return add(arguments.split(" "));
     }
 
     /**

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/CommandResult.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/CommandResult.java
@@ -20,8 +20,6 @@ public class CommandResult {
     private final int exitCode;
     private final String output;
 
-    private boolean inMapFunction = false;
-
     CommandResult(CommandLine commandLine, int exitCode, String output) {
         this.commandLine = commandLine;
         this.exitCode = exitCode;
@@ -62,17 +60,10 @@ public class CommandResult {
      * This method is intended to be used as part of the verification of the output.
      */
     public <R> R map(Function<CommandResult, R> mapper) {
-        if (inMapFunction) {
-            throw new IllegalStateException("map() cannot be called recursively");
-        }
-        inMapFunction = true;
-
         try {
             return mapper.apply(this);
         } catch (RuntimeException e) {
             throw new UnexpectedOutputException2(e, "Failed to map output", commandLine.toString(), output);
-        } finally {
-            inMapFunction = false;
         }
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/TerminalImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/TerminalImpl.java
@@ -19,6 +19,7 @@ public class TerminalImpl implements Terminal {
         this.processFactory = processFactory;
     }
 
+    @Override
     public CommandLine newCommandLine(TaskContext taskContext) {
         return new CommandLine(taskContext, processFactory);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/UnexpectedOutputException2.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/UnexpectedOutputException2.java
@@ -13,4 +13,14 @@ public class UnexpectedOutputException2 extends ChildProcessException {
     public UnexpectedOutputException2(String problem, String commandLine, String possiblyHugeOutput) {
         super("output was not of the expected format: " + problem, commandLine, possiblyHugeOutput);
     }
+
+    /**
+     * @param problem Problem description, e.g. "Output is not of the form ^NAME=VALUE$"
+     */
+    public UnexpectedOutputException2(RuntimeException cause,
+                                      String problem,
+                                      String commandLine,
+                                      String possiblyHugeOutput) {
+        super(cause, "output was not of the expected format: " + problem, commandLine, possiblyHugeOutput);
+    }
 }


### PR DESCRIPTION
By using the CommandResult::map method, any exception thrown while parsing the
output will automatically be wrapped in an exception that also dumps the
command and (snippet of) the full output. It also facilitates simpler code,
e.g.:
  List<String> volumeGroups = terminal.newCommandLine(context)
          .addTokens("vgs --noheadings --options vg_name")
          .executeSilently()
          .mapEachLine(String::trim);