### PR TITLE
Use same path (and therefore, same file system) for tmp files

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -36,7 +36,7 @@ public class FileDownloader {
     public FileDownloader(ConnectionPool connectionPool) {
         this(connectionPool,
              new File(Defaults.getDefaults().underVespaHome("var/db/vespa/filedistribution")),
-             new File(Defaults.getDefaults().underVespaHome("tmp")),
+             new File(Defaults.getDefaults().underVespaHome("var/db/vespa/filedistribution")),
              Duration.ofMinutes(15));
     }
 


### PR DESCRIPTION
We move files from temp dir to file distribution dir after receiving them and
both need to be on the same file system for that to work