### PR TITLE
Require application version

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationVersion.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationVersion.java
@@ -5,8 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * An application package version. This represents an build artifact, identified by a source revision and a build
- * number.
+ * An application package version, identified by a source revision and a build number.
  *
  * @author bratseth
  * @author mpolden
@@ -17,65 +16,39 @@ public class ApplicationVersion implements Comparable<ApplicationVersion> {
      * Used in cases where application version cannot be determined, such as manual deployments (e.g. in dev
      * environment)
      */
-    public static final ApplicationVersion unknown = new ApplicationVersion();
+    public static final ApplicationVersion unknown = new ApplicationVersion(Optional.empty(), Optional.empty());
 
     // This never changes and is only used to create a valid semantic version number, as required by application bundles
     private static final String majorVersion = "1.0";
 
-    // TODO: Remove after 2018-03-01
-    private final Optional<String> applicationPackageHash;
     private final Optional<SourceRevision> source;
     private final Optional<Long> buildNumber;
 
-    private ApplicationVersion() {
-        this.applicationPackageHash = Optional.empty();
-        this.source = Optional.empty();
-        this.buildNumber = Optional.empty();
-    }
-
-    private ApplicationVersion(Optional<String> applicationPackageHash, Optional<SourceRevision> source,
-                               Optional<Long> buildNumber) {
-        Objects.requireNonNull(applicationPackageHash, "applicationPackageHash cannot be null");
+    private ApplicationVersion(Optional<SourceRevision> source, Optional<Long> buildNumber) {
         Objects.requireNonNull(source, "source cannot be null");
         Objects.requireNonNull(buildNumber, "buildNumber cannot be null");
-        if (!applicationPackageHash.isPresent() && source.isPresent() != buildNumber.isPresent()) {
+        if (source.isPresent() != buildNumber.isPresent()) {
             throw new IllegalArgumentException("both buildNumber and source must be set together");
         }
         if (buildNumber.isPresent() && buildNumber.get() <= 0) {
             throw new IllegalArgumentException("buildNumber must be > 0");
         }
-        this.applicationPackageHash = applicationPackageHash;
         this.source = source;
         this.buildNumber = buildNumber;
     }
 
-    /** Create an application package revision where there is no information about its source */
-    public static ApplicationVersion from(String applicationPackageHash) {
-        return new ApplicationVersion(Optional.of(applicationPackageHash), Optional.empty(), Optional.empty());
-    }
-
-    /** Create an application package revision with a source */
-    public static ApplicationVersion from(String applicationPackageHash, SourceRevision source) {
-        return new ApplicationVersion(Optional.of(applicationPackageHash), Optional.of(source), Optional.empty());
-    }
-
     /** Create an application package version from a completed build */
     public static ApplicationVersion from(SourceRevision source, long buildNumber) {
-        return new ApplicationVersion(Optional.empty(), Optional.of(source), Optional.of(buildNumber));
+        return new ApplicationVersion(Optional.of(source), Optional.of(buildNumber));
     }
 
-    /** Returns an unique identifier for this version */
+    /** Returns an unique identifier for this version or "unknown" if version is not known */
     public String id() {
-        if (applicationPackageHash.isPresent()) {
-            return applicationPackageHash.get();
+        if (isUnknown()) {
+            return "unknown";
         }
-        return source.map(sourceRevision -> String.format("%s.%d-%s", majorVersion, buildNumber.get(),
-                                                          abbreviateCommit(source.get().commit())))
-                     .orElse("unknown");
+        return String.format("%s.%d-%s", majorVersion, buildNumber.get(), abbreviateCommit(source.get().commit()));
     }
-
-    /** Returns the application package hash, if known */
-    public Optional<String> applicationPackageHash() { return applicationPackageHash; }
 
     /**
      * Returns information about the source of this revision, or empty if the source is not know/defined
@@ -96,14 +69,13 @@ public class ApplicationVersion implements Comparable<ApplicationVersion> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ApplicationVersion that = (ApplicationVersion) o;
-        return Objects.equals(applicationPackageHash, that.applicationPackageHash) &&
-               Objects.equals(source, that.source) &&
+        return Objects.equals(source, that.source) &&
                Objects.equals(buildNumber, that.buildNumber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(applicationPackageHash, source, buildNumber);
+        return Objects.hash(source, buildNumber);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
@@ -32,8 +32,7 @@ public final class Change {
         Objects.requireNonNull(platform, "platform cannot be null");
         Objects.requireNonNull(application, "application cannot be null");
         if (application.isPresent() && application.get().isUnknown()) {
-            // TODO: Require version to be known for application change
-            //throw new IllegalArgumentException("Application version to deploy must be a known version");
+            throw new IllegalArgumentException("Application version to deploy must be a known version");
         }
         this.platform = platform;
         this.application = application;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -264,8 +264,7 @@ public class DeploymentJobs {
             Objects.requireNonNull(jobError, "jobError cannot be null");
 
             if (jobType == JobType.component && !sourceRevision.isPresent()) {
-                // TODO: Throw after 2018-03-01
-                //throw new IllegalArgumentException("sourceRevision is required for job " + jobType);
+                throw new IllegalArgumentException("sourceRevision is required for job " + jobType);
             }
 
             this.applicationId = applicationId;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
@@ -172,7 +172,6 @@ public class JobList {
     private static boolean failingApplicationChange(JobStatus job) {
         if (   job.isSuccess()) return false;
         if ( ! job.lastSuccess().isPresent()) return true; // An application which never succeeded is surely bad.
-        if ( job.lastSuccess().get().applicationVersion().isUnknown()) return true; // Indicates the component job, which is always an application change.
         if ( ! job.firstFailing().get().version().equals(job.lastSuccess().get().version())) return false; // Version change may be to blame.
         return ! job.firstFailing().get().applicationVersion().equals(job.lastSuccess().get().applicationVersion()); // Return whether there is an application change.
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -136,8 +136,6 @@ public class DeploymentTrigger {
                 if (change.platform().get().isAfter(deployment.version())) return false; // later is ok
             }
             if (change.application().isPresent()) {
-                // If we don't yet know the application version we are deploying, then we are not complete
-                if (change.application().get().isUnknown()) return false;
                 if ( ! change.application().get().equals(deployment.applicationVersion())) return false;
             }
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OutstandingChangeDeployer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OutstandingChangeDeployer.java
@@ -22,9 +22,10 @@ public class OutstandingChangeDeployer extends Maintainer {
     protected void maintain() {
         ApplicationList applications = ApplicationList.from(controller().applications().asList()).notPullRequest();
         for (Application application : applications.asList()) {
-            if (!application.change().isPresent() && application.outstandingChange().isPresent())
+            if (!application.change().isPresent() && application.outstandingChange().isPresent()) {
                 controller().applications().deploymentTrigger().triggerChange(application.id(),
                                                                               application.outstandingChange());
+            }
         }
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
@@ -124,7 +124,7 @@ public class VersionStatus {
 
         ListMap<Version, String> versions = new ListMap<>();
         for (URI configServer : configServers)
-            versions.put(controller.applications().configserverClient().version(configServer), configServer.getHost());
+            versions.put(controller.applications().configServer().version(configServer), configServer.getHost());
         return versions;
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ArtifactRepositoryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ArtifactRepositoryMock.java
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller;
 
+import com.yahoo.component.AbstractComponent;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ArtifactRepository;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
@@ -12,7 +13,7 @@ import java.util.Objects;
 /**
  * @author mpolden
  */
-public class ArtifactRepositoryMock implements ArtifactRepository {
+public class ArtifactRepositoryMock extends AbstractComponent implements ArtifactRepository {
 
     private final Map<Integer, Artifact> repository = new HashMap<>();
 
@@ -28,19 +29,17 @@ public class ArtifactRepositoryMock implements ArtifactRepository {
         return artifact == null ? 0 : artifact.hits;
     }
 
-    public ArtifactRepository resetHits() {
-        repository.values().forEach(Artifact::resetHits);
-        return this;
+    public boolean contains(ApplicationId applicationId, String applicationVersion) {
+        return repository.containsKey(artifactHash(applicationId, applicationVersion));
     }
 
     @Override
     public byte[] getApplicationPackage(ApplicationId applicationId, String applicationVersion) {
-        int artifactHash = artifactHash(applicationId, applicationVersion);
-        if (!repository.containsKey(artifactHash)) {
+        Artifact artifact = repository.get(artifactHash(applicationId, applicationVersion));
+        if (artifact == null) {
             throw new IllegalArgumentException("No application package found for " + applicationId + " with version "
                                                + applicationVersion);
         }
-        Artifact artifact = repository.get(artifactHash);
         artifact.recordHit();
         return artifact.data;
     }
@@ -60,10 +59,6 @@ public class ArtifactRepositoryMock implements ArtifactRepository {
 
         private void recordHit() {
             hits++;
-        }
-
-        private void resetHits() {
-            hits = 0;
         }
 
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -609,6 +609,7 @@ public class ControllerTest {
                 .upgradePolicy("canary")
                 .region("cd-us-central-1")
                 .build();
+        tester.jobCompletion(component).application(application).uploadArtifact(applicationPackage).submit();
 
         long cdJobsCount = statuses.get().keySet().stream()
                         .filter(type -> type.zone(SystemName.cd).isPresent())

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/BuildJob.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/BuildJob.java
@@ -1,0 +1,119 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.deployment;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.ArtifactRepositoryMock;
+import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
+import com.yahoo.vespa.hosted.controller.application.SourceRevision;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Create a build job for testing purposes. In most cases this should be constructed by calling
+ * DeploymentTester.jobCompletion.
+ *
+ * @author mpolden
+ */
+public class BuildJob {
+
+    public static final SourceRevision defaultSourceRevision = new SourceRevision("repository1",
+                                                                                  "master", "commit1");
+    public static final long defaultBuildNumber = 42;
+
+    private DeploymentJobs.JobType job;
+    private ApplicationId applicationId;
+    private Optional<DeploymentJobs.JobError> jobError = Optional.empty();
+    private Optional<SourceRevision> sourceRevision = Optional.of(defaultSourceRevision);
+    private long projectId;
+    private long buildNumber = defaultBuildNumber;
+
+    private final Consumer<DeploymentJobs.JobReport> reportConsumer;
+    private final ArtifactRepositoryMock artifactRepository;
+
+    public BuildJob(Consumer<DeploymentJobs.JobReport> reportConsumer, ArtifactRepositoryMock artifactRepository) {
+        Objects.requireNonNull(reportConsumer, "reportConsumer cannot be null");
+        Objects.requireNonNull(artifactRepository, "artifactRepository cannot be null");
+        this.reportConsumer = reportConsumer;
+        this.artifactRepository = artifactRepository;
+    }
+
+    public BuildJob type(DeploymentJobs.JobType job) {
+        this.job = job;
+        return this;
+    }
+
+    public BuildJob application(Application application) {
+        this.applicationId = application.id();
+        if (application.deploymentJobs().projectId().isPresent()) {
+            this.projectId = application.deploymentJobs().projectId().get();
+        }
+        return this;
+    }
+
+    public BuildJob application(ApplicationId applicationId) {
+        this.applicationId = applicationId;
+        return this;
+    }
+
+    public BuildJob error(DeploymentJobs.JobError jobError) {
+        this.jobError = Optional.of(jobError);
+        return this;
+    }
+
+    public BuildJob sourceRevision(SourceRevision sourceRevision) {
+        this.sourceRevision = Optional.of(sourceRevision);
+        return this;
+    }
+
+    public BuildJob buildNumber(long buildNumber) {
+        this.buildNumber = buildNumber;
+        return this;
+    }
+
+    public BuildJob projectId(long projectId) {
+        this.projectId = projectId;
+        return this;
+    }
+
+    public BuildJob success(boolean success) {
+        this.jobError = success ? Optional.empty() : Optional.of(DeploymentJobs.JobError.unknown);
+        return this;
+    }
+
+    public BuildJob unsuccessful() {
+        return success(false);
+    }
+
+    /** Create a job report for this build job */
+    public DeploymentJobs.JobReport report() {
+        return new DeploymentJobs.JobReport(applicationId, job, projectId, buildNumber, sourceRevision, jobError);
+    }
+
+    /** Upload given application package to artifact repository as part of this job */
+    public BuildJob uploadArtifact(ApplicationPackage applicationPackage) {
+        Objects.requireNonNull(job, "job cannot be null");
+        if (job != DeploymentJobs.JobType.component) {
+            throw new IllegalStateException(job + " cannot upload artifact");
+        }
+        artifactRepository.put(applicationId, applicationPackage, applicationVersion());
+        return this;
+    }
+
+    /** Send report for this build job to the controller */
+    public void submit() {
+        if (job == DeploymentJobs.JobType.component &&
+            !artifactRepository.contains(applicationId, applicationVersion())) {
+            throw new IllegalStateException(job + " must upload artifact before reporting completion");
+        }
+        reportConsumer.accept(report());
+    }
+
+    private String applicationVersion() {
+        return String.format("1.0.%d-%s", buildNumber, sourceRevision.get().commit());
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentIssueReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentIssueReporterTest.java
@@ -78,14 +78,14 @@ public class DeploymentIssueReporterTest {
         // NOTE: All maintenance should be idempotent within a small enough time interval, so maintain is called twice in succession throughout.
 
         // apps 1 and 3 have one failure each.
-        tester.notifyJobCompletion(component, app1, true);
+        tester.jobCompletion(component).application(app1).uploadArtifact(applicationPackage).submit();
         tester.deployAndNotify(app1, applicationPackage, true, systemTest);
         tester.deployAndNotify(app1, applicationPackage, false, stagingTest);
 
         // app2 is successful, but will fail later.
         tester.deployCompletely(app2, canaryPackage);
 
-        tester.notifyJobCompletion(component, app3, true);
+        tester.jobCompletion(component).application(app3).uploadArtifact(applicationPackage).submit();
         tester.deployAndNotify(app3, applicationPackage, true, systemTest);
         tester.deployAndNotify(app3, applicationPackage, true, stagingTest);
         tester.deployAndNotify(app3, applicationPackage, false, productionCorpUsEast1);
@@ -134,7 +134,7 @@ public class DeploymentIssueReporterTest {
 
 
         // app3 now has a new failure past max failure age; see that a new issue is filed.
-        tester.notifyJobCompletion(component, app3, true);
+        tester.jobCompletion(component).application(app3).submit();
         tester.deployAndNotify(app3, applicationPackage, false, systemTest);
         tester.clock().advance(maxInactivity.plus(maxFailureAge));
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainerTest.java
@@ -4,11 +4,11 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
-import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
-import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.athenz.api.NToken;
+import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
@@ -74,7 +74,8 @@ public class DnsMaintainerTest {
                 .environment(Environment.prod)
                 .allow(ValidationId.deploymentRemoval)
                 .build();
-        tester.notifyJobCompletion(component, application, true);
+        tester.jobCompletion(component).application(application).uploadArtifact(applicationPackage).submit();
+
         tester.deployAndNotify(application, applicationPackage, true, systemTest);
         tester.applications().deactivate(application, ZoneId.from(Environment.test, RegionName.from("us-east-1")));
         tester.applications().deactivate(application, ZoneId.from(Environment.staging, RegionName.from("us-east-3")));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
@@ -196,6 +196,7 @@ public class FailureRedeployerTest {
                 .upgradePolicy("canary")
                 .region("cd-us-central-1")
                 .build();
+        tester.jobCompletion(component).application(application).uploadArtifact(applicationPackage).submit();
 
         // New version is released
         version = Version.fromString("6.142.1");

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
 
+import static com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType.component;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -39,7 +40,7 @@ public class FailureRedeployerTest {
         tester.updateVersionStatus(version);
 
         Application app = tester.createApplication("app1", "tenant1", 1, 11L);
-        tester.notifyJobCompletion(DeploymentJobs.JobType.component, app, true);
+        tester.jobCompletion(component).application(app).uploadArtifact(applicationPackage).submit();
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.systemTest);
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.stagingTest);
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.productionUsEast3);
@@ -82,7 +83,7 @@ public class FailureRedeployerTest {
         tester.deployAndNotify(app, applicationPackage, false, DeploymentJobs.JobType.productionUsEast3);
         tester.buildSystem().takeJobsToRun();
         tester.clock().advance(Duration.ofMinutes(10));
-        tester.notifyJobCompletion(DeploymentJobs.JobType.productionUsEast3, app, false);
+        tester.jobCompletion(DeploymentJobs.JobType.productionUsEast3).application(app).unsuccessful().submit();
         assertTrue("Retries exhausted", tester.buildSystem().jobs().isEmpty());
         assertTrue("Failure is recorded", tester.application(app.id()).deploymentJobs().hasFailures());
 
@@ -108,7 +109,7 @@ public class FailureRedeployerTest {
                 .build();
 
         Application app = tester.createApplication("app1", "tenant1", 1, 11L);
-        tester.notifyJobCompletion(DeploymentJobs.JobType.component, app, true);
+        tester.jobCompletion(component).application(app).uploadArtifact(applicationPackage).submit();
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.systemTest);
 
         // staging-test starts, but does not complete
@@ -123,7 +124,7 @@ public class FailureRedeployerTest {
 
         // Deployment completes
         tester.deploy(DeploymentJobs.JobType.stagingTest, app, applicationPackage, true);
-        tester.notifyJobCompletion(DeploymentJobs.JobType.stagingTest, app, true);
+        tester.jobCompletion(DeploymentJobs.JobType.stagingTest).application(app).submit();
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.productionUsEast3);
         assertTrue("All jobs consumed", tester.buildSystem().jobs().isEmpty());
     }
@@ -140,7 +141,7 @@ public class FailureRedeployerTest {
         tester.updateVersionStatus(version);
 
         Application app = tester.createApplication("app1", "tenant1", 1, 11L);
-        tester.notifyJobCompletion(DeploymentJobs.JobType.component, app, true);
+        tester.jobCompletion(component).application(app).uploadArtifact(applicationPackage).submit();
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.systemTest);
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.stagingTest);
         tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.productionUsEast3);
@@ -156,7 +157,7 @@ public class FailureRedeployerTest {
         tester.deployAndNotify(app, applicationPackage, false, DeploymentJobs.JobType.systemTest);
         tester.buildSystem().takeJobsToRun();
         tester.clock().advance(Duration.ofMinutes(10));
-        tester.notifyJobCompletion(DeploymentJobs.JobType.systemTest, app, false);
+        tester.jobCompletion(DeploymentJobs.JobType.systemTest).application(app).unsuccessful().submit();
         assertTrue("Retries exhausted", tester.buildSystem().jobs().isEmpty());
 
         // Another version is released
@@ -207,12 +208,12 @@ public class FailureRedeployerTest {
         tester.deploy(DeploymentJobs.JobType.systemTest, application, applicationPackage);
         tester.buildSystem().takeJobsToRun();
         tester.clock().advance(Duration.ofMinutes(10));
-        tester.notifyJobCompletion(DeploymentJobs.JobType.systemTest, application, true);
+        tester.jobCompletion(DeploymentJobs.JobType.systemTest).application(application).submit();
 
         tester.deploy(DeploymentJobs.JobType.stagingTest, application, applicationPackage);
         tester.buildSystem().takeJobsToRun();
         tester.clock().advance(Duration.ofMinutes(10));
-        tester.notifyJobCompletion(DeploymentJobs.JobType.stagingTest, application, true);
+        tester.jobCompletion(DeploymentJobs.JobType.stagingTest).application(application).submit();
 
         // Production job starts, but does not complete
         assertEquals(1, tester.buildSystem().jobs().size());
@@ -224,12 +225,12 @@ public class FailureRedeployerTest {
         assertTrue("No jobs retried", tester.buildSystem().jobs().isEmpty());
 
         // Deployment notifies completeness but has not actually made a deployment
-        tester.notifyJobCompletion(DeploymentJobs.JobType.productionCdUsCentral1, application, true);
+        tester.jobCompletion(DeploymentJobs.JobType.productionCdUsCentral1).application(application).submit();
         assertTrue("Change not really deployed", tester.application(application.id()).change().isPresent());
 
         // Deployment actually deploys and notifies completeness
         tester.deploy(DeploymentJobs.JobType.productionCdUsCentral1, application, applicationPackage);
-        tester.notifyJobCompletion(DeploymentJobs.JobType.productionCdUsCentral1, application, true);
+        tester.jobCompletion(DeploymentJobs.JobType.productionCdUsCentral1).application(application).submit();
         assertFalse("Change not really deployed", tester.application(application.id()).change().isPresent());
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
@@ -85,7 +85,7 @@ public class MetricsReporterTest {
         assertEquals(0.0, metricsMock.getMetric(MetricsReporter.deploymentFailMetric));
 
         // 1 app fails system-test
-        tester.notifyJobCompletion(component, app4, true);
+        tester.jobCompletion(component).application(app4).submit();
         tester.deployAndNotify(app4, applicationPackage, false, systemTest);
 
         metricsReporter.maintain();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OutstandingChangeDeployerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OutstandingChangeDeployerTest.java
@@ -2,18 +2,20 @@
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.api.integration.BuildService;
+import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.Change;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.SourceRevision;
+import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -30,6 +32,11 @@ public class OutstandingChangeDeployerTest {
         tester.configServer().setDefaultVersion(new Version(6, 1));
         OutstandingChangeDeployer deployer = new OutstandingChangeDeployer(tester.controller(), Duration.ofMinutes(10),
                                                                            new JobControl(new MockCuratorDb()));
+        ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
+                .environment(Environment.prod)
+                .region("us-west-1")
+                .build();
+
         tester.createAndDeploy("app1", 11, "default");
         tester.createAndDeploy("app2", 22, "default");
 
@@ -38,14 +45,17 @@ public class OutstandingChangeDeployerTest {
 
         assertEquals(Change.of(version), tester.application("app1").change());
         assertFalse(tester.application("app1").outstandingChange().isPresent());
-        tester.notifyJobCompletion(DeploymentJobs.JobType.component, tester.application("app1"),
-                                   Optional.empty(), Optional.of(new SourceRevision("repo", "master",
-                                                                                    "cafed00d")),
-                                   42);
+
+        tester.jobCompletion(DeploymentJobs.JobType.component)
+              .application(tester.application("app1"))
+              .sourceRevision(new SourceRevision("repository1","master", "cafed00d"))
+              .buildNumber(43)
+              .uploadArtifact(applicationPackage)
+              .submit();
 
         Application app = tester.application("app1");
         assertTrue(app.outstandingChange().isPresent());
-        assertEquals("1.0.42-cafed00d", app.outstandingChange().application().get().id());
+        assertEquals("1.0.43-cafed00d", app.outstandingChange().application().get().id());
         assertEquals(1, tester.buildSystem().jobs().size());
 
         deployer.maintain();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -148,14 +148,13 @@ public class ApplicationSerializerTest {
         assertEquals(6, serialized.deployments().get(zone2).metrics().writeLatencyMillis(), Double.MIN_VALUE);
 
         { // test more deployment serialization cases
-            Application original2 = writable(original).withChange(Change.of(ApplicationVersion.from("hash1")));
+            Application original2 = writable(original).withChange(Change.of(ApplicationVersion.from(new SourceRevision("repo1", "branch1", "commit1"), 42)));
             Application serialized2 = applicationSerializer.fromSlime(applicationSerializer.toSlime(original2));
             assertEquals(original2.change(), serialized2.change());
             assertEquals(serialized2.change().application().get().source(),
                          original2.change().application().get().source());
 
-            Application original3 = writable(original).withChange(Change.of(ApplicationVersion.from("hash1",
-                                                                                                    new SourceRevision("a", "b", "c"))));
+            Application original3 = writable(original).withChange(Change.of(ApplicationVersion.from(new SourceRevision("a", "b", "c"), 42)));
             Application serialized3 = applicationSerializer.fromSlime(applicationSerializer.toSlime(original3));
             assertEquals(original3.change(), serialized3.change());
             assertEquals(serialized3.change().application().get().source(),
@@ -164,11 +163,11 @@ public class ApplicationSerializerTest {
             Application serialized4 = applicationSerializer.fromSlime(applicationSerializer.toSlime(original4));
             assertEquals(original4.change(), serialized4.change());
 
-            Application original5 = writable(original).withChange(Change.of(ApplicationVersion.unknown));
+            Application original5 = writable(original).withChange(Change.of(ApplicationVersion.from(new SourceRevision("a", "b", "c"), 42)));
             Application serialized5 = applicationSerializer.fromSlime(applicationSerializer.toSlime(original5));
             assertEquals(original5.change(), serialized5.change());
 
-            Application original6 = writable(original).withOutstandingChange(Change.of(ApplicationVersion.unknown));
+            Application original6 = writable(original).withOutstandingChange(Change.of(ApplicationVersion.from(new SourceRevision("a", "b", "c"), 42)));
             Application serialized6 = applicationSerializer.fromSlime(applicationSerializer.toSlime(original6));
             assertEquals(original6.outstandingChange(), serialized6.outstandingChange());
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/complete-application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/complete-application.json
@@ -501,7 +501,7 @@
     ]
   },
   "deployingField": {
-    "applicationPackageHash": "ec548fa61cbfab7a270a51d46b1263ec1be5d9a8",
+    "buildNumber": 42,
     "sourceRevision": {
       "repositoryField": "git@git.host:user/repo.git",
       "branchField": "origin/master",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
@@ -8,7 +8,8 @@ import com.yahoo.application.container.handler.Response;
 import org.junit.After;
 import org.junit.Before;
 
-import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.CharacterCodingException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -90,11 +91,15 @@ public class ControllerContainerTest {
             "  </handler>\n" +
             "</jdisc>";
 
-    protected void assertResponse(Request request, int responseStatus, String responseMessage) throws IOException {
+    protected void assertResponse(Request request, int responseStatus, String responseMessage) {
         Response response = container.handleRequest(request);
         // Compare both status and message at once for easier diagnosis
-        assertEquals("status: " + responseStatus + "\nmessage: " + responseMessage,
-                     "status: " + response.getStatus() + "\nmessage: " + response.getBodyAsString());
+        try {
+            assertEquals("status: " + responseStatus + "\nmessage: " + responseMessage,
+                         "status: " + response.getStatus() + "\nmessage: " + response.getBodyAsString());
+        } catch (CharacterCodingException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -200,7 +200,11 @@ public class ApplicationApiTest extends ControllerContainerTest {
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/test/region/us-east-1/instance/default", DELETE)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               "Deactivated tenant/tenant1/application/application1/environment/test/region/us-east-1/instance/default");
-        controllerTester.notifyJobCompletion(id, screwdriverProjectId, true, DeploymentJobs.JobType.systemTest); // Called through the separate screwdriver/v1 API
+        // Called through the separate screwdriver/v1 API
+        controllerTester.jobCompletion(DeploymentJobs.JobType.systemTest)
+                        .application(id)
+                        .projectId(screwdriverProjectId)
+                        .submit();
 
         // ... staging
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/staging/region/us-east-3/instance/default/", POST)
@@ -210,14 +214,21 @@ public class ApplicationApiTest extends ControllerContainerTest {
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/staging/region/us-east-3/instance/default", DELETE)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               "Deactivated tenant/tenant1/application/application1/environment/staging/region/us-east-3/instance/default");
-        controllerTester.notifyJobCompletion(id, screwdriverProjectId, true, DeploymentJobs.JobType.stagingTest);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.stagingTest)
+                        .application(id)
+                        .projectId(screwdriverProjectId)
+                        .submit();
 
         // ... prod zone
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/", POST)
                                       .data(createApplicationDeployData(applicationPackage, Optional.of(screwdriverProjectId)))
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
-        controllerTester.notifyJobCompletion(id, screwdriverProjectId, false, DeploymentJobs.JobType.productionCorpUsEast1);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.productionCorpUsEast1)
+                        .application(id)
+                        .projectId(screwdriverProjectId)
+                        .unsuccessful()
+                        .submit();
 
         // GET tenant screwdriver projects
         tester.assertResponse(request("/application/v4/tenant-pipeline/", GET),
@@ -405,16 +416,18 @@ public class ApplicationApiTest extends ControllerContainerTest {
                 .build();
         ApplicationId id = ApplicationId.from("tenant1", "application1", "default");
         long projectId = 1;
-        HttpEntity deployData = createApplicationDeployData(applicationPackage, Optional.of(projectId));
-
-        startAndTestChange(controllerTester, id, projectId, deployData);
+        HttpEntity deployData = createApplicationDeployData(Optional.empty(), Optional.of(projectId));
+        startAndTestChange(controllerTester, id, projectId, applicationPackage, deployData, 100);
 
         // us-east-3
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-east-3/instance/default/deploy", POST)
                                       .data(deployData)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
-        controllerTester.notifyJobCompletion(id, projectId, true, DeploymentJobs.JobType.productionUsEast3);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.productionUsEast3)
+                        .application(id)
+                        .projectId(projectId)
+                        .submit();
 
         // New zone is added before us-east-3
         applicationPackage = new ApplicationPackageBuilder()
@@ -423,21 +436,26 @@ public class ApplicationApiTest extends ControllerContainerTest {
                 .region("us-west-1")
                 .region("us-east-3")
                 .build();
-        deployData = createApplicationDeployData(applicationPackage, Optional.of(projectId));
-        startAndTestChange(controllerTester, id, projectId, deployData);
+        startAndTestChange(controllerTester, id, projectId, applicationPackage, deployData, 101);
 
         // us-west-1
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-west-1/instance/default/deploy", POST)
                                       .data(deployData)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
-        controllerTester.notifyJobCompletion(id, projectId, true, DeploymentJobs.JobType.productionUsWest1);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.productionUsWest1)
+                        .application(id)
+                        .projectId(projectId)
+                        .submit();
 
         // us-east-3
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-east-3/instance/default/deploy", POST)
                                       .data(deployData).screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
-        controllerTester.notifyJobCompletion(id, projectId, true, DeploymentJobs.JobType.productionUsEast3);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.productionUsEast3)
+                        .application(id)
+                        .projectId(projectId)
+                        .submit();
 
         setDeploymentMaintainedInfo(controllerTester);
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1", GET),
@@ -695,7 +713,11 @@ public class ApplicationApiTest extends ControllerContainerTest {
         controllerTester.authorize(ATHENZ_TENANT_DOMAIN, screwdriverId, ApplicationAction.deploy, application);
 
         // Allow systemtest to succeed by notifying completion of system test
-        controllerTester.notifyJobCompletion(application.id(), screwdriverProjectId, true, DeploymentJobs.JobType.component);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.component)
+                        .application(application.id())
+                        .projectId(screwdriverProjectId)
+                        .uploadArtifact(applicationPackage)
+                        .submit();
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/test/region/us-east-1/instance/default/", POST)
                                       .data(createApplicationDeployData(applicationPackage, Optional.of(screwdriverProjectId)))
                                       .screwdriverIdentity(screwdriverId),
@@ -704,9 +726,13 @@ public class ApplicationApiTest extends ControllerContainerTest {
     }
 
     private HttpEntity createApplicationDeployData(ApplicationPackage applicationPackage, Optional<Long> screwdriverJobId) {
+        return createApplicationDeployData(Optional.of(applicationPackage), screwdriverJobId);
+    }
+
+    private HttpEntity createApplicationDeployData(Optional<ApplicationPackage> applicationPackage, Optional<Long> screwdriverJobId) {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         builder.addTextBody("deployOptions", deployOptions(screwdriverJobId), ContentType.APPLICATION_JSON);
-        builder.addBinaryBody("applicationZip", applicationPackage.zippedContent());
+        applicationPackage.ifPresent(ap -> builder.addBinaryBody("applicationZip", ap.zippedContent()));
         return builder.build();
     }
     
@@ -811,12 +837,19 @@ public class ApplicationApiTest extends ControllerContainerTest {
         athenzApplication.addRoleMember(ApplicationAction.deploy, screwdriverIdentity);
     }
 
-    private void startAndTestChange(ContainerControllerTester controllerTester, ApplicationId application, long projectId,
-                                    HttpEntity deployData) throws IOException {
+    private void startAndTestChange(ContainerControllerTester controllerTester, ApplicationId application,
+                                    long projectId, ApplicationPackage applicationPackage,
+                                    HttpEntity deployData, long buildNumber) throws IOException {
         ContainerTester tester = controllerTester.containerTester();
 
         // Trigger application change
-        controllerTester.notifyJobCompletion(application, projectId, true, DeploymentJobs.JobType.component);
+        controllerTester.artifactRepository().put(application, applicationPackage,"1.0." + buildNumber
+                                                                                  + "-commit1");
+        controllerTester.jobCompletion(DeploymentJobs.JobType.component)
+                        .application(application)
+                        .projectId(projectId)
+                        .buildNumber(buildNumber)
+                        .submit();
 
         // system-test
         String testPath = String.format("/application/v4/tenant/%s/application/%s/environment/test/region/us-east-1/instance/default",
@@ -828,7 +861,10 @@ public class ApplicationApiTest extends ControllerContainerTest {
         tester.assertResponse(request(testPath, DELETE)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                 "Deactivated " + testPath.replaceFirst("/application/v4/", ""));
-        controllerTester.notifyJobCompletion(application, projectId, true, DeploymentJobs.JobType.systemTest);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.systemTest)
+                        .application(application)
+                        .projectId(projectId)
+                        .submit();
 
         // staging
         String stagingPath = String.format("/application/v4/tenant/%s/application/%s/environment/staging/region/us-east-3/instance/default",
@@ -840,7 +876,10 @@ public class ApplicationApiTest extends ControllerContainerTest {
         tester.assertResponse(request(stagingPath, DELETE)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                 "Deactivated " + stagingPath.replaceFirst("/application/v4/", ""));
-        controllerTester.notifyJobCompletion(application, projectId, true, DeploymentJobs.JobType.stagingTest);
+        controllerTester.jobCompletion(DeploymentJobs.JobType.stagingTest)
+                        .application(application)
+                        .projectId(projectId)
+                        .submit();
     }
 
     /**

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -187,10 +187,12 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                        ATHENZ_TENANT_DOMAIN,
                                        new com.yahoo.vespa.hosted.controller.api.identifiers.ApplicationId(id.application().value())); // (Necessary but not provided in this API)
 
-        // Trigger deployment
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/deploying", POST)
-                                      .data("6.1.0"),
-                              new File("application-deployment.json"));
+        // Trigger deployment from completion of component job
+        controllerTester.jobCompletion(DeploymentJobs.JobType.component)
+                        .application(id)
+                        .projectId(screwdriverProjectId)
+                        .uploadArtifact(applicationPackage)
+                        .submit();
 
         // ... systemtest
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/test/region/us-east-1/instance/default/", POST)
@@ -247,7 +249,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                       .userIdentity(USER_ID)
                                       .recursive("deployment"),
                               new File("recursive-root.json"));
-        // GET at root, with "&recursive=tenant", returns info about all tenants, with limmited info about their applications.
+        // GET at root, with "&recursive=tenant", returns info about all tenants, with limited info about their applications.
         tester.assertResponse(request("/application/v4/", GET)
                                       .userIdentity(USER_ID)
                                       .recursive("tenant"),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
@@ -6,14 +6,30 @@
       "type": "component",
       "success": true,
       "lastCompleted": {
-        "id": 42,
+        "id": 101,
         "version": "(ignore)",
+        "revision": {
+          "hash": "(ignore)",
+          "source": {
+            "gitRepository": "repository1",
+            "gitBranch": "master",
+            "gitCommit": "commit1"
+          }
+        },
         "reason": "Application commit",
         "at": "(ignore)"
       },
       "lastSuccess": {
-        "id": 42,
+        "id": 101,
         "version": "(ignore)",
+        "revision": {
+          "hash": "(ignore)",
+          "source": {
+            "gitRepository": "repository1",
+            "gitBranch": "master",
+            "gitCommit": "commit1"
+          }
+        },
         "reason": "Application commit",
         "at": "(ignore)"
       }
@@ -78,7 +94,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"system-test completed",
+        "reason": "system-test completed",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -92,7 +108,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"system-test completed",
+        "reason": "system-test completed",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -106,7 +122,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"system-test completed",
+        "reason": "system-test completed",
         "at": "(ignore)"
       }
     },
@@ -124,7 +140,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"staging-test completed",
+        "reason": "staging-test completed",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -138,7 +154,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"staging-test completed",
+        "reason": "staging-test completed",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -152,7 +168,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"staging-test completed",
+        "reason": "staging-test completed",
         "at": "(ignore)"
       }
     },
@@ -170,7 +186,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"production-us-west-1 completed",
+        "reason": "production-us-west-1 completed",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -184,7 +200,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"production-us-west-1 completed",
+        "reason": "production-us-west-1 completed",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -198,7 +214,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason":"production-us-west-1 completed",
+        "reason": "production-us-west-1 completed",
         "at": "(ignore)"
       }
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
@@ -2,9 +2,48 @@
   "application": "application1",
   "instance": "default",
   "deploying": {
-    "version": "(ignore)"
+    "revision": {
+      "hash": "(ignore)",
+      "source": {
+        "gitRepository": "repository1",
+        "gitBranch": "master",
+        "gitCommit": "commit1"
+      }
+    }
   },
   "deploymentJobs": [
+    {
+      "type": "component",
+      "success": true,
+      "lastCompleted": {
+        "id": 42,
+        "version": "(ignore)",
+        "revision": {
+          "hash": "(ignore)",
+          "source": {
+            "gitRepository": "repository1",
+            "gitBranch": "master",
+            "gitCommit": "commit1"
+          }
+        },
+        "reason": "Application commit",
+        "at": "(ignore)"
+      },
+      "lastSuccess": {
+        "id": 42,
+        "version": "(ignore)",
+        "revision": {
+          "hash": "(ignore)",
+          "source": {
+            "gitRepository": "repository1",
+            "gitBranch": "master",
+            "gitCommit": "commit1"
+          }
+        },
+        "reason": "Application commit",
+        "at": "(ignore)"
+      }
+    },
     {
       "type": "system-test",
       "success": true,
@@ -19,7 +58,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "",
+        "reason": "component completed",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -33,7 +72,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "",
+        "reason": "component completed",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -47,7 +86,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "",
+        "reason": "component completed",
         "at": "(ignore)"
       }
     },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
@@ -2,15 +2,54 @@
   "application": "application1",
   "instance": "default",
   "deploying": {
-    "version": "6.1"
+    "revision": {
+      "hash": "(ignore)",
+      "source": {
+        "gitRepository": "repository1",
+        "gitBranch": "master",
+        "gitCommit": "commit1"
+      }
+    }
   },
   "deploymentJobs": [
+    {
+      "type": "component",
+      "success": true,
+      "lastCompleted": {
+        "id": 42,
+        "version": "(ignore)",
+        "revision": {
+          "hash": "(ignore)",
+          "source": {
+            "gitRepository": "repository1",
+            "gitBranch": "master",
+            "gitCommit": "commit1"
+          }
+        },
+        "reason": "Application commit",
+        "at": "(ignore)"
+      },
+      "lastSuccess": {
+        "id": 42,
+        "version": "(ignore)",
+        "revision": {
+          "hash": "(ignore)",
+          "source": {
+            "gitRepository": "repository1",
+            "gitBranch": "master",
+            "gitCommit": "commit1"
+          }
+        },
+        "reason": "Application commit",
+        "at": "(ignore)"
+      }
+    },
     {
       "type": "system-test",
       "success": true,
       "lastTriggered": {
         "id": -1,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -19,12 +58,12 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "",
+        "reason": "component completed",
         "at": "(ignore)"
       },
       "lastCompleted": {
         "id": 42,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -33,12 +72,12 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "",
+        "reason": "component completed",
         "at": "(ignore)"
       },
       "lastSuccess": {
         "id": 42,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -47,7 +86,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "",
+        "reason": "component completed",
         "at": "(ignore)"
       }
     },
@@ -56,7 +95,7 @@
       "success": true,
       "lastTriggered": {
         "id": -1,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -70,7 +109,7 @@
       },
       "lastCompleted": {
         "id": 42,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -84,7 +123,7 @@
       },
       "lastSuccess": {
         "id": 42,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -102,7 +141,7 @@
       "success": false,
       "lastTriggered": {
         "id": -1,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -116,7 +155,7 @@
       },
       "lastCompleted": {
         "id": 42,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -130,7 +169,7 @@
       },
       "firstFailing": {
         "id": 42,
-        "version": "6.1.0",
+        "version": "(ignore)",
         "revision": {
           "hash": "(ignore)",
           "source": {
@@ -144,7 +183,7 @@
       }
     }
   ],
-  "compileVersion": "6.1.0",
+  "compileVersion": "(ignore)",
   "globalRotations": [
     "http://application1.tenant1.global.vespa.yahooapis.com:4080/",
     "https://application1--tenant1.global.vespa.yahooapis.com:4443/"

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-west-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-west-1.json
@@ -11,7 +11,7 @@
   ],
   "nodes": "http://localhost:8080/zone/v2/dev/us-west-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
   "yamasUrl": "http://monitoring-system.test/?environment=dev&region=us-west-1&application=tenant1.application1",
-  "version": "6.1.0",
+  "version": "(ignore)",
   "revision": "(ignore)",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "123",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-corp-us-east-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-corp-us-east-1.json
@@ -15,7 +15,7 @@
   "nodes": "http://localhost:8080/zone/v2/prod/corp-us-east-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
   "elkUrl": "http://log.prod.corp-us-east-1.test/#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'HV-tenant:%22tenant1%22%20AND%20HV-application:%22application1%22%20AND%20HV-region:%22corp-us-east-1%22%20AND%20HV-instance:%22default%22%20AND%20HV-environment:%22prod%22')),sort:!('@timestamp',desc))",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=corp-us-east-1&application=tenant1.application1",
-  "version": "6.1.0",
+  "version": "(ignore)",
   "revision": "(ignore)",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "123",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationTest.java
@@ -79,7 +79,7 @@ public class RotationTest {
                 .region("us-west-1")
                 .searchDefinition("search foo { }") // Update application package so there is something to deploy
                 .build();
-        tester.deployCompletely(application, applicationPackage);
+        tester.deployCompletely(application, applicationPackage, 43);
         assertEquals(expected.id(), tester.applications().require(application.id()).rotation().get().id());
     }
     


### PR DESCRIPTION
Application version is now required to be known for all automated deployments.
This is a large change, but most of it is making test code conform to the new
constraints.

Please review, but hold merge until all applications have migrated to the new
version number.