### PR TITLE
Revert "Throw instead of empty list when no service URLs"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -208,6 +208,7 @@ public class ApplicationController {
                 // RoutingEndpoints that lacks hostname is gone
                 if (hostname != null) {
 
+                    // Book-keeping
                     if (endpoint.isGlobal()) {
                         hostToGlobalEndpoint.put(hostname, endpoint);
                     } else {
@@ -518,12 +519,19 @@ public class ApplicationController {
         }
     }
 
-    /** Returns the endpoints of the deployment, or throws an exception if this fails. */
-    public List<URI> getDeploymentEndpoints(DeploymentId deploymentId) {
-        return ImmutableList.copyOf(routingGenerator.endpoints(deploymentId).stream()
-                                            .map(RoutingEndpoint::getEndpoint)
-                                            .map(URI::create)
-                                            .iterator());
+    /** Returns the endpoints of the deployment, or an empty list if the request fails */
+    public Optional<List<URI>> getDeploymentEndpoints(DeploymentId deploymentId) {
+        try {
+            return Optional.of(ImmutableList.copyOf(routingGenerator.endpoints(deploymentId).stream()
+                                                                    .map(RoutingEndpoint::getEndpoint)
+                                                                    .map(URI::create)
+                                                                    .iterator()));
+        }
+        catch (RuntimeException e) {
+            log.log(Level.WARNING, "Failed to get endpoint information for " + deploymentId + ": "
+                                   + Exceptions.toMessageString(e));
+            return Optional.empty();
+        }
     }
 
     /**

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -441,7 +441,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
 
         Cursor serviceUrlArray = response.setArray("serviceUrls");
         controller.applications().getDeploymentEndpoints(deploymentId)
-                .forEach(endpoint -> serviceUrlArray.addString(endpoint.toString()));
+                  .ifPresent(endpoints -> endpoints.forEach(endpoint -> serviceUrlArray.addString(endpoint.toString())));
 
         response.setString("nodes", withPath("/zone/v2/" + deploymentId.zoneId().environment() + "/" + deploymentId.zoneId().region() + "/nodes/v2/node/?&recursive=true&application=" + deploymentId.applicationId().tenant() + "." + deploymentId.applicationId().application() + "." + deploymentId.applicationId().instance(), request.getUri()).toString());
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/MockRoutingGenerator.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/MockRoutingGenerator.java
@@ -16,6 +16,7 @@ public class MockRoutingGenerator implements RoutingGenerator {
     @Override
     public List<RoutingEndpoint> endpoints(DeploymentId deployment) {
         List<RoutingEndpoint> endpoints = new ArrayList<>();
+        // TODO: TLS: Update to HTTPS when ready.
         endpoints.add(new RoutingEndpoint("http://old-endpoint.vespa.yahooapis.com:4080", false));
         endpoints.add(new RoutingEndpoint("http://qrs-endpoint.vespa.yahooapis.com:4080", "host1", false));
         endpoints.add(new RoutingEndpoint("http://feeding-endpoint.vespa.yahooapis.com:4080", "host2", false));


### PR DESCRIPTION
Reverts vespa-engine/vespa#4942

@hmusum too much code that assumes an empty list is legal, but retries when it gets that. This change will have to go with changes to those uses, and I can't easily know I've found them all, since this is an HTTP interface. 