### PR TITLE
Revert "Add task scoped log and logOnFailure"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/TaskContext.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/TaskContext.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.component;
 
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 public interface TaskContext {
@@ -17,39 +16,10 @@ public interface TaskContext {
      *     performed (sometimes this is not possible).
      *
      * @param logger Used to log the modification to help locate the source of the modification.
-     * @param message Description of the modification, e.g. "Changing owner of /foo from alice
-     *                to bob".
+     * @param description Description of the modification, e.g. "Changing owner of /foo from alice
+     *                    to bob".
      */
-    void recordSystemModification(Logger logger, String message);
-    default void recordSystemModification(Logger logger, String messageFormat, String... args) {
-        recordSystemModification(logger, String.format(messageFormat, (Object[]) args));
-    }
-
-    /**
-     * Log message at LogLevel.INFO, scoped to denote the current task. The message may
-     * also be directed to status pages or similar.
-     *
-     * Please do not call this too many times as that spams the log. Typically a task may call
-     * this zero times, or up to a few times.
-     *
-     * Do not log a message that is also recorded with recordSystemModification.
-     */
-    default void log(Logger logger, String message) {}
-    default void log(Logger logger, String messageFormat, String... args) {
-        log(logger, String.format(messageFormat, (Object[]) args));
-    }
-
-    /**
-     * Register a message supplier to be called if the task failed, to help with debugging
-     * of the task (and too verbose to log at every run). The message is also logged at
-     * LogLevel.DEBUG if enabled.
-     *
-     * Do not call logOnFailure for a message passed to either recordSystemModification or log.
-     *
-     * @param messageSupplier Supplier to be called possibly immediately (if DEBUG is enabled),
-     *                        or later if the task failed. Either way, it will only be called once.
-     */
-    void logOnFailure(Logger logger, Supplier<String> messageSupplier);
+    void recordSystemModification(Logger logger, String description);
 
     /**
      * Execute a task as a child of this task, and with its own sub-TaskContext. Please  avoid

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/TestTaskContext.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/TestTaskContext.java
@@ -4,29 +4,22 @@ package com.yahoo.vespa.hosted.node.admin.component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 public class TestTaskContext implements TaskContext {
-    private final List<String> systemModifications = new ArrayList<>();
+    private final List<String> logs = new ArrayList<>();
 
     @Override
     public void recordSystemModification(Logger logger, String description) {
-        systemModifications.add(description);
+        logs.add(description);
     }
 
-    @Override
-    public void log(Logger logger, String message) { }
-
-    @Override
-    public void logOnFailure(Logger logger, Supplier<String> messageSupplier) { }
-
     public List<String> getSystemModificationLog() {
-        return systemModifications;
+        return logs;
     }
 
     public void clearSystemModificationLog() {
-        systemModifications.clear();
+        logs.clear();
     }
 
     @Override


### PR DESCRIPTION
Reverts vespa-engine/vespa#4952

Broke compilation:

TaskContextImpl is not abstract and does not override abstract method logOnFailure