### PR TITLE
Use only standard gdb to avoid pulling in devtoolset as a runtime dep…

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -99,7 +99,6 @@ Requires: gdb
 Requires: net-tools
 %if 0%{?centos}
 Requires: llvm3.9
-Requires: devtoolset-7-gdb
 Requires: vespa-boost >= 1.59.0-6
 %define _extra_link_directory /usr/lib64/llvm3.9/lib;/opt/vespa-boost/lib;/opt/vespa-cppunit/lib
 %define _extra_include_directory /usr/include/llvm3.9;/opt/vespa-boost/include;/opt/vespa-cppunit/include


### PR DESCRIPTION
…endency.

FYI, @zoyvind
