### PR TITLE
Use shutdownNow()

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/certificate/ConfigServerKeyStoreRefresher.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/certificate/ConfigServerKeyStoreRefresher.java
@@ -90,7 +90,7 @@ public class ConfigServerKeyStoreRefresher {
     }
 
     public void stop() {
-        executor.shutdown();
+        executor.shutdownNow();
         do {
             try {
                 executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
`shutdownNow()`:
```
Attempts to stop all actively executing tasks, halts the
processing of waiting tasks, and returns a list of the tasks
that were awaiting execution.
```

`shutdown()`:
```
Initiates an orderly shutdown in which previously submitted
tasks are executed, but no new tasks will be accepted.
Invocation has no additional effect if already shut down.
```

Because the task submitted is to refresh the certificate when when it is passed 1/3 of lifetime (10 days), the pending task will on average be in 5 days...