### PR TITLE
Allow override of VESPA_USER in generated default-env.txt.

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -81,6 +81,11 @@ else()
 set (VESPA_BOOST_LIB_SUFFIX "-mt-d")
 endif()
 
+if(VESPA_USER)
+else()
+  set(VESPA_USER "vespa")
+endif()
+
 if(EXTRA_INCLUDE_DIRECTORY)
     include_directories(SYSTEM ${EXTRA_INCLUDE_DIRECTORY})
 endif()

--- a/vespabase/conf/default-env.txt.in
+++ b/vespabase/conf/default-env.txt.in
@@ -1,3 +1,3 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 fallback VESPA_HOME @CMAKE_INSTALL_PREFIX@
-override VESPA_USER vespa
+override VESPA_USER @VESPA_USER@


### PR DESCRIPTION
@aressem, @arnej27959: please review
