### PR TITLE
Set Environment resolver defaults

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/Environment.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/Environment.java
@@ -336,11 +336,14 @@ public class Environment {
         }
 
         public Environment build() {
-            return new Environment(configServerURIs, environment, region, parentHostHostname, inetAddressResolver,
-                                   pathResolver, logstashNodes, feedEndpoint,
-                                   Optional.ofNullable(keyStoreOptions), Optional.ofNullable(trustStoreOptions),
-                                   Optional.ofNullable(athenzIdentity),
-                                   nodeType);
+            return new Environment(configServerURIs, environment, region, parentHostHostname,
+                    Optional.ofNullable(inetAddressResolver).orElseGet(InetAddressResolver::new),
+                    Optional.ofNullable(pathResolver).orElseGet(PathResolver::new),
+                    logstashNodes, feedEndpoint,
+                    Optional.ofNullable(keyStoreOptions),
+                    Optional.ofNullable(trustStoreOptions),
+                    Optional.ofNullable(athenzIdentity),
+                    nodeType);
         }
     }
 }


### PR DESCRIPTION
Creates a new instance of `InetAddressResolver` and `PathResolver` if one wasn't specified to the `Environment.Builder`.