### PR TITLE
Reduce number of test iterations from 10k to 100.

### DIFF
--- a/application/src/test/java/com/yahoo/application/container/JDiscContainerProcessingTest.java
+++ b/application/src/test/java/com/yahoo/application/container/JDiscContainerProcessingTest.java
@@ -8,7 +8,6 @@ import com.yahoo.container.Container;
 import com.yahoo.processing.Request;
 import com.yahoo.processing.Response;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -63,7 +62,7 @@ public class JDiscContainerProcessingTest {
         }
 
         try (JDisc container = getContainerWithRot13()) {
-            final int NUM_TIMES = 10000;
+            final int NUM_TIMES = 100;
             for (int i = 0; i < NUM_TIMES; i++) {
 
 


### PR DESCRIPTION
This test took 10-15 seconds to run on my mac. I assume that all those iterations were done to verify that some instability was removed at one point in time.

FYI: @baldersheim or @bratseth, maybe you have some historical context.