### PR TITLE
Authorize parentHost filter

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/Authorizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/Authorizer.java
@@ -87,7 +87,8 @@ public class Authorizer implements BiPredicate<Principal, URI> {
     private static List<String> hostnamesFrom(URI uri) {
         return URLEncodedUtils.parse(uri, StandardCharsets.UTF_8.name())
                               .stream()
-                              .filter(pair -> "hostname".equals(pair.getName()))
+                              .filter(pair -> "hostname".equals(pair.getName()) ||
+                                              "parentHost".equals(pair.getName()))
                               .map(NameValuePair::getValue)
                               .filter(hostname -> !hostname.isEmpty())
                               .collect(Collectors.toList());
@@ -102,7 +103,8 @@ public class Authorizer implements BiPredicate<Principal, URI> {
 
     /** Returns whether given path supports filtering through query parameters */
     private static boolean supportsFiltering(URI uri) {
-        return isChildOf("/nodes/v2/command/", uri.getPath());
+        return isChildOf("/nodes/v2/command/", uri.getPath()) ||
+               "/nodes/v2/node/".equals(uri.getPath());
     }
 
     /** Returns whether child is a sub-path of parent */

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
@@ -42,6 +42,7 @@ public class AuthorizerTest {
         assertFalse(authorized("node1", "/nodes/v2/state/dirty/"));
         assertFalse(authorized("node1", "/nodes/v2/state/dirty/node2"));
         assertFalse(authorized("node1", "/nodes/v2/acl/node2"));
+        assertFalse(authorized("node1", "/nodes/v2/node/?parentHost=node2"));
         // Node resource always takes precedence over filter
         assertFalse(authorized("node1", "/nodes/v2/acl/node2?hostname=node1"));
         assertFalse(authorized("node1", "/nodes/v2/command/reboot/"));
@@ -51,6 +52,7 @@ public class AuthorizerTest {
         assertTrue(authorized("node1", "/nodes/v2/state/dirty/node1"));
         assertTrue(authorized("node1", "/nodes/v2/acl/node1"));
         assertTrue(authorized("node1", "/nodes/v2/command/reboot?hostname=node1"));
+        assertTrue(authorized("node1", "/nodes/v2/node/?parentHost=node1"));
 
         // Host node can access itself and its children
         assertFalse(authorized("dockerhost1.yahoo.com", "/nodes/v2/node/host5.yahoo.com"));


### PR DESCRIPTION
Docker hosts call /nodes/v2/node/?parentHost=_own hostname_.