### PR TITLE
Avoid Slobrok in node-admin cluster

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -12,6 +12,7 @@ import com.yahoo.config.model.provision.Host;
 import com.yahoo.config.model.provision.Hosts;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.model.provision.SingleNodeProvisioner;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
@@ -43,6 +44,7 @@ public class VespaModelTester {
 
     private boolean hosted = true;
     private Map<String, Collection<Host>> hostsByFlavor = new HashMap<>();
+    private ApplicationId applicationId = ApplicationId.defaultId();
 
     public VespaModelTester() {
         this(new NullConfigModelRegistry());
@@ -84,6 +86,11 @@ public class VespaModelTester {
     /** Sets whether this sets up a model for a hosted system. Default: true */
     public void setHosted(boolean hosted) { this.hosted = hosted; }
 
+    /** Sets the tenant, application name, and instance name of the model being built. */
+    public void setApplicationId(String tenant, String applicationName, String instanceName) {
+        applicationId = ApplicationId.from(tenant, applicationName, instanceName);
+    }
+
     /** Creates a model which uses 0 as start index and fails on out of capacity */
     public VespaModel createModel(String services, String ... retiredHostNames) {
         return createModel(services, true, retiredHostNames);
@@ -108,11 +115,16 @@ public class VespaModelTester {
                                       new InMemoryProvisioner(hostsByFlavor, failOnOutOfCapacity, startIndexForClusters, retiredHostNames) :
                                       new SingleNodeProvisioner();
 
+        DeployProperties properties = new DeployProperties.Builder()
+                .hostedVespa(hosted)
+                .applicationId(applicationId)
+                .build();
+
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(appPkg)
                 .modelHostProvisioner(provisioner)
-                .properties((new DeployProperties.Builder()).hostedVespa(hosted).build()).build(true);
+                .properties(properties)
+                .build(true);
         return modelCreatorWithMockPkg.create(false, deployState, configModelRegistry);
     }
-
 }


### PR DESCRIPTION
When this rolls out, two Slobroks on the node-admin will be removed, and 1
additional Slobrok will be put on one of the proxy nodes if the routing cluster
has 3 or more nodes.

The Orchestrator sees the latest model, i.e. expect 3 Slobroks on the proxy
nodes. Since the 1 additional Slobrok service is down at the start of the
rollout, only that host will be allowed to suspend among the 3. But if that 1
additional Slobrok service comes up quickly, then any of the 3 can suspend. I
think this will just work - no deadlocks or similar.

I couldn't find any test that would covers this code change, but will write
tests if someone can help me with this, if deemed necessary.