### PR TITLE
Don't use semi-unbound task limit for summary executor when visibility

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -168,7 +168,7 @@ DocumentDB::DocumentDB(const vespalib::string &baseDir,
     fastos::TimeStamp visibilityDelay = loaded_config->getMaintenanceConfigSP()->getVisibilityDelay();
     _visibility.setVisibilityDelay(visibilityDelay);
     if (_visibility.getVisibilityDelay() > 0) {
-        _writeService.setTaskLimit(_writeServiceConfig.semiUnboundTaskLimit());
+        _writeService.setTaskLimit(_writeServiceConfig.semiUnboundTaskLimit(), _writeServiceConfig.defaultTaskLimit());
     }
 }
 
@@ -413,9 +413,9 @@ DocumentDB::applyConfig(DocumentDBConfig::SP configSnapshot, SerialNum serialNum
         _visibility.setVisibilityDelay(visibilityDelay);
     }
     if (_visibility.getVisibilityDelay() > 0) {
-        _writeService.setTaskLimit(_writeServiceConfig.semiUnboundTaskLimit());
+        _writeService.setTaskLimit(_writeServiceConfig.semiUnboundTaskLimit(), _writeServiceConfig.defaultTaskLimit());
     } else {
-        _writeService.setTaskLimit(_writeServiceConfig.defaultTaskLimit());
+        _writeService.setTaskLimit(_writeServiceConfig.defaultTaskLimit(), _writeServiceConfig.defaultTaskLimit());
     }
     if (params.shouldSubDbsChange() || hasVisibilityDelayChanged) {
         applySubDBConfig(*configSnapshot, serialNum, params);

--- a/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.cpp
@@ -59,19 +59,13 @@ ExecutorThreadingService::shutdown()
 }
 
 void
-ExecutorThreadingService::setTaskLimit(uint32_t taskLimit)
+ExecutorThreadingService::setTaskLimit(uint32_t taskLimit, uint32_t summaryTaskLimit)
 {
     _indexExecutor.setTaskLimit(taskLimit);
-    _summaryExecutor.setTaskLimit(taskLimit);
+    _summaryExecutor.setTaskLimit(summaryTaskLimit);
     _indexFieldInverter.setTaskLimit(taskLimit);
     _indexFieldWriter.setTaskLimit(taskLimit);
     _attributeFieldWriter.setTaskLimit(taskLimit);
-}
-
-void
-ExecutorThreadingService::setUnboundTaskLimit()
-{
-    setTaskLimit(std::numeric_limits<uint32_t>::max());
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.h
+++ b/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.h
@@ -45,9 +45,7 @@ public:
 
     void shutdown();
 
-    void setTaskLimit(uint32_t taskLimit);
-
-    void setUnboundTaskLimit();
+    void setTaskLimit(uint32_t taskLimit, uint32_t summaryTaskLimit);
 
     // Expose the underlying executors for stats fetching and testing.
     vespalib::ThreadStackExecutorBase &getMasterExecutor() {


### PR DESCRIPTION
delay is nonzero.

@baldersheim: please review
