### PR TITLE
Cache Athenz certificate to disk. Prefer disk on load.

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/CertificateExpiryMetricUpdater.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/CertificateExpiryMetricUpdater.java
@@ -59,7 +59,7 @@ public class CertificateExpiryMetricUpdater extends AbstractComponent {
         Instant now = Instant.now();
 
         try {
-            Duration keyStoreExpiry = Duration.between(now, keyStoreConfigurator.getKeyStoreExpiry());
+            Duration keyStoreExpiry = Duration.between(now, keyStoreConfigurator.getCertificateExpiry());
             metric.set(ATHENZ_CONFIGSERVER_CERT_METRIC_NAME, keyStoreExpiry.getSeconds(), null);
         } catch (KeyStoreException e) {
             logger.log(Level.WARNING, "Failed to update key store expiry metric", e);

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/impl/AthenzCertificateClient.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/impl/AthenzCertificateClient.java
@@ -29,7 +29,7 @@ public class AthenzCertificateClient {
         this.zoneConfig = zoneConfig;
     }
 
-    public X509Certificate updateCertificate(PrivateKey privateKey, TemporalAmount expiryTime) {
+    public X509Certificate updateCertificate(PrivateKey privateKey) {
         SimpleServiceIdentityProvider identityProvider = new SimpleServiceIdentityProvider(
                 authority, zoneConfig.domain(), zoneConfig.serviceName(),
                 privateKey, Integer.toString(zoneConfig.secretVersion()), TimeUnit.MINUTES.toSeconds(10));
@@ -38,7 +38,7 @@ public class AthenzCertificateClient {
         InstanceRefreshRequest req =
                 ZTSClient.generateInstanceRefreshRequest(
                         zoneConfig.domain(), zoneConfig.serviceName(), privateKey,
-                        config.certDnsSuffix(), (int)expiryTime.get(ChronoUnit.SECONDS));
+                        config.certDnsSuffix(), /*expiryTime*/0);
         String pemEncoded = ztsClient.postInstanceRefreshRequest(zoneConfig.domain(), zoneConfig.serviceName(), req)
                 .getCertificate();
         return Crypto.loadX509Certificate(pemEncoded);

--- a/athenz-identity-provider-service/src/main/resources/configdefinitions/athenz-provider-service.def
+++ b/athenz-identity-provider-service/src/main/resources/configdefinitions/athenz-provider-service.def
@@ -24,3 +24,6 @@ certDnsSuffix                             string
 
 # Path to Athenz CA JKS trust store
 athenzCaTrustStore                        string
+
+# Period between certificate updates
+updatePeriodDays                          int  default=1


### PR DESCRIPTION
Do not include expiry to Athenz request as they are default 30 days
anyways.