### PR TITLE
Don't change VIP status when creating a new ClusterSearcher

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -591,11 +591,7 @@ public class ClusterSearcher extends Searcher {
 
     @Override
     public void deconstruct() {
-        try {
-            monitor.shutdown();
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        monitor.shutdown();
     }
 
     ExecutorService getExecutor() {

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/NodeMonitor.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/NodeMonitor.java
@@ -52,7 +52,7 @@ public class NodeMonitor {
     }
 
     // Whether or not dispatch has ever responded successfully
-    private boolean atStartUp = true;
+    private boolean statusIsKnown = false;
 
     public VespaBackEndSearcher getNode() {
         return node;
@@ -88,23 +88,26 @@ public class NodeMonitor {
         this.searchNodesOnline = searchNodesOnline;
         if (! isWorking)
             setWorking(true, "Responds correctly");
-        atStartUp = false;
+        statusIsKnown = true;
     }
 
     /** Changes the state of this node if required */
     private void setWorking(boolean working, String explanation) {
         if (isWorking == working) return; // Old news
 
-        if (working && ! atStartUp)
-            log.info("Putting " + node + " in service: " + explanation);
-        else if (! atStartUp)
-            log.info("Taking " + node + " out of service: " + explanation);
+        if (statusIsKnown) {
+            if (working)
+                log.info("Putting " + node + " in service: " + explanation);
+            else
+                log.info("Taking " + node + " out of service: " + explanation);
+        }
 
         isWorking = working;
     }
 
-    boolean searchNodesOnline() {
-        return searchNodesOnline;
-    }
+    boolean searchNodesOnline() { return searchNodesOnline; }
+
+    /** Returns true if we have had enough time to determine the status of this node since creating the monitor */
+    boolean statusIsKnown() { return statusIsKnown; }
 
 }


### PR DESCRIPTION
This should fix the problem where a container cluster briefly goes offline
when changing flavor of the cluster.
This change leads to a new Clustersearcher instance being constructed.
This instance will start issuing ping requests to all downstream nodes.
If the first response is form a failing node - which may happen here
because the newly added nodes (with new flavor) are not online yet,
the cluster monitor will conclude that no nodes are up and take itself
offline.

This PR defers any decision-making about VIP status until
we have status information from all nodes in the cluster.