### PR TITLE
Revert "Rewrite server TLS init to use bootstrap identity and allow AWS"

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzSslKeyStoreConfigurator.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/AthenzSslKeyStoreConfigurator.java
@@ -5,7 +5,6 @@ import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.config.provision.Zone;
-import com.yahoo.container.jdisc.athenz.AthenzIdentityProvider;
 import com.yahoo.jdisc.http.ssl.SslKeyStoreConfigurator;
 import com.yahoo.jdisc.http.ssl.SslKeyStoreContext;
 import com.yahoo.log.LogLevel;
@@ -58,14 +57,13 @@ public class AthenzSslKeyStoreConfigurator extends AbstractComponent implements 
     private volatile KeyStore currentKeyStore;
 
     @Inject
-    public AthenzSslKeyStoreConfigurator(AthenzIdentityProvider bootstrapIdentity,
-                                         KeyProvider keyProvider,
+    public AthenzSslKeyStoreConfigurator(KeyProvider keyProvider,
                                          AthenzProviderServiceConfig config,
                                          Zone zone,
                                          ConfigserverConfig configserverConfig) {
         AthenzProviderServiceConfig.Zones zoneConfig = getZoneConfig(config, zone);
         Path keystoreCachePath = createKeystoreCachePath(configserverConfig);
-        AthenzCertificateClient certificateClient = new AthenzCertificateClient(bootstrapIdentity, config, zoneConfig);
+        AthenzCertificateClient certificateClient = new AthenzCertificateClient(config, zoneConfig);
         Duration updatePeriod = Duration.ofDays(config.updatePeriodDays());
         this.certificateClient = certificateClient;
         this.keyProvider = keyProvider;

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGenerator.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGenerator.java
@@ -38,7 +38,7 @@ public class IdentityDocumentGenerator {
         this.nodeRepository = nodeRepository;
         this.zone = zone;
         this.keyProvider = keyProvider;
-        this.dnsSuffix = zoneConfig.certDnsSuffix();
+        this.dnsSuffix = config.certDnsSuffix();
         this.providerService = zoneConfig.serviceName();
         this.ztsUrl = config.ztsUrl();
         this.providerDomain = zoneConfig.domain();

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/impl/AthenzCertificateClient.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/impl/AthenzCertificateClient.java
@@ -1,15 +1,18 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.impl;
 
+import com.yahoo.athenz.auth.impl.PrincipalAuthority;
+import com.yahoo.athenz.auth.impl.SimpleServiceIdentityProvider;
 import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.athenz.zts.InstanceRefreshRequest;
 import com.yahoo.athenz.zts.ZTSClient;
-import com.yahoo.container.jdisc.athenz.AthenzIdentityProvider;
 import com.yahoo.vespa.hosted.athenz.instanceproviderservice.config.AthenzProviderServiceConfig;
 
-import javax.net.ssl.SSLContext;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author bjorncs
@@ -17,27 +20,41 @@ import java.security.cert.X509Certificate;
 public class AthenzCertificateClient {
 
     private final AthenzProviderServiceConfig config;
+    private final AthenzPrincipalAuthority authority;
     private final AthenzProviderServiceConfig.Zones zoneConfig;
-    private final AthenzIdentityProvider bootstrapIdentity;
 
-    public AthenzCertificateClient(AthenzIdentityProvider bootstrapIdentity,
-                                   AthenzProviderServiceConfig config,
-                                   AthenzProviderServiceConfig.Zones zoneConfig) {
-        this.bootstrapIdentity = bootstrapIdentity;
+    public AthenzCertificateClient(AthenzProviderServiceConfig config, AthenzProviderServiceConfig.Zones zoneConfig) {
         this.config = config;
+        this.authority = new AthenzPrincipalAuthority(config.athenzPrincipalHeaderName());
         this.zoneConfig = zoneConfig;
     }
 
     public X509Certificate updateCertificate(PrivateKey privateKey) {
-        SSLContext bootstrapSslContext = bootstrapIdentity.getIdentitySslContext();
-        ZTSClient ztsClient = new ZTSClient(config.ztsUrl(), bootstrapSslContext);
+        SimpleServiceIdentityProvider identityProvider = new SimpleServiceIdentityProvider(
+                authority, zoneConfig.domain(), zoneConfig.serviceName(),
+                privateKey, Integer.toString(zoneConfig.secretVersion()), TimeUnit.MINUTES.toSeconds(10));
+        ZTSClient ztsClient = new ZTSClient(
+                config.ztsUrl(), zoneConfig.domain(), zoneConfig.serviceName(), identityProvider);
         InstanceRefreshRequest req =
                 ZTSClient.generateInstanceRefreshRequest(
-                        zoneConfig.domain(), zoneConfig.serviceName(), privateKey, zoneConfig.certDnsSuffix(), /*expiryTime*/0);
-        req.setKeyId(Integer.toString(zoneConfig.secretVersion()));
+                        zoneConfig.domain(), zoneConfig.serviceName(), privateKey,
+                        config.certDnsSuffix(), /*expiryTime*/0);
         String pemEncoded = ztsClient.postInstanceRefreshRequest(zoneConfig.domain(), zoneConfig.serviceName(), req)
                 .getCertificate();
         return Crypto.loadX509Certificate(pemEncoded);
+    }
+
+    private static class AthenzPrincipalAuthority extends PrincipalAuthority {
+        private final String headerName;
+
+        public AthenzPrincipalAuthority(String headerName) {
+            this.headerName = headerName;
+        }
+
+        @Override
+        public String getHeader() {
+            return headerName;
+        }
     }
 
 }

--- a/athenz-identity-provider-service/src/main/resources/configdefinitions/athenz-provider-service.def
+++ b/athenz-identity-provider-service/src/main/resources/configdefinitions/athenz-provider-service.def
@@ -13,11 +13,14 @@ zones{}.secretName                        string
 # Secret version
 zones{}.secretVersion                     int
 
-# Certificate DNS suffix
-zones{}.certDnsSuffix                     string
+# Athenz principal authority header name
+athenzPrincipalHeaderName                 string        default="Athenz-Principal-Auth"
 
 # Athenz ZTS server url
 ztsUrl                                    string
+
+# Certificate DNS suffix
+certDnsSuffix                             string
 
 # Path to Athenz CA JKS trust store
 athenzCaTrustStore                        string

--- a/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/TestUtils.java
+++ b/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/TestUtils.java
@@ -19,12 +19,13 @@ public class TestUtils {
                         .serviceName(service)
                         .secretVersion(0)
                         .domain(domain)
-                        .certDnsSuffix(dnsSuffix)
                         .secretName("s3cr3t");
         return new AthenzProviderServiceConfig(
                 new AthenzProviderServiceConfig.Builder()
                         .zones(ImmutableMap.of(zone.environment().value() + "." + zone.region().value(), zoneConfig))
+                        .certDnsSuffix(dnsSuffix)
                         .ztsUrl("localhost/zts")
+                        .athenzPrincipalHeaderName("Athenz-Principal-Auth")
                         .athenzCaTrustStore("/dummy/path/to/athenz-ca.jks"));
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#5195

May have broken the integration tests.
