### PR TITLE
Revert npt subnet change

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -42,7 +42,7 @@ public class DockerOperationsImpl implements DockerOperations {
 
     private static final String MANAGER_NAME = "node-admin";
 
-    private static final String LOCAL_IPV6_PREFIX = "fd01::";
+    private static final String LOCAL_IPV6_PREFIX = "fd00::";
     private static final String DOCKER_CUSTOM_BRIDGE_NETWORK_NAME = "vespa-bridge";
     
     private final Docker docker;


### PR DESCRIPTION
Looks like we hit a docker bug. For now keep IPv6 default NPTed and IPv4 default NATed