### PR TITLE
Collect executor stats once per metrics update and pass the info to both

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -34,6 +34,7 @@ vespa_add_library(searchcore_server STATIC
     documentsubdbcollection.cpp
     emptysearchview.cpp
     executor_thread_service.cpp
+    executor_threading_service_stats.cpp
     executorthreadingservice.cpp
     fast_access_doc_subdb.cpp
     fast_access_doc_subdb_configurer.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -43,6 +43,7 @@ namespace proton {
 class IDocumentDBOwner;
 class MetricsWireService;
 class StatusReport;
+class ExecutorThreadingServiceStats;
 
 namespace matching { class SessionManager; }
 
@@ -198,8 +199,8 @@ private:
     virtual void notifyClusterStateChanged(const IBucketStateCalculator::SP &newCalc) override;
     void notifyAllBucketsChanged();
 
-    void updateLegacyMetrics(LegacyDocumentDBMetrics &metrics);
-    void updateMetrics(DocumentDBTaggedMetrics &metrics);
+    void updateLegacyMetrics(LegacyDocumentDBMetrics &metrics, const ExecutorThreadingServiceStats &threadingServiceStats);
+    void updateMetrics(DocumentDBTaggedMetrics &metrics, const ExecutorThreadingServiceStats &threadingServiceStats);
     void updateMetrics(DocumentDBTaggedMetrics::AttributeMetrics &metrics);
 
     /*

--- a/searchcore/src/vespa/searchcore/proton/server/executor_threading_service_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/executor_threading_service_stats.cpp
@@ -1,0 +1,25 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "executor_threading_service_stats.h"
+
+namespace proton {
+
+ExecutorThreadingServiceStats::ExecutorThreadingServiceStats(Stats masterExecutorStats,
+                                                             Stats indexExecutorStats,
+                                                             Stats summaryExecutorStats,
+                                                             Stats indexFieldInverterExecutorStats,
+                                                             Stats indexFieldWriterExecutorStats,
+                                                             Stats attributeFieldWriterExecutorStats)
+    : _masterExecutorStats(masterExecutorStats),
+      _indexExecutorStats(indexExecutorStats),
+      _summaryExecutorStats(summaryExecutorStats),
+      _indexFieldInverterExecutorStats(indexFieldInverterExecutorStats),
+      _indexFieldWriterExecutorStats(indexFieldWriterExecutorStats),
+      _attributeFieldWriterExecutorStats(attributeFieldWriterExecutorStats)
+{
+}
+
+ExecutorThreadingServiceStats::~ExecutorThreadingServiceStats() = default;
+
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/executor_threading_service_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/server/executor_threading_service_stats.h
@@ -1,0 +1,36 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/util/threadstackexecutorbase.h>
+
+namespace proton {
+
+class ExecutorThreadingServiceStats {
+public:
+    using Stats = vespalib::ThreadStackExecutorBase::Stats;
+
+private:
+    Stats _masterExecutorStats;
+    Stats _indexExecutorStats;
+    Stats _summaryExecutorStats;
+    Stats _indexFieldInverterExecutorStats;
+    Stats _indexFieldWriterExecutorStats;
+    Stats _attributeFieldWriterExecutorStats;
+public:
+    ExecutorThreadingServiceStats(Stats masterExecutorStats,
+                                  Stats indexExecutorStats,
+                                  Stats summaryExecutorStats,
+                                  Stats indexFieldInverterExecutorStats,
+                                  Stats indexFieldWriterExecutorStats,
+                                  Stats attributeFieldWriterExecutorStats);
+    ~ExecutorThreadingServiceStats();
+
+    const Stats &getMasterExecutorStats() const { return _masterExecutorStats; }
+    const Stats &getIndexExecutorStats() const { return _indexExecutorStats; }
+    const Stats &getSummaryExecutorStats() const { return _summaryExecutorStats; }
+    const Stats &getIndexFieldInverterExecutorStats() const { return _indexFieldInverterExecutorStats; }
+    const Stats &getIndexFieldWriterExecutorStats() const { return _indexFieldWriterExecutorStats; }
+    const Stats &getAttributeFieldWriterExecutorStats() const { return _attributeFieldWriterExecutorStats; }
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/executor_threading_service_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/server/executor_threading_service_stats.h
@@ -1,13 +1,18 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespa/vespalib/util/threadstackexecutorbase.h>
+#include <cstddef>
+#include <vespa/vespalib/util/executor_stats.h>
 
 namespace proton {
 
+/*
+ * This class contains executor stats for the executors used by a
+ * document db.
+ */
 class ExecutorThreadingServiceStats {
 public:
-    using Stats = vespalib::ThreadStackExecutorBase::Stats;
+    using Stats = vespalib::ExecutorStats;
 
 private:
     Stats _masterExecutorStats;

--- a/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.cpp
@@ -2,6 +2,7 @@
 
 #include "executorthreadingservice.h"
 #include <vespa/vespalib/util/executor.h>
+#include "executor_threading_service_stats.h"
 
 using vespalib::ThreadStackExecutorBase;
 
@@ -66,6 +67,17 @@ ExecutorThreadingService::setTaskLimit(uint32_t taskLimit, uint32_t summaryTaskL
     _indexFieldInverter.setTaskLimit(taskLimit);
     _indexFieldWriter.setTaskLimit(taskLimit);
     _attributeFieldWriter.setTaskLimit(taskLimit);
+}
+
+ExecutorThreadingServiceStats
+ExecutorThreadingService::getStats()
+{
+    return ExecutorThreadingServiceStats(_masterExecutor.getStats(),
+                                         _indexExecutor.getStats(),
+                                         _summaryExecutor.getStats(),
+                                         _indexFieldInverter.getStats(),
+                                         _indexFieldWriter.getStats(),
+                                         _attributeFieldWriter.getStats());
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.h
+++ b/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.h
@@ -9,6 +9,8 @@
 
 namespace proton {
 
+class ExecutorThreadingServiceStats;
+
 /**
  * Implementation of IThreadingService using 2 underlying thread stack executors
  * with 1 thread each.
@@ -83,6 +85,8 @@ public:
     virtual search::ISequencedTaskExecutor &attributeFieldWriter() override {
         return _attributeFieldWriter;
     }
+
+    ExecutorThreadingServiceStats getStats();
 };
 
 } // namespace proton

--- a/searchlib/src/vespa/searchlib/common/sequencedtaskexecutor.cpp
+++ b/searchlib/src/vespa/searchlib/common/sequencedtaskexecutor.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "sequencedtaskexecutor.h"
+#include <vespa/vespalib/util/blockingthreadstackexecutor.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 
 using vespalib::BlockingThreadStackExecutor;
@@ -67,5 +68,17 @@ SequencedTaskExecutor::sync()
     }
 }
 
+SequencedTaskExecutor::Stats
+SequencedTaskExecutor::getStats()
+{
+    Stats accumulatedStats;
+    for (auto &executor : _executors) {
+        Stats stats = executor->getStats();
+        accumulatedStats.maxPendingTasks += stats.maxPendingTasks;
+        accumulatedStats.acceptedTasks += stats.acceptedTasks;
+        accumulatedStats.rejectedTasks += stats.rejectedTasks;
+    }
+    return accumulatedStats;
+}
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/common/sequencedtaskexecutor.h
+++ b/searchlib/src/vespa/searchlib/common/sequencedtaskexecutor.h
@@ -3,12 +3,13 @@
 
 #include "isequencedtaskexecutor.h"
 #include <vespa/vespalib/stllike/hash_map.h>
-#include <vespa/vespalib/util/blockingthreadstackexecutor.h>
+#include <vector>
 
 namespace vespalib
 {
 
-class ThreadStackExecutorBase;
+class ExecutorStats;
+class BlockingThreadStackExecutor;
 
 }
 
@@ -21,6 +22,7 @@ namespace search
  */
 class SequencedTaskExecutor : public ISequencedTaskExecutor
 {
+    using Stats = vespalib::ExecutorStats;
     std::vector<std::shared_ptr<vespalib::BlockingThreadStackExecutor>> _executors;
     vespalib::hash_map<size_t, size_t> _ids;
 public:
@@ -37,6 +39,8 @@ public:
     virtual void executeTask(uint32_t executorId, vespalib::Executor::Task::UP task) override;
 
     virtual void sync() override;
+
+    Stats getStats();
 };
 
 } // namespace search

--- a/vespalib/src/vespa/vespalib/util/executor_stats.h
+++ b/vespalib/src/vespa/vespalib/util/executor_stats.h
@@ -1,0 +1,18 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace vespalib {
+
+/**
+ * Struct representing stats for an executor.
+ **/
+struct ExecutorStats {
+    size_t maxPendingTasks;
+    size_t acceptedTasks;
+    size_t rejectedTasks;
+    ExecutorStats() : maxPendingTasks(0), acceptedTasks(0), rejectedTasks(0) {}
+};
+
+}
+

--- a/vespalib/src/vespa/vespalib/util/threadstackexecutorbase.h
+++ b/vespalib/src/vespa/vespalib/util/threadstackexecutorbase.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 #include <functional>
+#include "executor_stats.h"
 
 class FastOS_ThreadPool;
 
@@ -39,12 +40,7 @@ public:
      * Internal stats that we want to observe externally. Note that
      * all stats are reset each time they are observed.
      **/
-    struct Stats {
-        size_t maxPendingTasks;
-        size_t acceptedTasks;
-        size_t rejectedTasks;
-        Stats() : maxPendingTasks(0), acceptedTasks(0), rejectedTasks(0) {}
-    };
+    using Stats = ExecutorStats;
 
     using init_fun_t = std::function<int(Runnable&)>;
 


### PR DESCRIPTION
metrics update method for document db legacy metrics and to metrics update
method for tagged document db metrics.

@geirst, @baldersheim: please review
