### PR TITLE
Make sure to remove from download queue if download fails, else

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -50,6 +50,8 @@ public class FileDownloader {
         try {
             return getFutureFile(fileReference).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.log(LogLevel.INFO, "Failed downloading file, removing from download queue");
+            fileReferenceDownloader.failedDownloading(fileReference);
             return Optional.empty();
         }
     }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -100,6 +100,13 @@ public class FileReferenceDownloader {
         }
     }
 
+    void failedDownloading(FileReference fileReference) {
+        synchronized (downloads) {
+            downloadStatus.put(fileReference, 0.0);
+            downloads.remove(fileReference);
+        }
+    }
+
     private boolean startDownloadRpc(FileReference fileReference) {
         Connection connection = connectionPool.getCurrent();
         Request request = new Request("filedistribution.serveFile");

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -161,14 +161,14 @@ public class FileDownloaderTest {
         File fileReferenceFullPath = fileReferenceFullPath(downloadDir, fileReference);
         assertFalse(fileReferenceFullPath.getAbsolutePath(), fileDownloader.getFile(fileReference).isPresent());
 
-        // Verify download status
+        // Getting file failed, verify download status and since there was an error is not downloading ATM
         assertDownloadStatus(fileDownloader, fileReference, 0.0);
+        assertFalse(fileDownloader.fileReferenceDownloader().isDownloading(fileReference));
 
         // Receives fileReference, should return and make it available to caller
         String filename = "abc.jar";
         receiveFile(fileReference, filename, FileReferenceData.Type.file, "some other content");
         Optional<File> downloadedFile = fileDownloader.getFile(fileReference);
-
         assertTrue(downloadedFile.isPresent());
         File downloadedFileFullPath = new File(fileReferenceFullPath, filename);
         assertEquals(downloadedFileFullPath.getAbsolutePath(), downloadedFile.get().getAbsolutePath());


### PR DESCRIPTION
we will never try to download again, even if there is an external request
for the file reference again