### PR TITLE
Run containers in privileged from host-admin

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/Docker.java
@@ -27,6 +27,7 @@ public interface Docker {
         CreateContainerCommand withManagedBy(String manager);
         CreateContainerCommand withAddCapability(String capabilityName);
         CreateContainerCommand withDropCapability(String capabilityName);
+        CreateContainerCommand withPrivileged(boolean privileged);
 
         void create();
     }

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -200,7 +200,8 @@ public class DockerImpl implements Docker {
     @Override
     public CreateContainerCommand createContainerCommand(DockerImage image, ContainerResources containerResources,
                                                          ContainerName name, String hostName) {
-        return new CreateContainerCommandImpl(dockerClient, image, containerResources, name, hostName);
+        return new CreateContainerCommandImpl(dockerClient, image, containerResources, name, hostName)
+                .withPrivileged(config.runContainersInPrivileged());
     }
 
     @Override

--- a/docker-api/src/main/resources/configdefinitions/docker.def
+++ b/docker-api/src/main/resources/configdefinitions/docker.def
@@ -13,3 +13,5 @@ isRunningLocally bool default = false
 imageGCMinTimeToLiveMinutes int default = 45
 
 networkNATed bool default = false
+
+runContainersInPrivileged bool default = false

--- a/node-admin/src/main/application/services.xml
+++ b/node-admin/src/main/application/services.xml
@@ -13,6 +13,7 @@
 
     <config name="vespa.hosted.dockerapi.docker">
       <uri>unix:///var/run/docker.sock</uri>
+      <runContainersInPrivileged>true</runContainersInPrivileged>
     </config>
 
     <preprocess:include file="variant.xml" required="false"/>

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerMock.java
@@ -221,6 +221,11 @@ public class DockerMock implements Docker {
         }
 
         @Override
+        public CreateContainerCommand withPrivileged(boolean privileged) {
+            return this;
+        }
+
+        @Override
         public void create() {
 
         }


### PR DESCRIPTION
Makes so that the default `CreateContainerCommand` is initialized with `privileged=true` for `docker-api` started in `host-admin`. This is needed until we can map secondary disk device into the container.