### PR TITLE
Bratseth/tf constants in parent doc

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -330,14 +330,12 @@ public class FastSearcher extends VespaBackEndSearcher {
                 result.hits().addError(ErrorMessage.createBackendCommunicationError("Error filling hits with summary fields, source: " + getName()));
                 return;
             }
-            if (skippedHits==0 && packetWrapper != null) {
+            if (skippedHits == 0 && packetWrapper != null) {
                 cacheControl.updateCacheEntry(cacheKey, query, packetKeys, receivedPackets);
             }
 
-            if ( skippedHits>0 ) {
-                getLogger().info("Could not fill summary '" + summaryClass + "' for " + skippedHits + " hits for query: " + result.getQuery());
+            if ( skippedHits > 0 )
                 result.hits().addError(com.yahoo.search.result.ErrorMessage.createEmptyDocsums("Missing hit data for summary '" + summaryClass + "' for " + skippedHits + " hits"));
-            }
             result.analyzeHits();
 
             if (query.getTraceLevel() >= 3) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -245,7 +245,7 @@ public class Dispatcher extends AbstractComponent {
             }
 
             Inspector summaries = new SlimeAdapter(root.field("docsums"));
-            if ( ! summaries.valid() && !hasErrors)
+            if ( ! summaries.valid() && ! hasErrors)
                 throw new IllegalArgumentException("Expected a Slime root object containing a 'docsums' field");
             for (int i = 0; i < hits.size(); i++) {
                 fill(hits.get(i), summaries.entry(i).field("docsum"));

--- a/container-search/src/main/java/com/yahoo/search/federation/sourceref/SourceRefResolver.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/sourceref/SourceRefResolver.java
@@ -18,13 +18,15 @@ import com.yahoo.processing.request.Properties;
  * @author tonytv
  */
 public class SourceRefResolver {
+
     private final SearchChainResolver searchChainResolver;
 
     public SourceRefResolver(SearchChainResolver searchChainResolver) {
         this.searchChainResolver = searchChainResolver;
     }
-    public Set<SearchChainInvocationSpec> resolve(ComponentSpecification sourceRef, Properties sourceToProviderMap,
-            IndexFacts indexFacts)
+    public Set<SearchChainInvocationSpec> resolve(ComponentSpecification sourceRef,
+                                                  Properties sourceToProviderMap,
+                                                  IndexFacts indexFacts)
             throws UnresolvedSearchChainException {
 
         try {
@@ -47,7 +49,7 @@ public class SourceRefResolver {
                 clusterSearchChains.add(resolveClusterSearchChain(cluster, sourceRef, sourceToProviderMap));
             }
 
-            if (!clusterSearchChains.isEmpty())
+            if ( ! clusterSearchChains.isEmpty())
                 return clusterSearchChains;
         }
 
@@ -55,17 +57,22 @@ public class SourceRefResolver {
 
     }
 
-    private SearchChainInvocationSpec resolveClusterSearchChain(String cluster, ComponentSpecification sourceRef,
-                                                                Properties sourceToProviderMap) throws UnresolvedSearchChainException {
+    private SearchChainInvocationSpec resolveClusterSearchChain(String cluster,
+                                                                ComponentSpecification sourceRef,
+                                                                Properties sourceToProviderMap)
+            throws UnresolvedSearchChainException {
         try {
             return searchChainResolver.resolve(new ComponentSpecification(cluster), sourceToProviderMap);
-        } catch (UnresolvedSearchChainException e) {
+        }
+        catch (UnresolvedSearchChainException e) {
             throw new UnresolvedSearchChainException("Failed to resolve cluster search chain " + quote(cluster) +
-                    " when using source ref " + quote(sourceRef) + " as a document name.");
+                                                     " when using source ref " + quote(sourceRef) +
+                                                     " as a document name.");
         }
     }
 
     private boolean hasOnlyName(ComponentSpecification sourceSpec) {
         return new ComponentSpecification(sourceSpec.getName()).equals(sourceSpec);
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/search/federation/sourceref/Target.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/sourceref/Target.java
@@ -8,9 +8,10 @@ import com.yahoo.processing.request.Properties;
 /**
  * TODO: What's this?
  *
-* @author tonytv
-*/
+ * @author tonytv
+ */
 public abstract class Target extends AbstractComponent {
+
     final ComponentId localId;
     final boolean isDerived;
 
@@ -28,4 +29,5 @@ public abstract class Target extends AbstractComponent {
     public abstract String searchRefDescription();
 
     abstract void freeze();
+
 }

--- a/document/src/main/java/com/yahoo/document/annotation/AnnotationTypes.java
+++ b/document/src/main/java/com/yahoo/document/annotation/AnnotationTypes.java
@@ -10,7 +10,7 @@ import java.util.List;
  * This is a container for all {@link Annotation}s constants used by built-in Vespa features. These must be in sync with
  * the corresponding class in the C++ file 'document/datatype/annotationtype.h'.
  *
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  */
 @SuppressWarnings({ "UnusedDeclaration" })
 public final class AnnotationTypes {

--- a/document/src/main/java/com/yahoo/document/annotation/SpanTrees.java
+++ b/document/src/main/java/com/yahoo/document/annotation/SpanTrees.java
@@ -4,7 +4,7 @@ package com.yahoo.document.annotation;
 /**
  * This is a container for all {@link SpanTree}s constants used by built-in Vespa features.
  *
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  */
 @SuppressWarnings({ "UnusedDeclaration" })
 // TODO: Remove. This is the wrong place.

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/OperationMapper.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/OperationMapper.java
@@ -34,9 +34,7 @@ public class OperationMapper {
 
     public static TensorFlowOperation get(NodeDef node, List<TensorFlowOperation> inputs, int port) {
         switch (node.getOp().toLowerCase()) {
-            /*
-             * array ops
-             */
+            // array ops
             case "const":       return new Const(node, inputs, port);
             case "expanddims":  return new ExpandDims(node, inputs, port);
             case "identity":    return new Identity(node, inputs, port);
@@ -46,15 +44,11 @@ public class OperationMapper {
             case "shape":       return new Shape(node, inputs, port);
             case "squeeze":     return new Squeeze(node, inputs, port);
 
-            /*
-             * control flow
-             */
+            // control flow
             case "merge":       return new Merge(node, inputs, port);
             case "switch":      return new Switch(node, inputs, port);
 
-            /*
-             * math ops
-             */
+            // math ops
             case "add":         return new Join(node, inputs, port, ScalarFunctions.add());
             case "add_n":       return new Join(node, inputs, port, ScalarFunctions.add());
             case "acos":        return new Map(node, inputs, port, ScalarFunctions.acos());
@@ -75,27 +69,17 @@ public class OperationMapper {
             case "sub":         return new Join(node, inputs, port, ScalarFunctions.subtract());
             case "subtract":    return new Join(node, inputs, port, ScalarFunctions.subtract());
 
-            /*
-             * nn ops
-             */
+            // nn ops
             case "biasadd":     return new Join(node, inputs, port, ScalarFunctions.add());
             case "elu":         return new Map(node, inputs, port, ScalarFunctions.elu());
             case "relu":        return new Map(node, inputs, port, ScalarFunctions.relu());
             case "selu":        return new Map(node, inputs, port, ScalarFunctions.selu());
 
-            /*
-             * random ops
-             */
-
-            /*
-             * state ops
-             */
+            // state ops
             case "variable":    return new Variable(node, inputs, port);
             case "variablev2":  return new Variable(node, inputs, port);
 
-            /*
-             * evaluation no-ops
-             */
+            // evaluation no-ops
             case "stopgradient":return new Identity(node, inputs, port);
             case "noop":        return new NoOp(node, inputs, port);
         }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Const.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Const.java
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression.integration.tensorflow.importer.operations;
 
+import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.evaluation.BooleanValue;
 import com.yahoo.searchlib.rankingexpression.evaluation.DoubleValue;
 import com.yahoo.searchlib.rankingexpression.evaluation.TensorValue;
@@ -46,7 +47,7 @@ public class Const extends TensorFlowOperation {
         if (type.type().rank() == 0 && getConstantValue().isPresent()) {
             expressionNode = new ConstantNode(getConstantValue().get().asDoubleValue());
         } else {
-            expressionNode = new ReferenceNode("constant(\"" + vespaName() + "\")");
+            expressionNode = new ReferenceNode(Reference.simple("constant", vespaName()));
         }
         return new TensorFunctionNode.TensorFunctionExpressionNode(expressionNode);
     }
@@ -72,7 +73,7 @@ public class Const extends TensorFlowOperation {
     private Value value() {
         if (!node.getAttrMap().containsKey("value")) {
             throw new IllegalArgumentException("Node '" + node.getName() + "' of type " +
-                    "const has missing 'value' attribute");
+                                               "const has missing 'value' attribute");
         }
         AttrValue attrValue = node.getAttrMap().get("value");
         if (attrValue.getValueCase() == AttrValue.ValueCase.TENSOR) {

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/TensorFlowOperation.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/TensorFlowOperation.java
@@ -2,6 +2,7 @@
 package com.yahoo.searchlib.rankingexpression.integration.tensorflow.importer.operations;
 
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
+import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 import com.yahoo.searchlib.rankingexpression.integration.tensorflow.importer.DimensionRenamer;
 import com.yahoo.searchlib.rankingexpression.integration.tensorflow.importer.OrderedTensorType;
@@ -67,7 +68,7 @@ public abstract class TensorFlowOperation {
     public Optional<TensorFunction> function() {
         if (function == null) {
             if (isConstant()) {
-                ExpressionNode constant = new ReferenceNode("constant(\"" + vespaName() + "\")");
+                ExpressionNode constant = new ReferenceNode(Reference.simple("constant", vespaName()));
                 function = new TensorFunctionNode.TensorFunctionExpressionNode(constant);
             } else if (outputs.size() > 1) {
                 macro = lazyGetFunction();

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/ReferenceNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/ReferenceNode.java
@@ -5,6 +5,7 @@ import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
 import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.evaluation.Context;
+import com.yahoo.searchlib.rankingexpression.evaluation.StringValue;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
@@ -105,7 +106,8 @@ public final class ReferenceNode extends CompositeNode {
         // TODO: Context should accept a Reference instead.
         if (reference.isIdentifier())
             return context.get(reference.name());
-        return context.get(getName(), getArguments(), getOutput());
+        else
+            return context.get(getName(), getArguments(), getOutput());
     }
 
     @Override

--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -777,19 +777,8 @@ ConstantNode constantPrimitive() :
     ( <SUB> { sign = "-";} ) ?
     ( <INTEGER> { value = token.image; } |
       <FLOAT> { value = token.image; } |
-      value = stringPath() )
+      <STRING> { value = token.image; } )
     { return new ConstantNode(Value.parse(sign + value),sign + value); }
-}
-
-// Strings separated by "/"
-String stringPath() :
-{
-    StringBuilder b = new StringBuilder();
-}
-{
-    <STRING> { b.append(token.image); }
-    ( LOOKAHEAD(2) <DIV> <STRING> { b.append("/").append(token.image); } ) *
-    { return b.toString(); }
 }
 
 Value primitiveValue() :

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/ReferenceTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/ReferenceTestCase.java
@@ -1,0 +1,33 @@
+package com.yahoo.searchlib.rankingexpression;
+
+import com.yahoo.searchlib.rankingexpression.rule.Arguments;
+import com.yahoo.searchlib.rankingexpression.rule.NameNode;
+import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author bratseth
+ */
+public class ReferenceTestCase {
+
+    @Test
+    public void testSimple() {
+        assertTrue(new Reference("foo", new Arguments(new ReferenceNode("arg")), null).isSimple());
+        assertTrue(new Reference("foo", new Arguments(new ReferenceNode("arg")), "out").isSimple());
+        assertTrue(new Reference("foo", new Arguments(new NameNode("arg")), "out").isSimple());
+        assertFalse(new Reference("foo", new Arguments(), null).isSimple());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("foo(arg_1)", new Reference("foo", new Arguments(new ReferenceNode("arg_1")), null).toString());
+        assertEquals("foo(arg_1).out", new Reference("foo", new Arguments(new ReferenceNode("arg_1")), "out").toString());
+        assertEquals("foo(arg_1).out", new Reference("foo", new Arguments(new NameNode("arg_1")), "out").toString());
+        assertEquals("foo", new Reference("foo", new Arguments(), null).toString());
+    }
+
+}

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/DropoutImportTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/DropoutImportTestCase.java
@@ -32,7 +32,7 @@ public class DropoutImportTestCase {
         RankingExpression output = signature.outputExpression("y");
         assertNotNull(output);
         assertEquals("outputs/BiasAdd", output.getName());
-        assertEquals("join(reduce(join(tf_macro_X, constant(\"outputs_kernel_read\"), f(a,b)(a * b)), sum, d2), constant(\"outputs_bias_read\"), f(a,b)(a + b))",
+        assertEquals("join(reduce(join(tf_macro_X, constant(outputs_kernel_read), f(a,b)(a * b)), sum, d2), constant(outputs_bias_read), f(a,b)(a + b))",
                 output.getRoot().toString());
         model.assertEqualResult("X", output.getName());
     }

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/MnistSoftmaxImportTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/MnistSoftmaxImportTestCase.java
@@ -59,7 +59,7 @@ public class MnistSoftmaxImportTestCase {
         RankingExpression output = signature.outputExpression("y");
         assertNotNull(output);
         assertEquals("add", output.getName());
-        assertEquals("join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), constant(\"Variable_read\"), f(a,b)(a * b)), sum, d2), constant(\"Variable_1_read\"), f(a,b)(a + b))",
+        assertEquals("join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), constant(Variable_read), f(a,b)(a * b)), sum, d2), constant(Variable_1_read), f(a,b)(a + b))",
                      output.getRoot().toString());
 
         // Test execution

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TestableTensorFlowModel.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TestableTensorFlowModel.java
@@ -68,8 +68,8 @@ public class TestableTensorFlowModel {
 
     private Context contextFrom(TensorFlowModel result) {
         MapContext context = new MapContext();
-        result.largeConstants().forEach((name, tensor) -> context.put("constant(\"" + name + "\")", new TensorValue(tensor)));
-        result.smallConstants().forEach((name, tensor) -> context.put("constant(\"" + name + "\")", new TensorValue(tensor)));
+        result.largeConstants().forEach((name, tensor) -> context.put("constant(" + name + ")", new TensorValue(tensor)));
+        result.smallConstants().forEach((name, tensor) -> context.put("constant(" + name + ")", new TensorValue(tensor)));
         return context;
     }
 

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/rule/ReferenceNodeTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/rule/ReferenceNodeTestCase.java
@@ -9,7 +9,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author <a href="mailto:simon@yahoo-inc.com">Simon Thoresen</a>
+ * @author Simon Thoresen
  */
 public class ReferenceNodeTestCase {
 


### PR DESCRIPTION
@lesters please review

This is the first part of supporting reinforcement learning with TF import: If a macro is defined in the rank profile with the same name as a TF variable, the file constant will not be created and the macro will be used instead. The user can implement the macro to reference a field imported from a parent document.

The second part will be to support TF variable conversion on the command line. I plan for the user to be required to input the (vespa) type of the tensor to be converted, because:
- We need the application package and config model to figure this out automatically, and that is not nice ...
- The type is needed in the parent document definition anyway, so the user must know it.