### PR TITLE
Revert "Properly set configserver client SSL options in Environment.Builder"

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImplTest.java
@@ -9,7 +9,6 @@ import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.ProcessResult;
 import com.yahoo.vespa.hosted.node.admin.component.Environment;
-import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.IPAddressesMock;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 public class DockerOperationsImplTest {
     private final Environment environment = new Environment.Builder()
-            .configServerConfig(new ConfigServerConfig(new ConfigServerConfig.Builder()))
             .region("us-east-1")
             .environment("prod")
             .system("main")

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -6,7 +6,6 @@ import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
-import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.node.admin.maintenance.acl.AclMaintainer;
@@ -60,7 +59,6 @@ public class DockerTester implements AutoCloseable {
         }
 
         Environment environment = new Environment.Builder()
-                .configServerConfig(new ConfigServerConfig(new ConfigServerConfig.Builder()))
                 .inetAddressResolver(inetAddressResolver)
                 .region("us-east-1")
                 .environment("prod")

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/logging/FilebeatConfigProviderTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/logging/FilebeatConfigProviderTest.java
@@ -4,11 +4,9 @@ package com.yahoo.vespa.hosted.node.admin.logging;
 import com.google.common.collect.ImmutableList;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
 import com.yahoo.vespa.hosted.node.admin.component.Environment;
-import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
 import com.yahoo.vespa.hosted.provision.Node;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,6 +19,7 @@ import static org.junit.Assert.*;
  */
 public class FilebeatConfigProviderTest {
 
+
     private static final String tenant = "vespa";
     private static final String application = "music";
     private static final String instance = "default";
@@ -31,7 +30,7 @@ public class FilebeatConfigProviderTest {
 
     @Test
     public void it_replaces_all_fields_correctly() {
-        FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(getEnvironment(logstashNodes));
+        FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(getEnvironment());
 
         Optional<String> config = filebeatConfigProvider.getConfig(getNodeSpec(tenant, application, instance));
 
@@ -42,7 +41,11 @@ public class FilebeatConfigProviderTest {
 
     @Test
     public void it_does_not_generate_config_when_no_logstash_nodes() {
-        Environment env = getEnvironment(Collections.emptyList());
+        Environment env = new Environment.Builder()
+                .environment(environment)
+                .region(region)
+                .system(system)
+                .build();
 
         FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(env);
         Optional<String> config = filebeatConfigProvider.getConfig(getNodeSpec(tenant, application, instance));
@@ -51,7 +54,7 @@ public class FilebeatConfigProviderTest {
 
     @Test
     public void it_does_not_generate_config_for_nodes_wihout_owner() {
-        FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(getEnvironment(logstashNodes));
+        FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(getEnvironment());
         ContainerNodeSpec nodeSpec = new ContainerNodeSpec.Builder()
                 .nodeFlavor("flavor")
                 .nodeState(Node.State.active)
@@ -77,7 +80,12 @@ public class FilebeatConfigProviderTest {
 
     @Test
     public void it_does_not_add_double_quotes() {
-        Environment environment = getEnvironment(ImmutableList.of("unquoted", "\"quoted\""));
+        Environment environment = new Environment.Builder()
+                .environment(FilebeatConfigProviderTest.environment)
+                .region(region)
+                .system(system)
+                .logstashNodes(ImmutableList.of("unquoted", "\"quoted\""))
+                .build();
         FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(environment);
         Optional<String> config = filebeatConfigProvider.getConfig(getNodeSpec(tenant, application, instance));
         assertThat(config.get(), containsString("hosts: [\"unquoted\",\"quoted\"]"));
@@ -90,14 +98,13 @@ public class FilebeatConfigProviderTest {
     }
 
     private String getConfigString() {
-        FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(getEnvironment(logstashNodes));
+        FilebeatConfigProvider filebeatConfigProvider = new FilebeatConfigProvider(getEnvironment());
         ContainerNodeSpec nodeSpec = getNodeSpec(tenant, application, instance);
         return filebeatConfigProvider.getConfig(nodeSpec).orElseThrow(() -> new RuntimeException("Failed to get filebeat config"));
     }
 
-    private Environment getEnvironment(List<String> logstashNodes) {
+    private Environment getEnvironment() {
         return new Environment.Builder()
-                .configServerConfig(new ConfigServerConfig(new ConfigServerConfig.Builder()))
                 .environment(environment)
                 .region(region)
                 .system(system)

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -8,7 +8,6 @@ import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
-import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.component.Environment;
 import com.yahoo.vespa.hosted.node.admin.component.PathResolver;
@@ -35,7 +34,6 @@ import static org.mockito.Mockito.when;
 public class StorageMaintainerTest {
     private final ManualClock clock = new ManualClock();
     private final Environment environment = new Environment.Builder()
-            .configServerConfig(new ConfigServerConfig(new ConfigServerConfig.Builder()))
             .region("us-east-1")
             .environment("prod")
             .system("main")

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -12,7 +12,6 @@ import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.ContainerNodeSpec;
-import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
 import com.yahoo.vespa.hosted.node.admin.containerdata.ConfigServerContainerData;
 import com.yahoo.vespa.hosted.node.admin.containerdata.ContainerData;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
@@ -82,7 +81,6 @@ public class NodeAgentImplTest {
     private final PathResolver pathResolver = mock(PathResolver.class);
     private final ManualClock clock = new ManualClock();
     private final Environment environment = new Environment.Builder()
-            .configServerConfig(new ConfigServerConfig(new ConfigServerConfig.Builder()))
             .environment("dev")
             .region("us-east-1")
             .system("main")

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/util/EnvironmentTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/util/EnvironmentTest.java
@@ -5,7 +5,6 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.component.Environment;
 import com.yahoo.vespa.hosted.node.admin.component.PathResolver;
-import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -18,7 +17,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class EnvironmentTest {
     private final Environment environment = new Environment.Builder()
-            .configServerConfig(new ConfigServerConfig(new ConfigServerConfig.Builder()))
             .region("us-east-1")
             .environment("prod")
             .system("main")


### PR DESCRIPTION
Reverts vespa-engine/vespa#5238

Factory failed with:

```Tests run: 3, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.667 sec <<< FAILURE! - in com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest
converge(com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest)  Time elapsed: 0.229 sec  <<< ERROR!
java.io.UncheckedIOException: java.io.FileNotFoundException: /opt/yahoo/share/ssl/certs/yahoo_certificate_bundle.jks (No such file or directory)
	at com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest.converge(EnableDockerAdminTest.java:46)
Caused by: java.io.FileNotFoundException: /opt/yahoo/share/ssl/certs/yahoo_certificate_bundle.jks (No such file or directory)
	at com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest.converge(EnableDockerAdminTest.java:46)

keepTryingToConverge(com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest)  Time elapsed: 0.011 sec  <<< ERROR!
java.io.UncheckedIOException: java.io.FileNotFoundException: /opt/yahoo/share/ssl/certs/yahoo_certificate_bundle.jks (No such file or directory)
	at com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest.keepTryingToConverge(EnableDockerAdminTest.java:90)
Caused by: java.io.FileNotFoundException: /opt/yahoo/share/ssl/certs/yahoo_certificate_bundle.jks (No such file or directory)
	at com.yahoo.vespa.hosted.hostadmin.task.docker.EnableDockerAdminTest.keepTryingToConverge(EnableDockerAdminTest.java:90)```