### PR TITLE
Only write metrics config if container is running

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -450,7 +450,7 @@ public class NodeAgentImpl implements NodeAgent {
         if (!nodeSpec.equals(lastNodeSpec)) {
             // Every time the node spec changes, we should clear the metrics for this container as the dimensions
             // will change and we will be reporting duplicate metrics.
-            if (container.isPresent()) {
+            if (container.map(c -> c.state.isRunning()).orElse(false)) {
                 storageMaintainer.writeMetricsConfig(containerName, nodeSpec);
             }
 


### PR DESCRIPTION
`writeMetricsConfig()` also runs `service yamas-agent restart` which fails if container is stopped. Because this is retried until the command succeeds, we are stuck forever.