### PR TITLE
Add simple constraint implementation for implicit maintenance state transitions

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterInfo.java
@@ -78,15 +78,17 @@ public class ClusterInfo {
 
         // Update node set
         nodes.clear();
-        for (ConfiguredNode node : newNodes)
+        for (ConfiguredNode node : newNodes) {
             this.nodes.put(node.index(), node);
+        }
     }
 
     private void addNodeInfo(NodeInfo nodeInfo) {
-        if (nodeInfo instanceof DistributorNodeInfo)
-            distributorNodeInfo.put(nodeInfo.getNodeIndex(), (DistributorNodeInfo)nodeInfo);
-        else
-            storageNodeInfo.put(nodeInfo.getNodeIndex(), (StorageNodeInfo)nodeInfo);
+        if (nodeInfo instanceof DistributorNodeInfo) {
+            distributorNodeInfo.put(nodeInfo.getNodeIndex(), (DistributorNodeInfo) nodeInfo);
+        } else {
+            storageNodeInfo.put(nodeInfo.getNodeIndex(), (StorageNodeInfo) nodeInfo);
+        }
         allNodeInfo.put(nodeInfo.getNode(), nodeInfo);
         nodeInfo.setReportedState(nodeInfo.getReportedState().setDescription("Node not seen in slobrok."), 0);
     }
@@ -108,8 +110,9 @@ public class ClusterInfo {
      */
     public NodeInfo setRpcAddress(Node node, String rpcAddress) {
         NodeInfo nodeInfo = getInfo(node);
-        if (nodeInfo != null)
+        if (nodeInfo != null) {
             nodeInfo.setRpcAddress(rpcAddress);
+        }
         return nodeInfo;
     }
     // TODO: Do all mutation of node info through setters in this

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -824,7 +824,8 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
     }
 
     private ClusterStateDeriver createBucketSpaceStateDeriver() {
-        return new MaintenanceWhenPendingGlobalMerges(stateVersionTracker.createMergePendingChecker());
+        return new MaintenanceWhenPendingGlobalMerges(stateVersionTracker.createMergePendingChecker(),
+                UpEdgeMaintenanceTransitionConstraint.forPreviouslyPublishedState(stateVersionTracker.getVersionedClusterState()));
     }
 
     /**

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -825,7 +825,13 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
 
     private ClusterStateDeriver createBucketSpaceStateDeriver() {
         return new MaintenanceWhenPendingGlobalMerges(stateVersionTracker.createMergePendingChecker(),
-                UpEdgeMaintenanceTransitionConstraint.forPreviouslyPublishedState(stateVersionTracker.getVersionedClusterState()));
+                createDefaultSpaceMaintenanceTransitionConstraint());
+    }
+
+    private MaintenanceTransitionConstraint createDefaultSpaceMaintenanceTransitionConstraint() {
+        AnnotatedClusterState currentDefaultSpaceState = stateVersionTracker.getVersionedClusterStateBundle()
+                .getDerivedBucketSpaceStates().getOrDefault(FixedBucketSpaces.defaultSpace(), AnnotatedClusterState.emptyState());
+        return UpEdgeMaintenanceTransitionConstraint.forPreviouslyPublishedState(currentDefaultSpaceState.getClusterState());
     }
 
     /**

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MaintenanceTransitionConstraint.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MaintenanceTransitionConstraint.java
@@ -1,0 +1,15 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+/**
+ * Implementations of this interface add constraints to when a node with
+ * pending global merges may be implicitly transitioned to Maintenance
+ * state in the default bucket space. This is to avoid flip-flopping nodes
+ * between being available and in maintenance when merge statistics
+ * change in a running system.
+ */
+public interface MaintenanceTransitionConstraint {
+
+    boolean maintenanceTransitionAllowed(int contentNodeIndex);
+
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/UpEdgeMaintenanceTransitionConstraint.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/UpEdgeMaintenanceTransitionConstraint.java
@@ -1,0 +1,37 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vdslib.state.ClusterState;
+import com.yahoo.vdslib.state.Node;
+import com.yahoo.vdslib.state.NodeState;
+
+/**
+ * Simple implementation which considers a node eligible for being set to maintenance iff
+ * it was down or in maintenance in the cluster state previously published. This avoids
+ * taking down nodes with pending global merges if these have already passed through an
+ * up-edge, but runs the risk of taking down a large set of nodes when the cluster
+ * controller is restarted (due to not knowing the previously published state).
+ *
+ * Output from this checker must always be combined with other constraints to decide whether
+ * a node should be in maintenance; used alone it would most certainly cause havoc.
+ *
+ * Considered sufficient for beta testing use cases.
+ */
+public class UpEdgeMaintenanceTransitionConstraint implements MaintenanceTransitionConstraint {
+
+    private final ClusterState previouslyPublishedDerivedState;
+
+    private UpEdgeMaintenanceTransitionConstraint(ClusterState previouslyPublishedDerivedState) {
+        this.previouslyPublishedDerivedState = previouslyPublishedDerivedState;
+    }
+
+    public static UpEdgeMaintenanceTransitionConstraint forPreviouslyPublishedState(ClusterState state) {
+        return new UpEdgeMaintenanceTransitionConstraint(state);
+    }
+
+    @Override
+    public boolean maintenanceTransitionAllowed(int contentNodeIndex) {
+        NodeState prevState = previouslyPublishedDerivedState.getNodeState(Node.ofStorage(contentNodeIndex));
+        return prevState.getState().oneOf("dm");
+    }
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MaintenanceWhenPendingGlobalMergesTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MaintenanceWhenPendingGlobalMergesTest.java
@@ -19,8 +19,13 @@ import static org.mockito.Mockito.when;
 public class MaintenanceWhenPendingGlobalMergesTest {
 
     private static class Fixture {
-        public MergePendingChecker mockPendingChecker = mock(MergePendingChecker.class);
-        public MaintenanceWhenPendingGlobalMerges deriver = new MaintenanceWhenPendingGlobalMerges(mockPendingChecker);
+        MergePendingChecker mockPendingChecker = mock(MergePendingChecker.class);
+        MaintenanceTransitionConstraint mockEligibilityChecker = mock(MaintenanceTransitionConstraint.class);
+        MaintenanceWhenPendingGlobalMerges deriver = new MaintenanceWhenPendingGlobalMerges(mockPendingChecker, mockEligibilityChecker);
+
+        Fixture() {
+            when(mockEligibilityChecker.maintenanceTransitionAllowed(anyInt())).thenReturn(true);
+        }
     }
 
     private static String defaultSpace() {
@@ -100,6 +105,16 @@ public class MaintenanceWhenPendingGlobalMergesTest {
         assertThat(derived, equalTo(AnnotatedClusterStateBuilder.ofState("distributor:5 storage:5 .1.s:m .3.s:m")
                 .reason(MAY_HAVE_MERGES_PENDING, 1, 3)
                 .reason(NODE_TOO_UNSTABLE, 2).build()));
+    }
+
+    @Test
+    public void node_with_pending_merges_only_set_to_maintenance_if_eligible() {
+        Fixture f = new Fixture();
+        Arrays.asList(1, 2, 3).forEach(idx -> when(f.mockPendingChecker.mayHaveMergesPending(globalSpace(), idx)).thenReturn(true));
+        Arrays.asList(1, 2, 4).forEach(idx -> when(f.mockEligibilityChecker.maintenanceTransitionAllowed(idx)).thenReturn(false));
+        AnnotatedClusterState derived = f.deriver.derivedFrom(stateFromString("distributor:5 storage:5"), defaultSpace());
+        assertThat(derived, equalTo(AnnotatedClusterStateBuilder.ofState("distributor:5 storage:5 .3.s:m")
+                .reason(MAY_HAVE_MERGES_PENDING, 3).build()));
     }
 
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MaintenanceWhenPendingGlobalMergesTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MaintenanceWhenPendingGlobalMergesTest.java
@@ -20,11 +20,11 @@ public class MaintenanceWhenPendingGlobalMergesTest {
 
     private static class Fixture {
         MergePendingChecker mockPendingChecker = mock(MergePendingChecker.class);
-        MaintenanceTransitionConstraint mockEligibilityChecker = mock(MaintenanceTransitionConstraint.class);
-        MaintenanceWhenPendingGlobalMerges deriver = new MaintenanceWhenPendingGlobalMerges(mockPendingChecker, mockEligibilityChecker);
+        MaintenanceTransitionConstraint mockTransitionConstraint = mock(MaintenanceTransitionConstraint.class);
+        MaintenanceWhenPendingGlobalMerges deriver = new MaintenanceWhenPendingGlobalMerges(mockPendingChecker, mockTransitionConstraint);
 
         Fixture() {
-            when(mockEligibilityChecker.maintenanceTransitionAllowed(anyInt())).thenReturn(true);
+            when(mockTransitionConstraint.maintenanceTransitionAllowed(anyInt())).thenReturn(true);
         }
     }
 
@@ -111,7 +111,7 @@ public class MaintenanceWhenPendingGlobalMergesTest {
     public void node_with_pending_merges_only_set_to_maintenance_if_eligible() {
         Fixture f = new Fixture();
         Arrays.asList(1, 2, 3).forEach(idx -> when(f.mockPendingChecker.mayHaveMergesPending(globalSpace(), idx)).thenReturn(true));
-        Arrays.asList(1, 2, 4).forEach(idx -> when(f.mockEligibilityChecker.maintenanceTransitionAllowed(idx)).thenReturn(false));
+        Arrays.asList(1, 2, 4).forEach(idx -> when(f.mockTransitionConstraint.maintenanceTransitionAllowed(idx)).thenReturn(false));
         AnnotatedClusterState derived = f.deriver.derivedFrom(stateFromString("distributor:5 storage:5"), defaultSpace());
         assertThat(derived, equalTo(AnnotatedClusterStateBuilder.ofState("distributor:5 storage:5 .3.s:m")
                 .reason(MAY_HAVE_MERGES_PENDING, 3).build()));

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/UpEdgeMaintenanceTransitionConstraintTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/UpEdgeMaintenanceTransitionConstraintTest.java
@@ -19,27 +19,27 @@ public class UpEdgeMaintenanceTransitionConstraintTest {
     }
 
     @Test
-    public void eligible_when_previous_state_is_down() {
+    public void transition_allowed_when_previous_state_is_down() {
         assertTrue(nodeMayTransitionToMaintenanceInState(1, "distributor:5 storage:5 .1.s:d"));
     }
 
     @Test
-    public void eligible_when_previous_state_is_maintenance() {
+    public void transition_allowed_when_previous_state_is_maintenance() {
         assertTrue(nodeMayTransitionToMaintenanceInState(1, "distributor:5 storage:5 .1.s:m"));
     }
 
     @Test
-    public void not_eligible_when_previous_state_is_up() {
+    public void transition_not_allowed_when_previous_state_is_up() {
         assertFalse(nodeMayTransitionToMaintenanceInState(0, "distributor:5 storage:5"));
     }
 
     @Test
-    public void not_eligible_when_previous_state_is_initializing() {
+    public void transition_not_allowed_when_previous_state_is_initializing() {
         assertFalse(nodeMayTransitionToMaintenanceInState(0, "distributor:5 storage:5 .0.s:i"));
     }
 
     @Test
-    public void not_eligible_when_previous_state_is_retired() {
+    public void transition_not_allowed_when_previous_state_is_retired() {
         assertFalse(nodeMayTransitionToMaintenanceInState(0, "distributor:5 storage:5 .0.s:r"));
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/UpEdgeMaintenanceTransitionConstraintTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/UpEdgeMaintenanceTransitionConstraintTest.java
@@ -1,0 +1,46 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vdslib.state.ClusterState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UpEdgeMaintenanceTransitionConstraintTest {
+
+    private static UpEdgeMaintenanceTransitionConstraint makeChecker(String state) {
+        return UpEdgeMaintenanceTransitionConstraint.forPreviouslyPublishedState(ClusterState.stateFromString(state));
+    }
+
+    private static boolean nodeMayTransitionToMaintenanceInState(int contentNodeIndex, String state) {
+        UpEdgeMaintenanceTransitionConstraint checker = makeChecker(state);
+        return checker.maintenanceTransitionAllowed(contentNodeIndex);
+    }
+
+    @Test
+    public void eligible_when_previous_state_is_down() {
+        assertTrue(nodeMayTransitionToMaintenanceInState(1, "distributor:5 storage:5 .1.s:d"));
+    }
+
+    @Test
+    public void eligible_when_previous_state_is_maintenance() {
+        assertTrue(nodeMayTransitionToMaintenanceInState(1, "distributor:5 storage:5 .1.s:m"));
+    }
+
+    @Test
+    public void not_eligible_when_previous_state_is_up() {
+        assertFalse(nodeMayTransitionToMaintenanceInState(0, "distributor:5 storage:5"));
+    }
+
+    @Test
+    public void not_eligible_when_previous_state_is_initializing() {
+        assertFalse(nodeMayTransitionToMaintenanceInState(0, "distributor:5 storage:5 .0.s:i"));
+    }
+
+    @Test
+    public void not_eligible_when_previous_state_is_retired() {
+        assertFalse(nodeMayTransitionToMaintenanceInState(0, "distributor:5 storage:5 .0.s:r"));
+    }
+
+}


### PR DESCRIPTION
@geirst please review. Prevents common-case flip-flopping of nodes when global merge stats change in a running system.
@toregge FYI