### PR TITLE
Fix ClusterStatsChangeTracker to keep previous 'may have merges pendi…

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/AggregatedStatsMergePendingChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/AggregatedStatsMergePendingChecker.java
@@ -31,16 +31,4 @@ public class AggregatedStatsMergePendingChecker implements MergePendingChecker {
         return true;
     }
 
-    public boolean mayHaveMergesPendingInGlobalSpace() {
-        if (!stats.hasUpdatesFromAllDistributors()) {
-            return true;
-        }
-        for (Iterator<ContentNodeStats> itr = stats.getStats().iterator(); itr.hasNext(); ) {
-            ContentNodeStats stats = itr.next();
-            if (mayHaveMergesPending(FixedBucketSpaces.globalSpace(), stats.getNodeIndex())) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsChangeTracker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsChangeTracker.java
@@ -1,8 +1,14 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.document.FixedBucketSpaces;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 /**
- * Class tracking whether we have changes in current and previous cluster stats.
+ * Class tracking whether we have changes in current and previous aggregated cluster stats.
  *
  * The cluster stats are considered changed if the current and previous stats differs in whether
  * they may have buckets pending in the 'global' bucket space. This signals that the ClusterStateBundle should be recomputed.
@@ -11,11 +17,10 @@ public class ClusterStatsChangeTracker {
 
     private AggregatedClusterStats aggregatedStats;
     private AggregatedStatsMergePendingChecker checker;
-    private boolean prevMayHaveMergesPending;
+    private Map<Integer, Boolean> prevMayHaveMergesPending = null;
 
     public ClusterStatsChangeTracker(AggregatedClusterStats aggregatedStats) {
         setAggregatedStats(aggregatedStats);
-        prevMayHaveMergesPending = false;
     }
 
     private void setAggregatedStats(AggregatedClusterStats aggregatedStats) {
@@ -23,12 +28,16 @@ public class ClusterStatsChangeTracker {
         checker = new AggregatedStatsMergePendingChecker(this.aggregatedStats);
     }
 
-    public void syncBucketsPendingFlag() {
-        prevMayHaveMergesPending = checker.mayHaveMergesPendingInGlobalSpace();
+    public void syncAggregatedStats() {
+        prevMayHaveMergesPending = new HashMap<>();
+        for (Iterator<ContentNodeStats> itr = aggregatedStats.getStats().iterator(); itr.hasNext(); ) {
+            int nodeIndex = itr.next().getNodeIndex();
+            prevMayHaveMergesPending.put(nodeIndex, mayHaveMergesPendingInGlobalSpace(nodeIndex));
+        }
     }
 
     public void updateAggregatedStats(AggregatedClusterStats newAggregatedStats) {
-        syncBucketsPendingFlag();
+        syncAggregatedStats();
         setAggregatedStats(newAggregatedStats);
     }
 
@@ -36,10 +45,30 @@ public class ClusterStatsChangeTracker {
         if (!aggregatedStats.hasUpdatesFromAllDistributors()) {
             return false;
         }
-        if (prevMayHaveMergesPending != checker.mayHaveMergesPendingInGlobalSpace()) {
-            return true;
+        for (Iterator<ContentNodeStats> itr = aggregatedStats.getStats().iterator(); itr.hasNext(); ) {
+            int nodeIndex = itr.next().getNodeIndex();
+            boolean currValue = mayHaveMergesPendingInGlobalSpace(nodeIndex);
+            Boolean prevValue = prevMayHaveMergesPendingInGlobalSpace(nodeIndex);
+            if (prevValue != null) {
+                if (prevValue != currValue) {
+                    return true;
+                }
+            } else if (currValue) {
+                return true;
+            }
         }
         return false;
+    }
+
+    private boolean mayHaveMergesPendingInGlobalSpace(int nodeIndex) {
+        return checker.mayHaveMergesPending(FixedBucketSpaces.globalSpace(), nodeIndex);
+    }
+
+    private Boolean prevMayHaveMergesPendingInGlobalSpace(int nodeIndex) {
+        if (prevMayHaveMergesPending != null) {
+            return prevMayHaveMergesPending.get(nodeIndex);
+        }
+        return null;
     }
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/StateVersionTracker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/StateVersionTracker.java
@@ -89,7 +89,7 @@ public class StateVersionTracker {
     public void updateLatestCandidateStateBundle(final ClusterStateBundle candidateBundle) {
         assert(latestCandidateState.getBaselineClusterState().getVersion() == 0);
         latestCandidateState = candidateBundle;
-        clusterStatsChangeTracker.syncBucketsPendingFlag();
+        clusterStatsChangeTracker.syncAggregatedStats();
     }
 
     /**

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/AggregatedStatsMergePendingCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/AggregatedStatsMergePendingCheckerTest.java
@@ -39,10 +39,6 @@ public class AggregatedStatsMergePendingCheckerTest {
             return checker.mayHaveMergesPending(bucketSpace, contentNodeIndex);
         }
 
-        public boolean mayHaveMergesPendingInGlobalSpace() {
-            return checker.mayHaveMergesPendingInGlobalSpace();
-        }
-
     }
 
     @Test
@@ -79,29 +75,6 @@ public class AggregatedStatsMergePendingCheckerTest {
     public void cluster_without_updates_from_all_distributors_may_have_merges_pending() {
         Fixture f = Fixture.fromIncompleteStats();
         assertTrue(f.mayHaveMergesPending("default", 1));
-    }
-
-    @Test
-    public void cluster_without_updates_from_all_distributors_may_have_merges_pending_in_global_space() {
-        Fixture f = Fixture.fromIncompleteStats();
-        assertTrue(f.mayHaveMergesPendingInGlobalSpace());
-    }
-
-    @Test
-    public void cluster_may_have_merges_pending_in_global_space_if_one_node_has_buckets_pending() {
-        Fixture f = new Fixture(new ContentClusterStatsBuilder()
-                .add(1, "global", 10, 0)
-                .add(2, "global", 11, 1), true);
-        assertTrue(f.mayHaveMergesPendingInGlobalSpace());
-    }
-
-    @Test
-    public void cluster_does_not_have_merges_pending_in_global_space_if_no_nodes_have_buckets_pending() {
-        Fixture f = new Fixture(new ContentClusterStatsBuilder()
-                .add(3, "global", 10, 0)
-                .add(4, "global", 11, 0)
-                .add(4, "default", 12, 1), true);
-        assertFalse(f.mayHaveMergesPendingInGlobalSpace());
     }
 
 }


### PR DESCRIPTION
…ng' state per content node.

@vekterli please review