### PR TITLE
Invalidate accumulated bucket space stats on recovery mode entry

### DIFF
--- a/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.h
+++ b/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.h
@@ -26,9 +26,12 @@ public:
           _bucketsTotal(0),
           _bucketsPending(0)
     {}
-    bool valid() const { return _valid; }
-    size_t bucketsTotal() const { return _bucketsTotal; }
-    size_t bucketsPending() const { return _bucketsPending; }
+
+    static BucketSpaceStats make_invalid() noexcept { return {}; }
+
+    bool valid() const noexcept { return _valid; }
+    size_t bucketsTotal() const noexcept { return _bucketsTotal; }
+    size_t bucketsPending() const noexcept { return _bucketsPending; }
 };
 
 /**

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -407,7 +407,7 @@ Distributor::enterRecoveryMode()
     _scanner->reset();
     _bucketDBMetricUpdater.reset();
     // TODO reset _bucketDbStats?
-    invalidate_bucket_space_stats();
+    invalidate_bucket_spaces_stats();
 
     _recoveryTimeStarted = framework::MilliSecTimer(_component.getClock());
 }
@@ -443,7 +443,7 @@ BucketSpacesStatsProvider::BucketSpacesStats Distributor::make_invalid_stats_per
     return invalid_space_stats;
 }
 
-void Distributor::invalidate_bucket_space_stats() {
+void Distributor::invalidate_bucket_spaces_stats() {
     vespalib::LockGuard guard(_metricLock);
     _bucketSpacesStats = BucketSpacesStatsProvider::PerNodeBucketSpacesStats();
     auto invalid_space_stats = make_invalid_stats_per_configured_space();

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -444,6 +444,7 @@ BucketSpacesStatsProvider::BucketSpacesStats Distributor::make_invalid_stats_per
 }
 
 void Distributor::invalidate_bucket_space_stats() {
+    vespalib::LockGuard guard(_metricLock);
     _bucketSpacesStats = BucketSpacesStatsProvider::PerNodeBucketSpacesStats();
     auto invalid_space_stats = make_invalid_stats_per_configured_space();
 

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -233,6 +233,11 @@ private:
     void propagateDefaultDistribution(std::shared_ptr<const lib::Distribution>);
     void propagateClusterStates();
 
+    BucketSpacesStatsProvider::BucketSpacesStats make_invalid_stats_per_configured_space() const;
+    template <typename NodeFunctor>
+    void for_each_available_content_node_in(const lib::ClusterState&, NodeFunctor&&);
+    void invalidate_bucket_space_stats();
+
     lib::ClusterStateBundle _clusterStateBundle;
 
     DistributorComponentRegister& _compReg;

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -236,7 +236,7 @@ private:
     BucketSpacesStatsProvider::BucketSpacesStats make_invalid_stats_per_configured_space() const;
     template <typename NodeFunctor>
     void for_each_available_content_node_in(const lib::ClusterState&, NodeFunctor&&);
-    void invalidate_bucket_space_stats();
+    void invalidate_bucket_spaces_stats();
 
     lib::ClusterStateBundle _clusterStateBundle;
 


### PR DESCRIPTION
@geirst please review

Recovery mode is entered whenever a cluster state or distribution config
change is detected. Invalidating the bucket space stats ensures that the
distributor does not report stale statistics from a previous cluster state
version to the cluster controller.