### PR TITLE
Test reservation event update

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -17,7 +17,6 @@ import com.yahoo.vespa.curator.transaction.CuratorOperations;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.node.Agent;
-import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.node.Status;
 
 import java.nio.charset.StandardCharsets;
@@ -193,7 +192,7 @@ public class CuratorDatabaseClient {
                                     newNodeStatus(node, toState),
                                     toState,
                                     toState.isAllocated() ? node.allocation() : Optional.empty(),
-                                    recordStateTransition(node, toState, agent),
+                                    node.history().recordStateTransition(node.state(), toState, agent, clock.instant()),
                                     node.type());
             curatorTransaction.add(CuratorOperations.delete(toPath(node).getAbsolute()))
                               .add(CuratorOperations.create(toPath(toState, newNode.hostname()).getAbsolute(), nodeSerializer.toJson(newNode)));
@@ -207,10 +206,6 @@ public class CuratorDatabaseClient {
             }
         });
         return writtenNodes;
-    }
-
-    private History recordStateTransition(Node node, Node.State toState, Agent agent) {
-        return node.history().recordStateTransition(node.state(), toState, agent, clock.instant());
     }
 
     private Status newNodeStatus(Node node, Node.State toState) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -708,8 +708,13 @@ public class ProvisioningTest {
         tester.clock().advance(Duration.ofMinutes(2));
         SystemState state = prepare(application, 2, 0, 2, 0,
                                     "default", tester);
-        assertEquals("Reserved required nodes", 4,
-                     tester.getNodes(application, Node.State.reserved).size());
+        List<Node> reserved = tester.getNodes(application, Node.State.reserved).asList();
+        assertEquals("Reserved required nodes", 4, reserved.size());
+        assertTrue("Time of event is updated for all nodes", reserved.stream()
+                                                                     .allMatch(n -> n.history()
+                                                                                     .event(History.Event.Type.reserved)
+                                                                                     .get().at()
+                                                                                     .equals(tester.clock().instant())));
 
         // Over 10 minutes pass since first reservation. First set of reserved nodes are not expired
         tester.clock().advance(Duration.ofMinutes(8).plus(Duration.ofSeconds(1)));


### PR DESCRIPTION
Since history exists independently of state, it makes sense to have the test
cover the fix in #5260.