### PR TITLE
Write secret-agent config

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -359,6 +359,7 @@ public class DockerOperationsImpl implements DockerOperations {
      */
     private static Map<Path, Boolean> getDirectoriesToMount(Environment environment) {
         final Map<Path, Boolean> directoriesToMount = new HashMap<>();
+        directoriesToMount.put(Paths.get("/var/log/secret-agent"), false);
         directoriesToMount.put(Paths.get("/etc/yamas-agent"), true);
         directoriesToMount.put(Paths.get("/etc/filebeat"), true);
         directoriesToMount.put(environment.pathInNodeUnderVespaHome("logs/daemontools_y"), false);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -98,6 +98,7 @@ public class StorageMaintainer {
             vespaSchedule.writeTo(yamasAgentFolder);
             hostLifeSchedule.writeTo(yamasAgentFolder);
             final String[] restartYamasAgent = new String[]{"service", "yamas-agent", "restart"};
+            writeSecretAgentConfig(containerName);
             dockerOperations.executeCommandInContainerAsRoot(containerName, restartYamasAgent);
         } catch (IOException e) {
             throw new RuntimeException("Failed to write secret-agent schedules for " + containerName, e);
@@ -429,5 +430,34 @@ public class StorageMaintainer {
             nextRemoveOldFilesAt = Instant.EPOCH;
             nextHandleOldCoredumpsAt = Instant.EPOCH;
         }
+    }
+
+    private void writeSecretAgentConfig(ContainerName containerName) {
+        String config = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
+                "<log4j:configuration xmlns:log4j=\"http://jakarta.apache.org/log4j/\">\n" +
+                "    <appender name=\"AppLog\" class=\"org.apache.log4j.rolling.RollingFileAppender\">\n" +
+                "        <param name=\"Threshold\" value=\"Debug\" />\n" +
+                "        <rollingPolicy class=\"org.apache.log4j.rolling.FixedWindowRollingPolicy\">\n" +
+                "            <param name=\"FileNamePattern\" value=\"/var/log/secret-agent/collector-writer.%i\"/>\n" +
+                "            <param name=\"MinIndex\" value=\"0\"/>\n" +
+                "            <param name=\"MaxIndex\" value=\"100\"/>\n" +
+                "        </rollingPolicy>\n" +
+                "        <triggeringPolicy class=\"org.apache.log4j.rolling.SizeBasedTriggeringPolicy\">\n" +
+                "            <param name=\"maxFileSize\" value=\"10MB\"/>\n" +
+                "        </triggeringPolicy>\n" +
+                "        <layout class=\"org.apache.log4j.PatternLayout\">\n" +
+                "            <param name=\"ConversionPattern\" value=\"%d %-5p [%c] - %m%n\" />\n" +
+                "        </layout>\n" +
+                "    </appender>\n" +
+                "\n" +
+                "    <root>\n" +
+                "        <priority value=\"all\" />\n" +
+                "        <appender-ref ref=\"AppLog\" />\n" +
+                "    </root>\n" +
+                "</log4j:configuration>";
+
+        Path configPath = Paths.get("/etc/secret-agent/log4cxx.collector-writer.xml");
+        String writeConfigCommand = String.format("echo '%s' > %s", config, configPath);
+        dockerOperations.executeCommandInContainerAsRoot(containerName, "/bin/sh", "-c", writeConfigCommand);
     }
 }


### PR DESCRIPTION
This is a temporary fix to get some debug logging for secret-agent for `YAMAS-9760`. This will be reverted when we understand what's wrong.

This does 2 things:
1) Maps in `/var/log/secret-agent`, this is to keep the logs between container restarts
2) Writes new secret agent config that 
2.1) Logs debug level
2.2) Keeps 100 log rotations instead of default 5

FYI: @ldalves 