### PR TITLE
Simplify key load/store

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/Environment.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/Environment.java
@@ -117,13 +117,11 @@ public class Environment {
         this.keyStoreOptions = createKeyStoreOptions(
                 configServerConfig.keyStoreConfig().path(),
                 configServerConfig.keyStoreConfig().password().toCharArray(),
-                configServerConfig.keyStoreConfig().type().name(),
-                "BC");
+                configServerConfig.keyStoreConfig().type().name());
         this.trustStoreOptions = createKeyStoreOptions(
                 configServerConfig.trustStoreConfig().path(),
                 configServerConfig.trustStoreConfig().password().toCharArray(),
-                configServerConfig.trustStoreConfig().type().name(),
-                null);
+                configServerConfig.trustStoreConfig().type().name());
         this.athenzIdentity = createAthenzIdentity(
                 configServerConfig.athenzDomain(),
                 configServerConfig.serviceName());
@@ -184,10 +182,10 @@ public class Environment {
         return Arrays.asList(logstashNodes.split("[,\\s]+"));
     }
 
-    private static Optional<KeyStoreOptions> createKeyStoreOptions(String pathToKeyStore, char[] password, String type, String provider) {
+    private static Optional<KeyStoreOptions> createKeyStoreOptions(String pathToKeyStore, char[] password, String type) {
         return Optional.ofNullable(pathToKeyStore)
                 .filter(path -> !Strings.isNullOrEmpty(path))
-                .map(path -> new KeyStoreOptions(Paths.get(path), password, type, provider));
+                .map(path -> new KeyStoreOptions(Paths.get(path), password, type));
     }
 
     private static Optional<AthenzIdentity> createAthenzIdentity(String athenzDomain, String serviceName) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConfigServerApiImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConfigServerApiImpl.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.node.admin.configserver;
 
 import com.yahoo.vespa.athenz.tls.AthenzIdentityVerifier;
 import com.yahoo.vespa.athenz.tls.AthenzSslContextBuilder;
-import com.yahoo.vespa.athenz.tls.KeyStoreType;
 import com.yahoo.vespa.hosted.node.admin.component.Environment;
 import com.yahoo.vespa.hosted.node.admin.configserver.certificate.ConfigServerKeyStoreRefresher;
 import com.yahoo.vespa.hosted.node.admin.util.KeyStoreOptions;
@@ -18,7 +17,7 @@ import java.util.Optional;
 
 /**
  * ConfigServerApi with proper keystore, truststore and hostname verifier to communicate with the
- * configserver(s). The keystore is refreshed automatically.
+ * config server(s). The keystore is refreshed automatically.
  *
  * @author freva
  */
@@ -99,16 +98,8 @@ public class SslConfigServerApiImpl implements ConfigServerApi {
 
     private SSLContext makeSslContext(Optional<KeyStoreOptions> keyStoreOptions) {
         AthenzSslContextBuilder sslContextBuilder = new AthenzSslContextBuilder();
-        environment.getTrustStoreOptions().ifPresent(
-                options -> sslContextBuilder.withTrustStore(options.path.toFile(), KeyStoreType.valueOf(options.type)));
-
-        keyStoreOptions.ifPresent(options -> {
-            try {
-                sslContextBuilder.withKeyStore(options.path.toFile(), options.password, KeyStoreType.valueOf(options.type));
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to read key store", e);
-            }
-        });
+        environment.getTrustStoreOptions().map(KeyStoreOptions::loadKeyStore).ifPresent(sslContextBuilder::withTrustStore);
+        keyStoreOptions.ifPresent(options -> sslContextBuilder.withKeyStore(options.loadKeyStore(), options.password));
 
         return sslContextBuilder.build();
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/KeyStoreOptions.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/KeyStoreOptions.java
@@ -1,45 +1,32 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.util;
 
-import java.io.FileInputStream;
-import java.io.IOException;
+import com.yahoo.vespa.athenz.tls.KeyStoreBuilder;
+import com.yahoo.vespa.athenz.tls.KeyStoreType;
+import com.yahoo.vespa.athenz.tls.KeyStoreUtils;
+
 import java.nio.file.Path;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.cert.CertificateException;
-import java.util.Optional;
 
 public class KeyStoreOptions {
     public final Path path;
     public final char[] password;
-    public final String type;
-    private final Optional<String> provider;
+    public final KeyStoreType keyStoreType;
 
     public KeyStoreOptions(Path path, char[] password, String type) {
-        this(path, password, type, null);
-    }
-
-    public KeyStoreOptions(Path path, char[] password, String type, String provider) {
         this.path = path;
         this.password = password;
-        this.type = type;
-        this.provider = Optional.ofNullable(provider);
+        this.keyStoreType = KeyStoreType.valueOf(type);
     }
 
-    public KeyStore loadKeyStore()
-            throws IOException, NoSuchProviderException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
-        try (FileInputStream in = new FileInputStream(path.toFile())) {
-            KeyStore keyStore = getKeyStoreInstance();
-            keyStore.load(in, password);
-            return keyStore;
-        }
+    public KeyStore loadKeyStore() {
+        return KeyStoreBuilder
+                .withType(keyStoreType)
+                .fromFile(path.toFile(), password)
+                .build();
     }
 
-    public KeyStore getKeyStoreInstance() throws NoSuchProviderException, KeyStoreException {
-        return provider.isPresent() ?
-                KeyStore.getInstance(type, provider.get()) :
-                KeyStore.getInstance(type);
+    public void storeKeyStore(KeyStore keyStore) {
+        KeyStoreUtils.writeKeyStoreToFile(keyStore, path.toFile(), password);
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/certificate/ConfigServerKeyStoreRefresherTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/certificate/ConfigServerKeyStoreRefresherTest.java
@@ -54,7 +54,7 @@ public class ConfigServerKeyStoreRefresherTest {
     @Before
     public void setup() {
         keyStoreOptions = new KeyStoreOptions(
-                tempFolder.getRoot().toPath().resolve("some/path/keystore.p12"), new char[0], "PKCS12", null);
+                tempFolder.getRoot().toPath().resolve("some/path/keystore.p12"), new char[0], "PKCS12");
     }
 
     @Test


### PR DESCRIPTION
Simplifies loading/storing config server certificate in node-admin with the helper methods added in #5296