### PR TITLE
Prefix constants by model name

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
@@ -13,6 +13,7 @@ import java.util.List;
  * Serves stor-filestor for storage clusters.
  */
 public class FileStorProducer implements StorFilestorConfig.Producer {
+
     public static class Builder {
         protected FileStorProducer build(ContentCluster parent, ModelElement clusterElem) {
             return new FileStorProducer(parent, getThreads(clusterElem));

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithTensorFlowTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithTensorFlowTestCase.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.*;
 public class RankingExpressionWithTensorFlowTestCase {
 
     private final Path applicationDir = Path.fromString("src/test/integration/tensorflow/");
-    private final String vespaExpression = "join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), constant(layer_Variable_read), f(a,b)(a * b)), sum, d2), constant(layer_Variable_1_read), f(a,b)(a + b))";
+    private final String vespaExpression = "join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), constant(mnist_softmax_saved_layer_Variable_read), f(a,b)(a * b)), sum, d2), constant(mnist_softmax_saved_layer_Variable_1_read), f(a,b)(a + b))";
 
     @After
     public void removeGeneratedConstantTensorFiles() {
@@ -54,8 +54,8 @@ public class RankingExpressionWithTensorFlowTestCase {
         RankProfileSearchFixture search = fixtureWith("tensor(d0[2],d1[784])(0.0)",
                                                       "tensorflow('mnist_softmax/saved')");
         search.assertFirstPhaseExpression(vespaExpression, "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
@@ -65,8 +65,8 @@ public class RankingExpressionWithTensorFlowTestCase {
                                                       "constant mytensor { file: ignored\ntype: tensor(d0[7],d1[784]) }",
                                                       null);
         search.assertFirstPhaseExpression(vespaExpression, "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
@@ -85,8 +85,8 @@ public class RankingExpressionWithTensorFlowTestCase {
                                                       "Placeholder",
                                                       application);
         search.assertFirstPhaseExpression(vespaExpression, "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
@@ -99,8 +99,8 @@ public class RankingExpressionWithTensorFlowTestCase {
                                                       "Placeholder",
                                                       application);
         search.assertFirstPhaseExpression(vespaExpression, "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
@@ -119,8 +119,8 @@ public class RankingExpressionWithTensorFlowTestCase {
                                                       "Placeholder",
                                                       application);
         search.assertFirstPhaseExpression(vespaExpression, "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
@@ -128,8 +128,8 @@ public class RankingExpressionWithTensorFlowTestCase {
         RankProfileSearchFixture search = fixtureWith("tensor(d0[2],d1[784])(0.0)",
                                                       "5 + sum(tensorflow('mnist_softmax/saved'))");
         search.assertFirstPhaseExpression("5 + reduce(" + vespaExpression + ", sum)", "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
@@ -224,8 +224,8 @@ public class RankingExpressionWithTensorFlowTestCase {
                                                       "tensorflow('mnist_softmax/saved')");
         search.assertFirstPhaseExpression(vespaExpression, "my_profile");
 
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
 
         // At this point the expression is stored - copy application to another location which do not have a models dir
         Path storedApplicationDirectory = applicationDir.getParentPath().append("copy");
@@ -243,8 +243,8 @@ public class RankingExpressionWithTensorFlowTestCase {
             searchFromStored.assertFirstPhaseExpression(vespaExpression, "my_profile");
             // Verify that the constants exists, but don't verify the content as we are not
             // simulating file distribution in this test
-            assertLargeConstant("layer_Variable_1_read", searchFromStored, Optional.empty());
-            assertLargeConstant("layer_Variable_read", searchFromStored, Optional.empty());
+            assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", searchFromStored, Optional.empty());
+            assertLargeConstant("mnist_softmax_saved_layer_Variable_read", searchFromStored, Optional.empty());
         }
         finally {
             IOUtils.recursiveDeleteDir(storedApplicationDirectory.toFile());
@@ -258,7 +258,7 @@ public class RankingExpressionWithTensorFlowTestCase {
                 "    macro Placeholder() {\n" +
                 "      expression: tensor(d0[2],d1[784])(0.0)\n" +
                 "    }\n" +
-                "    macro layer_Variable_read() {\n" +
+                "    macro mnist_softmax_saved_layer_Variable_read() {\n" +
                 "      expression: tensor(d1[10],d2[784])(0.0)\n" +
                 "    }\n" +
                 "    first-phase {\n" +
@@ -268,13 +268,13 @@ public class RankingExpressionWithTensorFlowTestCase {
 
 
         String vespaExpressionWithoutConstant =
-                "join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), layer_Variable_read, f(a,b)(a * b)), sum, d2), constant(layer_Variable_1_read), f(a,b)(a + b))";
+                "join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), mnist_softmax_saved_layer_Variable_read, f(a,b)(a * b)), sum, d2), constant(mnist_softmax_saved_layer_Variable_1_read), f(a,b)(a + b))";
         RankProfileSearchFixture search = fixtureWith(rankProfile, new StoringApplicationPackage(applicationDir));
         search.assertFirstPhaseExpression(vespaExpressionWithoutConstant, "my_profile");
 
         assertNull("Constant overridden by macro is not added",
-                   search.search().getRankingConstants().get("layer_Variable_read"));
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
+                   search.search().getRankingConstants().get("mnist_softmax_saved_layer_Variable_read"));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
 
         // At this point the expression is stored - copy application to another location which do not have a models dir
         Path storedApplicationDirectory = applicationDir.getParentPath().append("copy");
@@ -286,8 +286,8 @@ public class RankingExpressionWithTensorFlowTestCase {
             RankProfileSearchFixture searchFromStored = fixtureWith(rankProfile, storedApplication);
             searchFromStored.assertFirstPhaseExpression(vespaExpressionWithoutConstant, "my_profile");
             assertNull("Constant overridden by macro is not added",
-                       searchFromStored.search().getRankingConstants().get("layer_Variable_read"));
-            assertLargeConstant("layer_Variable_1_read", searchFromStored, Optional.of(10L));
+                       searchFromStored.search().getRankingConstants().get("mnist_softmax_saved_layer_Variable_read"));
+            assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", searchFromStored, Optional.of(10L));
         }
         finally {
             IOUtils.recursiveDeleteDir(storedApplicationDirectory.toFile());
@@ -296,22 +296,26 @@ public class RankingExpressionWithTensorFlowTestCase {
 
     @Test
     public void testTensorFlowReduceBatchDimension() {
-        final String expression = "join(join(reduce(join(reduce(rename(Placeholder, (d0, d1), (d0, d2)), sum, d0), constant(layer_Variable_read), f(a,b)(a * b)), sum, d2), constant(layer_Variable_1_read), f(a,b)(a + b)), tensor(d0[1])(0.0), f(a,b)(a + b))";
+        final String expression = "join(join(reduce(join(reduce(rename(Placeholder, (d0, d1), (d0, d2)), sum, d0), constant(mnist_softmax_saved_layer_Variable_read), f(a,b)(a * b)), sum, d2), constant(mnist_softmax_saved_layer_Variable_1_read), f(a,b)(a + b)), tensor(d0[1])(0.0), f(a,b)(a + b))";
         RankProfileSearchFixture search = fixtureWith("tensor(d0[1],d1[784])(0.0)",
                 "tensorflow('mnist_softmax/saved')");
         search.assertFirstPhaseExpression(expression, "my_profile");
-        assertLargeConstant("layer_Variable_1_read", search, Optional.of(10L));
-        assertLargeConstant("layer_Variable_read", search, Optional.of(7840L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_1_read", search, Optional.of(10L));
+        assertLargeConstant("mnist_softmax_saved_layer_Variable_read", search, Optional.of(7840L));
     }
 
     @Test
     public void testMacroGeneration() {
-        final String expression = "join(join(reduce(join(join(join(tf_macro_dnn_hidden2_add, reduce(constant(dnn_hidden2_Const), sum, d2), f(a,b)(a * b)), tf_macro_dnn_hidden2_add, f(a,b)(max(a,b))), constant(dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(dnn_outputs_bias_read), f(a,b)(a + b)), tensor(d0[1])(0.0), f(a,b)(a + b))";
-        final String macroExpression1 = "join(reduce(join(reduce(rename(input, (d0, d1), (d0, d4)), sum, d0), constant(dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(dnn_hidden1_bias_read), f(a,b)(a + b))";
-        final String macroExpression2 = "join(reduce(join(join(join(tf_macro_dnn_hidden1_add, 0.009999999776482582, f(a,b)(a * b)), tf_macro_dnn_hidden1_add, f(a,b)(max(a,b))), constant(dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(dnn_hidden2_bias_read), f(a,b)(a + b))";
+        final String expression = "join(join(reduce(join(join(join(tf_macro_dnn_hidden2_add, reduce(constant(mnist_saved_dnn_hidden2_Const), sum, d2), f(a,b)(a * b)), tf_macro_dnn_hidden2_add, f(a,b)(max(a,b))), constant(mnist_saved_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(mnist_saved_dnn_outputs_bias_read), f(a,b)(a + b)), tensor(d0[1])(0.0), f(a,b)(a + b))";
+        final String macroExpression1 = "join(reduce(join(reduce(rename(input, (d0, d1), (d0, d4)), sum, d0), constant(mnist_saved_dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(mnist_saved_dnn_hidden1_bias_read), f(a,b)(a + b))";
+        final String macroExpression2 = "join(reduce(join(join(join(tf_macro_dnn_hidden1_add, 0.009999999776482582, f(a,b)(a * b)), tf_macro_dnn_hidden1_add, f(a,b)(max(a,b))), constant(mnist_saved_dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(mnist_saved_dnn_hidden2_bias_read), f(a,b)(a + b))";
 
         RankProfileSearchFixture search = fixtureWith("tensor(d0[1],d1[784])(0.0)",
-                "tensorflow('mnist/saved')", null, null, "input", new StoringApplicationPackage(applicationDir));
+                                    "tensorflow('mnist/saved')",
+                                                      null,
+                                                      null,
+                                                      "input",
+                                                      new StoringApplicationPackage(applicationDir));
         search.assertFirstPhaseExpression(expression, "my_profile");
         search.assertMacro(macroExpression1, "tf_macro_dnn_hidden1_add", "my_profile");
         search.assertMacro(macroExpression2, "tf_macro_dnn_hidden2_add", "my_profile");
@@ -319,9 +323,9 @@ public class RankingExpressionWithTensorFlowTestCase {
 
     @Test
     public void testImportingFromStoredExpressionsWithSmallConstants() throws IOException {
-        final String expression = "join(join(reduce(join(join(join(tf_macro_dnn_hidden2_add, reduce(constant(dnn_hidden2_Const), sum, d2), f(a,b)(a * b)), tf_macro_dnn_hidden2_add, f(a,b)(max(a,b))), constant(dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(dnn_outputs_bias_read), f(a,b)(a + b)), tensor(d0[1])(0.0), f(a,b)(a + b))";
-        final String macroExpression1 = "join(reduce(join(reduce(rename(input, (d0, d1), (d0, d4)), sum, d0), constant(dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(dnn_hidden1_bias_read), f(a,b)(a + b))";
-        final String macroExpression2 = "join(reduce(join(join(join(tf_macro_dnn_hidden1_add, 0.009999999776482582, f(a,b)(a * b)), tf_macro_dnn_hidden1_add, f(a,b)(max(a,b))), constant(dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(dnn_hidden2_bias_read), f(a,b)(a + b))";
+        final String expression = "join(join(reduce(join(join(join(tf_macro_dnn_hidden2_add, reduce(constant(mnist_saved_dnn_hidden2_Const), sum, d2), f(a,b)(a * b)), tf_macro_dnn_hidden2_add, f(a,b)(max(a,b))), constant(mnist_saved_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(mnist_saved_dnn_outputs_bias_read), f(a,b)(a + b)), tensor(d0[1])(0.0), f(a,b)(a + b))";
+        final String macroExpression1 = "join(reduce(join(reduce(rename(input, (d0, d1), (d0, d4)), sum, d0), constant(mnist_saved_dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(mnist_saved_dnn_hidden1_bias_read), f(a,b)(a + b))";
+        final String macroExpression2 = "join(reduce(join(join(join(tf_macro_dnn_hidden1_add, 0.009999999776482582, f(a,b)(a * b)), tf_macro_dnn_hidden1_add, f(a,b)(max(a,b))), constant(mnist_saved_dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(mnist_saved_dnn_hidden2_bias_read), f(a,b)(a + b))";
 
         StoringApplicationPackage application = new StoringApplicationPackage(applicationDir);
         RankProfileSearchFixture search = fixtureWith("tensor(d0[1],d1[784])(0.0)",
@@ -331,7 +335,7 @@ public class RankingExpressionWithTensorFlowTestCase {
                 "input",
                 application);
         search.assertFirstPhaseExpression(expression, "my_profile");
-        assertSmallConstant("dnn_hidden2_Const", TensorType.fromSpec("tensor(d2[1])"), search);
+        assertSmallConstant("mnist_saved_dnn_hidden2_Const", TensorType.fromSpec("tensor(d2[1])"), search);
         search.assertMacro(macroExpression1, "tf_macro_dnn_hidden1_add", "my_profile");
         search.assertMacro(macroExpression2, "tf_macro_dnn_hidden2_add", "my_profile");
 
@@ -349,7 +353,7 @@ public class RankingExpressionWithTensorFlowTestCase {
                     "input",
                     storedApplication);
             searchFromStored.assertFirstPhaseExpression(expression, "my_profile");
-            assertSmallConstant("dnn_hidden2_Const", TensorType.fromSpec("tensor(d2[1])"), search);
+            assertSmallConstant("mnist_saved_dnn_hidden2_Const", TensorType.fromSpec("tensor(d2[1])"), search);
             searchFromStored.assertMacro(macroExpression1, "tf_macro_dnn_hidden1_add", "my_profile");
             searchFromStored.assertMacro(macroExpression2, "tf_macro_dnn_hidden2_add", "my_profile");
         }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TensorFlowModel.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TensorFlowModel.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * The result of importing a TensorFlow model into Vespa.
@@ -21,6 +22,25 @@ import java.util.Map;
  */
 // This object can be built incrementally within this package, but is immutable when observed from outside the package
 public class TensorFlowModel {
+
+    private static final Pattern nameRegexp = Pattern.compile("[A-Za-z0-9_]*");
+
+    private final String name;
+
+    /**
+     * Creates a TensorFlow model
+     *
+     * @param name the name of this mode, containing only characters in [A-Za-z0-9_]
+     */
+    public TensorFlowModel(String name) {
+        if ( ! nameRegexp.matcher(name).matches())
+            throw new IllegalArgumentException("A TensorFlow model name can only contain [A-Za-z0-9_], but is '" +
+                                               name + "'");
+        this.name = name;
+    }
+
+    /** Returns the name of this model, which can only contain the characters in [A-Za-z0-9_] */
+    public String name() { return name; }
 
     private final Map<String, Signature> signatures = new HashMap<>();
     private final Map<String, TensorType> arguments = new HashMap<>();

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/OperationMapper.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/OperationMapper.java
@@ -32,12 +32,12 @@ import java.util.List;
  */
 public class OperationMapper {
 
-    public static TensorFlowOperation get(NodeDef node, List<TensorFlowOperation> inputs, int port) {
+    public static TensorFlowOperation get(String modelName, NodeDef node, List<TensorFlowOperation> inputs, int port) {
         switch (node.getOp().toLowerCase()) {
             // array ops
-            case "const":       return new Const(node, inputs, port);
+            case "const":       return new Const(modelName, node, inputs, port);
             case "expanddims":  return new ExpandDims(node, inputs, port);
-            case "identity":    return new Identity(node, inputs, port);
+            case "identity":    return new Identity(modelName, node, inputs, port);
             case "placeholder": return new Placeholder(node, inputs, port);
             case "placeholderwithdefault": return new PlaceholderWithDefault(node, inputs, port);
             case "reshape":     return new Reshape(node, inputs, port);
@@ -76,11 +76,11 @@ public class OperationMapper {
             case "selu":        return new Map(node, inputs, port, ScalarFunctions.selu());
 
             // state ops
-            case "variable":    return new Variable(node, inputs, port);
-            case "variablev2":  return new Variable(node, inputs, port);
+            case "variable":    return new Variable(modelName, node, inputs, port);
+            case "variablev2":  return new Variable(modelName, node, inputs, port);
 
             // evaluation no-ops
-            case "stopgradient":return new Identity(node, inputs, port);
+            case "stopgradient":return new Identity(modelName, node, inputs, port);
             case "noop":        return new NoOp(node, inputs, port);
         }
         return new NoOp(node, inputs, port);

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Const.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Const.java
@@ -23,8 +23,11 @@ import java.util.Optional;
 
 public class Const extends TensorFlowOperation {
 
-    public Const(NodeDef node, List<TensorFlowOperation> inputs, int port) {
+    private final String modelName;
+
+    public Const(String modelName, NodeDef node, List<TensorFlowOperation> inputs, int port) {
         super(node, inputs, port);
+        this.modelName = modelName;
         setConstantValue(value());
     }
 
@@ -52,6 +55,12 @@ public class Const extends TensorFlowOperation {
         return new TensorFunctionNode.TensorFunctionExpressionNode(expressionNode);
     }
 
+    /** Constant names are prefixed by "modelName_" to avoid name conflicts between models */
+    @Override
+    public String vespaName() {
+        return modelName + "_" + super.vespaName();
+    }
+
     @Override
     public void addDimensionNameConstraints(DimensionRenamer renamer) {
         for (TensorType.Dimension dimension : type.type().dimensions()) {
@@ -71,7 +80,7 @@ public class Const extends TensorFlowOperation {
     }
 
     private Value value() {
-        if (!node.getAttrMap().containsKey("value")) {
+        if ( ! node.getAttrMap().containsKey("value")) {
             throw new IllegalArgumentException("Node '" + node.getName() + "' of type " +
                                                "const has missing 'value' attribute");
         }
@@ -89,6 +98,6 @@ public class Const extends TensorFlowOperation {
             return new DoubleValue(attrValue.getF());
         }
         throw new IllegalArgumentException("Requesting value of constant in " +
-                node.getName() + " but type is not recognized.");
+                                           node.getName() + " but type is not recognized.");
     }
 }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Identity.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Identity.java
@@ -9,8 +9,17 @@ import java.util.List;
 
 public class Identity extends TensorFlowOperation {
 
-    public Identity(NodeDef node, List<TensorFlowOperation> inputs, int port) {
+    private final String modelName;
+
+    public Identity(String modelName, NodeDef node, List<TensorFlowOperation> inputs, int port) {
         super(node, inputs, port);
+        this.modelName = modelName;
+    }
+
+    /** Constant names are prefixed by "modelName_" to avoid name conflicts between models */
+    @Override
+    public String vespaName() {
+        return modelName + "_" + super.vespaName();
     }
 
     @Override

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Mean.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Mean.java
@@ -37,7 +37,7 @@ public class Mean extends TensorFlowOperation {
         TensorFlowOperation reductionIndices = inputs.get(1);
         if (!reductionIndices.getConstantValue().isPresent()) {
             throw new IllegalArgumentException("Mean in " + node.getName() + ": " +
-                    "reduction indices must be a constant.");
+                                               "reduction indices must be a constant.");
         }
         Tensor indices = reductionIndices.getConstantValue().get().asTensor();
         reduceDimensions = new ArrayList<>();

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Variable.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/importer/operations/Variable.java
@@ -11,13 +11,22 @@ import java.util.List;
 
 public class Variable extends TensorFlowOperation {
 
-    public Variable(NodeDef node, List<TensorFlowOperation> inputs, int port) {
+    private final String modelName;
+
+    public Variable(String modelName, NodeDef node, List<TensorFlowOperation> inputs, int port) {
         super(node, inputs, port);
+        this.modelName = modelName;
+    }
+
+    /** Constant names are prefixed by "modelName_" to avoid name conflicts between models */
+    @Override
+    public String vespaName() {
+        return modelName + "_" + super.vespaName();
     }
 
     @Override
     protected OrderedTensorType lazyGetType() {
-        return OrderedTensorType.fromTensorFlowType(node, vespaName() + "_");
+        return OrderedTensorType.fromTensorFlowType(node, super.vespaName() + "_");
     }
 
     @Override

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/BatchNormImportTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/BatchNormImportTestCase.java
@@ -14,7 +14,7 @@ public class BatchNormImportTestCase {
 
     @Test
     public void testBatchNormImport() {
-        TestableTensorFlowModel model = new TestableTensorFlowModel("src/test/files/integration/tensorflow/batch_norm/saved");
+        TestableTensorFlowModel model = new TestableTensorFlowModel("test", "src/test/files/integration/tensorflow/batch_norm/saved");
         TensorFlowModel.Signature signature = model.get().signature("serving_default");
 
         assertEquals("Has skipped outputs",

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/DropoutImportTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/DropoutImportTestCase.java
@@ -16,7 +16,7 @@ public class DropoutImportTestCase {
 
     @Test
     public void testDropoutImport() {
-        TestableTensorFlowModel model = new TestableTensorFlowModel("src/test/files/integration/tensorflow/dropout/saved");
+        TestableTensorFlowModel model = new TestableTensorFlowModel("test", "src/test/files/integration/tensorflow/dropout/saved");
 
         // Check required macros
         assertEquals(1, model.get().requiredMacros().size());
@@ -32,7 +32,7 @@ public class DropoutImportTestCase {
         RankingExpression output = signature.outputExpression("y");
         assertNotNull(output);
         assertEquals("outputs/Maximum", output.getName());
-        assertEquals("join(join(tf_macro_outputs_BiasAdd, reduce(constant(outputs_Const), sum, d1), f(a,b)(a * b)), tf_macro_outputs_BiasAdd, f(a,b)(max(a,b)))",
+        assertEquals("join(join(tf_macro_outputs_BiasAdd, reduce(constant(test_outputs_Const), sum, d1), f(a,b)(a * b)), tf_macro_outputs_BiasAdd, f(a,b)(max(a,b)))",
                 output.getRoot().toString());
         model.assertEqualResult("X", output.getName());
     }

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/MnistSoftmaxImportTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/MnistSoftmaxImportTestCase.java
@@ -17,18 +17,18 @@ public class MnistSoftmaxImportTestCase {
 
     @Test
     public void testMnistSoftmaxImport() {
-        TestableTensorFlowModel model = new TestableTensorFlowModel("src/test/files/integration/tensorflow/mnist_softmax/saved");
+        TestableTensorFlowModel model = new TestableTensorFlowModel("test", "src/test/files/integration/tensorflow/mnist_softmax/saved");
 
         // Check constants
         assertEquals(2, model.get().largeConstants().size());
 
-        Tensor constant0 = model.get().largeConstants().get("Variable_read");
+        Tensor constant0 = model.get().largeConstants().get("test_Variable_read");
         assertNotNull(constant0);
         assertEquals(new TensorType.Builder().indexed("d2", 784).indexed("d1", 10).build(),
                      constant0.type());
         assertEquals(7840, constant0.size());
 
-        Tensor constant1 = model.get().largeConstants().get("Variable_1_read");
+        Tensor constant1 = model.get().largeConstants().get("test_Variable_1_read");
         assertNotNull(constant1);
         assertEquals(new TensorType.Builder().indexed("d1", 10).build(),
                      constant1.type());
@@ -59,7 +59,7 @@ public class MnistSoftmaxImportTestCase {
         RankingExpression output = signature.outputExpression("y");
         assertNotNull(output);
         assertEquals("add", output.getName());
-        assertEquals("join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), constant(Variable_read), f(a,b)(a * b)), sum, d2), constant(Variable_1_read), f(a,b)(a + b))",
+        assertEquals("join(reduce(join(rename(Placeholder, (d0, d1), (d0, d2)), constant(test_Variable_read), f(a,b)(a * b)), sum, d2), constant(test_Variable_1_read), f(a,b)(a + b))",
                      output.getRoot().toString());
 
         // Test execution

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TestableTensorFlowModel.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/integration/tensorflow/TestableTensorFlowModel.java
@@ -34,9 +34,9 @@ public class TestableTensorFlowModel {
     private final int d0Size = 1;
     private final int d1Size = 784;
 
-    public TestableTensorFlowModel(String modelDir) {
+    public TestableTensorFlowModel(String modelName, String modelDir) {
         tensorFlowModel = SavedModelBundle.load(modelDir, "serve");
-        model = new TensorFlowImporter().importModel(tensorFlowModel);
+        model = new TensorFlowImporter().importModel(modelName, tensorFlowModel);
     }
 
     public TensorFlowModel get() { return model; }


### PR DESCRIPTION
Large constants are cross rank profiles. This avoids name
conflicts when multiple models are used. It is not strictly
necessary because the user can always disambiguate when chosing
names, but there is a scenario where conflicts are plausible and
leaving this to users is inconvenient: Multiple versions of the
"same" model are tested in different rank profiles.