### PR TITLE
Share configserver certificate with proxy

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -96,6 +96,10 @@ public class DockerOperationsImpl implements DockerOperations {
                 command.withVolume("/var/lib/sia", "/var/lib/sia");
             }
 
+            if (environment.getNodeType() == NodeType.proxyhost) {
+                command.withVolume("/opt/yahoo/share/ssl/certs/", "/opt/yahoo/share/ssl/certs/");
+            }
+
             if (!docker.networkNPTed()) {
                 command.withIpAddress(nodeInetAddress);
                 command.withNetworkMode(DockerImpl.DOCKER_CUSTOM_MACVLAN_NETWORK_NAME);


### PR DESCRIPTION
Maps in host's certificate to talk to config server in the docker containers created on a `proxyhost`.

This certificates authorizes node-repo/orchestrator operations for the host and all the children on that host. This should be fine in this case because:
1) `proxyhost` can only run 1 node, `proxy`
2) The `proxy` node runs our code

The certificate is required by the `AkamaiStatusClient`.