### PR TITLE
Expand IPv6 loopback address in filter

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/filter/LocalhostFilter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/filter/LocalhostFilter.java
@@ -21,7 +21,7 @@ import java.io.UncheckedIOException;
 public class LocalhostFilter implements SecurityRequestFilter {
 
     private static final String inet4Loopback = "127.0.0.1";
-    private static final String inet6Loopback = "::1";
+    private static final String inet6Loopback = "0:0:0:0:0:0:0:1";
 
     @Override
     public void filter(DiscFilterRequest request, ResponseHandler handler) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/filter/LocalhostFilterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/filter/LocalhostFilterTest.java
@@ -25,7 +25,7 @@ public class LocalhostFilterTest {
                              "1.2.3.4: Unauthorized host\"}");
 
         tester.assertSuccess(new Request(Method.GET, "/").remoteAddr("127.0.0.1"));
-        tester.assertSuccess(new Request(Method.GET, "/").remoteAddr("::1"));
+        tester.assertSuccess(new Request(Method.GET, "/").remoteAddr("0:0:0:0:0:0:0:1"));
     }
 
 }


### PR DESCRIPTION
`request.getRemoteAddr()` returns the expanded variant.