### PR TITLE
Balder/add coverage metrics

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -144,10 +144,6 @@ public class StatisticsSearcher extends Searcher {
         }
     }
 
-    StatisticsSearcher(Metric metric) {
-        this(com.yahoo.statistics.Statistics.nullImplementation, metric, MetricReceiver.nullImplementation);
-    }
-
     public StatisticsSearcher(com.yahoo.statistics.Statistics manager, Metric metric, MetricReceiver metricReceiver) {
         this.peakQpsReporter = new PeakQpsReporter();
         this.metric = metric;
@@ -158,10 +154,6 @@ public class StatisticsSearcher extends Searcher {
     @Override
     public void deconstruct() {
         scheduler.cancel();
-    }
-
-    public String getMyID() {
-        return (getId().stringValue());
     }
 
     private void qps(Metric.Context metricContext) {

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -184,16 +184,20 @@ public class StatisticsSearcher extends Searcher {
             }
             degradedReasonContexts.put(chainName, reasons);
         }
+        return reasons.get(getMostImportantDegradeReason(coverage));
+    }
+
+    private DegradedReason getMostImportantDegradeReason(Coverage coverage) {
         if (coverage.isDegradedByMatchPhase()) {
-            return reasons.get(DegradedReason.match_phase);
+            return DegradedReason.match_phase;
         }
         if (coverage.isDegradedByTimeout()) {
-            return reasons.get(DegradedReason.timeout);
+            return DegradedReason.timeout;
         }
         if (coverage.isDegradedByAdapativeTimeout()) {
-            return reasons.get(DegradedReason.adaptive_timeout);
+            return DegradedReason.adaptive_timeout;
         }
-        return reasons.get(DegradedReason.non_ideal_state);
+        return DegradedReason.non_ideal_state;
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -240,13 +240,15 @@ public class StatisticsSearcher extends Searcher {
             incrementStatePageOnlyErrors(result);
         }
         Coverage queryCoverage = result.getCoverage(false);
-        if (queryCoverage != null && queryCoverage.isDegraded()) {
-            Metric.Context degradedContext = getDegradedMetricContext(execution.chain().getId().stringValue(), queryCoverage);
-            metric.add(DEGRADED_METRIC, 1, degradedContext);
+        if (queryCoverage != null) {
+            if (queryCoverage.isDegraded()) {
+                Metric.Context degradedContext = getDegradedMetricContext(execution.chain().getId().stringValue(), queryCoverage);
+                metric.add(DEGRADED_METRIC, 1, degradedContext);
+            }
+            metric.set(COVERAGE_METRIC, (double) queryCoverage.getResultPercentage(), metricContext);
         }
         int hitCount = result.getConcreteHitCount();
         hitsPerQuery.put((double) hitCount);
-        metric.set(COVERAGE_METRIC, (double) queryCoverage.getResultPercentage(), metricContext);
         metric.set(HITS_PER_QUERY_METRIC, (double) hitCount, metricContext);
         metric.set(TOTALHITS_PER_QUERY_METRIC, (double) result.getTotalHitCount(), metricContext);
         if (hitCount == 0) {

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -240,7 +240,7 @@ public class StatisticsSearcher extends Searcher {
             incrementStatePageOnlyErrors(result);
         }
         Coverage queryCoverage = result.getCoverage(false);
-        if (queryCoverage.isDegraded()) {
+        if (queryCoverage != null && queryCoverage.isDegraded()) {
             Metric.Context degradedContext = getDegradedMetricContext(execution.chain().getId().stringValue(), queryCoverage);
             metric.add(DEGRADED_METRIC, 1, degradedContext);
         }

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -74,7 +74,8 @@ public class StatisticsSearcher extends Searcher {
 
     private final PeakQpsReporter peakQpsReporter;
 
-    enum DegradedReason { MatchPhase, AdaptiveTimeout, Timeout, NonIdealState }
+    // Naming of enums are reflected directly in metric dimensions and should not be changed as they are public API
+    private enum DegradedReason { match_phase, adaptive_timeout, timeout, non_ideal_state }
 
     private Metric metric;
     private Map<String, Metric.Context> chainContexts = new CopyOnWriteHashMap<>();
@@ -174,8 +175,8 @@ public class StatisticsSearcher extends Searcher {
         Map<DegradedReason, Metric.Context> reasons = degradedReasonContexts.get(chainName);
         if (reasons == null) {
             DegradedReason [] reasonEnums = {
-                    DegradedReason.MatchPhase, DegradedReason.AdaptiveTimeout,
-                    DegradedReason.Timeout, DegradedReason.NonIdealState
+                    DegradedReason.match_phase, DegradedReason.adaptive_timeout,
+                    DegradedReason.timeout, DegradedReason.non_ideal_state
             };
             reasons = new HashMap<>(4);
             for (DegradedReason reason : reasonEnums ) {
@@ -188,15 +189,15 @@ public class StatisticsSearcher extends Searcher {
             degradedReasonContexts.put(chainName, reasons);
         }
         if (coverage.isDegradedByMatchPhase()) {
-            return reasons.get(DegradedReason.MatchPhase);
+            return reasons.get(DegradedReason.match_phase);
         }
         if (coverage.isDegradedByTimeout()) {
-            return reasons.get(DegradedReason.Timeout);
+            return reasons.get(DegradedReason.timeout);
         }
         if (coverage.isDegradedByAdapativeTimeout()) {
-            return reasons.get(DegradedReason.AdaptiveTimeout);
+            return reasons.get(DegradedReason.adaptive_timeout);
         }
-        return reasons.get(DegradedReason.NonIdealState);
+        return reasons.get(DegradedReason.non_ideal_state);
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -174,12 +174,8 @@ public class StatisticsSearcher extends Searcher {
     private Metric.Context getDegradedMetricContext(String chainName, Coverage coverage) {
         Map<DegradedReason, Metric.Context> reasons = degradedReasonContexts.get(chainName);
         if (reasons == null) {
-            DegradedReason [] reasonEnums = {
-                    DegradedReason.match_phase, DegradedReason.adaptive_timeout,
-                    DegradedReason.timeout, DegradedReason.non_ideal_state
-            };
             reasons = new HashMap<>(4);
-            for (DegradedReason reason : reasonEnums ) {
+            for (DegradedReason reason : DegradedReason.values() ) {
                 Map<String, String> dimensions = new HashMap<>();
                 dimensions.put("chain", chainName);
                 dimensions.put("reason", reason.toString());


### PR DESCRIPTION
@arnej27959 @jobergum @bratseth PR 
Note metric name "degraded_queries" and "coverage_per_query".
The former has the added dimension "reason" with 4 possible values
"match_phase", "timeout", "adaptive_timeout" and "non_ideal_state"