### PR TITLE
Immediately send getnodestate reply on no pending merges edge

### DIFF
--- a/storage/src/tests/distributor/distributortestutil.cpp
+++ b/storage/src/tests/distributor/distributortestutil.cpp
@@ -173,14 +173,11 @@ DistributorTestUtil::addIdealNodes(const lib::ClusterState& state,
     getBucketDatabase().update(entry);
 }
 
-void
-DistributorTestUtil::addNodesToBucketDB(const document::BucketId& id,
-                                        const std::string& nodeStr)
-{
-    BucketDatabase::Entry entry = getBucket(id);
+void DistributorTestUtil::addNodesToBucketDB(const document::Bucket& bucket, const std::string& nodeStr) {
+    BucketDatabase::Entry entry = getBucket(bucket);
 
     if (!entry.valid()) {
-        entry = BucketDatabase::Entry(id);
+        entry = BucketDatabase::Entry(bucket.getBucketId());
     }
 
     entry->clear();
@@ -228,7 +225,14 @@ DistributorTestUtil::addNodesToBucketDB(const document::BucketId& id,
         entry->addNodeManual(node);
     }
 
-    getBucketDatabase().update(entry);
+    getBucketDatabase(bucket.getBucketSpace()).update(entry);
+}
+
+void
+DistributorTestUtil::addNodesToBucketDB(const document::BucketId& id,
+                                        const std::string& nodeStr)
+{
+    addNodesToBucketDB(document::Bucket(makeBucketSpace(), id), nodeStr);
 }
 
 void
@@ -301,6 +305,10 @@ DistributorTestUtil::sendReply(Operation& op,
     op.receive(_sender, reply);
 }
 
+BucketDatabase::Entry DistributorTestUtil::getBucket(const document::Bucket& bucket) const {
+    return getBucketDatabase(bucket.getBucketSpace()).get(bucket.getBucketId());
+}
+
 BucketDatabase::Entry
 DistributorTestUtil::getBucket(const document::BucketId& bId) const
 {
@@ -356,9 +364,18 @@ BucketDatabase&
 DistributorTestUtil::getBucketDatabase() {
     return getDistributorBucketSpace().getBucketDatabase();
 }
+
+BucketDatabase& DistributorTestUtil::getBucketDatabase(document::BucketSpace space) {
+    return getBucketSpaceRepo().get(space).getBucketDatabase();
+}
+
 const BucketDatabase&
 DistributorTestUtil::getBucketDatabase() const {
     return getBucketSpaceRepo().get(makeBucketSpace()).getBucketDatabase();
+}
+
+const BucketDatabase& DistributorTestUtil::getBucketDatabase(document::BucketSpace space) const {
+    return getBucketSpaceRepo().get(space).getBucketDatabase();
 }
 
 DistributorBucketSpaceRepo &

--- a/storage/src/tests/distributor/distributortestutil.h
+++ b/storage/src/tests/distributor/distributortestutil.h
@@ -67,6 +67,8 @@ public:
      * Format:
      *   "node1=checksum/docs/size,node2=checksum/docs/size"
      */
+    void addNodesToBucketDB(const document::Bucket& bucket, const std::string& nodeStr);
+    // As the above, but always inserts into default bucket space
     void addNodesToBucketDB(const document::BucketId& id, const std::string& nodeStr);
 
    /**
@@ -124,8 +126,10 @@ public:
 
     // TODO explicit notion of bucket spaces for tests
     DistributorBucketSpace &getDistributorBucketSpace();
-    BucketDatabase& getBucketDatabase();
-    const BucketDatabase& getBucketDatabase() const;
+    BucketDatabase& getBucketDatabase(); // Implicit default space only
+    BucketDatabase& getBucketDatabase(document::BucketSpace space);
+    const BucketDatabase& getBucketDatabase() const; // Implicit default space only
+    const BucketDatabase& getBucketDatabase(document::BucketSpace space) const;
     DistributorBucketSpaceRepo &getBucketSpaceRepo();
     const DistributorBucketSpaceRepo &getBucketSpaceRepo() const;
 
@@ -164,6 +168,8 @@ public:
 
     void disableBucketActivationInConfig(bool disable);
 
+    BucketDatabase::Entry getBucket(const document::Bucket& bucket) const;
+    // Gets bucket entry from default space only
     BucketDatabase::Entry getBucket(const document::BucketId& bId) const;
 
     std::vector<document::BucketSpace> getBucketSpaces() const;

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -99,7 +99,8 @@ Distributor::Distributor(DistributorComponentRegister& compReg,
       _hostInfoReporter(*this, *this),
       _ownershipSafeTimeCalc(
             std::make_unique<OwnershipTransferSafeTimePointCalculator>(
-                std::chrono::seconds(0))) // Set by config later
+                std::chrono::seconds(0))), // Set by config later
+      _must_send_updated_host_info(false)
 {
     _component.registerMetric(*_metrics);
     _component.registerMetricUpdateHook(_metricUpdateHook,
@@ -420,7 +421,7 @@ Distributor::leaveRecoveryMode()
         _metrics->recoveryModeTime.addValue(
                 _recoveryTimeStarted.getElapsedTimeAsDouble());
         if (_doneInitializing) {
-            _component.getStateUpdater().immediately_send_get_node_state_replies();
+            _must_send_updated_host_info = true;
         }
     }
     _schedulingMode = MaintenanceScheduler::NORMAL_SCHEDULING_MODE;
@@ -695,10 +696,12 @@ toBucketSpaceStats(const NodeMaintenanceStats &stats)
     return BucketSpaceStats(0, stats.syncing + stats.copyingIn);
 }
 
-BucketSpacesStatsProvider::PerNodeBucketSpacesStats
+using PerNodeBucketSpacesStats = BucketSpacesStatsProvider::PerNodeBucketSpacesStats;
+
+PerNodeBucketSpacesStats
 toBucketSpacesStats(const NodeMaintenanceStatsTracker &maintenanceStats)
 {
-    BucketSpacesStatsProvider::PerNodeBucketSpacesStats result;
+    PerNodeBucketSpacesStats result;
     for (const auto &nodeEntry : maintenanceStats.perNodeStats()) {
         for (const auto &bucketSpaceEntry : nodeEntry.second) {
             auto bucketSpace = document::FixedBucketSpaces::to_string(bucketSpaceEntry.first);
@@ -706,6 +709,27 @@ toBucketSpacesStats(const NodeMaintenanceStatsTracker &maintenanceStats)
         }
     }
     return result;
+}
+
+size_t valid_space_stats_entries(const PerNodeBucketSpacesStats& stats) {
+    size_t valid = 0;
+    for (auto& node : stats) {
+        for (auto& space : node.second) {
+            valid += space.second.valid() ? 1 : 0;
+        }
+    }
+    return valid;
+}
+
+// TODO should we also trigger on !pending --> pending edge?
+bool merge_no_longer_pending_edge(const PerNodeBucketSpacesStats& prev_stats,
+                                  const PerNodeBucketSpacesStats& curr_stats) {
+    const auto prev_valid = valid_space_stats_entries(prev_stats);
+    const auto curr_valid = valid_space_stats_entries(curr_stats);
+    // Since the valid bucket space -> stats mapping is empty for a given space
+    // iff it has no pending merges, a reduction in the valid stats map size is
+    // a direct indicator that a space no longer has merges pending.
+    return curr_valid < prev_valid;
 }
 
 }
@@ -718,7 +742,11 @@ Distributor::updateInternalMetricsForCompletedScan()
     _bucketDBMetricUpdater.completeRound();
     _bucketDbStats = _bucketDBMetricUpdater.getLastCompleteStats();
     _maintenanceStats = _scanner->getPendingMaintenanceStats();
-    _bucketSpacesStats = toBucketSpacesStats(_maintenanceStats.perNodeStats);
+    auto new_space_stats = toBucketSpacesStats(_maintenanceStats.perNodeStats);
+    if (merge_no_longer_pending_edge(_bucketSpacesStats, new_space_stats)) {
+        _must_send_updated_host_info = true;
+    }
+    _bucketSpacesStats = std::move(new_space_stats);
 }
 
 void
@@ -734,8 +762,13 @@ Distributor::scanNextBucket()
     MaintenanceScanner::ScanResult scanResult(_scanner->scanNext());
     if (scanResult.isDone()) {
         updateInternalMetricsForCompletedScan();
-        leaveRecoveryMode(); // Must happen after internal metrics updates
+        leaveRecoveryMode();
         _scanner->reset();
+        // TODO factor out
+        if (_must_send_updated_host_info) {
+            _component.getStateUpdater().immediately_send_get_node_state_replies();
+            _must_send_updated_host_info = false;
+        }
     } else {
         const auto &distribution(_bucketSpaceRepo->get(scanResult.getBucketSpace()).getDistribution());
         _bucketDBMetricUpdater.visit(

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -763,12 +763,8 @@ Distributor::scanNextBucket()
     if (scanResult.isDone()) {
         updateInternalMetricsForCompletedScan();
         leaveRecoveryMode();
+        send_updated_host_info_if_required();
         _scanner->reset();
-        // TODO factor out
-        if (_must_send_updated_host_info) {
-            _component.getStateUpdater().immediately_send_get_node_state_replies();
-            _must_send_updated_host_info = false;
-        }
     } else {
         const auto &distribution(_bucketSpaceRepo->get(scanResult.getBucketSpace()).getDistribution());
         _bucketDBMetricUpdater.visit(
@@ -776,6 +772,13 @@ Distributor::scanNextBucket()
                 distribution.getRedundancy());
     }
     return scanResult;
+}
+
+void Distributor::send_updated_host_info_if_required() {
+    if (_must_send_updated_host_info) {
+        _component.getStateUpdater().immediately_send_get_node_state_replies();
+        _must_send_updated_host_info = false;
+    }
 }
 
 void

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -237,6 +237,7 @@ private:
     template <typename NodeFunctor>
     void for_each_available_content_node_in(const lib::ClusterState&, NodeFunctor&&);
     void invalidate_bucket_spaces_stats();
+    void send_updated_host_info_if_required();
 
     lib::ClusterStateBundle _clusterStateBundle;
 

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -310,6 +310,7 @@ private:
     BucketDBMetricUpdater::Stats _bucketDbStats;
     DistributorHostInfoReporter _hostInfoReporter;
     std::unique_ptr<OwnershipTransferSafeTimePointCalculator> _ownershipSafeTimeCalc;
+    bool _must_send_updated_host_info;
 };
 
 } // distributor


### PR DESCRIPTION
@geirst please review
@toregge FYI

Lets the cluster controller update the derived bucket space states
as quickly as possible when merges are done for the global space,
without having to wait for the normal reply timeout period.