### PR TITLE
Try to avoid using up all resources handling requests for non-existin…

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDistributionRpcServer.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDistributionRpcServer.java
@@ -13,14 +13,13 @@ import com.yahoo.jrt.Supervisor;
 import com.yahoo.log.LogLevel;
 
 import java.io.File;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * An RPC server that handles file distribution requests.
@@ -104,12 +103,10 @@ public class FileDistributionRpcServer {
 
     @SuppressWarnings({"UnusedDeclaration"})
     public final void setFileReferencesToDownload(Request req) {
-        String[] fileReferenceStrings = req.parameters().get(0).asStringArray();
-        List<FileReference> fileReferences = Stream.of(fileReferenceStrings)
+        Arrays.stream(req.parameters().get(0).asStringArray())
                 .map(FileReference::new)
-                .collect(Collectors.toList());
-        downloader.queueForAsyncDownload(fileReferences);
-
+                .forEach(fileReference -> downloader.queueForAsyncDownload(
+                        new FileReferenceDownload(fileReference)));
         req.returnValues().add(new Int32Value(0));
     }
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownload.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownload.java
@@ -8,19 +8,33 @@ import com.yahoo.config.FileReference;
 import java.io.File;
 import java.util.Optional;
 
-class FileReferenceDownload {
+public class FileReferenceDownload {
+
     private final FileReference fileReference;
     private final SettableFuture<Optional<File>> future;
+    // If a config server wants to download from another config server (because it does not have the
+    // file itself) we set this flag to true to avoid an eternal loop
+    private final boolean downloadFromOtherSourceIfNotFound;
 
-    FileReferenceDownload(FileReference fileReference, SettableFuture<Optional<File>> future) {
+    public FileReferenceDownload(FileReference fileReference) {
+        this(fileReference, true);
+    }
+
+    public FileReferenceDownload(FileReference fileReference, boolean downloadFromOtherSourceIfNotFound) {
         this.fileReference = fileReference;
-        this.future = future;
+        this.future = SettableFuture.create();
+        this.downloadFromOtherSourceIfNotFound = downloadFromOtherSourceIfNotFound;
     }
 
     FileReference fileReference() {
         return fileReference;
     }
+
     SettableFuture<Optional<File>> future() {
         return future;
+    }
+
+    boolean downloadFromOtherSourceIfNotFound() {
+        return downloadFromOtherSourceIfNotFound;
     }
 }

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -22,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import static com.yahoo.jrt.ErrorCode.CONNECTION;
@@ -190,8 +189,8 @@ public class FileDownloaderTest {
         FileDownloader fileDownloader = new FileDownloader(connectionPool, downloadDir, tempDir, timeout, sleepBetweenRetries);
         FileReference foo = new FileReference("foo");
         FileReference bar = new FileReference("bar");
-        List<FileReference> fileReferences = Arrays.asList(foo, bar);
-        fileDownloader.queueForAsyncDownload(fileReferences);
+        fileDownloader.queueForAsyncDownload(new FileReferenceDownload(foo));
+        fileDownloader.queueForAsyncDownload(new FileReferenceDownload(bar));
 
         // Verify download status
         assertDownloadStatus(fileDownloader, foo, 0.0);


### PR DESCRIPTION
…g file

Add field to request filedsitribution.serveFile that says if this request
might lead to download from another config server. Avoid doing this when
we are on a config server and try to download file from another config
server, as that will end up using up all resources on all config servers
if the file does not exist