### PR TITLE
Fix ClusterStatsChangeTracker to handle case where current node is no…

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsChangeTracker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsChangeTracker.java
@@ -53,7 +53,7 @@ public class ClusterStatsChangeTracker {
                 if (prevValue != currValue) {
                     return true;
                 }
-            } else if (currValue) {
+            } else {
                 return true;
             }
         }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsChangeTrackerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsChangeTrackerTest.java
@@ -77,14 +77,14 @@ public class ClusterStatsChangeTrackerTest {
     }
 
     @Test
-    public void stats_have_not_changed_if_all_nodes_in_sync_and_nothing_previous() {
-        Fixture f = Fixture.fromStats(stats().inSync(0).inSync(1));
-        assertFalse(f.statsHaveChanged());
+    public void stats_have_changed_if_in_sync_node_not_found_in_previous_stats() {
+        Fixture f = Fixture.fromStats(stats().inSync(0));
+        assertTrue(f.statsHaveChanged());
     }
 
     @Test
-    public void stats_have_changed_if_one_node_with_buckets_pending_and_nothing_previous() {
-        Fixture f = Fixture.fromStats(stats().inSync(0).bucketsPending(1));
+    public void stats_have_changed_if_buckets_pending_node_not_found_in_previous_stats() {
+        Fixture f = Fixture.fromStats(stats().bucketsPending(0));
         assertTrue(f.statsHaveChanged());
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateVersionTrackerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateVersionTrackerTest.java
@@ -277,10 +277,19 @@ public class StateVersionTrackerTest {
         when(distributorNode.isDistributor()).thenReturn(true);
         assertFalse(tracker.bucketSpaceMergeCompletionStateHasChanged());
 
+        // Set baseline state
         tracker.updateLatestCandidateStateBundle(ClusterStateBundle
                 .ofBaselineOnly(stateWithoutAnnotations("distributor:1 storage:1")));
         tracker.promoteCandidateToVersionedState(1234);
         assertFalse(tracker.bucketSpaceMergeCompletionStateHasChanged());
+
+        // Current node not in previous stats
+        tracker.handleUpdatedHostInfo(distributorNode, createHostInfo(0));
+        assertTrue(tracker.bucketSpaceMergeCompletionStateHasChanged());
+
+        // Sync aggregated stats
+        tracker.updateLatestCandidateStateBundle(ClusterStateBundle
+                .ofBaselineOnly(stateWithoutAnnotations("distributor:1 storage:1")));
 
         // Give 'global' bucket space no buckets pending, which is the same as previous stats
         tracker.handleUpdatedHostInfo(distributorNode, createHostInfo(0));


### PR DESCRIPTION
…t found in previous state.

Cluster stats may have changed in this case.

@vekterli please review
@toregge FYI