### PR TITLE
Less greedy matching

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerTester.java
@@ -73,9 +73,11 @@ public class ContainerTester {
         String responseString = response.getBodyAsString();
         if (expectedResponse.contains("(ignore)")) {
             // Convert expected response to a literal pattern and replace any ignored field with a pattern that matches
-            // anything
+            // until the first stop character
+            String stopCharacters = "[^,:\\\\[\\\\]{}]";
             String expectedResponsePattern = Pattern.quote(expectedResponse)
-                                                    .replaceAll("\"?\\(ignore\\)\"?", "\\\\E.*\\\\Q");
+                                                    .replaceAll("\"?\\(ignore\\)\"?", "\\\\E" +
+                                                                                      stopCharacters + "*\\\\Q");
             if (!Pattern.matches(expectedResponsePattern, responseString)) {
                 throw new ComparisonFailure(responseFile.toString() + " (with ignored fields)",
                                             expectedResponsePattern, responseString);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -587,9 +587,11 @@ public class RestApiTest {
         String responseString = container.handleRequest(request).getBodyAsString();
         if (expectedResponse.contains("(ignore)")) {
             // Convert expected response to a literal pattern and replace any ignored field with a pattern that matches
-            // anything
+            // until the first stop character
+            String stopCharacters = "[^,:\\\\[\\\\]{}]";
             String expectedResponsePattern = Pattern.quote(expectedResponse)
-                                                    .replaceAll("\"?\\(ignore\\)\"?", "\\\\E.*\\\\Q");
+                                                    .replaceAll("\"?\\(ignore\\)\"?", "\\\\E" +
+                                                                                      stopCharacters + "*\\\\Q");
             if (!Pattern.matches(expectedResponsePattern, responseString)) {
                 throw new ComparisonFailure(responseFile + " (with ignored fields)", expectedResponsePattern,
                                             responseString);


### PR DESCRIPTION
Pragmatic approach. Won't work for all cases, e.g. value contains any of
`stopCharacters`, but there doesn't seem to be any such cases in the tests.