### PR TITLE
Remove "vds.filestor.*" metrics from consumer fleetcontroller (cluste…

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
@@ -94,12 +94,6 @@ public class StorageCluster extends AbstractConfigProducer<StorageNode>
     @Override
     public void getConfig(MetricsmanagerConfig.Builder builder) {
         ContentCluster.getMetricBuilder("fleetcontroller", builder).
-                addedmetrics("vds.filestor.*.allthreads.put.sum").
-                addedmetrics("vds.filestor.*.allthreads.get.sum").
-                addedmetrics("vds.filestor.*.allthreads.multi.sum").
-                addedmetrics("vds.filestor.*.allthreads.update.sum").
-                addedmetrics("vds.filestor.*.allthreads.remove.sum").
-                addedmetrics("vds.filestor.*.allthreads.operations").
                 addedmetrics("vds.datastored.alldisks.docs").
                 addedmetrics("vds.datastored.alldisks.bytes").
                 addedmetrics("vds.datastored.alldisks.buckets");

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterTest.java
@@ -647,16 +647,10 @@ public class ClusterTest extends ContentBaseTest {
         assertEquals(6, config.consumer().size());
 
         assertEquals("fleetcontroller", config.consumer(4).name());
-        assertEquals(9, config.consumer(4).addedmetrics().size());
-        assertEquals("vds.filestor.*.allthreads.put.sum", config.consumer(4).addedmetrics(0));
-        assertEquals("vds.filestor.*.allthreads.get.sum", config.consumer(4).addedmetrics(1));
-        assertEquals("vds.filestor.*.allthreads.multi.sum", config.consumer(4).addedmetrics(2));
-        assertEquals("vds.filestor.*.allthreads.update.sum", config.consumer(4).addedmetrics(3));
-        assertEquals("vds.filestor.*.allthreads.remove.sum", config.consumer(4).addedmetrics(4));
-        assertEquals("vds.filestor.*.allthreads.operations", config.consumer(4).addedmetrics(5));
-        assertEquals("vds.datastored.alldisks.docs", config.consumer(4).addedmetrics(6));
-        assertEquals("vds.datastored.alldisks.bytes", config.consumer(4).addedmetrics(7));
-        assertEquals("vds.datastored.alldisks.buckets", config.consumer(4).addedmetrics(8));
+        assertEquals(3, config.consumer(4).addedmetrics().size());
+        assertEquals("vds.datastored.alldisks.docs", config.consumer(4).addedmetrics(0));
+        assertEquals("vds.datastored.alldisks.bytes", config.consumer(4).addedmetrics(1));
+        assertEquals("vds.datastored.alldisks.buckets", config.consumer(4).addedmetrics(2));
     }
 
     public MetricsmanagerConfig.Consumer getConsumer(String consumer, MetricsmanagerConfig config) {
@@ -731,12 +725,6 @@ public class ClusterTest extends ContentBaseTest {
             assertEquals("[logdefault]", getConsumer("log", config).tags().toString());
             expected =
                     "[extraextra\n" +
-                    "vds.filestor.*.allthreads.put.sum\n" +
-                    "vds.filestor.*.allthreads.get.sum\n" +
-                    "vds.filestor.*.allthreads.multi.sum\n" +
-                    "vds.filestor.*.allthreads.update.sum\n" +
-                    "vds.filestor.*.allthreads.remove.sum\n" +
-                    "vds.filestor.*.allthreads.operations\n" +
                     "vds.datastored.alldisks.docs\n" +
                     "vds.datastored.alldisks.bytes\n" +
                     "vds.datastored.alldisks.buckets]";


### PR DESCRIPTION
…rcontroller) that are not used.

@vekterli please review