### PR TITLE
Use hostname from Environment

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/DockerAdminComponent.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/DockerAdminComponent.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.node.admin.component;
 
 import com.yahoo.concurrent.classlock.ClassLocking;
-import com.yahoo.net.HostName;
 import com.yahoo.system.ProcessExecuter;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
@@ -87,7 +86,7 @@ public class DockerAdminComponent implements AdminComponent {
         }
 
         Clock clock = Clock.systemUTC();
-        String dockerHostHostName = HostName.getLocalhost();
+        String dockerHostHostName = environment.get().getParentHostHostname();
         ProcessExecuter processExecuter = new ProcessExecuter();
 
         docker.start();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConfigServerApiImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConfigServerApiImpl.java
@@ -46,7 +46,7 @@ public class SslConfigServerApiImpl implements ConfigServerApi {
                     makeSslConnectionSocketFactory(Optional.of(keyStoreOptions)));
 
             ConfigServerKeyStoreRefresher keyStoreRefresher = new ConfigServerKeyStoreRefresher(
-                    keyStoreOptions, connectionFactoryRefresher, configServerApi);
+                    keyStoreOptions, connectionFactoryRefresher, configServerApi, environment.getParentHostHostname());
 
             // Run the refresh once manually to make sure that we have a valid certificate, otherwise fail.
             try {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/certificate/ConfigServerKeyStoreRefresher.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/certificate/ConfigServerKeyStoreRefresher.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.certificate;
 
 import com.yahoo.log.LogLevel;
-import com.yahoo.net.HostName;
 import com.yahoo.vespa.athenz.tls.KeyStoreBuilder;
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
 import com.yahoo.vespa.hosted.node.admin.util.KeyStoreOptions;
@@ -51,9 +50,9 @@ public class ConfigServerKeyStoreRefresher {
     private final String hostname;
 
     public ConfigServerKeyStoreRefresher(
-            KeyStoreOptions keyStoreOptions, Runnable keyStoreUpdatedCallback, ConfigServerApi configServerApi) {
+            KeyStoreOptions keyStoreOptions, Runnable keyStoreUpdatedCallback, ConfigServerApi configServerApi, String hostname) {
         this(keyStoreOptions, keyStoreUpdatedCallback, configServerApi, Executors.newScheduledThreadPool(1),
-                Clock.systemUTC(), HostName.getLocalhost());
+                Clock.systemUTC(), hostname);
     }
 
     ConfigServerKeyStoreRefresher(KeyStoreOptions keyStoreOptions,

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.collections.Pair;
 import com.yahoo.io.IOUtils;
-import com.yahoo.net.HostName;
 import com.yahoo.system.ProcessExecuter;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.metrics.CounterWrapper;
@@ -237,7 +236,7 @@ public class StorageMaintainer {
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("hostname", nodeSpec.hostname);
-        attributes.put("parent_hostname", HostName.getLocalhost());
+        attributes.put("parent_hostname", environment.getParentHostHostname());
         attributes.put("region", environment.getRegion());
         attributes.put("environment", environment.getEnvironment());
         attributes.put("flavor", nodeSpec.nodeFlavor);


### PR DESCRIPTION
Replaces usage of `HostName.getLocalhost()` with parent hostname from `Environment`.

This is needed because we sometimes get some `*-ec2.internal` address in AWS, this is maybe our fault, maybe temporary, but why not use the one from `Environment` which is guaranteed to be correct and stable (set from `HostConfig`).

FYI: @smorgrav 