### PR TITLE
Fixed typo in environment variable assignment

### DIFF
--- a/docker/run/run-vespa-internal.sh
+++ b/docker/run/run-vespa-internal.sh
@@ -14,7 +14,7 @@ cd $DIR
 # Workaround until we figure out why rpm does not set the ownership.
 chown -R vespa:vespa /opt/vespa
 
-export VESPA_CONFIG_SERVERS=$(hostname)
+export VESPA_CONFIGSERVERS=$(hostname)
 
 /opt/vespa/bin/vespa-start-configserver
 # Give config server some time to come up before starting services


### PR DESCRIPTION
Value set for the VESPA_CONFIG_SERVERS environment variable gets ignored during startup. The environment variable VESPA_CONFIG_SERVERS should be VESPA_CONFIGSERVERS per the documentation specified in the populate_environment function in vespa/vespabase/src/common-env.sh and usage in defaults/src/vespa/defaults.cpp.

