### PR TITLE
Do not overwrite node-repository-config

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/containerdata/ConfigServerContainerData.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/containerdata/ConfigServerContainerData.java
@@ -19,7 +19,6 @@ public class ConfigServerContainerData {
 
     public void writeTo(ContainerData containerData) {
         containerData.addFile(getPath("configserver-config.xml"), createConfigServerConfigXml());
-        containerData.addFile(getPath("node-repository-config.xml"), createNodeRepoConfigXml());
     }
 
     private Path getPath(String fileName) {
@@ -42,12 +41,4 @@ public class ConfigServerContainerData {
                 "  <nodeAdminInContainer>false</nodeAdminInContainer>\n" +
                 "</config>\n";
     }
-
-    // TODO: Avoid hardcoded Docker registry
-    private String createNodeRepoConfigXml() {
-        return "<config name=\"config.provisioning.node-repository\">\n" +
-                "    <dockerImage>658543512185.dkr.ecr.us-east-2.amazonaws.com/vespa/aws</dockerImage>\n" +
-                "</config>\n";
-    }
-
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -717,7 +717,6 @@ public class NodeAgentImplTest {
         inOrder.verify(orchestrator).resume(hostName);
 
         // Files written in createContainerData()
-        assertFileExists(containerName, tempDirectory, "node-repository-config.xml");
         assertFileExists(containerName, tempDirectory, "configserver-config.xml");
     }
 


### PR DESCRIPTION
Merge after `vespa/hosted#5702`

This will make it so that non-configserver docker containers use the same docker image in AWS as in Yahoo.