### PR TITLE
No need to check twice if lock is held before releasing it

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ActivateLock.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ActivateLock.java
@@ -11,8 +11,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A lock to protect session activation.
  *
- * @author lulf
- * @since 5.1
+ * @author Ulf Lilleengen
  */
 public class ActivateLock {
 
@@ -35,9 +34,7 @@ public class ActivateLock {
     }
 
     public void release() {
-        if (curatorLock.hasLock()) {
-            curatorLock.unlock();
-        }
+        curatorLock.unlock();
     }
 
     @Override

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -34,8 +34,6 @@ public class ConfigServerBootstrapTest {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
-    @Ignore // TODO: An issue with how MockCurator.MockLock is implemented make this not work (it will hang
-            // not being able to acquire activate lock in ConfigServerBootstrap
     public void testBootStrap() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig();
         DeployTester tester = new DeployTester("src/test/apps/hosted/", configserverConfig);


### PR DESCRIPTION
We already check if lock is held before releasing, so not needed
here. Changing this makes it possible to acquire ActivateLock more than
once in a unit tests (which uses MockLock and does not work ATM when
trying to do this)