### PR TITLE
Add container hostname to /etc/hosts

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
@@ -149,6 +149,7 @@ class CreateContainerCommandImpl implements Docker.CreateContainerCommand {
                 .withEnv(environmentAssignments)
                 .withBinds(volumeBinds)
                 .withUlimits(ulimits)
+                .withExtraHosts(hostName + ":::1", hostName + ":127.0.0.1")
                 .withCapAdd(new ArrayList<>(addCapabilities))
                 .withCapDrop(new ArrayList<>(dropCapabilities))
                 .withPrivileged(privileged);


### PR DESCRIPTION
Add the container hostname to /etc/hosts as localhost addresses (127.1 and ::1).

This is a quick fix for bridged container networks where the source and destination ip would otherwise be the same (seen from the bridge) and thus cause a socket collision. A caveat is if the container has logic that explicitly needs to resolve the DNS entry for itself (but I don't think that is the the case). 

An alternative using iptables in the container will also be implemented together with a revamped ACL implementation.