### PR TITLE
X-Forwarded-For HTTP header take precedence for remote address in access log

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
@@ -35,10 +35,10 @@ public class AccessLogRequestLog extends AbstractLifeCycle implements RequestLog
 
     private static final Logger logger = Logger.getLogger(AccessLogRequestLog.class.getName());
 
+    private static final String HEADER_NAME_X_FORWARDED_FOR = "x-forwarded-for";
     private static final String HEADER_NAME_Y_RA = "y-ra";
     private static final String HEADER_NAME_Y_RP = "y-rp";
     private static final String HEADER_NAME_YAHOOREMOTEIP = "yahooremoteip";
-    private static final String HEADER_NAME_X_FORWARDED_FOR = "x-forwarded-for";
     private static final String HEADER_NAME_CLIENT_IP = "client-ip";
 
     private final AccessLog accessLog;
@@ -123,9 +123,9 @@ public class AccessLogRequestLog extends AbstractLifeCycle implements RequestLog
     }
 
     private static String getRemoteAddress(final HttpServletRequest request) {
-        return Alternative.preferred(request.getHeader(HEADER_NAME_Y_RA))
+        return Alternative.preferred(request.getHeader(HEADER_NAME_X_FORWARDED_FOR))
+                .alternatively(() -> request.getHeader(HEADER_NAME_Y_RA))
                 .alternatively(() -> request.getHeader(HEADER_NAME_YAHOOREMOTEIP))
-                .alternatively(() -> request.getHeader(HEADER_NAME_X_FORWARDED_FOR))
                 .alternatively(() -> request.getHeader(HEADER_NAME_CLIENT_IP))
                 .orElseGet(request::getRemoteAddr);
     }

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLogTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLogTest.java
@@ -90,4 +90,17 @@ public class AccessLogRequestLogTest {
         assertThat(actualRawQuery.get(), is(rawQuery));
     }
 
+    @Test
+    public void verify_x_forwarded_for_precedence () {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        when(httpServletRequest.getRequestURI()).thenReturn("//search/");
+        when(httpServletRequest.getQueryString()).thenReturn("q=%%2");
+        when(httpServletRequest.getHeader("x-forwarded-for")).thenReturn("1.2.3.4");
+        when(httpServletRequest.getHeader("y-ra")).thenReturn("2.3.4.5");
+
+        AccessLogEntry accessLogEntry = new AccessLogEntry();
+        AccessLogRequestLog.populateAccessLogEntryFromHttpServletRequest(httpServletRequest, accessLogEntry);
+        assertThat(accessLogEntry.getRemoteAddress(), is("1.2.3.4"));
+    }
+
 }


### PR DESCRIPTION
@mpolden or @bratseth : Please review

I'll also update the [documentation](http://docs.vespa.ai/documentation/logging-in-json-format.html) accordingly in a separate PR.