### PR TITLE
Use active lids bitvector for whitelisting.

### DIFF
--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -100,7 +100,7 @@ class Test : public vespalib::TestApp {
     void requireThatNoDocsGiveZeroDocFrequency();
     void requireThatWeakAndBlueprintsAreCreatedCorrectly();
     void requireThatParallelWandBlueprintsAreCreatedCorrectly();
-    void requireThatBlackListBlueprintCanBeUsed();
+    void requireThatWhiteListBlueprintCanBeUsed();
 
 public:
     ~Test();
@@ -825,7 +825,7 @@ void Test::requireThatParallelWandBlueprintsAreCreatedCorrectly() {
 }
 
 void
-Test::requireThatBlackListBlueprintCanBeUsed()
+Test::requireThatWhiteListBlueprintCanBeUsed()
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm("foo", field, field_id, string_weight);
@@ -839,7 +839,7 @@ Test::requireThatBlackListBlueprintCanBeUsed()
         .addResult(field, "foo", FakeResult().doc(1).doc(3).doc(5).doc(7).doc(9).doc(11));
     context.setLimit(42);
 
-    query.setBlackListBlueprint(SimpleBlueprint::UP(new SimpleBlueprint(SimpleResult().addHit(3).addHit(9))));
+    query.setWhiteListBlueprint(SimpleBlueprint::UP(new SimpleBlueprint(SimpleResult().addHit(1).addHit(2).addHit(4).addHit(5).addHit(6).addHit(7).addHit(8).addHit(10).addHit(11).addHit(12))));
 
     FakeRequestContext requestContext;
     MatchDataLayout mdl;
@@ -886,7 +886,7 @@ Test::Main()
     TEST_CALL(requireThatNoDocsGiveZeroDocFrequency);
     TEST_CALL(requireThatWeakAndBlueprintsAreCreatedCorrectly);
     TEST_CALL(requireThatParallelWandBlueprintsAreCreatedCorrectly);
-    TEST_CALL(requireThatBlackListBlueprintCanBeUsed);
+    TEST_CALL(requireThatWhiteListBlueprintCanBeUsed);
 
     TEST_DONE();
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -778,7 +778,7 @@ DocumentMetaStore::getLidUsageStats() const
 Blueprint::UP
 DocumentMetaStore::createWhiteListBlueprint() const
 {
-    return _lidAlloc.createWhiteListBlueprint();
+    return _lidAlloc.createWhiteListBlueprint(getCommittedDocIdLimit());
 }
 
 AttributeVector::SearchContext::UP

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -67,9 +67,6 @@ private:
                                  search::btree::BTreeNoLeafData,
                                  search::btree::NoAggregated,
                                  const KeyComp &> TreeType;
-    // Bit attribute vector used to keep track of active & inactive documents.
-    // Inactive documents will be black-listed during search.
-    typedef search::SingleValueBitNumericAttribute BitAttribute;
 
     MetaDataStore       _metaDataStore;
     TreeType            _gidToLidMap;
@@ -209,7 +206,7 @@ public:
     DocId   getNumUsedLids() const override { return _lidAlloc.getNumUsedLids(); }
     DocId getNumActiveLids() const override { return _lidAlloc.getNumActiveLids(); }
     search::LidUsageStats getLidUsageStats() const override;
-    search::queryeval::Blueprint::UP createBlackListBlueprint() const override;
+    search::queryeval::Blueprint::UP createWhiteListBlueprint() const override;
 
     /**
      * Implements search::AttributeVector
@@ -230,10 +227,6 @@ public:
     Iterator upperBound(const GlobalId &gid) const override;
 
     void getLids(const BucketId &bucketId, std::vector<DocId> &lids) override;
-
-    search::AttributeGuard getActiveLidsGuard() const override {
-        return _lidAlloc.getActiveLidsGuard();
-    }
 
     bool getFreeListActive() const override {
         return _lidAlloc.isFreeListConstructed();
@@ -266,7 +259,8 @@ public:
         return AttributeVector::getGenerationHandler();
     }
 
-    const BitAttribute &getActiveLids() const { return _lidAlloc.getActiveLids(); }
+    const search::GrowableBitVector &getActiveLids() const { return _lidAlloc.getActiveLids(); }
+
     void clearDocs(DocId lidLow, DocId lidLimit) override;
 
     /*

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastorecontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastorecontext.cpp
@@ -6,8 +6,7 @@ namespace proton {
 
 DocumentMetaStoreContext::ReadGuard::ReadGuard(const search::AttributeVector::SP &metaStoreAttr) :
     _guard(metaStoreAttr),
-    _store(static_cast<const DocumentMetaStore &>(*_guard)),
-    _activeLidsGuard(_store.getActiveLidsGuard())
+    _store(static_cast<const DocumentMetaStore &>(*_guard))
 {
 }
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastorecontext.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastorecontext.h
@@ -19,7 +19,6 @@ public:
     private:
         search::AttributeGuard   _guard;
         const DocumentMetaStore &_store;
-        search::AttributeGuard   _activeLidsGuard;
     public:
         ReadGuard(const search::AttributeVector::SP &metaStoreAttr);
         const search::IDocumentMetaStore &get() const override { return _store; }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/i_bucket_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/i_bucket_handler.h
@@ -51,7 +51,7 @@ struct IBucketHandler
 
     /**
      * Sets the bucket state to active / inactive.
-     * Documents that are inactive will be black-listed during search.
+     * Documents that are inactive will not be white-listed during search.
      **/
     virtual void setBucketState(const BucketId &bucketId, bool active) = 0;
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/i_document_meta_store.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/i_document_meta_store.h
@@ -59,8 +59,6 @@ struct IDocumentMetaStore : public search::IDocumentMetaStore,
 
     virtual void getLids(const BucketId &bucketId, std::vector<DocId> &lids) = 0;
 
-    virtual search::AttributeGuard getActiveLidsGuard() const = 0;
-
     /*
      * Called by document db executor to hold unblocking of shrinking of lid
      * space after all outstanding holdLid() operations at the time of

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -195,6 +195,7 @@ class WhiteListBlueprint : public SimpleLeafBlueprint
 {
 private:
     const search::GrowableBitVector &_activeLids;
+    const uint32_t _docIdLimit;
     mutable std::mutex _lock;
     mutable std::vector<search::fef::TermFieldMatchData *> _matchDataVector;
 
@@ -210,14 +211,14 @@ private:
             std::lock_guard<std::mutex> lock(_lock);
             _matchDataVector.push_back(tfmd);
         }
-        uint32_t docIdLimit = _activeLids.size();
-        return search::BitVectorIterator::create(&_activeLids, docIdLimit, *tfmd, strict);
+        return search::BitVectorIterator::create(&_activeLids, _docIdLimit, *tfmd, strict);
     }
 
 public:
-    WhiteListBlueprint(const search::GrowableBitVector &activeLids)
+    WhiteListBlueprint(const search::GrowableBitVector &activeLids, uint32_t docIdLimit)
         : SimpleLeafBlueprint(FieldSpecBaseList()),
           _activeLids(activeLids),
+          _docIdLimit(docIdLimit),
           _matchDataVector()
     {
         setEstimate(HitEstimate(_activeLids.size(), false));
@@ -233,9 +234,9 @@ public:
 }
 
 Blueprint::UP
-LidAllocator::createWhiteListBlueprint() const
+LidAllocator::createWhiteListBlueprint(uint32_t docIdLimit) const
 {
-    return std::make_unique<WhiteListBlueprint>(_activeLids.getBitVector());
+    return std::make_unique<WhiteListBlueprint>(_activeLids.getBitVector(), docIdLimit);
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -220,7 +220,7 @@ public:
           _activeLids(activeLids),
           _matchDataVector()
     {
-        setEstimate(HitEstimate(0, false));
+        setEstimate(HitEstimate(_activeLids.size(), false));
     }
 
     ~WhiteListBlueprint() {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.h
@@ -48,7 +48,7 @@ public:
                   generation_t currentGeneration);
     bool holdLidOK(DocId lid, DocId lidLimit) const;
     void constructFreeList(DocId lidLimit);
-    search::queryeval::Blueprint::UP createWhiteListBlueprint() const;
+    search::queryeval::Blueprint::UP createWhiteListBlueprint(uint32_t docIdLimit) const;
     void updateActiveLids(DocId lid, bool active);
     void clearDocs(DocId lidLow, DocId lidLimit);
     void shrinkLidSpace(DocId committedDocIdLimit);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.h
@@ -7,12 +7,6 @@
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 
-namespace search {
-class AttributeVector;
-class SingleValueBitNumericAttribute;
-class GrowStrategy;
-}
-
 namespace proton::documentmetastore {
 
 /**
@@ -22,33 +16,26 @@ namespace proton::documentmetastore {
 class LidAllocator
 {
 private:
-    typedef search::SingleValueBitNumericAttribute BitAttribute;
     typedef uint32_t DocId;
     typedef vespalib::GenerationHandler::generation_t generation_t;
-    using AttributeVectorSP = std::shared_ptr<search::AttributeVector>;
 
     LidHoldList                 _holdLids;
     LidStateVector              _freeLids;
     LidStateVector              _usedLids;
     LidStateVector              _pendingHoldLids;
     bool                        _lidFreeListConstructed;
-    AttributeVectorSP           _activeLidsAttr;
-    BitAttribute               &_activeLids;
+    LidStateVector              _activeLids;
     uint32_t                    _numActiveLids;
 
 public:
     LidAllocator(uint32_t size,
                  uint32_t capacity,
-                 vespalib::GenerationHolder &genHolder,
-                 const search::GrowStrategy & grow);
+                 vespalib::GenerationHolder &genHolder);
     ~LidAllocator();
 
     DocId getFreeLid(DocId lidLimit);
     DocId peekFreeLid(DocId lidLimit);
     void ensureSpace(uint32_t newSize,
-                     uint32_t newCapacity);
-    void ensureSpace(DocId lid,
-                     uint32_t newSize,
                      uint32_t newCapacity);
     void registerLid(DocId lid) { _usedLids.setBit(lid); }
     void unregisterLid(DocId lid);
@@ -61,11 +48,9 @@ public:
                   generation_t currentGeneration);
     bool holdLidOK(DocId lid, DocId lidLimit) const;
     void constructFreeList(DocId lidLimit);
-    search::queryeval::Blueprint::UP createBlackListBlueprint() const;
+    search::queryeval::Blueprint::UP createWhiteListBlueprint() const;
     void updateActiveLids(DocId lid, bool active);
-    void commitActiveLids();
     void clearDocs(DocId lidLow, DocId lidLimit);
-    void compactLidSpace(DocId wantedLidLimit);
     void shrinkLidSpace(DocId committedDocIdLimit);
     uint32_t getNumUsedLids() const;
     uint32_t getNumActiveLids() const {
@@ -89,13 +74,8 @@ public:
     DocId getHighestUsedLid() const {
         return _usedLids.getHighest();
     }
-    search::AttributeGuard getActiveLidsGuard() const {
-        return search::AttributeGuard(_activeLidsAttr);
-    }
-    const BitAttribute &getActiveLids() const {
-        return _activeLids;
-    }
 
+    const search::GrowableBitVector &getActiveLids() const { return _activeLids.getBitVector(); }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lidstatevector.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lidstatevector.h
@@ -100,6 +100,8 @@ public:
     {
         return _bv.getNextTrueBit(idx);
     }
+
+    const search::GrowableBitVector &getBitVector() const { return _bv; }
 }; 
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -148,7 +148,7 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
     if (_valid) {
         _query.extractTerms(_queryEnv.terms());
         _query.extractLocations(_queryEnv.locations());
-        _query.setBlackListBlueprint(metaStore.createBlackListBlueprint());
+        _query.setWhiteListBlueprint(metaStore.createWhiteListBlueprint());
         _query.reserveHandles(_requestContext, searchContext, _mdl);
         _query.optimize();
         _query.fetchPostings();

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -36,7 +36,7 @@ namespace proton::matching {
 
 namespace {
 
-// used to give out empty blacklist blueprints
+// used to give out empty whitelist blueprints
 struct StupidMetaStore : search::IDocumentMetaStore {
     bool getGid(DocId, GlobalId &) const override { return false; }
     bool getGidEvenIfMoved(DocId, GlobalId &) const override { return false; }
@@ -48,7 +48,7 @@ struct StupidMetaStore : search::IDocumentMetaStore {
     DocId getNumActiveLids() const override { return 0; }
     uint64_t getCurrentGeneration() const override { return 0; }
     LidUsageStats getLidUsageStats() const override { return LidUsageStats(); }
-    Blueprint::UP createBlackListBlueprint() const override { return Blueprint::UP(); }
+    Blueprint::UP createWhiteListBlueprint() const override { return Blueprint::UP(); }
 };
 
 FeatureSet::SP findFeatureSet(const DocsumRequest &req,

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -26,7 +26,7 @@ using search::fef::Location;
 using search::query::Node;
 using search::query::QueryTreeCreator;
 using search::query::Weight;
-using search::queryeval::AndNotBlueprint;
+using search::queryeval::AndBlueprint;
 using search::queryeval::Blueprint;
 using search::queryeval::IRequestContext;
 using search::queryeval::SearchIterator;
@@ -112,9 +112,9 @@ Query::extractLocations(vector<const Location *> &locations)
 }
 
 void
-Query::setBlackListBlueprint(Blueprint::UP blackListBlueprint)
+Query::setWhiteListBlueprint(Blueprint::UP whiteListBlueprint)
 {
-    _blackListBlueprint = std::move(blackListBlueprint);
+    _whiteListBlueprint = std::move(whiteListBlueprint);
 }
 
 void
@@ -125,14 +125,14 @@ Query::reserveHandles(const IRequestContext & requestContext, ISearchContext &co
 
     _blueprint = BlueprintBuilder::build(requestContext, *_query_tree, context);
     LOG(debug, "original blueprint:\n%s\n", _blueprint->asString().c_str());
-    if (_blackListBlueprint.get() != NULL) {
-        std::unique_ptr<AndNotBlueprint> andNotBlueprint(new AndNotBlueprint());
-        (*andNotBlueprint)
+    if (_whiteListBlueprint) {
+        std::unique_ptr<AndBlueprint> andBlueprint(new AndBlueprint());
+        (*andBlueprint)
             .addChild(std::move(_blueprint))
-            .addChild(std::move(_blackListBlueprint));
-        _blueprint = std::move(andNotBlueprint);
+            .addChild(std::move(_whiteListBlueprint));
+        _blueprint = std::move(andBlueprint);
         _blueprint->setDocIdLimit(context.getDocIdLimit());
-        LOG(debug, "blueprint after black listing:\n%s\n", _blueprint->asString().c_str());
+        LOG(debug, "blueprint after white listing:\n%s\n", _blueprint->asString().c_str());
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -56,7 +56,7 @@ public:
     /**
      * Use the given blueprint as white list node in the blueprint tree.
      * The search iterator created by this blueprint should return all
-     * invisible / inactive documents as hits. These hits will then not be
+     * visible / active documents as hits. These hits will then be
      * part of the result set for the query executed.
      *
      * @param whiteListBlueprint the blueprint used for white listing.

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -22,7 +22,7 @@ private:
     search::query::Node::UP _query_tree;
     Blueprint::UP           _blueprint;
     search::fef::Location   _location;
-    Blueprint::UP           _blackListBlueprint;
+    Blueprint::UP           _whiteListBlueprint;
 
 public:
     Query();
@@ -54,14 +54,14 @@ public:
     void extractLocations(std::vector<const search::fef::Location *> &locs);
 
     /**
-     * Use the given blueprint as black list node in the blueprint tree.
+     * Use the given blueprint as white list node in the blueprint tree.
      * The search iterator created by this blueprint should return all
      * invisible / inactive documents as hits. These hits will then not be
      * part of the result set for the query executed.
      *
-     * @param blackListBlueprint the blueprint used for black listing.
+     * @param whiteListBlueprint the blueprint used for white listing.
      **/
-    void setBlackListBlueprint(Blueprint::UP blackListBlueprint);
+    void setWhiteListBlueprint(Blueprint::UP whiteListBlueprint);
 
     /**
      * Reserve room for terms in the query in the given match data

--- a/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
@@ -46,8 +46,8 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
     virtual search::LidUsageStats getLidUsageStats() const override {
         return _store.getLidUsageStats();
     }
-    virtual search::queryeval::Blueprint::UP createBlackListBlueprint() const override {
-        return _store.createBlackListBlueprint();
+    virtual search::queryeval::Blueprint::UP createWhiteListBlueprint() const override {
+        return _store.createWhiteListBlueprint();
     }
     uint64_t getCurrentGeneration() const override {
         return _store.getCurrentGeneration();
@@ -154,9 +154,6 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
     }
     virtual DocId getNumActiveLids() const override {
         return _store.getNumActiveLids();
-    }
-    virtual search::AttributeGuard getActiveLidsGuard() const override {
-        return _store.getActiveLidsGuard();
     }
     virtual bool getFreeListActive() const override {
         return _store.getFreeListActive();

--- a/searchlib/src/vespa/searchlib/common/idocumentmetastore.h
+++ b/searchlib/src/vespa/searchlib/common/idocumentmetastore.h
@@ -143,10 +143,10 @@ struct IDocumentMetaStore {
     virtual LidUsageStats getLidUsageStats() const = 0;
 
     /**
-     * Creates a black list blueprint that returns a search iterator
-     * that gives hits for all documents that should not be visible.
+     * Creates a white list blueprint that returns a search iterator
+     * that gives hits for all documents that should be visible.
      **/
-    virtual std::unique_ptr<queryeval::Blueprint> createBlackListBlueprint() const = 0;
+    virtual std::unique_ptr<queryeval::Blueprint> createWhiteListBlueprint() const = 0;
 
     /**
      * Give read access to the current generation of the metastore.


### PR DESCRIPTION
This replaces nested small numeric attribute vector for blaclisting.

@geirst, @baldersheim: please review
