### PR TITLE
Write DocumentAPI test data in two phases

### DIFF
--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/TestFileUtil.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/TestFileUtil.java
@@ -20,7 +20,6 @@ public class TestFileUtil {
         String tmpPath = path + ".tmp";
         try (FileOutputStream stream = new FileOutputStream(tmpPath)) {
             stream.write(data);
-            stream.flush();
         }
         // We make the assumption that all file systems we run these tests on support some form
         // of atomic moving rather than "move by content copy".

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/TestFileUtil.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/TestFileUtil.java
@@ -4,16 +4,27 @@ package com.yahoo.documentapi.messagebus.protocol.test;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 
 public class TestFileUtil {
     protected static final String DATA_PATH = "./test/crosslanguagefiles";
 
     public static void writeToFile(String path, byte[] data) throws IOException {
-        try (FileOutputStream stream = new FileOutputStream(path)) {
+        // Write to a temporary file to avoid racing with cross-language tests reading the
+        // exact same file we're trying to write.
+        String tmpPath = path + ".tmp";
+        try (FileOutputStream stream = new FileOutputStream(tmpPath)) {
             stream.write(data);
+            stream.flush();
         }
+        // We make the assumption that all file systems we run these tests on support some form
+        // of atomic moving rather than "move by content copy".
+        Files.move(FileSystems.getDefault().getPath(tmpPath), FileSystems.getDefault().getPath(path), ATOMIC_MOVE);
     }
 
     /**

--- a/documentapi/src/tests/messages/testbase.cpp
+++ b/documentapi/src/tests/messages/testbase.cpp
@@ -181,7 +181,7 @@ TestBase::writeFile(const string &filename, const mbus::Blob& blob) const
         return false;
     }
     if (write(file, blob.data(), blob.size()) != static_cast<ssize_t>(blob.size())) {
-	    throw vespalib::Exception("write failed");
+        throw vespalib::Exception("write failed");
     }
     close(file);
     if (rename(tmp_filename.c_str(), filename.c_str()) != 0) {
@@ -199,8 +199,8 @@ TestBase::readFile(const string &filename) const
     if (file != -1) {
         lseek(file, 0, SEEK_SET);
         if (read(file, blob.data(), len) != len) {
-	    throw vespalib::Exception("read failed");
-	}
+            throw vespalib::Exception("read failed");
+        }
         close(file);
     }
 

--- a/documentapi/src/tests/messages/testbase.cpp
+++ b/documentapi/src/tests/messages/testbase.cpp
@@ -175,14 +175,18 @@ TestBase::dump(const mbus::Blob& blob) const
 bool
 TestBase::writeFile(const string &filename, const mbus::Blob& blob) const
 {
-    int file = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    std::string tmp_filename = filename + ".tmp";
+    int file = open(tmp_filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (file == -1) {
         return false;
     }
-    if (write(file, blob.data(), blob.size()) != (ssize_t)blob.size()) {
-	throw vespalib::Exception("write failed");
+    if (write(file, blob.data(), blob.size()) != static_cast<ssize_t>(blob.size())) {
+	    throw vespalib::Exception("write failed");
     }
     close(file);
+    if (rename(tmp_filename.c_str(), filename.c_str()) != 0) {
+        throw vespalib::Exception("rename failed");
+    }
     return true;
 }
 


### PR DESCRIPTION
@freva please review. Spuriously failing DocumentAPI tests during concurrent module builds indicate that cross-language tests can step on each other toes during file writing and reading. Now writing to temporary files and doing atomic renames, which should hopefully provide inode-level read isolation and stabilize things.