### PR TITLE
Use makeAvailiableForNewAllocations to handle ready state transition

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -169,9 +169,12 @@ public class RestApiTest {
                        "{\"message\":\"Moved test-container-1 to dirty\"}");
 
         // ... and set it back to ready as if this was from the node-admin with the temporary state rest api
-        assertResponse(new Request("http://localhost:8080/nodes/v2/state/availablefornewallocations/test-container-1",
+        assertResponse(new Request("http://localhost:8080/nodes/v2/state/ready/test-container-1",
                         new byte[0], Request.Method.PUT),
-                "{\"message\":\"Marked following nodes as available for new allocation: test-container-1\"}");
+                "{\"message\":\"Moved test-container-1 to ready\"}");
+
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/test-container-1",  new byte[0], Request.Method.GET),
+                404, "{\"error-code\":\"NOT_FOUND\",\"message\":\"No node with hostname 'test-container-1'\"}");
 
         // Put a host in failed and make sure it's children are also failed
         assertResponse(new Request("http://localhost:8080/nodes/v2/state/failed/dockerhost1.yahoo.com", new byte[0], Request.Method.PUT),


### PR DESCRIPTION
This is the first PR in a series of 3 to remove the temporary REST endpoint `PUT` `/nodes/v2/state/availablefornewallocations/`.

1. (This PR): Handle `availablefornewallocations` same way `PUT` `/nodes/v2/state/ready/`
2. Switch to calling `/nodes/v2/state/ready/` in node-admin
3. Remove `/nodes/v2/state/availablefornewallocations/`