### PR TITLE
Do not redirect zkcli stderr implicitly

### DIFF
--- a/zkfacade/src/main/sh/zkctl
+++ b/zkfacade/src/main/sh/zkctl
@@ -58,4 +58,4 @@ findroot
 
 # END environment bootstrap section
 
-(echo "$@" | $VESPA_HOME/bin/zkcli) 2>&1
+echo "$@" | $VESPA_HOME/bin/zkcli


### PR DESCRIPTION
I want to be able to skip the ZK barf by doing this:

```
$ ./zkcli ls / 2> /dev/null
Connecting to localhost:2181

WATCHER::

WatchedEvent state:SyncConnected type:None path:null
[controller, vespa, zookeeper, config, provision]
```