### PR TITLE
Add authorization for type filter

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
@@ -96,6 +96,7 @@ public class AuthorizerTest {
         assertTrue(authorized("node1", "/nodes/v2/command/reboot?hostname=node1"));
         assertTrue(authorized("node1", "/nodes/v2/node/?parentHost=node1"));
         assertTrue(authorized("cfg1-host", "/nodes/v2/node/?recursive=true&type=config"));
+        assertFalse(authorized("cfg1-host", "/nodes/v2/node/?recursive=true&type=proxy"));
 
         // Host node can access itself and its children
         assertFalse(authorized("host1", "/nodes/v2/node/child2-1"));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
@@ -57,6 +57,9 @@ public class AuthorizerTest {
 
             nodes.add(nodeRepository.createNode("proxy1-host1", "proxy1-host", ipAddresses,
                                                 Optional.empty(), flavor, NodeType.proxyhost));
+
+            nodes.add(nodeRepository.createNode("cfg1-host", "cfg1-host", ipAddresses,
+                                                Optional.empty(), flavor, NodeType.confighost));
             nodeRepository.addNodes(nodes);
         }
     }
@@ -92,6 +95,7 @@ public class AuthorizerTest {
         assertTrue(authorized("node1", "/nodes/v2/acl/node1"));
         assertTrue(authorized("node1", "/nodes/v2/command/reboot?hostname=node1"));
         assertTrue(authorized("node1", "/nodes/v2/node/?parentHost=node1"));
+        assertTrue(authorized("cfg1-host", "/nodes/v2/node/?recursive=true&type=config"));
 
         // Host node can access itself and its children
         assertFalse(authorized("host1", "/nodes/v2/node/child2-1"));


### PR DESCRIPTION
Allows `cfghost` to get nodes with `type=config` (`/nodes/v2/node/?recursive=true&type=config`), this is needed for the new logic on when to deploy the zone app (want to do it after _all_ the config servers have upgraded).