### PR TITLE
Set to ready to make node available for new allocations in node-admin

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -164,7 +164,7 @@ public class RealNodeRepository implements NodeRepository {
 
     @Override
     public void setNodeState(String hostName, Node.State nodeState) {
-        String state = nodeState == Node.State.ready ? "availablefornewallocations" : nodeState.name();
+        String state = nodeState.name();
         NodeMessageResponse response = configServerApi.put(
                 "/nodes/v2/state/" + state + "/" + hostName,
                 Optional.empty(), /* body */


### PR DESCRIPTION
This is the second PR in a series of 3 to remove the temporary REST endpoint `/nodes/v2/state/availablefornewallocations/`.

1. Handle `availablefornewallocations` same way PUT /nodes/v2/state/ready/ #5497 (6.229.5)
2. (This PR) Switch to calling `/nodes/v2/state/ready/` in node-admin
3. Remove `/nodes/v2/state/availablefornewallocations/`