### PR TITLE
Jvenstad/do unified

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -150,8 +150,8 @@ public class Application {
 
     /** Returns the version a new deployment to this zone should use for this application */
     public Version deployVersionIn(ZoneId zone, Controller controller) {
-        // TODO jvenstad: Return max of current and change.
-        return change.platform().orElse(versionIn(zone, controller));
+        Version current = versionIn(zone, controller);
+        return change.platform().filter(version -> ! current.isAfter(version)).orElse(current);
     }
 
     /** Returns the current version this application has, or if none; should use, in the given zone */
@@ -175,21 +175,19 @@ public class Application {
      */
     public Optional<ApplicationVersion> deployApplicationVersionFor(DeploymentJobs.JobType jobType,
                                                                     Controller controller,
-                                                                    boolean currentVersion) {
-        // TODO jvenstad: Return max of current and change's.
+                                                                    boolean useCurrentVersion) {
         if (jobType == DeploymentJobs.JobType.component)
             return Optional.empty();
 
-        if (currentVersion || ! change().application().isPresent()) {
-            Deployment deployment = deployments().get(jobType.zone(controller.system()).get());
-            if (deployment != null)
-                return Optional.of(deployment.applicationVersion());
+        Optional<ApplicationVersion> current = Optional.ofNullable(deployments.get(jobType.zone(controller.system()).get()))
+                .map(Deployment::applicationVersion);
 
-            if (deploymentJobs().lastSuccessfulApplicationVersionFor(jobType).isPresent())
-                return deploymentJobs().lastSuccessfulApplicationVersionFor(jobType);
-        }
-
-        return change().application();
+        return Optional.ofNullable(change.application()
+                                         .filter(version -> ! (useCurrentVersion || current.filter(cv -> cv.compareTo(version) > 0).isPresent()))
+                                         .orElse(current
+                                                         .orElse(deploymentJobs().lastSuccessfulApplicationVersionFor(jobType)
+                                                                                 .orElse(change.application()
+                                                                                               .orElse(null)))));
     }
 
     /** Returns the global rotation of this, if present */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -151,7 +151,7 @@ public class Application {
     /** Returns the version a new deployment to this zone should use for this application */
     public Version deployVersionIn(ZoneId zone, Controller controller) {
         Version current = versionIn(zone, controller);
-        return change.platform().filter(ignored -> change.downgrades(current)).orElse(current);
+        return change.platform().filter(ignored -> ! change.downgrades(current)).orElse(current);
     }
 
     /** Returns the current version this application has, or if none; should use, in the given zone */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -151,7 +151,7 @@ public class Application {
     /** Returns the version a new deployment to this zone should use for this application */
     public Version deployVersionIn(ZoneId zone, Controller controller) {
         Version current = versionIn(zone, controller);
-        return change.platform().filter(version -> ! current.isAfter(version)).orElse(current);
+        return change.platform().filter(ignored -> change.downgrades(current)).orElse(current);
     }
 
     /** Returns the current version this application has, or if none; should use, in the given zone */
@@ -162,6 +162,7 @@ public class Application {
 
     /** Returns the Vespa version to use for the given job */
     public Version deployVersionFor(DeploymentJobs.JobType jobType, Controller controller) {
+        // TODO jvenstad: Eliminate this and its sibling for component.
         return jobType == DeploymentJobs.JobType.component
                 ? controller.systemVersion()
                 : deployVersionIn(jobType.zone(controller.system()).get(), controller);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -637,7 +637,7 @@ public class ApplicationController {
         deploymentSpec.zones().stream()
                 .filter(zone -> zone.environment() == Environment.prod)
                 .forEach(zone -> {
-                    if (!controller.zoneRegistry().hasZone(ZoneId.from(zone.environment(),
+                    if ( ! controller.zoneRegistry().hasZone(ZoneId.from(zone.environment(),
                                                                        zone.region().orElse(null)))) {
                         throw new IllegalArgumentException("Zone " + zone + " in deployment spec was not found in " +
                                                            "this system!");
@@ -647,8 +647,7 @@ public class ApplicationController {
 
     /** Verify that change is tested and that we aren't downgrading */
     private void validateChange(Application application, ZoneId zone, Version version) {
-        // TODO jvenstad: Hmmm ... Make it possible to deploy only the legal parts of the Change.
-        if (!application.deploymentJobs().isDeployableTo(zone.environment(), application.change())) {
+        if ( ! application.deploymentJobs().isDeployableTo(zone.environment(), application.change())) {
             throw new IllegalArgumentException("Rejecting deployment of " + application + " to " + zone +
                                                " as " + application.change() + " is not tested");
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
@@ -95,4 +95,25 @@ public final class Change {
         return new Change(Optional.of(platformChange), Optional.empty());
     }
 
+    /** Returns whether this change carries an application downgrade relative to the given version. */
+    public boolean downgrades(ApplicationVersion version) {
+        return application.map(version::compareTo).orElse(0) < 0;
+    }
+
+    /** Returns whether this change carries a platform downgrade relative to the given version. */
+    public boolean downgrades(Version version) {
+        return platform.map(version::compareTo).orElse(0) < 0;
+    }
+
+    /** Returns whether this change carries an application upgrade relative to the given version. */
+    public boolean upgrades(ApplicationVersion version) {
+        return application.map(version::compareTo).orElse(0) > 0;
+    }
+
+    /** Returns whether this change carries a platform upgrade relative to the given version. */
+    public boolean upgrades(Version version) {
+        return platform.map(version::compareTo).orElse(0) > 0;
+    }
+
 }
+

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
@@ -97,22 +97,22 @@ public final class Change {
 
     /** Returns whether this change carries an application downgrade relative to the given version. */
     public boolean downgrades(ApplicationVersion version) {
-        return application.map(version::compareTo).orElse(0) < 0;
+        return application.map(version::compareTo).orElse(0) > 0;
     }
 
     /** Returns whether this change carries a platform downgrade relative to the given version. */
     public boolean downgrades(Version version) {
-        return platform.map(version::compareTo).orElse(0) < 0;
+        return platform.map(version::compareTo).orElse(0) > 0;
     }
 
     /** Returns whether this change carries an application upgrade relative to the given version. */
     public boolean upgrades(ApplicationVersion version) {
-        return application.map(version::compareTo).orElse(0) > 0;
+        return application.map(version::compareTo).orElse(0) < 0;
     }
 
     /** Returns whether this change carries a platform upgrade relative to the given version. */
     public boolean upgrades(Version version) {
-        return platform.map(version::compareTo).orElse(0) > 0;
+        return platform.map(version::compareTo).orElse(0) < 0;
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -269,9 +269,9 @@ public class DeploymentTrigger {
 
         Deployment deployment = application.deployments().get(jobType.zone(controller.system()).get());
         return Optional.ofNullable(deployment).map(Deployment::at)
-                       .filter(ignored ->      (   application.change().upgrades(deployment.version())
+                       .filter(ignored ->    ! (   application.change().upgrades(deployment.version())
                                                 || application.change().upgrades(deployment.applicationVersion()))
-                                          && ! (   application.change().downgrades(deployment.version())
+                                          &&   (   application.change().downgrades(deployment.version())
                                                 || application.change().downgrades(deployment.applicationVersion())));
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -376,5 +376,5 @@ public class CuratorDb {
     private static Path applicationPath(ApplicationId application) {
         return applicationRoot.append(application.serializedForm());
     }
-    
+
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
@@ -181,24 +181,6 @@
         "reason": "Available change in staging-test",
         "at": "(ignore)"
       }
-    },
-    {
-      "type": "production-us-east-3",
-      "success": false,
-      "lastTriggered": {
-        "id": -1,
-        "version": "(ignore)",
-        "revision": {
-          "hash": "(ignore)",
-          "source": {
-            "gitRepository": "repository1",
-            "gitBranch": "master",
-            "gitCommit": "commit1"
-          }
-        },
-        "reason": "Available change in production-corp-us-east-1",
-        "at": "(ignore)"
-      }
     }
   ],
   "changeBlockers": [

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
@@ -181,24 +181,6 @@
         "reason": "Available change in staging-test",
         "at": "(ignore)"
       }
-    },
-    {
-      "type": "production-us-east-3",
-      "success": false,
-      "lastTriggered": {
-        "id": -1,
-        "version": "(ignore)",
-        "revision": {
-          "hash": "(ignore)",
-          "source": {
-            "gitRepository": "repository1",
-            "gitBranch": "master",
-            "gitCommit": "commit1"
-          }
-        },
-        "reason": "Available change in production-corp-us-east-1",
-        "at": "(ignore)"
-      }
     }
   ],
   "changeBlockers": [


### PR DESCRIPTION
@mpolden please review. 

This changes deployment orchestration to less eagerly upgrade failing versions -- comments in doc. 
The code which determines versions for deployment is also change to take the max of change's and currently deployed version, when both exist. This makes it possible to deploy with a change which, e.g.,  upgrades application but downgrades platform -- it will simply upgrade application, and leave platform alone. 