### PR TITLE
refactor, saving just the state we need to

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -39,7 +39,7 @@ public class Admin extends AbstractConfigProducer implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final DeployState deployState;
+    private final boolean isHostedVespa;
     private final Monitoring monitoring;
     private final Metrics metrics;
     private final Map<String, MetricsConsumer> legacyMetricsConsumers;
@@ -73,7 +73,7 @@ public class Admin extends AbstractConfigProducer implements Serializable {
                  boolean multitenant,
                  FileDistributionConfigProducer fileDistributionConfigProducer) {
         super(parent, "admin");
-        this.deployState = deployStateFrom(parent);
+        this.isHostedVespa = stateIsHosted(deployStateFrom(parent));
         this.monitoring = monitoring;
         this.metrics = metrics;
         this.legacyMetricsConsumers = legacyMetricsConsumers;
@@ -140,14 +140,10 @@ public class Admin extends AbstractConfigProducer implements Serializable {
         return zooKeepersConfigProvider;
     }
 
-    public boolean isHostedVespa() {
-        return stateIsHosted(deployState);
-    }
-
     public void getConfig(LogdConfig.Builder builder) {
         builder.
             logserver(new LogdConfig.Logserver.Builder().
-                    use(!isHostedVespa()).
+                    use(!isHostedVespa).
                     host(logserver.getHostName()).
                     port(logserver.getRelativePort(1)));
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -70,7 +70,7 @@ public class ClusterControllerContainer extends Container implements
         addBundle("file:" + getDefaults().underVespaHome("lib/jars/zkfacade-jar-with-dependencies.jar"));
 
         log.log(LogLevel.DEBUG, "Adding access log for cluster controller ...");
-        addComponent(new AccessLogComponent(AccessLogComponent.AccessLogType.queryAccessLog, "controller", deployStateFrom(parent)));
+        addComponent(new AccessLogComponent(AccessLogComponent.AccessLogType.queryAccessLog, "controller", stateIsHosted(deployStateFrom(parent))));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -56,7 +56,7 @@ public class Container extends AbstractService implements
 
     private final AbstractConfigProducer parent;
     private final String name;
-    private final DeployState deployState;
+    private final boolean isHostedVespa;
 
     private String clusterName = null;
     private boolean rpcServerEnabled = true;
@@ -96,7 +96,7 @@ public class Container extends AbstractService implements
         super(parent, name);
         this.name = name;
         this.parent = parent;
-        this.deployState = deployStateFrom(parent);
+        this.isHostedVespa = stateIsHosted(deployStateFrom(parent));
         this.portOverrides = Collections.unmodifiableList(new ArrayList<>(portOverrides));
         this.retired = retired;
         this.index = index;
@@ -313,15 +313,11 @@ public class Container extends AbstractService implements
         }
     }
 
-    private boolean isHostedVespa() {
-        return stateIsHosted(deployState);
-    }
-
     /** Returns the jvm arguments this should start with */
     @Override
     public String getJvmArgs() {
         String jvmArgs = super.getJvmArgs();
-        return isHostedVespa() && hasDocproc()
+        return isHostedVespa && hasDocproc()
                 ? ("".equals(jvmArgs) ? defaultHostedJVMArgs : defaultHostedJVMArgs + " " + jvmArgs)
                 : jvmArgs;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/AccessLogBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/AccessLogBuilder.java
@@ -7,7 +7,6 @@ import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.AccessLogComponent.AccessLogType;
-import com.yahoo.config.model.deploy.DeployState;
 import org.w3c.dom.Element;
 
 import java.util.Optional;
@@ -46,11 +45,11 @@ public class AccessLogBuilder {
 
     private static class DomBuilder extends VespaDomBuilder.DomConfigProducerBuilder<AccessLogComponent> {
         private final AccessLogType accessLogType;
-        private final DeployState deployState;
+        private final boolean isHostedVespa;
 
-        public DomBuilder(AccessLogType accessLogType, DeployState deployState) {
+        public DomBuilder(AccessLogType accessLogType, boolean isHostedVespa) {
             this.accessLogType = accessLogType;
-            this.deployState = deployState;
+            this.isHostedVespa = isHostedVespa;
         }
 
         @Override
@@ -61,7 +60,7 @@ public class AccessLogBuilder {
                     rotationInterval(spec),
                     rotationScheme(spec),
                     compressOnRotation(spec),
-                    deployState,
+                    isHostedVespa,
                     symlinkName(spec));
         }
 
@@ -111,7 +110,7 @@ public class AccessLogBuilder {
         if (logType == null) {
             return Optional.empty();
         }
-        DeployState deployState = cluster.getDeployState();
-        return Optional.of(new DomBuilder(logType, deployState).build(cluster, accessLogSpec));
+        boolean hosted = cluster.isHostedVespa();
+        return Optional.of(new DomBuilder(logType, hosted).build(cluster, accessLogSpec));
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
@@ -49,7 +49,7 @@ public class SearchNode extends AbstractService implements
         TranslogserverConfig.Producer {
 
     private static final long serialVersionUID = 1L;
-    private final DeployState deployState;
+    private final boolean isHostedVespa;
     private final boolean flushOnShutdown;
     private NodeSpec nodeSpec;
     private int distributionKey;
@@ -104,7 +104,7 @@ public class SearchNode extends AbstractService implements
 
     private SearchNode(AbstractConfigProducer parent, String name, NodeSpec nodeSpec, String clusterName, boolean flushOnShutdown, Optional<Tuning> tuning) {
         super(parent, name);
-        this.deployState = deployStateFrom(parent);
+        this.isHostedVespa = stateIsHosted(deployStateFrom(parent));
         this.nodeSpec = nodeSpec;
         this.clusterName = clusterName;
         this.flushOnShutdown = flushOnShutdown;
@@ -235,10 +235,6 @@ public class SearchNode extends AbstractService implements
         }
     }
 
-    private boolean isHostedVespa() {
-        return stateIsHosted(deployState);
-    }
-
     @Override
     public void getConfig(ProtonConfig.Builder builder) {
         builder.
@@ -253,7 +249,7 @@ public class SearchNode extends AbstractService implements
             slobrokconfigid(getClusterConfigId()).
             routingconfigid(getClusterConfigId()).
             distributionkey(getDistributionKey());
-        if (isHostedVespa()) {
+        if (isHostedVespa) {
             // 4 days, 1 hour, 1 minute due to failed nodes can be in failed for 4 days and we want at least one hour more
             // to make sure the node failer has done its work
             builder.pruneremoveddocumentsage(4 * 24 * 3600 + 3600 + 60);


### PR DESCRIPTION
* avoid caching DeployState since we want to free those resources
  after the model is completely built.

@bratseth please review
@hmusum FYI

after this, only these classes have DeployState lying around:

com/yahoo/config/model/test/MockRoot.java
com/yahoo/config/model/ConfigModelContext.java
com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
com/yahoo/vespa/model/VespaModel.java
