### PR TITLE
Make set node to dirty recursive

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -122,8 +121,9 @@ public class NodesApiHandler extends LoggingRequestHandler {
             return new MessageResponse("Moved " + parkedHostnames + " to parked");
         }
         else if (path.startsWith("/nodes/v2/state/dirty/")) {
-            nodeRepository.setDirty(lastElement(path), Agent.operator, "Dirtied through the nodes/v2 API");
-            return new MessageResponse("Moved " + lastElement(path) + " to dirty");
+            List<Node> dirtiedNodes = nodeRepository.dirtyRecursively(lastElement(path), Agent.operator, "Dirtied through the nodes/v2 API");
+            String dirtiedHostnames = dirtiedNodes.stream().map(Node::hostname).sorted().collect(Collectors.joining(", "));
+            return new MessageResponse("Moved " + dirtiedHostnames + " to dirty");
         }
         else if (path.startsWith("/nodes/v2/state/active/")) {
             nodeRepository.reactivate(lastElement(path), Agent.operator, "Reactivated through nodes/v2 API");

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -108,7 +108,7 @@ public class MockNodeRepository extends NodeRepository {
         setReady(nodes, Agent.system, getClass().getSimpleName());
 
         fail("host5.yahoo.com", Agent.system, getClass().getSimpleName());
-        setDirty("host55.yahoo.com", Agent.system, getClass().getSimpleName());
+        dirtyRecursively("host55.yahoo.com", Agent.system, getClass().getSimpleName());
 
         ApplicationId zoneApp = ApplicationId.from(TenantName.from("zoneapp"), ApplicationName.from("zoneapp"), InstanceName.from("zoneapp"));
         ClusterSpec zoneCluster = ClusterSpec.request(ClusterSpec.Type.container,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.provisioning.FlavorConfigBuilder;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
 
@@ -56,6 +57,16 @@ public class NodeRepositoryTester {
         Node node = nodeRepository.createNode(id, hostname, Optional.of(parentHostname),
                 nodeFlavors.getFlavorOrThrow(flavor), type);
         return nodeRepository.addNodes(Collections.singletonList(node)).get(0);
+    }
+
+    /**
+     * Moves a node directly to the given state without doing any validation, useful
+     * to create wanted test scenario without having to move every node through series
+     * of valid state transitions
+     */
+    public void setNodeState(String hostname, Node.State state) {
+        Node node = nodeRepository.getNode(hostname).orElseThrow(RuntimeException::new);
+        nodeRepository.database().writeTo(state, node, Agent.system, Optional.empty());
     }
 
     private FlavorsConfig createConfig() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/monitoring/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/monitoring/MetricsReporterTest.java
@@ -125,7 +125,7 @@ public class MetricsReporterTest {
 
         Node dockerHost = Node.create("openStackId1", Collections.singleton("::1"), additionalIps, "dockerHost", Optional.empty(), nodeFlavors.getFlavorOrThrow("host"), NodeType.host);
         nodeRepository.addNodes(Collections.singletonList(dockerHost));
-        nodeRepository.setDirty("dockerHost", Agent.system, getClass().getSimpleName());
+        nodeRepository.dirtyRecursively("dockerHost", Agent.system, getClass().getSimpleName());
         nodeRepository.setReady("dockerHost", Agent.system, getClass().getSimpleName());
 
         Node container1 = Node.createDockerNode("openStackId1:1", Collections.singleton("::2"), Collections.emptySet(), "container1", Optional.of("dockerHost"), nodeFlavors.getFlavorOrThrow("docker"), NodeType.tenant);


### PR DESCRIPTION
Retirement of parent host will first retire all its children (they will end up in `parked`), then the host itself. 
To take the host back in, we would often set the node to `dirty`, but for docker hosts, this will only move the parent, leaving the children stuck in `parked`.

This PR makes setting node to state `dirty` recursive. (VESPA-11906)