### PR TITLE
Whitelist hostnames in Authorizer

### DIFF
--- a/config-provisioning/src/main/resources/configdefinitions/node-repository.def
+++ b/config-provisioning/src/main/resources/configdefinitions/node-repository.def
@@ -6,3 +6,6 @@ namespace=config.provisioning
 dockerImage string default="dummyImage"
 
 useCuratorClientCache bool default=false
+
+# Comma separated list of hostnames that are authorized for all config server REST APIs
+hostnameWhitelist string default=""

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/AuthorizerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +36,7 @@ public class AuthorizerTest {
     public void before() {
         NodeFlavors flavors = new MockNodeFlavors();
         nodeRepository = new MockNodeRepository(new MockCurator(), flavors);
-        authorizer = new Authorizer(SystemName.main, nodeRepository, () -> "cfg1");
+        authorizer = new Authorizer(SystemName.main, nodeRepository, new HashSet<>(Arrays.asList("cfg1", "cfghost1")));
         { // Populate with nodes used in this test. Note that only nodes requiring node repository lookup are added here
             Set<String> ipAddresses = new HashSet<>(Arrays.asList("127.0.0.1", "::1"));
             Flavor flavor = flavors.getFlavorOrThrow("default");
@@ -102,7 +103,7 @@ public class AuthorizerTest {
 
         // Trusted services can access everything in their own system
         assertFalse(authorized("vespa.vespa.cd.hosting", "/")); // Wrong system
-        assertTrue(new Authorizer(SystemName.cd, nodeRepository).test(() -> "vespa.vespa.cd.hosting", uri("/")));
+        assertTrue(new Authorizer(SystemName.cd, nodeRepository, Collections.emptySet()).test(() -> "vespa.vespa.cd.hosting", uri("/")));
         assertTrue(authorized("vespa.vespa.hosting", "/"));
         assertTrue(authorized("vespa.vespa.hosting", "/nodes/v2/node/"));
         assertTrue(authorized("vespa.vespa.hosting", "/nodes/v2/node/node1"));
@@ -144,6 +145,7 @@ public class AuthorizerTest {
     public void host_authorization() {
         assertTrue(authorized("cfg1", "/"));
         assertTrue(authorized("cfg1", "/application/v2"));
+        assertTrue(authorized("cfghost1", "/application/v2"));
     }
 
     private boolean authorized(String principal, String path) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/filter/AuthorizationFilterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/filter/AuthorizationFilterTest.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.config.provisioning.NodeRepositoryConfig;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.hosted.provision.restapi.v2.filter.FilterTester.Request;
 import com.yahoo.vespa.hosted.provision.testutils.MockNodeFlavors;
@@ -45,8 +46,10 @@ public class AuthorizationFilterTest {
 
     private static FilterTester filterTester(SystemName system) {
         Zone zone = new Zone(system, Environment.prod, RegionName.defaultName());
-        return new FilterTester(new AuthorizationFilter(zone, new MockNodeRepository(new MockCurator(),
-                                                                                     new MockNodeFlavors())));
+        return new FilterTester(new AuthorizationFilter(
+                zone,
+                new MockNodeRepository(new MockCurator(), new MockNodeFlavors()),
+                new NodeRepositoryConfig(new NodeRepositoryConfig.Builder())));
     }
 
 }


### PR DESCRIPTION
Allows to send it a comma separated list of hostnames in node-repository config that are authorized to all REST APIs. The list is combined with the localhost hostname.

Wanted to use config array, but they do not support default value :( 

Intended use case: Add configserver host to the list.