### PR TITLE
Set VESPA_CONFIGSERVERS

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -76,7 +76,8 @@ public class DockerOperationsImpl implements DockerOperations {
                     containerName,
                     node.hostname)
                     .withManagedBy(MANAGER_NAME)
-                    .withEnvironment("CONFIG_SERVER_ADDRESS", configServers) // TODO: Remove when all images support CONTAINER_ENVIRONMENT_SETTINGS
+                    .withEnvironment("CONFIG_SERVER_ADDRESS", configServers) // TODO: Remove when all images support VESPA_CONFIGSERVERS
+                    .withEnvironment("VESPA_CONFIGSERVERS", configServers)
                     .withEnvironment("CONTAINER_ENVIRONMENT_SETTINGS",
                                      environment.getContainerEnvironmentResolver().createSettings(environment, node))
                     .withUlimit("nofile", 262_144, 262_144)


### PR DESCRIPTION
By setting this we will be able to avoid avoid setting other variables or
write any setting to file when using Docker images. Start script needs to be updated after this goes in. Ref. https://github.com/vespa-engine/vespa/pull/5591