### PR TITLE
Revert "Use Jetty 9.4.9"

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -439,7 +439,7 @@
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>18.0</guava.version>
         <guice.version>3.0</guice.version>
-        <jetty.version>9.4.9.v20180320</jetty.version>
+        <jetty.version>9.4.8.v20171121</jetty.version>
         <scala.version>2.11.4</scala.version>  <!-- When updating this, the scala.major-version in parent must also be updated! -->
         <slf4j.version>1.7.5</slf4j.version>
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#5603

Performance tests not too happy about this one (I suspect).
@bjorncs @baldersheim @hmusum 