### PR TITLE
Remove org.osgi dependencies.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -621,16 +621,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.compendium</artifactId>
-                <version>4.3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.core</artifactId>
-                <version>4.3.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.scala-lang.modules</groupId>
                 <artifactId>scala-parser-combinators_${scala.major-version}</artifactId>
                 <version>1.0.1</version>

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -61,11 +61,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-    	<groupId>org.osgi</groupId>
-    	<artifactId>org.osgi.core</artifactId>
-    	<scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
- Only usage was org.osgi.core as test dep in statistics and
  jdisc_http_filters.