### PR TITLE
Add directory cache listener before starting

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSessionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSessionRepo.java
@@ -68,8 +68,8 @@ public class RemoteSessionRepo extends SessionRepo<RemoteSession> implements Nod
         this.reloadHandler = reloadHandler;
         this.metrics = metricUpdater;
         this.directoryCache = curator.createDirectoryCache(sessionsPath.getAbsolute(), false, false, executorService);
-        this.directoryCache.start();
         this.directoryCache.addListener(this);
+        this.directoryCache.start();
         sessionsChanged();
     }
 


### PR DESCRIPTION
Might fix unstable system test that sometimes misses creating a session