### PR TITLE
Use getAttributeReadGuard in AttributeContext

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
@@ -366,12 +366,18 @@ public:
      */
     virtual bool getIsFastSearch() const = 0;
 
-    /*
+    /**
      * Returns the committed docid limit for the attribute.
      *
      * @return committed docid limit for the attribute.
      */
     virtual uint32_t getCommittedDocIdLimitSlow() const = 0;
+
+    /*
+     * Returns whether the current attribute vector is an imported attribute
+     * vector.
+     */
+    virtual bool isImported() const = 0;
 
     /**
      * Will serialize the values for the documentid in ascending order. The serialized form can be used by memcmp and

--- a/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
@@ -353,6 +353,27 @@ public:
     virtual bool hasEnum() const = 0;
 
     /**
+     * Returns whether the attribute vector is a filter attribute.
+     *
+     * @return true if attribute vector is a filter attribute.
+     */
+    virtual bool getIsFilter() const = 0;
+
+    /**
+     * Returns whether the attribute vector is marked as fast search.
+     *
+     * @return true if attribute vector is marked as fast search.
+     */
+    virtual bool getIsFastSearch() const = 0;
+
+    /*
+     * Returns the committed docid limit for the attribute.
+     *
+     * @return committed docid limit for the attribute.
+     */
+    virtual uint32_t getCommittedDocIdLimitSlow() const = 0;
+
+    /**
      * Will serialize the values for the documentid in ascending order. The serialized form can be used by memcmp and
      * sortorder will be preserved.
      * @param doc The document id to serialize for.

--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -23,11 +23,11 @@ LOG_SETUP("attribute_manager_test");
 #include <vespa/searchcore/proton/test/attribute_vectors.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/attributevector.hpp>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector_factory.h>
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
-#include <vespa/searchlib/attribute/reference_attribute.h>
 #include <vespa/searchlib/attribute/reference_attribute.h>
 #include <vespa/searchlib/attribute/singlenumericattribute.hpp>
 #include <vespa/searchlib/common/foregroundtaskexecutor.h>
@@ -268,9 +268,9 @@ TEST_F("require that attributes are added", Fixture)
     EXPECT_TRUE(f.addAttribute("a1").get() != NULL);
     EXPECT_TRUE(f.addAttribute("a2").get() != NULL);
     EXPECT_EQUAL("a1", (*f._m.getAttribute("a1"))->getName());
-    EXPECT_EQUAL("a1", (*f._m.getAttributeStableEnum("a1"))->getName());
+    EXPECT_EQUAL("a1", (*f._m.getAttributeReadGuard("a1", true))->getName());
     EXPECT_EQUAL("a2", (*f._m.getAttribute("a2"))->getName());
-    EXPECT_EQUAL("a2", (*f._m.getAttributeStableEnum("a2"))->getName());
+    EXPECT_EQUAL("a2", (*f._m.getAttributeReadGuard("a2", true))->getName());
     EXPECT_TRUE(!f._m.getAttribute("not")->valid());
 }
 
@@ -279,7 +279,7 @@ TEST_F("require that predicate attributes are added", Fixture)
     EXPECT_TRUE(f._m.addAttribute({"p1", AttributeUtils::getPredicateConfig()},
                                   createSerialNum).get() != NULL);
     EXPECT_EQUAL("p1", (*f._m.getAttribute("p1"))->getName());
-    EXPECT_EQUAL("p1", (*f._m.getAttributeStableEnum("p1"))->getName());
+    EXPECT_EQUAL("p1", (*f._m.getAttributeReadGuard("p1", true))->getName());
 }
 
 TEST_F("require that attributes are flushed and loaded", BaseFixture)

--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -747,7 +747,7 @@ ImportedAttributeVector::SP
 createImportedAttribute(const vespalib::string &name)
 {
     auto result = ImportedAttributeVectorFactory::create(name,
-                                                         ReferenceAttribute::SP(),
+                                                         std::shared_ptr<ReferenceAttribute>(),
                                                          AttributeVector::SP(),
                                                          std::shared_ptr<search::IDocumentMetaStoreContext>(),
                                                          true);

--- a/searchcore/src/tests/proton/attribute/imported_attributes_context/imported_attributes_context_test.cpp
+++ b/searchcore/src/tests/proton/attribute/imported_attributes_context/imported_attributes_context_test.cpp
@@ -84,7 +84,10 @@ struct Fixture {
         return *this;
     }
     AttributeVector::SP getTargetAttribute(const vespalib::string &importedName) const {
-        return repo.get(importedName)->getTargetAttribute();
+        auto readable_target_attr = repo.get(importedName)->getTargetAttribute();
+        auto target_attr = std::dynamic_pointer_cast<AttributeVector>(readable_target_attr);
+        ASSERT_TRUE(target_attr);
+        return target_attr;
     }
     void clearContext() {
         ctx.reset();

--- a/searchcore/src/tests/proton/attribute/imported_attributes_context/imported_attributes_context_test.cpp
+++ b/searchcore/src/tests/proton/attribute/imported_attributes_context/imported_attributes_context_test.cpp
@@ -9,6 +9,7 @@ LOG_SETUP("imported_attributes_context_test");
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector_factory.h>
+#include <vespa/searchlib/attribute/reference_attribute.h>
 #include <vespa/searchlib/test/mock_gid_to_lid_mapping.h>
 #include <future>
 
@@ -23,7 +24,7 @@ using search::attribute::ReferenceAttribute;
 using search::attribute::test::MockGidToLidMapperFactory;
 using generation_t = AttributeVector::generation_t;
 
-ReferenceAttribute::SP
+std::shared_ptr<ReferenceAttribute>
 createReferenceAttribute(const vespalib::string &name)
 {
     auto refAttr = std::make_shared<ReferenceAttribute>(name, Config(BasicType::REFERENCE));

--- a/searchcore/src/tests/proton/common/cachedselect_test.cpp
+++ b/searchcore/src/tests/proton/common/cachedselect_test.cpp
@@ -48,7 +48,6 @@ using document::select::ResultSet;
 using proton::CachedSelect;
 using proton::SelectContext;
 using search::AttributeContext;
-using search::AttributeEnumGuard;
 using search::AttributeFactory;
 using search::AttributeGuard;
 using search::AttributePosting;

--- a/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
+++ b/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
@@ -27,7 +27,6 @@ using document::Field;
 using document::IntFieldValue;
 using document::StringFieldValue;
 using search::AttributeContext;
-using search::AttributeEnumGuard;
 using search::AttributeGuard;
 using search::AttributeVector;
 using search::DocumentIdT;

--- a/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
@@ -21,6 +21,7 @@
 #include <vespa/searchcore/proton/server/documentdbconfigmanager.h>
 #include <vespa/searchcore/proton/server/memoryconfigstore.h>
 #include <vespa/searchcorespi/index/indexflushtarget.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/vespalib/data/slime/slime.h>
@@ -240,7 +241,8 @@ TEST_F("require that document db registers reference", Fixture)
     EXPECT_TRUE(reference);
     auto attr = reference->getAttribute("attr1");
     EXPECT_TRUE(attr);
-    EXPECT_EQUAL(search::attribute::BasicType::INT32, attr->getBasicType());
+    auto attrReadGuard = attr->makeReadGuard(false);
+    EXPECT_EQUAL(search::attribute::BasicType::INT32, attrReadGuard->attribute()->getBasicType());
 }
 
 }  // namespace

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -339,7 +339,7 @@ struct MyAttributeManager : public proton::IAttributeManager
     virtual AttributeGuard::UP getAttribute(const string &) const override {
         abort();
     }
-    virtual AttributeGuard::UP getAttributeStableEnum(const string &) const override {
+    virtual std::unique_ptr<search::attribute::AttributeReadGuard> getAttributeReadGuard(const string &, bool) const override {
         abort();
     }
     virtual void getAttributeList(std::vector<AttributeGuard> &) const override {

--- a/searchcore/src/tests/proton/reference/document_db_reference_resolver/document_db_reference_resolver_test.cpp
+++ b/searchcore/src/tests/proton/reference/document_db_reference_resolver/document_db_reference_resolver_test.cpp
@@ -67,7 +67,7 @@ struct MyDocumentDBReference : public MockDocumentDBReference {
     virtual IGidToLidMapperFactory::SP getGidToLidMapperFactory() override {
         return factory;
     }
-    virtual AttributeVector::SP getAttribute(vespalib::stringref name) override {
+    virtual std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(vespalib::stringref name) override {
         auto itr = attributes.find(name);
         ASSERT_TRUE(itr != attributes.end());
         return itr->second;

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
@@ -158,8 +158,7 @@ public:
 
     // Implements search::IAttributeManager
     virtual search::AttributeGuard::UP getAttribute(const vespalib::string &name) const override;
-
-    virtual search::AttributeGuard::UP getAttributeStableEnum(const vespalib::string &name) const override;
+    virtual std::unique_ptr<search::attribute::AttributeReadGuard> getAttributeReadGuard(const string &name, bool stableEnumGuard) const override;
 
     /**
      * Fills all regular registered attributes (not extra attributes)

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/common/isequencedtaskexecutor.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 
 using search::AttributeGuard;
 using searchcorespi::IFlushTarget;
@@ -70,10 +71,6 @@ FilterAttributeManager::FilterAttributeManager(const AttributeSet &acceptedAttri
 
 FilterAttributeManager::~FilterAttributeManager() { }
 
-search::AttributeGuard::UP
-FilterAttributeManager::getAttributeStableEnum(const vespalib::string &) const {
-    throw vespalib::IllegalArgumentException("Not implemented");
-}
 search::attribute::IAttributeContext::UP
 FilterAttributeManager::createContext() const {
     throw vespalib::IllegalArgumentException("Not implemented");
@@ -131,6 +128,15 @@ FilterAttributeManager::getAttribute(const vespalib::string &name) const
         return _mgr->getAttribute(name);
     }
     return AttributeGuard::UP();
+}
+
+std::unique_ptr<search::attribute::AttributeReadGuard>
+FilterAttributeManager::getAttributeReadGuard(const vespalib::string &name, bool stableEnumGuard) const
+{
+    if (acceptAttribute(name)) {
+        return _mgr->getAttributeReadGuard(name, stableEnumGuard);
+    }
+    return std::unique_ptr<search::attribute::AttributeReadGuard>();
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.h
@@ -35,8 +35,8 @@ public:
     virtual search::AttributeGuard::UP getAttribute(const vespalib::string &name) const override;
     virtual void getAttributeList(std::vector<search::AttributeGuard> &list) const override;
     virtual search::SerialNum getFlushedSerialNum(const vespalib::string &name) const override;
-    virtual search::AttributeGuard::UP getAttributeStableEnum(const vespalib::string &) const override;
     virtual search::attribute::IAttributeContext::UP createContext() const override;
+    virtual std::unique_ptr<search::attribute::AttributeReadGuard> getAttributeReadGuard(const vespalib::string &name, bool stableEnumGuard) const override;
 
     // Implements proton::IAttributeManager
     virtual IAttributeManager::SP create(const AttributeCollectionSpec &) const override;

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.cpp
@@ -5,11 +5,13 @@
 #include "gid_to_lid_change_registrator.h"
 #include <vespa/searchcore/proton/documentmetastore/documentmetastore.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
-#include <vespa/searchlib/attribute/iattributemanager.h>
+#include <vespa/searchlib/attribute/imported_attribute_vector.h>
+#include <vespa/searchcore/proton/attribute/attributemanager.h>
+#include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
 
 namespace proton {
 
-DocumentDBReference::DocumentDBReference(std::shared_ptr<search::IAttributeManager> attrMgr,
+DocumentDBReference::DocumentDBReference(std::shared_ptr<AttributeManager> attrMgr,
                                          std::shared_ptr<DocumentMetaStore> dms,
                                          std::shared_ptr<IGidToLidChangeHandler> gidToLidChangeHandler)
     : _attrMgr(std::move(attrMgr)),
@@ -22,14 +24,18 @@ DocumentDBReference::~DocumentDBReference()
 {
 }
 
-std::shared_ptr<search::AttributeVector>
+std::shared_ptr<search::attribute::ReadableAttributeVector>
 DocumentDBReference::getAttribute(vespalib::stringref name)
 {
     search::AttributeGuard::UP guard = _attrMgr->getAttribute(name);
-    if (guard) {
+    if (guard && guard->valid()) {
         return guard->getSP();
     } else {
-        return std::shared_ptr<search::AttributeVector>();
+        auto importedAttributesRepo = _attrMgr->getImportedAttributes();
+        if (importedAttributesRepo != nullptr) {
+            return importedAttributesRepo->get(name);
+        }
+        return std::shared_ptr<search::attribute::ReadableAttributeVector>();
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.cpp
@@ -6,12 +6,12 @@
 #include <vespa/searchcore/proton/documentmetastore/documentmetastore.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector.h>
-#include <vespa/searchcore/proton/attribute/attributemanager.h>
+#include <vespa/searchcore/proton/attribute/i_attribute_manager.h>
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
 
 namespace proton {
 
-DocumentDBReference::DocumentDBReference(std::shared_ptr<AttributeManager> attrMgr,
+DocumentDBReference::DocumentDBReference(std::shared_ptr<IAttributeManager> attrMgr,
                                          std::shared_ptr<DocumentMetaStore> dms,
                                          std::shared_ptr<IGidToLidChangeHandler> gidToLidChangeHandler)
     : _attrMgr(std::move(attrMgr)),

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.h
@@ -3,15 +3,9 @@
 
 #include "i_document_db_reference.h"
 
-namespace search
-{
-
-class IAttributeManager;
-
-}
-
 namespace proton {
 
+class AttributeManager;
 class DocumentMetaStore;
 class IGidToLidChangeHandler;
 
@@ -22,15 +16,15 @@ class IGidToLidChangeHandler;
  */
 class DocumentDBReference : public IDocumentDBReference
 {
-    std::shared_ptr<search::IAttributeManager> _attrMgr;
+    std::shared_ptr<AttributeManager> _attrMgr;
     std::shared_ptr<DocumentMetaStore> _dms;
     std::shared_ptr<IGidToLidChangeHandler> _gidToLidChangeHandler;
 public:
-    DocumentDBReference(std::shared_ptr<search::IAttributeManager> attrMgr,
+    DocumentDBReference(std::shared_ptr<AttributeManager> attrMgr,
                         std::shared_ptr<DocumentMetaStore> dms,
                         std::shared_ptr<IGidToLidChangeHandler> gidToLidChangeHandler);
     virtual ~DocumentDBReference();
-    virtual std::shared_ptr<search::AttributeVector> getAttribute(vespalib::stringref name) override;
+    virtual std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(vespalib::stringref name) override;
     virtual std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() override;
     virtual std::unique_ptr<GidToLidChangeRegistrator> makeGidToLidChangeRegistrator(const vespalib::string &docTypeName) override;
 };

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.h
@@ -5,7 +5,7 @@
 
 namespace proton {
 
-class AttributeManager;
+class IAttributeManager;
 class DocumentMetaStore;
 class IGidToLidChangeHandler;
 
@@ -16,11 +16,11 @@ class IGidToLidChangeHandler;
  */
 class DocumentDBReference : public IDocumentDBReference
 {
-    std::shared_ptr<AttributeManager> _attrMgr;
+    std::shared_ptr<IAttributeManager> _attrMgr;
     std::shared_ptr<DocumentMetaStore> _dms;
     std::shared_ptr<IGidToLidChangeHandler> _gidToLidChangeHandler;
 public:
-    DocumentDBReference(std::shared_ptr<AttributeManager> attrMgr,
+    DocumentDBReference(std::shared_ptr<IAttributeManager> attrMgr,
                         std::shared_ptr<DocumentMetaStore> dms,
                         std::shared_ptr<IGidToLidChangeHandler> gidToLidChangeHandler);
     virtual ~DocumentDBReference();

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_resolver.cpp
@@ -143,7 +143,7 @@ DocumentDBReferenceResolver::createImportedAttributesRepo(const IAttributeManage
     if (_useReferences) {
         for (const auto &attr : _importedFieldsCfg.attribute) {
             ReferenceAttribute::SP refAttr = getReferenceAttribute(attr.referencefield, attrMgr);
-            AttributeVector::SP targetAttr = getTargetDocumentDB(refAttr->getName())->getAttribute(attr.targetfield);
+            auto targetAttr = getTargetDocumentDB(refAttr->getName())->getAttribute(attr.targetfield);
             auto importedAttr = ImportedAttributeVectorFactory::create(attr.name, refAttr, targetAttr, documentMetaStore, useSearchCache);
             result->add(importedAttr->getName(), importedAttr);
         }

--- a/searchcore/src/vespa/searchcore/proton/reference/i_document_db_reference.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/i_document_db_reference.h
@@ -3,9 +3,10 @@
 
 #include <vespa/vespalib/stllike/string.h>
 
+namespace search::attribute { class ReadableAttributeVector; }
+
 namespace search {
 
-class AttributeVector;
 class IGidToLidMapperFactory;
 
 }
@@ -24,7 +25,7 @@ class IDocumentDBReference
 public:
     using SP = std::shared_ptr<IDocumentDBReference>;
     virtual ~IDocumentDBReference() { }
-    virtual std::shared_ptr<search::AttributeVector> getAttribute(vespalib::stringref name) = 0;
+    virtual std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(vespalib::stringref name) = 0;
     virtual std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() = 0;
     virtual std::unique_ptr<GidToLidChangeRegistrator> makeGidToLidChangeRegistrator(const vespalib::string &docTypeName) = 0;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -364,9 +364,7 @@ SearchableDocSubDB::close()
 std::shared_ptr<IDocumentDBReference>
 SearchableDocSubDB::getDocumentDBReference()
 {
-    auto attrMgr = std::dynamic_pointer_cast<AttributeManager>(getAttributeManager());
-    assert(attrMgr);
-    return std::make_shared<DocumentDBReference>(attrMgr, _dms, _gidToLidChangeHandler);
+    return std::make_shared<DocumentDBReference>(getAttributeManager(), _dms, _gidToLidChangeHandler);
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -364,7 +364,9 @@ SearchableDocSubDB::close()
 std::shared_ptr<IDocumentDBReference>
 SearchableDocSubDB::getDocumentDBReference()
 {
-    return std::make_shared<DocumentDBReference>(getAttributeManager(), _dms, _gidToLidChangeHandler);
+    auto attrMgr = std::dynamic_pointer_cast<AttributeManager>(getAttributeManager());
+    assert(attrMgr);
+    return std::make_shared<DocumentDBReference>(attrMgr, _dms, _gidToLidChangeHandler);
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/test/mock_document_db_reference.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_document_db_reference.h
@@ -4,10 +4,8 @@
 #include <vespa/searchcore/proton/reference/i_document_db_reference.h>
 #include <vespa/searchcore/proton/reference/gid_to_lid_change_registrator.h>
 
-namespace search {
-class AttributeVector;
-class IGidToLidMapperFactory;
-}
+namespace search::attribute { class ReadableAttributeVector; }
+namespace search { class IGidToLidMapperFactory; }
 
 namespace proton {
 namespace test {
@@ -17,8 +15,8 @@ namespace test {
  */
 struct MockDocumentDBReference : public IDocumentDBReference {
     using SP = std::shared_ptr<MockDocumentDBReference>;
-    virtual std::shared_ptr<search::AttributeVector> getAttribute(vespalib::stringref) override {
-        return std::shared_ptr<search::AttributeVector>();
+    virtual std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(vespalib::stringref) override {
+        return std::shared_ptr<search::attribute::ReadableAttributeVector>();
     }
     virtual std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() override {
         return std::shared_ptr<search::IGidToLidMapperFactory>();

--- a/searchlib/src/tests/attribute/guard/attributeguard.cpp
+++ b/searchlib/src/tests/attribute/guard/attributeguard.cpp
@@ -20,7 +20,7 @@ AttributeGuardTest::Main()
 
 
     AttributeVector::SP ssattr(new SingleStringExtAttribute("ss1"));
-    AttributeEnumGuard guard(ssattr);
+    AttributeGuard guard(ssattr);
     EXPECT_TRUE(guard.valid());
 
     TEST_DONE();

--- a/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
+++ b/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
@@ -20,7 +20,7 @@ struct Fixture : ImportedAttributeFixture {
     Fixture(bool useSearchCache = false) : ImportedAttributeFixture(useSearchCache) {}
 
     std::unique_ptr<ImportedSearchContext> create_context(std::unique_ptr<QueryTermSimple> term) {
-        return std::make_unique<ImportedSearchContext>(std::move(term), SearchContextParams(), *imported_attr);
+        return std::make_unique<ImportedSearchContext>(std::move(term), SearchContextParams(), *imported_attr, *target_attr);
     }
 
     std::unique_ptr<SearchIterator> create_iterator(

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/attribute/attributecontext.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/extendableattributes.h>
 #include <vespa/searchlib/attribute/iattributemanager.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
@@ -27,7 +28,6 @@
 #include <vespa/searchlib/queryeval/wand/parallel_weak_and_search.h>
 #include <memory>
 
-using search::AttributeEnumGuard;
 using search::AttributeFactory;
 using search::AttributeGuard;
 using search::AttributeVector;
@@ -100,13 +100,13 @@ public:
         }
     }
 
-    AttributeGuard::UP getAttributeStableEnum(const string &name) const override {
-        if (name == field) {
-            return AttributeGuard::UP(new AttributeEnumGuard(_attribute_vector));
-        } else if (name == other) {
-            return AttributeGuard::UP(new AttributeEnumGuard(_other));
+    std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &name, bool stableEnumGuard) const override {
+        if (name == field && _attribute_vector) {
+            return _attribute_vector->makeReadGuard(stableEnumGuard);
+        } else if (name == other && _other) {
+            return _other->makeReadGuard(stableEnumGuard);
         } else {
-            return AttributeGuard::UP(nullptr);
+            return std::unique_ptr<attribute::AttributeReadGuard>();
         }
     }
 

--- a/searchlib/src/tests/attribute/searchable/attribute_weighted_set_blueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_weighted_set_blueprint_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/attribute/attribute_weighted_set_blueprint.h>
 #include <vespa/searchlib/attribute/attributecontext.h>
 #include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/extendableattributes.h>
 #include <vespa/searchlib/attribute/singlestringattribute.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
@@ -50,8 +51,13 @@ public:
         return AttributeGuard::UP(new AttributeGuard(lookup(name)));
     }
 
-    virtual AttributeGuard::UP getAttributeStableEnum(const vespalib::string &name) const override {
-        return AttributeGuard::UP(new AttributeEnumGuard(lookup(name)));
+    virtual std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &name, bool stableEnumGuard) const override {
+        auto vector = lookup(name);
+        if (vector) {
+            return vector->makeReadGuard(stableEnumGuard);
+        } else {
+            return std::unique_ptr<attribute::AttributeReadGuard>();
+        }
     }
 
     virtual void getAttributeList(std::vector<AttributeGuard> &list) const override {

--- a/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/searchlib/attribute/attribute_blueprint_factory.h>
 #include <vespa/searchlib/attribute/attributecontext.h>
 #include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/extendableattributes.h>
 #include <vespa/searchlib/attribute/singlenumericattribute.h>
 #include <vespa/searchlib/attribute/singlenumericattribute.hpp>
@@ -17,7 +18,6 @@
 #include <vespa/log/log.h>
 LOG_SETUP("attributeblueprint_test");
 
-using search::AttributeEnumGuard;
 using search::AttributeGuard;
 using search::AttributeVector;
 using search::IAttributeManager;
@@ -64,10 +64,13 @@ public:
         return AttributeGuard::UP(new AttributeGuard(_attribute_vector));
     }
 
-    AttributeGuard::UP getAttributeStableEnum(const string &) const override {
-        return AttributeGuard::UP(new AttributeEnumGuard(_attribute_vector));
+    virtual std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &, bool stableEnumGuard) const override {
+        if (_attribute_vector) {
+            return _attribute_vector->makeReadGuard(stableEnumGuard);
+        } else {
+            return std::unique_ptr<attribute::AttributeReadGuard>();
+        }
     }
-
     void getAttributeList(vector<AttributeGuard> &) const override {
         assert(!"Not implemented");
     }

--- a/searchlib/src/vespa/searchlib/attribute/attributecontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributecontext.h
@@ -16,7 +16,7 @@ namespace search {
 class AttributeContext : public attribute::IAttributeContext
 {
 private:
-    typedef vespalib::hash_map<string, AttributeGuard::UP> AttributeMap;
+    typedef vespalib::hash_map<string, std::unique_ptr<attribute::AttributeReadGuard>> AttributeMap;
 
     const search::IAttributeManager & _manager;
     mutable AttributeMap              _attributes;

--- a/searchlib/src/vespa/searchlib/attribute/attributeguard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeguard.cpp
@@ -16,31 +16,6 @@ AttributeGuard::AttributeGuard(const AttributeVector::SP & attr) :
 {
 }
 
-AttributeEnumGuard::AttributeEnumGuard(const AttributeVector::SP & attr) :
-    AttributeGuard(attr),
-    _lock()
-{
-    takeLock();
-}
-
-AttributeEnumGuard::AttributeEnumGuard(const AttributeGuard & attr) :
-    AttributeGuard(attr),
-    _lock()
-{
-    takeLock();
-}
-
-AttributeEnumGuard::~AttributeEnumGuard() { }
-
-void AttributeEnumGuard::takeLock() {
-    if (valid()) {
-        std::shared_lock<std::shared_timed_mutex> take(get()->getEnumLock(),
-                                                       std::defer_lock);
-        _lock = std::move(take);
-        _lock.lock();
-    }
-}
-
 template class ComponentGuard<AttributeVector>;
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/attributeguard.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeguard.h
@@ -23,21 +23,5 @@ public:
     AttributeGuard(const AttributeVectorSP & attribute);
 };
 
-/**
- * This class makes sure that the attribute vector is not updated with enum changes while the guard is held.
- **/
-class AttributeEnumGuard : public AttributeGuard
-{
-public:
-    AttributeEnumGuard(const AttributeEnumGuard &) = delete;
-    AttributeEnumGuard & operator = (const AttributeEnumGuard &) = delete;
-    explicit AttributeEnumGuard(const AttributeVectorSP & attribute);
-    explicit AttributeEnumGuard(const AttributeGuard & attribute);
-    ~AttributeEnumGuard();
-private:
-    mutable std::shared_lock<std::shared_timed_mutex> _lock;
-    void takeLock();
-};
-
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/attributemanager.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributemanager.cpp
@@ -3,6 +3,7 @@
 #include "attributemanager.h"
 #include "attributecontext.h"
 #include "attributefactory.h"
+#include "attribute_read_guard.h"
 #include "attrvector.h"
 #include "attributefile.h"
 #include "interlock.h"
@@ -177,15 +178,15 @@ AttributeManager::getAttribute(const string & name) const
     return attrGuard;
 }
 
-AttributeGuard::UP
-AttributeManager::getAttributeStableEnum(const string & name) const
+std::unique_ptr<attribute::AttributeReadGuard>
+AttributeManager::getAttributeReadGuard(const string &name, bool stableEnumGuard) const
 {
-    AttributeGuard::UP attrGuard(new AttributeEnumGuard(VectorHolder()));
     const VectorHolder * vh = findAndLoadAttribute(name);
-    if ( vh != NULL ) {
-        attrGuard.reset(new AttributeEnumGuard(*vh));
+    if (vh != nullptr) {
+        return (*vh)->makeReadGuard(stableEnumGuard);
+    } else {
+        return std::unique_ptr<attribute::AttributeReadGuard>();
     }
-    return attrGuard;
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/attribute/attributemanager.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributemanager.h
@@ -37,7 +37,7 @@ public:
     const VectorHolder * getAttributeRef(const string & name) const;
 
     AttributeGuard::UP getAttribute(const string & name) const override;
-    AttributeGuard::UP getAttributeStableEnum(const string & name) const override;
+    std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &name, bool stableEnumGuard) const override;
     /**
      * This will load attributes in the most memory economical way by loading largest first.
      */

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -908,19 +908,25 @@ AttributeVector::getEstimatedShrinkLidSpaceGain() const
     return canFree;
 }
 
-class AttributeVector::ReadGuard : public attribute::AttributeReadGuard
+
+namespace {
+
+class ReadGuard : public attribute::AttributeReadGuard
 {
+    using GenerationHandler = vespalib::GenerationHandler;
     GenerationHandler::Guard _generationGuard;
     using EnumGuard = std::shared_lock<std::shared_timed_mutex>;
     EnumGuard _enumGuard;
 public:
-    ReadGuard(const IAttributeVector *attr, GenerationHandler::Guard &&generationGuard, std::shared_timed_mutex *enumLock)
+    ReadGuard(const attribute::IAttributeVector *attr, GenerationHandler::Guard &&generationGuard, std::shared_timed_mutex *enumLock)
         : attribute::AttributeReadGuard(attr),
           _generationGuard(std::move(generationGuard)),
           _enumGuard(enumLock != nullptr ? EnumGuard(*enumLock) : EnumGuard())
     {
     }
 };
+
+}
 
 std::unique_ptr<attribute::AttributeReadGuard>
 AttributeVector::makeReadGuard(bool stableEnumGuard) const

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -330,6 +330,22 @@ AttributeVector::getCollectionType() const {
 }
 
 bool
+AttributeVector::getIsFilter() const {
+    return _config.getIsFilter();
+}
+
+bool
+AttributeVector::getIsFastSearch() const {
+    return _config.fastSearch();
+}
+
+uint32_t
+AttributeVector::getCommittedDocIdLimitSlow() const
+{
+    return getCommittedDocIdLimit();
+}
+
+bool
 AttributeVector::headerTypeOK(const vespalib::GenericHeader &header) const
 {
     return header.hasTag(dataTypeTag) &&

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -346,6 +346,12 @@ AttributeVector::getCommittedDocIdLimitSlow() const
 }
 
 bool
+AttributeVector::isImported() const
+{
+    return false;
+}
+
+bool
 AttributeVector::headerTypeOK(const vespalib::GenericHeader &header) const
 {
     return header.hasTag(dataTypeTag) &&

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -590,7 +590,7 @@ private:
     BaseName               _baseFileName;
     Config                 _config;
     std::shared_ptr<attribute::Interlock> _interlock;
-    std::shared_timed_mutex _enumLock;
+    mutable std::shared_timed_mutex _enumLock;
     GenerationHandler      _genHandler;
     GenerationHolder       _genHolder;
     Status                 _status;
@@ -624,6 +624,8 @@ private:
      * reader/writer guards.
      */
     std::shared_timed_mutex & getEnumLock() { return _enumLock; }
+
+    class ReadGuard;
 
     friend class ComponentGuard<AttributeVector>;
     friend class AttributeEnumGuard;

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -431,6 +431,9 @@ public:
     // Implements IAttributeVector
     virtual BasicType::Type getBasicType() const override;
     virtual CollectionType::Type getCollectionType() const override;
+    virtual bool getIsFilter() const override;
+    virtual bool getIsFastSearch() const override;
+    virtual uint32_t getCommittedDocIdLimitSlow() const override;
 
     /**
      * Updates the base file name of this attribute vector and saves

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -629,8 +629,6 @@ private:
      */
     std::shared_timed_mutex & getEnumLock() { return _enumLock; }
 
-    class ReadGuard;
-
     friend class ComponentGuard<AttributeVector>;
     friend class AttributeValueGuard;
     friend class AttributeTest;

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -434,6 +434,7 @@ public:
     virtual bool getIsFilter() const override;
     virtual bool getIsFastSearch() const override;
     virtual uint32_t getCommittedDocIdLimitSlow() const override;
+    virtual bool isImported() const override;
 
     /**
      * Updates the base file name of this attribute vector and saves

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -631,7 +631,6 @@ private:
     class ReadGuard;
 
     friend class ComponentGuard<AttributeVector>;
-    friend class AttributeEnumGuard;
     friend class AttributeValueGuard;
     friend class AttributeTest;
     friend class AttributeManagerTest;

--- a/searchlib/src/vespa/searchlib/attribute/iattributemanager.h
+++ b/searchlib/src/vespa/searchlib/attribute/iattributemanager.h
@@ -29,11 +29,11 @@ public:
     virtual AttributeGuard::UP getAttribute(const string & name) const = 0;
 
     /**
-     * Returns a view of the attribute vector with the given name.
+     * Returns a read view of the attribute vector with the given name.
      *
      * @param name name of the attribute vector.
      * @param stableEnumGuard flag to block enumeration changes during use of the attribute vector via the view.
-     * @return view of the attribute vector if the attribute vector exists
+     * @return read view of the attribute vector if the attribute vector exists
      **/
     virtual std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &name, bool stableEnumGuard) const = 0;
 

--- a/searchlib/src/vespa/searchlib/attribute/iattributemanager.h
+++ b/searchlib/src/vespa/searchlib/attribute/iattributemanager.h
@@ -8,6 +8,8 @@
 
 namespace search {
 
+namespace attribute { class AttributeReadGuard; }
+
 /**
  * This is an interface used to access all registered attribute vectors.
  **/
@@ -28,12 +30,12 @@ public:
 
     /**
      * Returns a view of the attribute vector with the given name.
-     * Makes sure that the underlying enum values are stable during the use of this attribute vector.
      *
      * @param name name of the attribute vector.
-     * @return view of the attribute vector or empty view if the attribute vector does not exists.
+     * @param stableEnumGuard flag to block enumeration changes during use of the attribute vector via the view.
+     * @return view of the attribute vector if the attribute vector exists
      **/
-    virtual AttributeGuard::UP getAttributeStableEnum(const string & name) const = 0;
+    virtual std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &name, bool stableEnumGuard) const = 0;
 
     /**
      * Fill the given list with all attribute vectors registered in this manager.

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
@@ -10,7 +10,7 @@ namespace search::attribute {
 ImportedAttributeVector::ImportedAttributeVector(
             vespalib::stringref name,
             std::shared_ptr<ReferenceAttribute> reference_attribute,
-            std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
+            std::shared_ptr<ReadableAttributeVector> target_attribute,
             std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
             bool use_search_cache)
     : _name(name),
@@ -24,7 +24,7 @@ ImportedAttributeVector::ImportedAttributeVector(
 
 ImportedAttributeVector::ImportedAttributeVector(vespalib::stringref name,
                                                  std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                                 std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
+                                                 std::shared_ptr<ReadableAttributeVector> target_attribute,
                                                  std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                                  std::shared_ptr<BitVectorSearchCache> search_cache)
     : _name(name),

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.cpp
@@ -10,7 +10,7 @@ namespace search::attribute {
 ImportedAttributeVector::ImportedAttributeVector(
             vespalib::stringref name,
             std::shared_ptr<ReferenceAttribute> reference_attribute,
-            std::shared_ptr<AttributeVector> target_attribute,
+            std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
             std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
             bool use_search_cache)
     : _name(name),
@@ -24,7 +24,7 @@ ImportedAttributeVector::ImportedAttributeVector(
 
 ImportedAttributeVector::ImportedAttributeVector(vespalib::stringref name,
                                                  std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                                 std::shared_ptr<AttributeVector> target_attribute,
+                                                 std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                                  std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                                  std::shared_ptr<BitVectorSearchCache> search_cache)
     : _name(name),

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
@@ -3,19 +3,19 @@
 #pragma once
 
 #include "readable_attribute_vector.h"
-#include "reference_attribute.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <memory>
 
 namespace search {
 
-class AttributeGuard;
+class AttributeVector;
 class AttributeEnumGuard;
 class IDocumentMetaStoreContext;
 
 namespace attribute {
 
 class BitVectorSearchCache;
+class ReferenceAttribute;
 
 /**
  * Attribute vector which does not store values of its own, but rather serves as a

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
@@ -26,17 +26,17 @@ class ReferenceAttribute;
  * Any accessor on the imported attribute for a local LID yields the same result as
  * if the same accessor were invoked with the target LID on the target attribute vector.
  */
-class ImportedAttributeVector : public attribute::ReadableAttributeVector {
+class ImportedAttributeVector : public ReadableAttributeVector {
 public:
     using SP = std::shared_ptr<ImportedAttributeVector>;
     ImportedAttributeVector(vespalib::stringref name,
                             std::shared_ptr<ReferenceAttribute> reference_attribute,
-                            std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
+                            std::shared_ptr<ReadableAttributeVector> target_attribute,
                             std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                             bool use_search_cache);
     ImportedAttributeVector(vespalib::stringref name,
                             std::shared_ptr<ReferenceAttribute> reference_attribute,
-                            std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
+                            std::shared_ptr<ReadableAttributeVector> target_attribute,
                             std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                             std::shared_ptr<BitVectorSearchCache> search_cache);
     virtual ~ImportedAttributeVector();
@@ -44,7 +44,7 @@ public:
     const std::shared_ptr<ReferenceAttribute>& getReferenceAttribute() const noexcept {
         return _reference_attribute;
     }
-    const std::shared_ptr<attribute::ReadableAttributeVector>& getTargetAttribute() const noexcept {
+    const std::shared_ptr<ReadableAttributeVector>& getTargetAttribute() const noexcept {
         return _target_attribute;
     }
     const std::shared_ptr<IDocumentMetaStoreContext> &getDocumentMetaStore() const {
@@ -63,7 +63,7 @@ public:
 protected:
     vespalib::string                           _name;
     std::shared_ptr<ReferenceAttribute>        _reference_attribute;
-    std::shared_ptr<attribute::ReadableAttributeVector>  _target_attribute;
+    std::shared_ptr<ReadableAttributeVector>   _target_attribute;
     std::shared_ptr<IDocumentMetaStoreContext> _document_meta_store;
     std::shared_ptr<BitVectorSearchCache>      _search_cache;
 };

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector.h
@@ -8,13 +8,12 @@
 
 namespace search {
 
-class AttributeVector;
-class AttributeEnumGuard;
 class IDocumentMetaStoreContext;
 
 namespace attribute {
 
 class BitVectorSearchCache;
+class ReadableAttributeVector;
 class ReferenceAttribute;
 
 /**
@@ -27,17 +26,17 @@ class ReferenceAttribute;
  * Any accessor on the imported attribute for a local LID yields the same result as
  * if the same accessor were invoked with the target LID on the target attribute vector.
  */
-class ImportedAttributeVector : public ReadableAttributeVector {
+class ImportedAttributeVector : public attribute::ReadableAttributeVector {
 public:
     using SP = std::shared_ptr<ImportedAttributeVector>;
     ImportedAttributeVector(vespalib::stringref name,
                             std::shared_ptr<ReferenceAttribute> reference_attribute,
-                            std::shared_ptr<AttributeVector> target_attribute,
+                            std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                             std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                             bool use_search_cache);
     ImportedAttributeVector(vespalib::stringref name,
                             std::shared_ptr<ReferenceAttribute> reference_attribute,
-                            std::shared_ptr<AttributeVector> target_attribute,
+                            std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                             std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                             std::shared_ptr<BitVectorSearchCache> search_cache);
     virtual ~ImportedAttributeVector();
@@ -45,7 +44,7 @@ public:
     const std::shared_ptr<ReferenceAttribute>& getReferenceAttribute() const noexcept {
         return _reference_attribute;
     }
-    const std::shared_ptr<AttributeVector>& getTargetAttribute() const noexcept {
+    const std::shared_ptr<attribute::ReadableAttributeVector>& getTargetAttribute() const noexcept {
         return _target_attribute;
     }
     const std::shared_ptr<IDocumentMetaStoreContext> &getDocumentMetaStore() const {
@@ -64,7 +63,7 @@ public:
 protected:
     vespalib::string                           _name;
     std::shared_ptr<ReferenceAttribute>        _reference_attribute;
-    std::shared_ptr<AttributeVector>           _target_attribute;
+    std::shared_ptr<attribute::ReadableAttributeVector>  _target_attribute;
     std::shared_ptr<IDocumentMetaStoreContext> _document_meta_store;
     std::shared_ptr<BitVectorSearchCache>      _search_cache;
 };

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.cpp
@@ -17,7 +17,7 @@ BasicType::Type getBasicType(const std::shared_ptr<attribute::ReadableAttributeV
     if (attr) {
         auto readGuard = attr->makeReadGuard(false);
         return readGuard->attribute()->getBasicType();
-    }else {
+    } else {
         return BasicType::Type::NONE;
     }
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.cpp
@@ -2,7 +2,8 @@
 
 #include "imported_attribute_vector_factory.h"
 #include "imported_attribute_vector.h"
-#include "attributevector.h"
+#include "attribute_read_guard.h"
+#include <vespa/searchcommon/attribute/iattributevector.h>
 #include <vespa/searchlib/tensor/imported_tensor_attribute_vector.h>
 
 namespace search::attribute {
@@ -11,9 +12,14 @@ using search::tensor::ImportedTensorAttributeVector;
 
 namespace {
 
-BasicType::Type getBasicType(const std::shared_ptr<AttributeVector> &attr)
+BasicType::Type getBasicType(const std::shared_ptr<attribute::ReadableAttributeVector> &attr)
 {
-    return attr ? attr->getBasicType() : BasicType::Type::NONE;
+    if (attr) {
+        auto readGuard = attr->makeReadGuard(false);
+        return readGuard->attribute()->getBasicType();
+    }else {
+        return BasicType::Type::NONE;
+    }
 }
 
 }
@@ -21,7 +27,7 @@ BasicType::Type getBasicType(const std::shared_ptr<AttributeVector> &attr)
 std::shared_ptr<ImportedAttributeVector>
 ImportedAttributeVectorFactory::create(vespalib::stringref name,
                                        std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                       std::shared_ptr<AttributeVector> target_attribute,
+                                       std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                        std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                        bool use_search_cache)
 {
@@ -37,7 +43,7 @@ ImportedAttributeVectorFactory::create(vespalib::stringref name,
 std::shared_ptr<ImportedAttributeVector>
 ImportedAttributeVectorFactory::create(vespalib::stringref name,
                                        std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                       std::shared_ptr<AttributeVector> target_attribute,
+                                       std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                        std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                        std::shared_ptr<BitVectorSearchCache> search_cache)
 {

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.cpp
@@ -2,6 +2,7 @@
 
 #include "imported_attribute_vector_factory.h"
 #include "imported_attribute_vector.h"
+#include "attributevector.h"
 #include <vespa/searchlib/tensor/imported_tensor_attribute_vector.h>
 
 namespace search::attribute {

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_factory.h
@@ -7,13 +7,13 @@
 
 namespace search {
 
-class AttributeVector;
 class IDocumentMetaStoreContext;
 
 namespace attribute {
 
 class BitVectorSearchCache;
 class ImportedAttributeVector;
+class ReadableAttributeVector;
 class ReferenceAttribute;
 
 /*
@@ -25,14 +25,14 @@ public:
     static std::shared_ptr<ImportedAttributeVector>
     create(vespalib::stringref name,
            std::shared_ptr<ReferenceAttribute> reference_attribute,
-           std::shared_ptr<AttributeVector> target_attribute,
+           std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
            std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
            bool use_search_cache);
 
     static std::shared_ptr<ImportedAttributeVector>
     create(vespalib::stringref name,
            std::shared_ptr<ReferenceAttribute> reference_attribute,
-           std::shared_ptr<AttributeVector> target_attribute,
+           std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
            std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
            std::shared_ptr<BitVectorSearchCache> search_cache);
 };

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -146,6 +146,11 @@ uint32_t ImportedAttributeVectorReadGuard::getCommittedDocIdLimitSlow() const {
     return _reference_attribute.getCommittedDocIdLimit();
 }
 
+bool ImportedAttributeVectorReadGuard::isImported() const
+{
+    return true;
+}
+
 long ImportedAttributeVectorReadGuard::onSerializeForAscendingSort(DocId doc,
                                                                    void *serTo,
                                                                    long available,

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -2,6 +2,7 @@
 
 #include "imported_attribute_vector_read_guard.h"
 #include "imported_search_context.h"
+#include "reference_attribute.h"
 #include <vespa/searchlib/common/i_gid_to_lid_mapper.h>
 #include <vespa/searchlib/common/i_gid_to_lid_mapper_factory.h>
 #include <vespa/searchlib/query/queryterm.h>

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -5,6 +5,7 @@
 #include "attribute_read_guard.h"
 #include "attributeguard.h"
 #include "imported_attribute_vector.h"
+#include <vespa/vespalib/util/arrayref.h>
 #include <vespa/searchcommon/attribute/iattributevector.h>
 
 namespace search { class IGidToLidMapper; }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -4,7 +4,6 @@
 
 #include "attribute_read_guard.h"
 #include "attributeguard.h"
-#include "imported_attribute_vector.h"
 #include <vespa/vespalib/util/arrayref.h>
 #include <vespa/searchcommon/attribute/iattributevector.h>
 
@@ -13,6 +12,8 @@ namespace search { class IGidToLidMapper; }
 namespace search::attribute {
 
 class BitVectorSearchCache;
+class ImportedAttributeVector;
+class ReferenceAttribute;
 
 /*
  * Short lived attribute vector that does not store values on its own.
@@ -28,10 +29,11 @@ private:
     const ImportedAttributeVector   &_imported_attribute;
     ReferencedLids                   _referencedLids;
     AttributeGuard                   _reference_attribute_guard;
-    AttributeGuard                   _target_attribute_guard;
-    AttributeEnumGuard               _target_attribute_enum_guard;
+    std::unique_ptr<attribute::AttributeReadGuard> _target_attribute_guard;
     const ReferenceAttribute        &_reference_attribute;
-    const AttributeVector           &_target_attribute;
+protected:
+    const IAttributeVector          &_target_attribute;
+private:
     std::unique_ptr<IGidToLidMapper> _mapper;
 
 protected:
@@ -71,6 +73,9 @@ public:
     virtual size_t getFixedWidth() const override;
     virtual CollectionType::Type getCollectionType() const override;
     virtual bool hasEnum() const override;
+    virtual bool getIsFilter() const override;
+    virtual bool getIsFastSearch() const override;
+    virtual uint32_t getCommittedDocIdLimitSlow() const override;
 
 protected:
     virtual long onSerializeForAscendingSort(DocId doc, void * serTo, long available,

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -76,6 +76,7 @@ public:
     virtual bool getIsFilter() const override;
     virtual bool getIsFastSearch() const override;
     virtual uint32_t getCommittedDocIdLimitSlow() const override;
+    virtual bool isImported() const override;
 
 protected:
     virtual long onSerializeForAscendingSort(DocId doc, void * serTo, long available,

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -3,6 +3,7 @@
 #include "bitvector_search_cache.h"
 #include "imported_search_context.h"
 #include "imported_attribute_vector.h"
+#include "reference_attribute.h"
 #include <vespa/searchlib/common/bitvectoriterator.h>
 #include <vespa/searchlib/queryeval/emptysearch.h>
 #include "attributeiterators.hpp"

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -25,7 +25,7 @@ ImportedSearchContext::ImportedSearchContext(
         std::unique_ptr<QueryTermSimple> term,
         const SearchContextParams& params,
         const ImportedAttributeVector& imported_attribute,
-        const attribute::IAttributeVector &target_attribute)
+        const IAttributeVector &target_attribute)
     : _imported_attribute(imported_attribute),
       _queryTerm(term->getTerm()),
       _useSearchCache(_imported_attribute.getSearchCache().get() != nullptr),

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -33,7 +33,7 @@ class ImportedSearchContext : public ISearchContext {
     BitVectorSearchCache::Entry::SP                 _searchCacheLookup;
     IDocumentMetaStoreContext::IReadGuard::UP       _dmsReadGuard;
     const ReferenceAttribute&                       _reference_attribute;
-    const attribute::IAttributeVector              &_target_attribute;
+    const IAttributeVector                         &_target_attribute;
     std::unique_ptr<ISearchContext>                 _target_search_context;
     ReferencedLids                                  _referencedLids;
     PostingListMerger<int32_t>                      _merger;

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -33,7 +33,7 @@ class ImportedSearchContext : public ISearchContext {
     BitVectorSearchCache::Entry::SP                 _searchCacheLookup;
     IDocumentMetaStoreContext::IReadGuard::UP       _dmsReadGuard;
     const ReferenceAttribute&                       _reference_attribute;
-    const AttributeVector&                          _target_attribute;
+    const attribute::IAttributeVector              &_target_attribute;
     std::unique_ptr<ISearchContext>                 _target_search_context;
     ReferencedLids                                  _referencedLids;
     PostingListMerger<int32_t>                      _merger;
@@ -48,7 +48,8 @@ class ImportedSearchContext : public ISearchContext {
 public:
     ImportedSearchContext(std::unique_ptr<QueryTermSimple> term,
                           const SearchContextParams& params,
-                          const ImportedAttributeVector& imported_attribute);
+                          const ImportedAttributeVector& imported_attribute,
+                          const attribute::IAttributeVector &target_attribute);
     ~ImportedSearchContext();
 
 

--- a/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
@@ -355,10 +355,6 @@ template class ArrayParam<double>;
 
 namespace {
 
-bool isImportedAttribute(const IAttributeVector& attribute) noexcept {
-    return dynamic_cast<const ImportedAttributeVectorReadGuard*>(&attribute) != nullptr;
-}
-
 using dotproduct::ArrayParam;
 
 template <typename A>
@@ -373,7 +369,7 @@ bool supportsGetRawValues(const A & attr) noexcept {
     }
 }
 
-// Precondition: isImportedAttribute(*attribute) == false
+// Precondition: attribute->isImported() == false
 template <typename A>
 FeatureExecutor &
 createForDirectArrayImpl(const IAttributeVector * attribute,
@@ -471,7 +467,7 @@ FeatureExecutor &
 createFromObject(const IAttributeVector * attribute, const fef::Anything & object, vespalib::Stash &stash)
 {
     if (attribute->getCollectionType() == attribute::CollectionType::ARRAY) {
-        if (!isImportedAttribute(*attribute)) {
+        if (!attribute->isImported()) {
             switch (attribute->getBasicType()) {
                 case BasicType::INT32:
                     return createForDirectArray<IntegerAttributeTemplate<int32_t>>(attribute, dynamic_cast<const ArrayParam<int32_t> &>(object), stash);
@@ -507,7 +503,7 @@ createFromObject(const IAttributeVector * attribute, const fef::Anything & objec
 FeatureExecutor * createTypedArrayExecutor(const IAttributeVector * attribute,
                                            const Property & prop,
                                            vespalib::Stash & stash) {
-    if (!isImportedAttribute(*attribute)) {
+    if (!attribute->isImported()) {
         switch (attribute->getBasicType()) {
             case BasicType::INT32:
                 return &createForDirectArray<IntegerAttributeTemplate<int32_t>>(attribute, prop, stash);
@@ -586,7 +582,7 @@ createFromString(const IAttributeVector * attribute, const Property & prop, vesp
 }
 
 fef::Anything::UP attemptParseArrayQueryVector(const IAttributeVector & attribute, const Property & prop) {
-    if (!isImportedAttribute(attribute)) {
+    if (!attribute.isImported()) {
         switch (attribute.getBasicType()) {
             case BasicType::INT32:
                 return std::make_unique<ArrayParam<int32_t>>(prop);

--- a/searchlib/src/vespa/searchlib/features/internal_max_reduce_prod_join_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/internal_max_reduce_prod_join_feature.cpp
@@ -143,10 +143,6 @@ InternalMaxReduceProdJoinBlueprint::setup(const IIndexEnvironment &env, const Pa
     return true;
 }
 
-bool isImportedAttribute(const IAttributeVector &attribute) noexcept {
-    return dynamic_cast<const ImportedAttributeVectorReadGuard*>(&attribute) != nullptr;
-}
-
 template<typename A>
 bool supportsGetRawValues(const A &attr) noexcept {
     try {
@@ -163,7 +159,7 @@ template <typename BaseType>
 FeatureExecutor &
 selectTypedExecutor(const IAttributeVector *attribute, const IntegerVector &vector, vespalib::Stash &stash)
 {
-    if (!isImportedAttribute(*attribute)) {
+    if (!attribute->isImported()) {
         using A = IntegerAttributeTemplate<BaseType>;
         using VT = multivalue::Value<BaseType>;
         using ExactA = MultiValueNumericAttribute<A, VT>;

--- a/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector.cpp
@@ -10,7 +10,7 @@ using vespalib::tensor::Tensor;
 
 ImportedTensorAttributeVector::ImportedTensorAttributeVector(vespalib::stringref name,
                                                              std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                                             std::shared_ptr<AttributeVector> target_attribute,
+                                                             std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                                              std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                                              bool use_search_cache)
     : ImportedAttributeVector(name, std::move(reference_attribute),
@@ -22,7 +22,7 @@ ImportedTensorAttributeVector::ImportedTensorAttributeVector(vespalib::stringref
 
 ImportedTensorAttributeVector::ImportedTensorAttributeVector(vespalib::stringref name,
                                                              std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                                             std::shared_ptr<AttributeVector> target_attribute,
+                                                             std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                                              std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                                              std::shared_ptr<BitVectorSearchCache> search_cache)
     : ImportedAttributeVector(name, std::move(reference_attribute),

--- a/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector.h
@@ -19,12 +19,12 @@ class ImportedTensorAttributeVector : public attribute::ImportedAttributeVector
 public:
     ImportedTensorAttributeVector(vespalib::stringref name,
                                   std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                  std::shared_ptr<AttributeVector> target_attribute,
+                                  std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                   std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                   bool use_search_cache);
     ImportedTensorAttributeVector(vespalib::stringref name,
                                   std::shared_ptr<ReferenceAttribute> reference_attribute,
-                                  std::shared_ptr<AttributeVector> target_attribute,
+                                  std::shared_ptr<attribute::ReadableAttributeVector> target_attribute,
                                   std::shared_ptr<IDocumentMetaStoreContext> document_meta_store,
                                   std::shared_ptr<BitVectorSearchCache> search_cache);
     ~ImportedTensorAttributeVector();

--- a/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.cpp
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "imported_tensor_attribute_vector_read_guard.h"
+#include <vespa/searchlib/attribute/attributevector.h>
 #include <vespa/eval/tensor/tensor.h>
 
 namespace search::tensor {

--- a/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.cpp
@@ -24,7 +24,7 @@ ImportedTensorAttributeVectorReadGuard::ImportedTensorAttributeVectorReadGuard(c
                                                                                bool stableEnumGuard)
     : ImportedAttributeVectorReadGuard(imported_attribute,
                                        stableEnumGuard),
-      _target_tensor_attribute(getTensorAttribute(*imported_attribute.getTargetAttribute()))
+      _target_tensor_attribute(getTensorAttribute(_target_attribute))
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/imported_attribute_fixture.h
+++ b/searchlib/src/vespa/searchlib/test/imported_attribute_fixture.h
@@ -13,6 +13,7 @@
 #include <vespa/searchlib/attribute/imported_attribute_vector_factory.h>
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/not_implemented_attribute.h>
+#include <vespa/searchlib/attribute/reference_attribute.h>
 #include <vespa/searchlib/attribute/stringbase.h>
 #include <vespa/searchlib/common/i_document_meta_store_context.h>
 #include <vespa/searchlib/query/queryterm.h>

--- a/searchlib/src/vespa/searchlib/test/mock_attribute_manager.h
+++ b/searchlib/src/vespa/searchlib/test/mock_attribute_manager.h
@@ -4,6 +4,7 @@
 #include <vespa/searchlib/attribute/attributecontext.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/iattributemanager.h>
 
 namespace search {
@@ -33,9 +34,13 @@ public:
         return AttributeGuard::UP(new AttributeGuard(attr));
     }
 
-    virtual AttributeGuard::UP getAttributeStableEnum(const vespalib::string &name) const override {
+    virtual std::unique_ptr<AttributeReadGuard> getAttributeReadGuard(const vespalib::string &name, bool stableEnumGuard) const override {
         AttributeVector::SP attr = findAttribute(name);
-        return AttributeGuard::UP(new AttributeEnumGuard(attr));
+        if (attr) {
+            return attr->makeReadGuard(stableEnumGuard);
+        } else {
+            return std::unique_ptr<AttributeReadGuard>();
+        }
     }
 
     virtual void getAttributeList(std::vector<AttributeGuard> &list) const override {

--- a/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
@@ -76,7 +76,7 @@ public:
     virtual AttributeGuard::UP getAttribute(const string &) const override {
         abort();
     }
-    virtual AttributeGuard::UP getAttributeStableEnum(const string &) const override {
+    virtual std::unique_ptr<attribute::AttributeReadGuard> getAttributeReadGuard(const string &, bool) const override {
         abort();
     }
     virtual void getAttributeList(vector<AttributeGuard> &) const override {


### PR DESCRIPTION
Issue #3339 

@vekterli: please review
@baldersheim, @geirst: FYI

These changes consolidates how AttributeContext and ImportedAttributeContext gets attribute read guards and allows for limited chaining of ImportedAttributeVector.
