### PR TITLE
Don't add sddocname when no summary is available

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -233,20 +233,6 @@ public class FastSearcher extends VespaBackEndSearcher {
     }
 
     /**
-     * Only used to fill the sddocname field when using direct dispatching as that is normally done in VespaBackEndSearcher.decodeSummary
-     *
-     * @param result The result
-     */
-    private void fillSDDocName(Result result) {
-        DocumentDatabase db = getDocumentDatabase(result.getQuery());
-        for (Iterator<Hit> i = hitIterator(result); i.hasNext();) {
-            Hit hit = i.next();
-            if (hit instanceof FastHit) {
-                hit.setField(Hit.SDDOCNAME_FIELD, db.getName());
-            }
-        }
-    }
-    /**
      * Perform a partial docsum fill for a temporary result
      * representing a partition of the complete fill request.
      *
@@ -267,7 +253,6 @@ public class FastSearcher extends VespaBackEndSearcher {
 
             CompressionType compression =
                 CompressionType.valueOf(query.properties().getString(dispatchCompression, "LZ4").toUpperCase());
-            fillSDDocName(result);
             dispatcher.fill(result, summaryClass, getDocumentDatabase(query), compression);
             return;
         }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -264,6 +264,7 @@ public class Dispatcher extends AbstractComponent {
             for (int i = 0; i < hits.size(); i++) {
                 Inspector summary = summaries.entry(i).field("docsum");
                 if (summary.fieldCount() != 0) {
+                    hits.get(i).setField(Hit.SDDOCNAME_FIELD, documentDb.getName());
                     hits.get(i).addSummary(documentDb.getDocsumDefinitionSet().getDocsum(summaryClass), summary);
                     hits.get(i).setFilled(summaryClass);
                 } else {


### PR DESCRIPTION
@hmusum please review

Slight change which replicates the exact behavior we have today with RPC summaries, which fixes 2 of the tests currently failing.