### PR TITLE
Make getCommittedDocIdLimit() method virtual.

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
@@ -371,7 +371,7 @@ public:
      *
      * @return committed docid limit for the attribute.
      */
-    virtual uint32_t getCommittedDocIdLimitSlow() const = 0;
+    virtual uint32_t getCommittedDocIdLimit() const = 0;
 
     /*
      * Returns whether the current attribute vector is an imported attribute

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -340,9 +340,9 @@ AttributeVector::getIsFastSearch() const {
 }
 
 uint32_t
-AttributeVector::getCommittedDocIdLimitSlow() const
+AttributeVector::getCommittedDocIdLimit() const
 {
-    return getCommittedDocIdLimit();
+    return _committedDocIdLimit;
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -417,7 +417,6 @@ public:
 
     // Implements IAttributeVector
     uint32_t getNumDocs() const override;
-    uint32_t getCommittedDocIdLimit() const { return _committedDocIdLimit; }
     uint32_t & getCommittedDocIdLimitRef() { return _committedDocIdLimit; }
     void setCommittedDocIdLimit(uint32_t committedDocIdLimit) {
         _committedDocIdLimit = committedDocIdLimit;
@@ -433,7 +432,7 @@ public:
     virtual CollectionType::Type getCollectionType() const override;
     virtual bool getIsFilter() const override;
     virtual bool getIsFastSearch() const override;
-    virtual uint32_t getCommittedDocIdLimitSlow() const override;
+    virtual uint32_t getCommittedDocIdLimit() const override;
     virtual bool isImported() const override;
 
     /**

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -142,7 +142,7 @@ bool ImportedAttributeVectorReadGuard::getIsFastSearch() const {
     return _target_attribute.getIsFastSearch();
 }
 
-uint32_t ImportedAttributeVectorReadGuard::getCommittedDocIdLimitSlow() const {
+uint32_t ImportedAttributeVectorReadGuard::getCommittedDocIdLimit() const {
     return _reference_attribute.getCommittedDocIdLimit();
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -75,7 +75,7 @@ public:
     virtual bool hasEnum() const override;
     virtual bool getIsFilter() const override;
     virtual bool getIsFastSearch() const override;
-    virtual uint32_t getCommittedDocIdLimitSlow() const override;
+    virtual uint32_t getCommittedDocIdLimit() const override;
     virtual bool isImported() const override;
 
 protected:

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -195,7 +195,7 @@ public:
 
 void ImportedSearchContext::makeMergedPostings(bool isFilter)
 {
-    uint32_t committedTargetDocIdLimit = _target_attribute.getCommittedDocIdLimitSlow();
+    uint32_t committedTargetDocIdLimit = _target_attribute.getCommittedDocIdLimit();
     std::atomic_thread_fence(std::memory_order_acquire);
     const auto &reverseMapping = _reference_attribute.getReverseMapping();
     if (isFilter) {


### PR DESCRIPTION
Remove getCommittedDocidLimitSlow() method.

@geirst: please review
