### PR TITLE
Jvenstad/require equal source versions in tests and upgrades

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/BuildService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/BuildService.java
@@ -18,6 +18,7 @@ public interface BuildService {
     /**
      * Returns whether the given job is currently running.
      */
+    // TODO jvenstad: Change to enum State { idle, running, queued, disabled }
     boolean isRunning(BuildJob buildJob);
 
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -291,10 +291,10 @@ public class ApplicationController {
                     return unexpectedDeployment(applicationId, zone);
                 platformVersion = preferOldestVersion
                         ? application.oldestDeployedPlatform().orElse(controller.systemVersion())
-                        : triggered.get().version();
+                        : triggered.get().platform();
                 applicationVersion = preferOldestVersion
-                        ? application.oldestDeployedApplication().orElse(triggered.get().applicationVersion())
-                        : triggered.get().applicationVersion();
+                        ? application.oldestDeployedApplication().orElse(triggered.get().application())
+                        : triggered.get().application();
                 applicationPackage = new ApplicationPackage(artifactRepository.getApplicationPackage(application.id(), applicationVersion.id()));
                 validateRun(application, zone, platformVersion, applicationVersion);
             }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -290,10 +290,10 @@ public class ApplicationController {
                 if ( ! triggered.isPresent())
                     return unexpectedDeployment(applicationId, zone);
                 platformVersion = preferOldestVersion
-                        ? application.oldestDeployedPlatform().orElse(controller.systemVersion())
+                        ? triggered.get().sourcePlatform().orElse(triggered.get().platform())
                         : triggered.get().platform();
                 applicationVersion = preferOldestVersion
-                        ? application.oldestDeployedApplication().orElse(triggered.get().application())
+                        ? triggered.get().sourceApplication().orElse(triggered.get().application())
                         : triggered.get().application();
                 applicationPackage = new ApplicationPackage(artifactRepository.getApplicationPackage(application.id(), applicationVersion.id()));
                 validateRun(application, zone, platformVersion, applicationVersion);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
@@ -62,10 +62,8 @@ public class LockedApplication extends Application {
         return new LockedApplication(new Builder(this).with(deploymentJobs().with(issueId)));
     }
 
-    public LockedApplication withJobCompletion(DeploymentJobs.JobReport report, ApplicationVersion applicationVersion,
-                                               Instant notificationTime, Controller controller) {
-        return new LockedApplication(new Builder(this).with(deploymentJobs().withCompletion(
-                report, applicationVersion, notificationTime, controller))
+    public LockedApplication withJobCompletion(long projectId, JobType jobType, JobStatus.JobRun completion, Optional<DeploymentJobs.JobError> jobError) {
+        return new LockedApplication(new Builder(this).with(deploymentJobs().withCompletion(projectId, jobType, completion, jobError))
         );
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -57,15 +57,13 @@ public class DeploymentJobs {
     }
 
     /** Return a new instance with the given completion */
-    public DeploymentJobs withCompletion(JobReport report, ApplicationVersion applicationVersion,
-                                         Instant notificationTime, Controller controller) {
+    public DeploymentJobs withCompletion(long projectId, JobType jobType, JobStatus.JobRun completion, Optional<JobError> jobError) {
         Map<JobType, JobStatus> status = new LinkedHashMap<>(this.status);
-        status.compute(report.jobType(), (type, job) -> {
-            if (job == null) job = JobStatus.initial(report.jobType());
-            return job.withCompletion(report.buildNumber(), applicationVersion, report.jobError(), notificationTime,
-                                      controller);
+        status.compute(jobType, (type, job) -> {
+            if (job == null) job = JobStatus.initial(jobType);
+            return job.withCompletion(completion, jobError);
         });
-        return new DeploymentJobs(OptionalLong.of(report.projectId()), status, issueId);
+        return new DeploymentJobs(OptionalLong.of(projectId), status, issueId);
     }
 
     public DeploymentJobs withTriggering(JobType jobType, JobStatus.JobRun jobRun) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
@@ -70,7 +70,7 @@ public class JobList {
         return filter(job ->      job.lastSuccess().isPresent()
                              &&   job.lastTriggered().isPresent()
                              && ! job.lastTriggered().get().at().isBefore(job.lastCompleted().get().at())
-                             &&   job.lastSuccess().get().version().isBefore(job.lastTriggered().get().version()));
+                             &&   job.lastSuccess().get().platform().isBefore(job.lastTriggered().get().platform()));
     }
 
     /** Returns the subset of jobs which are currently failing */
@@ -147,12 +147,12 @@ public class JobList {
 
         /** Returns the subset of jobs where the run of the given type was on the given version */
         public JobList on(ApplicationVersion version) {
-            return filter(run -> run.applicationVersion().equals(version));
+            return filter(run -> run.application().equals(version));
         }
 
         /** Returns the subset of jobs where the run of the given type was on the given version */
         public JobList on(Version version) {
-            return filter(run -> run.version().equals(version));
+            return filter(run -> run.platform().equals(version));
         }
 
         /** Transforms the JobRun condition to a JobStatus condition, by considering only the JobRun mapped by which, and executes */
@@ -167,8 +167,8 @@ public class JobList {
     private static boolean failingApplicationChange(JobStatus job) {
         if (   job.isSuccess()) return false;
         if ( ! job.lastSuccess().isPresent()) return true; // An application which never succeeded is surely bad.
-        if ( ! job.firstFailing().get().version().equals(job.lastSuccess().get().version())) return false; // Version change may be to blame.
-        return ! job.firstFailing().get().applicationVersion().equals(job.lastSuccess().get().applicationVersion()); // Return whether there is an application change.
+        if ( ! job.firstFailing().get().platform().equals(job.lastSuccess().get().platform())) return false; // Version change may be to blame.
+        return ! job.firstFailing().get().application().equals(job.lastSuccess().get().application()); // Return whether there is an application change.
     }
 
     /** Returns a new JobList which is the result of filtering with the -- possibly negated -- condition */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
@@ -186,7 +186,11 @@ public class JobStatus {
 
         @Override
         public String toString() {
-            return "job run " + id + " of version " + platform + " " + application + " at " + at;
+            return "job run " + id + " of version " + platform +
+                   (sourcePlatform.map(version -> " (" + version + ")").orElse("")) +
+                   " " + application.id() +
+                   (sourceApplication.map(version -> " (" + version.id() + ")").orElse("")) +
+                   " at " + at;
         }
 
         @Override
@@ -199,6 +203,8 @@ public class JobStatus {
             if (id != run.id) return false;
             if (!platform.equals(run.platform)) return false;
             if (!application.equals(run.application)) return false;
+            if (!sourcePlatform.equals(run.sourcePlatform)) return false;
+            if (!sourceApplication.equals(run.sourceApplication)) return false;
             return at.equals(run.at);
         }
 
@@ -207,10 +213,11 @@ public class JobStatus {
             int result = (int) (id ^ (id >>> 32));
             result = 31 * result + platform.hashCode();
             result = 31 * result + application.hashCode();
+            result = 31 * result + sourcePlatform.hashCode();
+            result = 31 * result + sourceApplication.hashCode();
             result = 31 * result + at.hashCode();
             return result;
         }
-
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
@@ -145,12 +145,12 @@ public class JobStatus {
         private final String reason;
         private final Instant at;
 
-        public JobRun(long id, Version platform, ApplicationVersion applicationVersion, Optional<Version> sourcePlatform, Optional<ApplicationVersion> application, String reason, Instant at) {
+        public JobRun(long id, Version platform, ApplicationVersion application, Optional<Version> sourcePlatform, Optional<ApplicationVersion> sourceApplication, String reason, Instant at) {
             this.id = id;
             this.platform = requireNonNull(platform);
-            this.application = requireNonNull(applicationVersion);
+            this.application = requireNonNull(application);
             this.sourcePlatform = sourcePlatform;
-            this.sourceApplication = application;
+            this.sourceApplication = sourceApplication;
             this.reason = requireNonNull(reason);
             this.at = requireNonNull(at);
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -976,9 +976,9 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
 
     private void toSlime(JobStatus.JobRun jobRun, Cursor object) {
         object.setLong("id", jobRun.id());
-        object.setString("version", jobRun.version().toFullString());
-        if (!jobRun.applicationVersion().isUnknown())
-            toSlime(jobRun.applicationVersion(), object.setObject("revision"));
+        object.setString("version", jobRun.platform().toFullString());
+        if (!jobRun.application().isUnknown())
+            toSlime(jobRun.application(), object.setObject("revision"));
         object.setString("reason", jobRun.reason());
         object.setLong("at", jobRun.at().toEpochMilli());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
@@ -175,20 +175,20 @@ public class VersionStatus {
                     .failing()
                     .not().failingApplicationChange()
                     .not().failingBecause(outOfCapacity)
-                    .mapToList(job -> job.lastCompleted().get().version())
+                    .mapToList(job -> job.lastCompleted().get().platform())
                     .forEach(version -> versionMap.put(version, versionMap.getOrDefault(version, DeploymentStatistics.empty(version)).withFailing(application.id())));
 
             // Succeeding versions
             JobList.from(application)
                     .lastSuccess().present()
                     .production()
-                    .mapToList(job -> job.lastSuccess().get().version())
+                    .mapToList(job -> job.lastSuccess().get().platform())
                     .forEach(version -> versionMap.put(version, versionMap.getOrDefault(version, DeploymentStatistics.empty(version)).withProduction(application.id())));
 
             // Deploying versions
             JobList.from(application)
                     .upgrading()
-                    .mapToList(job -> job.lastTriggered().get().version())
+                    .mapToList(job -> job.lastTriggered().get().platform())
                     .forEach(version -> versionMap.put(version, versionMap.getOrDefault(version, DeploymentStatistics.empty(version)).withDeploying(application.id())));
         }
         return versionMap.values();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.yahoo.config.provision.SystemName.main;
@@ -491,14 +490,14 @@ public class DeploymentTriggerTest {
 
         // New application version should run system and staging tests first against 6.2, then against 6.1.
         tester.jobCompletion(component).application(application).nextBuildNumber().uploadArtifact(applicationPackage).submit();
-        assertEquals(v2, app.get().deploymentJobs().jobStatus().get(systemTest).lastTriggered().get().version());
+        assertEquals(v2, app.get().deploymentJobs().jobStatus().get(systemTest).lastTriggered().get().platform());
         tester.deployAndNotify(application, empty(), true, systemTest);
-        assertEquals(v2, app.get().deploymentJobs().jobStatus().get(stagingTest).lastTriggered().get().version());
+        assertEquals(v2, app.get().deploymentJobs().jobStatus().get(stagingTest).lastTriggered().get().platform());
         tester.deployAndNotify(application, empty(), true, stagingTest);
         tester.deployAndNotify(application, empty(), true, productionUsCentral1);
-        assertEquals(v1, app.get().deploymentJobs().jobStatus().get(systemTest).lastTriggered().get().version());
+        assertEquals(v1, app.get().deploymentJobs().jobStatus().get(systemTest).lastTriggered().get().platform());
         tester.deployAndNotify(application, empty(), true, systemTest);
-        assertEquals(v1, app.get().deploymentJobs().jobStatus().get(stagingTest).lastTriggered().get().version());
+        assertEquals(v1, app.get().deploymentJobs().jobStatus().get(stagingTest).lastTriggered().get().platform());
         tester.deployAndNotify(application, empty(), true, stagingTest);
 
         // The production job on version 6.2 fails and must retry -- this is OK, even though staging now has a different version.
@@ -506,9 +505,9 @@ public class DeploymentTriggerTest {
         tester.deployAndNotify(application, empty(), true, productionUsEast3);
         tester.deployAndNotify(application, empty(), true, productionEuWest1);
         assertFalse(app.get().change().isPresent());
-        assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionUsCentral1).lastSuccess().get().applicationVersion().buildNumber().get().longValue());
-        assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionEuWest1).lastSuccess().get().applicationVersion().buildNumber().get().longValue());
-        assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionUsEast3).lastSuccess().get().applicationVersion().buildNumber().get().longValue());
+        assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionUsCentral1).lastSuccess().get().application().buildNumber().get().longValue());
+        assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionEuWest1).lastSuccess().get().application().buildNumber().get().longValue());
+        assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionUsEast3).lastSuccess().get().application().buildNumber().get().longValue());
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -439,7 +439,6 @@ public class DeploymentTriggerTest {
 
         assertEquals(v2, app.get().deployments().get(productionUsCentral1.zone(main).get()).version());
         assertEquals((Long) 42L, app.get().deployments().get(productionUsCentral1.zone(main).get()).applicationVersion().buildNumber().get());
-        // TODO jvenstad: Fails here now, because job isn't triggered any more, as deploy target is not verified.
         assertNotEquals(triggered, app.get().deploymentJobs().jobStatus().get(productionUsCentral1).lastTriggered().get().at());
 
         // Change has a higher application version than what is deployed -- deployment should trigger.
@@ -508,6 +507,47 @@ public class DeploymentTriggerTest {
         assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionUsCentral1).lastSuccess().get().application().buildNumber().get().longValue());
         assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionEuWest1).lastSuccess().get().application().buildNumber().get().longValue());
         assertEquals(43, app.get().deploymentJobs().jobStatus().get(productionUsEast3).lastSuccess().get().application().buildNumber().get().longValue());
+    }
+
+    @Test
+    public void eachDifferentUpgradeCombinationIsTested() {
+        DeploymentTester tester = new DeploymentTester();
+        Application application = tester.createApplication("app1", "tenant1", 1, 1L);
+        Supplier<Application> app = () -> tester.application(application.id());
+        ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
+                .environment(Environment.prod)
+                .region("us-central-1")
+                .parallel("eu-west-1", "us-east-3")
+                .build();
+        // Application version 42 and platform version 6.1.
+        tester.deployCompletely(application, applicationPackage);
+
+        // Application partially upgrades, then a new version is released.
+        Version v1 = new Version("6.1");
+        Version v2 = new Version("6.2");
+        tester.upgradeSystem(v2);
+        tester.deployAndNotify(application, empty(), true, systemTest);
+        tester.deployAndNotify(application, empty(), true, stagingTest);
+        tester.deployAndNotify(application, empty(), true, productionUsCentral1);
+        tester.deployAndNotify(application, empty(), true, productionEuWest1);
+        tester.deployAndNotify(application, empty(), false, productionUsEast3);
+        assertEquals(v2, app.get().deployments().get(ZoneId.from("prod", "us-central-1")).version());
+        assertEquals(v2, app.get().deployments().get(ZoneId.from("prod", "eu-west-1")).version());
+        assertEquals(v1, app.get().deployments().get(ZoneId.from("prod", "us-east-3")).version());
+
+        Version v3 = new Version("6.3");
+        tester.upgradeSystem(v3);
+        tester.deployAndNotify(application, empty(), false, productionUsEast3);
+
+        // See that sources for staging are: first v2, then v1.
+        tester.deployAndNotify(application, empty(), true, systemTest);
+        tester.deployAndNotify(application, empty(), true, stagingTest);
+        assertEquals(v2, app.get().deploymentJobs().jobStatus().get(stagingTest).lastSuccess().get().sourcePlatform().get());
+        tester.deployAndNotify(application, empty(), true, productionUsCentral1);
+        assertEquals(v1, app.get().deploymentJobs().jobStatus().get(stagingTest).lastTriggered().get().sourcePlatform().get());
+        tester.deployAndNotify(application, empty(), true, stagingTest);
+        tester.deployAndNotify(application, empty(), true, productionEuWest1);
+        tester.deployAndNotify(application, empty(), true, productionUsEast3);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/FailureRedeployerTest.java
@@ -131,7 +131,7 @@ public class FailureRedeployerTest {
         assertEquals("Application has pending upgrade to " + version, version, tester.application(app.id()).change().platform().get());
 
         // Cancellation of outdated version and triggering on a new version is done by the upgrader.
-        assertEquals(version, tester.application(app.id()).deploymentJobs().jobStatus().get(systemTest).lastTriggered().get().version());
+        assertEquals(version, tester.application(app.id()).deploymentJobs().jobStatus().get(systemTest).lastTriggered().get().platform());
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 import static com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType.component;
+import static com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType.productionUsCentral1;
 import static com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType.productionUsEast3;
 import static com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType.productionUsWest1;
 import static com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobType.stagingTest;
@@ -717,7 +718,7 @@ public class UpgraderTest {
         // Another hour pass, time is 20:00 and application upgrades
         tester.clock().advance(Duration.ofHours(1));
         readyJobsTrigger.maintain();
-        tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.productionUsCentral1);
+        tester.deployAndNotify(app, applicationPackage, true, productionUsCentral1);
         tester.deployAndNotify(app, applicationPackage, true, productionUsEast3);
         assertTrue("All jobs consumed", tester.buildService().jobs().isEmpty());
     }
@@ -760,7 +761,7 @@ public class UpgraderTest {
         tester.deployAndNotify(app, applicationPackage, true, stagingTest);
         tester.deployAndNotify(app, applicationPackage, true, productionUsWest1);
         clock.advance(Duration.ofHours(1)); // Entering block window after prod job is triggered
-        tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.productionUsCentral1);
+        tester.deployAndNotify(app, applicationPackage, true, productionUsCentral1);
         assertTrue(tester.buildService().jobs().isEmpty()); // Next job not triggered due to being in the block window
 
         // A day passes and we get a new version
@@ -776,12 +777,12 @@ public class UpgraderTest {
         tester.clock().advance(Duration.ofHours(17)); // Monday, 10:00
         tester.upgrader().maintain();
         tester.readyJobTrigger().maintain();
-        // We proceed with the new version in the expected order, not starting with the previously blocked version:
-        // Test jobs are run with the new version, but not production as we are in the block window
         tester.deployAndNotify(app, applicationPackage, true, systemTest);
         tester.deployAndNotify(app, applicationPackage, true, stagingTest);
         tester.deployAndNotify(app, applicationPackage, true, productionUsWest1);
-        tester.deployAndNotify(app, applicationPackage, true, DeploymentJobs.JobType.productionUsCentral1);
+        tester.deployAndNotify(app, applicationPackage, true, productionUsCentral1);
+        // us-east-3 has an older version than the other zones, and needs a new staging test run.
+        tester.deployAndNotify(app, applicationPackage, true, stagingTest);
         tester.deployAndNotify(app, applicationPackage, true, productionUsEast3);
         assertTrue("All jobs consumed", tester.buildService().jobs().isEmpty());
         

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -38,7 +38,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static com.yahoo.config.provision.SystemName.main;
 import static com.yahoo.vespa.hosted.controller.ControllerTester.writable;
+import static java.util.Optional.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -74,13 +76,16 @@ public class ApplicationSerializerTest {
         List<JobStatus> statusList = new ArrayList<>();
 
         statusList.add(JobStatus.initial(DeploymentJobs.JobType.systemTest)
-                                .withTriggering(Version.fromString("5.6.7"), ApplicationVersion.unknown, "Test", Instant.ofEpochMilli(7))
-                                .withCompletion(30, Optional.empty(), Instant.ofEpochMilli(8), tester.controller()));
+                                .withTriggering(Version.fromString("5.6.7"), ApplicationVersion.unknown, empty(), "Test", Instant.ofEpochMilli(7))
+                                .withCompletion(30, empty(), Instant.ofEpochMilli(8)));
         statusList.add(JobStatus.initial(DeploymentJobs.JobType.stagingTest)
-                                .withTriggering(Version.fromString("5.6.6"), ApplicationVersion.unknown, "Test 2", Instant.ofEpochMilli(5))
-                                .withCompletion(11, Optional.of(JobError.unknown), Instant.ofEpochMilli(6), tester.controller()));
+                                .withTriggering(Version.fromString("5.6.6"), ApplicationVersion.unknown, empty(), "Test 2", Instant.ofEpochMilli(5))
+                                .withCompletion(11, Optional.of(JobError.unknown), Instant.ofEpochMilli(6)));
+        statusList.add(JobStatus.initial(DeploymentJobs.JobType.from(main, zone1).get())
+                                .withTriggering(Version.fromString("5.6.6"), ApplicationVersion.unknown, deployments.stream().findFirst(), "Test 3", Instant.ofEpochMilli(6))
+                                .withCompletion(11, empty(), Instant.ofEpochMilli(7)));
 
-        DeploymentJobs deploymentJobs = new DeploymentJobs(projectId, statusList, Optional.empty());
+        DeploymentJobs deploymentJobs = new DeploymentJobs(projectId, statusList, empty());
 
         Application original = new Application(ApplicationId.from("t1", "a1", "i1"),
                                                deploymentSpec,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -515,9 +515,25 @@ public class ApplicationApiTest extends ControllerContainerTest {
                         .projectId(projectId)
                         .submit();
 
+        // staging-test again for us-east-3
+        String stagingPath = String.format("/application/v4/tenant/%s/application/%s/environment/staging/region/us-east-3/instance/default",
+                                           id.tenant().value(), id.application().value());
+        tester.assertResponse(request(stagingPath, POST)
+                                      .data(deployData)
+                                      .screwdriverIdentity(SCREWDRIVER_ID),
+                              new File("deploy-result.json"));
+        tester.assertResponse(request(stagingPath, DELETE)
+                                      .screwdriverIdentity(SCREWDRIVER_ID),
+                              "Deactivated " + stagingPath.replaceFirst("/application/v4/", ""));
+        controllerTester.jobCompletion(DeploymentJobs.JobType.stagingTest)
+                        .application(id)
+                        .projectId(projectId)
+                        .submit();
+
         // us-east-3
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-east-3/instance/default/deploy", POST)
-                                      .data(deployData).screwdriverIdentity(SCREWDRIVER_ID),
+                                      .data(deployData)
+                                      .screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
         controllerTester.jobCompletion(DeploymentJobs.JobType.productionUsEast3)
                         .application(id)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -874,7 +874,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
         assertNotNull("Status was recorded", recordedStatus);
         assertTrue(recordedStatus.isSuccess());
-        assertEquals(vespaVersion, recordedStatus.lastCompleted().get().version());
+        assertEquals(vespaVersion, recordedStatus.lastCompleted().get().platform());
 
         recordedStatus =
                 tester.controller().applications().get(app.id()).get().deploymentJobs().jobStatus().get(DeploymentJobs.JobType.productionApNortheast2);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
@@ -94,7 +94,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-us-west-1",
+        "reason": "Testing deployment for production-us-east-3",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -108,7 +108,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-us-west-1",
+        "reason": "Testing deployment for production-us-east-3",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -122,7 +122,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-us-west-1",
+        "reason": "Testing deployment for production-us-east-3",
         "at": "(ignore)"
       }
     },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobreport-unexpected-completion.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobreport-unexpected-completion.json
@@ -1,4 +1,4 @@
 {
   "error-code": "BAD_REQUEST",
-  "message": "Got notified about completion of job status of productionUsEast3[ last triggered: (never), last completed: (never), first failing: (not failing), lastSuccess: (never)], but that has neither been triggered nor deployed"
+  "message": "Got notified about completion of production-us-east-3 for tenant1.application1, but that has neither been triggered nor deployed"
 }


### PR DESCRIPTION
@mpolden please review. 

JobRun now includes source versions as well as targets. For production jobs where source versions are present, i.e., where there is a previous deployment, and where these source versions differ from the target versions, i.e., actual upgrades, it is required that the same combination of sources and targets has been through staging-tests. 