### PR TITLE
ZooKeeper-persist and load published cluster state bundles

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
@@ -78,6 +78,10 @@ public class ClusterStateBundle {
         return new ClusterStateBundle(baselineState, Collections.emptyMap());
     }
 
+    public static ClusterStateBundle empty() {
+        return ofBaselineOnly(AnnotatedClusterState.emptyState());
+    }
+
     public AnnotatedClusterState getBaselineAnnotatedState() {
         return baselineState;
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/Database.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/Database.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core.database;
 
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
+import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
 
 import java.util.Map;
 
@@ -82,4 +83,9 @@ public abstract class Database {
      * Fetch the start times of distributor and service layer nodes.
      */
     public abstract Map<Node, Long> retrieveStartTimestamps() throws InterruptedException;
+
+    public abstract boolean storeLastPublishedStateBundle(ClusterStateBundle stateBundle) throws InterruptedException;
+
+    public abstract ClusterStateBundle retrieveLastPublishedStateBundle() throws InterruptedException;
+
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseFactory.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseFactory.java
@@ -1,0 +1,34 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core.database;
+
+import com.yahoo.vespa.clustercontroller.core.ContentCluster;
+
+/**
+ * Database factory to enable test mocking of DB features. In practice, this
+ * will always be {@link ZooKeeperDatabase} due to rather heavy ZK feature
+ * dependencies and leaky abstractions built on top of them.
+ */
+public interface DatabaseFactory {
+
+    class Params {
+        ContentCluster cluster;
+        int nodeIndex;
+        String dbAddress;
+        int dbSessionTimeout;
+        Database.DatabaseListener listener;
+
+        Params cluster(ContentCluster c) { this.cluster = c; return this; }
+        ContentCluster cluster() { return cluster; }
+        Params nodeIndex(int i) { this.nodeIndex = i; return this; }
+        int nodeIndex() { return nodeIndex; }
+        Params databaseAddress(String address) { this.dbAddress = address; return this; }
+        String databaseAddress() { return dbAddress; }
+        Params databaseSessionTimeout(int timeout) { this.dbSessionTimeout = timeout; return this; }
+        int databaseSessionTimeout() { return dbSessionTimeout; }
+        Params databaseListener(Database.DatabaseListener listener) { this.listener = listener; return this; }
+        Database.DatabaseListener databaseListener() { return listener; }
+    }
+
+    Database create(Params params) throws Exception;
+
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
@@ -1,7 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.database;
 
+import com.yahoo.vespa.clustercontroller.core.AnnotatedClusterState;
+import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
 import com.yahoo.vespa.clustercontroller.core.ContentCluster;
+import com.yahoo.vespa.clustercontroller.core.rpc.EnvelopedClusterStateBundleCodec;
+import com.yahoo.vespa.clustercontroller.core.rpc.SlimeClusterStateBundleCodec;
 import org.apache.zookeeper.*;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.data.ACL;
@@ -128,6 +132,7 @@ public class ZooKeeperDatabase extends Database {
         createNode(zooKeeperRoot, "wantedstates", new byte[0]);
         createNode(zooKeeperRoot, "starttimestamps", new byte[0]);
         createNode(zooKeeperRoot, "latestversion", new Integer(0).toString().getBytes(utf8));
+        createNode(zooKeeperRoot, "published_state_bundle", new byte[0]); // TODO dedupe string constants
         byte val[] = String.valueOf(nodeIndex).getBytes(utf8);
         deleteNodeIfExists(getMyIndexPath());
         log.log(LogLevel.INFO, "Fleetcontroller " + nodeIndex +
@@ -165,6 +170,15 @@ public class ZooKeeperDatabase extends Database {
         return (!sessionOpen || watcher.getState().equals(Watcher.Event.KeeperState.Expired));
     }
 
+    private void maybeLogExceptionWarning(Exception e, String message) {
+        if (sessionOpen && reportErrors) {
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            log.log(LogLevel.WARNING, String.format("Fleetcontroller %s: %s. Exception: %s\n%s",
+                    nodeIndex, message, e.getMessage(), sw.toString()));
+        }
+    }
+
     public boolean storeMasterVote(int wantedMasterIndex) throws InterruptedException {
         byte val[] = String.valueOf(wantedMasterIndex).getBytes(utf8);
         try{
@@ -174,11 +188,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to create our ephemeral node and store master vote:\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to create our ephemeral node and store master vote");
         }
         return false;
     }
@@ -191,11 +201,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to store latest system state version used " + version + "\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to store latest system state version used " + version);
             return false;
         }
     }
@@ -211,11 +217,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to retrieve latest system state version used. Returning null.\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to retrieve latest system state version used. Returning null");
             return null;
         }
     }
@@ -242,11 +244,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to store wanted states in zookeeper: " + e.getMessage() + "\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to store wanted states in ZooKeeper");
             return false;
         }
     }
@@ -276,11 +274,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to retrieve wanted states from zookeeper: " + e.getMessage() + "\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to retrieve wanted states from ZooKeeper");
             return null;
         }
     }
@@ -301,11 +295,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to store start timestamps in zookeeper: " + e.getMessage() + "\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to store start timestamps in ZooKeeper");
             return false;
         }
     }
@@ -336,12 +326,45 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            if (sessionOpen && reportErrors) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                log.log(LogLevel.WARNING, "Fleetcontroller " + nodeIndex + ": Failed to retrieve start timestamps from zookeeper: " + e.getMessage() + "\n" + sw);
-            }
+            maybeLogExceptionWarning(e, "Failed to retrieve start timestamps from ZooKeeper");
             return null;
         }
     }
+
+    @Override
+    public boolean storeLastPublishedStateBundle(ClusterStateBundle stateBundle) throws InterruptedException {
+        EnvelopedClusterStateBundleCodec envelopedBundleCodec = new SlimeClusterStateBundleCodec();
+        byte[] encodedBundle = envelopedBundleCodec.encodeWithEnvelope(stateBundle);
+        try{
+            log.log(LogLevel.DEBUG, () -> String.format("Fleetcontroller %d: Storing published state bundle %s at '%spublished_state_bundle'",
+                    nodeIndex, stateBundle, zooKeeperRoot));
+            // TODO CAS on expected zknode version
+            session.setData(zooKeeperRoot + "published_state_bundle", encodedBundle, -1);
+        } catch (InterruptedException e) {
+            throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
+        } catch (Exception e) {
+            maybeLogExceptionWarning(e, "Failed to store start timestamps in ZooKeeper");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public ClusterStateBundle retrieveLastPublishedStateBundle() throws InterruptedException {
+        Stat stat = new Stat();
+        try {
+            byte[] data = session.getData(zooKeeperRoot + "published_state_bundle", false, stat);
+            if (data != null && data.length != 0) {
+                EnvelopedClusterStateBundleCodec envelopedBundleCodec = new SlimeClusterStateBundleCodec();
+                return envelopedBundleCodec.decodeWithEnvelope(data);
+            }
+        } catch (InterruptedException e) {
+            throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
+        } catch (Exception e) {
+            maybeLogExceptionWarning(e, "Failed to retrieve last published cluster state bundle from " +
+                    "ZooKeeper, will use an empty state as baseline");
+        }
+        return ClusterStateBundle.ofBaselineOnly(AnnotatedClusterState.emptyState());
+    }
+
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
@@ -343,7 +343,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
-            maybeLogExceptionWarning(e, "Failed to store start timestamps in ZooKeeper");
+            maybeLogExceptionWarning(e, "Failed to store last published cluster state bundle in ZooKeeper");
             return false;
         }
         return true;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabaseFactory.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabaseFactory.java
@@ -1,0 +1,14 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core.database;
+
+import com.yahoo.vespa.clustercontroller.core.ContentCluster;
+
+public class ZooKeeperDatabaseFactory implements DatabaseFactory {
+
+    @Override
+    public Database create(Params params) throws Exception {
+        return new ZooKeeperDatabase(params.cluster, params.nodeIndex, params.dbAddress,
+                params.dbSessionTimeout, params.listener);
+    }
+
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/listeners/SystemStateListener.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/listeners/SystemStateListener.java
@@ -5,6 +5,9 @@ import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
 
 public interface SystemStateListener {
 
-    void handleNewSystemState(ClusterStateBundle states);
+    // TODO consider rename to bundle
+    void handleNewPublishedState(ClusterStateBundle states);
+
+    default void handleNewCandidateState(ClusterStateBundle states) {}
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/EnvelopedClusterStateBundleCodec.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/EnvelopedClusterStateBundleCodec.java
@@ -1,0 +1,19 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core.rpc;
+
+import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
+
+/**
+ * Cluster state bundle codec which opaquely encodes/decodes both the bundle
+ * as well as the metadata required to correctly perform compression/decompression.
+ *
+ * Useful for embedding an opaque bundle blob somewhere without needing to care aboout
+ * any of the associated metadata.
+ */
+public interface EnvelopedClusterStateBundleCodec {
+
+    byte[] encodeWithEnvelope(ClusterStateBundle stateBundle);
+
+    ClusterStateBundle decodeWithEnvelope(byte[] encodedClusterStateBundle);
+
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
@@ -75,7 +75,6 @@ public class DatabaseHandlerTest {
         DatabaseHandler handler = f.createHandler();
         handler.doNextZooKeeperTask(f.createMockContext()); // Database setup step
         handler.saveLatestClusterStateBundle(f.createMockContext(), f.dummyBundle);
-        handler.doNextZooKeeperTask(f.createMockContext()); // Bundle store step
 
         verify(f.mockDatabase).storeLastPublishedStateBundle(eq(f.dummyBundle));
     }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
@@ -1,0 +1,107 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vespa.clustercontroller.core.database.Database;
+import com.yahoo.vespa.clustercontroller.core.database.DatabaseFactory;
+import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
+import com.yahoo.vespa.clustercontroller.core.listeners.NodeAddedOrRemovedListener;
+import com.yahoo.vespa.clustercontroller.core.listeners.NodeStateOrHostInfoChangeHandler;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DatabaseHandlerTest {
+
+    static class Fixture {
+        final ClusterFixture clusterFixture = ClusterFixture.forFlatCluster(10);
+        final FleetController mockController = mock(FleetController.class);
+        final Database mockDatabase = mock(Database.class);
+        final Timer mockTimer = mock(Timer.class);
+        final DatabaseFactory mockDbFactory = (params) -> mockDatabase;
+        final String databaseAddress = "localhost:0";
+        final Object monitor = new Object();
+        final ClusterStateBundle dummyBundle;
+
+        Fixture() throws Exception {
+            dummyBundle = ClusterStateBundleUtil.makeBundle("distributor:2 storage:2",
+                    StateMapping.of("default", "distributor:2 storage:2 .0.s:d"),
+                    StateMapping.of("upsidedown", "distributor:2 .0.s:d storage:2"));
+
+            when(mockDatabase.isClosed()).thenReturn(false);
+            when(mockDatabase.storeMasterVote(anyInt())).thenReturn(true);
+            when(mockDatabase.storeLastPublishedStateBundle(any())).thenReturn(true);
+            when(mockTimer.getCurrentTimeInMillis()).thenReturn(1000000L);
+        }
+
+        DatabaseHandler.Context createMockContext() {
+            return new DatabaseHandler.Context() {
+                @Override
+                public ContentCluster getCluster() {
+                    return clusterFixture.cluster();
+                }
+
+                @Override
+                public FleetController getFleetController() {
+                    return mockController;
+                }
+
+                @Override
+                public NodeAddedOrRemovedListener getNodeAddedOrRemovedListener() {
+                    return null;
+                }
+
+                @Override
+                public NodeStateOrHostInfoChangeHandler getNodeStateUpdateListener() {
+                    return null;
+                }
+            };
+        }
+
+        DatabaseHandler createHandler() throws Exception {
+            return new DatabaseHandler(mockDbFactory, mockTimer, databaseAddress, 0, monitor);
+        }
+    }
+
+    @Test
+    public void can_store_latest_cluster_state_bundle() throws Exception {
+        Fixture f = new Fixture();
+        DatabaseHandler handler = f.createHandler();
+        handler.doNextZooKeeperTask(f.createMockContext()); // Database setup step
+        handler.saveLatestClusterStateBundle(f.createMockContext(), f.dummyBundle);
+        handler.doNextZooKeeperTask(f.createMockContext()); // Bundle store step
+
+        verify(f.mockDatabase).storeLastPublishedStateBundle(eq(f.dummyBundle));
+    }
+
+    @Test
+    public void can_load_latest_cluster_state_bundle() throws Exception {
+        Fixture f = new Fixture();
+        DatabaseHandler handler = f.createHandler();
+        handler.doNextZooKeeperTask(f.createMockContext()); // Database setup step
+
+        when(f.mockDatabase.retrieveLastPublishedStateBundle()).thenReturn(f.dummyBundle);
+
+        ClusterStateBundle retrievedBundle = handler.getLatestClusterStateBundle();
+        assertThat(retrievedBundle, equalTo(f.dummyBundle));
+    }
+
+    // FIXME I don't like the semantics of this, but it mirrors the legacy behavior for the
+    // rest of the DB load operations exposed by the DatabaseHandler.
+    @Test
+    public void empty_bundle_is_returned_if_no_db_connection() throws Exception {
+        Fixture f = new Fixture();
+        DatabaseHandler handler = f.createHandler();
+        // Note: no DB setup step
+
+        ClusterStateBundle retrievedBundle = handler.getLatestClusterStateBundle();
+        assertThat(retrievedBundle, equalTo(ClusterStateBundle.empty()));
+    }
+
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
@@ -18,6 +18,7 @@ import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
+import com.yahoo.vespa.clustercontroller.core.database.ZooKeeperDatabaseFactory;
 import com.yahoo.vespa.clustercontroller.core.rpc.RPCCommunicator;
 import com.yahoo.vespa.clustercontroller.core.rpc.RpcServer;
 import com.yahoo.vespa.clustercontroller.core.rpc.SlobrokClient;
@@ -157,7 +158,7 @@ public abstract class FleetControllerTest implements Waiter {
             status = new StatusPageServer(timer, timer, options.httpPort);
         }
         RpcServer rpcServer = new RpcServer(timer, timer, options.clusterName, options.fleetControllerIndex, options.slobrokBackOffPolicy);
-        DatabaseHandler database = new DatabaseHandler(timer, options.zooKeeperServerAddress, options.fleetControllerIndex, timer);
+        DatabaseHandler database = new DatabaseHandler(new ZooKeeperDatabaseFactory(), timer, options.zooKeeperServerAddress, options.fleetControllerIndex, timer);
         StateChangeHandler stateGenerator = new StateChangeHandler(timer, log, metricUpdater);
         SystemStateBroadcaster stateBroadcaster = new SystemStateBroadcaster(timer, timer);
         MasterElectionHandler masterElectionHandler = new MasterElectionHandler(options.fleetControllerIndex, options.fleetControllerCount, timer, timer);
@@ -311,6 +312,8 @@ public abstract class FleetControllerTest implements Waiter {
     public ClusterState waitForStableSystem() throws Exception { return waiter.waitForStableSystem(); }
     public ClusterState waitForStableSystem(int nodeCount) throws Exception { return waiter.waitForStableSystem(nodeCount); }
     public ClusterState waitForState(String state) throws Exception { return waiter.waitForState(state); }
+    public ClusterState waitForStateInAllSpaces(String state) throws Exception { return waiter.waitForStateInAllSpaces(state); }
+    public ClusterState waitForStateInSpace(String space, String state) throws Exception { return waiter.waitForStateInSpace(space, state); }
     public ClusterState waitForState(String state, int timeoutMS) throws Exception { return waiter.waitForState(state, timeoutMS); }
     public ClusterState waitForInitProgressPassed(Node n, double progress) { return waiter.waitForInitProgressPassed(n, progress); }
     public ClusterState waitForClusterStateIncludingNodesWithMinUsedBits(int bitcount, int nodecount) { return waiter.waitForClusterStateIncludingNodesWithMinUsedBits(bitcount, nodecount); }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ZooKeeperDatabaseTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ZooKeeperDatabaseTest.java
@@ -1,0 +1,76 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vespa.clustercontroller.core.database.Database;
+import com.yahoo.vespa.clustercontroller.core.database.ZooKeeperDatabase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ZooKeeperDatabaseTest {
+
+    private static class Fixture implements AutoCloseable {
+        final ZooKeeperTestServer zkServer;
+        ClusterFixture clusterFixture;
+        ZooKeeperDatabase zkDatabase;
+        int nodeIndex = 1;
+        Duration sessionTimeout = Duration.ofSeconds(60);
+        Database.DatabaseListener mockListener = mock(Database.DatabaseListener.class);
+
+        Fixture() throws IOException {
+            zkServer = new ZooKeeperTestServer();
+            clusterFixture = ClusterFixture.forFlatCluster(10);
+        }
+
+        void createDatabase() throws Exception {
+            closeDatabaseIfOpen();
+            zkDatabase = new ZooKeeperDatabase(clusterFixture.cluster(), nodeIndex, zkServer.getAddress(),
+                    (int)sessionTimeout.toMillis(), mockListener);
+        }
+
+        ZooKeeperDatabase db() { return zkDatabase; }
+
+        void closeDatabaseIfOpen() {
+            if (zkDatabase != null) {
+                zkDatabase.close();
+                zkDatabase = null;
+            }
+        }
+
+        @Override
+        public void close() {
+            closeDatabaseIfOpen();
+            zkServer.shutdown(true);
+        }
+    }
+
+    @Test
+    public void can_store_and_load_cluster_state_bundle_from_database() throws Exception {
+        try (Fixture f = new Fixture()) {
+            f.createDatabase();
+            ClusterStateBundle bundleToStore = ClusterStateBundleUtil.makeBundle("distributor:2 storage:2",
+                    StateMapping.of("default", "distributor:2 storage:2 .0.s:d"),
+                    StateMapping.of("upsidedown", "distributor:2 .0.s:d storage:2"));
+            f.db().storeLastPublishedStateBundle(bundleToStore);
+
+            ClusterStateBundle bundleReceived = f.db().retrieveLastPublishedStateBundle();
+            assertThat(bundleReceived, equalTo(bundleToStore));
+        }
+    }
+
+    @Test
+    public void empty_state_bundle_is_returned_if_no_bundle_already_stored_in_database() throws Exception {
+        try (Fixture f = new Fixture()) {
+            f.createDatabase();
+            ClusterStateBundle bundleReceived = f.db().retrieveLastPublishedStateBundle();
+
+            assertThat(bundleReceived, equalTo(ClusterStateBundle.empty()));
+        }
+    }
+
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
@@ -18,6 +18,12 @@ public class SlimeClusterStateBundleCodecTest {
         return codec.decode(encoded);
     }
 
+    private static ClusterStateBundle roundtripEncodeWithEnvelope(ClusterStateBundle stateBundle) {
+        SlimeClusterStateBundleCodec codec = new SlimeClusterStateBundleCodec();
+        byte[] encoded = codec.encodeWithEnvelope(stateBundle);
+        return codec.decodeWithEnvelope(encoded);
+    }
+
     @Test
     public void baseline_only_bundle_can_be_round_trip_encoded() {
         ClusterStateBundle stateBundle = ClusterStateBundleUtil.makeBundle("distributor:2 storage:2");
@@ -51,6 +57,19 @@ public class SlimeClusterStateBundleCodecTest {
         assertThat(encoded.getCompression().data().length, lessThan(stateBundle.getBaselineClusterState().toString().length()));
         ClusterStateBundle decodedBundle = codec.decode(encoded);
         assertThat(decodedBundle, equalTo(stateBundle));
+    }
+
+    @Test
+    public void uncompressed_enveloped_bundle_can_be_roundtrip_encoded() {
+        // Insufficient length and too much entropy to be compressed
+        ClusterStateBundle stateBundle = ClusterStateBundleUtil.makeBundle("distributor:2 storage:3");
+        assertThat(roundtripEncodeWithEnvelope(stateBundle), equalTo(stateBundle));
+    }
+
+    @Test
+    public void compressable_enveloped_bundle_can_be_roundtrip_encoded() {
+        ClusterStateBundle stateBundle = makeCompressableBundle();
+        assertThat(roundtripEncodeWithEnvelope(stateBundle), equalTo(stateBundle));
     }
 
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/testutils/StateWaiter.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/testutils/StateWaiter.java
@@ -23,13 +23,21 @@ public class StateWaiter implements SystemStateListener {
         this.timer = timer;
     }
 
-    public void handleNewSystemState(ClusterStateBundle state) {
+    @Override
+    public void handleNewPublishedState(ClusterStateBundle state) {
         synchronized(timer) {
             current = state.getBaselineClusterState();
 
             ++stateUpdates;
             timer.notifyAll();
         }
+    }
+
+    @Override
+    public void handleNewCandidateState(ClusterStateBundle states) {
+        // Treat candidate states as if they were published for the tests that use
+        // this (deprecated) waiter class.
+        handleNewPublishedState(states);
     }
 
     public int getStateUpdates() { return Math.max(0, stateUpdates); }


### PR DESCRIPTION
@geirst please review.

Store synchronously upon each new versioned state, load whenever controller
is elected master. Effectively carries over visible node states from one
controller's lifetime to the next. This removes the edge case where default
bucket space content nodes are marked as in Maintainence until their global
merge status is known.

To avoid controller tripping over its own feet, state bundles are now _not_
versioned at all until the initial send time period has passed. This prevents
overwriting the state persisted from a previous controller with a transient
state where all nodes are down due to not having Slobrok contact yet.

A new cluster state recompute+send edge has been added when the master passes
its initial state send time period.