### PR TITLE
Select 2 cluster controllers by index

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -53,29 +53,30 @@ import java.util.stream.Collectors;
  * @author mostly somebody unknown
  * @author bratseth
  */
-public class ContentCluster extends AbstractConfigProducer implements StorDistributionConfig.Producer,
-        StorDistributormanagerConfig.Producer,
-        FleetcontrollerConfig.Producer,
-        MetricsmanagerConfig.Producer,
-        MessagetyperouteselectorpolicyConfig.Producer,
-        BucketspacesConfig.Producer {
+public class ContentCluster extends AbstractConfigProducer implements
+                                                           StorDistributionConfig.Producer,
+                                                           StorDistributormanagerConfig.Producer,
+                                                           FleetcontrollerConfig.Producer,
+                                                           MetricsmanagerConfig.Producer,
+                                                           MessagetyperouteselectorpolicyConfig.Producer,
+                                                           BucketspacesConfig.Producer {
 
     // TODO: Make private
     private String documentSelection;
-    ContentSearchCluster search;
+    private ContentSearchCluster search;
     private final boolean isHostedVespa;
     private final Map<String, NewDocumentType> documentDefinitions;
     private final Set<NewDocumentType> globallyDistributedDocuments;
     // Experimental flag (TODO: remove when feature is enabled by default)
     private boolean enableMultipleBucketSpaces = false;
-    com.yahoo.vespa.model.content.StorageGroup rootGroup;
-    StorageCluster storageNodes;
-    DistributorCluster distributorNodes;
+    private com.yahoo.vespa.model.content.StorageGroup rootGroup;
+    private StorageCluster storageNodes;
+    private DistributorCluster distributorNodes;
     private Redundancy redundancy;
-    ClusterControllerConfig clusterControllerConfig;
-    PersistenceEngine.PersistenceFactory persistenceFactory;
-    String clusterName;
-    Integer maxNodesPerMerge;
+    private ClusterControllerConfig clusterControllerConfig;
+    private PersistenceEngine.PersistenceFactory persistenceFactory;
+    private String clusterName;
+    private Integer maxNodesPerMerge;
     private Zone zone;
 
     /**
@@ -87,7 +88,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
     private ContainerCluster clusterControllers;
 
     public enum DistributionMode { LEGACY, STRICT, LOOSE }
-    DistributionMode distributionMode;
+    private DistributionMode distributionMode;
 
     public static class Builder {
 
@@ -341,7 +342,7 @@ public class ContentCluster extends AbstractConfigProducer implements StorDistri
             List<HostResource> hostsByIndex = drawContentHostsRecursively(count, true, rootGroup);
             // if (hosts.size() < count) // supply with containers TODO: Currently disabled due to leading to topology change problems
             //     hosts.addAll(drawContainerHosts(count - hosts.size(), containers, new HashSet<>(hosts)));
-            List<HostResource> hosts = HostResource.pickHosts(hostsByName, hostsByIndex, count, 1);
+            List<HostResource> hosts = HostResource.pickHosts(hostsByName, hostsByIndex, count, 2);
             if (hosts.size() % 2 == 0) // ZK clusters of even sizes are less available (even in the size=2 case)
                 hosts = hosts.subList(0, hosts.size()-1);
             return hosts;

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.fail;
 /**
  * Test cases for provisioning nodes to entire vespamodels
  *
- * @author vegardh
+ * @author Vegard Havdal
  * @author bratseth
  */
 public class ModelProvisioningTest {
@@ -403,8 +403,8 @@ public class ModelProvisioningTest {
         assertEquals(3, clusterControllers.getContainers().size());
         assertEquals("bar-controllers", clusterControllers.getName());
         assertEquals("default28", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals("default31", clusterControllers.getContainers().get(1).getHostName());
-        assertEquals("default54", clusterControllers.getContainers().get(2).getHostName());
+        assertEquals("default54", clusterControllers.getContainers().get(1).getHostName());
+        assertEquals("default51", clusterControllers.getContainers().get(2).getHostName());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(9, cluster.getRootGroup().getSubgroups().size());
         assertThat(cluster.getRootGroup().getSubgroups().get(0).getIndex(), is("0"));
@@ -442,8 +442,8 @@ public class ModelProvisioningTest {
         assertEquals(3, clusterControllers.getContainers().size());
         assertEquals("baz-controllers", clusterControllers.getName());
         assertEquals("default01", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals("default02", clusterControllers.getContainers().get(1).getHostName());
-        assertEquals("default27", clusterControllers.getContainers().get(2).getHostName());
+        assertEquals("default27", clusterControllers.getContainers().get(1).getHostName());
+        assertEquals("default26", clusterControllers.getContainers().get(2).getHostName());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(27, cluster.getRootGroup().getSubgroups().size());
         assertThat(cluster.getRootGroup().getSubgroups().get(0).getIndex(), is("0"));
@@ -495,8 +495,8 @@ public class ModelProvisioningTest {
         assertEquals(3, clusterControllers.getContainers().size());
         assertEquals("bar-controllers", clusterControllers.getName());
         assertEquals("default01", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals("default02", clusterControllers.getContainers().get(1).getHostName());
-        assertEquals("default08", clusterControllers.getContainers().get(2).getHostName());
+        assertEquals("default08", clusterControllers.getContainers().get(1).getHostName());
+        assertEquals("default07", clusterControllers.getContainers().get(2).getHostName());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(8, cluster.getRootGroup().getSubgroups().size());
         assertEquals(8, cluster.distributionBits());
@@ -555,7 +555,7 @@ public class ModelProvisioningTest {
         assertEquals("default02", clusterControllers.getContainers().get(1).getHostName());
         assertEquals("default04", clusterControllers.getContainers().get(2).getHostName());
         assertEquals("default05", clusterControllers.getContainers().get(3).getHostName());
-        assertEquals("default07", clusterControllers.getContainers().get(4).getHostName());
+        assertEquals("default09", clusterControllers.getContainers().get(4).getHostName());
         assertEquals("default09", cluster.getRootGroup().getSubgroups().get(0).getNodes().get(0).getHostName());
         assertEquals("default08", cluster.getRootGroup().getSubgroups().get(0).getNodes().get(1).getHostName());
         assertEquals("default06", cluster.getRootGroup().getSubgroups().get(1).getNodes().get(0).getHostName());
@@ -592,8 +592,8 @@ public class ModelProvisioningTest {
         assertEquals("We get the closest odd number", 3, clusterControllers.getContainers().size());
         assertEquals("bar-controllers", clusterControllers.getName());
         assertEquals("default01", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals("default03", clusterControllers.getContainers().get(1).getHostName());
-        assertEquals("default08", clusterControllers.getContainers().get(2).getHostName());
+        assertEquals("default08", clusterControllers.getContainers().get(1).getHostName());
+        assertEquals("default06", clusterControllers.getContainers().get(2).getHostName());
     }
 
     @Test
@@ -659,8 +659,8 @@ public class ModelProvisioningTest {
         assertEquals(3, clusterControllers.getContainers().size());
         assertEquals("bar-controllers", clusterControllers.getName());
         assertEquals("Skipping retired default09", "default01", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals("Skipping retired default03", "default04", clusterControllers.getContainers().get(1).getHostName());
-        assertEquals("Skipping retired default06", "default08", clusterControllers.getContainers().get(2).getHostName());
+        assertEquals("Skipping retired default06", "default08", clusterControllers.getContainers().get(1).getHostName());
+        assertEquals("Skipping retired default03", "default05", clusterControllers.getContainers().get(2).getHostName());
     }
 
     @Test


### PR DESCRIPTION
It's that time again.
review: @kkraune @hmusum 
optional: @vekterli 

This is part of an ongoing effort to move from selecting
cluster controllers by hostname to selecting by index -
which is more stable given node set changes.

We want to make the change in increments of a single node
to minimize issues during automatic upgrades.