### PR TITLE
Jvenstad/suppress parts of change to roll out unsuppressed part or test full change

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -130,7 +130,11 @@ public class Application {
      * Returns the change that should used for this application at the given instant, typically now.
      */
     public Change changeAt(Instant now) {
-        return change.effectiveAt(deploymentSpec, now); }
+        Change change = change();
+        if ( ! deploymentSpec.canUpgradeAt(now)) change = change.withoutPlatform();
+        if ( ! deploymentSpec.canChangeRevisionAt(now)) change = change.withoutApplication();
+        return change;
+    }
 
     /**
      * Returns whether this has an outstanding change (in the source repository), which

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
@@ -39,10 +39,12 @@ public final class Change {
         this.application = application;
     }
 
-    /** Returns this change with currently blocked parts removed. */
-    public Change effectiveAt(DeploymentSpec deploymentSpec, Instant instant) {
-        return new Change(platform.filter(__ -> deploymentSpec.canUpgradeAt(instant)),
-                          application.filter(__ -> deploymentSpec.canChangeRevisionAt(instant)));
+    public Change withoutPlatform() {
+        return new Change(Optional.empty(), application);
+    }
+
+    public Change withoutApplication() {
+        return new Change(platform, Optional.empty());
     }
 
     /** Returns whether a change should currently be deployed */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -117,7 +117,8 @@ public class DeploymentTrigger {
                 triggering = JobRun.triggering(controller.systemVersion(), applicationVersion, empty(), empty(), "Application commit", clock.instant());
                 if (report.success()) {
                     if (acceptNewApplicationVersion(application))
-                        application = application.withChange(application.change().with(applicationVersion));
+                        application = application.withChange(application.change().with(applicationVersion))
+                                                 .withOutstandingChange(Change.empty());
                     else
                         application = application.withOutstandingChange(Change.of(applicationVersion));
                 }


### PR DESCRIPTION
@mpolden please review. 
@bratseth FYI. 

When inside a block window for a part of change, that part is effectively suppressed when determining what to deploy (and test).
This allows rolling out, e.g., an application change in a platform block window, even though an upgrade was in progress at the start of the window. If the application change finishes during the window, it is removed from the application's change. When the block window ends, deployment continues with whatever change is left (both parts, or just the platform). 
When no tests are needed to proceed with production deployments, the full change (ignoring blockers) is tested, for development purposes. This is always the case when both parts of change are blocked. 