### PR TITLE
Export state API

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/state/package-info.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/state/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.vespa.hosted.node.admin.configserver.state;
+
+import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
```
Caused by: java.lang.NoClassDefFoundError: com/yahoo/vespa/hosted/node/admin/configserver/state/State
	at com.yahoo.vespa.hosted.hostadmin.configserver.server.VerifyLocalConfigServerIsHealthy.converge(VerifyLocalConfigServerIsHealthy.java:34)
	at com.yahoo.vespa.hosted.hostadmin.configserver.server.VerifyLocalConfigServerIsHealthy.converge(VerifyLocalConfigServerIsHealthy.java:17)
	at com.yahoo.vespa.hosted.hostadmin.scheduler.TaskDriver.runTask(TaskDriver.java:26)
```