### PR TITLE
Stable acl order

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/Acl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/Acl.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.node.admin.task.util.network.IPVersion;
 import java.net.InetAddress;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -32,34 +33,38 @@ public class Acl {
         this.trustedPorts = trustedPorts != null ? ImmutableList.copyOf(trustedPorts) : Collections.emptyList();
     }
 
-    public String toRules(IPVersion ipVersion) {
+    public List<String> toRules(IPVersion ipVersion) {
+        List<String> rules = new LinkedList<>();
 
-        String basics = String.join("\n"
-                // We reject with rules instead of using policies
-                , "-P INPUT ACCEPT"
-                , "-P FORWARD ACCEPT"
-                , "-P OUTPUT ACCEPT"
-                // Allow packets belonging to established connections
-                , "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT"
-                // Allow any loopback traffic
-                , "-A INPUT -i lo -j ACCEPT"
-                // Allow ICMP packets. See http://shouldiblockicmp.com/
-                , "-A INPUT -p " + ipVersion.icmpProtocol() + " -j ACCEPT");
+        // We reject with rules instead of using policies
+        rules.add("-P INPUT ACCEPT");
+        rules.add("-P FORWARD ACCEPT");
+        rules.add("-P OUTPUT ACCEPT");
+
+        // Allow packets belonging to established connections
+        rules.add( "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT");
+
+        // Allow any loopback traffic
+        rules.add("-A INPUT -i lo -j ACCEPT");
+
+        // Allow ICMP packets. See http://shouldiblockicmp.com/
+        rules.add("-A INPUT -p " + ipVersion.icmpProtocol() + " -j ACCEPT");
 
         // Allow trusted ports if any
         String commaSeparatedPorts = trustedPorts.stream().map(i -> Integer.toString(i)).collect(Collectors.joining(","));
-        String ports = commaSeparatedPorts.isEmpty() ? "" : "-A INPUT -p tcp -m multiport --dports " + commaSeparatedPorts + " -j ACCEPT\n";
+        if (!commaSeparatedPorts.isEmpty())
+            rules.add("-A INPUT -p tcp -m multiport --dports " + commaSeparatedPorts + " -j ACCEPT");
 
         // Allow traffic from trusted nodes
-        String nodes = trustedNodes.stream()
+        trustedNodes.stream()
                 .filter(ipVersion::match)
                 .map(ipAddress -> "-A INPUT -s " + InetAddresses.toAddrString(ipAddress) + ipVersion.singleHostCidr() + " -j ACCEPT")
-                .collect(Collectors.joining("\n"));
+                .forEach(rules::add);
 
         // We reject instead of dropping to give us an easier time to figure out potential network issues
-        String rejectEverythingElse = "-A INPUT -j REJECT --reject-with " + ipVersion.icmpPortUnreachable();
+        rules.add("-A INPUT -j REJECT --reject-with " + ipVersion.icmpPortUnreachable());
 
-        return basics + "\n" + ports + nodes + "\n" + rejectEverythingElse;
+        return Collections.unmodifiableList(rules);
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/Acl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/Acl.java
@@ -51,7 +51,7 @@ public class Acl {
         rules.add("-A INPUT -p " + ipVersion.icmpProtocol() + " -j ACCEPT");
 
         // Allow trusted ports if any
-        String commaSeparatedPorts = trustedPorts.stream().map(i -> Integer.toString(i)).collect(Collectors.joining(","));
+        String commaSeparatedPorts = trustedPorts.stream().map(i -> Integer.toString(i)).sorted().collect(Collectors.joining(","));
         if (!commaSeparatedPorts.isEmpty())
             rules.add("-A INPUT -p tcp -m multiport --dports " + commaSeparatedPorts + " -j ACCEPT");
 
@@ -59,6 +59,7 @@ public class Acl {
         trustedNodes.stream()
                 .filter(ipVersion::match)
                 .map(ipAddress -> "-A INPUT -s " + InetAddresses.toAddrString(ipAddress) + ipVersion.singleHostCidr() + " -j ACCEPT")
+                .sorted()
                 .forEach(rules::add);
 
         // We reject instead of dropping to give us an easier time to figure out potential network issues

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/FilterTableLineEditor.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/FilterTableLineEditor.java
@@ -5,7 +5,6 @@ import com.yahoo.vespa.hosted.node.admin.task.util.file.LineEdit;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.LineEditor;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.IPVersion;
 
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -16,12 +15,12 @@ class FilterTableLineEditor implements LineEditor {
 
     private final LinkedList<String> wantedRules;
 
-    FilterTableLineEditor(List<String> wantedRules) {
+    private FilterTableLineEditor(List<String> wantedRules) {
         this.wantedRules = new LinkedList<>(wantedRules);
     }
 
     static FilterTableLineEditor from(Acl acl, IPVersion ipVersion) {
-        List<String> rules = Arrays.asList(acl.toRules(ipVersion).split("\n"));
+        List<String> rules = acl.toRules(ipVersion);
         return new FilterTableLineEditor(rules);
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/FilterTableLineEditor.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/FilterTableLineEditor.java
@@ -26,6 +26,9 @@ class FilterTableLineEditor implements LineEditor {
 
     @Override
     public LineEdit edit(String line) {
+        // We have already added all the lines we wanted, remove the remainer
+        if (wantedRules.isEmpty()) return LineEdit.remove();
+
         String wantedRule = wantedRules.pop();
         return wantedRule.equals(line) ? LineEdit.none() : LineEdit.replaceWith(wantedRule);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/IPTablesEditor.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/IPTablesEditor.java
@@ -59,6 +59,7 @@ class IPTablesEditor {
             ProcessResult currentRulesResult =
                     dockerOperations.executeCommandInNetworkNamespace(containerName, ipVersion.iptablesCmd(), "-S", "-t", table);
             return Arrays.stream(currentRulesResult.getOutput().split("\n"))
+                    .map(String::trim)
                     .collect(Collectors.toList());
         };
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -232,7 +232,6 @@ public class NodeAgentImpl implements NodeAgent {
         if (! resumeScriptRun) {
             storageMaintainer.writeMetricsConfig(containerName, node);
             storageMaintainer.writeFilebeatConfig(containerName, node);
-            aclMaintainer.run();
             stopFilebeatSchedulerIfNeeded();
             currentFilebeatRestarter = Optional.of(filebeatRestarter.scheduleWithFixedDelay(
                     () -> serviceRestarter.accept("filebeat"), 1, 1, TimeUnit.DAYS));
@@ -490,6 +489,7 @@ public class NodeAgentImpl implements NodeAgent {
                     containerState = STARTING;
                     startContainer(node);
                     containerState = UNKNOWN;
+                    aclMaintainer.run();
                 }
 
                 runLocalResumeScriptIfNeeded(node);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AclTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AclTest.java
@@ -69,6 +69,16 @@ public class AclTest {
                         "-A INPUT -j REJECT --reject-with icmp6-port-unreachable", listRulesIpv6);
     }
 
+    @Test
+    public void ipv6_rules_stable() {
+        Acl aclCommonDifferentOrder = new Acl(
+                createPortList(453, 1234),
+                createTrustedNodes("fe80::2", "192.1.2.2", "fb00::1", "fe80::3"));
+
+        for (IPVersion ipVersion: IPVersion.values()) {
+            Assert.assertEquals(aclCommon.toRules(ipVersion), aclCommonDifferentOrder.toRules(ipVersion));
+        }
+    }
 
     private List<Integer> createPortList(Integer... ports) {
         return Arrays.asList(ports);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AclTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AclTest.java
@@ -1,7 +1,6 @@
-package com.yahoo.vespa.hosted.node.admin.maintenance.acl;
+package com.yahoo.vespa.hosted.node.admin.configserver.noderepository;
 
 import com.google.common.net.InetAddresses;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.Acl;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.IPVersion;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public class AclTest {
 
     private final Acl aclCommon = new Acl(
             createPortList(1234, 453),
-            createTrustedNodes("192.1.2.2", "fb00::1", "fe80::2"));
+            createTrustedNodes("192.1.2.2", "fb00::1", "fe80::2", "fe80::3"));
 
     private final Acl aclNoPorts = new Acl(
             Collections.emptyList(),
@@ -24,7 +23,7 @@ public class AclTest {
 
     @Test
     public void no_trusted_ports() {
-        String listRulesIpv4 = aclNoPorts.toRules(IPVersion.IPv4);
+        String listRulesIpv4 = String.join("\n", aclNoPorts.toRules(IPVersion.IPv4));
         Assert.assertEquals(
                 "-P INPUT ACCEPT\n" +
                         "-P FORWARD ACCEPT\n" +
@@ -39,7 +38,7 @@ public class AclTest {
 
     @Test
     public void ipv4_list_rules() {
-        String listRulesIpv4 = aclCommon.toRules(IPVersion.IPv4);
+        String listRulesIpv4 = String.join("\n", aclCommon.toRules(IPVersion.IPv4));
         Assert.assertEquals(
                 "-P INPUT ACCEPT\n" +
                         "-P FORWARD ACCEPT\n" +
@@ -55,7 +54,7 @@ public class AclTest {
 
     @Test
     public void ipv6_list_rules() {
-        String listRulesIpv6 = aclCommon.toRules(IPVersion.IPv6);
+        String listRulesIpv6 = String.join("\n", aclCommon.toRules(IPVersion.IPv6));
         Assert.assertEquals(
                 "-P INPUT ACCEPT\n" +
                         "-P FORWARD ACCEPT\n" +
@@ -66,8 +65,10 @@ public class AclTest {
                         "-A INPUT -p tcp -m multiport --dports 1234,453 -j ACCEPT\n" +
                         "-A INPUT -s fb00::1/128 -j ACCEPT\n" +
                         "-A INPUT -s fe80::2/128 -j ACCEPT\n" +
+                        "-A INPUT -s fe80::3/128 -j ACCEPT\n" +
                         "-A INPUT -j REJECT --reject-with icmp6-port-unreachable", listRulesIpv6);
     }
+
 
     private List<Integer> createPortList(Integer... ports) {
         return Arrays.asList(ports);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
@@ -131,7 +131,7 @@ public class AclMaintainerTest {
                 "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT\n" +
                 "-A INPUT -i lo -j ACCEPT\n" +
                 "-A INPUT -p ipv6-icmp -j ACCEPT\n" +
-                "-A INPUT -p tcp -m multiport --dports 4321,2345,22 -j ACCEPT\n" +
+                "-A INPUT -p tcp -m multiport --dports 22,2345,4321 -j ACCEPT\n" +
                 "-A INPUT -s 2001::1/128 -j ACCEPT\n" +
                 "-A INPUT -s fd01:1234::4321/128 -j ACCEPT\n" +
                 "-A INPUT -j REJECT --reject-with icmp6-port-unreachable";
@@ -165,7 +165,7 @@ public class AclMaintainerTest {
                 "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT\n" +
                 "-A INPUT -i lo -j ACCEPT\n" +
                 "-A INPUT -p icmp -j ACCEPT\n" +
-                "-A INPUT -p tcp -m multiport --dports 22,4443,2222 -j ACCEPT\n" +
+                "-A INPUT -p tcp -m multiport --dports 22,2222,4443 -j ACCEPT\n" +
                 "-A INPUT -s 192.64.13.2/32 -j ACCEPT\n" +
                 "-A INPUT -j REJECT --reject-with icmp-port-unreachable";
 
@@ -175,7 +175,7 @@ public class AclMaintainerTest {
                 "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT\n" +
                 "-A INPUT -i lo -j ACCEPT\n" +
                 "-A INPUT -p ipv6-icmp -j ACCEPT\n" +
-                "-A INPUT -p tcp -m multiport --dports 22,4443,2222 -j ACCEPT\n" +
+                "-A INPUT -p tcp -m multiport --dports 22,2222,4443 -j ACCEPT\n" +
                 "-A INPUT -s 2001::1/128 -j ACCEPT\n" +
                 "-A INPUT -j REJECT --reject-with icmp6-port-unreachable";
 


### PR DESCRIPTION
When we check the diff between the current and candidate IP tables, we often detect a diff even though the diff size is the same. We should expect a diff only when a node enters/leaves the application, while we get it every 1-2 minutes:
```
[2018-04-30 06:39:09.220] NodeAgent-zt74759-v6-2: Patching file ip6tables-filter: Diff too large (4188)
[2018-04-30 06:39:09.242] NodeAgent-zt74759-v6-2: Patching file iptables-filter: Diff too large (2306)
[2018-04-30 06:39:09.260] NodeAgent-zt74759-v6-6: Patching file ip6tables-filter: Diff too large (8026)
[2018-04-30 06:39:09.287] NodeAgent-zt74759-v6-6: Patching file iptables-filter: Diff too large (3873)
[2018-04-30 06:39:09.307] NodeAgent-zt74759-v6-3: Patching file ip6tables-filter: Diff too large (8127)
[2018-04-30 06:39:09.329] NodeAgent-zt74759-v6-3: Patching file iptables-filter: Diff too large (4100)
[2018-04-30 06:39:09.339] NodeAdmin: Configuring ACLs
...
[2018-04-30 06:39:12.916] NodeAgent-zt74759-v6-2: Patching file ip6tables-filter: Diff too large (4188)
[2018-04-30 06:39:12.934] NodeAgent-zt74759-v6-2: Patching file iptables-filter: Diff too large (2306)
[2018-04-30 06:39:12.950] NodeAgent-zt74759-v6-6: Patching file ip6tables-filter: Diff too large (8026)
[2018-04-30 06:39:12.966] NodeAgent-zt74759-v6-6: Patching file iptables-filter: Diff too large (3873)
[2018-04-30 06:39:12.982] NodeAgent-zt74759-v6-3: Patching file ip6tables-filter: Diff too large (8127)
[2018-04-30 06:39:12.998] NodeAgent-zt74759-v6-3: Patching file iptables-filter: Diff too large (4100)
...
[2018-04-30 06:39:30.710] NodeAdmin: Configuring ACLs
[2018-04-30 06:39:34.544] NodeAgent-zt74759-v6-2: Patching file ip6tables-filter: Diff too large (4188)
[2018-04-30 06:39:34.565] NodeAgent-zt74759-v6-2: Patching file iptables-filter: Diff too large (2306)
[2018-04-30 06:39:34.585] NodeAgent-zt74759-v6-6: Patching file ip6tables-filter: Diff too large (8026)
[2018-04-30 06:39:34.605] NodeAgent-zt74759-v6-6: Patching file iptables-filter: Diff too large (3873)
[2018-04-30 06:39:34.624] NodeAgent-zt74759-v6-3: Patching file ip6tables-filter: Diff too large (8127)
[2018-04-30 06:39:34.644] NodeAgent-zt74759-v6-3: Patching file iptables-filter: Diff too large (4100)
```

This PR sorts the IP addresses and ports before applying/comparing the rules, this should produce fewer and smaller diffs.

Last commit fixes VESPA-12013.