### PR TITLE
Only derive default bucket space node states when cluster has global docs

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
@@ -74,6 +74,7 @@ public class ClusterControllerClusterConfigurer {
         options.minNodeRatioPerGroup = config.min_node_ratio_per_group();
         options.setMaxDeferredTaskVersionWaitTime(Duration.ofMillis((int)(config.max_deferred_task_version_wait_time_sec() * 1000)));
         options.enableMultipleBucketSpaces = config.enable_multiple_bucket_spaces();
+        options.clusterHasGlobalDocumentTypes = config.cluster_has_global_document_types();
         options.minMergeCompletionRatio = config.min_merge_completion_ratio();
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -857,8 +857,16 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
     }
 
     private ClusterStateDeriver createBucketSpaceStateDeriver() {
-        return new MaintenanceWhenPendingGlobalMerges(stateVersionTracker.createMergePendingChecker(),
-                createDefaultSpaceMaintenanceTransitionConstraint());
+        if (options.clusterHasGlobalDocumentTypes) {
+            return new MaintenanceWhenPendingGlobalMerges(stateVersionTracker.createMergePendingChecker(),
+                    createDefaultSpaceMaintenanceTransitionConstraint());
+        } else {
+            return createIdentityClonedBucketSpaceStateDeriver();
+        }
+    }
+
+    private static ClusterStateDeriver createIdentityClonedBucketSpaceStateDeriver() {
+        return (state, space) -> state.clone();
     }
 
     private MaintenanceTransitionConstraint createDefaultSpaceMaintenanceTransitionConstraint() {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -122,6 +122,8 @@ public class FleetControllerOptions implements Cloneable {
     // TODO replace this flag with a set of bucket spaces instead
     public boolean enableMultipleBucketSpaces = false;
 
+    public boolean clusterHasGlobalDocumentTypes = false;
+
     // TODO: Choose a default value
     public double minMergeCompletionRatio = 1.0;
 
@@ -232,6 +234,7 @@ public class FleetControllerOptions implements Cloneable {
         sb.append("<tr><td><nobr>Wanted distribution bits</nobr></td><td align=\"right\">").append(distributionBits).append("</td></tr>");
         sb.append("<tr><td><nobr>Max deferred task version wait time</nobr></td><td align=\"right\">").append(maxDeferredTaskVersionWaitTime.toMillis()).append("ms</td></tr>");
         sb.append("<tr><td><nobr>Multiple bucket spaces enabled</nobr></td><td align=\"right\">").append(enableMultipleBucketSpaces).append("</td></tr>");
+        sb.append("<tr><td><nobr>Cluster has global document types configured</nobr></td><td align=\"right\">").append(clusterHasGlobalDocumentTypes).append("</td></tr>");
 
         sb.append("</table>");
     }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
@@ -502,8 +502,9 @@ public class MasterElectionTest extends FleetControllerTest {
         startingTest("MasterElectionTest::previously_published_state_is_taken_into_account_for_default_space_when_controller_bootstraps");
         FleetControllerOptions options = new FleetControllerOptions("mycluster");
         options.enableMultipleBucketSpaces = true;
+        options.clusterHasGlobalDocumentTypes = true;
         options.masterZooKeeperCooldownPeriod = 1;
-        options.minTimeBeforeFirstSystemStateBroadcast = 10000;
+        options.minTimeBeforeFirstSystemStateBroadcast = 100000;
         setUpFleetController(3, true, options);
         setUpVdsNodes(true, new DummyVdsNodeOptions());
         fleetController = fleetControllers.get(0); // Required to prevent waitForStableSystem from NPE'ing
@@ -537,6 +538,22 @@ public class MasterElectionTest extends FleetControllerTest {
         // We should NOT publish a state where all storage nodes are in Maintenance, since they were
         // marked as Up in the last published cluster state.
         log.info("Bundle after restart cycle: " + fleetControllers.get(0).getClusterStateBundle());
+        waitForStateInAllSpaces("version:\\d+ distributor:10 storage:10");
+    }
+
+    @Test
+    public void default_space_nodes_not_marked_as_maintenance_when_cluster_has_no_global_document_types() throws Exception {
+        startingTest("MasterElectionTest::default_space_nodes_not_marked_as_maintenance_when_cluster_has_no_global_document_types");
+        FleetControllerOptions options = new FleetControllerOptions("mycluster");
+        options.enableMultipleBucketSpaces = true;
+        options.clusterHasGlobalDocumentTypes = false;
+        options.masterZooKeeperCooldownPeriod = 1;
+        options.minTimeBeforeFirstSystemStateBroadcast = 100000;
+        setUpFleetController(3, true, options);
+        setUpVdsNodes(true, new DummyVdsNodeOptions());
+        fleetController = fleetControllers.get(0); // Required to prevent waitForStableSystem from NPE'ing
+        waitForMaster(0);
+        waitForStableSystem();
         waitForStateInAllSpaces("version:\\d+ distributor:10 storage:10");
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -597,6 +597,12 @@ public class ContentCluster extends AbstractConfigProducer implements
             builder.min_storage_up_ratio(0);
         }
         builder.enable_multiple_bucket_spaces(enableMultipleBucketSpaces);
+        // Telling the controller whether we actually _have_ global document types lets
+        // it selectively enable or disable constraints that aren't needed when these
+        // are not are present, even if full protocol and backend support is enabled
+        // for multiple bucket spaces. Basically, if you don't use it, you don't
+        // pay for it.
+        builder.cluster_has_global_document_types(enableMultipleBucketSpaces && !globallyDistributedDocuments.isEmpty());
     }
 
     @Override

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -158,6 +158,12 @@ max_deferred_task_version_wait_time_sec double default=30.0
 ## Switch to enable multiple bucket spaces in cluster controller.
 enable_multiple_bucket_spaces bool default=false
 
+## Whether or not the content cluster the controller has responsibility for
+## contains any document types that are tagged as global. If this is true,
+## global document-specific behavior is enabled that marks nodes down in the
+## default space if they have merges pending in the global bucket space.
+cluster_has_global_document_types bool default=false
+
 ## The minimum merge completion ratio of buckets in a bucket space before it is considered complete.
 ##
 ## Bucket merges are considered complete when:


### PR DESCRIPTION
@geirst please review

Lets cluster controller use new protocols for sending compressed cluster state
bundles, but without triggering implicit Maintenance edges for nodes in the
default bucket space. Also allows for easy live reconfiguration when global
document types are added or removed.