### PR TITLE
Deprecate all builtin XML providers in jdisc.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -31,16 +31,6 @@ import com.yahoo.container.jdisc.messagebus.MbusServerProvider;
 import com.yahoo.container.jdisc.state.StateHandler;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.container.usability.BindingsOverviewHandler;
-import com.yahoo.container.xml.providers.DatatypeFactoryProvider;
-import com.yahoo.container.xml.providers.DocumentBuilderFactoryProvider;
-import com.yahoo.container.xml.providers.JAXBContextFactoryProvider;
-import com.yahoo.container.xml.providers.SAXParserFactoryProvider;
-import com.yahoo.container.xml.providers.SchemaFactoryProvider;
-import com.yahoo.container.xml.providers.TransformerFactoryProvider;
-import com.yahoo.container.xml.providers.XMLEventFactoryProvider;
-import com.yahoo.container.xml.providers.XMLInputFactoryProvider;
-import com.yahoo.container.xml.providers.XMLOutputFactoryProvider;
-import com.yahoo.container.xml.providers.XPathFactoryProvider;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.jdisc.http.ServletPathsConfig;
 import com.yahoo.metrics.simple.runtime.MetricProperties;
@@ -298,17 +288,18 @@ public final class ContainerCluster
         addComponent(statsHandler);
     }
 
-    public void addJaxProviders() {
-        addSimpleComponent(DatatypeFactoryProvider.class);
-        addSimpleComponent(DocumentBuilderFactoryProvider.class);
-        addSimpleComponent(JAXBContextFactoryProvider.class);
-        addSimpleComponent(SAXParserFactoryProvider.class);
-        addSimpleComponent(SchemaFactoryProvider.class);
-        addSimpleComponent(TransformerFactoryProvider.class);
-        addSimpleComponent(XMLEventFactoryProvider.class);
-        addSimpleComponent(XMLInputFactoryProvider.class);
-        addSimpleComponent(XMLOutputFactoryProvider.class);
-        addSimpleComponent(XPathFactoryProvider.class);
+    @SuppressWarnings("deprecation")
+    private void addJaxProviders() {
+        addSimpleComponent(com.yahoo.container.xml.providers.DatatypeFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.DocumentBuilderFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.JAXBContextFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.SAXParserFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.SchemaFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.TransformerFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.XMLEventFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.XMLInputFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.XMLOutputFactoryProvider.class);
+        addSimpleComponent(com.yahoo.container.xml.providers.XPathFactoryProvider.class);
     }
 
     public final void addComponent(Component<?, ?> component) {

--- a/container-core/src/main/java/com/yahoo/container/xml/bind/JAXBContextFactory.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/bind/JAXBContextFactory.java
@@ -16,7 +16,9 @@ import javax.xml.bind.JAXBException;
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @author gjoranv
  * @since 5.3
+ * @deprecated Do not use!
  */
+@Deprecated
 public class JAXBContextFactory {
     public static final String FACTORY_CLASS = "com.sun.xml.internal.bind.v2.ContextFactory";
 

--- a/container-core/src/main/java/com/yahoo/container/xml/bind/package-info.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/bind/package-info.java
@@ -1,7 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 @ExportPackage
-@PublicApi
 package com.yahoo.container.xml.bind;
 
-import com.yahoo.api.annotations.PublicApi;
 import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/DatatypeFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/DatatypeFactoryProvider.java
@@ -9,7 +9,9 @@ import javax.xml.datatype.DatatypeFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class DatatypeFactoryProvider implements Provider<DatatypeFactory> {
     public static final String FACTORY_CLASS = DatatypeFactory.DATATYPEFACTORY_IMPLEMENTATION_CLASS;
 

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/DocumentBuilderFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/DocumentBuilderFactoryProvider.java
@@ -8,7 +8,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class DocumentBuilderFactoryProvider implements Provider<DocumentBuilderFactory> {
     public static final String FACTORY_CLASS = "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl";
 

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/JAXBContextFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/JAXBContextFactoryProvider.java
@@ -2,18 +2,20 @@
 package com.yahoo.container.xml.providers;
 
 import com.yahoo.container.di.componentgraph.Provider;
-import com.yahoo.container.xml.bind.JAXBContextFactory;
 
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
-public class JAXBContextFactoryProvider implements Provider<JAXBContextFactory> {
-    public static final String FACTORY_CLASS = JAXBContextFactory.class.getName();
+@Deprecated
+@SuppressWarnings("deprecation")
+public class JAXBContextFactoryProvider implements Provider<com.yahoo.container.xml.bind.JAXBContextFactory> {
+    public static final String FACTORY_CLASS = com.yahoo.container.xml.bind.JAXBContextFactory.class.getName();
 
     @Override
-    public JAXBContextFactory get() {
-        return new JAXBContextFactory();
+    public com.yahoo.container.xml.bind.JAXBContextFactory get() {
+        return new com.yahoo.container.xml.bind.JAXBContextFactory();
     }
 
     @Override

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/SAXParserFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/SAXParserFactoryProvider.java
@@ -8,7 +8,9 @@ import javax.xml.parsers.SAXParserFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class SAXParserFactoryProvider implements Provider<SAXParserFactory> {
     public static final String FACTORY_CLASS = "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl";
 

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/SchemaFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/SchemaFactoryProvider.java
@@ -9,7 +9,9 @@ import javax.xml.validation.SchemaFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class SchemaFactoryProvider implements Provider<SchemaFactory> {
     public static final String FACTORY_CLASS = "com.sun.org.apache.xerces.internal.jaxp.validation.XMLSchemaFactory";
 

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/TransformerFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/TransformerFactoryProvider.java
@@ -8,7 +8,9 @@ import javax.xml.transform.TransformerFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class TransformerFactoryProvider implements Provider<TransformerFactory> {
     public static final String FACTORY_CLASS = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
 

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/XMLEventFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/XMLEventFactoryProvider.java
@@ -8,7 +8,9 @@ import javax.xml.stream.XMLEventFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class XMLEventFactoryProvider implements Provider<XMLEventFactory> {
     public static final String FACTORY_CLASS = "com.sun.xml.internal.stream.events.XMLEventFactoryImpl";
 

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/XMLInputFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/XMLInputFactoryProvider.java
@@ -8,7 +8,9 @@ import javax.xml.stream.XMLInputFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class XMLInputFactoryProvider implements Provider<XMLInputFactory> {
     private static final String INPUT_FACTORY_INTERFACE = XMLInputFactory.class.getName();
     public static final String FACTORY_CLASS = "com.sun.xml.internal.stream.XMLInputFactoryImpl";

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/XMLOutputFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/XMLOutputFactoryProvider.java
@@ -8,7 +8,9 @@ import javax.xml.stream.XMLOutputFactory;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class XMLOutputFactoryProvider implements Provider<XMLOutputFactory> {
     public static final String FACTORY_CLASS = "com.sun.xml.internal.stream.XMLOutputFactoryImpl";
     @Override

--- a/container-core/src/main/java/com/yahoo/container/xml/providers/XPathFactoryProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/xml/providers/XPathFactoryProvider.java
@@ -9,7 +9,9 @@ import javax.xml.xpath.XPathFactoryConfigurationException;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
+ * @deprecated Do not use!
  */
+@Deprecated
 public class XPathFactoryProvider implements Provider<XPathFactory> {
     public static final String FACTORY_CLASS = "com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl";
 

--- a/container-core/src/test/java/com/yahoo/container/xml/bind/JAXBContextFactoryTest.java
+++ b/container-core/src/test/java/com/yahoo/container/xml/bind/JAXBContextFactoryTest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.xml.bind;
 
-import com.yahoo.container.xml.providers.JAXBContextFactoryProvider;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -13,13 +12,14 @@ import static org.junit.Assert.fail;
  * @author gjoranv
  * @since 5.3
  */
+@SuppressWarnings("deprecation")
 public class JAXBContextFactoryTest {
     @Test
     public void testInstantiationAndDestruction() {
 
-        JAXBContextFactoryProvider provider = new JAXBContextFactoryProvider();
+        com.yahoo.container.xml.providers.JAXBContextFactoryProvider provider = new com.yahoo.container.xml.providers.JAXBContextFactoryProvider();
         JAXBContextFactory factory = provider.get();
-        assertThat(factory.getClass().getName(), equalTo(JAXBContextFactoryProvider.FACTORY_CLASS));
+        assertThat(factory.getClass().getName(), equalTo(com.yahoo.container.xml.providers.JAXBContextFactoryProvider.FACTORY_CLASS));
 
         try {
             JAXBContextFactory.getContextPath((Class) null);

--- a/container-core/src/test/java/com/yahoo/container/xml/providers/XMLProviderTest.java
+++ b/container-core/src/test/java/com/yahoo/container/xml/providers/XMLProviderTest.java
@@ -1,18 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.xml.providers;
 
-import com.yahoo.container.Server;
-import com.yahoo.container.xml.bind.JAXBContextFactory;
-import com.yahoo.container.xml.providers.DatatypeFactoryProvider;
-import com.yahoo.container.xml.providers.DocumentBuilderFactoryProvider;
-import com.yahoo.container.xml.providers.JAXBContextFactoryProvider;
-import com.yahoo.container.xml.providers.SAXParserFactoryProvider;
-import com.yahoo.container.xml.providers.SchemaFactoryProvider;
-import com.yahoo.container.xml.providers.TransformerFactoryProvider;
-import com.yahoo.container.xml.providers.XMLEventFactoryProvider;
-import com.yahoo.container.xml.providers.XMLInputFactoryProvider;
-import com.yahoo.container.xml.providers.XMLOutputFactoryProvider;
-import com.yahoo.container.xml.providers.XPathFactoryProvider;
 import org.junit.Test;
 
 import javax.xml.datatype.DatatypeFactory;
@@ -27,12 +15,12 @@ import javax.xml.xpath.XPathFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
  */
+@SuppressWarnings("deprecation")
 public class XMLProviderTest {
 
     @Test


### PR DESCRIPTION
I'm hoping to remove all this code before Vespa 7. I could not find any external use, except for a couple of projects that were put down at least 3 years ago (e.g. japi).

FYI: @bjorncs