### PR TITLE
Gjoranv/java9 prep 09

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/FileDistributionFactory.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/FileDistributionFactory.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.session;
 
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Transport;
 import com.yahoo.vespa.config.server.filedistribution.FileDistributionProvider;
@@ -23,6 +22,7 @@ public class FileDistributionFactory {
     }
 
     @Override
+    @SuppressWarnings("deprecation")  // finalize() is deprecated from Java 9
     protected void finalize() throws Throwable {
         super.finalize();
         supervisor.transport().shutdown().join();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
@@ -113,6 +113,7 @@ public class FileServerTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")  // finalize() is deprecated from Java 9
     protected void finalize() throws Throwable {
         super.finalize();
         cleanup();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
@@ -112,6 +112,7 @@ public class FileServerTest {
         created.clear();
     }
 
+    // TODO: Why not use @After instead of finalizer?
     @Override
     @SuppressWarnings("deprecation")  // finalize() is deprecated from Java 9
     protected void finalize() throws Throwable {

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
@@ -41,12 +41,19 @@ public class ExportPackages {
            .append("javax.inject;version=1.0.0,")  // Included in guice, but not exported. Needed by container-jersey.
            .append("org.aopalliance.intercept,")
            .append("org.aopalliance.aop,")
+
+           // xml-apis:xml-apis:1.4.01 is not a bundle
+           .append("org.w3c.dom,")
+           .append("org.w3c.dom.bootstrap,")
            .append("org.w3c.dom.css,")
+           .append("org.w3c.dom.events,")
            .append("org.w3c.dom.html,")
+           .append("org.w3c.dom.ls,")
            .append("org.w3c.dom.ranges,")
            .append("org.w3c.dom.stylesheets,")
            .append("org.w3c.dom.traversal,")
            .append("org.w3c.dom.views,")
+
            .append("sun.misc,")
            .append("sun.net.util,")
            .append("sun.security.krb5");

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SelfCloseableHttpClient.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SelfCloseableHttpClient.java
@@ -61,6 +61,7 @@ class SelfCloseableHttpClient implements AutoCloseable {
     }
 
     @Override
+    @SuppressWarnings("deprecation")  // finalize() is deprecated from Java 9
     public void finalize() throws Throwable {
         close();
         super.finalize();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -419,11 +419,6 @@
                 <version>3.4.0</version>
             </dependency>
             <dependency>
-                <groupId>com.googlecode.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <dependency>
                 <groupId>com.goldmansachs</groupId>
                 <artifactId>gs-collections</artifactId>
                 <version>6.1.0</version>

--- a/standalone-container/src/main/scala/com/yahoo/container/standalone/StandaloneSubscriberFactory.scala
+++ b/standalone-container/src/main/scala/com/yahoo/container/standalone/StandaloneSubscriberFactory.scala
@@ -59,7 +59,7 @@ class StandaloneSubscriberFactory(root: VespaModel) extends SubscriberFactory {
 object StandaloneSubscriberFactory {
 
   private def newBuilderInstance(key: ConfigKeyT) =
-    builderClass(key).newInstance()
+    builderClass(key).getDeclaredConstructor().newInstance()
 
   private def builderClass(key: ConfigKeyT) = {
     val nestedClasses = key.getConfigClass.getClasses

--- a/standalone-container/src/test/scala/com/yahoo/container/standalone/StandaloneSubscriberTest.scala
+++ b/standalone-container/src/test/scala/com/yahoo/container/standalone/StandaloneSubscriberTest.scala
@@ -21,7 +21,7 @@ class StandaloneSubscriberTest {
 
   def key(name: String) = new ConfigKey(name, "container", "container").asInstanceOf[ConfigKey[ConfigInstance]]
 
-  def box(i: Int) = new java.lang.Integer(i)
+  def box(i: Int) = java.lang.Integer.valueOf(i)
 
   @Test
   @Ignore


### PR DESCRIPTION
All vespa.ai code builds successfully with JDK 9, but there are unit test failures that indicate real problems with e.g. osgi and jersey.