### PR TITLE
Revert "Further simplifications of config server clients"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerApi.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerApi.java
@@ -1,6 +1,8 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.configserver;
 
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+
 import java.util.Optional;
 
 /**
@@ -19,6 +21,9 @@ public interface ConfigServerApi extends AutoCloseable {
     <T> T patch(String path, Object bodyJsonPojo, Class<T> wantedReturnType);
 
     <T> T delete(String path, Class<T> wantedReturnType);
+
+    /** Set or update the socket factory */
+    void setSSLConnectionSocketFactory(SSLConnectionSocketFactory sslSocketFactory);
 
     /** Close the underlying HTTP client and any threads this class might have started. */
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerClients.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerClients.java
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.configserver;
 
+import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeRepository;
 import com.yahoo.vespa.hosted.node.admin.configserver.orchestrator.Orchestrator;
 import com.yahoo.vespa.hosted.node.admin.configserver.state.State;
@@ -17,8 +18,8 @@ public interface ConfigServerClients {
     /** Get handle to /orchestrator/v1/ REST API */
     Orchestrator orchestrator();
 
-    /** Get handle to the /state/v1 REST API */
-    default State state() { throw new UnsupportedOperationException(); }
+    /** Get handle to the /state/v1 REST API of the specified config server */
+    default State state(HostName hostname) { throw new java.lang.UnsupportedOperationException(); }
 
     void stop();
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/RealConfigServerClients.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/RealConfigServerClients.java
@@ -1,6 +1,9 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.configserver;
 
+import com.yahoo.config.provision.HostName;
+import com.yahoo.vespa.athenz.identity.SiaIdentityProvider;
+import com.yahoo.vespa.hosted.node.admin.component.ConfigServerInfo;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeRepository;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.RealNodeRepository;
 import com.yahoo.vespa.hosted.node.admin.configserver.orchestrator.Orchestrator;
@@ -8,26 +11,38 @@ import com.yahoo.vespa.hosted.node.admin.configserver.orchestrator.OrchestratorI
 import com.yahoo.vespa.hosted.node.admin.configserver.state.State;
 import com.yahoo.vespa.hosted.node.admin.configserver.state.StateImpl;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
- * {@link ConfigServerClients} using the default implementation for the various clients,
- * and backed by a {@link ConfigServerApi}.
- *
  * @author freva
  */
 public class RealConfigServerClients implements ConfigServerClients {
+
+    private final SslConnectionSocketFactoryUpdater updater;
+
+    // ConfigServerApi that talks to all config servers
     private final ConfigServerApi configServerApi;
+
     private final NodeRepository nodeRepository;
     private final Orchestrator orchestrator;
-    private final State state;
+    private final ConcurrentHashMap<HostName, State> states = new ConcurrentHashMap<>();
+    private final ConfigServerInfo configServerInfo;
 
     /**
-     * @param configServerApi the backend API to use - will be closed at {@link #stop()}.
+     * Create config server clients against a real (remote) config server.
+     *
+     * If a client certificate is required, one will be requested from the config server
+     * and kept up to date. On failure, this constructor will throw an exception and
+     * the caller may retry later.
      */
-    public RealConfigServerClients(ConfigServerApi configServerApi) {
-        this.configServerApi = configServerApi;
+    public RealConfigServerClients(SiaIdentityProvider identityProvider, ConfigServerInfo info) {
+        this.configServerInfo = info;
+        updater = SslConnectionSocketFactoryUpdater.createAndRefreshKeyStoreIfNeeded(identityProvider, info.getAthenzIdentity().get());
+
+        configServerApi = ConfigServerApiImpl.create(info, updater);
+
         nodeRepository = new RealNodeRepository(configServerApi);
         orchestrator = new OrchestratorImpl(configServerApi);
-        state = new StateImpl(configServerApi);
     }
 
     @Override
@@ -41,12 +56,21 @@ public class RealConfigServerClients implements ConfigServerClients {
     }
 
     @Override
-    public State state() {
-        return state;
+    public State state(HostName hostname) {
+        return states.computeIfAbsent(hostname, this::createState);
     }
 
     @Override
     public void stop() {
+        updater.unregisterConfigServerApi(configServerApi);
         configServerApi.close();
+        updater.close();
+    }
+
+    private State createState(HostName hostname) {
+        ConfigServerApi configServerApi = ConfigServerApiImpl.createFor(
+                configServerInfo, updater, hostname);
+
+        return new StateImpl(configServerApi);
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConnectionSocketFactoryUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConnectionSocketFactoryUpdater.java
@@ -1,0 +1,104 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.configserver;
+
+import com.yahoo.vespa.athenz.api.AthenzIdentity;
+import com.yahoo.vespa.athenz.api.AthenzService;
+import com.yahoo.vespa.athenz.identity.SiaIdentityProvider;
+import com.yahoo.vespa.athenz.tls.AthenzIdentityVerifier;
+import com.yahoo.vespa.athenz.tls.SslContextBuilder;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+
+/**
+ * Responsible for updating {@link SSLConnectionSocketFactory} on {@link ConfigServerApiImpl} asynchronously
+ * using SIA based certificates (through {@link SiaIdentityProvider}).
+ *
+ * @author bjorncs
+ * @author hakon
+ */
+public class SslConnectionSocketFactoryUpdater implements AutoCloseable {
+
+    private final Object monitor = new Object();
+    private final HostnameVerifier configServerHostnameVerifier;
+    private final SiaIdentityProvider sia;
+
+    private final Set<ConfigServerApi> configServerApis = new HashSet<>();
+    private SSLConnectionSocketFactory socketFactory;
+
+    /**
+     * Creates an updater with valid initial {@link SSLConnectionSocketFactory}
+     *
+     * @throws RuntimeException if e.g. key store options have been specified, but was unable
+     *                          create a create a key store with a valid certificate
+     */
+    public static SslConnectionSocketFactoryUpdater createAndRefreshKeyStoreIfNeeded(SiaIdentityProvider identityProvider,
+                                                                                     AthenzIdentity configserverIdentity) {
+        return new SslConnectionSocketFactoryUpdater(identityProvider, createHostnameVerifier(configserverIdentity));
+    }
+
+    SslConnectionSocketFactoryUpdater(SiaIdentityProvider siaIdentityProvider,
+                                      HostnameVerifier configServerHostnameVerifier) {
+        this.configServerHostnameVerifier = configServerHostnameVerifier;
+        this.sia = siaIdentityProvider;
+        if (siaIdentityProvider != null) {
+            siaIdentityProvider.addIdentityListener(this::updateSocketFactory);
+            socketFactory = createSocketFactory(siaIdentityProvider.getIdentitySslContext());
+        } else {
+            socketFactory = createDefaultSslConnectionSocketFactory();
+        }
+    }
+
+    private void updateSocketFactory(SSLContext sslContext, AthenzService identity) {
+        synchronized (monitor) {
+            socketFactory = createSocketFactory(sslContext);
+            configServerApis.forEach(api -> api.setSSLConnectionSocketFactory(socketFactory));
+        }
+    }
+
+    public SSLConnectionSocketFactory getCurrentSocketFactory() {
+        synchronized (monitor) {
+            return socketFactory;
+        }
+    }
+
+    /** Register a {@link ConfigServerApi} whose {@link SSLConnectionSocketFactory} will be kept up to date */
+    public void registerConfigServerApi(ConfigServerApi configServerApi) {
+        synchronized (monitor) {
+            configServerApi.setSSLConnectionSocketFactory(socketFactory);
+            configServerApis.add(configServerApi);
+        }
+    }
+
+    public void unregisterConfigServerApi(ConfigServerApi configServerApi) {
+        synchronized (monitor) {
+            configServerApis.remove(configServerApi);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (sia != null) {
+            sia.deconstruct();
+        }
+    }
+
+    private SSLConnectionSocketFactory createSocketFactory(SSLContext sslContext) {
+        return new SSLConnectionSocketFactory(sslContext, configServerHostnameVerifier);
+    }
+
+    private SSLConnectionSocketFactory createDefaultSslConnectionSocketFactory() {
+        SSLContext sslContext = new SslContextBuilder().build();
+        return createSocketFactory(sslContext);
+    }
+
+    private static HostnameVerifier createHostnameVerifier(AthenzIdentity identity) {
+        return new AthenzIdentityVerifier(singleton(identity));
+    }
+
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/NodeAdminProvider.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/provider/NodeAdminProvider.java
@@ -10,8 +10,6 @@ import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.component.ConfigServerInfo;
 import com.yahoo.vespa.hosted.node.admin.component.DockerAdminComponent;
 import com.yahoo.vespa.hosted.node.admin.config.ConfigServerConfig;
-import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
-import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApiImpl;
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerClients;
 import com.yahoo.vespa.hosted.node.admin.configserver.RealConfigServerClients;
 
@@ -24,9 +22,8 @@ public class NodeAdminProvider implements Provider<NodeAdminStateUpdater> {
                              Docker docker,
                              MetricReceiverWrapper metricReceiver,
                              ClassLocking classLocking) {
-        ConfigServerInfo configServerInfo = new ConfigServerInfo(configServerConfig);
-        ConfigServerApi configServerApi = ConfigServerApiImpl.create(configServerInfo, identityProvider);
-        ConfigServerClients clients = new RealConfigServerClients(configServerApi);
+        ConfigServerClients clients =
+                new RealConfigServerClients(identityProvider, new ConfigServerInfo(configServerConfig));
 
         dockerAdmin = new DockerAdminComponent(configServerConfig,
                 identityProvider,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConnectionSocketFactoryUpdaterTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/SslConnectionSocketFactoryUpdaterTest.java
@@ -1,0 +1,31 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.configserver;
+
+import com.yahoo.vespa.athenz.identity.SiaIdentityProvider;
+import com.yahoo.vespa.athenz.tls.SslContextBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author bjorncs
+ */
+public class SslConnectionSocketFactoryUpdaterTest {
+
+    @Test
+    public void creates_default_ssl_connection_factory_when_no_sia_provided() {
+        SslConnectionSocketFactoryUpdater updater =
+                new SslConnectionSocketFactoryUpdater(null, (hostname, session) -> true);
+        assertNotNull(updater.getCurrentSocketFactory());
+    }
+
+    @Test
+    public void creates_ssl_connection_factory_when_sia_provided() {
+        SiaIdentityProvider sia = mock(SiaIdentityProvider.class);
+        when(sia.getIdentitySslContext()).thenReturn(new SslContextBuilder().build());
+        SslConnectionSocketFactoryUpdater updater = new SslConnectionSocketFactoryUpdater(sia, (hostname, session) -> true);
+        assertNotNull(updater.getCurrentSocketFactory());
+    }
+}


### PR DESCRIPTION
Reverts vespa-engine/vespa#5822

Broke CD tests. Node admin does not start.