### PR TITLE
Require same version dependencies for node-admin

### DIFF
--- a/node-admin/vespa-node-admin.spec
+++ b/node-admin/vespa-node-admin.spec
@@ -17,10 +17,10 @@ URL:            http://vespa.ai
 
 Requires: bash
 Requires: java-1.8.0-openjdk-headless
-Requires: vespa-base
-Requires: vespa-standalone-container
-Requires: vespa-node-maintainer
-Requires: vespa-log-utils
+Requires: vespa-base = %{version}
+Requires: vespa-standalone-container = %{version}
+Requires: vespa-node-maintainer = %{version}
+Requires: vespa-log-utils = %{version}
 
 Conflicts: vespa
 

--- a/node-maintainer/vespa-node-maintainer.spec
+++ b/node-maintainer/vespa-node-maintainer.spec
@@ -17,7 +17,7 @@ URL:            http://vespa.ai
 
 Requires: bash
 Requires: java-1.8.0-openjdk-headless
-Requires: vespa-base
+Requires: vespa-base = %{version}
 
 Conflicts: vespa
 

--- a/standalone-container/vespa-standalone-container.spec
+++ b/standalone-container/vespa-standalone-container.spec
@@ -17,7 +17,7 @@ URL:            http://vespa.ai
 
 Requires: bash
 Requires: java-1.8.0-openjdk-headless
-Requires: vespa-base
+Requires: vespa-base = %{version}
 
 Conflicts: vespa
 

--- a/vespalog/vespa-log-utils.spec
+++ b/vespalog/vespa-log-utils.spec
@@ -13,7 +13,7 @@ License:        Commercial
 URL:            http://vespa.ai
 
 Requires: bash
-Requires: vespa-base
+Requires: vespa-base = %{version}
 
 Conflicts: vespa
 


### PR DESCRIPTION
**Motivation:**
When we install for the first time, its enough to install `vespa-host-admin` and all the dependencies will also be installed, but to update we use `'vespa-*-6.123.456'`. Simply updating `vespa-host-admin-6.123.456` will only update that package and none of the dependencies

Additionally, there are no guarantees of `vespa-abc-x.y.z` working with `vespa-def-x.y.w`. 

This PR will hopefully solve both problems by requiring same version for all `vespa-*` dependencies. If this works, I'll make similar PR in `vespa/hosted` for `vespa-host-admin`.