### PR TITLE
Set VESPA_HOSTNAME when calling node-maintainer

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -340,6 +340,7 @@ public class StorageMaintainer {
     private String executeMaintainer(String mainClass, String... args) {
         String[] command = Stream.concat(
                 Stream.of("sudo",
+                        "VESPA_HOSTNAME=" + getDefaults().vespaHostname(),
                         "VESPA_HOME=" + getDefaults().vespaHome(),
                         getDefaults().underVespaHome("libexec/vespa/node-admin/maintenance.sh"),
                         mainClass),


### PR DESCRIPTION
`node-maintainer` spec verifier checks IP addresses by performing lookup on hostname, since https://github.com/vespa-engine/vespa/commit/724e1929962a70c7d2730ff4afa65aee79a12036#diff-10973d41f98e44f9107ba3f5beca0054L58:L66, `Defaults` does not actually get the hostname, but instead use an environment variable set... somewhere.., this variable is not preserved when `node-maintainer` is called from `node-admin` or from chef. As result, all nodes in CD currently have hardware divergence annotation. 

@hmusum or @hakonhall 