### PR TITLE
Allow vespaVersion PATCH

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -111,6 +111,7 @@ public class NodePatcher {
                         .map(DockerImage::tagAsVersion)
                         .orElse(Version.emptyVersion);
                 return node.with(node.status().withVespaVersion(versionFromImage));
+            case "vespaVersion" :
             case "currentVespaVersion" :
                 return node.with(node.status().withVespaVersion(Version.fromString(asString(value))));
             case "failCount" :


### PR DESCRIPTION
Controller's and `node-admin`/`host-admin`'s node-repository client use the same jackson binding class to both getting a node and to patch a node. However, this fails for `vespaVersion`: https://github.com/vespa-engine/vespa/blob/bbfa8456064e99c65ea4e78902d4fb02591ee7f3/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java#L44

`NodesReponse` returns `vespaVersion`: https://github.com/vespa-engine/vespa/blob/bbfa8456064e99c65ea4e78902d4fb02591ee7f3/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java#L175
While `NodePatcher` only accepts `currentVespaVersion`:
https://github.com/vespa-engine/vespa/blob/bbfa8456064e99c65ea4e78902d4fb02591ee7f3/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java#L114

This PR makes it possible to set the version both using `currentVespaVersion` and just `vespaVersion`.