### PR TITLE
Add vespaVersion to NodeAttributes

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeAttributes.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeAttributes.java
@@ -5,12 +5,15 @@ import com.yahoo.vespa.hosted.dockerapi.DockerImage;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class NodeAttributes {
 
     private Optional<Long> restartGeneration = Optional.empty();
     private Optional<Long> rebootGeneration = Optional.empty();
     private Optional<DockerImage> dockerImage = Optional.empty();
+    private Optional<String> vespaVersion = Optional.empty();
     private Optional<String> hardwareDivergence = Optional.empty();
 
     public NodeAttributes() { }
@@ -27,6 +30,11 @@ public class NodeAttributes {
 
     public NodeAttributes withDockerImage(DockerImage dockerImage) {
         this.dockerImage = Optional.of(dockerImage);
+        return this;
+    }
+
+    public NodeAttributes withVespaVersion(String vespaVersion) {
+        this.vespaVersion = Optional.of(vespaVersion);
         return this;
     }
 
@@ -48,13 +56,17 @@ public class NodeAttributes {
         return dockerImage;
     }
 
+    public Optional<String> getVespaVersion() {
+        return vespaVersion;
+    }
+
     public Optional<String> getHardwareDivergence() {
         return hardwareDivergence;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(restartGeneration, rebootGeneration, dockerImage, hardwareDivergence);
+        return Objects.hash(restartGeneration, rebootGeneration, dockerImage, vespaVersion, hardwareDivergence);
     }
 
     @Override
@@ -67,16 +79,20 @@ public class NodeAttributes {
         return Objects.equals(restartGeneration, other.restartGeneration)
                 && Objects.equals(rebootGeneration, other.rebootGeneration)
                 && Objects.equals(dockerImage, other.dockerImage)
+                && Objects.equals(vespaVersion, other.vespaVersion)
                 && Objects.equals(hardwareDivergence, other.hardwareDivergence);
     }
 
     @Override
     public String toString() {
-        return "NodeAttributes{" +
-                "restartGeneration=" + restartGeneration.map(String::valueOf).orElse("") +
-                ", rebootGeneration=" + rebootGeneration.map(String::valueOf).orElse("") +
-                ", dockerImage=" + dockerImage.map(DockerImage::asString).orElse("") +
-                ", hardwareDivergence='" + hardwareDivergence.orElse(null) + "'" +
-                '}';
+        return Stream.of(
+                        restartGeneration.map(gen -> "restartGeneration=" + gen),
+                        rebootGeneration.map(gen -> "rebootGeneration=" + gen),
+                        dockerImage.map(img -> "dockerImage=" + img.asString()),
+                        vespaVersion.map(ver -> "vespaVersion=" + ver),
+                        hardwareDivergence.map(hwDivg -> "hardwareDivergence=" + hwDivg))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.joining(", ", "NodeAttributes{", "}"));
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -207,6 +207,7 @@ public class RealNodeRepository implements NodeRepository {
         node.currentDockerImage = nodeAttributes.getDockerImage().map(DockerImage::asString).orElse(null);
         node.currentRestartGeneration = nodeAttributes.getRestartGeneration().orElse(null);
         node.currentRebootGeneration = nodeAttributes.getRebootGeneration().orElse(null);
+        node.vespaVersion = nodeAttributes.getVespaVersion().orElse(null);
         node.hardwareDivergence = nodeAttributes.getHardwareDivergence().orElse(null);
         return node;
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -55,10 +55,10 @@ public class MultiDockerTest {
                     "DeleteContainerStorage with ContainerName { name=host2 }");
 
             dockerTester.callOrderVerifier.assertInOrder(
-                    "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image1, hardwareDivergence='null'}",
-                    "updateNodeAttributes with HostName: host2.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image2, hardwareDivergence='null'}",
+                    "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image1}",
+                    "updateNodeAttributes with HostName: host2.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image2}",
                     "setNodeState host2.test.yahoo.com to ready",
-                    "updateNodeAttributes with HostName: host3.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image1, hardwareDivergence='null'}");
+                    "updateNodeAttributes with HostName: host3.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image1}");
         }
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -30,7 +30,7 @@ public class RestartTest {
             // Check that the container is started and NodeRepo has received the PATCH update
             dockerTester.callOrderVerifier.assertInOrder(
                     "createContainerCommand with DockerImage { imageId=image:1.2.3 }, HostName: host1.test.yahoo.com, ContainerName { name=host1 }",
-                    "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image:1.2.3, hardwareDivergence='null'}");
+                    "updateNodeAttributes with HostName: host1.test.yahoo.com, NodeAttributes{restartGeneration=1, rebootGeneration=0, dockerImage=image:1.2.3}");
 
             wantedRestartGeneration = 2;
             currentRestartGeneration = 1;


### PR DESCRIPTION
Requires #5910

Makes it possible to patch `vespaVersion` with `node-admin`'s `node-repo` client. This is needed by `host-admin` to update its version after it has upgraded.