### PR TITLE
Revert "Remove aries.spifly and asm-debug-all."

### DIFF
--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -123,6 +123,10 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.scala-lang</groupId>
           <artifactId>scala-library</artifactId>
         </exclusion>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -21,12 +21,6 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-dev</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -175,6 +175,7 @@
         <extensions>true</extensions>
         <configuration>
           <discPreInstallBundle>
+            asm-debug-all-${asm-debug-all.version}.jar,
             bcpkix-jdk15on-${bouncycastle.version}.jar,
             bcprov-jdk15on-${bouncycastle.version}.jar,
             javax.servlet-api-3.1.0.jar,
@@ -187,6 +188,8 @@
             jetty-servlet-${jetty.version}.jar,
             jetty-servlets-${jetty.version}.jar,
             jetty-util-${jetty.version}.jar,
+            org.apache.aries.spifly.dynamic.bundle-${aries.spifly.version}.jar,
+            org.apache.aries.util-${aries.util.version}.jar,
             component-jar-with-dependencies.jar
           </discPreInstallBundle>
         </configuration>

--- a/jdisc_jetty/pom.xml
+++ b/jdisc_jetty/pom.xml
@@ -16,6 +16,10 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
+        <groupId>org.apache.aries.spifly</groupId>
+        <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-continuation</artifactId>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -498,6 +498,11 @@
                 <version>${antlr4.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.aries.spifly</groupId>
+                <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+                <version>${aries.spifly.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.1</version>
@@ -681,6 +686,9 @@
     <properties>
         <antlr.version>3.5.2</antlr.version>
         <antlr4.version>4.5</antlr4.version>
+        <aries.spifly.version>1.0.8</aries.spifly.version>
+        <aries.util.version>1.0.0</aries.util.version>
+        <asm-debug-all.version>5.0.3</asm-debug-all.version>
         <!-- Athenz dependencies. Make sure these dependencies matches those in Vespa's internal repositories -->
         <athenz.version>1.7.43</athenz.version>
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
FYI: @toregge 

jetty-util needs aries-spifly which again needs the other two bundles. ~~However, the requirement for osgi.serviceloader is optional, so I'm a bit puzzled about the exception.~~

```
1527164483.320045       vespadev-c7.trondheim   62706   configserver    stdout  
debug   Unexpected: 1527164483.318\tvespadev-c7.trondheim\t62706/1\tjdisc/config
server\t/com.yahoo.jdisc.core.StandaloneMain\terror\tJDisc exiting: Throwable ca
ught: \
!org.apache.felix.log.LogException: org.osgi.framework.BundleException: 

Unable to resolve standalone-container [1](R 1.0): missing requirement [standalo
ne-container [1](R 1.0)] osgi.wiring.package; (&(osgi.wiring.package=com.yahoo.c
onfig.application.api)(version>=1.0.0)(!(version>=2.0.0)))

[caused by: Unable to
resolve config-model-api [5](R 5.0): missing requirement [config-model-api [5](
R 5.0)] osgi.wiring.package; (&(osgi.wiring.package=com.yahoo.component)(version
>=1.0.0)(!(version>=2.0.0)))

[caused by: Unable to resolve component [25](R 25.0
:disappointed: missing requirement [component [25](R 25.0)] osgi.wiring.package; (&(osgi.wir
ing.package=com.yahoo.vespa.config)(version>=1.0.0)(!(version>=2.0.0)))

[caused 
by: Unable to resolve config-bundle [4](R 4.0): missing requirement [config-bund
le [4](R 4.0)] osgi.wiring.package; (&(osgi.wiring.package=com.yahoo.jrt)(versio
n>=1.0.0)(!(version>=2.0.0)))

[caused by: Unable to resolve container-disc [7](R
7.0): missing requirement [container-disc [7](R 7.0)] osgi.wiring.package; (&(o
sgi.wiring.package=com.yahoo.jdisc.http.server)(version>=1.0.0)(!(version>=2.0.0
)))

[caused by: Unable to resolve jdisc_http_service [12](R 12.0): missing requi
rement [jdisc_http_service [12](R 12.0)] osgi.wiring.package; (&(osgi.wiring.pac
kage=org.eclipse.jetty.http)(version>=9.4.9)(!(version>=10.0.0)))

[caused by: Un
able to resolve org.eclipse.jetty.http [17](R 17.0): missing requirement [org.ec
lipse.jetty.http [17](R 17.0)] osgi.wiring.package; (&(osgi.wiring.package=org.e
clipse.jetty.io)(version>=9.4.9)(!(version>=9.4.10)))

[caused by: Unable to resolve org.eclipse.jetty.io [18](R 18.0): missing requirement
 [org.eclipse.jetty.io [18](R 18.0)] osgi.wiring.package;
 (&(osgi.wiring.package=org.eclipse.jetty.util)(version>=9.4.9)(!(version>=9.4.10)))

[caused by: Unable to resolve org.eclipse.jetty.util [24](R 24.0:disappointed: missing
requirement [org.eclipse.jetty.util [24](R 24.0)] osgi.extender;
(osgi.extender=osgi.serviceloader.processor)]]]]]]]]

Unresolved requirements: [[standalone-container [1](R 1.0)] osgi.wiring.package; (&(osgi.wiring.package=com.yahoo.config.application.api)(version>=1.0.0)(!(version>=2.0.0)))]\

\tat org.apache.felix.framework.Felix.resolveBundleRevision(Felix.java:4114)\
\tat org.apache.felix.framework.Felix.startBundle(Felix.java:2111)\
\tat org.apache.felix.framework.BundleImpl.start(BundleImpl.java:977)\
\tat org.apache.felix.framework.BundleImpl.start(BundleImpl.java:964)\
\tat com.yahoo.jdisc.core.FelixFramework.startBundles(FelixFramework.java:100)\
\tat com.yahoo.jdisc.core.ApplicationLoader.init(ApplicationLoader.java:120)\
\tat com.yahoo.jdisc.core.StandaloneMain.run(StandaloneMain.java:42)\
\tat com.yahoo.jdisc.core.StandaloneMain.main(StandaloneMain.java:34)\
```