### PR TITLE
Revert "Remove aries.spifly and asm-debug-all."

### DIFF
--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -123,6 +123,10 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.scala-lang</groupId>
           <artifactId>scala-library</artifactId>
         </exclusion>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -21,12 +21,6 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-dev</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -175,6 +175,7 @@
         <extensions>true</extensions>
         <configuration>
           <discPreInstallBundle>
+            asm-debug-all-${asm-debug-all.version}.jar,
             bcpkix-jdk15on-${bouncycastle.version}.jar,
             bcprov-jdk15on-${bouncycastle.version}.jar,
             javax.servlet-api-3.1.0.jar,
@@ -187,6 +188,8 @@
             jetty-servlet-${jetty.version}.jar,
             jetty-servlets-${jetty.version}.jar,
             jetty-util-${jetty.version}.jar,
+            org.apache.aries.spifly.dynamic.bundle-${aries.spifly.version}.jar,
+            org.apache.aries.util-${aries.util.version}.jar,
             component-jar-with-dependencies.jar
           </discPreInstallBundle>
         </configuration>

--- a/jdisc_jetty/pom.xml
+++ b/jdisc_jetty/pom.xml
@@ -16,6 +16,10 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
+        <groupId>org.apache.aries.spifly</groupId>
+        <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-continuation</artifactId>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -498,6 +498,11 @@
                 <version>${antlr4.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.aries.spifly</groupId>
+                <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+                <version>${aries.spifly.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.1</version>
@@ -681,6 +686,9 @@
     <properties>
         <antlr.version>3.5.2</antlr.version>
         <antlr4.version>4.5</antlr4.version>
+        <aries.spifly.version>1.0.8</aries.spifly.version>
+        <aries.util.version>1.0.0</aries.util.version>
+        <asm-debug-all.version>5.0.3</asm-debug-all.version>
         <!-- Athenz dependencies. Make sure these dependencies matches those in Vespa's internal repositories -->
         <athenz.version>1.7.43</athenz.version>
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#5938

Failed with `While analyzing the class 'module-info.class' in jar file '/tmp/sd-cache/vespa/mavenrepo/component/org/ow2/asm/asm/6.1.1/asm-6.1.1.jar': NullPointerException` when building integration-tests module