### PR TITLE
Use force option when compressing

### DIFF
--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/maintainer/CoreCollector.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/maintainer/CoreCollector.java
@@ -157,7 +157,7 @@ public class CoreCollector {
     private Path compressCoredump(Path coredumpPath) throws IOException {
         if (! coredumpPath.toString().endsWith(".lz4")) {
             processExecuter.exec(
-                    new String[]{LZ4_PATH, coredumpPath.toString(), coredumpPath.toString() + ".lz4"});
+                    new String[]{LZ4_PATH, "-f", coredumpPath.toString(), coredumpPath.toString() + ".lz4"});
             return coredumpPath;
 
         } else {
@@ -167,7 +167,7 @@ public class CoreCollector {
 
             Path decompressedPath = Paths.get(coredumpPath.toString().replaceFirst("\\.lz4$", ""));
             Pair<Integer, String> result = processExecuter.exec(
-                    new String[]{LZ4_PATH, "-f", "-d", coredumpPath.toString(), decompressedPath.toString()});
+                    new String[] {LZ4_PATH, "-f", "-d", coredumpPath.toString(), decompressedPath.toString()});
             if (result.getFirst() != 0) {
                 throw new RuntimeException("Failed to decompress file " + coredumpPath + ": " + result);
             }


### PR DESCRIPTION
When (de)compressing file with LZ4 to a file that already exists, LZ4 will ask for confirmation to overwrite the existing file. This PR will set force flag to skip the confirmation when compressing (already done when decompressing).