### PR TITLE
Use maven 3.5 (per now gives 3.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also setup CentOS 7 natively and install the following build dependencie
 ### Build Java modules
 
     export MAVEN_OPTS="-Xms128m -Xmx1024m"
-    source /opt/rh/rh-maven33/enable
+    source /opt/rh/rh-maven35/enable
     bash bootstrap.sh java
     mvn -T <num-threads> install
 

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -21,9 +21,9 @@ BuildRequires: centos-release-scl
 BuildRequires: devtoolset-7-gcc-c++
 BuildRequires: devtoolset-7-libatomic-devel
 BuildRequires: devtoolset-7-binutils
-BuildRequires: rh-maven33
+BuildRequires: rh-maven35
 %define _devtoolset_enable /opt/rh/devtoolset-7/enable
-%define _rhmaven33_enable /opt/rh/rh-maven33/enable
+%define _rhmaven35_enable /opt/rh/rh-maven35/enable
 %endif
 %if 0%{?fedora}
 BuildRequires: gcc-c++
@@ -148,8 +148,8 @@ Vespa - The open big data serving engine
 %if 0%{?_devtoolset_enable:1}
 source %{_devtoolset_enable} || true
 %endif
-%if 0%{?_rhmaven33_enable:1}
-source %{_rhmaven33_enable} || true
+%if 0%{?_rhmaven35_enable:1}
+source %{_rhmaven35_enable} || true
 %endif
 sh bootstrap.sh java
 mvn --batch-mode -nsu -T 2C install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true


### PR DESCRIPTION
Needed by latest version of maven-bundle-plugin, which is again needed for Java 9 support.