### PR TITLE
Handle insertion of non-copyable keys and values in hash map.

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/hash_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_map.h
@@ -36,6 +36,7 @@ public:
     size_t size()                      const { return _ht.size(); }
     bool empty()                       const { return _ht.empty(); }
     insert_result insert(const value_type & value) { return _ht.insert(value); }
+    insert_result insert(value_type &&value) { return _ht.insert(std::move(value)); }
     template <typename InputIt>
     void insert(InputIt first, InputIt last);
 

--- a/vespalib/src/vespa/vespalib/stllike/hash_set.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_set.h
@@ -37,6 +37,7 @@ public:
     size_t size()                      const { return _ht.size(); }
     bool empty()                       const { return _ht.empty(); }
     insert_result insert(const K & value);
+    insert_result insert(K &&value);
     template<typename InputIt>
     void insert(InputIt first, InputIt last);
     void erase(const K & key);

--- a/vespalib/src/vespa/vespalib/stllike/hash_set.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/hash_set.hpp
@@ -74,6 +74,12 @@ hash_set<K, H, EQ, M>::insert(const K & value) {
     return _ht.insert(value);
 }
 
+template<typename K, typename H, typename EQ, typename M>
+typename hash_set<K, H, EQ, M>::insert_result
+hash_set<K, H, EQ, M>::insert(K &&value) {
+    return _ht.insert(std::move(value));
+}
+
 }
 
 #define VESPALIB_HASH_SET_INSTANTIATE(K) \


### PR DESCRIPTION
Handle insertion of non-copyable keys in hash set.

@baldersheim: please review
