### PR TITLE
match_loop must call next_range until empty

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
@@ -75,7 +75,7 @@ private:
     bool try_share(DocidRange &docid_range, uint32_t next_docid) __attribute__((noinline));
 
     template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work>
-    uint32_t inner_match_loop(Context &context, MatchTools &tools, DocidRange docid_range) __attribute__((noinline));
+    uint32_t inner_match_loop(Context &context, MatchTools &tools, DocidRange &docid_range) __attribute__((noinline));
 
     template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work>
     void match_loop(MatchTools &tools, HitCollector &hits) __attribute__((noinline));


### PR DESCRIPTION
* even if the search is softDoomed we must still call next_range
  until we get an empty range to ensure threads can rendezvous
  correctly.
* inner_match_loop may update the docid_range if adaptive scheduling
  is active, so we must pass it by reference to ensure we compare
  with the correct end id.

@baldersheim please review
@toregge FYI
@havardpe FYI