### PR TITLE
Perform fixup on put and update operations using non-current document type repo.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/feedoperation/putoperation.cpp
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/putoperation.cpp
@@ -49,6 +49,15 @@ PutOperation::deserialize(vespalib::nbostream &is,
     _serializedDocSize = oldSize - is.size();
 }
 
+void
+PutOperation::deserializeDocument(const DocumentTypeRepo &repo)
+{
+    vespalib::nbostream stream;
+    _doc->serialize(stream);
+    auto fixedDoc = std::make_shared<Document>(repo, stream);
+    _doc = std::move(fixedDoc);
+}
+
 vespalib::string
 PutOperation::toString() const
 {

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/putoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/putoperation.h
@@ -21,6 +21,7 @@ public:
     virtual void serialize(vespalib::nbostream &os) const override;
     virtual void deserialize(vespalib::nbostream &is,
                              const document::DocumentTypeRepo &repo) override;
+    void deserializeDocument(const document::DocumentTypeRepo &repo);
     virtual vespalib::string toString() const override;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.h
@@ -3,7 +3,10 @@
 
 #include "documentoperation.h"
 
-namespace document { class DocumentUpdate; }
+namespace document {
+class DocumentTypeRepo;
+class DocumentUpdate;
+}
 
 namespace proton {
 
@@ -16,6 +19,8 @@ private:
                     const document::BucketId &bucketId,
                     const storage::spi::Timestamp &timestamp,
                     const DocumentUpdateSP &upd);
+    void serializeUpdate(vespalib::nbostream &os) const;
+    void deserializeUpdate(vespalib::nbostream &is, const document::DocumentTypeRepo &repo);
 public:
     UpdateOperation();
     UpdateOperation(Type type);
@@ -26,6 +31,7 @@ public:
     const DocumentUpdateSP &getUpdate() const { return _upd; }
     void serialize(vespalib::nbostream &os) const override;
     void deserialize(vespalib::nbostream &is, const document::DocumentTypeRepo &repo) override;
+    void deserializeUpdate(const document::DocumentTypeRepo &repo);
     virtual vespalib::string toString() const override;
     static UpdateOperation makeOldUpdate(const document::BucketId &bucketId,
                                          const storage::spi::Timestamp &timestamp,

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
@@ -96,6 +96,11 @@ void FeedHandler::performPut(FeedToken token, PutOperation &op) {
         }
         return;
     }
+    /*
+     * Check if document type repos are equal. DocumentTypeRepoFactory::make
+     * returns the same document type repo if document type configs are equal,
+     * thus we can just perform a cheaper identity check here.
+     */
     if (_repo != op.getDocument()->getRepo()) {
         op.deserializeDocument(*_repo);
     }

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
@@ -90,6 +90,8 @@ private:
     FeedStateSP                            _feedState;
     // used by master write thread tasks
     IFeedView                             *_activeFeedView;
+    const document::DocumentTypeRepo      *_repo;
+    const document::DocumentType          *_documentType;
     bucketdb::IBucketDBHandler            *_bucketDBHandler;
     std::mutex                             _syncLock;
     SerialNum                              _syncedSerialNum; 
@@ -102,7 +104,7 @@ private:
     void doHandleOperation(FeedToken token, FeedOperationUP op);
 
     bool considerWriteOperationForRejection(FeedToken & token, const FeedOperation &op);
-    bool considerUpdateOperationForRejection(FeedToken &token, const UpdateOperation &op);
+    bool considerUpdateOperationForRejection(FeedToken &token, UpdateOperation &op);
 
     /**
      * Delayed execution of feed operations against feed view, in
@@ -203,9 +205,7 @@ public:
      * Update the active feed view.
      * Always called by the master write thread so locking is not needed.
      */
-    void setActiveFeedView(IFeedView *feedView) {
-        _activeFeedView = feedView;
-    }
+    void setActiveFeedView(IFeedView *feedView);
 
     void setBucketDBHandler(bucketdb::IBucketDBHandler *bucketDBHandler) {
         _bucketDBHandler = bucketDBHandler;


### PR DESCRIPTION
This ensures that document type used do access fields is the same for live
feeding and transaction log replay.

@geirst: please review
@baldersheim: FYI
