### PR TITLE
Temporarly restore the old JobType

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -137,6 +137,7 @@ public class DeploymentJobs {
         productionApSoutheast1 ("production-ap-southeast-1" , ZoneId.from("prod"   , "ap-southeast-1") , null                                                        ),
         productionEuWest1      ("production-eu-west-1"      , ZoneId.from("prod"   , "eu-west-1")      , null                                                        ),
         productionAwsUsEast1a  ("production-aws-us-east-1a" , ZoneId.from("prod"   , "aws-us-east-1a") , null                                                        ),
+        productionCdUsEast1a   ("production-cd-us-east-1a"  , null                                                       , ZoneId.from("prod"   , "cd-us-east-1a")   ),
         productionCdAwsUsEast1a("production-cd-aws-us-east-1a" , null                                                    , ZoneId.from("prod"    , "cd-aws-us-east-1a")),
         productionCdUsCentral1 ("production-cd-us-central-1", null                                                       , ZoneId.from("prod"    , "cd-us-central-1")),
         productionCdUsCentral2 ("production-cd-us-central-2", null                                                       , ZoneId.from("prod"    , "cd-us-central-2"));


### PR DESCRIPTION
This enum value was removed in #5967 and now controller constantly fails with
```
[2018-05-29 14:20:27.581] WARNING : configserver     Container.com.yahoo.vespa.hosted.controller.maintenance.Maintainer 
        ReadyJobsTrigger failed. Will retry in 0 minutes
        exception=
        java.lang.IllegalArgumentException: Invalid zone prod.cd-us-east-1a
        at com.yahoo.vespa.hosted.controller.deployment.DeploymentOrder.lambda$toJob$5(DeploymentOrder.java:67)
        at java.util.Optional.orElseThrow(Optional.java:290)
        at com.yahoo.vespa.hosted.controller.deployment.DeploymentOrder.toJob(DeploymentOrder.java:67)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Collections$2.tryAdvance(Collections.java:4717)
        at java.util.Collections$2.forEachRemaining(Collections.java:4725)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at com.yahoo.vespa.hosted.controller.deployment.DeploymentTrigger.lambda$computeReadyJobs$18(DeploymentTrigger.java:289)
        at java.util.Optional.ifPresent(Optional.java:159)
        at com.yahoo.vespa.hosted.controller.deployment.DeploymentTrigger.computeReadyJobs(DeploymentTrigger.java:278)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at com.yahoo.vespa.hosted.controller.deployment.DeploymentTrigger.computeReadyJobs(DeploymentTrigger.java:270)
        at com.yahoo.vespa.hosted.controller.deployment.DeploymentTrigger.triggerReadyJobs(DeploymentTrigger.java:151)
        at com.yahoo.vespa.hosted.controller.maintenance.ReadyJobsTrigger.maintain(ReadyJobsTrigger.java:21)
        at com.yahoo.vespa.hosted.controller.maintenance.Maintainer.run(Maintainer.java:49)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```