### PR TITLE
Avoid encoding between utf-8 and 16 unnecessarily

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumField.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumField.java
@@ -96,4 +96,7 @@ public abstract class DocsumField {
      */
     public abstract Object convert(Inspector value);
 
+    /** Returns whether this is the string field type. */
+    boolean isString() { return false; }
+
 }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/StringField.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/StringField.java
@@ -31,4 +31,6 @@ public class StringField extends DocsumField {
         return value.asString("");
     }
 
+    boolean isString() { return true; }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/rendering/JsonRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/JsonRendererTestCase.java
@@ -101,7 +101,7 @@ public class JsonRendererTestCase {
     }
 
     @Test
-    public void testDocumentId() throws IOException, InterruptedException, ExecutionException, JSONException {
+    public void testDocumentId() throws IOException, InterruptedException, ExecutionException {
         String expected = "{\n"
                 + "    \"root\": {\n"
                 + "        \"children\": [\n"


### PR DESCRIPTION
@arnej27959 it's back!

Once this is verified I'll do the same for the XML renderer. Ideally we should do all of this for struct fields as well.