### PR TITLE
Remove unneeded check method.

### DIFF
--- a/searchcore/src/tests/proton/attribute/document_field_extractor/document_field_extractor_test.cpp
+++ b/searchcore/src/tests/proton/attribute/document_field_extractor/document_field_extractor_test.cpp
@@ -86,19 +86,6 @@ makeStringWeightedSet(const std::vector<std::pair<vespalib::string, int32_t>> &a
     return result;
 }
 
-template <typename F1, typename F2>
-void
-checkFieldPathChange(F1 f1, F2 f2, const vespalib::string &path, bool same)
-{
-    FieldPath fieldPath1 = f1.makeFieldPath(path);
-    FieldPath fieldPath2 = f2.makeFieldPath(path);
-    EXPECT_TRUE(!fieldPath1.empty());
-    EXPECT_TRUE(!fieldPath2.empty());
-    EXPECT_TRUE(DocumentFieldExtractor::isSupported(fieldPath1));
-    EXPECT_TRUE(DocumentFieldExtractor::isSupported(fieldPath2));
-    EXPECT_EQUAL(same, DocumentFieldExtractor::isCompatible(fieldPath1, fieldPath2));
-}
-
 }
 
 struct FixtureBase
@@ -352,26 +339,6 @@ TEST_F("require that unknown field gives null value", FixtureBase(false))
 {
     f.makeDoc();
     TEST_DO(f.assertExtracted("unknown", std::unique_ptr<FieldValue>()));
-}
-
-TEST("require that type changes are detected")
-{
-    TEST_DO(checkFieldPathChange(SimpleFixture(false), SimpleFixture(false), "weight", true));
-    TEST_DO(checkFieldPathChange(SimpleFixture(false), SimpleFixture(true), "weight", false));
-    TEST_DO(checkFieldPathChange(ArrayFixture(false), ArrayFixture(false), "weight", true));
-    TEST_DO(checkFieldPathChange(ArrayFixture(false), ArrayFixture(true), "weight", false));
-    TEST_DO(checkFieldPathChange(SimpleFixture(false), ArrayFixture(false), "weight", false));
-    TEST_DO(checkFieldPathChange(WeightedSetFixture(false), WeightedSetFixture(false), "weight", true));
-    TEST_DO(checkFieldPathChange(WeightedSetFixture(false), WeightedSetFixture(true), "weight", false));
-    TEST_DO(checkFieldPathChange(SimpleFixture(false), WeightedSetFixture(false), "weight", false));
-    TEST_DO(checkFieldPathChange(ArrayFixture(false), WeightedSetFixture(false), "weight", false));
-    TEST_DO(checkFieldPathChange(StructArrayFixture(false), StructArrayFixture(false), "s.weight", true));
-    TEST_DO(checkFieldPathChange(StructArrayFixture(false), StructArrayFixture(true), "s.weight", false));
-    TEST_DO(checkFieldPathChange(StructMapFixture(false, false), StructMapFixture(false, false), "s.value.weight", true));
-    TEST_DO(checkFieldPathChange(StructMapFixture(false, false), StructMapFixture(true, false), "s.value.weight", false));
-    TEST_DO(checkFieldPathChange(StructMapFixture(false, false), StructMapFixture(false, true), "s.value.weight", false));
-    TEST_DO(checkFieldPathChange(StructMapFixture(false, false), StructMapFixture(false, false), "s.key", true));
-    TEST_DO(checkFieldPathChange(StructMapFixture(false, false), StructMapFixture(false, true), "s.key", false));
 }
 
 TEST_MAIN()

--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_extractor.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_extractor.cpp
@@ -146,23 +146,6 @@ DocumentFieldExtractor::isSupported(const FieldPath &fieldPath)
     return true;
 }
 
-bool
-DocumentFieldExtractor::isCompatible(const FieldPath &fieldPath1, const FieldPath &fieldPath2)
-{
-    if (fieldPath1.size() != fieldPath2.size()) {
-        return false;
-    }
-    uint32_t arrayIndex = 0;
-    for (const auto &fieldPathEntry1 : fieldPath1) {
-        const auto &fieldPathEntry2 = fieldPath2[arrayIndex++];
-        if (fieldPathEntry1->getType() != fieldPathEntry2.getType() ||
-            fieldPathEntry1->getDataType() != fieldPathEntry2.getDataType()) {
-            return false;
-        }
-    }
-    return true;
-}
-
 const FieldValue *
 DocumentFieldExtractor::getCachedFieldValue(const FieldPathEntry &fieldPathEntry)
 {

--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_extractor.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_extractor.h
@@ -41,15 +41,6 @@ public:
      * Check if fieldPath is in a supported form.
      */
     static bool isSupported(const document::FieldPath &fieldPath);
-
-    /**
-     * Check if two field paths are compatible, i.e. same types in whole path
-     * and same data type would be returned from getFieldValue().  This is
-     * meant to be used when document type in received document doesn't match
-     * the document type for the current config (can happen right before and
-     * after live config change when validation override is used).
-     */
-    static bool isCompatible(const document::FieldPath &fieldPath1, const document::FieldPath &fieldPath2);
 };
 
 }


### PR DESCRIPTION
Feed handler now ensures that current document type repo is used to deserialize documents and updates.

@geirst: please review
