### PR TITLE
Make consistent with search to dispatch

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -244,7 +244,7 @@ public class FastSearcher extends VespaBackEndSearcher {
         if (result.isFilled(summaryClass)) return;
 
         Query query = result.getQuery();
-        traceQuery(getName(), "fill", query, query.getOffset(), query.getHits(), 2, quotedSummaryClass(summaryClass));
+        traceQuery(getName(), "fill", query, query.getOffset(), query.getHits(), 1, quotedSummaryClass(summaryClass));
 
         if (query.properties().getBoolean(dispatchSummaries, true)
             && ! summaryNeedsQuery(query)


### PR DESCRIPTION
Useful when tracing query execution. search to dispatch is level 1, while fill is level 2. This to change them to consistent level. 