### PR TITLE
Hardcode DocumentAPI RemoveLocation bucket space for now

### DIFF
--- a/documentapi/src/tests/messages/messages50test.cpp
+++ b/documentapi/src/tests/messages/messages50test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/update/fieldpathupdates.h>
 #include <vespa/documentapi/documentapi.h>
+#include <vespa/document/bucket/fixed_bucket_spaces.h>
 
 using document::DataType;
 using document::DocumentTypeRepo;
@@ -240,6 +241,8 @@ Messages50Test::testRemoveLocationMessage()
             if (EXPECT_TRUE(obj.get() != NULL)) {
                 RemoveLocationMessage &ref = static_cast<RemoveLocationMessage&>(*obj);
                 EXPECT_EQUAL(string("id.group == \"mygroup\""), ref.getDocumentSelection());
+                // FIXME add to wire format, currently hardcoded.
+                EXPECT_EQUAL(string(document::FixedBucketSpaces::default_space_name()), ref.getBucketSpace());
             }
         }
     }

--- a/documentapi/src/vespa/documentapi/messagebus/routablefactories50.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/routablefactories50.cpp
@@ -696,7 +696,10 @@ RoutableFactories50::RemoveLocationMessageFactory::doDecode(document::ByteBuffer
     document::BucketIdFactory factory;
     document::select::Parser parser(_repo, factory);
 
-    return DocumentMessage::UP(new RemoveLocationMessage(factory, parser, selection));
+    auto msg = std::make_unique<RemoveLocationMessage>(factory, parser, selection);
+    // FIXME bucket space not part of wire format, implicitly limiting to only default space for now.
+    msg->setBucketSpace(document::FixedBucketSpaces::default_space_name());
+    return msg;
 }
 
 bool


### PR DESCRIPTION
@geirst please review
@toregge FYI

Not present in wire format, so doing a pragmatic workaround until
we can bump the protocol version. Should not be too problematic, as using
RemoveLocation in the global bucket space sounds like a pretty esoteric
use case.