### PR TITLE
Upgrade hosts

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -66,12 +66,10 @@ public class SystemUpgrader extends Maintainer {
     private boolean deployInZone(ZoneId zone, List<SystemApplication> applications, Version target) {
         boolean converged = true;
         for (SystemApplication application : applications) {
-            boolean dependenciesConverged = application.dependencies().stream()
-                    .allMatch(dependency -> convergedOn(zone, dependency, target));
-            if (dependenciesConverged) {
+            if (convergedOn(target, application.dependencies(), zone)) {
                 deploy(target, application, zone);
             }
-            converged &= convergedOn(zone, application, target);
+            converged &= convergedOn(target, application, zone);
         }
         return converged;
     }
@@ -84,7 +82,11 @@ public class SystemUpgrader extends Maintainer {
         }
     }
 
-    private boolean convergedOn(ZoneId zone, SystemApplication application, Version target) {
+    private boolean convergedOn(Version target, List<SystemApplication> applications, ZoneId zone) {
+        return applications.stream().allMatch(application -> convergedOn(target, application, zone));
+    }
+
+    private boolean convergedOn(Version target, SystemApplication application, ZoneId zone) {
         return currentVersion(zone, application.id(), target).equals(target);
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
@@ -121,7 +121,6 @@ public class SystemUpgraderTest {
     }
 
     @Test
-    @Ignore // TODO: Unignore once host applications support upgrade
     public void upgrade_system_containing_host_applications() {
         tester.controllerTester().zoneRegistry().setUpgradePolicy(
                 UpgradePolicy.create()


### PR DESCRIPTION
Automatic upgrade of host-admin is now supported!

Had to bring back `convergedOn()` to handle the case where zones don't have any `cfghost`/`proxyhost` in node-repo.