### PR TITLE
Revert "Change vespa-athenz to scope compile to ease node-admin upgrades"

### DIFF
--- a/node-admin/pom.xml
+++ b/node-admin/pom.xml
@@ -72,7 +72,7 @@
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>vespa-athenz</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Reverts vespa-engine/vespa#6011

FYI @hakonhall 

Node-admin was unable to start due to `java.lang.LinkageError`:
```
    Caused by: java.lang.LinkageError: com/yahoo/vespa/athenz/identity/SiaIdentityProvider
    at com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApiImpl.<init>(ConfigServerApiImpl.java:80)
    at com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApiImpl.create(ConfigServerApiImpl.java:64)
    at com.yahoo.vespa.hosted.hostadmin.configserver.RealConfigServerClientsManager.<init>(RealConfigServerClientsManager.java:31)
    at com.yahoo.vespa.hosted.hostadmin.configserver.HostAdminConfigServerClients.createConfigServerClients(HostAdminConfigServerClients.java:34)
    at com.yahoo.vespa.hosted.hostadmin.configserver.HostAdminConfigServerClients.<init>(HostAdminConfigServerClients.java:27)
    at com.yahoo.vespa.hosted.hostadmin.configserver.ConfigServerTask.converge(ConfigServerTask.java:58)
    at com.yahoo.vespa.hosted.hostadmin.configserver.ConfigServerTask.converge(ConfigServerTask.java:28)
    at com.yahoo.vespa.hosted.hostadmin.scheduler.TaskDriver.runTask(TaskDriver.java:26)
```