### PR TITLE
Remove deprecated and undocumented feed handlers from container model

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -42,8 +42,6 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
 
     private void setupHandlers(ContainerCluster cluster) {
         cluster.addComponent(newVespaClientHandler("com.yahoo.feedhandler.VespaFeedHandler", "feed"));
-        cluster.addComponent(newVespaClientHandler("com.yahoo.feedhandler.VespaFeedHandlerRemove", "remove"));
-        cluster.addComponent(newVespaClientHandler("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation", "removelocation"));
         cluster.addComponent(newVespaClientHandler("com.yahoo.feedhandler.VespaFeedHandlerGet", "get"));
         cluster.addComponent(newVespaClientHandler("com.yahoo.feedhandler.VespaFeedHandlerVisit", "visit"));
         cluster.addComponent(newVespaClientHandler("com.yahoo.document.restapi.resource.RestApi", "document/v1/*"));

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessControlTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessControlTest.java
@@ -37,8 +37,6 @@ public class AccessControlTest extends ContainerModelBuilderTestBase {
             "/custom-handler/",
             "/search/",
             "/feed/",
-            "/remove/",
-            "/removelocation/",
             "/get/",
             "/visit/",
             "/document/",

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
@@ -75,8 +75,6 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
         verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandler", "feed");
         verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandlerCompatibility", "document");
         verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandlerGet", "get");
-        verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandlerRemove", "remove");
-        verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation", "removelocation");
         verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandlerStatus", "feedstatus");
         verifyCustomBindings("com.yahoo.feedhandler.VespaFeedHandlerVisit", "visit");
         verifyCustomBindings("com.yahoo.vespa.http.server.FeedHandler", ContainerCluster.RESERVED_URI_PREFIX + "/feedapi");
@@ -129,20 +127,6 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
         assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerGet").getServerBindings().contains("http://*/get/"), is(true));
         assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerGet").getServerBindings().contains("https://*/get/"), is(true));
         assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerGet").getServerBindings().size(), equalTo(4));
-
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemove"), not(nullValue()));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemove").getServerBindings().contains("http://*/remove"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemove").getServerBindings().contains("https://*/remove"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemove").getServerBindings().contains("http://*/remove/"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemove").getServerBindings().contains("https://*/remove/"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemove").getServerBindings().size(), equalTo(4));
-
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation"), not(nullValue()));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation").getServerBindings().contains("http://*/removelocation"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation").getServerBindings().contains("https://*/removelocation"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation").getServerBindings().contains("http://*/removelocation/"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation").getServerBindings().contains("https://*/removelocation/"), is(true));
-        assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerRemoveLocation").getServerBindings().size(), equalTo(4));
 
         assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerStatus"), not(nullValue()));
         assertThat(handlerMap.get("com.yahoo.feedhandler.VespaFeedHandlerStatus").getServerBindings().contains("http://*/feedstatus"), is(true));

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/StatusResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/StatusResponse.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
+@Deprecated
 public class StatusResponse extends HttpResponse {
 
     MetricManager manager;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerCompatibility.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerCompatibility.java
@@ -9,6 +9,7 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 
+@Deprecated
 public class VespaFeedHandlerCompatibility extends ThreadedHttpRequestHandler {
 
     private final VespaFeedHandlerGet getHandler;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerGet.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerGet.java
@@ -11,6 +11,7 @@ import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.search.handler.SearchHandler;
 
+@Deprecated
 public class VespaFeedHandlerGet extends ThreadedHttpRequestHandler {
 
     private final SearchHandler searchHandler;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemove.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemove.java
@@ -21,6 +21,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.concurrent.Executor;
 
+@Deprecated
 public class VespaFeedHandlerRemove extends VespaFeedHandlerBase {
 
     @Inject

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemoveLocation.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemoveLocation.java
@@ -20,6 +20,7 @@ import com.yahoo.vespaclient.config.FeederConfig;
 
 import java.util.concurrent.Executor;
 
+@Deprecated
 public class VespaFeedHandlerRemoveLocation extends VespaFeedHandlerBase {
 
     @Inject

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
@@ -15,6 +15,7 @@ import com.yahoo.metrics.MetricManager;
 import com.yahoo.metrics.MetricSet;
 import com.yahoo.vespaclient.config.FeederConfig;
 
+@Deprecated
 public class VespaFeedHandlerStatus extends ThreadedHttpRequestHandler {
 
     private MetricManager manager;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerVisit.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerVisit.java
@@ -14,6 +14,7 @@ import com.yahoo.search.handler.SearchHandler;
 /**
  * @author thomasg
  */
+@Deprecated
 public class VespaFeedHandlerVisit extends ThreadedHttpRequestHandler {
 
     private final SearchHandler searchHandler;

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/VespaFeedHandlerTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/VespaFeedHandlerTestCase.java
@@ -39,6 +39,7 @@ import java.util.zip.GZIPOutputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation") // Tests a deprecated class
 public class VespaFeedHandlerTestCase {
 
     private VespaFeedHandler feedHandler;


### PR DESCRIPTION
@bratseth @gjoranv @hmusum please review
@bjorncs FYI

We _probably_ want to hold off merging this one until after we've had the ✨multiple bucket spaces✨ version pushed into production. Also it is likely to break more than zero internal system tests that use old APIs.

More fodder for the "make document V2 API soon" argument.