### PR TITLE
Revert "Upgrade felix to 5.2.0"

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -459,7 +459,7 @@
 
     <properties>
         <bouncycastle.version>1.58</bouncycastle.version>
-        <felix.version>5.2.0</felix.version>
+        <felix.version>5.0.1</felix.version>
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>18.0</guava.version>
         <guice.version>3.0</guice.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#6019

Fails mysteriously with

```
1527774009.789	vespa8.dev.corp.gq1.yahoo.com	25645/738	configserver	Container.com.yahoo.container.jdisc.ConfiguredApplication	error	Reconfiguration failed, your application package must be fixed, unless this is a JNI reload issue: java.lang.InterruptedException: InterruptedException
exception=
java.lang.RuntimeException: java.lang.InterruptedException
\tat org.apache.felix.framework.ServiceRegistry.getService(ServiceRegistry.java:360)
\tat org.apache.felix.framework.Felix.getService(Felix.java:3692)
\tat org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.transformClass(BundleWiringImpl.java:2399)
\tat org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.findClass(BundleWiringImpl.java:2092)
\tat org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1526)
\tat org.apache.felix.framework.BundleWiringImpl.access$400(BundleWiringImpl.java:79)
\tat org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1998)
\tat java.lang.ClassLoader.loadClass(ClassLoader.java:357)
\tat com.yahoo.container.di.Container.invalidateGeneration(Container.scala:76)
\tat com.yahoo.container.di.Container.runOnce(Container.scala:70)
\tat com.yahoo.container.core.config.HandlersConfigurerDi.runOnceAndEnsureRegistryHackRun(HandlersConfigurerDi.java:142)
\tat com.yahoo.container.jdisc.ConfiguredApplication.lambda$startReconfigurerThread$0(ConfiguredApplication.java:202)
\tat java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.InterruptedException
\tat java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1302)
\tat java.util.concurrent.CountDownLatch.await(CountDownLatch.java:231)
\tat org.apache.felix.framework.ServiceRegistry.getService(ServiceRegistry.java:356)
\t... 12 more
```
