### PR TITLE
Revert "Handle struct map in attribute writer."

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -868,7 +868,7 @@ struct StructArrayFixture : public StructFixtureBase
 
 StructArrayFixture::~StructArrayFixture() = default;
 
-TEST_F("require that update with doc argument updates compound attributes (array)", StructArrayFixture)
+TEST_F("require that update with doc argument only updates compound attributes", StructArrayFixture)
 {
     auto doc = f.makeDoc(10,  {11, 12});
     f.put(10, *doc, 1);
@@ -876,64 +876,6 @@ TEST_F("require that update with doc argument updates compound attributes (array
     doc = f.makeDoc(20, {21});
     f.update(11, *doc, 1, true);
     TEST_DO(f.checkAttrs(1, 10, {21}));
-}
-
-struct StructMapFixture : public StructFixtureBase
-{
-    using StructFixtureBase::makeDoc;
-    const MapDataType _structMapFieldType;
-    const Field _structMapField;
-
-    StructMapFixture()
-        : StructFixtureBase(),
-          _structMapFieldType(*DataType::INT, _structFieldType),
-          _structMapField("map", _structMapFieldType, true)
-    {
-        addAttribute({"map.value.value", AVConfig(AVBasicType::INT32, AVCollectionType::ARRAY)}, createSerialNum);
-        addAttribute({"map.key", AVConfig(AVBasicType::INT32, AVCollectionType::ARRAY)}, createSerialNum);
-        _type.addField(_structMapField);
-    }
-
-    std::unique_ptr<Document>
-    makeDoc(int32_t value, const std::map<int32_t, int32_t> &mapValues)
-    {
-        auto doc = makeDoc();
-        doc->setValue(_valueField, IntFieldValue(value));
-        MapFieldValue s(_structMapFieldType);
-        for (const auto &mapValue : mapValues) {
-            s.put(IntFieldValue(mapValue.first), *makeStruct(mapValue.second));
-        }
-        doc->setValue(_structMapField, s);
-        return doc;
-    }
-    void checkAttrs(uint32_t lid, int32_t expValue, const std::map<int32_t, int32_t> &expMap) {
-        auto valueAttr = _m->getAttribute("value")->getSP();
-        auto mapKeyAttr = _m->getAttribute("map.key")->getSP();
-        auto mapValueAttr = _m->getAttribute("map.value.value")->getSP();
-        EXPECT_EQUAL(expValue, valueAttr->getInt(lid));
-        attribute::IntegerContent mapKeys;
-        mapKeys.fill(*mapKeyAttr, lid);
-        attribute::IntegerContent mapValues;
-        mapValues.fill(*mapValueAttr, lid);
-        EXPECT_EQUAL(expMap.size(), mapValues.size());
-        EXPECT_EQUAL(expMap.size(), mapKeys.size());
-        size_t i = 0;
-        for (const auto &expMapElem : expMap) {
-            EXPECT_EQUAL(expMapElem.first, mapKeys[i]);
-            EXPECT_EQUAL(expMapElem.second, mapValues[i]);
-            ++i;
-        }
-    }
-};
-
-TEST_F("require that update with doc argument updates compound attributes (map)", StructMapFixture)
-{
-    auto doc = f.makeDoc(10,  {{1, 11}, {2, 12}});
-    f.put(10, *doc, 1);
-    TEST_DO(f.checkAttrs(1, 10, {{1, 11}, {2, 12}}));
-    doc = f.makeDoc(20, {{42, 21}});
-    f.update(11, *doc, 1, true);
-    TEST_DO(f.checkAttrs(1, 10, {{42, 21}}));
 }
 
 TEST_MAIN()

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -34,19 +34,6 @@ AttributeWriter::WriteField::WriteField(AttributeVector &attribute)
 
 AttributeWriter::WriteField::~WriteField() = default;
 
-void
-AttributeWriter::WriteField::buildFieldPath(const DocumentType &docType)
-{
-    const vespalib::string &name = _attribute.getName();
-    FieldPath fp;
-    try {
-        docType.buildFieldPath(fp, name);
-    } catch (document::FieldNotFoundException & e) {
-        fp = FieldPath();
-    }
-    _fieldPath = std::move(fp);
-}
-
 AttributeWriter::WriteContext::WriteContext(uint32_t executorId)
     : _executorId(executorId),
       _fields(),
@@ -74,7 +61,14 @@ void
 AttributeWriter::WriteContext::buildFieldPaths(const DocumentType &docType)
 {
     for (auto &field : _fields) {
-        field.buildFieldPath(docType);
+        const vespalib::string &name = field.getAttribute().getName();
+        FieldPath fp;
+        try {
+            docType.buildFieldPath(fp, name);
+        } catch (document::FieldNotFoundException & e) {
+            fp = FieldPath();
+        }
+        field.setFieldPath(std::move(fp));
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
@@ -33,7 +33,7 @@ public:
         ~WriteField();
         AttributeVector &getAttribute() const { return _attribute; }
         const FieldPath &getFieldPath() const { return _fieldPath; }
-        void buildFieldPath(const DocumentType &docType);
+        void setFieldPath(FieldPath &&fieldPath) { _fieldPath = std::move(fieldPath); }
         bool getCompoundAttribute() const { return _compoundAttribute; }
     };
     class WriteContext


### PR DESCRIPTION
Reverts vespa-engine/vespa#6030

@toregge if you wish. The first PR could not be reverted, and it looks @baldersheim has some commits after the potential culprit #6014 