### PR TITLE
Restore code to previous functionality, except for intended change

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -93,8 +93,8 @@ public class DockerOperationsImpl implements DockerOperations {
 
             // TODO When rolling out host-admin on-prem: Always map in /var/zpe from host + make sure zpu is configured on host
             if (environment.getCloud().equalsIgnoreCase("yahoo")) {
-                command.withVolume(environment.pathInHostFromPathInNode(containerName, Paths.get("var/zpe")).toString(),
-                                   environment.pathInNodeUnderVespaHome("var/zpe").toString());
+                Path pathInNode = environment.pathInNodeUnderVespaHome("var/zpe");
+                command.withVolume(environment.pathInHostFromPathInNode(containerName, pathInNode).toString(), pathInNode.toString());
             } else if (environment.getNodeType() == NodeType.host) {
                 command.withVolume("/var/zpe", environment.pathInNodeUnderVespaHome("var/zpe").toString());
             }


### PR DESCRIPTION
@bjorncs or anyone. 

I think this fixes https://github.com/yahoo/vespa/commit/fe3d564ddf26df3e72bf4244d1edbef2237044d3
which unintentionally removed a call `environment.pathInNodeUnderVespaHome("var/zpe")`. 