### PR TITLE
do less reverse-lookups in DNS

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/Host.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/Host.java
@@ -42,16 +42,14 @@ public final class Host extends AbstractConfigProducer<AbstractConfigProducer<?>
 
     private void checkName(HostSystem parent, String hostname) {
         // Give a warning if the host does not exist
-        // Host exists - warn if given hostname is not a fully qualified one.
-        String canonical = hostname;
         try {
-            canonical = parent.getCanonicalHostname(hostname);
+            Object address = java.net.InetAddress.getByName(hostname);
         } catch (UnknownHostException e) {
-            deployLogger().log(Level.WARNING, "Unable to find canonical hostname of host: " + hostname);
+            deployLogger().log(Level.WARNING, "Unable to lookup IP address of host: " + hostname);
         }
-        if ((null != canonical) && (! hostname.equals(canonical))) {
+        if (! hostname.contains(".")) {
             deployLogger().log(Level.WARNING, "Host named '" + hostname + "' may not receive any config " +
-                                              "since it does not match its canonical hostname: " + canonical);
+                                              "since it is not a canonical hostname");
         }
     }
 


### PR DESCRIPTION
* with docker (and especially docker swarm) validating host names by
  doing reverse DNS lookups have become even less reliable, so just
  skip it, check only that the hostname isn't in "short" form.

@havardpe please review
@hmusum FYI
@aressem FYI