### PR TITLE
Do not delete unused tenants that have been created last week

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -438,14 +438,14 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
     // ---------------- Tenant operations ----------------------------------------------------------------
 
-    public Set<TenantName> removeUnusedTenants() {
-        Set<TenantName> tenantsToBeDeleted = tenantRepository.getAllTenantNames().stream()
+    public Set<TenantName> deleteUnusedTenants(Duration ttlForUnusedTenant, Instant now) {
+        return tenantRepository.getAllTenantNames().stream()
                 .filter(tenantName -> activeApplications(tenantName).isEmpty())
                 .filter(tenantName -> !tenantName.equals(TenantName.defaultName())) // Not allowed to remove 'default' tenant
                 .filter(tenantName -> !tenantName.equals(TenantRepository.HOSTED_VESPA_TENANT)) // Not allowed to remove 'hosted-vespa' tenant
+                .filter(tenantName -> tenantRepository.getTenant(tenantName).getCreatedTime().isBefore(now.minus(ttlForUnusedTenant)))
+                .peek(tenantRepository::deleteTenant)
                 .collect(Collectors.toSet());
-        tenantsToBeDeleted.forEach(tenantRepository::deleteTenant);
-        return tenantsToBeDeleted;
     }
 
     public void deleteTenant(TenantName tenantName) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainer.java
@@ -5,15 +5,24 @@ import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.curator.Curator;
 
 import java.time.Duration;
+import java.time.Instant;
 
 public class TenantsMaintainer extends Maintainer {
 
+    private final Duration ttlForUnusedTenant;
+
     TenantsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval) {
+        this(applicationRepository, curator, interval, Duration.ofDays(7));
+    }
+
+    private TenantsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval, Duration ttlForUnusedTenant) {
         super(applicationRepository, curator, interval);
+        this.ttlForUnusedTenant = ttlForUnusedTenant;
     }
 
     @Override
+    // Delete unused tenants that were created more than ttlForUnusedTenant ago
     protected void maintain() {
-        applicationRepository.removeUnusedTenants();
+        applicationRepository.deleteUnusedTenants(ttlForUnusedTenant, Instant.now());
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/Tenant.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/Tenant.java
@@ -11,6 +11,11 @@ import com.yahoo.vespa.config.server.session.LocalSessionRepo;
 import com.yahoo.vespa.config.server.session.RemoteSessionRepo;
 import com.yahoo.vespa.config.server.session.SessionFactory;
 import com.yahoo.vespa.curator.Curator;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.data.Stat;
+
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Contains all tenant-level components for a single tenant, dealing with editing sessions and
@@ -122,6 +127,14 @@ public class Tenant implements TenantHandlerProvider {
 
     public Curator getCurator() {
         return curator;
+    }
+
+    public Instant getCreatedTime() {
+        Optional<Stat> stat = curator.getStat(path);
+        if (stat.isPresent())
+            return Instant.ofEpochMilli(stat.get().getCtime());
+        else
+            return Instant.now();
     }
 
     @Override

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -21,6 +21,7 @@ import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.zookeeper.data.Stat;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -292,6 +293,21 @@ public class Curator implements AutoCloseable {
 
         try {
             return Optional.of(framework().getData().forPath(path.getAbsolute()));
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Could not get data at " + path.getAbsolute(), e);
+        }
+    }
+
+    /**
+     * Returns the stat data at the given path.
+     * Empty is returned if the path does not exist.
+     */
+    public Optional<Stat> getStat(Path path) {
+        if ( ! exists(path)) return Optional.empty();
+
+        try {
+            return Optional.of(framework().checkExists().forPath(path.getAbsolute()));
         }
         catch (Exception e) {
             throw new RuntimeException("Could not get data at " + path.getAbsolute(), e);


### PR DESCRIPTION
* Add support for getting stat info for a zookeeper node
* For unused tenants, check when tenant was created and do not delete
  unless TTL (7 days) has been exceeded