### PR TITLE
Avoid synthetic document step for fieldpath updates

### DIFF
--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -80,7 +80,7 @@ public class DocumentScriptTestCase {
         out = (StringFieldValue)processFieldUpdate(in).getValue();
         assertSpanTrees(out, "mySpanTree");
 
-        out = (StringFieldValue)processPathUpdate(in);
+        out = (StringFieldValue)processPathUpdate(in).getValue();
         assertSpanTrees(out, "mySpanTree");
     }
 
@@ -97,7 +97,7 @@ public class DocumentScriptTestCase {
         assertEquals(1, out.size());
         assertSpanTrees(out.get(0), "mySpanTree");
 
-        out = (Array<StringFieldValue>)processPathUpdate(in);
+        out = (Array<StringFieldValue>)processPathUpdate(in).getValue();
         assertEquals(1, out.size());
         assertSpanTrees(out.get(0), "mySpanTree");
     }
@@ -115,7 +115,7 @@ public class DocumentScriptTestCase {
         assertEquals(1, out.size());
         assertSpanTrees(out.keySet().iterator().next(), "mySpanTree");
 
-        out = (WeightedSet<StringFieldValue>)processPathUpdate(in);
+        out = (WeightedSet<StringFieldValue>)processPathUpdate(in).getValue();
         assertEquals(1, out.size());
         assertSpanTrees(out.keySet().iterator().next(), "mySpanTree");
     }
@@ -138,7 +138,7 @@ public class DocumentScriptTestCase {
         assertSpanTrees(out.keySet().iterator().next(), "myKeySpanTree");
         assertSpanTrees(out.values().iterator().next(), "myValueSpanTree");
 
-        out = (MapFieldValue<StringFieldValue, StringFieldValue>)processPathUpdate(in);
+        out = (MapFieldValue<StringFieldValue, StringFieldValue>)processPathUpdate(in).getValue();
         assertEquals(1, out.size());
         assertSpanTrees(out.keySet().iterator().next(), "myKeySpanTree");
         assertSpanTrees(out.values().iterator().next(), "myValueSpanTree");
@@ -235,13 +235,13 @@ public class DocumentScriptTestCase {
         return update.getFieldUpdate("myField").getValueUpdate(0);
     }
 
-    private static FieldValue processPathUpdate(FieldValue fieldValue) {
+    private static ValueUpdate<?> processPathUpdate(FieldValue fieldValue) {
         DocumentType docType = new DocumentType("myDocumentType");
         docType.addField("myField", fieldValue.getDataType());
         DocumentUpdate update = new DocumentUpdate(docType, "doc:scheme:");
         update.addFieldPathUpdate(new AssignFieldPathUpdate(docType, "myField", fieldValue));
         update = newScript(docType).execute(ADAPTER_FACTORY, update);
-        return ((AssignFieldPathUpdate)update.getFieldPathUpdates().get(0)).getFieldValue();
+        return update.getFieldUpdate("myField").getValueUpdate(0);
     }
 
     private static DocumentScript newScript(DocumentType docType, String fieldName) {

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -229,13 +229,6 @@ public class DocumentScriptTestCase {
         StringFieldValue newTitleValue = new StringFieldValue("iron moose 4, moose with a vengeance");
         DocumentUpdate update = f.executeWithUpdate("structfield", new AssignFieldPathUpdate(f.type, "structfield.title", newTitleValue));
 
-        Document doc = new Document(f.type, "id:test:documentType::balle");
-        Struct s = new Struct(f.structType);
-        s.setFieldValue("title", new StringFieldValue("banan"));
-        doc.setFieldValue("structfield", s);
-
-        update.applyTo(doc);
-
         assertEquals(1, update.getFieldPathUpdates().size());
         assertEquals(0, update.getFieldUpdates().size());
         assertTrue(update.getFieldPathUpdates().get(0) instanceof AssignFieldPathUpdate);

--- a/document/src/main/java/com/yahoo/document/datatypes/Array.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/Array.java
@@ -290,7 +290,8 @@ public final class Array<T extends FieldValue> extends CollectionFieldValue<T> i
         if (pos < fieldPath.size()) {
             switch (fieldPath.get(pos).getType()) {
                 case ARRAY_INDEX:
-                    return iterateSubset(fieldPath.get(pos).getLookupIndex(), fieldPath.get(pos).getLookupIndex(), fieldPath, null, pos + 1, handler);
+                    final int elemIndex = fieldPath.get(pos).getLookupIndex();
+                    return iterateSubset(elemIndex, elemIndex, fieldPath, null, pos + 1, handler);
                 case VARIABLE: {
                     FieldPathIteratorHandler.IndexValue val = handler.getVariables().get(fieldPath.get(pos).getVariableName());
                     if (val != null) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldPathUpdateHelper.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldPathUpdateHelper.java
@@ -20,19 +20,10 @@ public abstract class FieldPathUpdateHelper {
         if (!(update instanceof AssignFieldPathUpdate)) {
             return false;
         }
-        for (FieldPathEntry entry : update.getFieldPath()) {
-            switch (entry.getType()) {
-            case STRUCT_FIELD:
-            case MAP_ALL_KEYS:
-            case MAP_ALL_VALUES:
-                continue;
-            case ARRAY_INDEX:
-            case MAP_KEY:
-            case VARIABLE:
-                return false;
-            }
-        }
-        return true;
+        // Only consider field path updates that touch a top-level field as 'complete',
+        // as these may be converted to regular field value updates.
+        return ((update.getFieldPath().size() == 1)
+                && update.getFieldPath().get(0).getType() == FieldPathEntry.Type.STRUCT_FIELD);
     }
 
     public static void applyUpdate(FieldPathUpdate update, Document doc) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/IdentityFieldPathUpdateAdapter.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/IdentityFieldPathUpdateAdapter.java
@@ -1,0 +1,68 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.FieldPath;
+import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.expressions.FieldValueAdapter;
+
+/**
+ * No-op update adapter which simply passes through the input update unchanged.
+ * I.e. getOutput() will return a DocumentUpdate containing only the FieldPathUpdate
+ * the IdentityFieldPathUpdateAdapter was created with. All other applicable calls are
+ * forwarded to the provided DocumentAdapter instance.
+ *
+ * This removes the need for a potentially lossy round-trip of update -&gt; synthetic document -&gt; update.
+ */
+public class IdentityFieldPathUpdateAdapter implements UpdateAdapter {
+
+    private final FieldPathUpdate update;
+    private final DocumentAdapter fwdAdapter;
+
+    public IdentityFieldPathUpdateAdapter(FieldPathUpdate update, DocumentAdapter fwdAdapter) {
+        this.update = update;
+        this.fwdAdapter = fwdAdapter;
+    }
+
+    @Override
+    public DocumentUpdate getOutput() {
+        Document doc = fwdAdapter.getFullOutput();
+        DocumentUpdate upd = new DocumentUpdate(doc.getDataType(), doc.getId());
+        upd.addFieldPathUpdate(update);
+        return upd;
+    }
+
+    @Override
+    public Expression getExpression(Expression expression) {
+        return expression;
+    }
+
+    @Override
+    public FieldValue getInputValue(String fieldName) {
+        return fwdAdapter.getInputValue(fieldName);
+    }
+
+    @Override
+    public FieldValue getInputValue(FieldPath fieldPath) {
+        return fwdAdapter.getInputValue(fieldPath);
+    }
+
+    @Override
+    public FieldValueAdapter setOutputValue(Expression exp, String fieldName, FieldValue fieldValue) {
+        return fwdAdapter.setOutputValue(exp, fieldName, fieldValue);
+    }
+
+    @Override
+    public DataType getInputType(Expression exp, String fieldName) {
+        return fwdAdapter.getInputType(exp, fieldName);
+    }
+
+    @Override
+    public void tryOutputType(Expression exp, String fieldName, DataType valueType) {
+        fwdAdapter.tryOutputType(exp, fieldName, valueType);
+    }
+}

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/SimpleAdapterFactory.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/SimpleAdapterFactory.java
@@ -48,12 +48,7 @@ public class SimpleAdapterFactory implements AdapterFactory {
         DocumentId docId = upd.getId();
         Document complete = new Document(docType, upd.getId());
         for (FieldPathUpdate fieldUpd : upd) {
-            if (FieldPathUpdateHelper.isComplete(fieldUpd)) {
-                FieldPathUpdateHelper.applyUpdate(fieldUpd, complete);
-            } else {
-                Document partial = FieldPathUpdateHelper.newPartialDocument(docId, fieldUpd);
-                ret.add(new FieldPathUpdateAdapter(newDocumentAdapter(partial, true), fieldUpd));
-            }
+            ret.add(new IdentityFieldPathUpdateAdapter(fieldUpd, newDocumentAdapter(complete, true)));
         }
         for (FieldUpdate fieldUpd : upd.getFieldUpdates()) {
             Field field = fieldUpd.getField();

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/SimpleAdapterFactory.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/SimpleAdapterFactory.java
@@ -48,7 +48,14 @@ public class SimpleAdapterFactory implements AdapterFactory {
         DocumentId docId = upd.getId();
         Document complete = new Document(docType, upd.getId());
         for (FieldPathUpdate fieldUpd : upd) {
-            ret.add(new IdentityFieldPathUpdateAdapter(fieldUpd, newDocumentAdapter(complete, true)));
+            if (FieldPathUpdateHelper.isComplete(fieldUpd)) {
+                // A 'complete' field path update is basically a regular top-level field update
+                // in wolf's clothing. Convert it to a regular field update to be friendlier
+                // towards the search core backend.
+                FieldPathUpdateHelper.applyUpdate(fieldUpd, complete);
+            } else {
+                ret.add(new IdentityFieldPathUpdateAdapter(fieldUpd, newDocumentAdapter(complete, true)));
+            }
         }
         for (FieldUpdate fieldUpd : upd.getFieldUpdates()) {
             Field field = fieldUpd.getField();


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

All field path updates that cannot be converted to field value updates are now passed verbatim through the indexing docproc.