### PR TITLE
Don't exlude tensorflow-jni.

### DIFF
--- a/fat-model-dependencies/pom.xml
+++ b/fat-model-dependencies/pom.xml
@@ -16,13 +16,6 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-model</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <!-- Large, and installed separately as part of Vespa -->
-          <groupId>org.tensorflow</groupId>
-          <artifactId>libtensorflow_jni</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
- It's not installed by us on open source nodes.

Jon's earlier removal of the exclusion was lost in the creation of fat-model-dependencies.