### PR TITLE
Use the same repo for all builtin config definitions in ServerCache

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/StaticConfigDefinitionRepo.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/StaticConfigDefinitionRepo.java
@@ -22,8 +22,7 @@ import java.util.stream.Collectors;
  * A global pool of all config definitions that this server knows about. These objects can be shared
  * by all tenants, as they are not modified.
  *
- * @author lulf
- * @since 5.10
+ * @author Ulf Lilleengen
  */
 public class StaticConfigDefinitionRepo implements ConfigDefinitionRepo {
 
@@ -66,5 +65,8 @@ public class StaticConfigDefinitionRepo implements ConfigDefinitionRepo {
     public Map<ConfigDefinitionKey, ConfigDefinition> getConfigDefinitions() {
         return Collections.unmodifiableMap(configDefinitions);
     }
+
+    @Override
+    public ConfigDefinition get(ConfigDefinitionKey key) { return configDefinitions.get(key); }
 
 }

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ConfigDefinitionRepo.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ConfigDefinitionRepo.java
@@ -7,10 +7,9 @@ import com.yahoo.vespa.config.buildergen.ConfigDefinition;
 import java.util.Map;
 
 /**
- * Represents a repository of config definitions.
+ * A config definition repository.
  *
- * @author lulf
- * @since 5.10
+ * @author Ulf Lillengen
  */
 public interface ConfigDefinitionRepo {
 
@@ -18,5 +17,11 @@ public interface ConfigDefinitionRepo {
      * Retrieve a map with all config definitions in this repo.
      */
     Map<ConfigDefinitionKey, ConfigDefinition> getConfigDefinitions();
+
+    /**
+     * Gets a config definition from repo or null if not found
+     */
+    // TODO: Remove default implementation when 6.246 is the oldest version in use
+    default ConfigDefinition get(ConfigDefinitionKey key) { return null; }
 
 }

--- a/config-model/src/test/java/com/yahoo/config/model/deploy/DeployStateTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/deploy/DeployStateTest.java
@@ -126,6 +126,10 @@ public class DeployStateTest {
             public Map<ConfigDefinitionKey, com.yahoo.vespa.config.buildergen.ConfigDefinition> getConfigDefinitions() {
                 return defs;
             }
+            @Override
+            public com.yahoo.vespa.config.buildergen.ConfigDefinition get(ConfigDefinitionKey key) {
+                return null;
+            }
         });
         return builder.build(true);
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/StaticConfigDefinitionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/StaticConfigDefinitionRepo.java
@@ -13,19 +13,23 @@ import java.util.Map;
  * A global pool of all config definitions that this server knows about. These objects can be shared
  * by all tenants, as they are not modified.
  *
- * @author lulf
- * @since 5.10
+ * @author Ulf Lilleengen
  */
 public class StaticConfigDefinitionRepo implements ConfigDefinitionRepo {
 
     private final ConfigDefinitionRepo repo;
 
-    // Only useful in tests that dont need full blown repo.
+    // Only useful in tests that don't need full blown repo.
     public StaticConfigDefinitionRepo() {
         this.repo = new ConfigDefinitionRepo() {
             @Override
             public Map<ConfigDefinitionKey, ConfigDefinition> getConfigDefinitions() {
                 return Collections.emptyMap();
+            }
+
+            @Override
+            public ConfigDefinition get(ConfigDefinitionKey key) {
+                return null;
             }
         };
     }
@@ -39,4 +43,7 @@ public class StaticConfigDefinitionRepo implements ConfigDefinitionRepo {
     public Map<ConfigDefinitionKey, ConfigDefinition> getConfigDefinitions() {
         return repo.getConfigDefinitions();
     }
+
+    @Override
+    public ConfigDefinition get(ConfigDefinitionKey key) { return repo.get(key); }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/UserConfigDefinitionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/UserConfigDefinitionRepo.java
@@ -1,0 +1,33 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server;
+
+
+import com.yahoo.config.model.api.ConfigDefinitionRepo;
+import com.yahoo.vespa.config.ConfigDefinitionKey;
+import com.yahoo.vespa.config.buildergen.ConfigDefinition;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author hmusum
+ */
+public class UserConfigDefinitionRepo implements ConfigDefinitionRepo {
+
+    private final Map<ConfigDefinitionKey, ConfigDefinition> defs = new LinkedHashMap<>();
+
+
+    public void add(ConfigDefinitionKey key, ConfigDefinition configDefinition) {
+        defs.put(key, configDefinition);
+    }
+
+    @Override
+    public Map<ConfigDefinitionKey, ConfigDefinition> getConfigDefinitions() {
+        return defs;
+    }
+
+    @Override
+    public ConfigDefinition get(ConfigDefinitionKey key) {
+        return defs.get(key);
+    }
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -15,7 +15,6 @@ import com.yahoo.config.provision.Version;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.tenant.Rotations;
-import com.yahoo.vespa.config.server.ServerCache;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.vespa.config.server.application.PermanentApplicationPackage;
@@ -74,7 +73,6 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                                             Instant now) {
         log.log(LogLevel.DEBUG, String.format("Loading model version %s for session %s application %s",
                                               modelFactory.getVersion(), appGeneration, applicationId));
-        ServerCache cache = zkClient.loadServerCache();
         ModelContext modelContext = new ModelContextImpl(
                 applicationPackage,
                 Optional.empty(),
@@ -88,7 +86,7 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                 new com.yahoo.component.Version(modelFactory.getVersion().toString()),
                 wantedNodeVespaVersion);
         MetricUpdater applicationMetricUpdater = metrics.getOrCreateMetricUpdater(Metrics.createDimensions(applicationId));
-        return new Application(modelFactory.createModel(modelContext), cache, appGeneration,
+        return new Application(modelFactory.createModel(modelContext), zkClient.loadServerCache(), appGeneration,
                                applicationPackage.getMetaData().isInternalRedeploy(),
                                modelFactory.getVersion(),
                                applicationMetricUpdater, applicationId);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/ServerCacheLoader.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/ServerCacheLoader.java
@@ -3,33 +3,30 @@ package com.yahoo.vespa.config.server.session;
 
 import com.google.common.base.Splitter;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
-import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import com.yahoo.vespa.config.buildergen.ConfigDefinition;
 import com.yahoo.vespa.config.server.ServerCache;
+import com.yahoo.vespa.config.server.UserConfigDefinitionRepo;
 import com.yahoo.vespa.config.util.ConfigUtils;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;
 
-import java.util.Map;
-
 /**
- * This class is tasked with reading config definitions and legacy configs/ from zookeeper, and create
- * a {@link ServerCache} instance containing these in memory.
+ * Loads config definitions from zookeeper and creates a {@link ServerCache} instance containing these
+ * and the builtin config definitions in memory.
  *
- * @author lulf
- * @since 5.1
+ * @author Ulf Lilleengen
  */
 public class ServerCacheLoader {
 
-    private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(ServerCacheLoader.class.getName());
     private final ConfigDefinitionRepo repo;
     private final ConfigCurator configCurator;
     private final Path path;
-    public ServerCacheLoader(ConfigCurator configCurator, Path rootPath, ConfigDefinitionRepo repo) {
+
+    ServerCacheLoader(ConfigCurator configCurator, Path rootPath, ConfigDefinitionRepo builtinConfigDefinitions) {
         this.configCurator = configCurator;
         this.path = rootPath;
-        this.repo = repo;
+        this.repo = builtinConfigDefinitions;
     }
 
     public ServerCache loadCache() {
@@ -40,39 +37,31 @@ public class ServerCacheLoader {
      * Reads config definitions from zookeeper, parses them and puts both ConfigDefinition instances
      * and payload (raw config definition) into cache.
      *
-     * @return            the populated cache.
+     * @return the populated cache.
      */
-    public ServerCache loadConfigDefinitions() {
-        ServerCache cache = new ServerCache();
+    private ServerCache loadConfigDefinitions() {
         try {
-            log.log(LogLevel.DEBUG, "Getting config definitions");
-            loadGlobalConfigDefinitions(cache);
-            loadConfigDefinitionsFromPath(cache, path.append(ConfigCurator.USER_DEFCONFIGS_ZK_SUBPATH).getAbsolute());
-            log.log(LogLevel.DEBUG, "Done getting config definitions");
+            return new ServerCache(repo, createUserConfigDefinitionsRepo(path.append(ConfigCurator.USER_DEFCONFIGS_ZK_SUBPATH).getAbsolute()));
         } catch (Exception e) {
-            throw new IllegalStateException("Could not load config definitions for " + path, e);
-        }
-        return cache;
-    }
-
-    private void loadGlobalConfigDefinitions(ServerCache cache) {
-        for (Map.Entry<ConfigDefinitionKey, ConfigDefinition> entry : repo.getConfigDefinitions().entrySet()) {
-            cache.addDef(entry.getKey(), entry.getValue());
+            throw new IllegalStateException("Could not load user config definitions from " + path, e);
         }
     }
 
     /**
-     * Loads config definitions from a specified path into server cache and returns it.
+     * Creates repo with user config definitions
      *
      * @param appPath the path to load config definitions from
      */
-    private void loadConfigDefinitionsFromPath(ServerCache cache, String appPath) {
-        if ( ! configCurator.exists(appPath)) return;
+    private UserConfigDefinitionRepo createUserConfigDefinitionsRepo(String appPath) {
+        UserConfigDefinitionRepo userConfigDefinitionRepo = new UserConfigDefinitionRepo();
+        if ( ! configCurator.exists(appPath)) return userConfigDefinitionRepo;
+
         for (String nodeName : configCurator.getChildren(appPath)) {
             String payload = configCurator.getData(appPath, nodeName);
             ConfigDefinitionKey dKey = ConfigUtils.createConfigDefinitionKeyFromZKString(nodeName);
-            cache.addDef(dKey, new ConfigDefinition(dKey.getName(), Splitter.on("\n").splitToList(payload).toArray(new String[0])));
+            userConfigDefinitionRepo.add(dKey, new ConfigDefinition(dKey.getName(), Splitter.on("\n").splitToList(payload).toArray(new String[0])));
         }
+        return userConfigDefinitionRepo;
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ServerCacheTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ServerCacheTest.java
@@ -17,8 +17,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author lulf
- * @since 5.1
+ * @author Ulf Lilleengen
  */
 public class ServerCacheTest {
     private ServerCache cache;
@@ -27,8 +26,8 @@ public class ServerCacheTest {
     private static String defMd5_2 = "a2f8edfc965802bf6d44826f9da7e2b0";
     private static String configMd5 = "mymd5";
     private static String configMd5_2 = "mymd5_2";
-    private static ConfigDefinition payload = new ConfigDefinition("mypayload", new String[0]);
-    private static ConfigDefinition payload_2 = new ConfigDefinition("otherpayload", new String[0]);
+    private static ConfigDefinition def = new ConfigDefinition("mypayload", new String[0]);
+    private static ConfigDefinition def_2 = new ConfigDefinition("otherpayload", new String[0]);
 
     private static ConfigDefinitionKey fooBarDefKey = new ConfigDefinitionKey("foo", "bar");
     private static ConfigDefinitionKey fooBazDefKey = new ConfigDefinitionKey("foo", "baz");
@@ -37,28 +36,28 @@ public class ServerCacheTest {
     private static ConfigKey<?> fooConfigKey = new ConfigKey<>("foo", "id", "bar");
     private static ConfigKey<?> bazConfigKey = new ConfigKey<>("foo", "id2", "bar");
 
-    ConfigCacheKey fooBarCacheKey = new ConfigCacheKey(fooConfigKey, defMd5);
-    ConfigCacheKey bazQuuxCacheKey = new ConfigCacheKey(bazConfigKey, defMd5);
-    ConfigCacheKey fooBarCacheKeyDifferentMd5 = new ConfigCacheKey(fooConfigKey, defMd5_2);
+    private ConfigCacheKey fooBarCacheKey = new ConfigCacheKey(fooConfigKey, defMd5);
+    private ConfigCacheKey bazQuuxCacheKey = new ConfigCacheKey(bazConfigKey, defMd5);
+    private ConfigCacheKey fooBarCacheKeyDifferentMd5 = new ConfigCacheKey(fooConfigKey, defMd5_2);
 
     @Before
     public void setup() {
-        cache = new ServerCache();
+        UserConfigDefinitionRepo userConfigDefinitionRepo = new UserConfigDefinitionRepo();
+        userConfigDefinitionRepo.add(fooBarDefKey, def);
+        userConfigDefinitionRepo.add(fooBazDefKey, new com.yahoo.vespa.config.buildergen.ConfigDefinition("baz", new String[0]));
+        userConfigDefinitionRepo.add(fooBimDefKey, new ConfigDefinition("mynode", new String[0]));
 
-        cache.addDef(fooBarDefKey, payload);
-        cache.addDef(fooBazDefKey, new com.yahoo.vespa.config.buildergen.ConfigDefinition("baz", new String[0]));
+        cache = new ServerCache(new TestConfigDefinitionRepo(), userConfigDefinitionRepo);
 
-        cache.addDef(fooBimDefKey, new ConfigDefinition("mynode", new String[0]));
-
-        cache.put(fooBarCacheKey, SlimeConfigResponse.fromConfigPayload(ConfigPayload.empty(), payload.getCNode(), 2, false, configMd5), configMd5);
-        cache.put(bazQuuxCacheKey, SlimeConfigResponse.fromConfigPayload(ConfigPayload.empty(), payload.getCNode(), 2, false, configMd5), configMd5);
-        cache.put(fooBarCacheKeyDifferentMd5, SlimeConfigResponse.fromConfigPayload(ConfigPayload.empty(), payload_2.getCNode(), 2, false, configMd5_2), configMd5_2);
+        cache.put(fooBarCacheKey, SlimeConfigResponse.fromConfigPayload(ConfigPayload.empty(), def.getCNode(), 2, false, configMd5), configMd5);
+        cache.put(bazQuuxCacheKey, SlimeConfigResponse.fromConfigPayload(ConfigPayload.empty(), def.getCNode(), 2, false, configMd5), configMd5);
+        cache.put(fooBarCacheKeyDifferentMd5, SlimeConfigResponse.fromConfigPayload(ConfigPayload.empty(), def_2.getCNode(), 2, false, configMd5_2), configMd5_2);
     }
 
     @Test
     public void testThatCacheWorks() {
         assertNotNull(cache.getDef(fooBazDefKey));
-        assertThat(cache.getDef(fooBarDefKey), is(payload));
+        assertThat(cache.getDef(fooBarDefKey), is(def));
         assertThat(cache.getDef(fooBimDefKey).getCNode().getName(), is("mynode"));
         ConfigResponse raw = cache.get(fooBarCacheKey);
         assertThat(raw.getConfigMd5(), is(configMd5));
@@ -66,7 +65,7 @@ public class ServerCacheTest {
 
     @Test
     public void testThatCacheWorksWithSameKeyDifferentMd5() {
-        assertThat(cache.getDef(fooBarDefKey), is(payload));
+        assertThat(cache.getDef(fooBarDefKey), is(def));
         ConfigResponse raw = cache.get(fooBarCacheKey);
         assertThat(raw.getConfigMd5(), is(configMd5));
         raw = cache.get(fooBarCacheKeyDifferentMd5);


### PR DESCRIPTION
Avoid creating many instances of identical data for builtin config
definitions. Also put user config definitions in a repo, the same
way the builtin config definitions are.