### PR TITLE
Fix deserialization of MapValueUpdates for array fields in C++

### DIFF
--- a/document/src/vespa/document/update/mapvalueupdate.cpp
+++ b/document/src/vespa/document/update/mapvalueupdate.cpp
@@ -141,12 +141,15 @@ MapValueUpdate::deserialize(const DocumentTypeRepo& repo,
     VespaDocumentDeserializer deserializer(repo, stream, version);
     switch(type.getClass().id()) {
         case ArrayDataType::classId:
+        {
             _key.reset(new IntFieldValue);
             deserializer.read(*_key);
             buffer.incPos(buffer.getRemaining() - stream.size());
+            const ArrayDataType& arrayType = static_cast<const ArrayDataType&>(type);
             _update.reset(ValueUpdate::createInstance(
-                            repo, type, buffer, version).release());
+                    repo, arrayType.getNestedType(), buffer, version).release());
             break;
+        }
         case WeightedSetDataType::classId:
         {
             const WeightedSetDataType& wset(


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

Must deserialize element with _nested_ data type (since that's what's
on the wire), not with data type of array itself.