### PR TITLE
Remove support for ancient legacy node state protocol versions

### DIFF
--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/RPCCommunicatorTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/RPCCommunicatorTest.java
@@ -3,6 +3,9 @@ package com.yahoo.vespa.clustercontroller.core.rpc;
 
 import com.yahoo.jrt.*;
 import com.yahoo.vdslib.state.Node;
+import com.yahoo.vdslib.state.NodeState;
+import com.yahoo.vdslib.state.NodeType;
+import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.*;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -87,6 +90,8 @@ public class RPCCommunicatorTest {
 
         when(target.isValid()).thenReturn(true);
         when(nodeInfo.getConnection()).thenReturn(target);
+        when(nodeInfo.getVersion()).thenReturn(3);
+        when(nodeInfo.getReportedState()).thenReturn(new NodeState(NodeType.DISTRIBUTOR, State.UP));
         communicator.getNodeState(nodeInfo, null);
         Mockito.verify(target).invokeAsync(
                 (Request)any(),


### PR DESCRIPTION
@geirst please review
@hmusum FYI

Protocol versions 0 and 1 haven't been in use for years. No point
in maintaining complexity to support automatic downgrades to these.