### PR TITLE
Use shade plugin instead of assembly.

### DIFF
--- a/vespaclient-java/pom.xml
+++ b/vespaclient-java/pom.xml
@@ -84,18 +84,27 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+                    <finalName>${artifactId}-jar-with-dependencies</finalName>
+                    <filters>
+                        <filter>
+                            <!-- Don't include signature files in uber jar (most likely from bouncycastle).  -->
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>make-assembly</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
The assembly-plugin used over 2 minutes packaging the fat jar.
Like with vespaclient-spooler, I assume that the fat jar does not need to be attached to the artifact.

FYI: @tokle, this fixes the slow maven build which seemed like it was caused by OBR-metadata.