### PR TITLE
Avoid set-node-state retry

### DIFF
--- a/jaxrs_client_utils/src/main/java/com/yahoo/vespa/jaxrs/client/JaxRsStrategyFactory.java
+++ b/jaxrs_client_utils/src/main/java/com/yahoo/vespa/jaxrs/client/JaxRsStrategyFactory.java
@@ -53,7 +53,7 @@ public class JaxRsStrategyFactory {
         this.scheme = scheme;
     }
 
-    public <T> JaxRsStrategy<T> apiWithRetries(final Class<T> apiClass, final String pathPrefix) {
+    public <T> RetryingJaxRsStrategy<T> apiWithRetries(final Class<T> apiClass, final String pathPrefix) {
         Objects.requireNonNull(apiClass, "apiClass argument may not be null");
         Objects.requireNonNull(pathPrefix, "pathPrefix argument may not be null");
         return new RetryingJaxRsStrategy<T>(hostNames, port, jaxRsClientFactory, apiClass, pathPrefix, scheme);

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/RetryingClusterControllerClientFactory.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/RetryingClusterControllerClientFactory.java
@@ -41,7 +41,13 @@ public class RetryingClusterControllerClientFactory implements ClusterController
         Set<HostName> clusterControllerSet = clusterControllers.stream().collect(Collectors.toSet());
         JaxRsStrategy<ClusterControllerJaxRsApi> jaxRsApi
                 = new JaxRsStrategyFactory(clusterControllerSet, HARDCODED_CLUSTERCONTROLLER_PORT, jaxRsClientFactory, CLUSTERCONTROLLER_SCHEME)
-                .apiWithRetries(ClusterControllerJaxRsApi.class, CLUSTERCONTROLLER_API_PATH);
+                .apiWithRetries(ClusterControllerJaxRsApi.class, CLUSTERCONTROLLER_API_PATH)
+                // Use max iteration 1. The JaxRsStrategyFactory will try host 1, 2, then 3:
+                //  - If host 1 responds, it will redirect to master if necessary. Otherwise
+                //  - If host 2 responds, it will redirect to master if necessary. Otherwise
+                //  - If host 3 responds, it may redirect to master if necessary (if they're up
+                //    after all), but more likely there's no quorum and this will fail too.
+                .setMaxIterations(1);
         return new ClusterControllerClientImpl(jaxRsApi, clusterName);
     }
 


### PR DESCRIPTION
Today, the Orchestrator will call each cluster controller twice, e.g. indices
1, 2, 0, 1, 2, 0, if each time out.

This is unnecessary. The minimum number of calls is 2:
 - Either the first CC is up and will redirect to master if necessary, or
 - the second is up and will redirect to master if necessary, or
 - the third won't have quorum.

This PR changes the current strategy to call all CCs once, e.g. indices 1, 2,
and 0.