### PR TITLE
Only deserialize the docId on the initial deserialize of the header.

### DIFF
--- a/document/src/vespa/document/update/documentupdate.cpp
+++ b/document/src/vespa/document/update/documentupdate.cpp
@@ -36,7 +36,7 @@ readCStr(nbostream & stream) {
 
 std::pair<const DocumentType *, DocumentId>
 deserializeTypeAndId(const DocumentTypeRepo& repo, vespalib::nbostream & stream) {
-    DocumentId docId(stream);
+    DocumentId docId(readCStr(stream));
 
     // Read content bit vector.
     unsigned char content = 0x00;
@@ -63,9 +63,7 @@ deserializeTypeAndId(const DocumentTypeRepo& repo, vespalib::nbostream & stream)
 const DocumentType *
 deserializeHeader(const DocumentTypeRepo &repo, vespalib::nbostream & stream, vespalib::stringref & documentId)
 {
-    size_t sz = strnlen(stream.peek(), stream.size());
-    documentId = vespalib::stringref(stream.peek(), sz);
-    stream.adjustReadPos(sz + 1);
+    documentId = readCStr(stream);
     vespalib::stringref typestr = readCStr(stream);
     int16_t version = 0;
     stream >> version;

--- a/document/src/vespa/document/update/documentupdate.cpp
+++ b/document/src/vespa/document/update/documentupdate.cpp
@@ -22,8 +22,62 @@ using namespace vespalib::xml;
 
 namespace document {
 
-// Declare content bits.
-static const unsigned char CONTENT_HASTYPE = 0x01;
+namespace {
+
+constexpr unsigned char CONTENT_HASTYPE = 0x01;
+
+vespalib::stringref
+readCStr(nbostream & stream) {
+    const char * s = stream.peek();
+    size_t sz = strnlen(s, stream.size());
+    stream.adjustReadPos(sz+1);
+    return vespalib::stringref(s, sz);
+}
+
+std::pair<const DocumentType *, DocumentId>
+deserializeTypeAndId(const DocumentTypeRepo& repo, vespalib::nbostream & stream) {
+    DocumentId docId(stream);
+
+    // Read content bit vector.
+    unsigned char content = 0x00;
+    stream >> content;
+
+    // Why on earth do we have this whether we have type part?
+    // We need type for object to work, so just throwing exception if it's
+    // not there.
+    if((content & CONTENT_HASTYPE) == 0) {
+        throw IllegalStateException("Missing document type", VESPA_STRLOC);
+    }
+
+    vespalib::stringref typestr = readCStr(stream);
+
+    int16_t version = 0;
+    stream >> version;
+    const DocumentType *type = repo.getDocumentType(typestr);
+    if (!type) {
+        throw DocumentTypeNotFoundException(typestr, VESPA_STRLOC);
+    }
+    return std::make_pair(type, docId);
+}
+
+const DocumentType *
+deserializeHeader(const DocumentTypeRepo &repo, vespalib::nbostream & stream, vespalib::stringref & documentId)
+{
+    size_t sz = strnlen(stream.peek(), stream.size());
+    documentId = vespalib::stringref(stream.peek(), sz);
+    stream.adjustReadPos(sz + 1);
+    vespalib::stringref typestr = readCStr(stream);
+    int16_t version = 0;
+    stream >> version;
+    const DocumentType * docType =  repo.getDocumentType(typestr);
+    if (!docType) {
+        throw DocumentTypeNotFoundException(typestr, VESPA_STRLOC);
+    }
+    return docType;
+}
+
+}
+
 
 DocumentUpdate::DocumentUpdate(const DocumentTypeRepo & repo, const DataType &type, const DocumentId& id)
     : _documentId(id),
@@ -86,7 +140,9 @@ DocumentUpdate::eagerDeserialize() const {
 
 void DocumentUpdate::lazyDeserialize(const DocumentTypeRepo & repo, nbostream & stream) {
     size_t start(stream.rp());
-    deserializeHEAD(repo, stream);
+    vespalib::stringref voidId;
+    deserializeHeader(repo, stream, voidId);
+    deserializeBody(repo, stream);
     stream.rp(start);
 }
 void DocumentUpdate::ensureDeserialized() const {
@@ -203,43 +259,6 @@ DocumentUpdate::serializeFlags(int size_) const
     return flags.injectInto(size_);
 }
 
-namespace {
-
-vespalib::stringref
-readCStr(nbostream & stream) {
-    const char * s = stream.peek();
-    size_t sz = strnlen(s, stream.size());
-    stream.adjustReadPos(sz+1);
-    return vespalib::stringref(s, sz);
-}
-
-std::pair<const DocumentType *, DocumentId>
-deserializeTypeAndId(const DocumentTypeRepo& repo, vespalib::nbostream & stream) {
-    DocumentId docId(stream);
-
-    // Read content bit vector.
-    unsigned char content = 0x00;
-    stream >> content;
-
-    // Why on earth do we have this whether we have type part?
-    // We need type for object to work, so just throwing exception if it's
-    // not there.
-    if((content & CONTENT_HASTYPE) == 0) {
-        throw IllegalStateException("Missing document type", VESPA_STRLOC);
-    }
-
-    vespalib::stringref typestr = readCStr(stream);
-
-    int16_t version = 0;
-    stream >> version;
-    const DocumentType *type = repo.getDocumentType(typestr);
-    if (!type) {
-        throw DocumentTypeNotFoundException(typestr, VESPA_STRLOC);
-    }
-    return std::make_pair(type, docId);
-}
-}
-
 // Deserialize the content of the given buffer into this document update.
 DocumentUpdate::UP
 DocumentUpdate::create42(const DocumentTypeRepo& repo, vespalib::nbostream & stream)
@@ -280,7 +299,9 @@ DocumentUpdate::initHEAD(const DocumentTypeRepo & repo, vespalib::nbostream && s
     _repo = &repo;
     _backing = std::move(stream);
     size_t startPos = _backing.rp();
-    deserializeHeader(repo, _backing);
+    vespalib::stringref docId;
+    _type = deserializeHeader(repo, _backing, docId);
+    _documentId.set(docId);
     _backing.rp(startPos);
 }
 
@@ -288,7 +309,10 @@ void
 DocumentUpdate::initHEAD(const DocumentTypeRepo & repo, vespalib::nbostream & stream)
 {
     size_t startPos = stream.rp();
-    deserializeHEAD(repo, stream);
+    vespalib::stringref docId;
+    _type = deserializeHeader(repo, stream, docId);
+    _documentId.set(docId);
+    deserializeBody(repo, stream);
     size_t sz = stream.rp() - startPos;
     _backing = nbostream(stream.peek() - sz, sz);
 }
@@ -323,49 +347,19 @@ DocumentUpdate::deserialize42(const DocumentTypeRepo& repo, vespalib::nbostream 
 }
 
 void
-DocumentUpdate::deserializeHeader(const DocumentTypeRepo &repo, vespalib::nbostream & stream)
-{
-    assert(_updates.empty());
-    assert(_fieldPathUpdates.empty());
-    _documentId = DocumentId(stream);
-
-    vespalib::stringref typestr = readCStr(stream);
-    int16_t version = 0;
-    stream >> version;
-    const DocumentType *docType = repo.getDocumentType(typestr);
-    if (!docType) {
-        throw DocumentTypeNotFoundException(typestr, VESPA_STRLOC);
-    }
-    _type = docType;
-    _type = docType;
-}
-
-void
-DocumentUpdate::deserializeHEAD(const DocumentTypeRepo &repo, vespalib::nbostream & stream)
+DocumentUpdate::deserializeBody(const DocumentTypeRepo &repo, vespalib::nbostream &stream)
 {
     _updates.clear();
     _fieldPathUpdates.clear();
     size_t pos = stream.rp();
     try {
-        _documentId = DocumentId(stream);
-
-        vespalib::stringref typestr = readCStr(stream);
-
-        int16_t version = 0;
-        stream >> version;
-        const DocumentType *docType = repo.getDocumentType(typestr);
-        if (!docType) {
-            throw DocumentTypeNotFoundException(typestr, VESPA_STRLOC);
-        }
-        _type = docType;
-
         // Read field updates, if any.
         if ( ! stream.empty() ) {
             int32_t numUpdates = 0;
             stream >> numUpdates;
             _updates.reserve(numUpdates);
             for (int i = 0; i < numUpdates; i++) {
-                _updates.emplace_back(repo, *docType, stream);
+                _updates.emplace_back(repo, *_type, stream);
             }
         }
         // Read fieldpath updates, if any

--- a/document/src/vespa/document/update/documentupdate.h
+++ b/document/src/vespa/document/update/documentupdate.h
@@ -133,12 +133,11 @@ private:
     void initHEAD(const DocumentTypeRepo & repo, vespalib::nbostream && stream);
     void initHEAD(const DocumentTypeRepo & repo, vespalib::nbostream & stream);
     void deserialize42(const DocumentTypeRepo & repo, vespalib::nbostream & stream);
-    void deserializeHEAD(const DocumentTypeRepo & repo, vespalib::nbostream & stream);
+    void deserializeBody(const DocumentTypeRepo &repo, vespalib::nbostream &stream);
     void lazyDeserialize(const DocumentTypeRepo & repo, vespalib::nbostream & stream);
     void ensureDeserialized() const;
     void serializeHeader();
     void reserialize();
-    void deserializeHeader(const DocumentTypeRepo & repo, vespalib::nbostream & stream);
     friend VespaDocumentSerializer;
 };
 


### PR DESCRIPTION
Just skip and verify on subsequent invocations.
@vekterli or @toregge PR