### PR TITLE
Precompute and store attribute and executor id together in a single h…

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/iattributevector.h
@@ -71,6 +71,11 @@ public:
      **/
     virtual const vespalib::string & getName() const = 0;
 
+    vespalib::stringref getNamePrefix() const {
+        vespalib::stringref name = getName();
+        return name.substr(0, name.find('.'));
+    }
+
     /**
      * Returns the number of documents stored in this attribute vector.
      *

--- a/searchcore/src/tests/proton/attribute/exclusive_attribute_read_accessor/exclusive_attribute_read_accessor_test.cpp
+++ b/searchcore/src/tests/proton/attribute/exclusive_attribute_read_accessor/exclusive_attribute_read_accessor_test.cpp
@@ -37,7 +37,7 @@ TEST_F("require that attribute write thread is blocked while guard is held", Fix
 {
     ReadGuard::UP guard = f.accessor.takeGuard();
     Gate gate;
-    f.writer.execute("myattr", [&gate]() { gate.countDown(); });
+    f.writer.execute(f.writer.getExecutorId(f.attribute->getNamePrefix()), [&gate]() { gate.countDown(); });
     bool reachedZero = gate.await(100);
     EXPECT_FALSE(reachedZero);
     EXPECT_EQUAL(1u, gate.getCount());

--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -829,20 +829,16 @@ Test::requireThatAttributesAreUsed()
                              "bi:[]}", *rep, 1, false));
     TEST_DO(assertTensor(Tensor::UP(), "bj", *rep, 1, rclass));
 
-    proton::IAttributeManager::SP attributeManager =
-        dc._ddb->getReadySubDB()->getAttributeManager();
-    search::ISequencedTaskExecutor &attributeFieldWriter =
-        attributeManager->getAttributeFieldWriter();
-    search::AttributeVector *bjAttr =
-        attributeManager->getWritableAttribute("bj");
-    search::tensor::TensorAttribute *bjTensorAttr =
-        dynamic_cast<search::tensor::TensorAttribute *>(bjAttr);
+    proton::IAttributeManager::SP attributeManager = dc._ddb->getReadySubDB()->getAttributeManager();
+    search::ISequencedTaskExecutor &attributeFieldWriter = attributeManager->getAttributeFieldWriter();
+    search::AttributeVector *bjAttr = attributeManager->getWritableAttribute("bj");
+    auto bjTensorAttr = dynamic_cast<search::tensor::TensorAttribute *>(bjAttr);
 
-    attributeFieldWriter.
-        execute("bj",
-                [&]() { bjTensorAttr->setTensor(3,
-                                                *createTensor({ {{{"x", "a"},{"y", "b"}}, 4} }, { "x"}));
-                           bjTensorAttr->commit(); });
+    attributeFieldWriter.execute(attributeFieldWriter.getExecutorId(bjAttr->getNamePrefix()),
+                                 [&]() {
+                                     bjTensorAttr->setTensor(3, *createTensor({ {{{"x", "a"},{"y", "b"}}, 4} }, { "x"}));
+                                     bjTensorAttr->commit();
+                                 });
     attributeFieldWriter.sync();
 
     DocsumReply::UP rep2 = dc._ddb->getDocsums(req);
@@ -961,8 +957,7 @@ Test::requireThatUrisAreUsed()
     Document::UP exp = bc._bld.startDocument("doc::0").
                        startIndexField("urisingle").
                        startSubField("all").
-                       addUrlTokenizedString(
-                               "http://www.example.com:81/fluke?ab=2#4").
+                       addUrlTokenizedString("http://www.example.com:81/fluke?ab=2#4").
                        endSubField().
                        startSubField("scheme").
                        addUrlTokenizedString("http").
@@ -986,8 +981,7 @@ Test::requireThatUrisAreUsed()
                        startIndexField("uriarray").
                        startElement(1).
                        startSubField("all").
-                       addUrlTokenizedString(
-                               "http://www.example.com:82/fluke?ab=2#8").
+                       addUrlTokenizedString("http://www.example.com:82/fluke?ab=2#8").
                        endSubField().
                        startSubField("scheme").
                        addUrlTokenizedString("http").
@@ -1010,8 +1004,7 @@ Test::requireThatUrisAreUsed()
                        endElement().
                        startElement(1).
                        startSubField("all").
-                       addUrlTokenizedString(
-                               "http://www.flickr.com:82/fluke?ab=2#9").
+                       addUrlTokenizedString("http://www.flickr.com:82/fluke?ab=2#9").
                        endSubField().
                        startSubField("scheme").
                        addUrlTokenizedString("http").
@@ -1036,8 +1029,7 @@ Test::requireThatUrisAreUsed()
                        startIndexField("uriwset").
                        startElement(4).
                        startSubField("all").
-                       addUrlTokenizedString(
-                               "http://www.example.com:83/fluke?ab=2#12").
+                       addUrlTokenizedString("http://www.example.com:83/fluke?ab=2#12").
                        endSubField().
                        startSubField("scheme").
                        addUrlTokenizedString("http").
@@ -1060,8 +1052,7 @@ Test::requireThatUrisAreUsed()
                        endElement().
                        startElement(7).
                        startSubField("all").
-                       addUrlTokenizedString(
-                               "http://www.flickr.com:85/fluke?ab=2#13").
+                       addUrlTokenizedString("http://www.flickr.com:85/fluke?ab=2#13").
                        endSubField().
                        startSubField("scheme").
                        addUrlTokenizedString("http").

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -86,11 +86,6 @@ AttributeWriter::WriteContext::buildFieldPaths(const DocumentType &docType)
 
 namespace {
 
-vespalib::stringref
-getPrefix(vespalib::stringref name ) {
-    return name.substr(0, name.find('.'));
-}
-
 void
 ensureLidSpace(SerialNum serialNum, DocumentIdT lid, AttributeVector &attr)
 {
@@ -237,7 +232,7 @@ public:
 
 FieldContext::FieldContext(ISequencedTaskExecutor &writer, AttributeVector *attr)
     :  _name(attr->getName()),
-       _executorId(writer.getExecutorId(getPrefix(_name))),
+       _executorId(writer.getExecutorId(attr->getNamePrefix()),
        _attr(attr)
 {
 }
@@ -488,7 +483,7 @@ AttributeWriter::AttributeWriter(const proton::IAttributeManager::SP &mgr)
 void AttributeWriter::setupAttriuteMapping() {
     for (auto attr : getWritableAttributes()) {
         vespalib::stringref name = attr->getName();
-        _attrMap[name] = AttrWithId(attr, _attributeFieldWriter.getExecutorId(getPrefix(name)));
+        _attrMap[name] = AttrWithId(attr, _attributeFieldWriter.getExecutorId(attr->getNamePrefix()));
     }    
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -86,6 +86,11 @@ AttributeWriter::WriteContext::buildFieldPaths(const DocumentType &docType)
 
 namespace {
 
+vespalib::stringref
+getPrefix(vespalib::stringref name ) {
+    return name.substr(0, name.find('.'));
+}
+
 void
 ensureLidSpace(SerialNum serialNum, DocumentIdT lid, AttributeVector &attr)
 {
@@ -232,7 +237,7 @@ public:
 
 FieldContext::FieldContext(ISequencedTaskExecutor &writer, AttributeVector *attr)
     :  _name(attr->getName()),
-       _executorId(writer.getExecutorId(_name)),
+       _executorId(writer.getExecutorId(getPrefix(_name))),
        _attr(attr)
 {
 }
@@ -480,8 +485,7 @@ AttributeWriter::AttributeWriter(const proton::IAttributeManager::SP &mgr)
     setupWriteContexts();
     for (auto attr : getWritableAttributes()) {
         vespalib::stringref name = attr->getName();
-        vespalib::stringref prefix = name.substr(0, name.find('.'));
-        _attrMap[attr->getName()] = AttrWithId(attr, _attributeFieldWriter.getExecutorId(prefix));
+        _attrMap[name] = AttrWithId(attr, _attributeFieldWriter.getExecutorId(getPrefix(name)));
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -232,7 +232,7 @@ public:
 
 FieldContext::FieldContext(ISequencedTaskExecutor &writer, AttributeVector *attr)
     :  _name(attr->getName()),
-       _executorId(writer.getExecutorId(attr->getNamePrefix()),
+       _executorId(writer.getExecutorId(attr->getNamePrefix())),
        _attr(attr)
 {
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
@@ -26,7 +26,6 @@ private:
     typedef document::FieldValue FieldValue;
     const IAttributeManager::SP _mgr;
     search::ISequencedTaskExecutor &_attributeFieldWriter;
-    const std::vector<search::AttributeVector *> &_writableAttributes;
     using ExecutorId = search::ISequencedTaskExecutor::ExecutorId;
 public:
     class WriteField
@@ -67,6 +66,7 @@ private:
     AttrMap                   _attrMap;
 
     void setupWriteContexts();
+    void setupAttriuteMapping();
     void buildFieldPaths(const DocumentType &docType, const DataType *dataType);
     void internalPut(SerialNum serialNum, const Document &doc, DocumentIdT lid,
                      bool immediateCommit, bool allAttributes, OnWriteDoneType onWriteDone);
@@ -77,13 +77,13 @@ public:
     AttributeWriter(const proton::IAttributeManager::SP &mgr);
     ~AttributeWriter();
 
+    /* Only for in tests that add attributes after AttributeWriter construction. */
+
     /**
      * Implements IAttributeWriter.
      */
-    std::vector<search::AttributeVector *>
-    getWritableAttributes() const override;
-    search::AttributeVector *
-    getWritableAttribute(const vespalib::string &name) const override;
+    std::vector<search::AttributeVector *> getWritableAttributes() const override;
+    search::AttributeVector *getWritableAttribute(const vespalib::string &name) const override;
     void put(SerialNum serialNum, const Document &doc, DocumentIdT lid,
              bool immediateCommit, OnWriteDoneType onWriteDone) override;
     void remove(SerialNum serialNum, DocumentIdT lid,

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
@@ -6,6 +6,7 @@
 #include <vespa/searchcore/proton/common/commit_time_tracker.h>
 #include <vespa/document/base/fieldpath.h>
 #include <vespa/searchlib/common/isequencedtaskexecutor.h>
+#include <vespa/vespalib/stllike/hash_map.h>
 
 namespace document { class DocumentType; }
 
@@ -58,9 +59,12 @@ public:
         bool hasStructFieldAttribute() const { return _hasStructFieldAttribute; }
     };
 private:
+    using AttrWithId = std::pair<search::AttributeVector *, ExecutorId>;
+    using AttrMap = vespalib::hash_map<vespalib::string, AttrWithId>;
     std::vector<WriteContext> _writeContexts;
     const DataType           *_dataType;
     bool                      _hasStructFieldAttribute;
+    AttrMap                   _attrMap;
 
     void setupWriteContexts();
     void buildFieldPaths(const DocumentType &docType, const DataType *dataType);

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -569,16 +569,15 @@ AttributeManager::getWritableAttributes() const
 
 
 void
-AttributeManager::asyncForEachAttribute(std::shared_ptr<IAttributeFunctor>
-                                        func) const
+AttributeManager::asyncForEachAttribute(std::shared_ptr<IAttributeFunctor> func) const
 {
     for (const auto &attr : _attributes) {
         if (attr.second.isExtra()) {
             continue;
         }
         AttributeVector::SP attrsp = attr.second.getAttribute();
-        _attributeFieldWriter.
-            execute(attr.first, [attrsp, func]() { (*func)(*attrsp); });
+        _attributeFieldWriter.execute(_attributeFieldWriter.getExecutorId(attrsp->getNamePrefix()),
+                                      [attrsp, func]() { (*func)(*attrsp); });
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -78,8 +78,8 @@ std::shared_ptr<ShrinkLidSpaceFlushTarget> allocShrinker(const AttributeVector::
     using Type = IFlushTarget::Type;
     using Component = IFlushTarget::Component;
 
+    auto shrinkwrap = std::make_shared<ThreadedCompactableLidSpace>(attr, attributeFieldWriter, attributeFieldWriter.getExecutorId(attr->getNamePrefix()));
     const vespalib::string &name = attr->getName();
-    auto shrinkwrap = std::make_shared<ThreadedCompactableLidSpace>(attr, attributeFieldWriter, attributeFieldWriter.getExecutorId(name));
     auto dir = diskLayout.createAttributeDir(name);
     search::SerialNum shrinkSerialNum = estimateShrinkSerialNum(*attr);
     return std::make_shared<ShrinkLidSpaceFlushTarget>("attribute.shrink." + name, Type::GC, Component::ATTRIBUTE, shrinkSerialNum, dir->getLastFlushTime(), shrinkwrap);

--- a/searchcore/src/vespa/searchcore/proton/attribute/exclusive_attribute_read_accessor.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/exclusive_attribute_read_accessor.cpp
@@ -37,8 +37,7 @@ ExclusiveAttributeReadAccessor(const AttributeVector::SP &attribute,
 namespace {
 
 void
-attributeWriteBlockingTask(GateSP entranceGate,
-                           GateSP exitGate)
+attributeWriteBlockingTask(GateSP entranceGate, GateSP exitGate)
 {
     entranceGate->countDown();
     exitGate->await();
@@ -51,9 +50,8 @@ ExclusiveAttributeReadAccessor::takeGuard()
 {
     GateSP entranceGate = std::make_shared<Gate>();
     GateSP exitGate = std::make_shared<Gate>();
-    _attributeFieldWriter.execute(_attribute->getName(),
-            [entranceGate, exitGate]()
-            { attributeWriteBlockingTask(entranceGate, exitGate); });
+    _attributeFieldWriter.execute(_attributeFieldWriter.getExecutorId(_attribute->getNamePrefix()),
+                                  [entranceGate, exitGate]() { attributeWriteBlockingTask(entranceGate, exitGate); });
     entranceGate->await();
     return std::make_unique<Guard>(*_attribute, exitGate);
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
@@ -197,9 +197,8 @@ FilterAttributeManager::asyncForEachAttribute(std::shared_ptr<IAttributeFunctor>
         search::AttributeVector::SP attrsp = guard.getSP();
         // Name must be extracted in document db master thread or attribute
         // writer thread
-        vespalib::string attributeName = attrsp->getName();
-        attributeFieldWriter.
-            execute(attributeName, [attrsp, func]() { (*func)(*attrsp); });
+        attributeFieldWriter.execute(attributeFieldWriter.getExecutorId(attrsp->getNamePrefix()),
+                                     [attrsp, func]() { (*func)(*attrsp); });
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -243,10 +243,8 @@ FlushableAttribute::initFlush(SerialNum currentSerial)
     // Called by document db executor
     std::promise<IFlushTarget::Task::UP> promise;
     std::future<IFlushTarget::Task::UP> future = promise.get_future();
-    _attributeFieldWriter.execute(_attr->getName(),
-                                  [&]() { promise.set_value(
-                                              internalInitFlush(currentSerial));
-                                         });
+    _attributeFieldWriter.execute(_attributeFieldWriter.getExecutorId(_attr->getNamePrefix()),
+                                  [&]() { promise.set_value(internalInitFlush(currentSerial)); });
     return future.get();
 }
 
@@ -256,6 +254,5 @@ FlushableAttribute::getApproxBytesToWriteToDisk() const
 {
     return _attr->getEstimatedSaveByteSize();
 }
-
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_listener.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_listener.cpp
@@ -12,7 +12,7 @@ GidToLidChangeListener::GidToLidChangeListener(search::ISequencedTaskExecutor &a
                                                const vespalib::string &name,
                                                const vespalib::string &docTypeName)
     : _attributeFieldWriter(attributeFieldWriter),
-      _executorId(_attributeFieldWriter.getExecutorId(attr->getName())),
+      _executorId(_attributeFieldWriter.getExecutorId(attr->getNamePrefix())),
       _attr(std::move(attr)),
       _refCount(refCount),
       _name(name),

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -32,8 +32,7 @@ using search::index::DummyFileHeaderContext;
 using search::attribute::BasicType;
 using search::attribute::IAttributeVector;
 
-namespace
-{
+namespace {
 
 vespalib::string empty;
 vespalib::string tmpDir("tmp");
@@ -2315,6 +2314,23 @@ AttributeTest::testPendingCompaction()
     populateSimple(iv, 1, 2);  // should not trigger new compaction
 }
 
+void testNamePrefix() {
+    Config cfg(BasicType::INT32, CollectionType::SINGLE);
+    AttributeVector::SP vFlat = createAttribute("sfsint32_pc", cfg);
+    AttributeVector::SP vS1 = createAttribute("sfsint32_pc.abc", cfg);
+    AttributeVector::SP vS2 = createAttribute("sfsint32_pc.xyz", cfg);
+    AttributeVector::SP vSS1 = createAttribute("sfsint32_pc.xyz.abc", cfg);
+    EXPECT_EQUAL("sfsint32_pc", vFlat->getName());
+    EXPECT_EQUAL("sfsint32_pc", vFlat->getNamePrefix());
+    EXPECT_EQUAL("sfsint32_pc.abc", vS1->getName());
+    EXPECT_EQUAL("sfsint32_pc", vS1->getNamePrefix());
+    EXPECT_EQUAL("sfsint32_pc.xyz", vS2->getName());
+    EXPECT_EQUAL("sfsint32_pc", vS2->getNamePrefix());
+    EXPECT_EQUAL("sfsint32_pc.xyz.abc", vSS1->getName());
+    EXPECT_EQUAL("sfsint32_pc", vSS1->getNamePrefix());
+
+}
+
 void
 deleteDataDirs()
 {
@@ -2361,6 +2377,7 @@ int AttributeTest::Main()
     TEST_DO(requireThatAddressSpaceUsageIsReported());
     testReaderDuringLastUpdate();
     TEST_DO(testPendingCompaction());
+    TEST_DO(testNamePrefix());
 
     deleteDataDirs();
     TEST_DONE();

--- a/searchlib/src/tests/common/sequencedtaskexecutor/sequencedtaskexecutor_test.cpp
+++ b/searchlib/src/tests/common/sequencedtaskexecutor/sequencedtaskexecutor_test.cpp
@@ -122,8 +122,8 @@ TEST_F("require that task with same string component id are serialized", Fixture
     std::shared_ptr<TestObj> tv(std::make_shared<TestObj>());
     EXPECT_EQUAL(0, tv->_val);
     auto test2 = [=]() { tv->modify(14, 42); };
-    f._threads.execute("0", [=]() { usleep(2000); tv->modify(0, 14); });
-    f._threads.execute("0", test2);
+    f._threads.execute(f._threads.getExecutorId("0"), [=]() { usleep(2000); tv->modify(0, 14); });
+    f._threads.execute(f._threads.getExecutorId("0"), test2);
     tv->wait(2);
     EXPECT_EQUAL(0,  tv->_fail);
     EXPECT_EQUAL(42, tv->_val);
@@ -132,8 +132,7 @@ TEST_F("require that task with same string component id are serialized", Fixture
     EXPECT_EQUAL(42, tv->_val);
 }
 
-namespace
-{
+namespace {
 
 int detectSerializeFailure(Fixture &f, vespalib::stringref altComponentId, int tryLimit)
 {
@@ -141,8 +140,8 @@ int detectSerializeFailure(Fixture &f, vespalib::stringref altComponentId, int t
     for (tryCnt = 0; tryCnt < tryLimit; ++tryCnt) {
         std::shared_ptr<TestObj> tv(std::make_shared<TestObj>());
         EXPECT_EQUAL(0, tv->_val);
-        f._threads.execute("0", [=]() { usleep(2000); tv->modify(0, 14); });
-        f._threads.execute(altComponentId, [=]() { tv->modify(14, 42); });
+        f._threads.execute(f._threads.getExecutorId("0"), [=]() { usleep(2000); tv->modify(0, 14); });
+        f._threads.execute(f._threads.getExecutorId(altComponentId), [=]() { tv->modify(14, 42); });
         tv->wait(2);
         if (tv->_fail != 1) {
              continue;

--- a/searchlib/src/vespa/searchlib/common/isequencedtaskexecutor.h
+++ b/searchlib/src/vespa/searchlib/common/isequencedtaskexecutor.h
@@ -89,14 +89,14 @@ public:
      * call sync before tearing down pointed to/referenced data.
      * All tasks must be scheduled from same thread.
      *
-     * @param componentId   component id
-     * @param function      function to be wrapped in a task and later executed
+     * @param id        executor id
+     * @param function  function to be wrapped in a task and later executed
      */
     template <class FunctionType>
-    void execute(vespalib::stringref componentId, FunctionType &&function) {
-        ExecutorId id = getExecutorId(componentId);
+    void execute(ExecutorId id, FunctionType &&function) {
         executeTask(id, vespalib::makeLambdaTask(std::forward<FunctionType>(function)));
     }
+
 };
 
 } // namespace search


### PR DESCRIPTION
…ashmap.

the executor id so complex fields use the same executor.
@toregge and @geirst PR