### PR TITLE
Reuse allocation decisions

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSession.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSession.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.session;
 
+import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.provision.*;
 import com.yahoo.lang.SettableOptional;
 import com.yahoo.vespa.config.server.*;
@@ -54,10 +55,15 @@ public class RemoteSession extends Session {
     }
 
     private ApplicationSet loadApplication() {
+        ApplicationPackage applicationPackage = zooKeeperClient.loadApplicationPackage();
+
+        // Read hosts allocated on the config server instance which created this
+        Optional<AllocatedHosts> allocatedHosts = applicationPackage.getAllocatedHosts();
+
         return ApplicationSet.fromList(applicationLoader.buildModels(zooKeeperClient.readApplicationId(),
                                                                      zooKeeperClient.readVespaVersion(),
                                                                      zooKeeperClient.loadApplicationPackage(),
-                                                                     new SettableOptional<>(),
+                                                                     new SettableOptional<>(allocatedHosts),
                                                                      clock.instant()));
     }
 

--- a/vespajlib/src/main/java/com/yahoo/lang/SettableOptional.java
+++ b/vespajlib/src/main/java/com/yahoo/lang/SettableOptional.java
@@ -19,6 +19,11 @@ public final class SettableOptional<T> {
     /** Creates a new settable optional with the given value */
     public SettableOptional(T value) { this.value = value; }
 
+    /** Creates a new settable optional with the given value, or an empty */
+    public SettableOptional(Optional<T> value) {
+        this.value = value.isPresent() ? value.get() : null;
+    }
+
     public boolean isPresent() {
         return value != null;
     }


### PR DESCRIPTION
During deployment we first prepare the application on one config server
then notifies the other config servers (by setting state=PREPARED)
that they should load it. That will cause allocation requests against
the node repo to be done once over on the those config servers.
These simultaneous requests against the node repo may cause ut
to time out waiting for the node repo's application lock if
these requests take a somewhat long time.

This change reads existing allocations instead of redoing
allocation requests against the node repo. The existing allocation
is saved (on the first config server) before state=PREPARED is set.

@hmusum please review