### PR TITLE
Reduce default feeding.concurrency from 0.5 to 0.2.

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -467,7 +467,7 @@ hwinfo.cpu.cores int default = 0 restart
 ##   max(ceil(hwinfo.cpu.cores * feeding.concurrency), summary.log.numthreads)
 ## The number of threads in each of pools 2-4 is calculated as:
 ##   max(ceil((hwinfo.cpu.cores * feeding.concurrency)/3), indexing.threads)
-feeding.concurrency double default = 0.5 restart
+feeding.concurrency double default = 0.2 restart
 
 ## Adjustment to resource limit when determining if maintenance jobs can run.
 ##


### PR DESCRIPTION
This should reduce problems with query latency spikes during re-distribution of data.

@baldersheim please review
@toregge FYI