### PR TITLE
Log config changes from Bouncer component

### DIFF
--- a/storage/src/vespa/storage/storageserver/CMakeLists.txt
+++ b/storage/src/vespa/storage/storageserver/CMakeLists.txt
@@ -8,6 +8,7 @@ vespa_add_library(storage_storageserver
     communicationmanager.cpp
     communicationmanagermetrics.cpp
     configurable_bucket_resolver.cpp
+    config_logging.cpp
     distributornode.cpp
     distributornodecontext.cpp
     documentapiconverter.cpp

--- a/storage/src/vespa/storage/storageserver/bouncer.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer.cpp
@@ -2,6 +2,7 @@
 
 #include "bouncer.h"
 #include "bouncer_metrics.h"
+#include "config_logging.h"
 #include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/storageapi/message/state.h>
 #include <vespa/storageapi/message/persistence.h>
@@ -69,6 +70,7 @@ Bouncer::onClose()
 void
 Bouncer::configure(std::unique_ptr<vespa::config::content::core::StorBouncerConfig> config)
 {
+    log_config_received(*config);
     validateConfig(*config);
     vespalib::LockGuard lock(_lock);
     _config = std::move(config);

--- a/storage/src/vespa/storage/storageserver/config_logging.cpp
+++ b/storage/src/vespa/storage/storageserver/config_logging.cpp
@@ -1,0 +1,22 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "config_logging.h"
+#include <vespa/config/configgen/configinstance.h>
+#include <vespa/config/print/configdatabuffer.h>
+#include <vespa/vespalib/data/slime/slime.h>
+
+#include <vespa/log/log.h>
+
+LOG_SETUP(".storageserver.config_logging");
+
+namespace storage {
+
+void log_config_received(const config::ConfigInstance& cfg) {
+    if (LOG_WOULD_LOG(debug)) {
+        config::ConfigDataBuffer buf;
+        cfg.serialize(buf);
+        LOG(debug, "Received new %s config: %s", cfg.defName().c_str(), buf.slimeObject().toString().c_str());
+    }
+}
+
+}

--- a/storage/src/vespa/storage/storageserver/config_logging.h
+++ b/storage/src/vespa/storage/storageserver/config_logging.h
@@ -1,0 +1,11 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace config { class ConfigInstance; }
+
+namespace storage {
+
+void log_config_received(const config::ConfigInstance& cfg);
+
+}

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "config_logging.h"
 #include "storagenode.h"
 #include "communicationmanager.h"
 #include "statemanager.h"
@@ -16,7 +17,6 @@
 #include <fcntl.h>
 
 #include <vespa/log/log.h>
-#include <vespa/config/print/configdatabuffer.h>
 
 LOG_SETUP(".node.server");
 
@@ -466,18 +466,6 @@ StorageNode::shutdown()
     }
 
     LOG(debug, "Done shutting down node");
-}
-
-namespace {
-
-void log_config_received(const config::ConfigInstance& cfg) {
-    if (LOG_WOULD_LOG(debug)) {
-        config::ConfigDataBuffer buf;
-        cfg.serialize(buf);
-        LOG(debug, "Received new %s config: %s", cfg.defName().c_str(), buf.getEncodedString().c_str());
-    }
-}
-
 }
 
 void StorageNode::configure(std::unique_ptr<StorServerConfig> config) {


### PR DESCRIPTION
@geirst please review. Followup from yesterday's PR.

Also change debug output to be Slime structure, since the encoded
string does not seem to have had the intended semantics.