### PR TITLE
Java 9: Truncate Instants from Instant.now() to MILLIS

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
@@ -13,8 +13,10 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.function.Supplier;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -50,13 +52,13 @@ public class DeploymentMetricsMaintainerTest {
         assertEquals(3, deployment.get().metrics().documentCount(), Double.MIN_VALUE);
         assertEquals(4, deployment.get().metrics().queryLatencyMillis(), Double.MIN_VALUE);
         assertEquals(5, deployment.get().metrics().writeLatencyMillis(), Double.MIN_VALUE);
-        Instant t1 = tester.clock().instant();
+        Instant t1 = tester.clock().instant().truncatedTo(MILLIS);
         assertEquals(t1, deployment.get().activity().lastQueried().get());
         assertEquals(t1, deployment.get().activity().lastWritten().get());
 
         // Time passes. Activity is updated as app is still receiving traffic
         tester.clock().advance(Duration.ofHours(1));
-        Instant t2 = tester.clock().instant();
+        Instant t2 = tester.clock().instant().truncatedTo(MILLIS);
         maintainer.maintain();
         assertEquals(t2, deployment.get().activity().lastQueried().get());
         assertEquals(t2, deployment.get().activity().lastWritten().get());
@@ -65,7 +67,7 @@ public class DeploymentMetricsMaintainerTest {
 
         // Query traffic disappears. Query activity stops updating
         tester.clock().advance(Duration.ofHours(1));
-        Instant t3 = tester.clock().instant();
+        Instant t3 = tester.clock().instant().truncatedTo(MILLIS);
         tester.metricsService().setMetric("queriesPerSecond", 0D);
         tester.metricsService().setMetric("writesPerSecond", 5D);
         maintainer.maintain();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.function.Supplier;
 
 import static java.time.temporal.ChronoUnit.MILLIS;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializerTest.java
@@ -10,11 +10,13 @@ import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -46,7 +48,7 @@ public class VersionStatusSerializerTest {
             VespaVersion a = status.versions().get(i);
             VespaVersion b = deserialized.versions().get(i);
             assertEquals(a.releaseCommit(), b.releaseCommit());
-            assertEquals(a.committedAt(), b.committedAt());
+            assertEquals(a.committedAt().truncatedTo(MILLIS), b.committedAt());
             assertEquals(a.isControllerVersion(), b.isControllerVersion());
             assertEquals(a.isSystemVersion(), b.isSystemVersion());
             assertEquals(a.statistics(), b.statistics());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializerTest.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SerializationTest.java
@@ -24,11 +24,13 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -93,7 +95,7 @@ public class SerializationTest {
         assertEquals(node.allocation().get().membership(), copy.allocation().get().membership());
         assertEquals(node.allocation().get().isRemovable(), copy.allocation().get().isRemovable());
         assertEquals(1, copy.history().events().size());
-        assertEquals(clock.instant(), copy.history().event(History.Event.Type.reserved).get().at());
+        assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().event(History.Event.Type.reserved).get().at());
         assertEquals(NodeType.tenant, copy.type());
     }
 
@@ -170,7 +172,7 @@ public class SerializationTest {
         node = node.retire(Agent.application, clock.instant());
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
         assertEquals(2, copy.history().events().size());
-        assertEquals(clock.instant(), copy.history().event(History.Event.Type.retired).get().at());
+        assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().event(History.Event.Type.retired).get().at());
         assertEquals(Agent.application,
                      (copy.history().event(History.Event.Type.retired).get()).agent());
         assertTrue(copy.allocation().get().membership().retired());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -34,7 +34,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -34,6 +34,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -45,6 +46,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -736,11 +738,12 @@ public class ProvisioningTest {
                                     "default", tester);
         List<Node> reserved = tester.getNodes(application, Node.State.reserved).asList();
         assertEquals("Reserved required nodes", 4, reserved.size());
-        assertTrue("Time of event is updated for all nodes", reserved.stream()
-                                                                     .allMatch(n -> n.history()
-                                                                                     .event(History.Event.Type.reserved)
-                                                                                     .get().at()
-                                                                                     .equals(tester.clock().instant())));
+        assertTrue("Time of event is updated for all nodes",
+                   reserved.stream()
+                           .allMatch(n -> n.history()
+                           .event(History.Event.Type.reserved)
+                           .get().at()
+                           .equals(tester.clock().instant().truncatedTo(MILLIS))));
 
         // Over 10 minutes pass since first reservation. First set of reserved nodes are not expired
         tester.clock().advance(Duration.ofMinutes(8).plus(Duration.ofSeconds(1)));


### PR DESCRIPTION
I'm not sure if this is the correct way to fix it. It would probably be better if serialization/deserialization preserved the full precision of the clock, but I wasn't able to dig into how/where to fix it.

- JDK 9 has higher resolution for Instant.now() than JDK 1.8, while
  instants deserialized from slime only has ms resolution.