### PR TITLE
add ContainerLatencySearcher

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
@@ -42,7 +42,8 @@ public class LocalProviderSpec {
                             com.yahoo.prelude.searcher.ValidatePredicateSearcher.class,
                             com.yahoo.search.searchers.ValidateMatchPhaseSearcher.class,
                             com.yahoo.search.yql.FieldFiller.class,
-                            com.yahoo.search.searchers.InputCheckingSearcher.class);
+                            com.yahoo.search.searchers.InputCheckingSearcher.class,
+                            com.yahoo.search.searchers.ContainerLatencySearcher.class);
 
     public final String clusterName;
 

--- a/container-search/src/main/java/com/yahoo/search/searchers/ContainerLatencySearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ContainerLatencySearcher.java
@@ -1,0 +1,40 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.searchers;
+
+import com.yahoo.component.chain.dependencies.After;
+import com.yahoo.metrics.simple.Gauge;
+import com.yahoo.metrics.simple.Point;
+import com.yahoo.metrics.simple.PointBuilder;
+import com.yahoo.metrics.simple.MetricReceiver;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.searchchain.PhaseNames;
+
+/**
+ * Measure latency in container before query is sent to backend
+ *
+ * @author Arne H Juul
+ */
+@After(PhaseNames.BACKEND)
+public class ContainerLatencySearcher extends Searcher {
+    private final Gauge latencyGauge;
+    private Point dims = null;
+
+    public ContainerLatencySearcher(MetricReceiver metrics) {
+        latencyGauge = metrics.declareGauge("query_container_latency");
+    }
+
+    @Override
+    public Result search(Query query, Execution execution) {
+        if (dims == null) {
+            PointBuilder p = latencyGauge.builder();
+            p.set("chain", execution.chain().getId().stringValue());
+            dims = p.build();
+        }
+        latencyGauge.sample(query.getDurationTime(), dims);
+        return execution.search(query);
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/searchers/ContainerLatencySearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ContainerLatencySearcher.java
@@ -20,7 +20,6 @@ import com.yahoo.search.searchchain.PhaseNames;
 @After(PhaseNames.BACKEND)
 public class ContainerLatencySearcher extends Searcher {
     private final Gauge latencyGauge;
-    private Point dims = null;
 
     public ContainerLatencySearcher(MetricReceiver metrics) {
         latencyGauge = metrics.declareGauge("query_container_latency");
@@ -28,11 +27,9 @@ public class ContainerLatencySearcher extends Searcher {
 
     @Override
     public Result search(Query query, Execution execution) {
-        if (dims == null) {
-            PointBuilder p = latencyGauge.builder();
-            p.set("chain", execution.chain().getId().stringValue());
-            dims = p.build();
-        }
+        Point dims = latencyGauge.builder()
+                .set("chain", execution.chain().getId().stringValue())
+                .build();
         latencyGauge.sample(query.getDurationTime(), dims);
         return execution.search(query);
     }


### PR DESCRIPTION
@jobergum please check if this looks like what you wanted
@bratseth please review - I would like to have some more constraints in searchers to ensure that this one is really "just before clustersearcher", the best i could think of was to specify that it's "part of" the backend in the "After" annotation.
