### PR TITLE
Gjoranv/java9 prep 12

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -88,6 +88,7 @@
                                                 <include>com.google.inject.extensions:guice-assistedinject:[${guice.version}]:jar:provided</include>
                                                 <include>com.google.inject.extensions:guice-multibindings:[${guice.version}]:jar:provided</include>
                                                 <include>com.google.inject:guice:[${guice.version}]:jar:provided:no_aop</include>
+                                                <include>com.sun.activation:javax.activation:jar[1.2.0]:jar:provided</include>
                                                 <include>commons-codec:commons-codec:[1.4]:jar:provided</include>
                                                 <include>commons-daemon:commons-daemon:[1.0.3]:jar:provided</include>
                                                 <include>commons-logging:commons-logging:[1.1.1]:jar:provided</include>
@@ -96,6 +97,7 @@
                                                 <include>javax.servlet:javax.servlet-api:[3.1.0]:jar:provided</include>
                                                 <include>javax.validation:validation-api:[${javax.validation-api.version}]:jar:provided</include>
                                                 <include>javax.ws.rs:javax.ws.rs-api:[${javax.ws.rs-api.version}]:jar:provided</include>
+                                                <include>javax.xml.bind:jaxb-api:[${jaxb.version}]:jar:provided</include>
                                                 <include>net.jcip:jcip-annotations:[1.0]:jar:provided</include>
                                                 <include>net.jpountz.lz4:lz4:[1.3.0]:jar:provided</include>
                                                 <include>org.apache.felix:org.apache.felix.framework:[${felix.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -186,7 +186,7 @@
                 <version>${javax.ws.rs-api.version}</version>
             </dependency>
 
-            <!-- TODO: upgrade jaxb-api artifacts to >=2.3.0. Note that from 2.3, these are OSGi bundles.
+            <!-- TODO: upgrade jaxb-api artifacts to >=2.3.0.
             See https://stackoverflow.com/questions/50237516/proper-fix-for-java-10-complaining-about-illegal-reflection-access-by-jaxb-impl  -->
             <dependency>
                 <groupId>javax.xml.bind</groupId>
@@ -204,10 +204,11 @@
                 <version>${jaxb.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>javax.activation-api</artifactId>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>javax.activation</artifactId>
                 <version>1.2.0</version>
             </dependency>
+            <!-- jaxb end -->
 
             <dependency>
                 <groupId>net.jcip</groupId>
@@ -463,7 +464,7 @@
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>18.0</guava.version>
         <guice.version>3.0</guice.version>
-        <jaxb.version>2.2.7</jaxb.version>
+        <jaxb.version>2.3.0</jaxb.version>
         <jetty.version>9.4.10.v20180503</jetty.version>
         <scala.version>2.11.12</scala.version>  <!-- When updating this, the scala.major-version in parent must also be updated! -->
         <slf4j.version>1.7.5</slf4j.version>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -16,6 +16,17 @@
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <dependencies>
+        <!-- Necessary for jaxb support from java 9. (Could be deployed as bundles since 2.2.11.) -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+        </dependency>
+        <!-- jaxb end -->
+
         <dependency>
             <!-- Newer version than the one in rt.jar, including the ElementTraversal class needed by Xerces (Aug 2015, still valid Sep 2017) -->
             <groupId>xml-apis</groupId>
@@ -228,6 +239,8 @@
                                 <argument>${project.build.directory}/dependency/log4j-over-slf4j.jar</argument>
                                 <argument>${project.build.directory}/dependency/config-lib.jar</argument>
                                 <argument>${project.build.directory}/dependency/yolean.jar</argument>
+                                <argument>${project.build.directory}/dependency/jaxb-api.jar</argument>
+                                <argument>${project.build.directory}/dependency/javax.activation.jar</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
@@ -38,9 +38,11 @@ public class ExportPackages {
            .append("javax.inject;version=1.0.0,")  // Included in guice, but not exported. Needed by container-jersey.
            .append("org.aopalliance.intercept,")
            .append("org.aopalliance.aop,")
+           .append("sun.misc,")
+           .append("sun.net.util,")
+           .append("sun.security.krb5,")
 
-           // xml-apis:xml-apis:1.4.01 is not a bundle
-           .append("org.w3c.dom,")
+           // TODO: remove for Vespa 7 (xml-apis:xml-apis:1.4.01 is not a bundle, but exposed from system classpath on Java 9)
            .append("org.w3c.dom.bootstrap,")
            .append("org.w3c.dom.css,")
            .append("org.w3c.dom.events,")
@@ -49,11 +51,8 @@ public class ExportPackages {
            .append("org.w3c.dom.ranges,")
            .append("org.w3c.dom.stylesheets,")
            .append("org.w3c.dom.traversal,")
-           .append("org.w3c.dom.views,")
+           .append("org.w3c.dom.views");
 
-           .append("sun.misc,")
-           .append("sun.net.util,")
-           .append("sun.security.krb5");
         for (int i = 1; i < args.length; ++i) {
             out.append(",").append(getExportedPackages(args[i]));
         }

--- a/jdisc_core_test/integration_test/pom.xml
+++ b/jdisc_core_test/integration_test/pom.xml
@@ -230,12 +230,32 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>java9-surefire</id>
+            <activation>
+                <jdk>[9, )</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <!-- Allow installing fragment bundles, see felix.framework:ExtensionManager.addExtensionBundle -->
+                                <argLine>
+                                    --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
+                                </argLine>
+                             </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/jdisc_core_test/test_bundles/cert-k-pkgs/pom.xml
+++ b/jdisc_core_test/test_bundles/cert-k-pkgs/pom.xml
@@ -14,13 +14,6 @@
     <version>6-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>${project.artifactId}</name>
-    <dependencies>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/jdisc_core_test/test_bundles/cert-k-pkgs/src/main/java/com/yahoo/jdisc/bundle/k/CertificateK.java
+++ b/jdisc_core_test/test_bundles/cert-k-pkgs/src/main/java/com/yahoo/jdisc/bundle/k/CertificateK.java
@@ -112,12 +112,6 @@ public class CertificateK {
     private final javax.tools.FileObject fileObject = null;
     private final javax.transaction.xa.XAException xaException = null;
     private final javax.xml.XMLConstants xmlConstants = null;
-    private final javax.xml.bind.DataBindingException dataBindingException = null;
-    private final javax.xml.bind.annotation.DomHandler<?,?> domHandler = null;
-    private final javax.xml.bind.annotation.adapters.CollapsedStringAdapter collapsedStringAdapter = null;
-    private final javax.xml.bind.attachment.AttachmentMarshaller attachmentMarshaller = null;
-    private final javax.xml.bind.helpers.AbstractMarshallerImpl abstractMarshaller = null;
-    private final javax.xml.bind.util.JAXBResult jaxbResult = null;
     private final javax.xml.crypto.AlgorithmMethod algorithmMethod = null;
     private final javax.xml.crypto.dom.DOMCryptoContext domCryptoContext = null;
     private final javax.xml.crypto.dsig.CanonicalizationMethod canonicalizationMethod = null;
@@ -174,8 +168,23 @@ public class CertificateK {
     private final org.xml.sax.ext.Attributes2Impl attributes2 = null;
     private final org.xml.sax.helpers.AttributesImpl attributes = null;
 
+
     // Packages made invisible from Java 9
-//    private final javax.activation.CommandInfo commandInfo = null;
+
+    // Added as dep in jdisc_core: com.sun.activation:javax.activation (OSGi bundle)
+    private final javax.activation.CommandInfo commandInfo = null;
+
+    // Added as dep in jdisc_core: javax.xml.bind:jaxb-api (OSGi bundle)
+    private final javax.xml.bind.DataBindingException dataBindingException = null;
+    private final javax.xml.bind.annotation.DomHandler<?,?> domHandler = null;
+    private final javax.xml.bind.annotation.adapters.CollapsedStringAdapter collapsedStringAdapter = null;
+    private final javax.xml.bind.attachment.AttachmentMarshaller attachmentMarshaller = null;
+    private final javax.xml.bind.helpers.AbstractMarshallerImpl abstractMarshaller = null;
+    private final javax.xml.bind.util.JAXBResult jaxbResult = null;
+
+
+    // Packages that most likely won't be provided from JDisc from Vespa 7
+
 //    private final javax.activity.ActivityCompletedException activityCompletedException = null;
 //    private final javax.jws.HandlerChain handlerChain = null;
 //    private final javax.jws.soap.SOAPBinding soapBinding = null;


### PR DESCRIPTION
With this PR, all vespa unit tests pass on JDK 9.