### PR TITLE
Make sure to build config model for wanted vespa version as well

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
@@ -95,6 +95,11 @@ public final class PrepareParams {
             return this;
         }
 
+        public Builder vespaVersion(com.yahoo.config.provision.Version vespaVersion) {
+            this.vespaVersion = Optional.ofNullable(Version.fromString(vespaVersion.toSerializedForm()));
+            return this;
+        }
+
         public Builder rotations(String rotationsString) {
             this.rotations = new LinkedHashSet<>();
             if (rotationsString != null && !rotationsString.isEmpty()) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
@@ -23,7 +23,6 @@ import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;
 import com.yahoo.vespa.model.VespaModelFactory;
 
-import java.io.File;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Optional;
@@ -155,7 +154,7 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
             final PermanentApplicationPackage permApp = this.permanentApplicationPackage
                     .orElse(new PermanentApplicationPackage(configserverConfig));
             FileDistributionFactory fileDistributionFactory = this.fileDistributionFactory
-                    .orElse(new MockFileDistributionFactory(new File(configserverConfig.fileReferencesDir())));
+                    .orElse(new MockFileDistributionFactory(configserverConfig));
             HostProvisionerProvider hostProvisionerProvider = hostProvisioner.isPresent() ?
                     HostProvisionerProvider.withProvisioner(hostProvisioner.get()) :
                     HostProvisionerProvider.empty();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/MockFileDistributionFactory.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/MockFileDistributionFactory.java
@@ -14,9 +14,9 @@ public class MockFileDistributionFactory extends FileDistributionFactory {
 
     public final MockFileDistributionProvider mockFileDistributionProvider;
 
-    public MockFileDistributionFactory(File fileReferencesDir) {
-        super(new ConfigserverConfig(new ConfigserverConfig.Builder()));
-        mockFileDistributionProvider = new MockFileDistributionProvider(fileReferencesDir);
+    public MockFileDistributionFactory(ConfigserverConfig configserverConfig) {
+        super(configserverConfig);
+        mockFileDistributionProvider = new MockFileDistributionProvider(new File(configserverConfig.fileReferencesDir()));
     }
 
     @Override


### PR DESCRIPTION
When we build the needed config model versions based on
versions used on allocated hosts:
Add wanted vespa version to the set of models to be built, since
this is needed when wanted vespa version is not the latest vespa version
and there are no nodes having the wanted vespa version.