### PR TITLE
Avoid fatal first CC request timeout

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorContext.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorContext.java
@@ -26,10 +26,6 @@ public class OrchestratorContext {
         return timeBudget.originalTimeout().get().getSeconds();
     }
 
-    public float getSuboperationTimeoutInSeconds() {
-        return getSuboperationTimeoutInSeconds(60);
-    }
-
     /**
      * Get timeout for a suboperation that should take up {@code shareOfRemaining} of the
      * remaining time, or throw an {@link UncheckedTimeoutException} if timed out.

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorContext.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorContext.java
@@ -26,11 +26,19 @@ public class OrchestratorContext {
         return timeBudget.originalTimeout().get().getSeconds();
     }
 
-    /**
-     * Get number of seconds until the deadline, or empty if there's no deadline, or throw
-     * an {@link UncheckedTimeoutException} if timed out.
-     */
     public float getSuboperationTimeoutInSeconds() {
-        return (float) (timeBudget.timeLeftOrThrow().get().toMillis() / 1000.0);
+        return getSuboperationTimeoutInSeconds(60);
+    }
+
+    /**
+     * Get timeout for a suboperation that should take up {@code shareOfRemaining} of the
+     * remaining time, or throw an {@link UncheckedTimeoutException} if timed out.
+     */
+    public float getSuboperationTimeoutInSeconds(float shareOfRemaining) {
+        if (!(0f <= shareOfRemaining && shareOfRemaining <= 1.0f)) {
+            throw new IllegalArgumentException("Share of remaining time must be between 0 and 1: " + shareOfRemaining);
+        }
+
+        return shareOfRemaining * timeBudget.timeLeftOrThrow().get().toMillis() / 1000.0f;
     }
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerClientImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerClientImpl.java
@@ -30,7 +30,7 @@ public class ClusterControllerClientImpl implements ClusterControllerClient{
     //   timeout(3. request) = T * 0.125
     //
     // which seems fine
-    public static final float SHARE_REMAINING_TIME = 0.6f;
+    public static final float SHARE_REMAINING_TIME = 0.5f;
 
     private final JaxRsStrategy<ClusterControllerJaxRsApi> clusterControllerApi;
     private final String clusterName;

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerClientTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerClientTest.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.jaxrs.client.LocalPassThroughJaxRsStrategy;
 import com.yahoo.vespa.orchestrator.OrchestratorContext;
 import org.junit.Test;
 
+import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -27,7 +28,7 @@ public class ClusterControllerClientTest {
         final ClusterControllerNodeState wantedState = ClusterControllerNodeState.MAINTENANCE;
 
         OrchestratorContext context = mock(OrchestratorContext.class);
-        when(context.getSuboperationTimeoutInSeconds()).thenReturn(1.0f);
+        when(context.getSuboperationTimeoutInSeconds(anyFloat())).thenReturn(1.0f);
         clusterControllerClient.setNodeState(context, STORAGE_NODE_INDEX, wantedState);
 
         final ClusterControllerStateRequest expectedNodeStateRequest = new ClusterControllerStateRequest(

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/controller/SingleInstanceClusterControllerClientFactoryTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/controller/SingleInstanceClusterControllerClientFactoryTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
@@ -66,7 +67,7 @@ public class SingleInstanceClusterControllerClientFactoryTest {
     public void testCreateClientWithSingleClusterControllerInstance() throws Exception {
         final List<HostName> clusterControllers = Arrays.asList(HOST_NAME_1);
 
-        when(context.getSuboperationTimeoutInSeconds()).thenReturn(1.0f);
+        when(context.getSuboperationTimeoutInSeconds(anyFloat())).thenReturn(1.0f);
         clientFactory.createClient(clusterControllers, "clusterName")
                 .setNodeState(context, 0, ClusterControllerNodeState.MAINTENANCE);
 
@@ -94,7 +95,7 @@ public class SingleInstanceClusterControllerClientFactoryTest {
     public void testCreateClientWithThreeClusterControllerInstances() throws Exception {
         final List<HostName> clusterControllers = Arrays.asList(HOST_NAME_1, HOST_NAME_2, HOST_NAME_3);
 
-        when(context.getSuboperationTimeoutInSeconds()).thenReturn(1.0f);
+        when(context.getSuboperationTimeoutInSeconds(anyFloat())).thenReturn(1.0f);
         clientFactory.createClient(clusterControllers, "clusterName")
                 .setNodeState(context, 0, ClusterControllerNodeState.MAINTENANCE);
 


### PR DESCRIPTION
If the first setNodeState to the "first" cluster controller times out, then
we'd like to leave enough time to try the second CC. This avoids making a
single CC a single point of failure.

The strategy is to set a timeout of 50% of the remaining time, so if everything
times out the timeouts would roughly be 50%, 25%, and 12.5% of original
timeout.

An alternative strategy would be to use 33% for each, which would be more
democratic.