### PR TITLE
Ensure that all attribute iterators expose the search context creatin…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/search_context.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/search_context.cpp
@@ -36,8 +36,9 @@ private:
 protected:
     const DocumentMetaStore & _store;
 public:
-    GidAllSearchIterator(TermFieldMatchData *matchData, const DocumentMetaStore &store)
-        : AttributeIteratorBase(matchData),
+    GidAllSearchIterator(const search::attribute::ISearchContext &baseSearchCtx,
+                         TermFieldMatchData *matchData, const DocumentMetaStore &store)
+        : AttributeIteratorBase(baseSearchCtx, matchData),
           _store(store)
     {
     }
@@ -64,9 +65,10 @@ private:
     }
 
 public:
-    GidStrictAllSearchIterator(TermFieldMatchData *matchData,
+    GidStrictAllSearchIterator(const search::attribute::ISearchContext &baseSearchCtx,
+                               TermFieldMatchData *matchData,
                                const DocumentMetaStore &store)
-        : GidAllSearchIterator(matchData, store),
+        : GidAllSearchIterator(baseSearchCtx, matchData, store),
           _numDocs(store.getNumDocs())
     {
     }
@@ -88,8 +90,9 @@ private:
         }
     }
 public:
-    GidSearchIterator(TermFieldMatchData *matchData, const DocumentMetaStore &store, const GlobalId &gid)
-        : GidAllSearchIterator(matchData, store),
+    GidSearchIterator(const search::attribute::ISearchContext &baseSearchCtx,
+                      TermFieldMatchData *matchData, const DocumentMetaStore &store, const GlobalId &gid)
+        : GidAllSearchIterator(baseSearchCtx, matchData, store),
           _gid(gid)
     {
     }
@@ -119,10 +122,10 @@ SearchIterator::UP
 SearchContext::createIterator(TermFieldMatchData *matchData, bool strict)
 {
     return _isWord
-        ? std::make_unique<GidSearchIterator>(matchData, getStore(), _gid)
+        ? std::make_unique<GidSearchIterator>(*this, matchData, getStore(), _gid)
         : strict
-            ?  std::make_unique<GidStrictAllSearchIterator>(matchData, getStore())
-            :  std::make_unique<GidAllSearchIterator>(matchData, getStore());
+            ?  std::make_unique<GidStrictAllSearchIterator>(*this, matchData, getStore())
+            :  std::make_unique<GidAllSearchIterator>(*this, matchData, getStore());
 }
 
 const DocumentMetaStore &

--- a/searchlib/src/tests/attribute/searchcontext/searchcontext.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext.cpp
@@ -266,6 +266,11 @@ private:
     void requireThatOutOfBoundsSearchTermGivesZeroHits(const vespalib::string &name, const Config &cfg, int64_t maxValue);
     void requireThatOutOfBoundsSearchTermGivesZeroHits();
 
+
+    template <typename AttributeType, typename ValueType>
+    void requireThatSearchIteratorExposesSearchContext(const ConfigMap &cfg, ValueType value, const vespalib::string &searchTerm);
+    void requireThatSearchIteratorExposesSearchContext();
+
     // init maps with config objects
     void initIntegerConfig();
     void initFloatConfig();
@@ -1809,6 +1814,46 @@ SearchContextTest::requireThatOutOfBoundsSearchTermGivesZeroHits()
     }
 }
 
+void
+assertSearchIteratorExposesSearchContext(search::attribute::ISearchContext &ctx)
+{
+    ASSERT_TRUE(ctx.valid());
+    ctx.fetchPostings(true);
+    TermFieldMatchData dummy;
+    SearchBasePtr itr = ctx.createIterator(&dummy, true);
+    EXPECT_TRUE(itr->getAttributeSearchContext() != nullptr);
+    EXPECT_EQUAL(&ctx, itr->getAttributeSearchContext());
+}
+
+template <typename AttributeType, typename ValueType>
+void
+SearchContextTest::requireThatSearchIteratorExposesSearchContext(const ConfigMap &cfgMap,
+                                                                 ValueType value,
+                                                                 const vespalib::string &searchTerm)
+{
+    vespalib::string attrSuffix = "-itr-exposes-ctx";
+    std::vector<ValueType> values = {value};
+    for (const auto &cfg : cfgMap) {
+        vespalib::string attrName = cfg.first + attrSuffix;
+        AttributePtr attr = AttributeFactory::createAttribute(attrName, cfg.second);
+        addDocs(*attr, 2);
+        AttributeType &concreteAttr = dynamic_cast<AttributeType &>(*attr);
+        if (attr->hasMultiValue()) {
+            fillAttribute(concreteAttr, values);
+        } else {
+            resetAttribute(concreteAttr, value);
+        }
+        assertSearchIteratorExposesSearchContext(*getSearch(*attr, searchTerm));
+    }
+}
+
+void
+SearchContextTest::requireThatSearchIteratorExposesSearchContext()
+{
+    requireThatSearchIteratorExposesSearchContext<IntegerAttribute, largeint_t>(_integerCfg, 3, "3");
+    requireThatSearchIteratorExposesSearchContext<FloatingPointAttribute, double>(_floatCfg, 5.7, "5.7");
+    requireThatSearchIteratorExposesSearchContext<StringAttribute, vespalib::string>(_stringCfg, "foo", "foo");
+}
 
 void
 SearchContextTest::initIntegerConfig()
@@ -1940,6 +1985,7 @@ SearchContextTest::Main()
     TEST_DO(requireThatInvalidSearchTermGivesZeroHits());
     TEST_DO(requireThatFlagAttributeHandlesTheByteRange());
     TEST_DO(requireThatOutOfBoundsSearchTermGivesZeroHits());
+    TEST_DO(requireThatSearchIteratorExposesSearchContext());
 
     TEST_DONE();
 }

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
@@ -11,9 +11,11 @@ namespace search {
 using queryeval::MinMaxPostingInfo;
 using fef::TermFieldMatchData;
 
-AttributeIteratorBase::AttributeIteratorBase(TermFieldMatchData * matchData) :
-    _matchData(matchData),
-    _matchPosition(_matchData->populate_fixed())
+AttributeIteratorBase::AttributeIteratorBase(const attribute::ISearchContext &baseSearchCtx,
+                                             TermFieldMatchData *matchData)
+    : _baseSearchCtx(baseSearchCtx),
+      _matchData(matchData),
+      _matchPosition(_matchData->populate_fixed())
 { }
 
 void
@@ -24,8 +26,9 @@ AttributeIteratorBase::visitMembers(vespalib::ObjectVisitor &visitor) const
     visit(visitor, "tfmd.docId", _matchData->getDocId());
 }
 
-FilterAttributeIterator::FilterAttributeIterator(fef::TermFieldMatchData * matchData)
-    : AttributeIteratorBase(matchData)
+FilterAttributeIterator::FilterAttributeIterator(const attribute::ISearchContext &baseSearchCtx,
+                                                 fef::TermFieldMatchData *matchData)
+    : AttributeIteratorBase(baseSearchCtx, matchData)
 {
     _matchPosition->setElementWeight(1);
 }
@@ -44,15 +47,17 @@ FlagAttributeIterator::doUnpack(uint32_t docId)
     _matchData->resetOnlyDocId(docId);
 }
 
-AttributePostingListIterator:: AttributePostingListIterator(bool hasWeight, TermFieldMatchData *matchData)
-    : AttributeIteratorBase(matchData),
+AttributePostingListIterator::AttributePostingListIterator(const attribute::ISearchContext &baseSearchCtx,
+                                                           bool hasWeight,
+                                                           TermFieldMatchData *matchData)
+    : AttributeIteratorBase(baseSearchCtx, matchData),
       _hasWeight(hasWeight)
 {
 }
 
 FilterAttributePostingListIterator::
-FilterAttributePostingListIterator(TermFieldMatchData *matchData)
-    : AttributeIteratorBase(matchData)
+FilterAttributePostingListIterator(const attribute::ISearchContext &baseSearchCtx, TermFieldMatchData *matchData)
+    : AttributeIteratorBase(baseSearchCtx, matchData)
 {
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -67,7 +67,7 @@ ImportedSearchContext::createIterator(fef::TermFieldMatchData* matchData, bool s
             DocIt postings;
             auto array = _merger.getArray();
             postings.set(&array[0], &array[array.size()]);
-            return std::make_unique<AttributePostingListIteratorT<DocIt>>(true, matchData, postings);
+            return std::make_unique<AttributePostingListIteratorT<DocIt>>(*this, true, matchData, postings);
         }
     } else if (_merger.hasBitVector()) {
         return BitVectorIterator::create(_merger.getBitVector(), _merger.getDocIdLimit(), *matchData, strict);

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.cpp
@@ -23,7 +23,8 @@ PostingListSearchContext(const Dictionary &dictionary,
                          bool hasWeight,
                          const EnumStoreBase &esb,
                          uint32_t minBvDocFreq,
-                         bool useBitVector)
+                         bool useBitVector,
+                         const ISearchContext &baseSearchCtx)
     : _frozenDictionary(dictionary.getFrozenView()),
       _lowerDictItr(BTreeNode::Ref(), dictionary.getAllocator()),
       _upperDictItr(BTreeNode::Ref(), dictionary.getAllocator()),
@@ -39,7 +40,8 @@ PostingListSearchContext(const Dictionary &dictionary,
       _PLSTC(0.0),
       _esb(esb),
       _minBvDocFreq(minBvDocFreq),
-      _gbv(nullptr)
+      _gbv(nullptr),
+      _baseSearchCtx(baseSearchCtx)
 {
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -13,6 +13,8 @@
 
 namespace search::attribute {
 
+class ISearchContext;
+
 /**
  * Search context helper for posting list attributes, used to instantiate
  * iterators based on posting lists instead of brute force filtering search.
@@ -42,10 +44,11 @@ protected:
     const EnumStoreBase    &_esb;
     uint32_t                _minBvDocFreq;
     const GrowableBitVector *_gbv; // bitvector if _useBitVector has been set
+    const ISearchContext    &_baseSearchCtx;
 
 
     PostingListSearchContext(const Dictionary &dictionary, uint32_t docIdLimit, uint64_t numValues, bool hasWeight,
-                             const EnumStoreBase &esb, uint32_t minBvDocFreq, bool useBitVector);
+                             const EnumStoreBase &esb, uint32_t minBvDocFreq, bool useBitVector, const ISearchContext &baseSearchCtx);
 
     ~PostingListSearchContext();
 
@@ -111,7 +114,7 @@ protected:
 
     PostingListSearchContextT(const Dictionary &dictionary, uint32_t docIdLimit, uint64_t numValues,
                               bool hasWeight, const PostingList &postingList, const EnumStoreBase &esb,
-                              uint32_t minBvCocFreq, bool useBitVector);
+                              uint32_t minBvCocFreq, bool useBitVector, const ISearchContext &baseSearchCtx);
     ~PostingListSearchContextT();
 
     void lookupSingle();
@@ -149,7 +152,7 @@ protected:
 
     PostingListFoldedSearchContextT(const Dictionary &dictionary, uint32_t docIdLimit, uint64_t numValues,
                                     bool hasWeight, const PostingList &postingList, const EnumStoreBase &esb,
-                                    uint32_t minBvCocFreq, bool useBitVector);
+                                    uint32_t minBvCocFreq, bool useBitVector, const ISearchContext &baseSearchCtx);
 
     unsigned int approximateHits() const override;
 };
@@ -253,7 +256,8 @@ PostingSearchContext(QueryTermSimpleUP qTerm, bool useBitVector, const AttrT &to
               toBeSearched.getPostingList(),
               toBeSearched.getEnumStore(),
               toBeSearched._postingList._minBvDocFreq,
-              useBitVector),
+              useBitVector,
+              *this),
       _toBeSearched(toBeSearched),
       _enumStore(_toBeSearched.getEnumStore())
 {

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -21,8 +21,8 @@ template <typename DataT>
 PostingListSearchContextT<DataT>::
 PostingListSearchContextT(const Dictionary &dictionary, uint32_t docIdLimit, uint64_t numValues, bool hasWeight,
                           const PostingList &postingList, const EnumStoreBase &esb,
-                          uint32_t minBvDocFreq, bool useBitVector)
-    : PostingListSearchContext(dictionary, docIdLimit, numValues, hasWeight, esb, minBvDocFreq, useBitVector),
+                          uint32_t minBvDocFreq, bool useBitVector, const ISearchContext &searchContext)
+    : PostingListSearchContext(dictionary, docIdLimit, numValues, hasWeight, esb, minBvDocFreq, useBitVector, searchContext),
       _postingList(postingList),
       _merger(docIdLimit),
       _fetchPostingsDone(false)
@@ -164,9 +164,9 @@ createPostingIterator(fef::TermFieldMatchData *matchData, bool strict)
             vespalib::ConstArrayRef<Posting> array = _merger.getArray();
             postings.set(&array[0], &array[array.size()]);
             if (_postingList._isFilter) {
-                return std::make_unique<FilterAttributePostingListIteratorT<DocIt>>(matchData, postings);
+                return std::make_unique<FilterAttributePostingListIteratorT<DocIt>>(_baseSearchCtx, matchData, postings);
             } else {
-                return std::make_unique<AttributePostingListIteratorT<DocIt>>(_hasWeight, matchData, postings);
+                return std::make_unique<AttributePostingListIteratorT<DocIt>>(_baseSearchCtx, _hasWeight, matchData, postings);
             }
         }
         if (_merger.hasArray()) {
@@ -192,18 +192,18 @@ createPostingIterator(fef::TermFieldMatchData *matchData, bool strict)
             const Posting *array = postingList.getKeyDataEntry(_pidx, clusterSize);
             postings.set(array, array + clusterSize);
             if (postingList._isFilter) {
-                return std::make_unique<FilterAttributePostingListIteratorT<DocIt>>(matchData, postings);
+                return std::make_unique<FilterAttributePostingListIteratorT<DocIt>>(_baseSearchCtx, matchData, postings);
             } else {
-                return std::make_unique<AttributePostingListIteratorT<DocIt>>(_hasWeight, matchData, postings);
+                return std::make_unique<AttributePostingListIteratorT<DocIt>>(_baseSearchCtx, _hasWeight, matchData, postings);
             }
         }
         typename PostingList::BTreeType::FrozenView frozen(_frozenRoot, postingList.getAllocator());
 
         using DocIt = typename PostingList::ConstIterator;
         if (_postingList._isFilter) {
-            return std::make_unique<FilterAttributePostingListIteratorT<DocIt>>(matchData, frozen.getRoot(), frozen.getAllocator());
+            return std::make_unique<FilterAttributePostingListIteratorT<DocIt>>(_baseSearchCtx, matchData, frozen.getRoot(), frozen.getAllocator());
         } else {
-            return std::make_unique<AttributePostingListIteratorT<DocIt>> (_hasWeight, matchData, frozen.getRoot(), frozen.getAllocator());
+            return std::make_unique<AttributePostingListIteratorT<DocIt>> (_baseSearchCtx, _hasWeight, matchData, frozen.getRoot(), frozen.getAllocator());
         }
     }
     // returning nullptr will trigger fallback to filter iterator
@@ -287,8 +287,8 @@ template <typename DataT>
 PostingListFoldedSearchContextT<DataT>::
 PostingListFoldedSearchContextT(const Dictionary &dictionary, uint32_t docIdLimit, uint64_t numValues,
                                 bool hasWeight, const PostingList &postingList, const EnumStoreBase &esb,
-                                uint32_t minBvDocFreq, bool useBitVector)
-    : Parent(dictionary, docIdLimit, numValues, hasWeight, postingList, esb, minBvDocFreq, useBitVector)
+                                uint32_t minBvDocFreq, bool useBitVector, const ISearchContext &searchContext)
+    : Parent(dictionary, docIdLimit, numValues, hasWeight, postingList, esb, minBvDocFreq, useBitVector, searchContext)
 {
 }
 


### PR DESCRIPTION
…g the iterator.

This ensures that also fast-search struct field attributes work together with the sameElement operator.

@vekterli please review
@arnej27959 FYI