### PR TITLE
Exclude jaxb-api from config-model-fat.

### DIFF
--- a/fat-model-dependencies/pom.xml
+++ b/fat-model-dependencies/pom.xml
@@ -26,6 +26,13 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>provided-dependencies</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Not needed runtime, and a multi-release jar which is currently not supported by maven-bundle-plugin (really bndtools) -->
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
- Multi-release jars not supported by maven-bundle-plugin yet.