### PR TITLE
Remove unused method

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSessionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSessionRepo.java
@@ -91,11 +91,6 @@ public class RemoteSessionRepo extends SessionRepo<RemoteSession> implements Nod
 
     //---------- START overrides to keep sessions changed in sync 
 
-    public synchronized void addSession(RemoteSession session) {
-        super.addSession(session);
-        sessionAdded(session.getSessionId());
-    }
-
     @Override
     public void removeSession(long id, NestedTransaction transaction) {
         super.removeSession(id, transaction);


### PR DESCRIPTION
Use method in superclass instead. The sessionAdded() call is wrong, it's sessionAdded() that should call addSession() (bug introduced in https://github.com/vespa-engine/vespa/pull/6290)