### PR TITLE
Add HTTPS binding for /status

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -93,6 +93,7 @@
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.status.StatusHandler' bundle='configserver'>
       <binding>http://*/status</binding>
+      <binding>https://*/status</binding>
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.TenantHandler' bundle='configserver'>
       <binding>http://*/application/v2/tenant/</binding>


### PR DESCRIPTION
Noticed that this was unreachable via `/zone/v2`.