### PR TITLE
Support deleting an application on any config server

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -46,8 +46,8 @@ public class ApplicationHandler extends HttpHandler {
     @Override
     public HttpResponse handleDELETE(HttpRequest request) {
         ApplicationId applicationId = getApplicationIdFromRequest(request);
-        boolean removed = applicationRepository.remove(applicationId);
-        if ( ! removed)
+        boolean deleted = applicationRepository.delete(applicationId);
+        if ( ! deleted)
             return HttpErrorResponse.notFoundError("Unable to delete " + applicationId + ": Not found");
         return new DeleteApplicationResponse(Response.Status.OK, applicationId);
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
@@ -120,14 +120,6 @@ public class LocalSession extends Session implements Comparable<LocalSession> {
         return getSessionId() > sessionId;
     }
 
-    /** Delete this session */
-    // TODO: Use transactional delete instead
-    public void delete() {
-        superModelGenerationCounter.increment();
-        IOUtils.recursiveDeleteDir(serverDB);
-        zooKeeperClient.delete();
-    }
-
     /** Add transactions to delete this session to the given nested transaction */
     public void delete(NestedTransaction transaction) {
         transaction.add(zooKeeperClient.deleteTransaction(), FileTransaction.class);
@@ -174,6 +166,8 @@ public class LocalSession extends Session implements Comparable<LocalSession> {
     public AllocatedHosts getAllocatedHosts() {
         return zooKeeperClient.getAllocatedHosts();
     }
+
+    public TenantName getTenantName() { return tenant; }
 
     @Override
     public String logPre() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSessionStateWatcher.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSessionStateWatcher.java
@@ -1,0 +1,76 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server.session;
+
+import com.yahoo.concurrent.ThreadFactoryFactory;
+import com.yahoo.log.LogLevel;
+import com.yahoo.text.Utf8;
+import com.yahoo.vespa.curator.Curator;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+
+/**
+ * Watches one particular local session (/config/v2/tenants/&lt;tenantName&gt;/sessions/&lt;n&gt;/sessionState in ZooKeeper)
+ * to pick up when an application is deleted (the delete might be done on any config server in the cluster)
+ *
+ * @author Harald Musum
+ */
+public class LocalSessionStateWatcher implements NodeCacheListener {
+
+    private static final Logger log = Logger.getLogger(LocalSessionStateWatcher.class.getName());
+    // One thread pool for all instances of this class
+    private static final Executor executor = Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory(LocalSessionStateWatcher.class.getName()));
+
+    private final Curator.FileCache fileCache;
+    private final LocalSession session;
+    private final LocalSessionRepo localSessionRepo;
+
+    LocalSessionStateWatcher(Curator.FileCache fileCache, LocalSession session, LocalSessionRepo localSessionRepo) {
+        this.fileCache = fileCache;
+        this.session = session;
+        this.localSessionRepo = localSessionRepo;
+        this.fileCache.start();
+        this.fileCache.addListener(this);
+    }
+
+    // Will delete session if it exists in local session repo
+    private void sessionChanged(Session.Status status) {
+        long sessionId = session.getSessionId();
+        log.log(LogLevel.DEBUG, session.logPre() + "Session change: Local session " + sessionId + " changed status to " + status);
+
+        if (status.equals(Session.Status.DELETE) && localSessionRepo.getSession(sessionId) != null) {
+            log.log(LogLevel.DEBUG, session.logPre() + "Deleting session " + sessionId);
+            localSessionRepo.deleteSession(session);
+        }
+    }
+
+    public long getSessionId() {
+        return session.getSessionId();
+    }
+
+    public void close() {
+        try {
+            fileCache.close();
+        } catch (Exception e) {
+            log.log(LogLevel.WARNING, "Exception when closing watcher", e);
+        }
+    }
+
+    @Override
+    public void nodeChanged() {
+        executor.execute(() -> {
+            try {
+                ChildData data = fileCache.getCurrentData();
+                if (data != null) {
+                    sessionChanged(Session.Status.parse(Utf8.toString(fileCache.getCurrentData().getData())));
+                }
+            } catch (Exception e) {
+                log.log(LogLevel.WARNING, session.logPre() + "Error handling session changed for session " + getSessionId(), e);
+            }
+        });
+    }
+
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
@@ -43,7 +43,7 @@ public abstract class Session {
      * Represents the status of this session.
      */
     public enum Status {
-        NEW, PREPARE, ACTIVATE, DEACTIVATE, NONE;
+        NEW, PREPARE, ACTIVATE, DEACTIVATE, DELETE, NONE;
 
         public static Status parse(String data) {
             for (Status status : Status.values()) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SilentDeployLogger.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SilentDeployLogger.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 import com.yahoo.config.application.api.DeployLogger;
 
 /**
- * The purpose of this is to mute the log messages from model and application building in {@link RemoteSession} that is triggered by {@link SessionStateWatcher}, since those messages already
+ * The purpose of this is to mute the log messages from model and application building in {@link RemoteSession} that is triggered by {@link RemoteSessionStateWatcher}, since those messages already
  * have been emitted by the prepare handler, for the same prepare operation.
  * 
  * @author vegardh

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantBuilder.java
@@ -101,7 +101,9 @@ public class TenantBuilder {
 
 	private void createLocalSessionRepo() {
         if (localSessionRepo == null) {
-            localSessionRepo = new LocalSessionRepo(tenantFileSystemDirs, localSessionLoader, componentRegistry.getClock(), componentRegistry.getConfigserverConfig().sessionLifetime());
+            localSessionRepo = new LocalSessionRepo(tenantFileSystemDirs, localSessionLoader, componentRegistry.getClock(),
+                                                    componentRegistry.getConfigserverConfig().sessionLifetime(),
+                                                    componentRegistry.getCurator());
         }
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
@@ -160,9 +160,6 @@ public class SessionHandlerTest {
         }
 
         @Override
-        public void delete() {  }
-
-        @Override
         public void delete(NestedTransaction transaction) {  }
 
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -19,7 +19,6 @@ import com.yahoo.vespa.config.server.http.HttpErrorResponse;
 import com.yahoo.vespa.config.server.http.StaticResponse;
 import com.yahoo.vespa.config.server.http.SessionHandlerTest;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
-import com.yahoo.vespa.config.server.session.LocalSession;
 import com.yahoo.vespa.config.server.session.PrepareParams;
 import com.yahoo.vespa.config.server.tenant.Tenant;
 import com.yahoo.vespa.config.server.tenant.TenantBuilder;
@@ -33,12 +32,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Clock;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -78,25 +74,9 @@ public class ApplicationHandlerTest {
     @Test
     public void testDelete() throws Exception {
         {
-            // This block is a real test of the interplay of (most of) the components of the config server
-            // TODO: Extract it to ApplicationRepositoryTest, rewrite to bypass the HTTP layer and extend
-            //       as login is moved from the HTTP layer into ApplicationRepository
-
-            PrepareResult result = applicationRepository.deploy(testApp, prepareParams(applicationId));
-            long sessionId = result.sessionId();
+            applicationRepository.deploy(testApp, prepareParams(applicationId));
             Tenant mytenant = tenantRepository.getTenant(applicationId.tenant());
-            LocalSession applicationData = mytenant.getLocalSessionRepo().getSession(sessionId);
-            assertNotNull(applicationData);
-            assertNotNull(applicationData.getApplicationId());
-            assertFalse(provisioner.removed);
-
             deleteAndAssertOKResponse(mytenant, applicationId);
-            assertTrue(provisioner.removed);
-            assertThat(provisioner.lastApplicationId.tenant(), is(mytenantName));
-            assertThat(provisioner.lastApplicationId, is(applicationId));
-
-            assertNull(mytenant.getLocalSessionRepo().getSession(sessionId));
-            assertNull(mytenant.getRemoteSessionRepo().getSession(sessionId));
         }
         
         {
@@ -114,7 +94,6 @@ public class ApplicationHandlerTest {
 
             assertApplicationExists(fooId, Zone.defaultZone());
             deleteAndAssertOKResponseMocked(fooId, true);
-            assertThat(provisioner.lastApplicationId, is(fooId));
             assertApplicationExists(applicationId, Zone.defaultZone());
 
             deleteAndAssertOKResponseMocked(applicationId, true);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
@@ -100,7 +100,7 @@ public class SessionActiveHandlerTest extends SessionHandlerTest {
         applicationRepo = new MemoryTenantApplications();
         curator = new MockCurator();
         configCurator = ConfigCurator.create(curator);
-        localRepo = new LocalSessionRepo(clock);
+        localRepo = new LocalSessionRepo(clock, curator);
         pathPrefix = "/application/v2/tenant/" + tenantName + "/session/";
         hostProvisioner = new MockProvisioner();
         modelFactory = new VespaModelFactory(new NullConfigModelRegistry());

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
@@ -17,6 +17,7 @@ import com.yahoo.vespa.config.server.http.SessionHandlerTest;
 import com.yahoo.vespa.config.server.session.LocalSessionRepo;
 import com.yahoo.vespa.config.server.tenant.TenantBuilder;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
+import com.yahoo.vespa.curator.mock.MockCurator;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class SessionCreateHandlerTest extends SessionHandlerTest {
     @Before
     public void setupRepo() {
         applicationRepo = new MemoryTenantApplications();
-        localSessionRepo = new LocalSessionRepo(Clock.systemUTC());
+        localSessionRepo = new LocalSessionRepo(Clock.systemUTC(), new MockCurator());
         tenantRepository = new TenantRepository(componentRegistry, false);
         sessionFactory = new MockSessionFactory();
         TenantBuilder tenantBuilder = TenantBuilder.create(componentRegistry, tenant)

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -16,6 +16,7 @@ import com.yahoo.jdisc.http.HttpRequest;
 import com.yahoo.path.Path;
 import com.yahoo.slime.JsonDecoder;
 import com.yahoo.slime.Slime;
+import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.transaction.Transaction;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.TestComponentRegistry;
@@ -74,7 +75,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     @Before
     public void setupRepo() {
         curator = new MockCurator();
-        localRepo = new LocalSessionRepo(clock);
+        localRepo = new LocalSessionRepo(clock, curator);
         pathPrefix = "/application/v2/tenant/" + tenant + "/session/";
         preparedMessage = " for tenant '" + tenant + "' prepared.\"";
         tenantMessage = ",\"tenant\":\"" + tenant + "\"";
@@ -243,7 +244,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     @Test
     public void require_that_preparing_with_multiple_tenants_work() throws Exception {
         // Need different repo for 'test2' tenant
-        LocalSessionRepo localRepoDefault = new LocalSessionRepo(clock);
+        LocalSessionRepo localRepoDefault = new LocalSessionRepo(clock, curator);
         final TenantName defaultTenant = TenantName.from("test2");
         TenantBuilder defaultTenantBuilder = TenantBuilder.create(componentRegistry, defaultTenant)
                 .withLocalSessionRepo(localRepoDefault)
@@ -444,6 +445,6 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
         }
 
         @Override
-        public void delete() {  }
+        public void delete(NestedTransaction transaction) {  }
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionRepoTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionRepoTest.java
@@ -57,7 +57,7 @@ public class LocalSessionRepoTest {
                                                            new MemoryTenantApplications(),
                                                            tenantFileSystemDirs, new HostRegistry<>(),
                                                            tenantName);
-        repo = new LocalSessionRepo(tenantFileSystemDirs, loader, clock, 5);
+        repo = new LocalSessionRepo(tenantFileSystemDirs, loader, clock, 5, globalComponentRegistry.getCurator());
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
@@ -2,12 +2,12 @@
 package com.yahoo.vespa.config.server.session;
 
 import com.google.common.io.Files;
-import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.provision.*;
 import com.yahoo.path.Path;
 import com.yahoo.config.model.application.provider.*;
 import com.yahoo.slime.Slime;
+import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.config.server.*;
 import com.yahoo.vespa.config.server.application.MemoryTenantApplications;
 import com.yahoo.vespa.config.server.deploy.DeployHandlerLogger;
@@ -115,7 +115,9 @@ public class LocalSessionTest {
         assertTrue(configCurator.exists(sessionNode));
         assertTrue(new File(tenantFileSystemDirs.sessionsPath(), "3").exists());
         long gen = superModelGenerationCounter.get();
-        session.delete();
+        NestedTransaction transaction = new NestedTransaction();
+        session.delete(transaction);
+        transaction.commit();
         assertThat(superModelGenerationCounter.get(), is(gen + 1));
         assertFalse(configCurator.exists(sessionNode));
         assertFalse(new File(tenantFileSystemDirs.sessionsPath(), "3").exists());


### PR DESCRIPTION
Support application delete on any config server, not just the one the
application was deployed to. Legacy method that does it the old way kept
and used in most places until we have got some expericence with the new one.