### PR TITLE
Application deployments inhibits periodic redeploys for a while

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Deployer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Deployer.java
@@ -2,6 +2,7 @@
 package com.yahoo.config.provision;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -32,5 +33,8 @@ public interface Deployer {
      *         node in the config server cluster)
      */
     Optional<Deployment> deployFromLocalActive(ApplicationId application, Duration timeout);
+
+    /** Returns the time the current local active session was created, or empty if there is no local active session */
+    Optional<Instant> lastDeployTime(ApplicationId application);
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -232,6 +232,15 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                                                  false /* don't validate as this is already deployed */, version));
     }
 
+    @Override
+    public Optional<Instant> lastDeployTime(ApplicationId application) {
+        Tenant tenant = tenantRepository.getTenant(application.tenant());
+        if (tenant == null) return Optional.empty();
+        LocalSession activeSession = getActiveSession(tenant, application);
+        if (activeSession == null) return Optional.empty();
+        return Optional.of(Instant.ofEpochSecond(activeSession.getCreateTime()));
+    }
+
     public ApplicationId activate(Tenant tenant,
                                   long sessionId,
                                   TimeoutBudget timeoutBudget,

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/MockDeployer.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/MockDeployer.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployment;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -22,6 +23,11 @@ public class MockDeployer implements com.yahoo.config.provision.Deployer {
     @Override
     public Optional<Deployment> deployFromLocalActive(ApplicationId application, Duration timeout) {
         lastDeployed = application;
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Instant> lastDeployTime(ApplicationId application) {
         return Optional.empty();
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
@@ -39,15 +39,20 @@ public abstract class ApplicationMaintainer extends Maintainer {
     protected final void maintain() {
         Set<ApplicationId> applications = applicationsNeedingMaintenance();
         for (ApplicationId application : applications) {
-            deploy(application);
+            if (canDeployNow(application))
+                deploy(application);
             throttle(applications.size());
         }
+    }
+
+    protected boolean canDeployNow(ApplicationId application) {
+        return true;
     }
 
     /**
      * Redeploy this application.
      *
-     * The default implementation deploys asynchronously to make sure we do all applications timely 
+     * The default implementation deploys asynchronously to make sure we do all applications timely
      * even when deployments are slow.
      */
     protected void deploy(ApplicationId application) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
@@ -10,6 +10,7 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +54,8 @@ public abstract class ApplicationMaintainer extends Maintainer {
         deploymentExecutor.execute(() -> deployWithLock(application));
     }
 
+    protected Deployer deployer() { return deployer; }
+
     /** Block in this method until the next application should be maintained */
     protected abstract void throttle(int applicationCount);
 
@@ -78,7 +81,6 @@ public abstract class ApplicationMaintainer extends Maintainer {
             if ( ! isActive(application)) return; // became inactive since deployment was requested
             Optional<Deployment> deployment = deployer.deployFromLocalActive(application);
             if ( ! deployment.isPresent()) return; // this will be done at another config server
-
             deployment.get().activate();
         } catch (RuntimeException e) {
             log.log(Level.WARNING, "Exception on maintenance redeploy", e);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
@@ -32,13 +32,12 @@ public class PeriodicApplicationMaintainer extends ApplicationMaintainer {
     }
 
     @Override
-    protected void deploy(ApplicationId application) {
+    protected boolean canDeployNow(ApplicationId application) {
         Optional<Instant> lastDeploy = deployer().lastDeployTime(application);
         if (lastDeploy.isPresent() &&
             lastDeploy.get().isAfter(nodeRepository().clock().instant().minus(interval())))
-            return; // Don't deploy if a regular deploy just happened
-
-        super.deploy(application);
+            return false; // Don't deploy if a regular deploy just happened
+        return true;
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
@@ -1,12 +1,15 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The application maintainer regularly redeploys all applications to make sure the node repo and application
@@ -26,6 +29,16 @@ public class PeriodicApplicationMaintainer extends ApplicationMaintainer {
     protected void throttle(int applicationCount) {
         // Sleep for a length of time that will spread deployment evenly over the maintenance period
         try { Thread.sleep(interval().toMillis() / applicationCount); } catch (InterruptedException e) { return; }
+    }
+
+    @Override
+    protected void deploy(ApplicationId application) {
+        Optional<Instant> lastDeploy = deployer().lastDeployTime(application);
+        if (lastDeploy.isPresent() &&
+            lastDeploy.get().isAfter(nodeRepository().clock().instant().minus(interval())))
+            return; // Don't deploy if a regular deploy just happened
+
+        super.deploy(application);
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDeployer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDeployer.java
@@ -13,6 +13,7 @@ import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,11 @@ public class MockDeployer implements Deployer {
     @Override
     public Optional<Deployment> deployFromLocalActive(ApplicationId id, Duration timeout) {
         return Optional.of(new MockDeployment(provisioner, applications.get(id)));
+    }
+
+    @Override
+    public Optional<Instant> lastDeployTime(ApplicationId application) {
+        return Optional.empty(); // not implemented
     }
 
     public class MockDeployment implements Deployment {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -13,6 +13,7 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.History;
@@ -142,6 +143,7 @@ public class InactiveAndFailedExpirerTest {
         tester.advanceTime(Duration.ofMinutes(11)); // Trigger RetiredExpirer
         MockDeployer deployer = new MockDeployer(
                 tester.provisioner(),
+                tester.clock(),
                 Collections.singletonMap(
                         applicationId,
                         new MockDeployer.ApplicationContext(applicationId, cluster,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -35,6 +35,7 @@ import com.yahoo.vespa.hosted.provision.testutils.ServiceMonitorStub;
 import com.yahoo.vespa.hosted.provision.testutils.TestHostLivenessTracker;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -111,7 +112,7 @@ public class NodeFailTester {
         Map<ApplicationId, MockDeployer.ApplicationContext> apps = new HashMap<>();
         apps.put(app1, new MockDeployer.ApplicationContext(app1, clusterApp1, Capacity.fromNodeCount(wantedNodesApp1, Optional.of("default"), false, true), 1));
         apps.put(app2, new MockDeployer.ApplicationContext(app2, clusterApp2, Capacity.fromNodeCount(wantedNodesApp2, Optional.of("default"), false, true), 1));
-        tester.deployer = new MockDeployer(tester.provisioner, apps);
+        tester.deployer = new MockDeployer(tester.provisioner, tester.clock(), apps);
         tester.serviceMonitor = new ServiceMonitorStub(apps, tester.nodeRepository);
         tester.metric = new MetricsReporterTest.TestMetric();
         tester.failer = tester.createFailer();
@@ -147,7 +148,7 @@ public class NodeFailTester {
         apps.put(nodeAdminApp, new MockDeployer.ApplicationContext(nodeAdminApp, clusterNodeAdminApp, allHosts, 1));
         apps.put(app1, new MockDeployer.ApplicationContext(app1, clusterApp1, capacity1, 1));
         apps.put(app2, new MockDeployer.ApplicationContext(app2, clusterApp2, capacity2, 1));
-        tester.deployer = new MockDeployer(tester.provisioner, apps);
+        tester.deployer = new MockDeployer(tester.provisioner, tester.clock(), apps);
         tester.serviceMonitor = new ServiceMonitorStub(apps, tester.nodeRepository);
         tester.metric = new MetricsReporterTest.TestMetric();
         tester.failer = tester.createFailer();
@@ -170,7 +171,7 @@ public class NodeFailTester {
 
         Map<ApplicationId, MockDeployer.ApplicationContext> apps = new HashMap<>();
         apps.put(app1, new MockDeployer.ApplicationContext(app1, clusterApp1, allProxies, 1));
-        tester.deployer = new MockDeployer(tester.provisioner, apps);
+        tester.deployer = new MockDeployer(tester.provisioner, tester.clock(), apps);
         tester.serviceMonitor = new ServiceMonitorStub(apps, tester.nodeRepository);
         tester.metric = new MetricsReporterTest.TestMetric();
         tester.failer = tester.createFailer();
@@ -179,7 +180,7 @@ public class NodeFailTester {
 
     public static NodeFailTester withNoApplications() {
         NodeFailTester tester = new NodeFailTester();
-        tester.deployer = new MockDeployer(tester.provisioner, Collections.emptyMap());
+        tester.deployer = new MockDeployer(tester.provisioner, tester.clock(), Collections.emptyMap());
         tester.serviceMonitor = new ServiceMonitorStub(Collections.emptyMap(), tester.nodeRepository);
         tester.metric = new MetricsReporterTest.TestMetric();
         tester.failer = tester.createFailer();
@@ -209,6 +210,8 @@ public class NodeFailTester {
                 hostLivenessTracker.receivedRequestFrom(node.hostname());
         }
     }
+
+    public Clock clock() { return clock; }
 
     public List<Node> createReadyNodes(int count) {
         return createReadyNodes(count, 0);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTester.java
@@ -75,7 +75,7 @@ public class NodeRetirerTester {
                                             new DockerImage("docker-registry.domain.tld:8080/dist/vespa"), true);
         jobControl = new JobControl(nodeRepository.database());
         NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone);
-        deployer = new MockDeployer(provisioner, apps);
+        deployer = new MockDeployer(provisioner, clock, apps);
         flavors = nodeFlavors.getFlavors().stream().sorted(Comparator.comparing(Flavor::name)).collect(Collectors.toList());
 
         try {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainerTest.java
@@ -136,7 +136,7 @@ public class OperatorChangeApplicationMaintainerTest {
                                                                Capacity.fromNodeCount(wantedNodesApp1, Optional.of("default"), false, true), 1));
             apps.put(app2, new MockDeployer.ApplicationContext(app2, clusterApp2,
                                                                Capacity.fromNodeCount(wantedNodesApp2, Optional.of("default"), false, true), 1));
-            this.deployer = new MockDeployer(provisioner, apps);
+            this.deployer = new MockDeployer(provisioner, nodeRepository.clock(), apps);
         }
 
         private void activate(ApplicationId applicationId, ClusterSpec cluster, int nodeCount, NodeRepositoryProvisioner provisioner) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -92,6 +92,7 @@ public class RetiredExpirerTest {
         clock.advance(Duration.ofHours(30)); // Retire period spent
         MockDeployer deployer =
             new MockDeployer(provisioner,
+                             clock,
                              Collections.singletonMap(applicationId, new MockDeployer.ApplicationContext(applicationId, cluster, Capacity.fromNodeCount(wantedNodes, Optional.of("default"), false, true), 1)));
         createRetiredExpirer(deployer).run();
         assertEquals(3, nodeRepository.getNodes(applicationId, Node.State.active).size());
@@ -120,6 +121,7 @@ public class RetiredExpirerTest {
         clock.advance(Duration.ofHours(30)); // Retire period spent
         MockDeployer deployer =
             new MockDeployer(provisioner,
+                             clock,
                              Collections.singletonMap(applicationId, new MockDeployer.ApplicationContext(applicationId, cluster, Capacity.fromNodeCount(2, Optional.of("default"), false, true), 1)));
         createRetiredExpirer(deployer).run();
         assertEquals(2, nodeRepository.getNodes(applicationId, Node.State.active).size());
@@ -151,9 +153,10 @@ public class RetiredExpirerTest {
         // Cause inactivation of retired nodes
         MockDeployer deployer =
                 new MockDeployer(provisioner,
-                        Collections.singletonMap(
-                                applicationId,
-                                new MockDeployer.ApplicationContext(applicationId, cluster, Capacity.fromNodeCount(wantedNodes, Optional.of("default"), false, true), 1)));
+                                 clock,
+                                 Collections.singletonMap(
+                                     applicationId,
+                                     new MockDeployer.ApplicationContext(applicationId, cluster, Capacity.fromNodeCount(wantedNodes, Optional.of("default"), false, true), 1)));
 
 
         // Allow the 1st and 3rd retired nodes permission to inactivate

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/MultigroupProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/MultigroupProvisioningTest.java
@@ -133,6 +133,7 @@ public class MultigroupProvisioningTest {
         tester.advanceTime(Duration.ofDays(7));
         MockDeployer deployer =
             new MockDeployer(tester.provisioner(),
+                             tester.clock(),
                              Collections.singletonMap(application1, 
                                                       new MockDeployer.ApplicationContext(application1, cluster(), 
                                                                                           Capacity.fromNodeCount(8, Optional.of("large"), false, true), 1)));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeTypeProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeTypeProvisioningTest.java
@@ -97,6 +97,7 @@ public class NodeTypeProvisioningTest {
     public void retire_proxy() {
         MockDeployer deployer = new MockDeployer(
                 tester.provisioner(),
+                tester.clock(),
                 Collections.singletonMap(
                         application, new MockDeployer.ApplicationContext(application, clusterSpec, capacity, 1)));
         RetiredExpirer retiredExpirer =  new RetiredExpirer(tester.nodeRepository(), tester.orchestrator(), deployer,
@@ -161,6 +162,7 @@ public class NodeTypeProvisioningTest {
     public void retire_multiple_proxy_simultaneously() {
         MockDeployer deployer = new MockDeployer(
                 tester.provisioner(),
+                tester.clock(),
                 Collections.singletonMap(
                         application, new MockDeployer.ApplicationContext(application, clusterSpec, capacity, 1)));
         RetiredExpirer retiredExpirer =  new RetiredExpirer(tester.nodeRepository(), tester.orchestrator(), deployer,


### PR DESCRIPTION
Why?
1) Too many redeploys are unecessary and have a cost
2) If restartOnDeploy is turned on, we may end up not able to
   respect it to make sure config is actually deployed if a periodic
   redeploy follows right after an application deploy.