### PR TITLE
Java 10: use latest javadoc plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -146,7 +146,7 @@
                     <configuration>
                         <doclint>${doclint},-missing</doclint>
                     </configuration>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- This fell out of an earlier commit that claimed to do the same.