### PR TITLE
Disable loading minimal set of config model versions in prod

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -8,6 +8,7 @@ import com.yahoo.config.model.api.ModelFactory;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationLockException;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.OutOfCapacityException;
 import com.yahoo.config.provision.Version;
 import com.yahoo.config.provision.Zone;
@@ -19,6 +20,7 @@ import com.yahoo.vespa.config.server.provision.StaticProvisioner;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -140,7 +142,10 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
         List<MODELRESULT> allApplicationVersions = new ArrayList<>();
         allApplicationVersions.add(latestModelVersion);
 
-        versions = keepThoseUsedOn(allocatedHosts.get(), versions);
+        // TODO: Enable for all zones
+        // Note: Cannot be enabled for prod zones yet, due to an issue with how AccessControlValidator works
+        if (Arrays.asList(Environment.dev, Environment.test, Environment.staging).contains(zone().environment()))
+            versions = keepThoseUsedOn(allocatedHosts.get(), versions);
 
         // Make sure we build wanted version if we are building models for this major version
         Version wantedVersion = Version.fromIntValues(wantedNodeVespaVersion.getMajor(), wantedNodeVespaVersion.getMinor(), wantedNodeVespaVersion.getMicro());


### PR DESCRIPTION
AccessControlValidator uses the existence of a model for the version
it validates to check if this is a first time deployment. If config
server has loaded the minimal set of versions (1, 3) and there comes a new deployment
with version 2 (e.g. because we have just released 3 and it is not rolled
out completely yet), there will exist no version 2 and AccessControlValidator
will think that this is a first time deployment and fail if access control
has not been enabled.

This is a revert of #6311 plus disabling it for all prod zones