### PR TITLE
Henrhoi/property-names-and-alias-change

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
@@ -10,6 +10,8 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.query.profile.types.FieldDescription;
+import com.yahoo.search.query.profile.types.QueryProfileType;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.PhaseNames;
@@ -28,10 +30,28 @@ import java.util.Map;
 @Before(PhaseNames.TRANSFORMED_QUERY)
 public class FieldCollapsingSearcher extends Searcher {
 
-    public static final CompoundName collapse = new CompoundName("collapse");
-    public static final CompoundName collapsefield=new CompoundName("collapse.field");
-    public static final CompoundName collapsesize=new CompoundName("collapse.size");
-    public static final CompoundName collapseSummaryName=new CompoundName("collapse.summary");
+
+    //Creating collapse's query profile type
+    private static final QueryProfileType argumentType;
+    public static final String COLLAPSE = "collapse";
+
+    private static final CompoundName collapse=new CompoundName("field");
+    private static final CompoundName collapsefield=new CompoundName("field");
+    private static final CompoundName collapsesize=new CompoundName("size");
+    private static final CompoundName collapseSummaryName=new CompoundName("summary");
+
+    static {
+        argumentType = new QueryProfileType(COLLAPSE);
+        argumentType.setStrict(true);
+        argumentType.setBuiltin(true);
+        argumentType.addField(new FieldDescription(collapsefield.toString(), "string", "collapsefield"));
+        argumentType.addField(new FieldDescription(collapsesize.toString(), "string", "collapsesize"));
+        argumentType.addField(new FieldDescription(collapseSummaryName.toString(), "string"));
+        argumentType.freeze();
+    }
+
+    /** QueryProfileType for the QueryProfileType collapse */
+    public static QueryProfileType getArgumentType() { return argumentType; }
 
     /** Maximum number of queries to send next searcher */
     private int maxQueries = 4;

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
@@ -29,8 +29,8 @@ import java.util.Map;
 public class FieldCollapsingSearcher extends Searcher {
 
     private static final CompoundName collapse = new CompoundName("collapse");
-    private static final CompoundName collapsefield=new CompoundName("collapsefield");
-    private static final CompoundName collapsesize=new CompoundName("collapsesize");
+    private static final CompoundName collapsefield=new CompoundName("collapse.field");
+    private static final CompoundName collapsesize=new CompoundName("collapse.size");
     private static final CompoundName collapseSummaryName=new CompoundName("collapse.summary");
 
     /** Maximum number of queries to send next searcher */

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
@@ -28,10 +28,10 @@ import java.util.Map;
 @Before(PhaseNames.TRANSFORMED_QUERY)
 public class FieldCollapsingSearcher extends Searcher {
 
-    private static final CompoundName collapse = new CompoundName("collapse");
-    private static final CompoundName collapsefield=new CompoundName("collapse.field");
-    private static final CompoundName collapsesize=new CompoundName("collapse.size");
-    private static final CompoundName collapseSummaryName=new CompoundName("collapse.summary");
+    public static final CompoundName collapse = new CompoundName("collapse");
+    public static final CompoundName collapsefield=new CompoundName("collapse.field");
+    public static final CompoundName collapsesize=new CompoundName("collapse.size");
+    public static final CompoundName collapseSummaryName=new CompoundName("collapse.summary");
 
     /** Maximum number of queries to send next searcher */
     private int maxQueries = 4;

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/SemanticSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/SemanticSearcher.java
@@ -29,7 +29,7 @@ public class SemanticSearcher extends Searcher {
 
     private static final CompoundName rulesRulebase=new CompoundName("rules.rulebase");
     private static final CompoundName rulesOff=new CompoundName("rules.off");
-    private static final CompoundName tracelevelRules=new CompoundName("tracelevel.rules");
+    private static final CompoundName tracelevelRules=new CompoundName("trace.rules");
 
     /** The default rule base of this */
     private RuleBase defaultRuleBase;

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/SemanticSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/SemanticSearcher.java
@@ -9,6 +9,7 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.PhaseNames;

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/SemanticSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/SemanticSearcher.java
@@ -30,7 +30,7 @@ public class SemanticSearcher extends Searcher {
 
     private static final CompoundName rulesRulebase=new CompoundName("rules.rulebase");
     private static final CompoundName rulesOff=new CompoundName("rules.off");
-    private static final CompoundName tracelevelRules=new CompoundName("trace.rules");
+    public static final CompoundName tracelevelRules=new CompoundName("trace.rules");
 
     /** The default rule base of this */
     private RuleBase defaultRuleBase;

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -198,7 +198,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         argumentType.addField(new FieldDescription(HITS.toString(), "integer", "hits count"));
         // TODO: Should this be added to com.yahoo.search.query.properties.QueryProperties? If not, why not?
         argumentType.addField(new FieldDescription(SEARCH_CHAIN.toString(), "string"));
-        argumentType.addField(new FieldDescription(TRACE_LEVEL.toString(), "integer", "tracelevel, traceLevel"));
+        argumentType.addField(new FieldDescription(TRACE_LEVEL.toString(), "integer", "trace.level tracelevel traceLevel"));
         argumentType.addField(new FieldDescription(NO_CACHE.toString(), "boolean", "nocache"));
         argumentType.addField(new FieldDescription(GROUPING_SESSION_CACHE.toString(), "boolean", "groupingSessionCache"));
         argumentType.addField(new FieldDescription(TIMEOUT.toString(), "string", "timeout"));

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -16,6 +16,7 @@ import com.yahoo.prelude.searcher.FieldCollapsingSearcher;
 import com.yahoo.prelude.semantics.SemanticSearcher;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.federation.FederationSearcher;
+import com.yahoo.search.handler.SearchHandler;
 import com.yahoo.search.query.Model;
 import com.yahoo.search.query.ParameterParser;
 import com.yahoo.search.query.Presentation;
@@ -182,11 +183,24 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
 
     //---------------- Static property handling ------------------------------------
 
+    //Creating trace's query profile type
+    private static final QueryProfileType traceArgumentType;
+    public static final String TRACE = "trace";
+    public static final CompoundName TRACE_LEVEL = new CompoundName("level");
+    static {
+        traceArgumentType = new QueryProfileType(TRACE);
+        traceArgumentType.setStrict(true);
+        traceArgumentType.setBuiltin(true);
+        traceArgumentType.addField(new FieldDescription(TRACE_LEVEL.toString(), "integer", "tracelevel traceLevel"));
+        traceArgumentType.addField(new FieldDescription(SearchHandler.FORCE_TIMESTAMPS.toString(), "boolean"));
+        traceArgumentType.addField(new FieldDescription(SemanticSearcher.tracelevelRules.toString(), "integer"));
+        traceArgumentType.freeze();
+    }
+
     public static final CompoundName OFFSET = new CompoundName("offset");
     public static final CompoundName HITS = new CompoundName("hits");
 
     public static final CompoundName SEARCH_CHAIN = new CompoundName("searchChain");
-    public static final CompoundName TRACE_LEVEL = new CompoundName("trace.level");
     public static final CompoundName NO_CACHE = new CompoundName("noCache");
     public static final CompoundName GROUPING_SESSION_CACHE = new CompoundName("groupingSessionCache");
     public static final CompoundName TIMEOUT = new CompoundName("timeout");
@@ -200,7 +214,6 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         argumentType.addField(new FieldDescription(HITS.toString(), "integer", "hits count"));
         // TODO: Should this be added to com.yahoo.search.query.properties.QueryProperties? If not, why not?
         argumentType.addField(new FieldDescription(SEARCH_CHAIN.toString(), "string"));
-        argumentType.addField(new FieldDescription(TRACE_LEVEL.toString(), "integer", "trace.level tracelevel traceLevel"));
         argumentType.addField(new FieldDescription(NO_CACHE.toString(), "boolean", "nocache"));
         argumentType.addField(new FieldDescription(GROUPING_SESSION_CACHE.toString(), "boolean", "groupingSessionCache"));
         argumentType.addField(new FieldDescription(TIMEOUT.toString(), "string", "timeout"));
@@ -209,8 +222,8 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         argumentType.addField(new FieldDescription(Presentation.PRESENTATION, new QueryProfileFieldType(Presentation.getArgumentType())));
         argumentType.addField(new FieldDescription(Ranking.RANKING, new QueryProfileFieldType(Ranking.getArgumentType())));
         argumentType.addField(new FieldDescription(Model.MODEL, new QueryProfileFieldType(Model.getArgumentType())));
-        argumentType.addField(new FieldDescription(FieldCollapsingSearcher.collapsefield.toString(), "string", "collapsefield"));
-        argumentType.addField(new FieldDescription(FieldCollapsingSearcher.collapsesize.toString(), "string", "collapsesize"));
+        argumentType.addField(new FieldDescription(TRACE, new QueryProfileFieldType(traceArgumentType)));
+        argumentType.addField(new FieldDescription(FieldCollapsingSearcher.COLLAPSE, new QueryProfileFieldType(FieldCollapsingSearcher.getArgumentType())));
         argumentType.freeze();
     }
     public static QueryProfileType getArgumentType() { return argumentType; }

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -184,7 +184,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
     public static final CompoundName HITS = new CompoundName("hits");
 
     public static final CompoundName SEARCH_CHAIN = new CompoundName("searchChain");
-    public static final CompoundName TRACE_LEVEL = new CompoundName("traceLevel");
+    public static final CompoundName TRACE_LEVEL = new CompoundName("trace.level");
     public static final CompoundName NO_CACHE = new CompoundName("noCache");
     public static final CompoundName GROUPING_SESSION_CACHE = new CompoundName("groupingSessionCache");
     public static final CompoundName TIMEOUT = new CompoundName("timeout");
@@ -198,7 +198,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         argumentType.addField(new FieldDescription(HITS.toString(), "integer", "hits count"));
         // TODO: Should this be added to com.yahoo.search.query.properties.QueryProperties? If not, why not?
         argumentType.addField(new FieldDescription(SEARCH_CHAIN.toString(), "string"));
-        argumentType.addField(new FieldDescription(TRACE_LEVEL.toString(), "integer", "tracelevel"));
+        argumentType.addField(new FieldDescription(TRACE_LEVEL.toString(), "integer", "tracelevel, traceLevel"));
         argumentType.addField(new FieldDescription(NO_CACHE.toString(), "boolean", "nocache"));
         argumentType.addField(new FieldDescription(GROUPING_SESSION_CACHE.toString(), "boolean", "groupingSessionCache"));
         argumentType.addField(new FieldDescription(TIMEOUT.toString(), "string", "timeout"));

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -12,6 +12,8 @@ import com.yahoo.prelude.fastsearch.DocumentDatabase;
 import com.yahoo.prelude.query.Highlight;
 import com.yahoo.prelude.query.QueryException;
 import com.yahoo.prelude.query.textualrepresentation.TextualQueryRepresentation;
+import com.yahoo.prelude.searcher.FieldCollapsingSearcher;
+import com.yahoo.prelude.semantics.SemanticSearcher;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.federation.FederationSearcher;
 import com.yahoo.search.query.Model;
@@ -207,6 +209,8 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         argumentType.addField(new FieldDescription(Presentation.PRESENTATION, new QueryProfileFieldType(Presentation.getArgumentType())));
         argumentType.addField(new FieldDescription(Ranking.RANKING, new QueryProfileFieldType(Ranking.getArgumentType())));
         argumentType.addField(new FieldDescription(Model.MODEL, new QueryProfileFieldType(Model.getArgumentType())));
+        argumentType.addField(new FieldDescription(FieldCollapsingSearcher.collapsefield.toString(), "string", "collapsefield"));
+        argumentType.addField(new FieldDescription(FieldCollapsingSearcher.collapsesize.toString(), "string", "collapsesize"));
         argumentType.freeze();
     }
     public static QueryProfileType getArgumentType() { return argumentType; }

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -96,7 +96,7 @@ public class SearchHandler extends LoggingRequestHandler {
 
     public static final String defaultSearchChainName = "default";
     private static final String fallbackSearchChain = "vespa";
-    private static final CompoundName FORCE_TIMESTAMPS = new CompoundName("trace.timestamps");;
+    public static final CompoundName FORCE_TIMESTAMPS = new CompoundName("timestamps");;
 
     private final Linguistics linguistics;
 


### PR DESCRIPTION
Have changed names on parameters, as discussed on Architect-meeting. I have only added the one alias "tracelevel".

I do not exactly see where I can and should add the new aliases, for the other parameters that do not have a QueryProfileType. Perhaps you could help me, or come with some tips? 

@bratseth 