### PR TITLE
Use default long field value instead of null when position field is n…

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveExpression.java
@@ -22,7 +22,7 @@ public class ZCurveExpression extends Expression {
         if (x != null && y != null) {
             ctx.setValue(new LongFieldValue(ZCurve.encode(x, y)));
         } else {
-            ctx.setValue(null);
+            ctx.setValue(DataType.LONG.createFieldValue());
         }
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveTestCase.java
@@ -41,8 +41,12 @@ public class ZCurveTestCase {
     }
 
     @Test
-    public void requireThatMissingFieldEvaluatesToNull() {
-        assertNull(new ZCurveExpression().execute(PositionDataType.valueOf(null, 9)));
-        assertNull(new ZCurveExpression().execute(PositionDataType.valueOf(6, null)));
+    public void requireThatMissingFieldEvaluatesToDefaultValue() {
+        assertEquals(DataType.LONG.createFieldValue(),
+                new ZCurveExpression().execute(PositionDataType.valueOf(null, 9)));
+        assertEquals(DataType.LONG.createFieldValue(),
+                new ZCurveExpression().execute(PositionDataType.valueOf(6, null)));
+        assertEquals(DataType.LONG.createFieldValue(),
+                new ZCurveExpression().execute(PositionDataType.valueOf(null, null)));
     }
 }


### PR DESCRIPTION
…ot complete.

This ensures the same handling as regular attribute fields when clearing
a field with an "assign: null" json update operation.

@arnej27959 please review