### PR TITLE
Bjorncs/cache metrics context

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -159,8 +159,6 @@ class HttpRequestDispatch {
         try (ResourceReference ref = References.fromResource(jdiscRequest)) {
             HttpRequestFactory.copyHeaders(jettyRequest, jdiscRequest);
             requestContentChannel = requestHandler.handleRequest(jdiscRequest, servletResponseController.responseHandler);
-            // Note: The matched binding is only available after FilteringRequestHandler has called resolveHandler() on the current Container instance.
-            //       resolveHandler() will assigned the matched binding on the Request object.
             metricReporter.setBindingMatch(jdiscRequest.getBindingMatch());
         }
 

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -159,6 +159,9 @@ class HttpRequestDispatch {
         try (ResourceReference ref = References.fromResource(jdiscRequest)) {
             HttpRequestFactory.copyHeaders(jettyRequest, jdiscRequest);
             requestContentChannel = requestHandler.handleRequest(jdiscRequest, servletResponseController.responseHandler);
+            // Note: The matched binding is only available after FilteringRequestHandler has called resolveHandler() on the current Container instance.
+            //       resolveHandler() will assigned the matched binding on the Request object.
+            metricReporter.setBindingMatch(jdiscRequest.getBindingMatch());
         }
 
         ServletInputStream servletInputStream = jettyRequest.getInputStream();

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscFilterInvokerFilter.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscFilterInvokerFilter.java
@@ -127,7 +127,7 @@ class JDiscFilterInvokerFilter implements Filter {
             final AccessLogEntry accessLogEntry = null; // Not used in this context.
             return new HttpRequestDispatch(jDiscContext,
                                            accessLogEntry,
-                                           getConnector(request).getRequestMetricDimensions(request),
+                                           getConnector(request).getRequestMetricContext(request),
                                            request, response);
         } catch (IOException e) {
             throw throwUnchecked(e);

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServlet.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServlet.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -91,7 +90,7 @@ class JDiscHttpServlet extends HttpServlet {
             throws ServletException, IOException {
         request.setAttribute(JDiscServerConnector.REQUEST_ATTRIBUTE, getConnector(request));
 
-        Metric.Context metricContext = context.metric.createContext(getRequestMetricDimensions(request));
+        Metric.Context metricContext = getMetricContext(request);
         context.metric.add(JettyHttpServer.Metrics.NUM_REQUESTS, 1, metricContext);
         context.metric.add(JettyHttpServer.Metrics.JDISC_HTTP_REQUESTS, 1, metricContext);
         context.metric.add(JettyHttpServer.Metrics.MANHATTAN_NUM_REQUESTS, 1, metricContext);
@@ -114,7 +113,7 @@ class JDiscHttpServlet extends HttpServlet {
         try {
             switch (request.getDispatcherType()) {
                 case REQUEST:
-                    new HttpRequestDispatch(context, accessLogEntry, getRequestMetricDimensions(request), request, response)
+                    new HttpRequestDispatch(context, accessLogEntry, getMetricContext(request), request, response)
                             .dispatch();
                     break;
                 default:
@@ -130,8 +129,8 @@ class JDiscHttpServlet extends HttpServlet {
         }
     }
 
-    private static Map<String, Object> getRequestMetricDimensions(HttpServletRequest request) {
-        return JDiscServerConnector.fromRequest(request).getRequestMetricDimensions(request);
+    private static Metric.Context getMetricContext(HttpServletRequest request) {
+        return JDiscServerConnector.fromRequest(request).getRequestMetricContext(request);
     }
 
     private static String formatAttributes(final HttpServletRequest request) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
@@ -15,7 +15,6 @@ import java.lang.reflect.Field;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
@@ -124,12 +123,12 @@ class JDiscServerConnector extends ServerConnector {
         return metricCtx;
     }
 
-    public Map<String, Object> getRequestMetricDimensions(HttpServletRequest request) {
-        Map<String, Object> props = new HashMap<>();
+    public Metric.Context getRequestMetricContext(HttpServletRequest request) {
+        Map<String, Object> props = new TreeMap<>();
         props.put(JettyHttpServer.Metrics.NAME_DIMENSION, connectorName);
         props.put(JettyHttpServer.Metrics.PORT_DIMENSION, listenPort);
         props.put(JettyHttpServer.Metrics.METHOD_DIMENSION, request.getMethod());
-        return props;
+        return metric.createContext(props);
     }
 
     public static JDiscServerConnector fromRequest(ServletRequest request) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
@@ -15,8 +15,9 @@ import java.lang.reflect.Field;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -27,6 +28,7 @@ class JDiscServerConnector extends ServerConnector {
     public static final String REQUEST_ATTRIBUTE = JDiscServerConnector.class.getName();
     private final static Logger log = Logger.getLogger(JDiscServerConnector.class.getName());
     private final Metric.Context metricCtx;
+    private final Map<String, Metric.Context> requestMetricContextCache = new ConcurrentHashMap<>();
     private final ServerConnectionStatistics statistics;
     private final boolean tcpKeepAlive;
     private final boolean tcpNoDelay;
@@ -41,20 +43,13 @@ class JDiscServerConnector extends ServerConnector {
         this.channelOpenedByActivator = channelOpenedByActivator;
         this.tcpKeepAlive = config.tcpKeepAliveEnabled();
         this.tcpNoDelay = config.tcpNoDelay();
-        this.metricCtx = createMetricContext(config, metric);
         this.metric = metric;
         this.connectorName = config.name();
         this.listenPort = config.listenPort();
+        this.metricCtx = metric.createContext(createConnectorDimensions(listenPort, connectorName));
 
         this.statistics = new ServerConnectionStatistics();
         addBean(statistics);
-    }
-
-    private Metric.Context createMetricContext(ConnectorConfig config, Metric metric) {
-        Map<String, Object> props = new TreeMap<>();
-        props.put(JettyHttpServer.Metrics.NAME_DIMENSION, config.name());
-        props.put(JettyHttpServer.Metrics.PORT_DIMENSION, config.listenPort());
-        return metric.createContext(props);
     }
 
     @Override
@@ -124,15 +119,23 @@ class JDiscServerConnector extends ServerConnector {
     }
 
     public Metric.Context getRequestMetricContext(HttpServletRequest request) {
-        Map<String, Object> props = new TreeMap<>();
-        props.put(JettyHttpServer.Metrics.NAME_DIMENSION, connectorName);
-        props.put(JettyHttpServer.Metrics.PORT_DIMENSION, listenPort);
-        props.put(JettyHttpServer.Metrics.METHOD_DIMENSION, request.getMethod());
-        return metric.createContext(props);
+        String method = request.getMethod();
+        return requestMetricContextCache.computeIfAbsent(method, ignored -> {
+            Map<String, Object> dimensions = createConnectorDimensions(listenPort, connectorName);
+            dimensions.put(JettyHttpServer.Metrics.METHOD_DIMENSION, method);
+            return metric.createContext(dimensions);
+        });
     }
 
     public static JDiscServerConnector fromRequest(ServletRequest request) {
         return (JDiscServerConnector) request.getAttribute(REQUEST_ATTRIBUTE);
+    }
+
+    private static Map<String, Object> createConnectorDimensions(int listenPort, String connectorName) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(JettyHttpServer.Metrics.NAME_DIMENSION, connectorName);
+        props.put(JettyHttpServer.Metrics.PORT_DIMENSION, listenPort);
+        return props;
     }
 
 }

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -67,7 +67,6 @@ public class JettyHttpServer extends AbstractServerProvider {
         String NAME_DIMENSION = "serverName";
         String PORT_DIMENSION = "serverPort";
         String METHOD_DIMENSION = "httpMethod";
-        String HANDLER_DIMENSION = "handler";
 
         String NUM_OPEN_CONNECTIONS = "serverNumOpenConnections";
         String NUM_CONNECTIONS_OPEN_MAX = "serverConnectionsOpenMax";

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/MetricReporter.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/MetricReporter.java
@@ -3,25 +3,20 @@ package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.Metric.Context;
-import com.yahoo.jdisc.application.BindingMatch;
-import com.yahoo.jdisc.application.UriPattern;
-import com.yahoo.jdisc.handler.RequestHandler;
-import com.yahoo.jdisc.http.server.jetty.JettyHttpServer.Metrics;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.yahoo.jdisc.http.server.jetty.JettyHttpServer.Metrics;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 
 /**
  * Responsible for metric reporting for JDisc http request handler support.
- *
  * @author Tony Vaagenes
  */
 public class MetricReporter {
     private final Metric metric;
-    private volatile Context context;
-    private final Map<String, Object> requestDimensions;
+    private final @Nullable Context context;
 
     private final long requestStartTime;
 
@@ -29,20 +24,10 @@ public class MetricReporter {
     private final AtomicBoolean firstSetOfTimeToFirstByte = new AtomicBoolean(true);
 
 
-    public MetricReporter(Metric metric, Map<String, Object> requestDimensions, long requestStartTime) {
+    public MetricReporter(Metric metric, @Nullable Context context, long requestStartTime) {
         this.metric = metric;
-        this.context = metric.createContext(requestDimensions);
-        this.requestDimensions = requestDimensions;
+        this.context = context;
         this.requestStartTime = requestStartTime;
-    }
-
-    public void setBindingMatch(BindingMatch<?> bindingMatch) {
-        if (bindingMatch == null) return;
-        UriPattern pattern = bindingMatch.matched();
-        if (pattern == null) return;
-        Map<String, Object> combinedDimensions = new HashMap<>(requestDimensions);
-        combinedDimensions.put(Metrics.HANDLER_DIMENSION, pattern.toString());
-        this.context = metric.createContext(combinedDimensions);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Removes the handler/binding dimension for now. Also introduces caching of metric context instances as they are expensive to manage.