### PR TITLE
Bjorncs/hotfix

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceConfirmationResource.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceConfirmationResource.java
@@ -32,6 +32,7 @@ public class InstanceConfirmationResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public InstanceConfirmation confirmInstance(InstanceConfirmation instanceConfirmation) {
+        log.log(LogLevel.DEBUG, instanceConfirmation.toString());
         if (!instanceValidator.isValidInstance(instanceConfirmation)) {
             log.log(LogLevel.ERROR, "Invalid instance: " + instanceConfirmation);
             throw new ForbiddenException("Instance is invalid");

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceRefreshResource.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceRefreshResource.java
@@ -34,6 +34,7 @@ public class InstanceRefreshResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public InstanceConfirmation confirmInstanceRefresh(InstanceConfirmation instanceConfirmation) {
+        log.log(LogLevel.DEBUG, instanceConfirmation.toString());
         if (!instanceValidator.isValidRefresh(instanceConfirmation)) {
             log.log(LogLevel.ERROR, "Invalid instance refresh: " + instanceConfirmation);
             throw new ForbiddenException("Instance is invalid");

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceRefreshResource.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceRefreshResource.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.athenz.instanceproviderservice.instanceconfirmation;
 
 import com.google.inject.Inject;
@@ -14,26 +14,28 @@ import javax.ws.rs.core.MediaType;
 import java.util.logging.Logger;
 
 /**
+ * ZTS calls this resource when it's requested to refresh an instance certificate
+ *
  * @author bjorncs
  */
-@Path("/instance")
-public class InstanceConfirmationResource {
+@Path("/refresh")
+public class InstanceRefreshResource {
 
-    private static final Logger log = Logger.getLogger(InstanceConfirmationResource.class.getName());
+    private static final Logger log = Logger.getLogger(InstanceRefreshResource.class.getName());
 
     private final InstanceValidator instanceValidator;
 
     @Inject
-    public InstanceConfirmationResource(@Component InstanceValidator instanceValidator) {
+    public InstanceRefreshResource(@Component InstanceValidator instanceValidator) {
         this.instanceValidator = instanceValidator;
     }
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public InstanceConfirmation confirmInstance(InstanceConfirmation instanceConfirmation) {
-        if (!instanceValidator.isValidInstance(instanceConfirmation)) {
-            log.log(LogLevel.ERROR, "Invalid instance: " + instanceConfirmation);
+    public InstanceConfirmation confirmInstanceRefresh(InstanceConfirmation instanceConfirmation) {
+        if (!instanceValidator.isValidRefresh(instanceConfirmation)) {
+            log.log(LogLevel.ERROR, "Invalid instance refresh: " + instanceConfirmation);
             throw new ForbiddenException("Instance is invalid");
         }
         return instanceConfirmation;

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceValidator.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceValidator.java
@@ -61,6 +61,17 @@ public class InstanceValidator {
         return false;
     }
 
+    // TODO Add actual validation. Cannot reuse isValidInstance as identity document is not part of the refresh request.
+    //      We'll have to perform some validation on the instance id and other fields of the attribute map.
+    //      Separate between tenant and node certificate as well.
+    public boolean isValidRefresh(InstanceConfirmation confirmation) {
+        log.log(LogLevel.INFO, () -> String.format("Accepting refresh for instance with identity '%s', provider '%s', instanceId '%s'.",
+                                                   new AthenzService(confirmation.domain, confirmation.service).getFullName(),
+                                                   confirmation.provider,
+                                                   confirmation.attributes.get("sanDNS").toString()));
+        return true;
+    }
+
     // If/when we dont care about logging exactly whats wrong, this can be simplified
     // TODO Use identity type to determine if this check should be performed
     boolean isSameIdentityAsInServicesXml(ApplicationId applicationId, String domain, String service) {


### PR DESCRIPTION
@tokle We have to revisit the certificate refresh logic as it has not been working correctly. This PR ensures that certificate refresh requests are accepted on the configserver, though without any extra validation.