### PR TITLE
Only create model for wanted vespa version on hosted vespa

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -28,7 +28,6 @@ import java.util.concurrent.Executors;
 public class ConfigServerBootstrap extends AbstractComponent implements Runnable {
 
     private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(ConfigServerBootstrap.class.getName());
-    private static final ExecutorService rpcServerExecutor  = Executors.newSingleThreadExecutor(new DaemonThreadFactory("config server RPC server"));
     private static final String vipStatusClusterIdentifier = "configserver";
 
     enum MainThread {START, DO_NOT_START}
@@ -43,6 +42,7 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
     private final Duration maxDurationOfRedeployment;
     private final Duration sleepTimeWhenRedeployingFails;
     private final RedeployingApplicationsFails exitIfRedeployingApplicationsFails;
+    private final ExecutorService rpcServerExecutor;
 
     // The tenants object is injected so that all initial requests handlers are
     // added to the rpc server before it starts answering rpc requests.
@@ -66,6 +66,7 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
         this.maxDurationOfRedeployment = Duration.ofSeconds(applicationRepository.configserverConfig().maxDurationOfBootstrap());
         this.sleepTimeWhenRedeployingFails = Duration.ofSeconds(applicationRepository.configserverConfig().sleepTimeWhenRedeployingFails());
         this.exitIfRedeployingApplicationsFails = exitIfRedeployingApplicationsFails;
+        rpcServerExecutor = Executors.newSingleThreadExecutor(new DaemonThreadFactory("config server RPC server"));
         initializing(); // Initially take server out of rotation
         if (mainThread == MainThread.START)
             start();

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -147,9 +147,10 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
         if (Arrays.asList(Environment.dev, Environment.test, Environment.staging).contains(zone().environment()))
             versions = keepThoseUsedOn(allocatedHosts.get(), versions);
 
-        // Make sure we build wanted version if we are building models for this major version
+        // Make sure we build wanted version if we are building models for this major version and we are on hosted vespa
+        // If not on hosted vespa, we do not want to try to build this version, since we have only one version (the latest)
         Version wantedVersion = Version.fromIntValues(wantedNodeVespaVersion.getMajor(), wantedNodeVespaVersion.getMinor(), wantedNodeVespaVersion.getMicro());
-        if (wantedVersion.getMajor() == latest.getMajor())
+        if (hosted && wantedVersion.getMajor() == latest.getMajor())
             versions.add(wantedVersion);
 
         // TODO: We use the allocated hosts from the newest version when building older model versions.

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -108,8 +108,13 @@ public class DeployTester {
     }
 
     public DeployTester(List<ModelFactory> modelFactories, ConfigserverConfig configserverConfig, Clock clock, Zone zone, HostProvisioner provisioner) {
+        this(modelFactories, configserverConfig, clock, zone, provisioner, new MockCurator());
+    }
+
+    public DeployTester(List<ModelFactory> modelFactories, ConfigserverConfig configserverConfig, Clock clock, Zone zone,
+                        HostProvisioner provisioner, Curator curator) {
         this.clock = clock;
-        TestComponentRegistry componentRegistry = createComponentRegistry(new MockCurator(), Metrics.createTestMetrics(),
+        TestComponentRegistry componentRegistry = createComponentRegistry(curator, Metrics.createTestMetrics(),
                                                                           modelFactories, configserverConfig, clock, zone,
                                                                           provisioner);
         try {


### PR DESCRIPTION
When not on hosted vespa, there will be only the latest model
version available, so make sure not to try to create wanted version
(the one stored in zookeeper, since wanted version is not used anywhere
else)