### PR TITLE
Add reader/writer persistence locking support

### DIFF
--- a/persistence/src/vespa/persistence/spi/persistenceprovider.h
+++ b/persistence/src/vespa/persistence/spi/persistenceprovider.h
@@ -232,6 +232,9 @@ struct PersistenceProvider
      * document id. If no versions were found, or the document was removed,
      * the result should be successful, but contain no document (see GetResult).
      *
+     * Concurrency note: may be called concurrently with other read-only
+     * operations.
+     *
      * @param fieldSet A set of fields that should be retrieved.
      * @param id The document id to retrieve.
      */
@@ -252,6 +255,9 @@ struct PersistenceProvider
      * the information required to match iterator ids up to their current
      * iteration progress and selection criteria. destroyIterator will NOT
      * be called when createIterator returns an error.
+     *
+     * Concurrency note: may be called concurrently with other read-only
+     * operations.
      *
      * @param selection Selection criteria used to limit the subset of
      *   the bucket's documents that will be returned by the iterator. The
@@ -322,6 +328,9 @@ struct PersistenceProvider
      * to indicate this to the caller. Calling iterate on an already completed
      * iterator must only set this flag on the result and return without any
      * documents.
+     *
+     * Concurrency note: may be called concurrently with other read-only
+     * operations.
      *
      * @param id An iterator ID returned by a previous call to createIterator
      * @param maxByteSize An indication of the maximum number of bytes that

--- a/storage/src/tests/persistence/common/filestortestfixture.h
+++ b/storage/src/tests/persistence/common/filestortestfixture.h
@@ -19,8 +19,6 @@ public:
 
     std::unique_ptr<TestServiceLayerApp> _node;
     std::unique_ptr<vdstestlib::DirConfig> _config;
-    std::unique_ptr<vdstestlib::DirConfig> _config2;
-    std::unique_ptr<vdstestlib::DirConfig> _smallConfig;
     const document::DocumentType* _testdoctype1;
 
     static const uint32_t MSG_WAIT_TIME = 60 * 1000;
@@ -30,9 +28,11 @@ public:
 
     void setUp() override;
     void tearDown() override;
-    void setupDisks(uint32_t diskCount);
+    void setupPersistenceThreads(uint32_t diskCount);
     void createBucket(const document::BucketId& bid);
     bool bucketExistsInDb(const document::BucketId& bucket) const;
+
+    static api::StorageMessageAddress makeSelfAddress();
 
     api::ReturnCode::Result resultOf(const api::StorageReply& reply) const {
         return reply.getResult().getResult();
@@ -98,8 +98,6 @@ public:
         TestFileStorComponents(FileStorTestFixture& fixture,
                                const char* testName,
                                const StorageLinkInjector& i = NoOpStorageLinkInjector());
-
-        api::StorageMessageAddress makeSelfAddress() const;
 
         void sendDummyGet(const document::BucketId& bid);
         void sendPut(const document::BucketId& bid,

--- a/storage/src/tests/persistence/filestorage/mergeblockingtest.cpp
+++ b/storage/src/tests/persistence/filestorage/mergeblockingtest.cpp
@@ -16,7 +16,7 @@ class MergeBlockingTest : public FileStorTestFixture
 {
 public:
     void setupDisks() {
-        FileStorTestFixture::setupDisks(1);
+        FileStorTestFixture::setupPersistenceThreads(1);
         _node->setPersistenceProvider(
                 spi::PersistenceProvider::UP(
                         new spi::dummy::DummyPersistence(_node->getTypeRepo(), 1)));

--- a/storage/src/tests/persistence/filestorage/operationabortingtest.cpp
+++ b/storage/src/tests/persistence/filestorage/operationabortingtest.cpp
@@ -86,9 +86,9 @@ public:
     std::unique_ptr<vespalib::Barrier> _queueBarrier;
     std::unique_ptr<vespalib::Barrier> _completionBarrier;
 
-    void setupDisks(uint32_t diskCount, uint32_t queueBarrierThreads) {
-        FileStorTestFixture::setupDisks(diskCount);
-        _dummyProvider.reset(new spi::dummy::DummyPersistence(_node->getTypeRepo(), diskCount));
+    void setupProviderAndBarriers(uint32_t queueBarrierThreads) {
+        FileStorTestFixture::setupPersistenceThreads(1);
+        _dummyProvider.reset(new spi::dummy::DummyPersistence(_node->getTypeRepo(), 1));
         _queueBarrier.reset(new vespalib::Barrier(queueBarrierThreads));
         _completionBarrier.reset(new vespalib::Barrier(2));
         _blockingProvider = new BlockingMockProvider(*_dummyProvider, *_queueBarrier, *_completionBarrier);
@@ -219,7 +219,7 @@ makeAbortCmd(const Container& buckets)
 void
 OperationAbortingTest::testAbortMessageClearsRelevantQueuedOperations()
 {
-    setupDisks(1, 2);
+    setupProviderAndBarriers(2);
     TestFileStorComponents c(*this, "testAbortMessageClearsRelevantQueuedOperations");
     document::BucketId bucket(16, 1);
     createBucket(bucket);
@@ -305,7 +305,7 @@ public:
 void
 OperationAbortingTest::testWaitForCurrentOperationCompletionForAbortedBucket()
 {
-    setupDisks(1, 3);
+    setupProviderAndBarriers(3);
     TestFileStorComponents c(*this, "testWaitForCurrentOperationCompletionForAbortedBucket");
 
     document::BucketId bucket(16, 1);
@@ -386,7 +386,7 @@ OperationAbortingTest::doTestSpecificOperationsNotAborted(const char* testName,
                                                           const std::vector<api::StorageMessage::SP>& msgs,
                                                           bool shouldCreateBucketInitially)
 {
-    setupDisks(1, 2);
+    setupProviderAndBarriers(2);
     TestFileStorComponents c(*this, testName);
     document::BucketId bucket(16, 1);
     document::BucketId blockerBucket(16, 2);    

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.cpp
@@ -71,9 +71,9 @@ FileStorHandler::getNextMessage(uint16_t disk, uint32_t stripeId, LockedMessage&
 }
 
 FileStorHandler::BucketLockInterface::SP
-FileStorHandler::lock(const document::Bucket& bucket, uint16_t disk)
+FileStorHandler::lock(const document::Bucket& bucket, uint16_t disk, api::LockingRequirements lockReq)
 {
-    return _impl->lock(bucket, disk);
+    return _impl->lock(bucket, disk, lockReq);
 }
 
 void

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -58,8 +58,9 @@ public:
         typedef std::shared_ptr<BucketLockInterface> SP;
 
         virtual const document::Bucket &getBucket() const = 0;
+        virtual api::LockingRequirements lockingRequirements() const noexcept = 0;
 
-        virtual ~BucketLockInterface() {};
+        virtual ~BucketLockInterface() = default;
     };
 
     typedef std::pair<BucketLockInterface::SP, api::StorageMessage::SP> LockedMessage;
@@ -139,7 +140,7 @@ public:
      *
      *
      */
-    BucketLockInterface::SP lock(const document::Bucket&, uint16_t disk);
+    BucketLockInterface::SP lock(const document::Bucket&, uint16_t disk, api::LockingRequirements lockReq);
 
     /**
      * Called by FileStorThread::onBucketDiskMove() after moving file, in case

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -959,7 +959,9 @@ FileStorHandlerImpl::Stripe::getNextMessage(FileStorHandler::LockedMessage& lck)
     }
 
     api::StorageMessage & m(*range.first->_command);
-    // We don't allow batching of operations across lock requirement modes.
+    // For now, don't allow batching of operations across lock requirement modes.
+    // We might relax this requirement later once we're 100% sure it can't trigger
+    // any unfortunate edge cases.
     if (lck.first->lockingRequirements() != m.lockingRequirements()) {
         lck.second.reset();
         return lck;

--- a/storage/src/vespa/storage/persistence/messages.h
+++ b/storage/src/vespa/storage/persistence/messages.h
@@ -38,6 +38,9 @@ public:
     void setMaxByteSize(uint32_t maxByteSize) { _maxByteSize = maxByteSize; }
     uint32_t getMaxByteSize() const { return _maxByteSize; }
 
+    api::LockingRequirements lockingRequirements() const noexcept override {
+        return api::LockingRequirements::Shared;
+    }
 
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 private:
@@ -104,6 +107,9 @@ public:
     }
     spi::ReadConsistency getReadConsistency() const noexcept {
         return _readConsistency;
+    }
+    api::LockingRequirements lockingRequirements() const noexcept override {
+        return api::LockingRequirements::Shared;
     }
 
     std::unique_ptr<api::StorageReply> makeReply() override;

--- a/storage/src/vespa/storage/visiting/stor-visitor.def
+++ b/storage/src/vespa/storage/visiting/stor-visitor.def
@@ -24,6 +24,7 @@ defaultparalleliterators int default=8
 ## will be 16 requests to persistence layer, but only 8 will be able to execute
 ## at the same time, since only one operation can be executed at the same time
 ## for one bucket)
+## DEPRECATED: ignored by backend, 1 is always used.
 iterators_per_bucket int default=1
 
 ## Default number of maximum client replies pending.

--- a/storage/src/vespa/storage/visiting/visitorthread.cpp
+++ b/storage/src/vespa/storage/visiting/visitorthread.cpp
@@ -637,7 +637,6 @@ VisitorThread::onInternal(const std::shared_ptr<api::InternalCommand>& cmd)
             _ignoreNonExistingVisitorTimeLimit
                     = config.ignorenonexistingvisitortimelimit;
             _defaultParallelIterators = config.defaultparalleliterators;
-            _iteratorsPerBucket = config.iteratorsPerBucket;
             _defaultPendingMessages = config.defaultpendingmessages;
             _defaultDocBlockSize = config.defaultdocblocksize;
             _visitorMemoryUsageLimit = config.visitorMemoryUsageLimit;
@@ -646,12 +645,6 @@ VisitorThread::onInternal(const std::shared_ptr<api::InternalCommand>& cmd)
             if (_defaultParallelIterators < 1) {
                 LOG(config, "Cannot use value of defaultParallelIterators < 1");
                 _defaultParallelIterators = 1;
-            }
-            if (_iteratorsPerBucket < 1 && _iteratorsPerBucket > 10) {
-                if (_iteratorsPerBucket < 1) _iteratorsPerBucket = 1;
-                else _iteratorsPerBucket = 10;
-                LOG(config, "Invalid value of iterators per bucket %u using %u",
-                    config.iteratorsPerBucket, _iteratorsPerBucket);
             }
             if (_defaultPendingMessages < 1) {
                 LOG(config, "Cannot use value of defaultPendingMessages < 1");

--- a/storageapi/src/vespa/storageapi/message/persistence.h
+++ b/storageapi/src/vespa/storageapi/message/persistence.h
@@ -24,7 +24,7 @@ class TestAndSetCommand : public BucketInfoCommand {
     TestAndSetCondition _condition;
 public:
     TestAndSetCommand(const MessageType & messageType, const document::Bucket &bucket);
-    ~TestAndSetCommand();
+    ~TestAndSetCommand() override;
 
     void setCondition(const TestAndSetCondition & condition) { _condition = condition; }
     const TestAndSetCondition & getCondition() const { return _condition; }
@@ -49,7 +49,7 @@ class PutCommand : public TestAndSetCommand {
 
 public:
     PutCommand(const document::Bucket &bucket, const DocumentSP&, Timestamp);
-    ~PutCommand();
+    ~PutCommand() override;
 
     void setTimestamp(Timestamp ts) { _timestamp = ts; }
 
@@ -86,7 +86,7 @@ class PutReply : public BucketInfoReply {
 
 public:
     explicit PutReply(const PutCommand& cmd, bool wasFound = true);
-    ~PutReply();
+    ~PutReply() override;
 
     const document::DocumentId& getDocumentId() const { return _docId; }
     bool hasDocument() const { return _document.get(); }
@@ -116,7 +116,7 @@ class UpdateCommand : public TestAndSetCommand {
 public:
     UpdateCommand(const document::Bucket &bucket,
                   const std::shared_ptr<document::DocumentUpdate>&, Timestamp);
-    ~UpdateCommand();
+    ~UpdateCommand() override;
 
     void setTimestamp(Timestamp ts) { _timestamp = ts; }
     void setOldTimestamp(Timestamp ts) { _oldTimestamp = ts; }
@@ -147,7 +147,7 @@ class UpdateReply : public BucketInfoReply {
 
 public:
     UpdateReply(const UpdateCommand& cmd, Timestamp oldTimestamp = 0);
-    ~UpdateReply();
+    ~UpdateReply() override;
 
     void setOldTimestamp(Timestamp ts) { _oldTimestamp = ts; }
 
@@ -189,7 +189,7 @@ class GetCommand : public BucketInfoCommand {
 public:
     GetCommand(const document::Bucket &bucket, const document::DocumentId&,
                const vespalib::stringref & fieldSet, Timestamp before = MAX_TIMESTAMP);
-    ~GetCommand();
+    ~GetCommand() override;
     void setBeforeTimestamp(Timestamp ts) { _beforeTimestamp = ts; }
     const document::DocumentId& getDocumentId() const { return _docId; }
     Timestamp getBeforeTimestamp() const { return _beforeTimestamp; }
@@ -198,6 +198,10 @@ public:
 
     vespalib::string getSummary() const override;
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
+
+    api::LockingRequirements lockingRequirements() const noexcept override {
+        return api::LockingRequirements::Shared;
+    }
 
     DECLARE_STORAGECOMMAND(GetCommand, onGet)
 };
@@ -219,7 +223,7 @@ public:
     GetReply(const GetCommand& cmd,
              const DocumentSP& doc = DocumentSP(),
              Timestamp lastModified = 0);
-    ~GetReply();
+    ~GetReply() override;
 
     const DocumentSP& getDocument() const { return _doc; }
     const document::DocumentId& getDocumentId() const { return _docId; }
@@ -245,7 +249,7 @@ class RemoveCommand : public TestAndSetCommand {
 
 public:
     RemoveCommand(const document::Bucket &bucket, const document::DocumentId& docId, Timestamp timestamp);
-    ~RemoveCommand();
+    ~RemoveCommand() override;
 
     void setTimestamp(Timestamp ts) { _timestamp = ts; }
     const document::DocumentId& getDocumentId() const override { return _docId; }
@@ -267,7 +271,7 @@ class RemoveReply : public BucketInfoReply {
     Timestamp _oldTimestamp;
 public:
     explicit RemoveReply(const RemoveCommand& cmd, Timestamp oldTimestamp = 0);
-    ~RemoveReply();
+    ~RemoveReply() override;
 
     const document::DocumentId& getDocumentId() const { return _docId; }
     Timestamp getTimestamp() { return _timestamp; };
@@ -289,7 +293,7 @@ class RevertCommand : public BucketInfoCommand {
 public:
     RevertCommand(const document::Bucket &bucket,
                   const std::vector<Timestamp>& revertTokens);
-    ~RevertCommand();
+    ~RevertCommand() override;
     const std::vector<Timestamp>& getRevertTokens() const { return _tokens; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGECOMMAND(RevertCommand, onRevert)
@@ -305,7 +309,7 @@ class RevertReply : public BucketInfoReply {
     std::vector<Timestamp> _tokens;
 public:
     explicit RevertReply(const RevertCommand& cmd);
-    ~RevertReply();
+    ~RevertReply() override;
     const std::vector<Timestamp>& getRevertTokens() const { return _tokens; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGEREPLY(RevertReply, onRevertReply)

--- a/storageapi/src/vespa/storageapi/messageapi/storagemessage.cpp
+++ b/storageapi/src/vespa/storageapi/messageapi/storagemessage.cpp
@@ -312,4 +312,9 @@ const char* to_string(LockingRequirements req) noexcept {
     assert(false);
 }
 
+std::ostream& operator<<(std::ostream& os, LockingRequirements req) {
+    os << to_string(req);
+    return os;
+}
+
 }

--- a/storageapi/src/vespa/storageapi/messageapi/storagemessage.cpp
+++ b/storageapi/src/vespa/storageapi/messageapi/storagemessage.cpp
@@ -302,4 +302,14 @@ StorageMessage::getSummary() const {
     return toString();
 }
 
+const char* to_string(LockingRequirements req) noexcept {
+    switch (req) {
+    case LockingRequirements::Exclusive:
+        return "Exclusive";
+    case LockingRequirements::Shared:
+        return "Shared";
+    }
+    assert(false);
+}
+
 }

--- a/storageapi/src/vespa/storageapi/messageapi/storagemessage.h
+++ b/storageapi/src/vespa/storageapi/messageapi/storagemessage.h
@@ -19,6 +19,7 @@
 #include <vespa/document/bucket/bucket.h>
 #include <vespa/vespalib/util/printable.h>
 #include <map>
+#include <iosfwd>
 
 namespace vespalib {
     class asciistream;
@@ -317,6 +318,8 @@ enum class LockingRequirements : uint8_t {
 };
 
 const char* to_string(LockingRequirements req) noexcept;
+
+std::ostream& operator<<(std::ostream&, LockingRequirements);
 
 class StorageMessage : public vespalib::Printable
 {


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

This adds support for concurrent processing of `get()`, `createIterator()` and `iterate()` against the SPI for a single bucket iff no conflicting operations are currently running for the bucket. We can finally do this now that VDS is but a fading memory of the past.

In particular, please verify that Proton handles these changes in SPI call concurrency semantics.