### PR TITLE
Increase deafult value for config server mainter interval

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -55,7 +55,7 @@ ztsUrl string default=""
 nodeAdminInContainer bool default=true
 
 # Maintainers
-maintainerIntervalMinutes int default=30
+maintainerIntervalMinutes int default=60
 # TODO: Default set to a high value (1 year) => maintainer will not run, change when maintainer verified out in prod
 tenantsMaintainerIntervalMinutes int default=525600
 


### PR DESCRIPTION
No need to run as often as every 30 minutes.