### PR TITLE
henrhoi/rank-profiles-and-sources-in-configuration-file

### DIFF
--- a/container-search-gui/pom.xml
+++ b/container-search-gui/pom.xml
@@ -44,6 +44,12 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>container-search</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/container-search-gui/src/main/resources/gui/_includes/index.html
+++ b/container-search-gui/src/main/resources/gui/_includes/index.html
@@ -84,7 +84,7 @@
                 	<option class="options" value="POST">POST</option>
                 	<option class="options" value="GET">GET</option>
               </select>
-              <input type="text" class="textbox" name="value" value="http://httpbin.org/post" id="url" size="30">
+              <input type="text" class="textbox" name="value" value="http://localhost:8080/search/" id="url" size="30">
               <button class="button" onclick="startSending();" id="send">Send</button>
 
               <br/>
@@ -184,48 +184,36 @@
 
 
 
-
-
       <SCRIPT language="javascript">
 
-        const CONFIG = $.getJSON('/querybuilder/gui_variables.json', function(data){window.CONFIG = data;});
+        const CONFIG = $.getJSON('/querybuilder/config.json', function(data){window.CONFIG = data;});
         method = "POST";
       	var number = 0;
       	var childno = {};
       	var json = JSON.parse("{}");
         var searchApiReference = null;
-
-      	var possible = ["yql", "hits", "offset", "queryProfile", "nocache", "groupingSessionCache", "searchChain", "timeout", "trace","tracelevel","traceLevel", "",
-      , "model", "ranking", "collapse","collapsesize","collapsesize","presentation", "pos", "streaming", "rules", "recall", "user", "nocachewrite", "metrics"];
-
+        var possible = null;
       	var usedProps = [];
       	var removedIndexes = [0];
-      	var childrenProps = {
-      		"model" : ["defaultIndex", "encoding", "language", "queryString", "restrict", "searchPath", "sources", "type"],
-      		"ranking" : ["location", "features", "listFeatures", "profile", "properties", "sorting", "freshness", "queryCache", "matchPhase"],
-      		"ranking.matchPhase" : ["maxHits", "attribute", "ascending", "diversity"],
-      		"ranking.matchPhase.diversity" : ["attribute", "minGroups"],
-      		"presentation" : ["bolding", "format", "summary", "template", "timing"],
-          "trace" : ["timestamps"],
-          "tracelevel" : ["rules"],
-          "metrics" : ["ignore"],
-      		"collapse":["summary"],
-      		"pos" : ["ll", "radius", "bb", "attribute"],
-      		"streaming" : ["userid", "groupname", "selection", "priority", "maxbucketspervisitor"],
-      		"rules" : ["off", "rulebase"]
-      	};
+        var childrenProps = null;
+
 
         window.onload = function() {
-          // Adding variables from configuration file
-          if (window.CONFIG.hasOwnProperty("featurename")){
-            childrenProps["ranking.features"] = window.CONFIG.featurename;
-          }
-          if (window.CONFIG.hasOwnProperty("propertyname")){
-            childrenProps["ranking.properties"] = window.CONFIG.propertyname;
-          }
+          setTimeout(function(){
+            possible = window.CONFIG.levelZeroParameters;
+            childrenProps = window.CONFIG.childMap;
 
-          addNewRow();
-          getSearchApiReference();
+            if (window.CONFIG.hasOwnProperty("ranking_features")){
+              childrenProps["ranking.features"] = window.CONFIG.ranking_features;
+            }
+            if (window.CONFIG.hasOwnProperty("ranking_properties")){
+              childrenProps["ranking.properties"] = window.CONFIG.ranking_properties;
+            }
+
+
+            addNewRow();
+            getSearchApiReference();
+          }, 250);
         };
 
         var stringType = ["yql", "queryProfile", "searchChain", "model.defaultIndex", "model.encoding", "model.language",
@@ -439,10 +427,17 @@
         newInput.classList.add("input")
       	var newDatalist = document.createElement("datalist");
       	newDatalist.id = "prop"+temp;
+
       	newInputVal = document.createElement("input");
       	newInputVal.type = "text";
       	newInputVal.id = "v"+temp;
         newInputVal.classList.add("propvalue");
+        newInputVal.setAttribute("list", "val"+temp);
+        var newDatalist2 = document.createElement("datalist");
+      	newDatalist2.id = "val"+temp;
+        //newDatalist2.style = "display: none;";
+
+
       	var newButton = document.createElement("button");
       	newButton.id = "b"+temp;
       	newButton.innerHTML = "-";
@@ -478,6 +473,7 @@
         div.appendChild(a);
 
       	div.appendChild(newInputVal);
+        div.appendChild(newDatalist2);
       	div.appendChild(newButton);
       	div.appendChild(br);
 
@@ -525,6 +521,23 @@
         return false;
       }
 
+
+      function checkConfigOptions(key, no){
+        var jsonID = key.replace(/\./g , "_");
+        var datalist = document.getElementById("val"+no);
+        datalist.innerHTML = "";
+        if (window.CONFIG.hasOwnProperty(jsonID)){
+          var optionlist = eval("window.CONFIG."+jsonID);
+          optionlist.forEach(function(item){
+            var option = document.createElement("option");
+            option.value = item;
+            datalist.appendChild(option);
+          });
+
+        }
+
+      }
+
       	function keySelected(no, value){
       		var key = document.getElementById("i"+no).value;
           showInformation(no, key);
@@ -536,6 +549,10 @@
               editAreaLoader.delete_instance(window.yqlID);
             }
       			var button = document.createElement("button");
+
+            //var datalist = document.getElementById("val"+no); //Hide value-datalist
+            //datalist.style = "display:none;";
+
       			button.id="propb"+no
       			button.innerHTML=" +   Add property";
       			button.onclick = function(){addChildProp(no);};
@@ -549,6 +566,8 @@
       				newInputVal.type = "text";
       				newInputVal.id = "v"+no;
               newInputVal.classList.add("propvalue");
+              newInputVal.setAttribute("list", "val"+no);
+
               var parent = button.parentNode;
               showType(newInputVal, no);
               if (key === "yql"){
@@ -586,6 +605,7 @@
                 newInputVal.type = "text";
                 newInputVal.id = "v"+no;
                 newInputVal.classList.add("propvalue");
+                newInputVal.setAttribute("list", "val"+no);
                 showType(newInputVal, no);
                 var parent = inputval.parentNode;
                 parent.replaceChild(newInputVal, inputval);
@@ -627,8 +647,14 @@
             //keyInput.style = "border-width: 1px; border-color: red;"
             var valueInput = document.getElementById("v"+no);
             valueInput.placeholder = "Possible invalid parameter";
+
+            //Removes possible options for for former parameter
+            var datalist = document.getElementById("val"+no);
+            datalist.innerHTML = "";
           }
           if (validKey(no, key)){
+            // Check if datalist should be visible and add options
+            checkConfigOptions(fullKey, no);
             var keyInput = document.getElementById("i"+no);
             //keyInput.style = "border-width: 0px;"
           }
@@ -712,6 +738,11 @@
       	newInputVal.type = "text";
       	newInputVal.id = "v"+temp;
         newInputVal.classList.add("propvalue");
+
+        newInputVal.setAttribute("list", "val"+temp);
+        var newDatalist2 = document.createElement("datalist");
+        newDatalist2.id = "val"+temp;
+
       	var newButton = document.createElement("button");
       	newButton.id = "b"+temp;
       	newButton.innerHTML = "-";
@@ -746,6 +777,7 @@
       	div.appendChild(newDatalist);
         div.append(a);
       	div.appendChild(newInputVal);
+        div.appendChild(newDatalist2);
       	div.appendChild(newButton);
       	div.appendChild(br);
       	parentNode.appendChild(div);

--- a/container-search-gui/src/main/resources/gui/editarea/edit_area/plugins/autocompletion/autocompletion.js
+++ b/container-search-gui/src/main/resources/gui/editarea/edit_area/plugins/autocompletion/autocompletion.js
@@ -480,7 +480,10 @@ var EditArea_autocompletion= {
 				{
 					var line= "<li><a href=\"#\" class=\"entry\" onmousedown=\"EditArea_autocompletion._select('"+ results[i][1]['replace_with'].replace(new RegExp('"', "g"), "&quot;") +"');return false;\">"+ results[i][1]['comment'];
 					if(results[i][0]['prefix_name'].length>0)
-						line+='<span class="prefix">'+ results[i][0]['prefix_name'] +'</span>';
+						var value = results[i][0]['prefix_name'];
+						value = (value == undefined) ? "" : value;
+						if (value == 'SOURCES' || value == ','){value = 'Source'}
+						line+='<span class="prefix">'+ value +'</span>';
 					line+='</a></li>';
 					lines[lines.length]=line;
 				}

--- a/container-search-gui/src/main/resources/gui/editarea/edit_area/reg_syntax/yql.js
+++ b/container-search-gui/src/main/resources/gui/editarea/edit_area/reg_syntax/yql.js
@@ -1,6 +1,19 @@
 /**
 * Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 */
+function getSources(bool){
+		var options = [];
+		if (window.CONFIG.hasOwnProperty("model_sources")){
+			var sources = window.CONFIG.model_sources;
+			for (i in sources){
+				option = [sources[i]];
+				options.push(option);
+			}
+			if (bool == true){options.push(["*"])}
+		}
+		return options;
+}
+
 editAreaLoader.load_syntax["yql"] = {
 	'DISPLAY_NAME' : 'YQL'
 	,'QUOTEMARKS' : {1: "'", 2: '"', 3: '`'}
@@ -74,9 +87,23 @@ editAreaLoader.load_syntax["yql"] = {
 						 ['DESC','DESC'],['ASC','ASC'],['ALL','ALL'], ['GROUP','GROUP'],
 						 ['RANGE','RANGE'],['EACH','EACH'],['OUTPUT','OUTPUT'],
 						 ['SUM','SUM'],['LIMIT','LIMIT'],['OFFSET','OFFSET'],
-						 ['TIMEOUT','TIMEOUT'],
-						]
+						 ['TIMEOUT','TIMEOUT']
+					 ]
+			}
+		},
+		"sources": {	// the name of this definition group. It's posisble to have different rules inside the same definition file
+			"REGEXP": { "before_word": "[^a-zA-Z0-9_]|^"	// \\s|\\.|
+						,"possible_words_letters": "[a-zA-Z0-9_]+"
+						,"letter_after_word_must_match": "[^a-zA-Z0-9_]|$"
+						,"prefix_separator": " "
+					}
+			,"CASE_SENSITIVE": false
+			,"MAX_TEXT_LENGTH": 50		// the maximum length of the text being analyzed before the cursor position
+			,"KEYWORDS": {
+					'SOURCES' : getSources(true) ,
+					',' : getSources(false)
 			}
 		}
+
 	}
 };

--- a/container-search-gui/src/main/resources/gui/gui_variables.json
+++ b/container-search-gui/src/main/resources/gui/gui_variables.json
@@ -1,4 +1,0 @@
-{
-  "propertyname" : ["propertyname"],
-  "featurename" : ["featurename"]
-}

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/CacheControl.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/CacheControl.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  */
 public class CacheControl {
 
-    private static final CompoundName nocachewrite=new CompoundName("nocachewrite");
+    public static final CompoundName nocachewrite=new CompoundName("nocachewrite");
 
     /** Whether this CacheControl actually should cache hits at all. */
     private final boolean activeCache;

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/RecallSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/RecallSearcher.java
@@ -35,7 +35,7 @@ import static com.yahoo.prelude.querytransform.StemmingSearcher.STEMMING;
 @Before({STEMMING, ACCENT_REMOVAL})
 public class RecallSearcher extends Searcher {
 
-    private static final CompoundName recallName=new CompoundName("recall");
+    public static final CompoundName recallName=new CompoundName("recall");
 
     @Override
     public Result search(Query query, Execution execution) {


### PR DESCRIPTION
… Added the predetermined sources from the genreated config.json to the autocompletion of yql-syntax. Now also possible to add possible values for all parameters, just put the parameter (full name with underscore instead of dots) and a list of possible values in the config-file to be generated. Model.sources, Ranking.rankprofile, Ranking.properties, ranking.features have now possible values on value-input.