### PR TITLE
Revert "As we changed to add a 5% summary cache some time ago, we should also…"

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/search/NodeFlavorTuningTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/NodeFlavorTuningTest.java
@@ -83,7 +83,7 @@ public class NodeFlavorTuningTest {
     @Test
     public void require_that_summary_read_io_is_set_based_on_disk() {
         assertSummaryReadIo(ProtonConfig.Summary.Read.Io.DIRECTIO, true);
-        assertSummaryReadIo(ProtonConfig.Summary.Read.Io.DIRECTIO, false);
+        assertSummaryReadIo(ProtonConfig.Summary.Read.Io.MMAP, false);
     }
 
     @Test

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -292,7 +292,7 @@ summary.write.io enum {NORMAL, OSYNC, DIRECTIO} default=DIRECTIO
 ## Control io options during read of stored documents.
 ## All summary.read options will take effect immediately on new files written.
 ## On old files it will take effect either upon compact or on restart.
-summary.read.io enum {NORMAL, DIRECTIO, MMAP } default=DIRECTIO restart
+summary.read.io enum {NORMAL, DIRECTIO, MMAP } default=MMAP restart
 
 ## Multiple optional options for use with mmap
 summary.read.mmap.options[] enum {MLOCK, POPULATE, HUGETLB} restart


### PR DESCRIPTION
Reverts vespa-engine/vespa#6398

Two performance tests saw significant increase in latency in one test and drop in lid space compaction througput in another. If this is as expected, just close this PR (but limits in tests should be updated).