### PR TITLE
bring C++ and Java APIs into sync

### DIFF
--- a/defaults/src/apps/printdefault/printdefault.cpp
+++ b/defaults/src/apps/printdefault/printdefault.cpp
@@ -4,6 +4,30 @@
 #include <stdio.h>
 #include <string.h>
 
+void dumpAllVars() {
+    printf("VESPA_HOME = '%s'\n", vespa::Defaults::vespaHome());
+    std::string v = vespa::Defaults::underVespaHome("foo");
+    printf("underVespaHome(foo) = '%s'\n", v.c_str());
+    printf("VESPA_USER = '%s'\n", vespa::Defaults::vespaUser());
+    printf("VESPA_HOSTNAME = '%s'\n", vespa::Defaults::vespaHostname());
+    printf("web service port = %d\n", vespa::Defaults::vespaWebServicePort());
+    printf("VESPA_PORT_BASE = %d\n", vespa::Defaults::vespaPortBase());
+    printf("config server rpc port = %d\n", vespa::Defaults::vespaConfigServerRpcPort());
+    size_t count = 0;
+    for (std::string vv : vespa::Defaults::vespaConfigServerHosts()) {
+        ++count;
+        printf("config server host %zu = '%s'\n", count, vv.c_str());
+    }
+    count = 0;
+    for (std::string vv : vespa::Defaults::vespaConfigServerRestUrls()) {
+        ++count;
+        printf("config server rest URL %zu = '%s'\n", count, vv.c_str());
+    }
+    v = vespa::Defaults::vespaConfigProxyRpcAddr();
+    printf("config proxy RPC addr = '%s'\n", v.c_str());
+    printf("vespa version = '%s'\n", V_TAG_COMPONENT);
+}
+
 int main(int argc, char **argv) {
     if (argc != 2) {
         fprintf(stderr, "usage: %s <variable>\n", argv[0]);
@@ -15,6 +39,8 @@ int main(int argc, char **argv) {
     }
     if (strcmp(argv[1], "home") == 0) {
         printf("%s\n", vespa::Defaults::vespaHome());
+    } else if (strcmp(argv[1], "everything") == 0) {
+        dumpAllVars();
     } else if (strcmp(argv[1], "user") == 0) {
         printf("%s\n", vespa::Defaults::vespaUser());
     } else if (strcmp(argv[1], "hostname") == 0) {

--- a/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
+++ b/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
@@ -32,20 +32,20 @@ public class Defaults {
     private final int vespaPortConfigProxyRpc;
 
     private Defaults() {
-        vespaHome = findVespaHome();
-        vespaUser = findVespaUser();
-        vespaHost = findVespaHostname();
+        vespaHome = findVespaHome("/opt/vespa");
+        vespaUser = findVespaUser("vespa");
+        vespaHost = findVespaHostname("localhost");
         vespaWebServicePort = findWebServicePort(8080);
         vespaPortBase = findVespaPortBase(19000);
         vespaPortConfigServerRpc = findConfigServerPort(vespaPortBase + 70);
         vespaPortConfigServerHttp = vespaPortConfigServerRpc + 1;
         vespaPortConfigProxyRpc = findConfigProxyPort(vespaPortBase + 90);
     }
-    static private String findVespaHome() {
+    static private String findVespaHome(String defHome) {
         Optional<String> vespaHomeEnv = Optional.ofNullable(System.getenv("VESPA_HOME"));
         if ( ! vespaHomeEnv.isPresent() || vespaHomeEnv.get().trim().isEmpty()) {
-            log.info("VESPA_HOME not set, using /opt/vespa");
-            return "/opt/vespa";
+            log.info("VESPA_HOME not set, using " + defHome);
+            return defHome;
         }
         String vespaHome = vespaHomeEnv.get().trim();
         if (vespaHome.endsWith("/")) {
@@ -55,19 +55,19 @@ public class Defaults {
         return vespaHome;
     }
 
-    static private String findVespaHostname() {
+    static private String findVespaHostname(String defHost) {
         Optional<String> vespaHostEnv = Optional.ofNullable(System.getenv("VESPA_HOSTNAME"));
         if (vespaHostEnv.isPresent() && ! vespaHostEnv.get().trim().isEmpty()) {
             return vespaHostEnv.get().trim();
         }
-        return "localhost";
+        return defHost;
     }
 
-    static private String findVespaUser() {
+    static private String findVespaUser(String defUser) {
         Optional<String> vespaUserEnv = Optional.ofNullable(System.getenv("VESPA_USER"));
         if (! vespaUserEnv.isPresent()) {
-            log.fine("VESPA_USER not set, using vespa");
-            return "vespa";
+            log.fine("VESPA_USER not set, using "+defUser);
+            return defUser;
         }
         return vespaUserEnv.get().trim();
     }

--- a/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
+++ b/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
@@ -27,15 +27,20 @@ public class Defaults {
     private final String vespaHost;
     private final int vespaWebServicePort;
     private final int vespaPortBase;
+    private final int vespaPortConfigServerRpc;
+    private final int vespaPortConfigServerHttp;
+    private final int vespaPortConfigProxyRpc;
 
     private Defaults() {
         vespaHome = findVespaHome();
         vespaUser = findVespaUser();
         vespaHost = findVespaHostname();
-        vespaWebServicePort = findVespaWebServicePort();
-        vespaPortBase = 19000; // TODO
+        vespaWebServicePort = findWebServicePort(8080);
+        vespaPortBase = findVespaPortBase(19000);
+        vespaPortConfigServerRpc = findConfigServerPort(vespaPortBase + 70);
+        vespaPortConfigServerHttp = vespaPortConfigServerRpc + 1;
+        vespaPortConfigProxyRpc = findConfigProxyPort(vespaPortBase + 91);
     }
-
     static private String findVespaHome() {
         Optional<String> vespaHomeEnv = Optional.ofNullable(System.getenv("VESPA_HOME"));
         if ( ! vespaHomeEnv.isPresent() || vespaHomeEnv.get().trim().isEmpty()) {
@@ -67,19 +72,31 @@ public class Defaults {
         return vespaUserEnv.get().trim();
     }
 
-    static private int findVespaWebServicePort() {
-        Optional<String> vespaWebServicePortString = Optional.ofNullable(System.getenv("VESPA_WEB_SERVICE_PORT"));
-        if ( ! vespaWebServicePortString.isPresent() || vespaWebServicePortString.get().trim().isEmpty()) {
-            log.info("VESPA_WEB_SERVICE_PORT not set, using 8080");
-            return 8080;
+    static private int findPort(String varName, int defaultPort) {
+        Optional<String> port = Optional.ofNullable(System.getenv(varName));
+        if ( ! port.isPresent() || port.get().trim().isEmpty()) {
+            log.fine("" + varName + " not set, using " + defaultPort);
+            return defaultPort;
         }
         try {
-            return Integer.parseInt(vespaWebServicePortString.get());
+            return Integer.parseInt(port.get());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("must be an integer, was '" +
+                                               port.get() + "'");
         }
-        catch (NumberFormatException e) {
-            throw new IllegalArgumentException("VESPA_WEB_SERVICE_PORT must be an integer, was '" +
-                                               vespaWebServicePortString.get() + "'");
-        }
+    }
+
+    static private int findVespaPortBase(int defaultPort) {
+        return findPort("VESPA_PORT_BASE", defaultPort);
+    }
+    static private int findConfigServerPort(int defaultPort) {
+        return findPort("port_configserver_rpc", defaultPort);
+    }
+    static private int findConfigProxyPort(int defaultPort) {
+        return findPort("port_configproxy_rpc", defaultPort);
+    }
+    static private int findWebServicePort(int defaultPort) {
+        return findPort("VESPA_WEB_SERVICE_PORT", defaultPort);
     }
 
     /**
@@ -134,6 +151,15 @@ public class Defaults {
      * @return the vespa base number for ports
      */
     public int vespaPortBase() { return vespaPortBase; }
+
+    /** @return port number used by cloud config server (for its RPC protocol) */
+    public int vespaConfigServerRpcPort() { return vespaPortConfigServerRpc; }
+
+    /** @return port number used by cloud config server (REST api on HTTP) */
+    public int vespaConfigServerHttpPort() { return vespaPortConfigServerHttp; }
+
+    /** @return port number used by config proxy server (RPC protocol) */
+    public int vespaConfigProxyRpcPort() { return vespaPortConfigProxyRpc; }
 
     /** Returns the defaults of this runtime environment */
     public static Defaults getDefaults() { return defaults; }

--- a/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
+++ b/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
@@ -39,7 +39,7 @@ public class Defaults {
         vespaPortBase = findVespaPortBase(19000);
         vespaPortConfigServerRpc = findConfigServerPort(vespaPortBase + 70);
         vespaPortConfigServerHttp = vespaPortConfigServerRpc + 1;
-        vespaPortConfigProxyRpc = findConfigProxyPort(vespaPortBase + 91);
+        vespaPortConfigProxyRpc = findConfigProxyPort(vespaPortBase + 90);
     }
     static private String findVespaHome() {
         Optional<String> vespaHomeEnv = Optional.ofNullable(System.getenv("VESPA_HOME"));

--- a/defaults/src/test/java/com/yahoo/vespa/defaults/DefaultsTestCase.java
+++ b/defaults/src/test/java/com/yahoo/vespa/defaults/DefaultsTestCase.java
@@ -22,4 +22,14 @@ public class DefaultsTestCase {
         assertEquals("vespa", Defaults.getDefaults().vespaUser());
     }
 
+    @Test
+    public void testPortsArePositive() {
+        Defaults d = Defaults.getDefaults();
+        assertEquals(true, d.vespaPortBase() > 0);
+        assertEquals(true, d.vespaWebServicePort() > 0);
+        assertEquals(true, d.vespaConfigServerRpcPort() > 0);
+        assertEquals(true, d.vespaConfigServerHttpPort() > 0);
+        assertEquals(true, d.vespaConfigProxyRpcPort() > 0);
+    }
+
 }

--- a/defaults/src/test/java/com/yahoo/vespa/defaults/DefaultsTestCase.java
+++ b/defaults/src/test/java/com/yahoo/vespa/defaults/DefaultsTestCase.java
@@ -32,4 +32,19 @@ public class DefaultsTestCase {
         assertEquals(true, d.vespaConfigProxyRpcPort() > 0);
     }
 
+    @Test
+    public void dumpAllVars() {
+        Defaults d = Defaults.getDefaults();
+        System.out.println("vespa user = '" + d.vespaUser() + "'");
+        System.out.println("vespa hostname = '" + d.vespaHostname() + "'");
+        System.out.println("vespa home = '" + d.vespaHome() + "'");
+        System.out.println("underVespaHome(foo) = '" + d.underVespaHome("foo") + "'");
+
+        System.out.println("web service port = '" + d.vespaWebServicePort() + "'");
+        System.out.println("vespa port base = '" + d.vespaPortBase() + "'");
+        System.out.println("config server RPC port = '" + d.vespaConfigServerRpcPort() + "'");
+        System.out.println("config server HTTP port = '" + d.vespaConfigServerHttpPort() + "'");
+        System.out.println("config proxy RPC port = '" + d.vespaConfigProxyRpcPort() + "'");
+    }
+
 }

--- a/defaults/src/vespa/defaults.cpp
+++ b/defaults/src/vespa/defaults.cpp
@@ -20,9 +20,9 @@ const char *defaultUser = "vespa";
 const char *defaultHost = "localhost";
 int defaultWebServicePort = 8080;
 int defaultPortBase = 19000;
-int defaultPortConfigServerRpc = 19070;
-int defaultPortConfigServerHttp = 19071;
-int defaultPortConfigProxyRpc = 19090;
+int defaultPortConfigServerRpc = 0;
+int defaultPortConfigServerHttp = 0;
+int defaultPortConfigProxyRpc = 0;
 const char *defaultConfigServers = "localhost";
 
 std::atomic<bool> initialized(false);
@@ -80,16 +80,16 @@ void findDefaults() {
         // fprintf(stderr, "debug\tdefault port base is '%ld'\n", p);
         defaultPortBase = p;
     }
+    defaultPortConfigServerRpc = defaultPortBase + 70;
+    defaultPortConfigProxyRpc = defaultPortBase + 90;
     p = getNumFromEnv("port_configserver_rpc");
     if (p > 0) {
         defaultPortConfigServerRpc = p;
-        defaultPortConfigServerHttp = p+1;
     }
+    defaultPortConfigServerHttp = defaultPortConfigServerRpc + 1;
     p = getNumFromEnv("port_configproxy_rpc");
     if (p > 0) {
         defaultPortConfigProxyRpc = p;
-    } else {
-        defaultPortConfigProxyRpc = defaultPortBase + 90;
     }
     env = getenv("VESPA_CONFIGSERVERS");
     if (env == NULL || *env == '\0') {
@@ -241,6 +241,7 @@ Defaults::vespaConfigServerHosts()
 int
 Defaults::vespaConfigServerRpcPort()
 {
+    findDefaults();
     return defaultPortConfigServerRpc;
 }
 

--- a/defaults/src/vespa/defaults.cpp
+++ b/defaults/src/vespa/defaults.cpp
@@ -15,15 +15,15 @@ namespace {
 
 #define HOST_BUF_SZ 1024
 
-const char *defaultHome = "/opt/vespa";
-const char *defaultUser = "vespa";
-const char *defaultHost = "localhost";
-int defaultWebServicePort = 8080;
-int defaultPortBase = 19000;
+const char *defaultHome = 0;
+const char *defaultUser = 0;
+const char *defaultHost = 0;
+int defaultWebServicePort = 0;
+int defaultPortBase = 0;
 int defaultPortConfigServerRpc = 0;
 int defaultPortConfigServerHttp = 0;
 int defaultPortConfigProxyRpc = 0;
-const char *defaultConfigServers = "localhost";
+const char *defaultConfigServers = 0;
 
 std::atomic<bool> initialized(false);
 
@@ -42,8 +42,7 @@ long getNumFromEnv(const char *envName)
     return -1;
 }
 
-void findDefaults() {
-    if (initialized) return;
+const char *findVespaHome(const char *defHome) {
     const char *env = getenv("VESPA_HOME");
     if (env != NULL && *env != '\0') {
         DIR *dp = NULL;
@@ -51,47 +50,72 @@ void findDefaults() {
             dp = opendir(env);
         }
         if (dp != NULL) {
-            defaultHome = env;
-            // fprintf(stderr, "debug\tVESPA_HOME is '%s'\n", defaultHome);
+            // fprintf(stderr, "debug\tVESPA_HOME is '%s'\n", env);
             closedir(dp);
+            return env;
         } else {
             fprintf(stderr, "warning\tbad VESPA_HOME '%s' (ignored)\n", env);
         }
     }
-    env = getenv("VESPA_USER");
+    return defHome;
+}
+
+const char *findVespaUser(const char *defUser) {
+    const char *env = getenv("VESPA_USER");
     if (env != NULL && *env != '\0') {
         if (getpwnam(env) == 0) {
             fprintf(stderr, "warning\tbad VESPA_USER '%s' (ignored)\n", env);
         } else {
-            defaultUser = env;
+            return env;
         }
     }
-    env = getenv("VESPA_HOSTNAME");
+    return defUser;
+}
+
+const char *findHostname(const char *defHost) {
+    const char *env = getenv("VESPA_HOSTNAME");
     if (env != NULL && *env != '\0') {
-        defaultHost = env;
+        return env;
     }
+    return defHost;
+}
+
+int findWebServicePort(int defPort) {
     long p = getNumFromEnv("VESPA_WEB_SERVICE_PORT");
     if (p > 0) {
         // fprintf(stderr, "debug\tdefault web service port is '%ld'\n", p);
-        defaultWebServicePort = p;
+        return p;
     }
-    p = getNumFromEnv("VESPA_PORT_BASE");
+    return defPort;
+}
+
+int findVespaPortBase(int defPort) {
+    long p = getNumFromEnv("VESPA_PORT_BASE");
     if (p > 0) {
         // fprintf(stderr, "debug\tdefault port base is '%ld'\n", p);
-        defaultPortBase = p;
+        return p;
     }
-    defaultPortConfigServerRpc = defaultPortBase + 70;
-    defaultPortConfigProxyRpc = defaultPortBase + 90;
-    p = getNumFromEnv("port_configserver_rpc");
+    return defPort;
+}
+
+int findConfigServerPort(int defPort) {
+    long p = getNumFromEnv("port_configserver_rpc");
     if (p > 0) {
-        defaultPortConfigServerRpc = p;
+        return p;
     }
-    defaultPortConfigServerHttp = defaultPortConfigServerRpc + 1;
-    p = getNumFromEnv("port_configproxy_rpc");
+    return defPort;
+}
+
+int findConfigProxyPort(int defPort) {
+    long p = getNumFromEnv("port_configproxy_rpc");
     if (p > 0) {
-        defaultPortConfigProxyRpc = p;
+        return p;
     }
-    env = getenv("VESPA_CONFIGSERVERS");
+    return defPort;
+}
+
+const char *findConfigServers(const char *defServers) {
+    const char *env = getenv("VESPA_CONFIGSERVERS");
     if (env == NULL || *env == '\0') {
         env = getenv("services__addr_configserver");
     }
@@ -103,14 +127,26 @@ void findDefaults() {
     }
     if (env != NULL && *env != '\0') {
         // fprintf(stderr, "debug\tdefault configserver(s) is '%s'\n", env);
-        defaultConfigServers = env;
+        return env;
     }
+    return defServers;
+}
+
+void findDefaults() {
+    if (initialized) return;
+
+    defaultHome = findVespaHome("/opt/vespa");
+    defaultUser = findVespaUser("vespa");
+    defaultHost = findHostname("localhost");
+    defaultWebServicePort = findWebServicePort(8080);
+    defaultPortBase = findVespaPortBase(19000);
+    defaultPortConfigServerRpc = findConfigServerPort(defaultPortBase + 70);
+    defaultPortConfigServerHttp = defaultPortConfigServerRpc + 1;
+    defaultPortConfigProxyRpc = findConfigProxyPort(defaultPortBase + 90);
+    defaultConfigServers = findConfigServers("localhost");
+
     initialized = true;
 }
-
-}
-
-namespace vespa {
 
 std::string myPath(const char *argv0)
 {
@@ -136,6 +172,10 @@ std::string myPath(const char *argv0)
     }
     return argv0;
 }
+
+}
+
+namespace vespa {
 
 void
 Defaults::bootstrap(const char *argv0)


### PR DESCRIPTION
* detect and make accessible port numbers to use for
  config server / config proxy from Java also.
* port numbers are relative to VESPA_PORT_BASE if not
  explicitly specified.
* try to make the logic in C++ and Java more similar.

@hmusum please review and merge
