### PR TITLE
Gjoranv/upgrade apache httpclient

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -104,8 +104,8 @@
                                                 <include>org.apache.felix:org.apache.felix.framework:[${felix.version}]:jar:provided</include>
                                                 <include>org.apache.felix:org.apache.felix.log:[1.0.1]:jar:provided</include>
                                                 <include>org.apache.felix:org.apache.felix.main:[${felix.version}]:jar:provided</include>
-                                                <include>org.apache.httpcomponents:httpclient:[4.3.6]:jar:provided</include>
-                                                <include>org.apache.httpcomponents:httpcore:[4.3.3]:jar:provided</include>
+                                                <include>org.apache.httpcomponents:httpclient:[${apache.httpclient.version}]:jar:provided</include>
+                                                <include>org.apache.httpcomponents:httpcore:[${apache.httpcore.version}]:jar:provided</include>
                                                 <include>org.bouncycastle:bcpkix-jdk15on:[${bouncycastle.version}]:jar:provided</include>
                                                 <include>org.bouncycastle:bcprov-jdk15on:[${bouncycastle.version}]:jar:provided</include>
                                                 <include>org.eclipse.jetty:jetty-http:[${jetty.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -238,12 +238,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.4.1</version>
+                <version>${apache.httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.1</version>
+                <version>${apache.httpcore.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -452,6 +452,8 @@
     </dependencyManagement>
 
     <properties>
+        <apache.httpclient.version>4.4.1</apache.httpclient.version>
+        <apache.httpcore.version>4.4.1</apache.httpcore.version>
         <bouncycastle.version>1.58</bouncycastle.version>
         <felix.version>5.6.10</felix.version>
         <findbugs.version>1.3.9</findbugs.version>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -238,12 +238,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.3.6</version>
+                <version>4.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.3.3</version>
+                <version>4.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/SimpleHttpClient.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/SimpleHttpClient.java
@@ -12,6 +12,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
@@ -59,7 +60,7 @@ public class SimpleHttpClient {
         if (sslContext != null) {
             SSLConnectionSocketFactory sslConnectionFactory = new SSLConnectionSocketFactory(
                     sslContext,
-                    SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+                    NoopHostnameVerifier.INSTANCE);
             builder.setSSLSocketFactory(sslConnectionFactory);
 
             Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()

--- a/vespa-http-client/pom.xml
+++ b/vespa-http-client/pom.xml
@@ -26,17 +26,11 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
      <version>3.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Let's try to see if this works now. It's an improvement, but not a solution to the problem with the federation http searchers. 

Note that on hosted, 4.4 has been required for a long time, so this should not be an issue for hosted tenants.

Self-hosted could fail to build if using deprecated or removed apis. It could fail runtime if they specify explicit version to 4.3 and use such apis. I will notify gemini native with a PR if this is successful. (Their code builds and tests ok with 4.4.)

FYI: @bratseth, @bjorncs 