### PR TITLE
Add initial wait in periodic application maintainer

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -266,6 +266,10 @@ public class PeriodicApplicationMaintainerTest {
             return true;
         }
 
+        protected boolean waitInitially() {
+            return false;
+        }
+
     }
 
 }


### PR DESCRIPTION
If it starts early it will try deploying while config server is
bootstrapping, which is at a point where there are many deployments
going on