### PR TITLE
just exit on out of memory

### DIFF
--- a/config-proxy/src/main/sh/vespa-config-ctl.sh
+++ b/config-proxy/src/main/sh/vespa-config-ctl.sh
@@ -115,7 +115,7 @@ case $1 in
         echo "Starting config proxy using $configsources as config source(s)"
         vespa-runserver -r 10 -s configproxy -p $P_CONFIG_PROXY -- \
             java ${jvmopts} \
-                 -XX:OnOutOfMemoryError="kill -9 %p" $(getJavaOptionsIPV46) \
+                 -XX:+ExitOnOutOfMemoryError $(getJavaOptionsIPV46) \
                  -Dproxyconfigsources="${configsources}" ${userargs} \
                  -cp $cp com.yahoo.vespa.config.proxy.ProxyServer 19090
 

--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -161,7 +161,7 @@ vespa-run-as-vespa-user vespa-runserver -s configserver -r 30 -p $pidfile -- \
 	-Xms128m -Xmx2048m \
         -XX:+PreserveFramePointer \
 	-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${VESPA_HOME}/var/crash \
-	-XX:OnOutOfMemoryError='kill -9 %p' \
+	-XX:+ExitOnOutOfMemoryError \
 	$jvmargs \
 	-Djava.library.path=${VESPA_HOME}/lib64 \
 	-Djava.awt.headless=true \

--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -193,7 +193,7 @@ exec_jsvc () {
         -XX:MaxJavaStackTraceDepth=1000000 \
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="${VESPA_HOME}/var/crash" \
-        -XX:OnOutOfMemoryError='kill -9 %p' \
+        -XX:+ExitOnOutOfMemoryError \
         -Djava.library.path="${VESPA_HOME}/lib64" \
         -Djava.awt.headless=true \
         -Djavax.net.ssl.keyStoreType=JKS \
@@ -265,7 +265,7 @@ exec $numactlcmd $envcmd java \
         -XX:MaxJavaStackTraceDepth=1000000 \
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="${VESPA_HOME}/var/crash" \
-        -XX:OnOutOfMemoryError='kill -9 %p' \
+        -XX:+ExitOnOutOfMemoryError \
         -Djava.library.path="${VESPA_HOME}/lib64" \
         -Djava.awt.headless=true \
         -Djavax.net.ssl.keyStoreType=JKS \

--- a/logserver/bin/logserver-start.sh
+++ b/logserver/bin/logserver-start.sh
@@ -76,7 +76,7 @@ cd $ROOT || { echo "Cannot cd to $ROOT" 1>&2; exit 1; }
 
 addopts="-server -Xms64m -Xmx256m -XX:MaxDirectMemorySize=76m -XX:MaxJavaStackTraceDepth=1000000"
 
-oomopt="-XX:OnOutOfMemoryError=kill -9 %p"
+oomopt="-XX:+ExitOnOutOfMemoryError"
 
 jar="-jar $ROOT/lib/jars/logserver-jar-with-dependencies.jar"
 

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -157,7 +157,7 @@ StartCommand() {
         -XX:+PreserveFramePointer \
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="$VESPA_HOME/var/crash" \
-        -XX:OnOutOfMemoryError="kill -9 %p" \
+        -XX:+ExitOnOutOfMemoryError \
         -Djava.library.path="$VESPA_HOME/lib64" \
         -Djava.awt.headless=true \
 	-Dsun.rmi.dgc.client.gcInterval=3600000 \


### PR DESCRIPTION
* asking java to fork 'kill -9 %p' will often fail with
  "os::fork_and_exec failed: Cannot allocate memory (12)" message.
* instead, use a newish option (from JDK 8u92) to just exit

@baldersheim please review and merge