### PR TITLE
Do not expose opennlp in the maven dependency graph.

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -136,7 +136,6 @@
                                                 <include>org.slf4j:slf4j-api:[${slf4j.version}]:jar:provided</include>
                                                 <include>org.slf4j:slf4j-jdk14:[${slf4j.version}]:jar:provided</include>
                                                 <include>xml-apis:xml-apis:[1.4.01]:jar:provided</include>
-                                                <include>org.apache.opennlp:opennlp-tools:1.8.4:jar:provided</include>
                                             </includes>
                                         </bannedDependencies>
                                     </rules>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -100,6 +100,10 @@
           <artifactId>httpclient</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.apache.opennlp</groupId>
+          <artifactId>opennlp-tools</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.tensorflow</groupId>
           <artifactId>proto</artifactId>
         </exclusion>


### PR DESCRIPTION
See #6407 