### PR TITLE
There must always be a stopsign visible to any concurrent reader no m…

### DIFF
--- a/searchlib/src/vespa/searchlib/common/bitvector.h
+++ b/searchlib/src/vespa/searchlib/common/bitvector.h
@@ -120,9 +120,12 @@ public:
     }
 
     void setSize(Index sz) {
-        clearBit(size());
+        setBit(sz);  // Need to place the new stop sign first
+        if (sz > _sz) {
+            // Can only remove the old stopsign if it is ahead of the new.
+            clearBit(_sz);
+        }
         _sz = sz;
-        setBit(size());
     }
     void setBit(Index idx) {
         _words[wordNum(idx)] |= mask(idx);


### PR DESCRIPTION
…atter where it is.

So before removing the old stopsign, the new one must be placed.
You can only remove the old one if it was ahead of new one.
If not, any readers scanning might have passed the location of the new one, and the old one might be gone
before it gets there. And hence it will continue into space or a concrete wall.
@geirst PR
@toregge FYI