### PR TITLE
- Do not follow the nullptr.

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/i_search_context.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/i_search_context.h
@@ -48,7 +48,7 @@ public:
 
     virtual bool valid() const = 0;
     virtual Int64Range getAsIntegerTerm() const = 0;
-    virtual const QueryTermBase &queryTerm() const = 0;
+    virtual const QueryTermBase * queryTerm() const = 0;
     virtual const vespalib::string &attributeName() const = 0;
 
     int32_t find(DocId docId, int32_t elementId, int32_t &weight) const { return onFind(docId, elementId, weight); }

--- a/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
+++ b/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
@@ -348,7 +348,7 @@ TEST_F("Multiple iterators can be created from the same context", SingleValueFix
 // implemented at all for (single) numeric attributes. Intentional?
 TEST_F("queryTerm() returns term context was created with", WsetValueFixture) {
     auto ctx = f.create_context(word_term("helloworld"));
-    EXPECT_EQUAL(std::string("helloworld"), std::string(ctx->queryTerm().getTerm()));
+    EXPECT_EQUAL(std::string("helloworld"), std::string(ctx->queryTerm()->getTerm()));
 }
 
 struct SearchCacheFixture : Fixture {

--- a/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
@@ -39,7 +39,7 @@ public:
     UseStringEnum(const IAttributeVector & attr)
         : UseAttr(attr) {}
     auto mapToken(const ISearchContext &context) const {
-        return attribute().findFoldedEnums(context.queryTerm().getTerm());
+        return attribute().findFoldedEnums(context.queryTerm()->getTerm());
     }
     int64_t getToken(uint32_t docId) const {
         return attribute().getEnum(docId);
@@ -196,8 +196,16 @@ AttributeWeightedSetBlueprint::visitMembers(vespalib::ObjectVisitor &visitor) co
     for (size_t i = 0; i < _contexts.size(); ++i) {
         const ISearchContext * context = _contexts[i];
         visitor.openStruct(vespalib::make_string("[%zu]", i), "Term");
-        visitor.visitString("term", context->queryTerm().getTerm());
-        visitor.visitInt("weight", _weights[i]);
+        visitor.visitBool("valid", context->valid());
+        if (context-> valid()) {
+            bool isString = (_attr.isStringType() && _attr.hasEnum());
+            if (isString) {
+                visitor.visitString("term", context->queryTerm()->getTerm());
+            } else {
+                visitor.visitInt("term", context->getAsIntegerTerm().lower());
+            }
+            visitor.visitInt("weight", _weights[i]);
+        }
         visitor.closeStruct();
     }
     visitor.closeStruct();

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -538,16 +538,15 @@ public:
         typedef std::unique_ptr<SearchContext> UP;
         ~SearchContext();
 
-        // Implements attribute::ISearchContext
-        virtual unsigned int approximateHits() const override;
-        virtual queryeval::SearchIterator::UP createIterator(fef::TermFieldMatchData *matchData, bool strict) override;
-        virtual void fetchPostings(bool strict) override;
-        virtual bool valid() const override { return false; }
-        virtual Int64Range getAsIntegerTerm() const override { return Int64Range(); }
-        virtual const QueryTermBase &queryTerm() const override {
-            return *static_cast<const QueryTermBase *>(NULL);
+        unsigned int approximateHits() const override;
+        queryeval::SearchIterator::UP createIterator(fef::TermFieldMatchData *matchData, bool strict) override;
+        void fetchPostings(bool strict) override;
+        bool valid() const override { return false; }
+        Int64Range getAsIntegerTerm() const override { return Int64Range(); }
+        const QueryTermBase * queryTerm() const override {
+            return static_cast<const QueryTermBase *>(nullptr);
         }
-        virtual const vespalib::string &attributeName() const override {
+        const vespalib::string &attributeName() const override {
             return _attr.getName();
         }
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -249,7 +249,7 @@ Int64Range ImportedSearchContext::getAsIntegerTerm() const {
     return _target_search_context->getAsIntegerTerm();
 }
 
-const QueryTermBase& ImportedSearchContext::queryTerm() const {
+const QueryTermBase * ImportedSearchContext::queryTerm() const {
     return _target_search_context->queryTerm();
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -59,7 +59,7 @@ public:
     void fetchPostings(bool strict) override;
     bool valid() const override;
     Int64Range getAsIntegerTerm() const override;
-    const QueryTermBase& queryTerm() const override;
+    const QueryTermBase * queryTerm() const override;
     const vespalib::string& attributeName() const override;
 
     using DocId = IAttributeVector::DocId;

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
@@ -119,14 +119,14 @@ StringTemplSearchContext(QueryTermSimpleUP qTerm, const AttrType & toBeSearched)
     this->_plsc = static_cast<attribute::IPostingListSearchContext *>(this);
     if (this->valid()) {
         if (this->isPrefix()) {
-            FoldedComparatorType comp(enumStore, queryTerm().getTerm(), true);
+            FoldedComparatorType comp(enumStore, queryTerm()->getTerm(), true);
             lookupRange(comp, comp);
         } else if (this->isRegex()) {
-            vespalib::string prefix(vespalib::Regexp::get_prefix(this->queryTerm().getTerm()));
+            vespalib::string prefix(vespalib::Regexp::get_prefix(this->queryTerm()->getTerm()));
             FoldedComparatorType comp(enumStore, prefix.c_str(), true);
             lookupRange(comp, comp);
         } else {
-            FoldedComparatorType comp(enumStore, queryTerm().getTerm());
+            FoldedComparatorType comp(enumStore, queryTerm()->getTerm());
             lookupTerm(comp);
         }
     }

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -283,14 +283,14 @@ StringPostingSearchContext(QueryTermSimpleUP qTerm, bool useBitVector, const Att
 
     if (this->valid()) {
         if (this->isPrefix()) {
-            FoldedComparatorType comp(_enumStore, this->queryTerm().getTerm(), true);
+            FoldedComparatorType comp(_enumStore, this->queryTerm()->getTerm(), true);
             this->lookupRange(comp, comp);
         } else if (this->isRegex()) {
-            vespalib::string prefix(Regexp::get_prefix(this->queryTerm().getTerm()));
+            vespalib::string prefix(Regexp::get_prefix(this->queryTerm()->getTerm()));
             FoldedComparatorType comp(_enumStore, prefix.c_str(), true);
             this->lookupRange(comp, comp);
         } else {
-            FoldedComparatorType comp(_enumStore, this->queryTerm().getTerm());
+            FoldedComparatorType comp(_enumStore, this->queryTerm()->getTerm());
             this->lookupTerm(comp);
         }
         if (this->_uniqueValues == 1u) {

--- a/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
@@ -55,14 +55,14 @@ SingleValueStringAttributeT<B>::StringTemplSearchContext::StringTemplSearchConte
     this->_plsc = static_cast<attribute::IPostingListSearchContext *>(this);
     if (this->valid()) {
         if (this->isPrefix()) {
-            FoldedComparatorType comp(enumStore, queryTerm().getTerm(), true);
+            FoldedComparatorType comp(enumStore, queryTerm()->getTerm(), true);
             lookupRange(comp, comp);
         } else if (this->isRegex()) {
-            vespalib::string prefix(vespalib::Regexp::get_prefix(this->queryTerm().getTerm()));
+            vespalib::string prefix(vespalib::Regexp::get_prefix(this->queryTerm()->getTerm()));
             FoldedComparatorType comp(enumStore, prefix.c_str(), true);
             lookupRange(comp, comp);
         } else {
-            FoldedComparatorType comp(enumStore, queryTerm().getTerm());
+            FoldedComparatorType comp(enumStore, queryTerm()->getTerm());
             lookupTerm(comp);
         }
     }

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
@@ -226,7 +226,7 @@ StringAttribute::StringSearchContext::StringSearchContext(QueryTermSimple::UP qT
     _isPrefix(qTerm->isPrefix()),
     _isRegex(qTerm->isRegex()),
     _queryTerm(std::move(qTerm)),
-    _termUCS4(queryTerm().getUCS4Term()),
+    _termUCS4(queryTerm()->getUCS4Term()),
     _bufferLen(toBeSearched.getMaxValueCount()),
     _buffer()
 {
@@ -247,9 +247,9 @@ StringAttribute::StringSearchContext::valid() const {
     return (_queryTerm.get() && (!_queryTerm->empty()));
 }
 
-const QueryTermBase &
+const QueryTermBase *
 StringAttribute::StringSearchContext::queryTerm() const {
-    return static_cast<const QueryTermBase &>(*_queryTerm);
+    return static_cast<const QueryTermBase *>(_queryTerm.get());
 }
 
 uint32_t StringAttribute::clearDoc(DocId doc)

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -104,7 +104,7 @@ private:
     protected:
         bool valid() const override;
 
-        const QueryTermBase & queryTerm() const override;
+        const QueryTermBase * queryTerm() const override;
         bool isMatch(const char *src) const {
             if (__builtin_expect(isRegex(), false)) {
                 return getRegex()->match(src);

--- a/searchlib/src/vespa/searchlib/queryeval/fake_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_search.cpp
@@ -19,7 +19,7 @@ struct FakeContext : search::attribute::ISearchContext {
     void fetchPostings(bool) override { }
     bool valid() const override { return true; }
     search::Int64Range getAsIntegerTerm() const override { abort(); }
-    const search::QueryTermBase &queryTerm() const override { abort(); }
+    const search::QueryTermBase * queryTerm() const override { abort(); }
     const vespalib::string &attributeName() const override { abort(); }
 };
 


### PR DESCRIPTION
- Do not have an interface return a reference when it might refer a nullptr...
@toregge PR There is a bug in #6446 as queryTerm only referred a legal object if it was a string attribute....