### PR TITLE
Ignore array element update with index out of bounds

### DIFF
--- a/document/src/tests/documentupdatetestcase.cpp
+++ b/document/src/tests/documentupdatetestcase.cpp
@@ -64,6 +64,7 @@ struct DocumentUpdateTest : public CppUnit::TestFixture {
   void testThatCreateIfNonExistentFlagIsSerializedAndDeserialized();
   void array_element_update_can_be_roundtrip_serialized();
   void array_element_update_applies_to_specified_element();
+  void array_element_update_for_invalid_index_is_ignored();
 
   CPPUNIT_TEST_SUITE(DocumentUpdateTest);
   CPPUNIT_TEST(testSimpleUsage);
@@ -91,6 +92,7 @@ struct DocumentUpdateTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testThatCreateIfNonExistentFlagIsSerializedAndDeserialized);
   CPPUNIT_TEST(array_element_update_can_be_roundtrip_serialized);
   CPPUNIT_TEST(array_element_update_applies_to_specified_element);
+  CPPUNIT_TEST(array_element_update_for_invalid_index_is_ignored);
   CPPUNIT_TEST_SUITE_END();
 
 };
@@ -1048,6 +1050,19 @@ void DocumentUpdateTest::array_element_update_applies_to_specified_element() {
     CPPUNIT_ASSERT_EQUAL(vespalib::string("foo"), (*result_array)[0].getAsString());
     CPPUNIT_ASSERT_EQUAL(vespalib::string("bar"), (*result_array)[1].getAsString());
     CPPUNIT_ASSERT_EQUAL(vespalib::string("blarg"), (*result_array)[2].getAsString());
+}
+
+void DocumentUpdateTest::array_element_update_for_invalid_index_is_ignored() {
+    ArrayUpdateFixture f;
+
+    ArrayFieldValue array_value(f.array_field.getDataType());
+    array_value.add("jerry");
+    f.doc->setValue(f.array_field, array_value);
+
+    f.update->applyTo(*f.doc); // MapValueUpdate for index 1, which does not exist
+
+    auto result_array = f.doc->getAs<ArrayFieldValue>(f.array_field);
+    CPPUNIT_ASSERT_EQUAL(array_value, *result_array);
 }
 
 }  // namespace document

--- a/document/src/vespa/document/update/mapvalueupdate.cpp
+++ b/document/src/vespa/document/update/mapvalueupdate.cpp
@@ -71,9 +71,9 @@ MapValueUpdate::applyTo(FieldValue& value) const
         ArrayFieldValue& val(static_cast<ArrayFieldValue&>(value));
         int32_t index = _key->getAsInt();
         if (index < 0 || static_cast<uint32_t>(index) >= val.size()) {
-            throw IllegalStateException(vespalib::make_string(
-                    "Tried to update element %i in an array of %zu elements",
-		            index, val.size()), VESPA_STRLOC);
+            // Silently ignoring updates with index out of bounds matches
+            // behavior of functionally identical fieldpath updates.
+            return true;
         }
         if (!_update->applyTo(val[_key->getAsInt()])) {
             val.remove(_key->getAsInt());


### PR DESCRIPTION
@baldersheim please review. Note that we silently ignore the update due to existing field path update semantics of sitting quietly in the boat when such updates are applied. Can of course still add logging if desired.
@toregge FYI. Ended up changing `MapValueUpdate` instead of `StoreOnlyFeedView` to avoid the slightly awkward situation where an update with an invalid array access update also contained other, _valid_ field updates that would end up being silently ignored. Would also have had to alter DummyPersistence to get consistent behavior, as it does all its update logic synchronously and returns an error to the client upon exceptions instead of ignoring the bad update.

Only affects "element match" field value updates. Silently ignoring
the update matches the semantics of semantically identical field
path updates.