### PR TITLE
Export new PublicApi com.yahoo.language.opennlp.

### DIFF
--- a/linguistics/src/main/java/com/yahoo/language/opennlp/package-info.java
+++ b/linguistics/src/main/java/com/yahoo/language/opennlp/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.language.opennlp;
+
+import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
FYI: @jefimm 

This is required to use the classes in this package from other bundles, both vespa-internal and searcher plugins created by users.