### PR TITLE
Exclude guava and slf4j-api in container-core

### DIFF
--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -95,8 +95,18 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
+          <!-- Pulled in by language-detector in scope compile -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Pulled in by language-detector in scope compile -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/linguistics/pom.xml
+++ b/linguistics/pom.xml
@@ -69,12 +69,6 @@
     <dependency>
       <groupId>com.optimaize.languagedetector</groupId>
       <artifactId>language-detector</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Verified by running system tests locally.

.. to prevent embedding them in container-disc and potentially
   other bundles.
- Must be compile scope in linguistics because they're  needed to
  run tests in modules depending on linguistics, e.g.
  indexinglanguage.