### PR TITLE
henrhoi/fix-queryprofile-for-post-queries

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -188,6 +188,8 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
     public static final CompoundName GROUPING_SESSION_CACHE = new CompoundName("groupingSessionCache");
     public static final CompoundName TIMEOUT = new CompoundName("timeout");
 
+    private Map<String, String> requestMap;
+
     private static QueryProfileType argumentType;
     static {
         argumentType = new QueryProfileType("native");
@@ -209,6 +211,8 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         argumentType.freeze();
     }
     public static QueryProfileType getArgumentType() { return argumentType; }
+
+    public Map<String, String> getRequestMap() { return this.requestMap; }
 
     /** The aliases of query properties */
     private static Map<String,CompoundName> propertyAliases;
@@ -323,6 +327,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
 
     private void init(Map<String, String> requestMap, CompiledQueryProfile queryProfile) {
         startTime = System.currentTimeMillis();
+        this.requestMap = requestMap;
         if (queryProfile != null) {
             // Move all request parameters to the query profile just to validate that the parameter settings are legal
             Properties queryProfileProperties = new QueryProfileProperties(queryProfile);

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -188,7 +188,6 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
     public static final CompoundName GROUPING_SESSION_CACHE = new CompoundName("groupingSessionCache");
     public static final CompoundName TIMEOUT = new CompoundName("timeout");
 
-    private Map<String, String> requestMap;
 
     private static QueryProfileType argumentType;
     static {
@@ -212,7 +211,6 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
     }
     public static QueryProfileType getArgumentType() { return argumentType; }
 
-    public Map<String, String> getRequestMap() { return this.requestMap; }
 
     /** The aliases of query properties */
     private static Map<String,CompoundName> propertyAliases;
@@ -327,7 +325,6 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
 
     private void init(Map<String, String> requestMap, CompiledQueryProfile queryProfile) {
         startTime = System.currentTimeMillis();
-        this.requestMap = requestMap;
         if (queryProfile != null) {
             // Move all request parameters to the query profile just to validate that the parameter settings are legal
             Properties queryProfileProperties = new QueryProfileProperties(queryProfile);


### PR DESCRIPTION
Solved queryProfile always being null when using JSON-query. QueryProfile was set before getting the JSON-payload with queryProfileName.

@bratseth will you review this PR? 