### PR TITLE
Log StoredInteger updates

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/TaskContext.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/TaskContext.java
@@ -21,8 +21,8 @@ public interface TaskContext {
      *                to bob".
      */
     void recordSystemModification(Logger logger, String message);
-    default void recordSystemModification(Logger logger, String messageFormat, String... args) {
-        recordSystemModification(logger, String.format(messageFormat, (Object[]) args));
+    default void recordSystemModification(Logger logger, String messageFormat, Object... args) {
+        recordSystemModification(logger, String.format(messageFormat, args));
     }
 
     /**
@@ -35,8 +35,8 @@ public interface TaskContext {
      * Do not log a message that is also recorded with recordSystemModification.
      */
     default void log(Logger logger, String message) {}
-    default void log(Logger logger, String messageFormat, String... args) {
-        log(logger, String.format(messageFormat, (Object[]) args));
+    default void log(Logger logger, String messageFormat, Object... args) {
+        log(logger, String.format(messageFormat, args));
     }
 
     /**

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/StoredInteger.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/StoredInteger.java
@@ -1,6 +1,8 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.task.util.file;
 
+import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -8,6 +10,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
+import java.util.logging.Logger;
 
 /**
  * Class wrapping an integer stored on disk
@@ -15,6 +18,8 @@ import java.util.function.Supplier;
  * @author freva
  */
 public class StoredInteger implements Supplier<OptionalInt> {
+
+    private static Logger logger = Logger.getLogger(StoredInteger.class.getName());
 
     private final Path path;
     private OptionalInt value;
@@ -40,11 +45,12 @@ public class StoredInteger implements Supplier<OptionalInt> {
         return value;
     }
 
-    public void write(int value) {
+    public void write(TaskContext taskContext, int value) {
         try {
             Files.write(path, Integer.toString(value).getBytes());
             this.value = OptionalInt.of(value);
             this.hasBeenRead = true;
+            taskContext.log(logger, "Stored new integer in %s: %d", path, value);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to store integer in " + path, e);
         }


### PR DESCRIPTION
Also allow `.log()` to take args as `Object` rather than `String`. If the default `toString()` is unhelpful, the use can always pass their own value. 