### PR TITLE
Fix race

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
@@ -71,8 +71,8 @@ public abstract class ApplicationMaintainer extends Maintainer {
         }
         log.log(LogLevel.INFO, application + " will be deployed, last deploy time " +
                                getLastDeployTime(application));
-        deploymentExecutor.execute(() -> deployWithLock(application));
         pendingDeployments.add(application);
+        deploymentExecutor.execute(() -> deployWithLock(application));
     }
 
     protected Deployer deployer() { return deployer; }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -31,7 +31,6 @@ import com.yahoo.vespa.hosted.provision.testutils.MockDeployer;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -48,7 +47,6 @@ import static org.junit.Assert.assertFalse;
 /**
  * @author bratseth
  */
-@Ignore
 public class PeriodicApplicationMaintainerTest {
 
     private static final NodeFlavors nodeFlavors = FlavorConfigBuilder.createDummies("default");


### PR DESCRIPTION
This fixes a rare race that only manifested itself if the executor thread is
prestarted and the executed runnable does so little work that it completes
before the method it was scheduled by.

The race is likely only possible in unit tests, where `MockDeployer` (naturally)
does minimal work compared to a real deployer.