### PR TITLE
Deactivate all buckets in content layer bucket db when derived cluster

### DIFF
--- a/storage/src/vespa/storage/common/content_bucket_space.cpp
+++ b/storage/src/vespa/storage/common/content_bucket_space.cpp
@@ -9,7 +9,8 @@ ContentBucketSpace::ContentBucketSpace(document::BucketSpace bucketSpace)
       _bucketDatabase(),
       _lock(),
       _clusterState(),
-      _distribution()
+      _distribution(),
+      _nodeUpInLastNodeStateSeenByProvider(false)
 {
 }
 
@@ -39,6 +40,20 @@ ContentBucketSpace::getDistribution() const
 {
     std::lock_guard guard(_lock);
     return _distribution;
+}
+
+bool
+ContentBucketSpace::getNodeUpInLastNodeStateSeenByProvider() const
+{
+    std::lock_guard guard(_lock);
+    return _nodeUpInLastNodeStateSeenByProvider;
+}
+
+void
+ContentBucketSpace::setNodeUpInLastNodeStateSeenByProvider(bool nodeUpInLastNodeStateSeenByProvider)
+{
+    std::lock_guard guard(_lock);
+    _nodeUpInLastNodeStateSeenByProvider = nodeUpInLastNodeStateSeenByProvider;
 }
 
 }

--- a/storage/src/vespa/storage/common/content_bucket_space.h
+++ b/storage/src/vespa/storage/common/content_bucket_space.h
@@ -22,6 +22,7 @@ private:
     mutable std::mutex _lock;
     std::shared_ptr<const lib::ClusterState> _clusterState;
     std::shared_ptr<const lib::Distribution> _distribution;
+    bool _nodeUpInLastNodeStateSeenByProvider;
 
 public:
     using UP = std::unique_ptr<ContentBucketSpace>;
@@ -33,6 +34,8 @@ public:
     std::shared_ptr<const lib::ClusterState> getClusterState() const;
     void setDistribution(std::shared_ptr<const lib::Distribution> distribution);
     std::shared_ptr<const lib::Distribution> getDistribution() const;
+    bool getNodeUpInLastNodeStateSeenByProvider() const;
+    void setNodeUpInLastNodeStateSeenByProvider(bool nodeUpInLastNodeStateSeenByProvider);
 };
 
 }

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -56,7 +56,6 @@ class FileStorManager : public StorageLinkQueued,
     const spi::PartitionStateList& _partitions;
     spi::PersistenceProvider& _providerCore;
     ProviderErrorWrapper _providerErrorWrapper;
-    bool _nodeUpInLastNodeStateSeenByProvider;
     spi::MetricPersistenceProvider::UP _providerMetric;
     spi::PersistenceProvider* _provider;
     


### PR DESCRIPTION
state indicates that node changes from up to down state even if node
remains up according to baseline cluster state.

@baldersheim: please review
