### PR TITLE
Avoid using the 'convenient' way to specify parameter types when

### DIFF
--- a/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
+++ b/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
@@ -84,6 +84,19 @@ struct FunctionBuilder : public NodeVisitor, public NodeTraverser {
     std::vector<gbdt::Forest::UP> &forests;
     std::vector<PluginState::UP> &plugin_state;
 
+    llvm::FunctionType *make_call_1_fun_t() {
+        std::vector<llvm::Type*> param_types;
+        param_types.push_back(builder.getDoubleTy());
+        return llvm::FunctionType::get(builder.getDoubleTy(), param_types, false);
+    }
+
+    llvm::FunctionType *make_call_2_fun_t() {
+        std::vector<llvm::Type*> param_types;
+        param_types.push_back(builder.getDoubleTy());
+        param_types.push_back(builder.getDoubleTy());
+        return llvm::FunctionType::get(builder.getDoubleTy(), param_types, false);
+    }
+
     llvm::PointerType *make_eval_forest_funptr_t() {
         std::vector<llvm::Type*> param_types;
         param_types.push_back(builder.getVoidTy()->getPointerTo());
@@ -320,8 +333,7 @@ struct FunctionBuilder : public NodeVisitor, public NodeTraverser {
         make_call_1(llvm::Intrinsic::getDeclaration(&module, id, builder.getDoubleTy()));
     }
     void make_call_1(const char *name) {
-        make_call_1(llvm::dyn_cast<llvm::Function>(
-                    module.getOrInsertFunction(name, builder.getDoubleTy(), builder.getDoubleTy(), nullptr)));
+        make_call_1(llvm::dyn_cast<llvm::Function>(module.getOrInsertFunction(name, make_call_1_fun_t())));
     }
 
     void make_call_2(llvm::Function *fun) {
@@ -336,8 +348,7 @@ struct FunctionBuilder : public NodeVisitor, public NodeTraverser {
         make_call_2(llvm::Intrinsic::getDeclaration(&module, id, builder.getDoubleTy()));
     }
     void make_call_2(const char *name) {
-        make_call_2(llvm::dyn_cast<llvm::Function>(
-                    module.getOrInsertFunction(name, builder.getDoubleTy(), builder.getDoubleTy(), builder.getDoubleTy(), nullptr)));
+        make_call_2(llvm::dyn_cast<llvm::Function>(module.getOrInsertFunction(name, make_call_2_fun_t())));
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
resolving application functions we want to call from an llvm-compiled
function. LLVM 3.9 uses varargs with a nullptr sentinel at the end
while newer versions of LLVM (5/6) uses variadic templates. This leads
to 'inconvenience' when upgrading where the code still compiles, but
the no longer needed/wanted nullptr sentinel triggers a signature
mismatch leading to not being able to call functions like 'sin'/'cos'
etc.

@baldersheim please review