### PR TITLE
Revert "Upgrade Jetty to version 9.4.11"

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -466,7 +466,7 @@
         <guava.version>18.0</guava.version>
         <guice.version>3.0</guice.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
         <slf4j.version>1.7.5</slf4j.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->


### PR DESCRIPTION
Reverts vespa-engine/vespa#6536
The enforcer must be updated to