### PR TITLE
Remove all old files in access log dir when disk is going full

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -271,7 +271,6 @@ public class StorageMaintainer {
         maintainerExecutor.addJob("delete-files")
                 .withArgument("basePath", qrsDir)
                 .withArgument("maxAgeSeconds", Duration.ofDays(3).getSeconds())
-                .withArgument("fileNameRegex", ".*QueryAccessLog.*")
                 .withArgument("recursive", false);
 
         Path logArchiveDir = environment.pathInNodeAdminFromPathInNode(


### PR DESCRIPTION
Customers may configure access log file pattern, so we need to delete
regardless of file name