### PR TITLE
Avoid unreliable path lookup of test data

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunnerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunnerTest.java
@@ -384,7 +384,7 @@ public class InternalStepRunnerTest {
 
     private void assertFile(String resourceName, String actualContent) {
         try {
-            Path path = Paths.get(getClass().getClassLoader().getResource(resourceName).getPath());
+            Path path = Paths.get("src/test/resources/").resolve(resourceName);
             String expectedContent = new String(Files.readAllBytes(path));
             assertEquals(expectedContent, actualContent);
         } catch (IOException e) {


### PR DESCRIPTION
IntelliJ occasionally fails to lookup resources via class loader for me, haven't
been able to figure out the exact cause, but when it happens tests that use this
method fail with NPE.

Anyway, relative path should always work and this pattern is used elsewhere.