### PR TITLE
Avoid ExitOnOutOfMemoryError

### DIFF
--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -157,7 +157,7 @@ StartCommand() {
         -XX:+PreserveFramePointer \
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="$VESPA_HOME/var/crash" \
-        -XX:+ExitOnOutOfMemoryError \
+        -XX:OnOutOfMemoryError='kill -9 %p' \
         -Djava.library.path="$VESPA_HOME/lib64" \
         -Djava.awt.headless=true \
 	-Dsun.rmi.dgc.client.gcInterval=3600000 \

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -151,6 +151,12 @@ StartCommand() {
     printenv > "$cfpfile"
     FixDataDirectory "$bundlecachedir"
 
+    # TODO: Change
+    #   -XX:OnOutOfMemoryError='kill -9 %p'
+    # to
+    #   -XX:+ExitOutOfMemoryError
+    # below once java version is guaranteed to be >= 8 u92
+
     java \
 	"${jvm_arguments[@]}" \
         -Xms128m -Xmx2048m \


### PR DESCRIPTION
The -XX:+ExitOnOutOfMemoryError flag was introduced in Java 8 update 92, thus
not compatible with all Java 8 installations.

http://www.oracle.com/technetwork/java/javase/8u92-relnotes-2949471.html