### PR TITLE
Fix typo

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -428,7 +428,7 @@ public class InternalStepRunner implements StepRunner {
                 "<services xmlns:deploy='vespa' version='1.0'>\n" +
                 "    <container version='1.0' id='default'>\n" +
                 "\n" +
-                "        <component id=\"com.yahoo.vespa.hosted.testrunner.TestRunner\" bundle=\"vepsa-testrunner-components\">\n" +
+                "        <component id=\"com.yahoo.vespa.hosted.testrunner.TestRunner\" bundle=\"vespa-testrunner-components\">\n" +
                 "            <config name=\"com.yahoo.vespa.hosted.testrunner.test-runner\">\n" +
                 "                <artifactsPath>artifacts</artifactsPath>\n" +
                 "            </config>\n" +

--- a/controller-server/src/test/resources/test_runner_services.xml-cd
+++ b/controller-server/src/test/resources/test_runner_services.xml-cd
@@ -2,7 +2,7 @@
 <services xmlns:deploy='vespa' version='1.0'>
     <container version='1.0' id='default'>
 
-        <component id="com.yahoo.vespa.hosted.testrunner.TestRunner" bundle="vepsa-testrunner-components">
+        <component id="com.yahoo.vespa.hosted.testrunner.TestRunner" bundle="vespa-testrunner-components">
             <config name="com.yahoo.vespa.hosted.testrunner.test-runner">
                 <artifactsPath>artifacts</artifactsPath>
             </config>


### PR DESCRIPTION
Making progress... The test application is now successfully deployed, but fails to come up:
```
[2018-08-17 17:45:41.771] WARNING : container        Container.com.yahoo.container.di.Container 
        Failed to set up first component graph. Exiting within PT1M
        exception=
        java.lang.IllegalArgumentException: Could not create a component with id 'com.yahoo.vespa.hosted.testrunner.TestRunner'. Tried to load class directly, since no bundle was found for spec: vepsa-testrunner-components. If a bundle with the same name is installed, there is a either a version mismatch or the installed bundle's version contains a qualifier string.
        at com.yahoo.osgi.OsgiImpl.resolveFromClassPath(OsgiImpl.java:48)
        at com.yahoo.osgi.OsgiImpl.resolveClass(OsgiImpl.java:39)
        at com.yahoo.container.di.Container.addNodes(Container.java:217)
        at com.yahoo.container.di.Container.createComponentsGraph(Container.java:206)
        at com.yahoo.container.di.Container.getConfigAndCreateGraph(Container.java:148)
        at com.yahoo.container.di.Container.getNewComponentGraph(Container.java:77)
        at com.yahoo.container.core.config.HandlersConfigurerDi.getNewComponentGraph(HandlersConfigurerDi.java:139)
        at com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:89)
        at com.yahoo.container.jdisc.ConfiguredApplication.configureComponents(ConfiguredApplication.java:260)
        at com.yahoo.container.jdisc.ConfiguredApplication.start(ConfiguredApplication.java:128)
        at com.yahoo.jdisc.core.ApplicationLoader.start(ApplicationLoader.java:154)
        at com.yahoo.jdisc.core.StandaloneMain.run(StandaloneMain.java:43)
        at com.yahoo.jdisc.core.StandaloneMain.main(StandaloneMain.java:34)
```