### PR TITLE
Rename AttributeVector::saveAs() method to save().

### DIFF
--- a/searchlib/src/apps/vespa-attribute-inspect/vespa-attribute-inspect.cpp
+++ b/searchlib/src/apps/vespa-attribute-inspect/vespa-attribute-inspect.cpp
@@ -200,7 +200,7 @@ LoadAttribute::Main()
         vespalib::string saveFile = fileName + ".save";
         std::cout << "saving attribute: " << saveFile << std::endl;
         timer.SetNow();
-        ptr->saveAs(saveFile);
+        ptr->save(saveFile);
         std::cout << "save time: " << timer.MilliSecsToNow() / 1000 << " seconds " << std::endl;
     }
 

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -439,7 +439,7 @@ void AttributeTest::testReload(const AttributePtr & a, const AttributePtr & b, c
     compare<VectorType, BufferType>
         (*(static_cast<VectorType *>(a.get())), *(static_cast<VectorType *>(b.get())));
     a->setCreateSerialNum(43u);
-    EXPECT_TRUE( a->saveAs(b->getBaseFileName()) );
+    EXPECT_TRUE( a->save(b->getBaseFileName()) );
     a->commit(true);
     if (preciseEstimatedSize(*a)) {
         EXPECT_EQUAL(statSize(*b), a->getEstimatedSaveByteSize());
@@ -449,7 +449,7 @@ void AttributeTest::testReload(const AttributePtr & a, const AttributePtr & b, c
         EXPECT_LESS_EQUAL(actSize * 1.0, estSize * 1.3);
         EXPECT_GREATER_EQUAL(actSize * 1.0, estSize * 0.7);
     }
-    EXPECT_TRUE( a->saveAs(c->getBaseFileName()) );
+    EXPECT_TRUE( a->save(c->getBaseFileName()) );
     if (preciseEstimatedSize(*a)) {
         EXPECT_EQUAL(statSize(*c), a->getEstimatedSaveByteSize());
     }
@@ -650,27 +650,27 @@ void AttributeTest::testHasLoadData()
         EXPECT_TRUE(!av->hasLoadData());
         av->save();
         EXPECT_TRUE(av->hasLoadData());
-        av->saveAs(baseFileName("loaddata2"));
+        av->save(baseFileName("loaddata2"));
         av = createAttribute("loaddata2", Config(BasicType::INT32));
         EXPECT_TRUE(av->hasLoadData());
-        av->saveAs(baseFileName("loaddata3"));
+        av->save(baseFileName("loaddata3"));
     }
     { // array
         AttributePtr av = createAttribute("loaddata3", Config(BasicType::INT32, CollectionType::ARRAY));
         EXPECT_TRUE(!av->hasLoadData());
         av->save();
         EXPECT_TRUE(av->hasLoadData());
-        av->saveAs(baseFileName("loaddata4"));
+        av->save(baseFileName("loaddata4"));
         av = createAttribute("loaddata4", Config(BasicType::INT32, CollectionType::ARRAY));
         EXPECT_TRUE(av->hasLoadData());
-        av->saveAs(baseFileName("loaddata5"));
+        av->save(baseFileName("loaddata5"));
     }
     { // wset
         AttributePtr av = createAttribute("loaddata5", Config(BasicType::INT32, CollectionType::WSET));
         EXPECT_TRUE(!av->hasLoadData());
         av->save();
         EXPECT_TRUE(av->hasLoadData());
-        av->saveAs(baseFileName("loaddata6"));
+        av->save(baseFileName("loaddata6"));
         av = createAttribute("loaddata6", Config(BasicType::INT32, CollectionType::WSET));
         EXPECT_TRUE(av->hasLoadData());
     }

--- a/searchlib/src/tests/attribute/benchmark/attributebenchmark.cpp
+++ b/searchlib/src/tests/attribute/benchmark/attributebenchmark.cpp
@@ -659,7 +659,7 @@ AttributeBenchmark::Main()
 
     if (dc._writeAttribute) {
         std::cout << "<!-- Writing attribute to disk -->" << std::endl;
-        ptr->saveAs(ptr->getBaseFileName());
+        ptr->save(ptr->getBaseFileName());
     }
 
     std::cout << "</attribute-benchmark>" << std::endl;

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -591,7 +591,7 @@ EnumeratedSaveTest::saveBoth(AttributePtr v)
     AttributePtr v2 = make(v->getConfig(), basename, true);
     EXPECT_TRUE(v2->load());
     v2->enableEnumeratedSave(true);
-    EXPECT_TRUE(v2->saveAs(basename + "_e"));
+    EXPECT_TRUE(v2->save(basename + "_e"));
     if ((v->getConfig().basicType() == BasicType::INT32 &&
          v->getConfig().collectionType() == CollectionType::WSET) || true) {
         search::AttributeMemorySaveTarget ms;

--- a/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
+++ b/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
@@ -541,7 +541,7 @@ PostingListAttributeTest::testPostingList(const AttributePtr & ptr1, const Attri
     checkPostingList(vec1, values, RangeAlpha(part));
 
     // load and save vector
-    ptr1->saveAs(ptr2->getBaseFileName());
+    ptr1->save(ptr2->getBaseFileName());
     ptr2->load();
 #if 0
     std::cout << "***** vec2.printPostingListContent *****" << std::endl;
@@ -560,7 +560,7 @@ PostingListAttributeTest::testPostingList(const AttributePtr & ptr1, const Attri
     checkPostingList(vec1, values, RangeBeta(part, values.size()));
 
     // load and save vector
-    ptr1->saveAs(ptr2->getBaseFileName());
+    ptr1->save(ptr2->getBaseFileName());
     ptr2->load();
     checkPostingList(vec2, values, RangeBeta(part, values.size()));
 }
@@ -841,7 +841,7 @@ PostingListAttributeTest::testReload(const AttributePtr & ptr1, const AttributeP
     }
     ptr1->commit();
 
-    ASSERT_TRUE(ptr1->saveAs(ptr2->getBaseFileName()));
+    ASSERT_TRUE(ptr1->save(ptr2->getBaseFileName()));
     ASSERT_TRUE(ptr2->load());
 
     EXPECT_TRUE(ptr2->getNumDocs() == 5);
@@ -975,7 +975,7 @@ PostingListAttributeTest::testMinMax(AttributePtr &ptr1, AttributePtr &ptr2)
     populate(as<VectorType>(ptr1));
     
     TEST_DO(testMinMax<VectorType>(ptr1, 0u));
-    ASSERT_TRUE(ptr1->saveAs(ptr2->getBaseFileName()));
+    ASSERT_TRUE(ptr1->save(ptr2->getBaseFileName()));
     ASSERT_TRUE(ptr2->load());
     testMinMax<VectorType>(ptr2, 0u);
 

--- a/searchlib/src/tests/attribute/searchcontext/searchcontext.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext.cpp
@@ -569,7 +569,7 @@ SearchContextTest::testMultiValueSearch(V & first, V & second, const std::vector
 
     testMultiValueSearchHelper(first, values);
 
-    ASSERT_TRUE(first.saveAs(second.getBaseFileName()));
+    ASSERT_TRUE(first.save(second.getBaseFileName()));
     ASSERT_TRUE(second.load());
 
     testMultiValueSearchHelper(second, values);
@@ -591,7 +591,7 @@ SearchContextTest::testMultiValueSearch(V & first, V & second, const std::vector
 
     testMultiValueSearchHelper(first, values);
 
-    ASSERT_TRUE(first.saveAs(second.getBaseFileName()));
+    ASSERT_TRUE(first.save(second.getBaseFileName()));
     ASSERT_TRUE(second.load());
 
     testMultiValueSearchHelper(second, values);
@@ -1558,7 +1558,7 @@ SearchContextTest::requireThatSearchIsWorkingAfterLoadAndClearDoc(const vespalib
     VectorType & va = dynamic_cast<VectorType &>(*a);
     resetAttribute(va, startValue); // triggers vector vector in posting list (count 15)
     AttributePtr b = AttributeFactory::createAttribute(name + "-save", cfg);
-    EXPECT_TRUE(a->saveAs(b->getBaseFileName()));
+    EXPECT_TRUE(a->save(b->getBaseFileName()));
     EXPECT_TRUE(b->load());
     b->clearDoc(6); // goes from vector vector to single vector with count 14
     b->commit(true);

--- a/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
+++ b/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
@@ -418,7 +418,7 @@ StringAttributeTest::testSingleValue(Attribute & svsa, Config &cfg)
 
 
     Attribute load("load", cfg);
-    svsa.saveAs(load.getBaseFileName());
+    svsa.save(load.getBaseFileName());
     load.load();
 }
 

--- a/searchlib/src/tests/features/prod_features.cpp
+++ b/searchlib/src/tests/features/prod_features.cpp
@@ -426,7 +426,7 @@ Test::setupForAttributeTest(FtFeatureTest &ft, bool setup_env)
     }
 
     // save 'sint' and load it into 'unique' (only way to set a noupdate attribute)
-    ASSERT_TRUE(avs[0]->saveAs(avs[9]->getBaseFileName()));
+    ASSERT_TRUE(avs[0]->save(avs[9]->getBaseFileName()));
     ASSERT_TRUE(avs[9]->load());
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -334,19 +334,18 @@ AttributeVector::loadFile(const char *suffix)
 
 
 bool
-AttributeVector::saveAs(vespalib::stringref baseFileName)
+AttributeVector::save(vespalib::stringref fileName)
 {
-    _baseFileName = baseFileName;
-    return save();
+    TuneFileAttributes tune;
+    DummyFileHeaderContext fileHeaderContext;
+    AttributeFileSaveTarget saveTarget(tune, fileHeaderContext);
+    return save(saveTarget, fileName);
 }
 
 bool
 AttributeVector::save()
 {
-    TuneFileAttributes tune;
-    DummyFileHeaderContext fileHeaderContext;
-    AttributeFileSaveTarget saveTarget(tune, fileHeaderContext);
-    return save(saveTarget, getBaseFileName());
+    return save(getBaseFileName());
 }
 
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -429,10 +429,9 @@ public:
     bool isImported() const override;
 
     /**
-     * Updates the base file name of this attribute vector and saves
-     * it to file(s)
+     * Saves this attribute vector to named file(s)
      */
-    bool saveAs(vespalib::stringref baseFileName);
+    bool save(vespalib::stringref fileName);
 
     /** Saves this attribute vector to file(s) **/
     bool save();


### PR DESCRIPTION
Don't update attribute vector file name in the renamed method.

@baldersheim: please review
