### PR TITLE
Don't set attribute base file name when flushing attribute.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -71,7 +71,6 @@ FlushableAttribute::Flusher::Flusher(FlushableAttribute & fattr, SerialNum syncT
     AttributeVector &attr = *_fattr._attr;
     // Called by attribute field writer executor
     _flushFile = writer.getSnapshotDir(_syncToken) + "/" + attr.getName();
-    attr.setBaseFileName(_flushFile);
     _saver = attr.initSave(_flushFile);
     if (!_saver) {
         // New style background save not available, use old style save.

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -39,7 +39,7 @@ private:
     search::AttributeMemorySaveTarget      _saveTarget;
     std::unique_ptr<search::AttributeSaver> _saver;
     uint64_t                          _syncToken;
-    search::AttributeVector::BaseName _flushFile;
+    vespalib::string                  _flushFile;
 
     bool saveAttribute(); // not updating snap info.
 public:
@@ -86,7 +86,7 @@ FlushableAttribute::Flusher::~Flusher()
 bool
 FlushableAttribute::Flusher::saveAttribute()
 {
-    vespalib::mkdir(_flushFile.getDirName(), false);
+    vespalib::mkdir(vespalib::dirname(_flushFile), false);
     SerialNumFileHeaderContext fileHeaderContext(_fattr._fileHeaderContext,
                                                  _syncToken);
     bool saveSuccess = true;
@@ -119,14 +119,14 @@ FlushableAttribute::Flusher::flush(AttributeDirectory::Writer &writer)
         return false;
     }
     writer.markValidSnapshot(_syncToken);
-    writer.setLastFlushTime(search::FileKit::getModificationTime(_flushFile.getDirName()));
+    writer.setLastFlushTime(search::FileKit::getModificationTime(vespalib::dirname(_flushFile)));
     return true;
 }
 
 void
 FlushableAttribute::Flusher::updateStats()
 {
-    _fattr._lastStats.setPath(_flushFile.getDirName());
+    _fattr._lastStats.setPath(vespalib::dirname(_flushFile));
 }
 
 bool

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
@@ -70,7 +70,6 @@ Flusher(DocumentMetaStoreFlushTarget &dmsft,
     // Called by document db executor
     _flushDir = writer.getSnapshotDir(syncToken);
     vespalib::string newBaseFileName(_flushDir + "/" + dms.getName());
-    dms.setBaseFileName(newBaseFileName);
     _saver = dms.initSave(newBaseFileName);
     assert(_saver);
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
@@ -108,8 +108,8 @@ DocumentMetaStoreFlushTarget::Flusher::flush(AttributeDirectory::Writer &writer)
 {
     writer.createInvalidSnapshot(_syncToken);
     if (!saveDocumentMetaStore()) {
-        LOG(warning, "Could not write document meta store '%s' to disk",
-            _dmsft._dms->getBaseFileName().c_str());
+        vespalib::string baseFileName(_flushDir + "/" + _dmsft._dms->getName());
+        LOG(warning, "Could not write document meta store '%s' to disk", baseFileName.c_str());
         return false;
     }
     /*


### PR DESCRIPTION
 It is no longer used to specify where to save the attribute.

@baldersheim: please review
