### PR TITLE
more restart penalty

### DIFF
--- a/configd/src/apps/sentinel/service.h
+++ b/configd/src/apps/sentinel/service.h
@@ -26,7 +26,7 @@ private:
     SentinelConfig::Service *_config;
     bool _isAutomatic;
 
-    static const unsigned int MAX_RESTART_PENALTY = 60;
+    static const int MAX_RESTART_PENALTY = 1800;
     unsigned int _restartPenalty;
     time_t _last_start;
 


### PR DESCRIPTION
* set max restart penalty to 30 minutes
* scale much faster (exponentially) to max restart penalty
* increment restart penalty when a service needs restarting
  before 30 minutes have passed
* reset restart penalty when a service was OK for 5 hours

@toregge please review
@frodelu FYI