### PR TITLE
NodeFailer: Fail on hardware failure

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Expirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Expirer.java
@@ -9,7 +9,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 /**
@@ -45,8 +44,7 @@ public abstract class Expirer extends Maintainer {
     protected void maintain() {
         List<Node> expired = new ArrayList<>();
         for (Node node : nodeRepository().getNodes(fromState)) {
-            Optional<History.Event> event = node.history().event(eventType);
-            if (event.isPresent() && event.get().at().plus(expiryTime).isBefore(clock.instant()))
+            if (node.history().hasEventBefore(eventType, clock.instant().minus(expiryTime)))
                 expired.add(node);
         }
         if ( ! expired.isEmpty())

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
@@ -86,9 +86,8 @@ public class FailedExpirer extends Maintainer {
     /** Get failed nodes that have expired according to given expiry */
     private List<Node> getExpiredNodes(Duration expiry) {
         return nodeRepository.getNodes(Node.State.failed).stream()
-                             .filter(node -> node.history().event(History.Event.Type.failed)
-                                                 .map(event -> event.at().plus(expiry).isBefore(clock.instant()))
-                                                 .orElse(false))
+                             .filter(node -> node.history()
+                                     .hasEventBefore(History.Event.Type.failed, clock.instant().minus(expiry)))
                              .collect(Collectors.toList());
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooter.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.hosted.provision.node.filter.NodeListFilter;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -47,8 +46,7 @@ public class NodeRebooter extends Maintainer {
     }
     
     private boolean shouldReboot(Node node) {
-        Optional<History.Event> lastReboot = node.history().event(History.Event.Type.rebooted);
-        if (lastReboot.isPresent() && lastReboot.get().at().plus(rebootInterval).isAfter(clock.instant()))
+        if (node.history().hasEventAfter(History.Event.Type.rebooted, clock.instant().minus(rebootInterval)))
             return false;
         else // schedule with a probability such that reboots of nodes are spread roughly over the reboot interval
             return random.nextDouble() < (double) interval().getSeconds() / (double)rebootInterval.getSeconds();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -14,7 +13,6 @@ import com.yahoo.vespa.orchestrator.Orchestrator;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -99,10 +97,7 @@ public class RetiredExpirer extends Maintainer {
                     .allMatch(child -> child.state() == Node.State.parked || child.state() == Node.State.failed);
         }
 
-        Optional<Instant> timeOfRetiredEvent = node.history().event(History.Event.Type.retired).map(History.Event::at);
-        Optional<Instant> retireAfter = timeOfRetiredEvent.map(retiredEvent -> retiredEvent.plus(retiredExpiry));
-        boolean shouldRetireNowBecauseExpired = retireAfter.map(time -> time.isBefore(clock.instant())).orElse(false);
-        if (shouldRetireNowBecauseExpired) {
+        if (node.history().hasEventBefore(History.Event.Type.retired, clock.instant().minus(retiredExpiry))) {
             return true;
         }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -39,6 +39,20 @@ public class History {
     /** Returns this event if it is present in this history */
     public Optional<Event> event(Event.Type type) { return Optional.ofNullable(events.get(type)); }
 
+    /** Returns true if a given event is registered in this history after the given time */
+    public boolean hasEventAfter(Event.Type type, Instant time) {
+        return event(type)
+                .map(event -> event.at().isAfter(time))
+                .orElse(false);
+    }
+
+    /** Returns true if a given event is registered in this history before the given time */
+    public boolean hasEventBefore(Event.Type type, Instant time) {
+        return event(type)
+                .map(event -> event.at().isBefore(time))
+                .orElse(false);
+    }
+
     public Collection<Event> events() { return events.values(); }
 
     /** Returns a copy of this history with the given event added */

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -19,6 +19,7 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.test.ManualClock;
 import com.yahoo.transaction.NestedTransaction;
+import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
@@ -190,8 +191,15 @@ public class NodeFailTester {
     public void suspend(ApplicationId app) {
         try {
             orchestrator.suspend(app);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
-        catch (Exception e) {
+    }
+
+    public void suspend(String hostName) {
+        try {
+            orchestrator.suspend(new HostName(hostName));
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
The first 2 commit should not have any function changes.

This adds functionality to `NodeFailer` to fail out nodes if `hardwareFailureDescription` is set **and** `orchestrator` allows the given node to be down. 
The only other way an active node can be failed it if has been down >= 1h (does **NOT** require `orchestrator` allowing the host to be down (same as before)).

Both paths go to the same throttling mechanism (including limiting failure to only 1 proxy/config at the time).