### PR TITLE
Upgrade Jetty to version 9.4.12.RC2

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -466,7 +466,7 @@
         <guava.version>18.0</guava.version>
         <guice.version>3.0</guice.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.12.RC2</jetty.version>
         <slf4j.version>1.7.5</slf4j.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -67,13 +67,21 @@ public class ConnectorFactory {
         connector.setReuseAddress(connectorConfig.reuseAddress());
         double soLingerTimeSeconds = connectorConfig.soLingerTime();
         if (soLingerTimeSeconds == -1) {
-            connector.setSoLingerTime(-1);
+            setSoLingerTime(connector, -1);
         } else {
-            connector.setSoLingerTime((int)(soLingerTimeSeconds * 1000.0));
+            setSoLingerTime(connector, (int)(soLingerTimeSeconds * 1000.0));
         }
         connector.setIdleTimeout((long)(connectorConfig.idleTimeout() * 1000.0));
         connector.setStopTimeout((long)(connectorConfig.stopTimeout() * 1000.0));
         return connector;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void setSoLingerTime(ServerConnector connector, int milliseconds) {
+        // TODO: Don't use deprecated methods. Deprecate soLingerTime from connector config
+        // Jetty says: "don't use as socket close linger time has undefined behavior for non-blocking sockets"
+        // Jetty implementation is now a noop: https://github.com/eclipse/jetty.project/issues/2468, http://mail.openjdk.java.net/pipermail/nio-dev/2018-June/005195.html
+        connector.setSoLingerTime(milliseconds);
     }
 
     private HttpConnectionFactory newHttpConnectionFactory() {


### PR DESCRIPTION
Motivation for upgrading Jetty: Fix for https://github.com/eclipse/jetty.project/issues/2755

FYI @gjoranv 