### PR TITLE
Migrate legacy document store cache metrics to new naming scheme.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
@@ -51,12 +51,25 @@ DocumentDBTaggedMetrics::SubDBMetrics::LidSpaceMetrics::LidSpaceMetrics(MetricSe
 
 DocumentDBTaggedMetrics::SubDBMetrics::LidSpaceMetrics::~LidSpaceMetrics() { }
 
+DocumentDBTaggedMetrics::SubDBMetrics::DocumentStoreMetrics::CacheMetrics::CacheMetrics(MetricSet *parent)
+    : MetricSet("cache", "", "Document store cache metrics", parent),
+      memoryUsage("memory_usage", "", "Memory usage of the cache (in bytes)", this),
+      elements("elements", "", "Number of elements in the cache", this),
+      hitRate("hit_rate", "", "Rate of hits in the cache compared to number of lookups", this),
+      lookups("lookups", "", "Number of lookups in the cache (hits + misses)", this),
+      invalidations("invalidations", "", "Number of invalidations (erased elements) in the cache. ", this)
+{
+}
+
+DocumentDBTaggedMetrics::SubDBMetrics::DocumentStoreMetrics::CacheMetrics::~CacheMetrics() {}
+
 DocumentDBTaggedMetrics::SubDBMetrics::DocumentStoreMetrics::DocumentStoreMetrics(MetricSet *parent)
-    : MetricSet("document_store", "", "document store metrics for this document sub DB", parent),
+    : MetricSet("document_store", "", "Document store metrics for this document sub DB", parent),
       diskUsage("disk_usage", "", "Disk space usage in bytes", this),
       diskBloat("disk_bloat", "", "Disk space bloat in bytes", this),
       maxBucketSpread("max_bucket_spread", "", "Max bucket spread in underlying files (sum(unique buckets in each chunk)/unique buckets in file)", this),
-      memoryUsage(this)
+      memoryUsage(this),
+      cache(this)
 { }
 
 DocumentDBTaggedMetrics::SubDBMetrics::DocumentStoreMetrics::~DocumentStoreMetrics() { }

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
@@ -49,10 +49,23 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
 
         struct DocumentStoreMetrics : metrics::MetricSet
         {
+            struct CacheMetrics : metrics::MetricSet
+            {
+                metrics::LongValueMetric memoryUsage;
+                metrics::LongValueMetric elements;
+                metrics::LongAverageMetric hitRate;
+                metrics::LongCountMetric lookups;
+                metrics::LongCountMetric invalidations;
+
+                CacheMetrics(metrics::MetricSet *parent);
+                ~CacheMetrics();
+            };
+
             metrics::LongValueMetric diskUsage;
             metrics::LongValueMetric diskBloat;
             metrics::DoubleValueMetric maxBucketSpread;
             MemoryUsageMetrics memoryUsage;
+            CacheMetrics cache;
 
             DocumentStoreMetrics(metrics::MetricSet *parent);
             ~DocumentStoreMetrics();

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -73,6 +73,13 @@ private:
         DocumentDBMetricsCollection &getMetrics() { return _metrics; }
     };
 
+    struct DocumentStoreCacheStats {
+        search::CacheStats total;
+        search::CacheStats readySubDb;
+        search::CacheStats notReadySubDb;
+        search::CacheStats removedSubDb;
+        DocumentStoreCacheStats() : total(), readySubDb(), notReadySubDb(), removedSubDb() {}
+    };
 
     using InitializeThreads = std::shared_ptr<vespalib::ThreadStackExecutorBase>;
     using IFlushTargetList = std::vector<std::shared_ptr<searchcorespi::IFlushTarget>>;
@@ -129,8 +136,8 @@ private:
     ILidSpaceCompactionHandler::Vector _lidSpaceCompactionHandlers;
     DocumentDBJobTrackers         _jobTrackers;
 
-    // Last updated cache statistics. Necessary due to metrics implementation is upside down.
-    search::CacheStats            _lastDocStoreCacheStats;
+    // Last updated document store cache statistics. Necessary due to metrics implementation is upside down.
+    DocumentStoreCacheStats       _lastDocStoreCacheStats;
     IBucketStateCalculator::SP    _calc;
 
     void registerReference();

--- a/searchlib/src/vespa/searchlib/docstore/cachestats.h
+++ b/searchlib/src/vespa/searchlib/docstore/cachestats.h
@@ -12,19 +12,22 @@ struct CacheStats {
     size_t misses;
     size_t elements;
     size_t memory_used;
+    size_t invalidations;
 
     CacheStats()
         : hits(0),
           misses(0),
           elements(0),
-          memory_used(0)
+          memory_used(0),
+          invalidations(0)
     { }
 
-    CacheStats(size_t hit, size_t miss, size_t elem, size_t mem)
-        : hits(hit),
-          misses(miss),
-          elements(elem),
-          memory_used(mem)
+    CacheStats(size_t hits_, size_t misses_, size_t elements_, size_t memory_used_, size_t invalidations_)
+        : hits(hits_),
+          misses(misses_),
+          elements(elements_),
+          memory_used(memory_used_),
+          invalidations(invalidations_)
     { }
 
     CacheStats &
@@ -34,9 +37,12 @@ struct CacheStats {
         misses += rhs.misses;
         elements += rhs.elements;
         memory_used += rhs.memory_used;
+        invalidations += rhs.invalidations;
         return *this;
     }
+
+    size_t lookups() const { return hits + misses; }
 };
 
-}  // namespace search
+}
 

--- a/searchlib/src/vespa/searchlib/docstore/documentstore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/documentstore.cpp
@@ -555,7 +555,7 @@ DocumentStore::getFileChunkStats() const
 CacheStats DocumentStore::getCacheStats() const {
     CacheStats visitStats = _visitCache->getCacheStats();
     CacheStats singleStats(_cache->getHit(), _cache->getMiss() + _uncached_lookups,
-                           _cache->size(), _cache->sizeBytes());
+                           _cache->size(), _cache->sizeBytes(), _cache->getInvalidate());
     singleStats += visitStats;
     return singleStats;
 }

--- a/searchlib/src/vespa/searchlib/docstore/visitcache.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/visitcache.cpp
@@ -221,7 +221,7 @@ VisitCache::remove(uint32_t key) {
 
 CacheStats
 VisitCache::getCacheStats() const {
-    return CacheStats(_cache->getHit(), _cache->getMiss(), _cache->size(), _cache->sizeBytes());
+    return CacheStats(_cache->getHit(), _cache->getMiss(), _cache->size(), _cache->sizeBytes(), _cache->getInvalidate());
 }
 
 VisitCache::Cache::Cache(BackingStore & b, size_t maxBytes) :


### PR DESCRIPTION
Also add number of cache invalidations as new metric.

@baldersheim please review