### PR TITLE
Allow for replacing a brand new buffer in an rcu vector.

### DIFF
--- a/searchlib/src/vespa/searchlib/common/rcuvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/rcuvector.cpp
@@ -2,8 +2,7 @@
 
 #include "rcuvector.hpp"
 
-namespace search {
-namespace attribute {
+namespace search::attribute {
 
 template class RcuVectorBase<uint8_t>;
 template class RcuVectorBase<uint16_t>;
@@ -35,5 +34,4 @@ template class RcuVectorHeld<int64_t>;
 template class RcuVectorHeld<float>;
 template class RcuVectorHeld<double>;
 
-}
 }

--- a/searchlib/src/vespa/searchlib/common/rcuvector.h
+++ b/searchlib/src/vespa/searchlib/common/rcuvector.h
@@ -8,8 +8,7 @@
 #include <vespa/vespalib/util/alloc.h>
 #include <vespa/vespalib/util/array.h>
 
-namespace search {
-namespace attribute {
+namespace search::attribute {
 
 template <typename T>
 class RcuVectorHeld : public vespalib::GenerationHeldBase
@@ -122,6 +121,7 @@ public:
 
     void reset();
     void shrink(size_t newSize) __attribute__((noinline));
+    void replaceVector(std::unique_ptr<Array> replacement);
 };
 
 template <typename T>
@@ -160,5 +160,4 @@ public:
     MemoryUsage getMemoryUsage() const override;
 };
 
-}
 }


### PR DESCRIPTION
And use that for first do the expensive resolving outside of the guard, beofre just swapping it in during a shortly held lock.
@geirst  and @toregge PR