### PR TITLE
Tune memory resource limit to get at least 2GB memory headroom per node.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -217,7 +217,8 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
         TransactionLogServer tls;
         Optional<Tuning> tuning = Optional.ofNullable(this.tuning);
         if (element == null) {
-            snode = SearchNode.create(parent, "" + node.getDistributionKey(), node.getDistributionKey(), spec, clusterName, node, flushOnShutdown, tuning);
+            snode = SearchNode.create(parent, "" + node.getDistributionKey(), node.getDistributionKey(), spec,
+                    clusterName, node, flushOnShutdown, tuning, resourceLimits);
             snode.setHostResource(node.getHostResource());
             snode.initService();
 
@@ -225,7 +226,8 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
             tls.setHostResource(snode.getHostResource());
             tls.initService();
         } else {
-            snode = new SearchNode.Builder(""+node.getDistributionKey(), spec, clusterName, node, flushOnShutdown, tuning).build(parent, element.getXml());
+            snode = new SearchNode.Builder("" + node.getDistributionKey(), spec, clusterName, node,
+                    flushOnShutdown, tuning, resourceLimits).build(parent, element.getXml());
             tls = new TransactionLogServer.Builder(clusterName).build(snode, element.getXml());
         }
         snode.setTls(tls);

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1672,6 +1672,9 @@ public class ModelProvisioningTest {
                 "    <nodes count='1' flavor='content-test-flavor'/>",
                 "    <engine>",
                 "      <proton>",
+                "        <resource-limits>",
+                "          <memory>0.6</memory>",
+                "        </resource-limits>",
                 "        <tuning>",
                 "          <searchnode>",
                 "            <flushstrategy>",
@@ -1690,13 +1693,14 @@ public class ModelProvisioningTest {
 
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts("default", 1);
-        tester.addHosts(createFlavorFromMemoryAndDisk("content-test-flavor", 128, 100), 1);
+        tester.addHosts(createFlavorFromMemoryAndDisk("content-test-flavor", 8, 100), 1);
         VespaModel model = tester.createModel(services, true, 0);
         ContentSearchCluster cluster = model.getContentClusters().get("test").getSearch();
         ProtonConfig cfg = getProtonConfig(model, cluster.getSearchNodes().get(0).getConfigId());
         assertEquals(2000, cfg.flush().memory().maxtlssize()); // from config override
         assertEquals(1000, cfg.flush().memory().maxmemory()); // from explicit tuning
-        assertEquals((long) 16 * GB, cfg.flush().memory().each().maxmemory()); // from default node flavor tuning
+        assertEquals(0.6, cfg.writefilter().memorylimit(), 0.000001); // from explicit resource-limits
+        assertEquals((long) 1 * GB, cfg.flush().memory().each().maxmemory()); // from default node flavor tuning
     }
 
     private static long GB = 1024 * 1024 * 1024;

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/MultilevelDispatchTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/MultilevelDispatchTest.java
@@ -290,7 +290,8 @@ public class MultilevelDispatchTest {
         List<SearchNode> searchNodes = new ArrayList<>();
         MockRoot root = new MockRoot("");
         for (int i = 0; i < numNodes; ++i) {
-            searchNodes.add(SearchNode.create(root, "mynode" + i, i, new NodeSpec(0, i), "mycluster", null, false, Optional.empty()));
+            searchNodes.add(SearchNode.create(root, "mynode" + i, i, new NodeSpec(0, i), "mycluster",
+                    null, false, Optional.empty(), Optional.empty()));
         }
         return searchNodes;
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/NodeFlavorTuningTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/NodeFlavorTuningTest.java
@@ -15,6 +15,7 @@ import static com.yahoo.vespa.model.search.NodeFlavorTuning.GB;
  */
 public class NodeFlavorTuningTest {
 
+
     @Test
     public void require_that_hwinfo_disk_size_is_set() {
         ProtonConfig cfg = configFromDiskSetting(100);
@@ -98,6 +99,14 @@ public class NodeFlavorTuningTest {
         assertSharedDisk(false, false);
     }
 
+    @Test
+    public void require_that_memory_resource_limit_is_tuned_to_get_at_least_2gb_memory_headroom() {
+        assertMemoryResourceLimit(0.6666667, configFromMemorySetting(6));
+        assertMemoryResourceLimit(0.75, configFromMemorySetting(8));
+        assertMemoryResourceLimit(0.8, configFromMemorySetting(10));
+        assertMemoryResourceLimit(0.8, configFromMemorySetting(12));
+    }
+
     private static void assertDocumentStoreMaxFileSize(long expFileSizeBytes, int memoryGb) {
         assertEquals(expFileSizeBytes, configFromMemorySetting(memoryGb).summary().log().maxfilesize());
     }
@@ -117,6 +126,10 @@ public class NodeFlavorTuningTest {
 
     private static void assertSharedDisk(boolean sharedDisk, boolean docker) {
         assertEquals(sharedDisk, configFromEnvironmentType(docker).hwinfo().disk().shared());
+    }
+
+    private static void assertMemoryResourceLimit(double expResourceLimit, ProtonConfig cfg) {
+        assertEquals(expResourceLimit, cfg.writefilter().memorylimit(), 0.000001);
     }
 
     private static ProtonConfig configFromDiskSetting(boolean fastDisk) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchNodeTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchNodeTest.java
@@ -48,7 +48,8 @@ public class SearchNodeTest {
     }
 
     private static SearchNode createSearchNode(AbstractConfigProducer parent, String name, int distributionKey, NodeSpec nodeSpec, boolean flushOnShutDown) {
-        return SearchNode.create(parent, name, distributionKey, nodeSpec, "mycluster", null, flushOnShutDown, Optional.empty());
+        return SearchNode.create(parent, name, distributionKey, nodeSpec, "mycluster", null,
+                flushOnShutDown, Optional.empty(), Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
This only applies when node flavor is available.

@baldersheim please review
@yngveaasheim FYI