### PR TITLE
Revert "Explicitly use legacy format option to vespa-get-config"

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -52,7 +52,7 @@ getconfig() {
             qrstartcfg="`cat ${config_dir}/qr-start.cfg`"
             ;;
         *)
-            qrstartcfg="`$VESPA_HOME/bin/vespa-get-config -l -w 10 -n search.config.qr-start -i ${VESPA_CONFIG_ID}`"
+            qrstartcfg="`$VESPA_HOME/bin/vespa-get-config -w 10 -n search.config.qr-start -i ${VESPA_CONFIG_ID}`"
             ;;
     esac
     cmds=`echo "$qrstartcfg" | perl -ne 's/^(\w+)\.(\w+) (.*)/$1_$2=$3/ && print'`

--- a/vespaclient/src/perl/lib/Yahoo/Vespa/VespaModel.pm
+++ b/vespaclient/src/perl/lib/Yahoo/Vespa/VespaModel.pm
@@ -162,7 +162,7 @@ sub setModelRetrievalFunction { # (Function)
 }
 sub retrieveModelConfigDefault { # ()
     my $VESPA_HOME= $ENV{'VESPA_HOME'};
-    my $cmd = ${VESPA_HOME} . '/bin/vespa-get-config -l -n cloud.config.model -i admin/model';
+    my $cmd = ${VESPA_HOME} . '/bin/vespa-get-config -n cloud.config.model -i admin/model';
 
     if (defined $CONFIG_REQUEST_TIMEOUT) {
         $cmd .= " -w $CONFIG_REQUEST_TIMEOUT";


### PR DESCRIPTION
Reverts vespa-engine/vespa#6710

@hmusum or @arnej27959 

This broke a lot of systemtests.