### PR TITLE
1 ms is probably far too little to be reliable

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/MockCuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/MockCuratorDb.java
@@ -25,7 +25,7 @@ public class MockCuratorDb extends CuratorDb {
             public String zooKeeperEnsembleConnectionSpec() {
                 return zooKeeperEnsembleConnectionSpec;
             }
-        }, Duration.ofMillis(1));
+        }, Duration.ofMillis(100));
     }
 
 }


### PR DESCRIPTION
@bratseth please merge.
@mpolden FYI. 

Build failed twice in a row on tests that actually need these locks, across different threads. 