### PR TITLE
Java dispatcher extensions

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/CloseableChannel.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/CloseableChannel.java
@@ -1,0 +1,44 @@
+package com.yahoo.search.dispatch;
+
+import com.yahoo.fs4.BasicPacket;
+import com.yahoo.fs4.ChannelTimeoutException;
+import com.yahoo.fs4.mplex.Backend;
+import com.yahoo.fs4.mplex.FS4Channel;
+import com.yahoo.fs4.mplex.InvalidChannelException;
+import com.yahoo.search.Query;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Optional;
+
+public class CloseableChannel implements Closeable {
+    private FS4Channel channel;
+
+    public CloseableChannel(Backend backend) {
+        this.channel = backend.openChannel();
+    }
+
+    public void setQuery(Query query) {
+        channel.setQuery(query);
+    }
+
+    public boolean sendPacket(BasicPacket packet) throws InvalidChannelException, IOException {
+        return channel.sendPacket(packet);
+    }
+
+    public BasicPacket[] receivePackets(long timeout, int packetCount) throws InvalidChannelException, ChannelTimeoutException {
+        return channel.receivePackets(timeout, packetCount);
+    }
+
+    public Optional<Integer> distributionKey() {
+        return channel.distributionKey();
+    }
+
+    @Override
+    public void close() {
+        if (channel != null) {
+            channel.close();
+            channel = null;
+        }
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -11,6 +11,7 @@ import com.yahoo.container.protect.Error;
 import com.yahoo.prelude.fastsearch.DocumentDatabase;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.data.access.slime.SlimeAdapter;
+import com.yahoo.fs4.mplex.Backend;
 import com.yahoo.prelude.fastsearch.FS4ResourcePool;
 import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.fastsearch.TimeoutException;
@@ -28,6 +29,7 @@ import com.yahoo.vespa.config.search.DispatchConfig;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -57,10 +59,15 @@ public class Dispatcher extends AbstractComponent {
 
     private final Compressor compressor = new Compressor();
 
+    private final LoadBalancer loadBalancer;
+    private final FS4ResourcePool fs4ResourcePool;
+
     public Dispatcher(DispatchConfig dispatchConfig, FS4ResourcePool fs4ResourcePool,
                       int containerClusterSize, VipStatus vipStatus) {
         this.client = new RpcClient();
         this.searchCluster = new SearchCluster(dispatchConfig, fs4ResourcePool, containerClusterSize, vipStatus);
+        this.fs4ResourcePool = fs4ResourcePool;
+        this.loadBalancer = new LoadBalancer(searchCluster);
 
         // Create node rpc connections, indexed by the node distribution key
         ImmutableMap.Builder<Integer, Client.NodeConnection> nodeConnectionsBuilder = new ImmutableMap.Builder<>();
@@ -75,6 +82,8 @@ public class Dispatcher extends AbstractComponent {
         this.searchCluster = null;
         this.nodeConnections = ImmutableMap.copyOf(nodeConnections);
         this.client = client;
+        this.fs4ResourcePool = null;
+        this.loadBalancer = new LoadBalancer(searchCluster);
     }
     
     /** Returns the search cluster this dispatches to */
@@ -275,4 +284,18 @@ public class Dispatcher extends AbstractComponent {
 
     }
 
+    public Optional<Backend> getDispatchBackend(Query query) {
+        Optional<SearchCluster.Group> groupInCluster = loadBalancer.getGroupForQuery(query);
+
+        return groupInCluster.flatMap(group -> {
+            if(group.nodes().size() == 1) {
+                return Optional.of(group.nodes().get(0));
+            } else {
+                return Optional.empty();
+            }
+        }).map(node -> {
+            query.trace(false, 2, "Dispatching directly (anywhere) to ", node);
+            return fs4ResourcePool.getBackend(node.hostname(), node.fs4port(), Optional.of(node.key()));
+        });
+    }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -284,7 +284,7 @@ public class Dispatcher extends AbstractComponent {
 
     }
 
-    public Optional<Backend> getDispatchBackend(Query query) {
+    public Optional<CloseableChannel> getDispatchBackend(Query query) {
         Optional<SearchCluster.Group> groupInCluster = loadBalancer.getGroupForQuery(query);
 
         return groupInCluster.flatMap(group -> {
@@ -295,7 +295,8 @@ public class Dispatcher extends AbstractComponent {
             }
         }).map(node -> {
             query.trace(false, 2, "Dispatching directly (anywhere) to ", node);
-            return fs4ResourcePool.getBackend(node.hostname(), node.fs4port(), Optional.of(node.key()));
+            Backend backend = fs4ResourcePool.getBackend(node.hostname(), node.fs4port(), Optional.of(node.key()));
+            return new CloseableChannel(backend);
         });
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
@@ -1,0 +1,27 @@
+package com.yahoo.search.dispatch;
+
+import com.yahoo.search.Query;
+import com.yahoo.search.dispatch.SearchCluster.Group;
+
+import java.util.Optional;
+
+public class LoadBalancer {
+
+    private final SearchCluster searchCluster;
+
+    public LoadBalancer(SearchCluster searchCluster) {
+        this.searchCluster = searchCluster;
+    }
+
+    public Optional<Group> getGroupForQuery(Query query) {
+        if (searchCluster.groups().size() == 1) {
+            for(Group group: searchCluster.groups().values()) {
+                // since the number of groups is 1, this will run only once
+                if(group.nodes().size() == 1) {
+                    return Optional.of(group);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/RpcClient.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/RpcClient.java
@@ -15,7 +15,6 @@ import com.yahoo.jrt.Values;
 import com.yahoo.prelude.fastsearch.FastHit;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A client which uses rpc request to search nodes to implement the Client API.

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/container-search/src/main/java/com/yahoo/search/yql/TypeCheckers.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/TypeCheckers.java
@@ -64,7 +64,8 @@ final class TypeCheckers {
                 TypeLiteral<?> arg = TypeLiteral.get(type.getActualTypeArguments()[0]);
                 if (OperatorNode.class.isAssignableFrom(arg.getRawType())) {
                     Preconditions.checkArgument(arg.getType() instanceof ParameterizedType, "Type spec must be List<OperatorNode<?>>");
-                    Class<? extends Operator> optype = (Class<? extends Operator>) TypeLiteral.get(((ParameterizedType) arg.getType()).getActualTypeArguments()[0]).getRawType();
+                    Class<?> rawType = (Class<?>) TypeLiteral.get(((ParameterizedType) arg.getType()).getActualTypeArguments()[0]).getRawType();
+                    Class<? extends Operator> optype = (Class<? extends Operator>) rawType;
                     return new OperatorNodeListTypeChecker(parent, idx, optype, ImmutableSet.<Operator>of());
                 } else {
                     return new JavaListTypeChecker(parent, idx, arg.getRawType());

--- a/container-search/src/test/java/com/yahoo/prelude/hitfield/test/JSONStringTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/hitfield/test/JSONStringTestCase.java
@@ -329,8 +329,8 @@ public class JSONStringTestCase {
             String rendered = js.renderFromInspector();
 
             assertTrue(-1 < rendered.indexOf(f1));
-            int offsetF2;
-            assertTrue(-1 < (offsetF2 = rendered.indexOf(f2)));
+            int offsetF2 = rendered.indexOf(f2);
+            assertTrue(-1 < offsetF2);
             offsetF2 += f2.length();
             assertTrue(-1 < rendered.indexOf(f2_1, offsetF2));
             assertTrue(-1 < rendered.indexOf(f2_2, offsetF2));

--- a/container-search/src/test/java/com/yahoo/search/dispatch/FillTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/FillTestCase.java
@@ -2,7 +2,6 @@
 package com.yahoo.search.dispatch;
 
 import com.yahoo.compress.CompressionType;
-import com.yahoo.log.event.Collection;
 import com.yahoo.prelude.fastsearch.DocsumDefinition;
 import com.yahoo.prelude.fastsearch.DocsumDefinitionSet;
 import com.yahoo.prelude.fastsearch.DocsumField;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -1,0 +1,64 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+import com.yahoo.search.dispatch.SearchCluster.Group;
+import com.yahoo.search.dispatch.SearchCluster.Node;
+import junit.framework.AssertionFailedError;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class LoadBalancerTest {
+    @Test
+    public void requreThatLoadBalancerServesSingleNodeSetups() {
+        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
+        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1), null, 1, null);
+        LoadBalancer lb = new LoadBalancer(cluster);
+
+        Optional<Group> grp = lb.getGroupForQuery(null);
+        Group group = grp.orElseGet(() -> {
+            throw new AssertionFailedError("Expected a SearchCluster.Group");
+        });
+        assertThat(group.nodes().size(), Matchers.equalTo(1));
+    }
+
+    @Test
+    public void requreThatLoadBalancerIgnoresMultiGroupSetups() {
+        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
+        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
+        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 1, null);
+        LoadBalancer lb = new LoadBalancer(cluster);
+
+        Optional<Group> grp = lb.getGroupForQuery(null);
+        assertThat(grp.isPresent(), is(false));
+    }
+
+    @Test
+    public void requreThatLoadBalancerIgnoresClusteredSingleGroup() {
+        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
+        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 0);
+        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 2, null);
+        LoadBalancer lb = new LoadBalancer(cluster);
+
+        Optional<Group> grp = lb.getGroupForQuery(null);
+        assertThat(grp.isPresent(), is(false));
+    }
+
+    @Test
+    public void requreThatLoadBalancerIgnoresClusteredGroups() {
+        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
+        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 0);
+        Node n3 = new SearchCluster.Node(0, "test-node3", 0, 1);
+        Node n4 = new SearchCluster.Node(1, "test-node4", 1, 1);
+        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
+        LoadBalancer lb = new LoadBalancer(cluster);
+
+        Optional<Group> grp = lb.getGroupForQuery(null);
+        assertThat(grp.isPresent(), is(false));
+    }
+}


### PR DESCRIPTION
Three commits:
- Some initial warning cleanup and changes to make Eclipse's compiler happy
- Extension of dispatcher to do direct dispatching to content nodes on other hosts (if there is only one), behind a feature flag
- Minor abstraction of the used protocol interface after which the load balancer can be extended with actions after a query is completed
