### PR TITLE
SO linger is not supported for non-blocking sockets in Jetty 9.4.12 and later

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -65,23 +65,9 @@ public class ConnectorFactory {
         connector.setName(connectorConfig.name());
         connector.setAcceptQueueSize(connectorConfig.acceptQueueSize());
         connector.setReuseAddress(connectorConfig.reuseAddress());
-        double soLingerTimeSeconds = connectorConfig.soLingerTime();
-        if (soLingerTimeSeconds == -1) {
-            setSoLingerTime(connector, -1);
-        } else {
-            setSoLingerTime(connector, (int)(soLingerTimeSeconds * 1000.0));
-        }
         connector.setIdleTimeout((long)(connectorConfig.idleTimeout() * 1000.0));
         connector.setStopTimeout((long)(connectorConfig.stopTimeout() * 1000.0));
         return connector;
-    }
-
-    @SuppressWarnings("deprecation")
-    private static void setSoLingerTime(ServerConnector connector, int milliseconds) {
-        // TODO: Don't use deprecated methods. Deprecate soLingerTime from connector config
-        // Jetty says: "don't use as socket close linger time has undefined behavior for non-blocking sockets"
-        // Jetty implementation is now a noop: https://github.com/eclipse/jetty.project/issues/2468, http://mail.openjdk.java.net/pipermail/nio-dev/2018-June/005195.html
-        connector.setSoLingerTime(milliseconds);
     }
 
     private HttpConnectionFactory newHttpConnectionFactory() {

--- a/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.connector.def
+++ b/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.connector.def
@@ -25,8 +25,8 @@ acceptQueueSize                     int      default=0
 # Whether the server socket reuses addresses.
 reuseAddress                        bool     default=true
 
-# TODO Vespa 7: Remove soLingerTime - Jetty no longer support it
-# DEPRECATED The linger time in seconds. Use -1.0 to disable.
+# TODO Vespa 7: Remove soLingerTime - Jetty no longer support it.
+# DEPRECATED No longer in use
 soLingerTime                        double   default=-1.0
 
 # The maximum idle time for a connection, which roughly translates to the Socket.setSoTimeout(int).


### PR DESCRIPTION
Quote from Jetty:
'For non-blocking sockets, StandardSocketOptions#SO_LINGER javadocs
report that the behavior is undefined. In JDK 11 setting SoLinger
for non-blocking sockets will be ignored.
As such, there is no point in allowing SoLinger to be configured
in Jetty that only uses non-blocking sockets.'

FYI @gjoranv