### PR TITLE
Exclude all transitive deps from searchcore.

### DIFF
--- a/model-evaluation/pom.xml
+++ b/model-evaluation/pom.xml
@@ -42,6 +42,12 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>searchcore</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
@@ -79,9 +85,6 @@
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <configuration>
-          <importPackage>com.yahoo.config</importPackage> <!-- To make DI see RankingConstantsConfig as a ConfigInstance -->
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- To prevent compile scope for config-lib and other provided
  libraries.

NOTE: the correct solution is most likely to move the required config definitions into the `configdefinitions` module, and not depend on `searchcore` in the first place.
