### PR TITLE
Mark legacy HTTP handlers as deprecated.

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/StatusResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/StatusResponse.java
@@ -11,6 +11,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class StatusResponse extends HttpResponse {
 
     MetricManager manager;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerCompatibility.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerCompatibility.java
@@ -9,6 +9,10 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerCompatibility extends ThreadedHttpRequestHandler {
 
     private final VespaFeedHandlerGet getHandler;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerGet.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerGet.java
@@ -11,6 +11,10 @@ import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.search.handler.SearchHandler;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerGet extends ThreadedHttpRequestHandler {
 
     private final SearchHandler searchHandler;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemove.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemove.java
@@ -21,6 +21,10 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.concurrent.Executor;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerRemove extends VespaFeedHandlerBase {
 
     @Inject

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemoveLocation.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemoveLocation.java
@@ -20,6 +20,10 @@ import com.yahoo.vespaclient.config.FeederConfig;
 
 import java.util.concurrent.Executor;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerRemoveLocation extends VespaFeedHandlerBase {
 
     @Inject

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
@@ -15,6 +15,10 @@ import com.yahoo.metrics.MetricManager;
 import com.yahoo.metrics.MetricSet;
 import com.yahoo.vespaclient.config.FeederConfig;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerStatus extends ThreadedHttpRequestHandler {
 
     private MetricManager manager;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerVisit.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerVisit.java
@@ -13,7 +13,10 @@ import com.yahoo.search.handler.SearchHandler;
 
 /**
  * @author thomasg
+ *
+ * @deprecated Legacy API. Will be removed in Vespa 7
  */
+@Deprecated
 public class VespaFeedHandlerVisit extends ThreadedHttpRequestHandler {
 
     private final SearchHandler searchHandler;


### PR DESCRIPTION
@bratseth @freva please review, re: architect meeting. This is a subset of the changes in #6034