### PR TITLE
Mark legacy handlers as deprecated; part 2 - electric boogaloo

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/StatusResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/StatusResponse.java
@@ -11,6 +11,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class StatusResponse extends HttpResponse {
 
     MetricManager manager;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerCompatibility.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerCompatibility.java
@@ -9,6 +9,10 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerCompatibility extends ThreadedHttpRequestHandler {
 
     private final VespaFeedHandlerGet getHandler;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerGet.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerGet.java
@@ -11,6 +11,10 @@ import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.search.handler.SearchHandler;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerGet extends ThreadedHttpRequestHandler {
 
     private final SearchHandler searchHandler;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemove.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemove.java
@@ -21,6 +21,10 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.concurrent.Executor;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerRemove extends VespaFeedHandlerBase {
 
     @Inject

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemoveLocation.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerRemoveLocation.java
@@ -20,6 +20,10 @@ import com.yahoo.vespaclient.config.FeederConfig;
 
 import java.util.concurrent.Executor;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerRemoveLocation extends VespaFeedHandlerBase {
 
     @Inject

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
@@ -15,6 +15,10 @@ import com.yahoo.metrics.MetricManager;
 import com.yahoo.metrics.MetricSet;
 import com.yahoo.vespaclient.config.FeederConfig;
 
+/**
+ * @deprecated Legacy API. Will be removed in Vespa 7
+ */
+@Deprecated
 public class VespaFeedHandlerStatus extends ThreadedHttpRequestHandler {
 
     private MetricManager manager;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerVisit.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerVisit.java
@@ -13,7 +13,10 @@ import com.yahoo.search.handler.SearchHandler;
 
 /**
  * @author thomasg
+ *
+ * @deprecated Legacy API. Will be removed in Vespa 7
  */
+@Deprecated
 public class VespaFeedHandlerVisit extends ThreadedHttpRequestHandler {
 
     private final SearchHandler searchHandler;

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/VespaFeedHandlerTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/VespaFeedHandlerTestCase.java
@@ -39,6 +39,7 @@ import java.util.zip.GZIPOutputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation") // VespaFeedHandler classes are going away on Vespa 7
 public class VespaFeedHandlerTestCase {
 
     private VespaFeedHandler feedHandler;


### PR DESCRIPTION
@bratseth please review, this time with 100% less compilation failures presumably.

In the spirit of introspection; gotta ensure to run `mvn clean package -DskipTests`, not just `mvn install -DskipTests`. Also, IntelliJ doesn't seem to care and doesn't fail any test compilations with deprecations present 👌.