### PR TITLE
Set scope 'provided' for config-lib.

### DIFF
--- a/model-evaluation/pom.xml
+++ b/model-evaluation/pom.xml
@@ -79,9 +79,6 @@
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <configuration>
-          <importPackage>com.yahoo.config</importPackage> <!-- To make DI see RankingConstantsConfig as a ConfigInstance -->
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/searchcore/pom.xml
+++ b/searchcore/pom.xml
@@ -20,6 +20,7 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-lib</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This replaces #6834.
FYI: @lesters 

- Searchcore is not used in any java standalone (non-jdisc) apps.