### PR TITLE
DistributionKey moved from Backend to CloseableChannel

### DIFF
--- a/container-search/src/main/java/com/yahoo/fs4/mplex/Backend.java
+++ b/container-search/src/main/java/com/yahoo/fs4/mplex/Backend.java
@@ -61,12 +61,11 @@ public class Backend implements ConnectionFactory {
     private final ConnectionPool connectionPool;
     private final PacketDumper packetDumper;
     private final AtomicInteger connectionCount = new AtomicInteger(0);
-    private final Optional<Integer> distributionKey;
 
     /**
      * For unit testing.  do not use
      */
-    protected Backend(Optional<Integer> distributionKey) {
+    protected Backend() {
         listeners = null;
         host = null;
         port = 0;
@@ -74,15 +73,13 @@ public class Backend implements ConnectionFactory {
         packetDumper = null;
         address = null;
         connectionPool = new ConnectionPool();
-        this.distributionKey = distributionKey;
     }
 
     public Backend(String host,
                    int port,
                    String serverDiscriminator,
                    ListenerPool listenerPool,
-                   ConnectionPool connectionPool,
-                   Optional<Integer> distributionKey) {
+                   ConnectionPool connectionPool) {
         String fileNamePattern = "qrs." + serverDiscriminator + '.' + host + ":" + port + ".%s" + ".dump";
         packetDumper = new PacketDumper(new File(Defaults.getDefaults().underVespaHome("logs/vespa/qrs/")),
                                         fileNamePattern);
@@ -92,7 +89,6 @@ public class Backend implements ConnectionFactory {
         this.port = port;
         address = new InetSocketAddress(host, port);
         this.connectionPool = connectionPool;
-        this.distributionKey = distributionKey;
     }
 
     private void logWarning(String attemptDescription, Exception e) {
@@ -102,9 +98,6 @@ public class Backend implements ConnectionFactory {
     private void logInfo(String attemptDescription, Exception e) {
         log.log(Level.INFO, "Exception on " + attemptDescription + " '" + host + ":" + port + "': " + Exceptions.toMessageString(e));
     }
-
-    /** Returns the distribution key of the content node this represents, or empty if it is a dispatch node */
-    public Optional<Integer> distributionKey() { return distributionKey; }
 
     // ============================================================
     // ==== connection pool stuff

--- a/container-search/src/main/java/com/yahoo/fs4/mplex/FS4Channel.java
+++ b/container-search/src/main/java/com/yahoo/fs4/mplex/FS4Channel.java
@@ -4,7 +4,6 @@ package com.yahoo.fs4.mplex;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -66,9 +65,6 @@ public class FS4Channel {
     public Integer getChannelId () {
         return channelId;
     }
-
-    /** Returns the distribution key of the content node this represents, or empty if it is a dispatch node */
-    public Optional<Integer> distributionKey() { return backend == null ? Optional.empty() : backend.distributionKey(); }
 
     /**
      * Closes the channel

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4ResourcePool.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4ResourcePool.java
@@ -9,12 +9,9 @@ import com.yahoo.container.search.Fs4Config;
 import com.yahoo.fs4.mplex.Backend;
 import com.yahoo.fs4.mplex.ConnectionPool;
 import com.yahoo.fs4.mplex.ListenerPool;
-import com.yahoo.io.Connection;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Timer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -61,14 +58,11 @@ public class FS4ResourcePool extends AbstractComponent {
     }
 
     public Backend getBackend(String host, int port) {
-        return getBackend(host, port, Optional.empty());
-    }
-    public Backend getBackend(String host, int port, Optional<Integer> distributionKey) {
         String key = host + ":" + port;
         synchronized (connectionPoolMap) {
             Backend pool = connectionPoolMap.get(key);
             if (pool == null) {
-                pool = new Backend(host, port, Server.get().getServerDiscriminator(), listeners, new ConnectionPool(timer), distributionKey);
+                pool = new Backend(host, port, Server.get().getServerDiscriminator(), listeners, new ConnectionPool(timer));
                 connectionPoolMap.put(key, pool);
             }
             return pool;

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -239,7 +239,7 @@ public class FastSearcher extends VespaBackEndSearcher {
         // Dispatch directly to the single, local search node
         query.trace(false, 2, "Dispatching directly to ", directDispatchRecipient.get());
         return new CloseableChannel(fs4ResourcePool.getBackend(directDispatchRecipient.get().hostname(),
-                directDispatchRecipient.get().fs4port(), Optional.of(directDispatchRecipient.get().key())));
+                directDispatchRecipient.get().fs4port()), Optional.of(directDispatchRecipient.get().key()));
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/dispatch/CloseableChannel.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/CloseableChannel.java
@@ -17,9 +17,15 @@ import java.util.Optional;
  */
 public class CloseableChannel implements Closeable {
     private FS4Channel channel;
+    private final Optional<Integer> distributionKey;
 
     public CloseableChannel(Backend backend) {
+        this(backend, Optional.empty());
+    }
+
+    public CloseableChannel(Backend backend, Optional<Integer> distributionKey) {
         this.channel = backend.openChannel();
+        this.distributionKey = distributionKey;
     }
 
     public void setQuery(Query query) {
@@ -35,7 +41,7 @@ public class CloseableChannel implements Closeable {
     }
 
     public Optional<Integer> distributionKey() {
-        return channel.distributionKey();
+        return distributionKey;
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/dispatch/DispatchedChannel.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/DispatchedChannel.java
@@ -18,7 +18,7 @@ public class DispatchedChannel extends CloseableChannel {
     private boolean groupAllocated = true;
 
     public DispatchedChannel(FS4ResourcePool fs4ResourcePool, LoadBalancer loadBalancer, Group group, Node node) {
-        super(fs4ResourcePool.getBackend(node.hostname(), node.fs4port(), Optional.of(node.key())));
+        super(fs4ResourcePool.getBackend(node.hostname(), node.fs4port()), Optional.of(node.key()));
 
         this.loadBalancer = loadBalancer;
         this.group = group;

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -288,7 +288,8 @@ public class Dispatcher extends AbstractComponent {
 
         return groupInCluster.flatMap(group -> {
             if(group.nodes().size() == 1) {
-                query.trace(false, 2, "Dispatching directly (anywhere) to ", group);
+                SearchCluster.Node node = group.nodes().iterator().next();
+                query.trace(false, 2, "Dispatching internally to ", group, " (", node.toString(), ")");
                 return Optional.of(new DispatchedChannel(fs4ResourcePool, loadBalancer, group));
             } else {
                 loadBalancer.releaseGroup(group);

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
@@ -52,7 +52,7 @@ class FastSearcherTester {
         vipStatus = new VipStatus(clustersStatus);
         mockFS4ResourcePool = new MockFS4ResourcePool();
         mockDispatcher = new MockDispatcher(searchNodes, mockFS4ResourcePool, containerClusterSize, vipStatus);
-        fastSearcher = new FastSearcher(new MockBackend(Optional.empty(), selfHostname, 0L, true),
+        fastSearcher = new FastSearcher(new MockBackend(selfHostname, 0L, true),
                                         mockFS4ResourcePool,
                                         mockDispatcher,
                                         new SummaryParameters(null),

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockBackend.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockBackend.java
@@ -4,9 +4,6 @@ package com.yahoo.prelude.fastsearch.test.fs4mock;
 import com.yahoo.fs4.mplex.Backend;
 import com.yahoo.fs4.mplex.FS4Channel;
 
-import java.util.Optional;
-import java.util.function.Supplier;
-
 /**
  * @author bratseth
  */
@@ -20,11 +17,11 @@ public class MockBackend extends Backend {
     private MockFSChannel channel = null;
 
     public MockBackend() {
-        this(Optional.empty(), "", 0L, true);
+        this("", 0L, true);
     }
     
-    public MockBackend(Optional<Integer> distributionKey, String hostname, long activeDocumentsInBackend, boolean working) {
-        super(distributionKey);
+    public MockBackend(String hostname, long activeDocumentsInBackend, boolean working) {
+        super();
         this.hostname = hostname;
         this.activeDocumentsInBackend = activeDocumentsInBackend;
         this.working = working;

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockFS4ResourcePool.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockFS4ResourcePool.java
@@ -26,12 +26,12 @@ public class MockFS4ResourcePool extends FS4ResourcePool {
     }
 
     @Override
-    public Backend getBackend(String hostname, int port, Optional<Integer> distributionKey) {
+    public Backend getBackend(String hostname, int port) {
         countRequest(hostname + ":" + port);
         if (nonRespondingBackends.contains(hostname))
-            return new MockBackend(distributionKey, hostname, 0L, false);
+            return new MockBackend(hostname, 0L, false);
         else
-            return new MockBackend(distributionKey, hostname, activeDocumentsInBackend.getOrDefault(hostname, 0L), true);
+            return new MockBackend(hostname, activeDocumentsInBackend.getOrDefault(hostname, 0L), true);
     }
 
     /** 


### PR DESCRIPTION
`distributionKey` was stored in `Backend`, which was cached in `FS4ResourcePool` using just host name + port as the cache key. There were code paths using different constructors and as such different values for `distributionKey`.

Given that there do not appear to be other uses for `distributionKey`, this patch moves it closer to the point of use, in `CloseableChannel`