### PR TITLE
Rename AttributeKeyedNode to AttributeMapLookupNode

### DIFF
--- a/searchcore/src/vespa/searchcore/grouping/groupingcontext.cpp
+++ b/searchcore/src/vespa/searchcore/grouping/groupingcontext.cpp
@@ -22,8 +22,6 @@ GroupingContext::deserialize(const char *groupSpec, uint32_t groupSpecLen)
         for (size_t i = 0; i < numGroupings; i++) {
             GroupingPtr grouping(new search::aggregation::Grouping);
             grouping->deserialize(nis);
-            aggregation::Attribute2AttributeKeyed attr2AttrKeyed;
-            grouping->select(attr2AttrKeyed, attr2AttrKeyed);
             grouping->setClock(&_clock);
             grouping->setTimeOfDoom(_timeOfDoom);
             _groupingList.push_back(grouping);

--- a/searchlib/src/tests/expression/attributenode/attribute_node_test.cpp
+++ b/searchlib/src/tests/expression/attributenode/attribute_node_test.cpp
@@ -10,7 +10,7 @@
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/stringbase.h>
 #include <vespa/searchlib/expression/attributenode.h>
-#include <vespa/searchlib/expression/attribute_keyed_node.h>
+#include <vespa/searchlib/expression/attribute_map_lookup_node.h>
 #include <vespa/searchlib/expression/resultvector.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/testkit/testapp.h>
@@ -31,7 +31,7 @@ using search::attribute::Config;
 using search::attribute::IAttributeVector;
 using search::attribute::getUndefined;
 using search::expression::AttributeNode;
-using search::expression::AttributeKeyedNode;
+using search::expression::AttributeMapLookupNode;
 using search::expression::EnumResultNode;
 using search::expression::EnumResultNodeVector;
 using search::expression::FloatResultNode;
@@ -220,7 +220,7 @@ Fixture::makeNode(const vespalib::string &attributeName, bool useEnumOptimizatio
     if (attributeName.find('{') == vespalib::string::npos) {
         node = std::make_unique<AttributeNode>(attributeName);
     } else {
-        node = std::make_unique<AttributeKeyedNode>(attributeName);
+        node = std::make_unique<AttributeMapLookupNode>(attributeName);
     }
     if (useEnumOptimization) {
         node->useEnumOptimization();

--- a/searchlib/src/tests/expression/attributenode/attribute_node_test.cpp
+++ b/searchlib/src/tests/expression/attributenode/attribute_node_test.cpp
@@ -75,11 +75,11 @@ makeAttributeMapLookupNode(const vespalib::string attributeName)
     if (rightBracePos != vespalib::string::npos && rightBracePos > leftBracePos) {
         if (attributeName[leftBracePos + 1] == '"' && attributeName[rightBracePos - 1] == '"') {
             vespalib::string key = attributeName.substr(leftBracePos + 2, rightBracePos - leftBracePos - 3);
-            return std::make_unique<AttributeMapLookupNode>(keyName.str(), valueName.str(), key, "");
+            return std::make_unique<AttributeMapLookupNode>(attributeName, keyName.str(), valueName.str(), key, "");
         } else if (attributeName.substr(leftBracePos + 1, indirectKeyMarker.size()) == indirectKeyMarker && attributeName[rightBracePos - 1] == ')') {
             auto startPos = leftBracePos + 1 + indirectKeyMarker.size();
             vespalib::string keySourceAttributeName = attributeName.substr(startPos, rightBracePos - 1 - startPos);
-            return std::make_unique<AttributeMapLookupNode>(keyName.str(), valueName.str(), "", keySourceAttributeName);
+            return std::make_unique<AttributeMapLookupNode>(attributeName, keyName.str(), valueName.str(), "", keySourceAttributeName);
         }
     }
     return std::unique_ptr<AttributeNode>();

--- a/searchlib/src/vespa/searchlib/aggregation/modifiers.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/modifiers.cpp
@@ -4,7 +4,7 @@
 #include "grouping.h"
 #include <vespa/searchlib/expression/multiargfunctionnode.h>
 #include <vespa/searchlib/expression/attributenode.h>
-#include <vespa/searchlib/expression/attribute_keyed_node.h>
+#include <vespa/searchlib/expression/attribute_map_lookup_node.h>
 #include <vespa/searchlib/expression/documentfieldnode.h>
 
 using namespace search::expression;
@@ -72,7 +72,7 @@ Attribute2AttributeKeyed::getReplacementNode(const AttributeNode &attributeNode)
     if (attributeNode.isKeyed() || lBracePos == vespalib::string::npos) {
         return std::unique_ptr<ExpressionNode>();
     } else {
-        return std::make_unique<AttributeKeyedNode>(attributeName);
+        return std::make_unique<AttributeMapLookupNode>(attributeName);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/aggregation/modifiers.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/modifiers.cpp
@@ -64,18 +64,6 @@ Attribute2DocumentAccessor::getReplacementNode(const AttributeNode &attributeNod
     return std::make_unique<DocumentFieldNode>(attributeNode.getAttributeName());
 }
 
-std::unique_ptr<ExpressionNode>
-Attribute2AttributeKeyed::getReplacementNode(const AttributeNode &attributeNode)
-{
-    const vespalib::string &attributeName = attributeNode.getAttributeName();
-    auto lBracePos = attributeName.find('{');
-    if (attributeNode.isKeyed() || lBracePos == vespalib::string::npos) {
-        return std::unique_ptr<ExpressionNode>();
-    } else {
-        return std::make_unique<AttributeMapLookupNode>(attributeName);
-    }
-}
-
 }
 
 // this function was added by ../../forcelink.sh

--- a/searchlib/src/vespa/searchlib/aggregation/modifiers.h
+++ b/searchlib/src/vespa/searchlib/aggregation/modifiers.h
@@ -28,10 +28,4 @@ private:
     std::unique_ptr<search::expression::ExpressionNode> getReplacementNode(const search::expression::AttributeNode &attributeNode) override;
 };
 
-class Attribute2AttributeKeyed : public AttributeNodeReplacer
-{
-private:
-    std::unique_ptr<search::expression::ExpressionNode> getReplacementNode(const search::expression::AttributeNode &attributeNode) override;
-};
-
 }

--- a/searchlib/src/vespa/searchlib/common/identifiable.h
+++ b/searchlib/src/vespa/searchlib/common/identifiable.h
@@ -148,6 +148,7 @@
 #define CID_search_expression_AggregationRefNode            SEARCHLIB_CID(142)
 #define CID_search_expression_NormalizeSubjectFunctionNode  SEARCHLIB_CID(143)
 #define CID_search_expression_DebugWaitFunctionNode         SEARCHLIB_CID(144)
+#define CID_search_expression_AttributeMapLookupNode        SEARCHLIB_CID(145)
 
 #define CID_search_QueryNode                                SEARCHLIB_CID(150)
 #define CID_search_Query                                    SEARCHLIB_CID(151)

--- a/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(searchlib_expression OBJECT
     SOURCES
-    attribute_keyed_node.cpp
+    attribute_map_lookup_node.cpp
     attributenode.cpp
     attributeresult.cpp
     enumattributeresult.cpp

--- a/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.cpp
@@ -245,8 +245,8 @@ AttributeMapLookupNode::AttributeMapLookupNode()
 
 AttributeMapLookupNode::AttributeMapLookupNode(const AttributeMapLookupNode &) = default;
 
-AttributeMapLookupNode::AttributeMapLookupNode(vespalib::stringref keyAttributeName, vespalib::stringref valueAttributeName, vespalib::stringref key, vespalib::stringref keySourceAttributeName)
-    : AttributeNode(""),
+AttributeMapLookupNode::AttributeMapLookupNode(vespalib::stringref name, vespalib::stringref keyAttributeName, vespalib::stringref valueAttributeName, vespalib::stringref key, vespalib::stringref keySourceAttributeName)
+    : AttributeNode(name),
       _keyAttributeName(keyAttributeName),
       _valueAttributeName(valueAttributeName),
       _key(key),
@@ -382,19 +382,20 @@ AttributeMapLookupNode::wireAttributes(const search::attribute::IAttributeContex
 
 Serializer & AttributeMapLookupNode::onSerialize(Serializer & os) const
 {
-    FunctionNode::onSerialize(os);
+    AttributeNode::onSerialize(os);
     return os << _keyAttributeName << _valueAttributeName << _key << _keySourceAttributeName;
 }
 
 Deserializer & AttributeMapLookupNode::onDeserialize(Deserializer & is)
 {
-    FunctionNode::onDeserialize(is);
+    AttributeNode::onDeserialize(is);
     return is >> _keyAttributeName >> _valueAttributeName >> _key >> _keySourceAttributeName;
 }
 
 void
 AttributeMapLookupNode::visitMembers(vespalib::ObjectVisitor &visitor) const
 {
+    AttributeNode::visitMembers(visitor);
     visit(visitor, "keyAttributeName", _keyAttributeName);
     visit(visitor, "keySourceAttributeName", _keySourceAttributeName);
     visit(visitor, "valueAttributeName", _valueAttributeName);

--- a/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.cpp
@@ -1,6 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "attribute_keyed_node.h"
+#include "attribute_map_lookup_node.h"
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/searchcommon/attribute/attributecontent.h>
@@ -15,7 +15,7 @@ using EnumHandle = IAttributeVector::EnumHandle;
 
 namespace search::expression {
 
-class AttributeKeyedNode::KeyHandler
+class AttributeMapLookupNode::KeyHandler
 {
 protected:
     const IAttributeVector &_attribute;
@@ -34,7 +34,7 @@ namespace {
 
 vespalib::string indirectKeyMarker("attribute(");
 
-class BadKeyHandler : public AttributeKeyedNode::KeyHandler
+class BadKeyHandler : public AttributeMapLookupNode::KeyHandler
 {
 public:
     BadKeyHandler(const IAttributeVector &attribute)
@@ -70,7 +70,7 @@ EnumHandle convertKey<EnumHandle>(const IAttributeVector &attribute, const vespa
 }
 
 template <typename T, typename KeyType = T>
-class KeyHandlerT : public AttributeKeyedNode::KeyHandler
+class KeyHandlerT : public AttributeMapLookupNode::KeyHandler
 {
     AttributeContent<T> _keys;
     KeyType _key;
@@ -119,7 +119,7 @@ matchingKey<const char *>(const char *lhs, const char *rhs)
 }
 
 template <typename T>
-class IndirectKeyHandlerT : public AttributeKeyedNode::KeyHandler
+class IndirectKeyHandlerT : public AttributeMapLookupNode::KeyHandler
 {
     const IAttributeVector &_keySourceAttribute;
     AttributeContent<T>     _keys;
@@ -157,9 +157,9 @@ using IndirectStringKeyHandler = IndirectKeyHandlerT<const char *>;
 class ValueHandler : public AttributeNode::Handler
 {
 protected:
-    std::unique_ptr<AttributeKeyedNode::KeyHandler> _keyHandler;
+    std::unique_ptr<AttributeMapLookupNode::KeyHandler> _keyHandler;
     const IAttributeVector &_attribute;
-    ValueHandler(std::unique_ptr<AttributeKeyedNode::KeyHandler> keyHandler, const IAttributeVector &attribute)
+    ValueHandler(std::unique_ptr<AttributeMapLookupNode::KeyHandler> keyHandler, const IAttributeVector &attribute)
         : _keyHandler(std::move(keyHandler)),
           _attribute(attribute)
     {
@@ -173,7 +173,7 @@ class ValueHandlerT : public ValueHandler
     ResultNodeType &_result;
     T _undefinedValue;
 public:
-    ValueHandlerT(std::unique_ptr<AttributeKeyedNode::KeyHandler> keyHandler, const IAttributeVector &attribute, ResultNodeType &result, T undefinedValue)
+    ValueHandlerT(std::unique_ptr<AttributeMapLookupNode::KeyHandler> keyHandler, const IAttributeVector &attribute, ResultNodeType &result, T undefinedValue)
         : ValueHandler(std::move(keyHandler), attribute),
           _values(),
           _result(result),
@@ -183,7 +183,7 @@ public:
     void handle(const AttributeResult & r) override {
         uint32_t docId = r.getDocId();
         uint32_t keyIdx  = _keyHandler->handle(docId);
-        if (keyIdx != AttributeKeyedNode::KeyHandler::noKeyIdx()) {
+        if (keyIdx != AttributeMapLookupNode::KeyHandler::noKeyIdx()) {
             _values.fill(_attribute, docId);
             if (keyIdx < _values.size()) {
                 _result = _values[keyIdx];
@@ -228,7 +228,7 @@ IAttributeVector::largeint_t getUndefinedValue(BasicType::Type basicType)
 
 }
 
-AttributeKeyedNode::AttributeKeyedNode()
+AttributeMapLookupNode::AttributeMapLookupNode()
     : AttributeNode(),
       _keyAttributeName(),
       _valueAttributeName(),
@@ -239,9 +239,9 @@ AttributeKeyedNode::AttributeKeyedNode()
 {
 }
 
-AttributeKeyedNode::AttributeKeyedNode(const AttributeKeyedNode &) = default;
+AttributeMapLookupNode::AttributeMapLookupNode(const AttributeMapLookupNode &) = default;
 
-AttributeKeyedNode::AttributeKeyedNode(vespalib::stringref name)
+AttributeMapLookupNode::AttributeMapLookupNode(vespalib::stringref name)
     : AttributeNode(name),
       _keyAttributeName(),
       _valueAttributeName(),
@@ -253,13 +253,13 @@ AttributeKeyedNode::AttributeKeyedNode(vespalib::stringref name)
     setupAttributeNames();
 }
 
-AttributeKeyedNode::~AttributeKeyedNode() = default;
+AttributeMapLookupNode::~AttributeMapLookupNode() = default;
 
-AttributeKeyedNode &
-AttributeKeyedNode::operator=(const AttributeKeyedNode &rhs) = default;
+AttributeMapLookupNode &
+AttributeMapLookupNode::operator=(const AttributeMapLookupNode &rhs) = default;
 
 void
-AttributeKeyedNode::setupAttributeNames()
+AttributeMapLookupNode::setupAttributeNames()
 {
     vespalib::asciistream keyName;
     vespalib::asciistream valueName;
@@ -282,15 +282,15 @@ AttributeKeyedNode::setupAttributeNames()
 
 template <typename ResultNodeType>
 void
-AttributeKeyedNode::prepareIntValues(std::unique_ptr<KeyHandler> keyHandler, const IAttributeVector &attribute, IAttributeVector::largeint_t undefinedValue)
+AttributeMapLookupNode::prepareIntValues(std::unique_ptr<KeyHandler> keyHandler, const IAttributeVector &attribute, IAttributeVector::largeint_t undefinedValue)
 {
     auto resultNode = std::make_unique<ResultNodeType>();
     _handler = std::make_unique<IntegerValueHandler<ResultNodeType>>(std::move(keyHandler), attribute, *resultNode, undefinedValue);
     setResultType(std::move(resultNode));
 }
 
-std::unique_ptr<AttributeKeyedNode::KeyHandler>
-AttributeKeyedNode::makeKeyHandlerHelper()
+std::unique_ptr<AttributeMapLookupNode::KeyHandler>
+AttributeMapLookupNode::makeKeyHandlerHelper()
 {
     const IAttributeVector &attribute = *_keyAttribute;
     if (_keySourceAttribute != nullptr) {
@@ -318,8 +318,8 @@ AttributeKeyedNode::makeKeyHandlerHelper()
     }
 }
 
-std::unique_ptr<AttributeKeyedNode::KeyHandler>
-AttributeKeyedNode::makeKeyHandler()
+std::unique_ptr<AttributeMapLookupNode::KeyHandler>
+AttributeMapLookupNode::makeKeyHandler()
 {
     try {
         return makeKeyHandlerHelper();
@@ -329,7 +329,7 @@ AttributeKeyedNode::makeKeyHandler()
 }
 
 void
-AttributeKeyedNode::onPrepare(bool preserveAccurateTypes)
+AttributeMapLookupNode::onPrepare(bool preserveAccurateTypes)
 {
     auto keyHandler = makeKeyHandler();
     const IAttributeVector * attribute = _scratchResult->getAttribute();
@@ -380,7 +380,7 @@ AttributeKeyedNode::onPrepare(bool preserveAccurateTypes)
 }
 
 void
-AttributeKeyedNode::cleanup()
+AttributeMapLookupNode::cleanup()
 {
     _keyAttribute = nullptr;
     _keySourceAttribute = nullptr;
@@ -388,7 +388,7 @@ AttributeKeyedNode::cleanup()
 }
 
 void
-AttributeKeyedNode::wireAttributes(const search::attribute::IAttributeContext &attrCtx)
+AttributeMapLookupNode::wireAttributes(const search::attribute::IAttributeContext &attrCtx)
 {
     auto valueAttribute = findAttribute(attrCtx, _useEnumOptimization, _valueAttributeName);
     _hasMultiValue = false;
@@ -400,7 +400,7 @@ AttributeKeyedNode::wireAttributes(const search::attribute::IAttributeContext &a
 }
 
 void
-AttributeKeyedNode::visitMembers(vespalib::ObjectVisitor &visitor) const
+AttributeMapLookupNode::visitMembers(vespalib::ObjectVisitor &visitor) const
 {
     AttributeNode::visitMembers(visitor);
     visit(visitor, "keyAttributeName", _keyAttributeName);

--- a/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.h
+++ b/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.h
@@ -22,7 +22,6 @@ private:
     const IAttributeVector *_keyAttribute;
     const IAttributeVector *_keySourceAttribute;
 
-    void setupAttributeNames();
     template <typename ResultNodeType>
     void prepareIntValues(std::unique_ptr<KeyHandler> keyHandler, const IAttributeVector &attribute, IAttributeVector::largeint_t undefinedValue);
     std::unique_ptr<KeyHandler> makeKeyHandlerHelper();
@@ -31,15 +30,16 @@ private:
     void wireAttributes(const search::attribute::IAttributeContext & attrCtx) override;
     void onPrepare(bool preserveAccurateTypes) override;
 public:
+    DECLARE_NBO_SERIALIZE;
+    DECLARE_EXPRESSIONNODE(AttributeMapLookupNode);
     AttributeMapLookupNode();
-    AttributeMapLookupNode(vespalib::stringref name);
+    AttributeMapLookupNode(vespalib::stringref keyAttributeName, vespalib::stringref valueAttributeName, vespalib::stringref key, vespalib::stringref keySourceAttributeName);
     AttributeMapLookupNode(const AttributeMapLookupNode &);
     AttributeMapLookupNode(AttributeMapLookupNode &&) = delete;
     ~AttributeMapLookupNode() override;
     AttributeMapLookupNode &operator=(const AttributeMapLookupNode &rhs);
     AttributeMapLookupNode &operator=(AttributeMapLookupNode &&rhs) = delete;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
-    bool isKeyed() const override { return true; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.h
+++ b/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.h
@@ -9,7 +9,7 @@ namespace search::expression {
  * Extract map value from attribute for the map key specified in the
  * grouping expression.
  */
-class AttributeKeyedNode : public AttributeNode
+class AttributeMapLookupNode : public AttributeNode
 {
 public:
     using IAttributeVector = search::attribute::IAttributeVector;
@@ -31,13 +31,13 @@ private:
     void wireAttributes(const search::attribute::IAttributeContext & attrCtx) override;
     void onPrepare(bool preserveAccurateTypes) override;
 public:
-    AttributeKeyedNode();
-    AttributeKeyedNode(vespalib::stringref name);
-    AttributeKeyedNode(const AttributeKeyedNode &);
-    AttributeKeyedNode(AttributeKeyedNode &&) = delete;
-    ~AttributeKeyedNode() override;
-    AttributeKeyedNode &operator=(const AttributeKeyedNode &rhs);
-    AttributeKeyedNode &operator=(AttributeKeyedNode &&rhs) = delete;
+    AttributeMapLookupNode();
+    AttributeMapLookupNode(vespalib::stringref name);
+    AttributeMapLookupNode(const AttributeMapLookupNode &);
+    AttributeMapLookupNode(AttributeMapLookupNode &&) = delete;
+    ~AttributeMapLookupNode() override;
+    AttributeMapLookupNode &operator=(const AttributeMapLookupNode &rhs);
+    AttributeMapLookupNode &operator=(AttributeMapLookupNode &&rhs) = delete;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     bool isKeyed() const override { return true; }
 };

--- a/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.h
+++ b/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.h
@@ -33,7 +33,7 @@ public:
     DECLARE_NBO_SERIALIZE;
     DECLARE_EXPRESSIONNODE(AttributeMapLookupNode);
     AttributeMapLookupNode();
-    AttributeMapLookupNode(vespalib::stringref keyAttributeName, vespalib::stringref valueAttributeName, vespalib::stringref key, vespalib::stringref keySourceAttributeName);
+    AttributeMapLookupNode(vespalib::stringref name, vespalib::stringref keyAttributeName, vespalib::stringref valueAttributeName, vespalib::stringref key, vespalib::stringref keySourceAttributeName);
     AttributeMapLookupNode(const AttributeMapLookupNode &);
     AttributeMapLookupNode(AttributeMapLookupNode &&) = delete;
     ~AttributeMapLookupNode() override;

--- a/searchlib/src/vespa/searchlib/expression/attributenode.h
+++ b/searchlib/src/vespa/searchlib/expression/attributenode.h
@@ -55,7 +55,6 @@ public:
 
     void useEnumOptimization(bool use=true) { _useEnumOptimization = use; }
     bool hasMultiValue() const { return _hasMultiValue; }
-    virtual bool isKeyed() const { return false; }
 public:
     class Handler
     {


### PR DESCRIPTION
Allocate identifiable id for AttributeMapLookupNode.
Remove implicit conversion from AttributeNode.

@geirst: please review

This pull request depends on a matching change in corresponding java code.
