### PR TITLE
Due to some ugly inheritance you must use values with great care. In …

### DIFF
--- a/document/src/main/java/com/yahoo/document/datatypes/MapFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/MapFieldValue.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.datatypes;
 
-import com.yahoo.collections.CollectionComparator;
 import com.yahoo.document.DataType;
 import com.yahoo.document.Field;
 import com.yahoo.document.FieldPath;
@@ -12,6 +11,7 @@ import com.yahoo.document.serialization.XmlSerializationHelper;
 import com.yahoo.document.serialization.XmlStream;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Set;
@@ -81,7 +81,7 @@ public class MapFieldValue<K extends FieldValue, V extends FieldValue> extends C
      */
     public boolean equals(Object o) {
         if (!(o instanceof MapFieldValue)) return false;
-        return super.equals(o) && values.equals(((MapFieldValue) o).values);
+        return super.equals(o) && entrySet().equals(((MapFieldValue) o).entrySet());
     }
 
     @Override
@@ -290,8 +290,8 @@ public class MapFieldValue<K extends FieldValue, V extends FieldValue> extends C
         }
         Map.Entry<K,V> [] entries = entrySet().toArray(new Map.Entry[size()]);
         Map.Entry<K,V> [] rhsEntries = rhs.entrySet().toArray(new Map.Entry[rhs.size()]);
-        Arrays.sort(entries, (Map.Entry<K,V> a, Map.Entry<K,V> b) -> { return a.getKey().compareTo(b.getKey()); });
-        Arrays.sort(rhsEntries, (Map.Entry<K,V> a, Map.Entry<K,V> b) -> { return a.getKey().compareTo(b.getKey()); });
+        Arrays.sort(entries, Comparator.comparing(Map.Entry<K,V>::getKey));
+        Arrays.sort(rhsEntries, Comparator.comparing(Map.Entry<K,V>::getKey));
         for (int i = 0; i < entries.length; i++) {
             comp = entries[i].getKey().compareTo(rhsEntries[i].getKey());
             if (comp != 0) return comp;

--- a/document/src/main/java/com/yahoo/document/datatypes/WeightedSet.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/WeightedSet.java
@@ -1,14 +1,25 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.datatypes;
 
-import com.yahoo.collections.CollectionComparator;
-import com.yahoo.document.*;
+import com.yahoo.document.DataType;
+import com.yahoo.document.Field;
+import com.yahoo.document.WeightedSetDataType;
+import com.yahoo.document.MapDataType;
+import com.yahoo.document.FieldPath;
 import com.yahoo.document.serialization.FieldReader;
 import com.yahoo.document.serialization.FieldWriter;
 import com.yahoo.document.serialization.XmlSerializationHelper;
 import com.yahoo.document.serialization.XmlStream;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
 
 /**
  * A weighted set, a unique set of keys with an associated integer weight. This class

--- a/document/src/test/java/com/yahoo/document/datatypes/WeightedSetTestCase.java
+++ b/document/src/test/java/com/yahoo/document/datatypes/WeightedSetTestCase.java
@@ -4,6 +4,7 @@ package com.yahoo.document.datatypes;
 import com.yahoo.document.DataType;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -33,7 +34,23 @@ public class WeightedSetTestCase {
         assertEquals(a, b);
         assertEquals(0, a.compareTo(b));
         assertEquals(0, b.compareTo(a));
+    }
 
+    @Test
+    public void testEqualsOnMixedPrimitiveAndFieldValues() {
+        WeightedSet<StringFieldValue> a = new WeightedSet<>(DataType.TAG);
+        a.put(new StringFieldValue("this is a test"), 5);
+        a.put(new StringFieldValue("this is a second test"), 7);
+
+        WeightedSet<StringFieldValue> b = new WeightedSet<>(DataType.TAG);
+        Map<String, Integer> m = new HashMap<String, Integer>();
+        m.put("this is a second test", 7);
+        m.put("this is a test", 5);
+        b.assign(m);
+
+        assertEquals(a, b);
+        assertEquals(0, a.compareTo(b));
+        assertEquals(0, b.compareTo(a));
     }
 
     @Test


### PR DESCRIPTION
…equals it must use entrySet() due to some very ugly inheritance.
@bratseth PR
This is a mess... With this interface it can not be both convenient and fast.
Is there something that we can do to this mess.... 