### PR TITLE
Handle 4k logical sector size in vespalib::copy function.

### DIFF
--- a/vespalib/src/tests/io/fileutil/fileutiltest.cpp
+++ b/vespalib/src/tests/io/fileutil/fileutiltest.cpp
@@ -405,7 +405,7 @@ TEST("require that vespalib::copy works")
     f.write(buffer.get(), 4096, 0);
     f.close();
     std::cerr << "Simple copy\n";
-        // Simple copy works (512b dividable file)
+        // Simple copy works (4096b dividable file)
     copy("myfile", "targetfile");
     ASSERT_TRUE(system("diff myfile targetfile") == 0);
     std::cerr << "Overwriting\n";

--- a/vespalib/src/vespa/vespalib/io/fileutil.cpp
+++ b/vespalib/src/vespa/vespalib/io/fileutil.cpp
@@ -699,7 +699,7 @@ rename(const string & frompath, const string & topath,
 namespace {
 
     uint32_t bufferSize = 1024 * 1024;
-    uint32_t diskAlignmentSize = 512;
+    uint32_t diskAlignmentSize = 4096;
 
 }
 


### PR DESCRIPTION
@baldersheim: please review
