### PR TITLE
The first memory mapped region can be a long distance from the second one

### DIFF
--- a/vespalib/src/tests/alloc/alloc_test.cpp
+++ b/vespalib/src/tests/alloc/alloc_test.cpp
@@ -179,6 +179,7 @@ TEST("auto alloced mmap alloc can not be extended if no room") {
 }
 
 TEST("mmap alloc can be extended if room") {
+    Alloc dummy = Alloc::allocMMap(100);
     Alloc reserved = Alloc::allocMMap(100);
     Alloc buf = Alloc::allocMMap(100);
 
@@ -187,6 +188,7 @@ TEST("mmap alloc can be extended if room") {
 }
 
 TEST("mmap alloc can not be extended if no room") {
+    Alloc dummy = Alloc::allocMMap(100);
     Alloc reserved = Alloc::allocMMap(100);
     Alloc buf = Alloc::allocMMap(100);
 


### PR DESCRIPTION
if there is a hole in the memory mapping.

Add a dummy mapping to plug this hole.

@baldersheim: please review
