### PR TITLE
Allow OsUpgrader to upgrade main

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.google.common.collect.ImmutableSet;
 import com.yahoo.component.Version;
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.CloudName;
@@ -36,12 +35,6 @@ public class OsUpgrader extends InfrastructureUpgrader {
     public OsUpgrader(Controller controller, Duration interval, JobControl jobControl, CloudName cloud) {
         super(controller, interval, jobControl, controller.zoneRegistry().osUpgradePolicy(cloud), name(cloud));
         this.cloud = cloud;
-    }
-
-    @Override
-    protected void maintain() {
-        if (controller().system() != SystemName.cd) return; // TODO: Enable in all systems
-        super.maintain();
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -119,33 +119,6 @@ public class OsUpgraderTest {
                                                         .allMatch(node -> node.version().equals(version1)));
     }
 
-    // TODO: Remove once enabled in all systems
-    @Test
-    public void os_upgrade_in_main_does_nothing() {
-        OsUpgrader osUpgrader = osUpgrader(
-                UpgradePolicy.create()
-                             .upgrade(zone1)
-                             .upgradeInParallel(zone2, zone3)
-                             .upgrade(zone4),
-                SystemName.main
-        );
-
-        // Bootstrap system
-        tester.configServer().bootstrap(Arrays.asList(zone1, zone2, zone3, zone4, zone5),
-                                        singletonList(SystemApplication.zone),
-                                        Optional.of(NodeType.host));
-
-        // New OS is released
-        CloudName cloud = CloudName.defaultName();
-        Version version1 = Version.fromString("7.1");
-        tester.controller().upgradeOsIn(cloud, version1);
-        statusUpdater.maintain();
-
-        // Nothing happens as main is explicitly disabled
-        osUpgrader.maintain();
-        assertWanted(Version.emptyVersion, SystemApplication.zone, zone1);
-    }
-
     private List<OsVersionStatus.Node> nodesOn(Version version) {
         return tester.controller().osVersionStatus().versions().entrySet().stream()
                      .filter(entry -> entry.getKey().version().equals(version))


### PR DESCRIPTION
Note that nothing will happen until a target version is explicitly set for the
system via `/os/v1/` and the maintainer is enabled (currently disabled).