### PR TITLE
Correct isComplete to work also when jobs are running (and have deplo…

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -412,10 +412,13 @@ public class DeploymentTrigger {
      */
     public boolean isComplete(Change change, Application application, JobType jobType) {
         Optional<Deployment> existingDeployment = deploymentFor(application, jobType);
-        return    successOn(application, jobType, Versions.from(change, application, existingDeployment, controller.systemVersion())).isPresent()
+        return       application.deploymentJobs().statusOf(jobType).flatMap(JobStatus::lastSuccess)
+                                .map(job ->    change.platform().map(job.platform()::equals).orElse(true)
+                                            && change.application().map(job.application()::equals).orElse(true))
+                                .orElse(false)
                ||    jobType.isProduction()
                   && existingDeployment.map(deployment -> ! isUpgrade(change, deployment) && isDowngrade(application.change(), deployment))
-                                       .orElse(false);
+                                          .orElse(false);
     }
 
     private static boolean isUpgrade(Change change, Deployment deployment) {


### PR DESCRIPTION
…yed)

@bratseth please review. 

The old version was wrong whenever a job had deployed a new app/platform, and we checked for whether the current platform/app was done, as the `Versions.from(...)` would include the new version of the app/platform, which obviously wasn't a success yet. 