### PR TITLE
Reuse node group for allocations by same query

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
@@ -24,7 +24,7 @@ public class LoadBalancer {
 
     private static final Logger log = Logger.getLogger(LoadBalancer.class.getName());
 
-    private static final CompoundName QUERY_NODE_GROUP_AFFINITY = new CompoundName("loadbalancer.group.affinity");
+    private static final CompoundName QUERY_NODE_GROUP_AFFINITY = new CompoundName("dispatch.group.affinity");
 
     private final boolean isInternallyDispatchable;
     private final List<GroupSchedule> scoreboard;
@@ -49,7 +49,7 @@ public class LoadBalancer {
      * Select and allocate the search cluster group which is to be used for the provided query. Callers <b>must</b> call
      * {@link #releaseGroup} symmetrically for each taken allocation.
      *
-     * @param query The query for which this allocation is made.
+     * @param query the query for which this allocation is made
      * @return The node group to target, or <i>empty</i> if the internal dispatch logic cannot be used
      */
     public Optional<Group> takeGroupForQuery(Query query) {


### PR DESCRIPTION
Add node group affinity to LoadBalancer so that allocations go to the same group within the same query (since the code paths that search and fill don't necessarily cross conveniently)