### PR TITLE
Avoid NPE on non-exiting field

### DIFF
--- a/document/src/main/java/com/yahoo/document/DocumentUpdate.java
+++ b/document/src/main/java/com/yahoo/document/DocumentUpdate.java
@@ -278,7 +278,8 @@ public class DocumentUpdate extends DocumentOperation implements Iterable<FieldP
      * @return the update for the field, or null if that field has no update in this
      */
     public FieldUpdate getFieldUpdate(String fieldName) {
-        return getFieldUpdate(documentType.getField(fieldName));
+        Field field = documentType.getField(fieldName);
+        return field != null ? getFieldUpdate(field) : null;
     }
     private FieldUpdate getFieldUpdateById(Integer fieldId) {
         return id2FieldUpdateMap.get(fieldId);
@@ -396,7 +397,8 @@ public class DocumentUpdate extends DocumentOperation implements Iterable<FieldP
     }
 
     public FieldUpdate removeFieldUpdate(String fieldName) {
-        return removeFieldUpdate(documentType.getField(fieldName));
+        Field field = documentType.getField(fieldName);
+        return field != null ? removeFieldUpdate(field) : null;
     }
 
     /**

--- a/document/src/test/java/com/yahoo/document/DocumentUpdateTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentUpdateTestCase.java
@@ -442,7 +442,7 @@ public class DocumentUpdateTestCase {
     }
 
     @Test
-    public void testgetAndRemoveByName() {
+    public void testGetAndRemoveByName() {
         DocumentType docType = new DocumentType("my_type");
         Field my_int = new Field("my_int", DataType.INT);
         Field your_int = new Field("your_int", DataType.INT);
@@ -451,6 +451,8 @@ public class DocumentUpdateTestCase {
         DocumentUpdate update = new DocumentUpdate(docType, new DocumentId("doc:this:is:a:test"));
 
         update.addFieldUpdate(FieldUpdate.createAssign(my_int, new IntegerFieldValue(2)));
+        assertNull(update.getFieldUpdate("none-existing-field"));
+        assertNull(update.removeFieldUpdate("none-existing-field"));
         assertNull(update.getFieldUpdate("your_int"));
         assertEquals(new IntegerFieldValue(2), update.getFieldUpdate("my_int").getValueUpdate(0).getValue());
         assertNull(update.removeFieldUpdate("your_int"));


### PR DESCRIPTION
@vekterli or @bratseth PR
This is a followup to #6969 to avoid NPE instead of just returning null.