### PR TITLE
Update jackson to 2.8.11 and jackson-databind to 2.8.11.2

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -71,7 +71,7 @@
                                                 <include>aopalliance:aopalliance:[1.0]:jar:provided</include>
                                                 <include>com.fasterxml.jackson.core:jackson-annotations:[${jackson2.version}]:jar:provided</include>
                                                 <include>com.fasterxml.jackson.core:jackson-core:[${jackson2.version}]:jar:provided</include>
-                                                <include>com.fasterxml.jackson.core:jackson-databind:[${jackson2.version}]:jar:provided</include>
+                                                <include>com.fasterxml.jackson.core:jackson-databind:[${jackson-databind.version}]:jar:provided</include>
                                                 <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8:[${jackson2.version}]:jar:provided</include>
                                                 <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:[${jackson2.version}]:jar:provided</include>
 

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson2.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -475,7 +475,8 @@
         <!-- and then verify  by doing: ' ls -l vespa/vespa_jersey2/target/dependency' -->
         <hk2.version>2.5.0-b32</hk2.version>
         <hk2.osgi-resource-locator.version>1.0.1</hk2.osgi-resource-locator.version>
-        <jackson2.version>2.8.4</jackson2.version>
+        <jackson2.version>2.8.11</jackson2.version>
+        <jackson-databind.version>${jackson2.version}.2</jackson-databind.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <javax.annotation-api.version>1.2</javax.annotation-api.version>
         <javax.validation-api.version>1.1.0.Final</javax.validation-api.version>


### PR DESCRIPTION
- jackson-databind:2.8.11.2 includes a fix for a deserialization
  vulnerability.

FYI: @andreer 