### PR TITLE
Disable TLS RSA ciphers that do not support forward secrecy

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ConfigserverSslContextFactoryProvider.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ConfigserverSslContextFactoryProvider.java
@@ -30,7 +30,6 @@ import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -111,12 +110,6 @@ public class ConfigserverSslContextFactoryProvider extends AbstractComponent imp
                                                                  ZtsClient ztsClient,
                                                                  AthenzProviderServiceConfig.Zones zoneConfig) {
         SslContextFactory factory = new SslContextFactory();
-
-        // Allow safe TLS_RSA* ciphers
-        String[] excludedCiphersWithoutTlsRsaExclusion = Arrays.stream(factory.getExcludeCipherSuites())
-                .filter(cipher -> !cipher.equals("^TLS_RSA_.*$"))
-                .toArray(String[]::new);
-        factory.setExcludeCipherSuites(excludedCiphersWithoutTlsRsaExclusion);
 
         factory.setWantClientAuth(true);
 

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/DefaultSslContextFactoryProvider.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/DefaultSslContextFactoryProvider.java
@@ -48,14 +48,6 @@ public class DefaultSslContextFactoryProvider implements SslContextFactoryProvid
                 break;
         }
 
-        // NOTE: All ciphers matching ^TLS_RSA_.*$ are disabled by default in Jetty 9.4.12+ (https://github.com/eclipse/jetty.project/issues/2807)
-        // JDisc will allow these ciphers by default to support older clients (e.g. Java 8u60 and curl 7.29.0)
-        // Removing the exclusion will allow for the TLS_RSA variants that are not covered by other exclusions
-        String[] excludedCiphersWithoutTlsRsaExclusion = Arrays.stream(factory.getExcludeCipherSuites())
-                .filter(cipher -> !cipher.equals("^TLS_RSA_.*$"))
-                .toArray(String[]::new);
-        factory.setExcludeCipherSuites(excludedCiphersWithoutTlsRsaExclusion);
-
         // Check if using new ssl syntax from services.xml
         factory.setKeyStore(createKeystore(sslConfig));
         factory.setKeyStorePassword("");


### PR DESCRIPTION
This will essentially remove the temporary workaround introduced with
the Jetty 9.4.12 upgrade that was done recently. JDisc will with this
change only enable certificates marked as grade A by ssllabs.com