### PR TITLE
Migrate document counts metrics to new naming scheme.

### DIFF
--- a/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
@@ -221,8 +221,8 @@ TEST_F("requireThatStateIsReported", Fixture)
             "    },\n"
             "    \"documents\": {\n"
             "        \"active\": 0,\n"
-            "        \"indexed\": 0,\n"
-            "        \"stored\": 0,\n"
+            "        \"ready\": 0,\n"
+            "        \"total\": 0,\n"
             "        \"removed\": 0\n"
             "    }\n"
             "}\n",

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
@@ -222,6 +222,17 @@ DocumentDBTaggedMetrics::SessionCacheMetrics::SessionCacheMetrics(metrics::Metri
 
 DocumentDBTaggedMetrics::SessionCacheMetrics::~SessionCacheMetrics() = default;
 
+DocumentDBTaggedMetrics::DocumentsMetrics::DocumentsMetrics(metrics::MetricSet *parent)
+    : metrics::MetricSet("documents", "", "Metrics for various document counts in this document db", parent),
+      active("active", "", "The number of active / searchable documents in this document db", this),
+      ready("ready", "", "The number of ready documents in this document db", this),
+      total("total", "", "The total number of documents in this documents db (ready + not-ready)", this),
+      removed("removed", "", "The number of removed documents in this document db", this)
+{
+}
+
+DocumentDBTaggedMetrics::DocumentsMetrics::~DocumentsMetrics() = default;
+
 DocumentDBTaggedMetrics::DocumentDBTaggedMetrics(const vespalib::string &docTypeName)
     : MetricSet("documentdb", {{"documenttype", docTypeName}}, "Document DB metrics", nullptr),
       job(this),
@@ -232,7 +243,8 @@ DocumentDBTaggedMetrics::DocumentDBTaggedMetrics(const vespalib::string &docType
       removed("removed", this),
       threadingService("threading_service", this),
       matching(this),
-      sessionCache(this)
+      sessionCache(this),
+      documents(this)
 {
 }
 

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
@@ -168,6 +168,16 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
         ~SessionCacheMetrics();
     };
 
+    struct DocumentsMetrics : metrics::MetricSet {
+        metrics::LongValueMetric active;
+        metrics::LongValueMetric ready;
+        metrics::LongValueMetric total;
+        metrics::LongValueMetric removed;
+
+        DocumentsMetrics(metrics::MetricSet *parent);
+        ~DocumentsMetrics();
+    };
+
     JobMetrics job;
     AttributeMetrics attribute;
     IndexMetrics index;
@@ -177,6 +187,7 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
     ExecutorThreadingServiceMetrics threadingService;
     MatchingMetrics matching;
     SessionCacheMetrics sessionCache;
+    DocumentsMetrics documents;
 
     DocumentDBTaggedMetrics(const vespalib::string &docTypeName);
     ~DocumentDBTaggedMetrics();

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_explorer.cpp
@@ -38,8 +38,8 @@ DocumentDBExplorer::get_state(const Inserter &inserter, bool full) const
             (const_cast<DocumentSubDBCollection &>(_docDb->getDocumentSubDBs()));
         Cursor &documents = object.setObject("documents");
         documents.setLong("active", dmss.numActiveDocs());
-        documents.setLong("indexed", dmss.numIndexedDocs());
-        documents.setLong("stored", dmss.numStoredDocs());
+        documents.setLong("ready", dmss.numReadyDocs());
+        documents.setLong("total", dmss.numTotalDocs());
         documents.setLong("removed", dmss.numRemovedDocs());
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/server/document_meta_store_read_guards.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_meta_store_read_guards.h
@@ -24,11 +24,11 @@ struct DocumentMetaStoreReadGuards
     uint32_t numActiveDocs() const {
         return readydms ? readydms->get().getNumActiveLids() : 0;
     }
-    uint32_t numIndexedDocs() const {
+    uint32_t numReadyDocs() const {
         return readydms ? readydms->get().getNumUsedLids() : 0;
     }
-    uint32_t numStoredDocs() const {
-        return numIndexedDocs() + (notreadydms ? notreadydms->get().getNumUsedLids() : 0);
+    uint32_t numTotalDocs() const {
+        return numReadyDocs() + (notreadydms ? notreadydms->get().getNumUsedLids() : 0);
     }
     uint32_t numRemovedDocs() const {
         return remdms ? remdms->get().getNumUsedLids() : 0;


### PR DESCRIPTION
Also make terminology more clear with 'active', 'ready', 'total', 'removed'.

@toregge please review
@baldersheim FYI