### PR TITLE
Cache rotation status in DeploymentMetricsMaintainer

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/MetricsService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/MetricsService.java
@@ -1,9 +1,12 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.api.integration;
 
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.HostName;
+import com.yahoo.vespa.hosted.controller.api.integration.routing.RotationStatus;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -16,6 +19,11 @@ public interface MetricsService {
     ApplicationMetrics getApplicationMetrics(ApplicationId application);
 
     DeploymentMetrics getDeploymentMetrics(ApplicationId application, ZoneId zone);
+
+    // TODO: Remove default once implementation catches up
+    default Map<HostName, RotationStatus> getRotationStatus(String rotationName) {
+        return Collections.emptyMap();
+    }
 
     Map<String, SystemMetrics> getSystemMetrics(ApplicationId application, ZoneId zone);
 

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/GlobalRoutingService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/GlobalRoutingService.java
@@ -8,6 +8,7 @@ import java.util.Map;
  *
  * @author mpolden
  */
+// TODO: Remove once DeploymentMetricsMaintainer starts providing rotation status
 public interface GlobalRoutingService {
 
     /** Returns the health status for each endpoint behind the given rotation name */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -168,6 +168,7 @@ public class Controller extends AbstractComponent {
 
     public ZoneRegistry zoneRegistry() { return zoneRegistry; }
 
+    // TODO: Remove once DeploymentMetricsMaintainer has stored rotation status for all applications at least once
     public Map<String, RotationStatus> rotationStatus(Rotation rotation) {
         return globalRoutingService.getHealthStatus(rotation.name());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
@@ -6,10 +6,12 @@ import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.hosted.controller.api.integration.MetricsService;
 import com.yahoo.vespa.hosted.controller.api.integration.MetricsService.ApplicationMetrics;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueId;
+import com.yahoo.vespa.hosted.controller.application.RotationStatus;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.ApplicationRotation;
 import com.yahoo.vespa.hosted.controller.application.ApplicationVersion;
@@ -49,6 +51,7 @@ public class LockedApplication {
     private final Optional<IssueId> ownershipIssueId;
     private final ApplicationMetrics metrics;
     private final Optional<RotationId> rotation;
+    private final Map<HostName, RotationStatus> rotationStatus;
 
     /**
      * Used to create a locked application
@@ -62,14 +65,15 @@ public class LockedApplication {
              application.deployments(),
              application.deploymentJobs(), application.change(), application.outstandingChange(),
              application.ownershipIssueId(), application.metrics(),
-             application.rotation().map(ApplicationRotation::id));
+             application.rotation().map(ApplicationRotation::id),
+             application.rotationStatus());
     }
 
     private LockedApplication(Lock lock, ApplicationId id,
                               DeploymentSpec deploymentSpec, ValidationOverrides validationOverrides,
                               Map<ZoneId, Deployment> deployments, DeploymentJobs deploymentJobs, Change change,
                               Change outstandingChange, Optional<IssueId> ownershipIssueId, ApplicationMetrics metrics,
-                              Optional<RotationId> rotation) {
+                              Optional<RotationId> rotation, Map<HostName, RotationStatus> rotationStatus) {
         this.lock = lock;
         this.id = id;
         this.deploymentSpec = deploymentSpec;
@@ -81,43 +85,44 @@ public class LockedApplication {
         this.ownershipIssueId = ownershipIssueId;
         this.metrics = metrics;
         this.rotation = rotation;
+        this.rotationStatus = rotationStatus;
     }
 
     /** Returns a read-only copy of this */
     public Application get() {
         return new Application(id, deploymentSpec, validationOverrides, deployments, deploymentJobs, change,
-                               outstandingChange, ownershipIssueId, metrics, rotation);
+                               outstandingChange, ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withBuiltInternally(boolean builtInternally) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withBuiltInternally(builtInternally), change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withProjectId(OptionalLong projectId) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withProjectId(projectId), change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withDeploymentIssueId(IssueId issueId) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.with(issueId), change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withJobCompletion(long projectId, JobType jobType, JobStatus.JobRun completion,
                                                Optional<DeploymentJobs.JobError> jobError) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withCompletion(projectId, jobType, completion, jobError),
-                                     change, outstandingChange, ownershipIssueId, metrics, rotation);
+                                     change, outstandingChange, ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withJobTriggering(JobType jobType, JobStatus.JobRun job) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withTriggering(jobType, job), change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withNewDeployment(ZoneId zone, ApplicationVersion applicationVersion, Version version,
@@ -167,49 +172,54 @@ public class LockedApplication {
     public LockedApplication withoutDeploymentJob(JobType jobType) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.without(jobType), change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication with(DeploymentSpec deploymentSpec) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication with(ValidationOverrides validationOverrides) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withChange(Change change) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withOutstandingChange(Change outstandingChange) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication withOwnershipIssueId(IssueId issueId) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     Optional.ofNullable(issueId), metrics, rotation);
+                                     Optional.ofNullable(issueId), metrics, rotation, rotationStatus);
     }
 
     public LockedApplication with(MetricsService.ApplicationMetrics metrics) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     public LockedApplication with(RotationId rotation) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, Optional.of(rotation));
+                                     ownershipIssueId, metrics, Optional.of(rotation), rotationStatus);
+    }
+
+    public LockedApplication withRotationStatus(Map<HostName, RotationStatus> rotationStatus) {
+        return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments, deploymentJobs, change,
+                                     outstandingChange, ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     /** Don't expose non-leaf sub-objects. */
@@ -222,7 +232,7 @@ public class LockedApplication {
     private LockedApplication with(Map<ZoneId, Deployment> deployments) {
         return new LockedApplication(lock, id, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
-                                     ownershipIssueId, metrics, rotation);
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Deployment.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Deployment.java
@@ -30,7 +30,7 @@ public class Deployment {
 
     public Deployment(ZoneId zone, ApplicationVersion applicationVersion, Version version, Instant deployTime) {
         this(zone, applicationVersion, version, deployTime, Collections.emptyMap(), Collections.emptyMap(),
-             new DeploymentMetrics(), DeploymentActivity.none);
+             DeploymentMetrics.none, DeploymentActivity.none);
     }
 
     public Deployment(ZoneId zone, ApplicationVersion applicationVersion, Version version, Instant deployTime,

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentMetrics.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentMetrics.java
@@ -2,23 +2,19 @@
 package com.yahoo.vespa.hosted.controller.application;
 
 /**
+ * Metrics for a deployment of an application.
+ *
  * @author smorgrav
  */
 public class DeploymentMetrics {
+
+    public static final DeploymentMetrics none = new DeploymentMetrics(0, 0, 0, 0, 0);
 
     private final double queriesPerSecond;
     private final double writesPerSecond;
     private final double documentCount;
     private final double queryLatencyMillis;
     private final double writeLatencyMills;
-
-    DeploymentMetrics() {
-        this.queriesPerSecond = 0;
-        this.writesPerSecond = 0;
-        this.documentCount = 0;
-        this.queryLatencyMillis = 0;
-        this.writeLatencyMills = 0;
-    }
 
     public DeploymentMetrics(double queriesPerSecond, double writesPerSecond, double documentCount,
                              double queryLatencyMillis, double writeLatencyMills) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/RotationStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/RotationStatus.java
@@ -1,0 +1,20 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.application;
+
+/**
+ * Represents the health status of a global rotation.
+ *
+ * @author mpolden
+ */
+public enum RotationStatus {
+
+    /** Rotation has status 'in' and is receiving traffic */
+    in,
+
+    /** Rotation has status 'out' and is *NOT* receiving traffic */
+    out,
+
+    /** Rotation status is currently unknown, or no global rotation has been assigned */
+    unknown
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
@@ -1,16 +1,22 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.hosted.controller.maintenance;// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.maintenance;
 
+import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.ApplicationController;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.MetricsService;
 import com.yahoo.vespa.hosted.controller.application.ApplicationList;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
+import com.yahoo.vespa.hosted.controller.application.RotationStatus;
 import com.yahoo.yolean.Exceptions;
 
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -24,17 +30,23 @@ public class DeploymentMetricsMaintainer extends Maintainer {
 
     private static final Logger log = Logger.getLogger(DeploymentMetricsMaintainer.class.getName());
 
+    private final ApplicationController applications;
+
     DeploymentMetricsMaintainer(Controller controller, Duration duration, JobControl jobControl) {
         super(controller, duration, jobControl);
+        this.applications = controller.applications();
     }
 
     @Override
     protected void maintain() {
         boolean hasWarned = false;
-        for (Application application : ApplicationList.from(controller().applications().asList()).notPullRequest().asList()) {
+        for (Application application : ApplicationList.from(applications.asList()).notPullRequest().asList()) {
             try {
-                controller().applications().lockIfPresent(application.id(), lockedApplication ->
-                        controller().applications().store(lockedApplication.with(controller().metricsService().getApplicationMetrics(application.id()))));
+                applications.lockIfPresent(application.id(), locked ->
+                        applications.store(locked.with(controller().metricsService().getApplicationMetrics(application.id()))));
+
+                applications.lockIfPresent(application.id(), locked ->
+                        applications.store(locked.withRotationStatus(rotationStatus(application))));
 
                 for (Deployment deployment : application.deployments().values()) {
                     MetricsService.DeploymentMetrics deploymentMetrics = controller().metricsService()
@@ -45,9 +57,9 @@ public class DeploymentMetricsMaintainer extends Maintainer {
                                                                          deploymentMetrics.queryLatencyMillis(),
                                                                          deploymentMetrics.writeLatencyMillis());
 
-                    controller().applications().lockIfPresent(application.id(), lockedApplication ->
-                            controller().applications().store(lockedApplication.with(deployment.zone(), newMetrics)
-                                                                               .recordActivityAt(controller().clock().instant(), deployment.zone())));
+                    applications.lockIfPresent(application.id(), locked ->
+                            applications.store(locked.with(deployment.zone(), newMetrics)
+                                                     .recordActivityAt(controller().clock().instant(), deployment.zone())));
                 }
             } catch (UncheckedIOException e) {
                 if (!hasWarned) // produce only one warning per maintenance interval
@@ -55,6 +67,27 @@ public class DeploymentMetricsMaintainer extends Maintainer {
                                            ". Retrying in " + maintenanceInterval());
                 hasWarned = true;
             }
+        }
+    }
+
+    /** Get global rotation status for application */
+    private Map<HostName, RotationStatus> rotationStatus(Application application) {
+        return application.rotation()
+                          .map(rotation -> controller().metricsService().getRotationStatus(rotation.id().asString()))
+                          .map(rotationStatus -> {
+                              Map<HostName, RotationStatus> result = new TreeMap<>();
+                              rotationStatus.forEach((hostname, status) -> result.put(hostname, from(status)));
+                              return result;
+                          })
+                          .orElseGet(Collections::emptyMap);
+    }
+
+    private static RotationStatus from(com.yahoo.vespa.hosted.controller.api.integration.routing.RotationStatus status) {
+        switch (status) {
+            case IN: return RotationStatus.in;
+            case OUT: return RotationStatus.out;
+            case UNKNOWN: return RotationStatus.unknown;
+            default: throw new IllegalArgumentException("Unknown API value for rotation status: " + status);
         }
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/MetricsServiceMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/MetricsServiceMock.java
@@ -1,8 +1,10 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.integration;
 
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.hosted.controller.api.integration.MetricsService;
+import com.yahoo.vespa.hosted.controller.api.integration.routing.RotationStatus;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
 
 import java.util.HashMap;
@@ -14,9 +16,20 @@ import java.util.Map;
 public class MetricsServiceMock implements MetricsService {
 
     private final Map<String, Double> metrics = new HashMap<>();
+    private final Map<HostName, RotationStatus> rotationStatus = new HashMap<>();
 
     public MetricsServiceMock setMetric(String key, Double value) {
         metrics.put(key, value);
+        return this;
+    }
+
+    public MetricsServiceMock setRotationIn(String hostname) {
+        rotationStatus.put(HostName.from(hostname), RotationStatus.IN);
+        return this;
+    }
+
+    public MetricsServiceMock setRotationOut(String hostname) {
+        rotationStatus.put(HostName.from(hostname), RotationStatus.OUT);
         return this;
     }
 
@@ -41,6 +54,11 @@ public class MetricsServiceMock implements MetricsService {
         SystemMetrics system = new SystemMetrics(55.54, 69.90, 34.59);
         result.put("default", system);
         return result;
+    }
+
+    @Override
+    public Map<HostName, RotationStatus> getRotationStatus(String rotationName) {
+        return rotationStatus;
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
@@ -1,14 +1,18 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
-
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
-import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
+import com.yahoo.vespa.hosted.controller.application.RotationStatus;
+import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
+import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
+import com.yahoo.vespa.hosted.controller.integration.MetricsServiceMock;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -26,13 +30,11 @@ import static org.junit.Assert.assertFalse;
 public class DeploymentMetricsMaintainerTest {
 
     @Test
-    public void maintain() {
+    public void updates_metrics() {
         ControllerTester tester = new ControllerTester();
         ApplicationId appId = tester.createAndDeploy("tenant1", "domain1", "app1",
                                                   Environment.dev, 123).id();
-        DeploymentMetricsMaintainer maintainer = new DeploymentMetricsMaintainer(tester.controller(),
-                                                                                 Duration.ofDays(1),
-                                                                                 new JobControl(new MockCuratorDb()));
+        DeploymentMetricsMaintainer maintainer = maintainer(tester.controller());
         Supplier<Application> app = tester.application(appId);
         Supplier<Deployment> deployment = () -> app.get().deployments().values().stream().findFirst().get();
 
@@ -83,6 +85,50 @@ public class DeploymentMetricsMaintainerTest {
         assertEquals(t3, deployment.get().activity().lastWritten().get());
         assertEquals(1, deployment.get().activity().lastQueriesPerSecond().getAsDouble(), Double.MIN_VALUE);
         assertEquals(5, deployment.get().activity().lastWritesPerSecond().getAsDouble(), Double.MIN_VALUE);
+    }
+
+    @Test
+    public void updates_rotation_status() {
+        DeploymentTester tester = new DeploymentTester();
+        MetricsServiceMock metricsService = tester.controllerTester().metricsService();
+        DeploymentMetricsMaintainer maintainer = maintainer(tester.controller());
+        Application application = tester.createApplication("app1", "tenant1", 1, 1L);
+        ZoneId zone1 = ZoneId.from("prod", "us-west-1");
+        ZoneId zone2 = ZoneId.from("prod", "us-east-3");
+
+        // Deploy application with global rotation
+        ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
+                .environment(Environment.prod)
+                .globalServiceId("foo")
+                .region(zone1.region().value())
+                .region(zone2.region().value())
+                .build();
+        tester.deployCompletely(application, applicationPackage);
+
+        Supplier<Application> app = () -> tester.application(application.id());
+        Supplier<Deployment> deployment1 = () -> app.get().deployments().get(zone1);
+        Supplier<Deployment> deployment2 = () -> app.get().deployments().get(zone2);
+
+        // No status gathered yet
+        assertEquals(RotationStatus.unknown, app.get().rotationStatus(deployment1.get()));
+        assertEquals(RotationStatus.unknown, app.get().rotationStatus(deployment2.get()));
+
+        // One rotation out, one in
+        metricsService.setRotationIn("proxy.prod.us-west-1.vip.test");
+        metricsService.setRotationOut("proxy.prod.us-east-3.vip.test");
+        maintainer.maintain();
+        assertEquals(RotationStatus.in, app.get().rotationStatus(deployment1.get()));
+        assertEquals(RotationStatus.out, app.get().rotationStatus(deployment2.get()));
+
+        // All rotations in
+        metricsService.setRotationIn("proxy.prod.us-east-3.vip.test");
+        maintainer.maintain();
+        assertEquals(RotationStatus.in, app.get().rotationStatus(deployment1.get()));
+        assertEquals(RotationStatus.in, app.get().rotationStatus(deployment2.get()));
+    }
+
+    private static DeploymentMetricsMaintainer maintainer(Controller controller) {
+        return new DeploymentMetricsMaintainer(controller, Duration.ofDays(1), new JobControl(controller.curator()));
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -70,7 +70,7 @@ public class ApplicationSerializerTest {
         deployments.add(new Deployment(zone1, applicationVersion1, Version.fromString("1.2.3"), Instant.ofEpochMilli(3))); // One deployment without cluster info and utils
         deployments.add(new Deployment(zone2, applicationVersion2, Version.fromString("1.2.3"), Instant.ofEpochMilli(5),
                                        createClusterUtils(3, 0.2), createClusterInfo(3, 4),
-                                       new DeploymentMetrics(2,3,4,5,6),
+                                       new DeploymentMetrics(2, 3, 4, 5, 6),
                                        DeploymentActivity.create(Optional.of(activityAt), Optional.of(activityAt),
                                                                  OptionalDouble.of(200), OptionalDouble.of(10))));
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.persistence;
 
 import com.yahoo.component.Version;
@@ -6,6 +6,7 @@ import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.api.integration.MetricsService;
@@ -22,6 +23,7 @@ import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
 import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobError;
 import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
 import com.yahoo.vespa.hosted.controller.application.JobStatus;
+import com.yahoo.vespa.hosted.controller.application.RotationStatus;
 import com.yahoo.vespa.hosted.controller.application.SourceRevision;
 import com.yahoo.vespa.hosted.controller.rotation.RotationId;
 import org.junit.Test;
@@ -37,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
+import java.util.TreeMap;
 
 import static com.yahoo.config.provision.SystemName.main;
 import static com.yahoo.vespa.hosted.controller.ControllerTester.writable;
@@ -89,6 +92,10 @@ public class ApplicationSerializerTest {
 
         DeploymentJobs deploymentJobs = new DeploymentJobs(projectId, statusList, empty(), true);
 
+        Map<HostName, RotationStatus> rotationStatus = new TreeMap<>();
+        rotationStatus.put(HostName.from("rot1.fqdn"), RotationStatus.in);
+        rotationStatus.put(HostName.from("rot2.fqdn"), RotationStatus.out);
+
         Application original = new Application(ApplicationId.from("t1", "a1", "i1"),
                                                deploymentSpec,
                                                validationOverrides,
@@ -97,7 +104,8 @@ public class ApplicationSerializerTest {
                                                Change.of(ApplicationVersion.from(new SourceRevision("repo", "master", "deadcafe"), 42)),
                                                Optional.of(IssueId.from("1234")),
                                                new MetricsService.ApplicationMetrics(0.5, 0.9),
-                                               Optional.of(new RotationId("my-rotation")));
+                                               Optional.of(new RotationId("my-rotation")),
+                                               rotationStatus);
 
         Application serialized = applicationSerializer.fromSlime(applicationSerializer.toSlime(original));
 
@@ -129,6 +137,7 @@ public class ApplicationSerializerTest {
 
         assertEquals(original.change(), serialized.change());
         assertEquals(original.rotation().get().id(), serialized.rotation().get().id());
+        assertEquals(original.rotationStatus(), serialized.rotationStatus());
 
         // Test cluster utilization
         assertEquals(0, serialized.deployments().get(zone1).clusterUtils().size());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -1198,7 +1198,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                     clusterInfo.put(ClusterSpec.Id.from("cluster1"), new ClusterInfo("flavor1", 37, 2, 4, 50, ClusterSpec.Type.content, hostnames));
                     Map<ClusterSpec.Id, ClusterUtilization> clusterUtils = new HashMap<>();
                     clusterUtils.put(ClusterSpec.Id.from("cluster1"), new ClusterUtilization(0.3, 0.6, 0.4, 0.3));
-                    DeploymentMetrics metrics = new DeploymentMetrics(1,2,3,4,5);
+                    DeploymentMetrics metrics = new DeploymentMetrics(1, 2, 3, 4, 5);
 
                     lockedApplication = lockedApplication
                             .withClusterInfo(deployment.zone(), clusterInfo)


### PR DESCRIPTION
Extends `DeploymentMetricsMaintainer` to collect rotation status metrics and
write them to ZK. Currently it will store the result of the default
implementation of `MetricsService#getRotationStatus` (empty map).

Once the real implementation of `MetricsService` learns how to fetch these
metrics and `DeploymentMetricsMaintainer` has run at least once in production,
we can change the application API to use the cached values.

This can safely be merged as it does not depend on changes to internal code.