### PR TITLE
Pass rotation FQDN to metrics service

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/MetricsService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/MetricsService.java
@@ -21,6 +21,10 @@ public interface MetricsService {
     DeploymentMetrics getDeploymentMetrics(ApplicationId application, ZoneId zone);
 
     // TODO: Remove default once implementation catches up
+    /**
+     * Get status for a global rotation
+     * @param rotationName The fully qualified domain name of the rotation
+     */
     default Map<HostName, RotationStatus> getRotationStatus(String rotationName) {
         return Collections.emptyMap();
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
@@ -90,14 +90,14 @@ public class DeploymentMetricsMaintainer extends Maintainer {
 
     /** Get global rotation status for application */
     private Map<HostName, RotationStatus> rotationStatus(Application application) {
-        return application.rotation()
-                          .map(rotation -> controller().metricsService().getRotationStatus(rotation.id().asString()))
-                          .map(rotationStatus -> {
-                              Map<HostName, RotationStatus> result = new TreeMap<>();
-                              rotationStatus.forEach((hostname, status) -> result.put(hostname, from(status)));
-                              return result;
-                          })
-                          .orElseGet(Collections::emptyMap);
+        return applications.rotationRepository().getRotation(application)
+                           .map(rotation -> controller().metricsService().getRotationStatus(rotation.name()))
+                           .map(rotationStatus -> {
+                               Map<HostName, RotationStatus> result = new TreeMap<>();
+                               rotationStatus.forEach((hostname, status) -> result.put(hostname, from(status)));
+                               return result;
+                           })
+                           .orElseGet(Collections::emptyMap);
     }
 
     private static RotationStatus from(com.yahoo.vespa.hosted.controller.api.integration.routing.RotationStatus status) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/MetricsServiceMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/MetricsServiceMock.java
@@ -16,20 +16,31 @@ import java.util.Map;
 public class MetricsServiceMock implements MetricsService {
 
     private final Map<String, Double> metrics = new HashMap<>();
-    private final Map<HostName, RotationStatus> rotationStatus = new HashMap<>();
+    private final Map<String, Map<HostName, RotationStatus>> rotationStatus = new HashMap<>();
+
+    public MetricsServiceMock addRotation(String rotationName) {
+        rotationStatus.put(rotationName, new HashMap<>());
+        return this;
+    }
 
     public MetricsServiceMock setMetric(String key, Double value) {
         metrics.put(key, value);
         return this;
     }
 
-    public MetricsServiceMock setRotationIn(String hostname) {
-        rotationStatus.put(HostName.from(hostname), RotationStatus.IN);
+    public MetricsServiceMock setZoneIn(String rotationName, String vipName) {
+        if (!rotationStatus.containsKey(rotationName)) {
+            throw new IllegalArgumentException("Unknown rotation: " + rotationName);
+        }
+        rotationStatus.get(rotationName).put(HostName.from(vipName), RotationStatus.IN);
         return this;
     }
 
-    public MetricsServiceMock setRotationOut(String hostname) {
-        rotationStatus.put(HostName.from(hostname), RotationStatus.OUT);
+    public MetricsServiceMock setZoneOut(String rotationName, String vipName) {
+        if (!rotationStatus.containsKey(rotationName)) {
+            throw new IllegalArgumentException("Unknown rotation: " + rotationName);
+        }
+        rotationStatus.get(rotationName).put(HostName.from(vipName), RotationStatus.OUT);
         return this;
     }
 
@@ -58,7 +69,7 @@ public class MetricsServiceMock implements MetricsService {
 
     @Override
     public Map<HostName, RotationStatus> getRotationStatus(String rotationName) {
-        return rotationStatus;
+        return rotationStatus.get(rotationName);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainerTest.java
@@ -108,20 +108,22 @@ public class DeploymentMetricsMaintainerTest {
         Supplier<Application> app = () -> tester.application(application.id());
         Supplier<Deployment> deployment1 = () -> app.get().deployments().get(zone1);
         Supplier<Deployment> deployment2 = () -> app.get().deployments().get(zone2);
+        String assignedRotation = "rotation-fqdn-01";
+        tester.controllerTester().metricsService().addRotation(assignedRotation);
 
         // No status gathered yet
         assertEquals(RotationStatus.unknown, app.get().rotationStatus(deployment1.get()));
         assertEquals(RotationStatus.unknown, app.get().rotationStatus(deployment2.get()));
 
         // One rotation out, one in
-        metricsService.setRotationIn("proxy.prod.us-west-1.vip.test");
-        metricsService.setRotationOut("proxy.prod.us-east-3.vip.test");
+        metricsService.setZoneIn(assignedRotation, "proxy.prod.us-west-1.vip.test");
+        metricsService.setZoneOut(assignedRotation,"proxy.prod.us-east-3.vip.test");
         maintainer.maintain();
         assertEquals(RotationStatus.in, app.get().rotationStatus(deployment1.get()));
         assertEquals(RotationStatus.out, app.get().rotationStatus(deployment2.get()));
 
         // All rotations in
-        metricsService.setRotationIn("proxy.prod.us-east-3.vip.test");
+        metricsService.setZoneIn(assignedRotation,"proxy.prod.us-east-3.vip.test");
         maintainer.maintain();
         assertEquals(RotationStatus.in, app.get().rotationStatus(deployment1.get()));
         assertEquals(RotationStatus.in, app.get().rotationStatus(deployment2.get()));


### PR DESCRIPTION
..and not our internal ID. :)