### PR TITLE
Multiple node java dispatch support

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackEndSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackEndSearcher.java
@@ -213,11 +213,7 @@ public abstract class VespaBackEndSearcher extends PingableSearcher {
         if (root == null || root instanceof NullItem) // root can become null after resolving and transformation?
             return new Result(query);
 
-        QueryPacket queryPacket = QueryPacket.create(query);
-        int compressionLimit = query.properties().getInteger(PACKET_COMPRESSION_LIMIT, 0);
-        queryPacket.setCompressionLimit(compressionLimit);
-        if (compressionLimit != 0)
-            queryPacket.setCompressionType(query.properties().getString(PACKET_COMPRESSION_TYPE, "lz4"));
+        QueryPacket queryPacket = createQueryPacket(query);
 
         if (isLoggingFine())
             getLogger().fine("made QueryPacket: " + queryPacket);
@@ -239,6 +235,15 @@ public abstract class VespaBackEndSearcher extends PingableSearcher {
             result.trace(getName());
         }
         return result;
+    }
+
+    protected QueryPacket createQueryPacket(Query query) {
+        QueryPacket queryPacket = QueryPacket.create(query);
+        int compressionLimit = query.properties().getInteger(PACKET_COMPRESSION_LIMIT, 0);
+        queryPacket.setCompressionLimit(compressionLimit);
+        if (compressionLimit != 0)
+            queryPacket.setCompressionType(query.properties().getString(PACKET_COMPRESSION_TYPE, "lz4"));
+        return queryPacket;
     }
 
     /**
@@ -355,7 +360,7 @@ public abstract class VespaBackEndSearcher extends PingableSearcher {
             s.append(" location=")
                     .append(query.getRanking().getLocation().toString());
         }
-        
+
         if (query.getGroupingSessionCache()) {
             s.append(" groupingSessionCache=true");
         }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/CloseableChannel.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/CloseableChannel.java
@@ -8,19 +8,37 @@ import com.yahoo.search.Result;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 
 /**
- * CloseableChannel is an interface for running a search query and getting document summaries against some
- * content node, node group or dispatcher while abstracting the specifics of the invocation target.
+ * CloseableChannel is an interface for running a search query and getting document summaries against some content node, node group or
+ * dispatcher while abstracting the specifics of the invocation target. ClosebleChannel objects are stateful and should not be reused.
  *
  * @author ollivir
  */
 public abstract class CloseableChannel implements Closeable {
-    /** Retrieve the hits for the given {@link Query} */
-    public abstract Result search(Query query, QueryPacket queryPacket, CacheKey cacheKey) throws IOException;
+    /** Retrieve the hits for the given {@link Query}. The channel may return more than one result, in
+     * which case the caller is responsible for merging the results. If multiple results are returned
+     * and the search query had a hit offset other than zero, that offset will be set to zero and the
+     * number of requested hits will be adjusted accordingly. */
+    public List<Result> search(Query query, QueryPacket queryPacket, CacheKey cacheKey) throws IOException {
+        sendSearchRequest(query, queryPacket);
+        return getSearchResults(cacheKey);
+    }
+
+    protected abstract void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException;
+
+    protected abstract List<Result> getSearchResults(CacheKey cacheKey) throws IOException;
 
     /** Retrieve document summaries for the unfilled hits in the given {@link Result} */
-    public abstract void partialFill(Result result, String summaryClass);
+    public void partialFill(Result result, String summaryClass) {
+        sendPartialFillRequest(result, summaryClass);
+        getPartialFillResults(result, summaryClass);
+    }
+
+    protected abstract void getPartialFillResults(Result result, String summaryClass);
+
+    protected abstract void sendPartialFillRequest(Result result, String summaryClass);
 
     protected abstract void closeChannel();
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedCloseableChannel.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedCloseableChannel.java
@@ -1,0 +1,98 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+import com.yahoo.fs4.QueryPacket;
+import com.yahoo.prelude.fastsearch.CacheKey;
+import com.yahoo.prelude.fastsearch.FastHit;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.result.Hit;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * InterleavedCloseableChannel uses multiple {@link CloseableChannel} objects to interface with
+ * content nodes in parallel. Operationally it first sends requests to all channels and then
+ * collects the results. The invoker of this class is responsible for merging the results if
+ * needed.
+ *
+ * @author ollivir
+ */
+public class InterleavedCloseableChannel extends CloseableChannel {
+    private final Map<Integer, CloseableChannel> subchannels;
+    private Map<Integer, Result> expectedFillResults = null;
+
+    public InterleavedCloseableChannel(Map<Integer, CloseableChannel> subchannels) {
+        this.subchannels = subchannels;
+    }
+
+    /** Sends search queries to the contained {@link CloseableChannel} subchannels. If the
+     * search query has an offset other than zero, it will be reset to zero and the expected
+     * hit amount will be adjusted accordingly. */
+    @Override
+    protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+        for (CloseableChannel subchannel : subchannels.values()) {
+            Query subquery = query.clone();
+
+            subquery.setHits(subquery.getHits() + subquery.getOffset());
+            subquery.setOffset(0);
+            subchannel.sendSearchRequest(subquery, null);
+        }
+    }
+
+    @Override
+    protected List<Result> getSearchResults(CacheKey cacheKey) throws IOException {
+        List<Result> results = new ArrayList<>();
+
+        for (CloseableChannel subchannel : subchannels.values()) {
+            results.addAll(subchannel.getSearchResults(cacheKey));
+        }
+        return results;
+    }
+
+    @Override
+    protected void sendPartialFillRequest(Result result, String summaryClass) {
+        expectedFillResults = new HashMap<>();
+
+        for (Iterator<Hit> it = result.hits().deepIterator(); it.hasNext();) {
+            Hit hit = it.next();
+            if (hit instanceof FastHit) {
+                FastHit fhit = (FastHit) hit;
+                Result res = expectedFillResults.computeIfAbsent(fhit.getDistributionKey(), dk -> new Result(result.getQuery()));
+                res.hits().add(fhit);
+            }
+        }
+        expectedFillResults.forEach((distKey, partialResult) -> {
+            CloseableChannel channel = subchannels.get(distKey);
+            if (channel != null) {
+                channel.sendPartialFillRequest(partialResult, summaryClass);
+            }
+        });
+    }
+
+    @Override
+    protected void getPartialFillResults(Result result, String summaryClass) {
+        if (expectedFillResults == null) {
+            return;
+        }
+        expectedFillResults.forEach((distKey, partialResult) -> {
+            CloseableChannel channel = subchannels.get(distKey);
+            if (channel != null) {
+                channel.getPartialFillResults(partialResult, summaryClass);
+            }
+        });
+    }
+
+    @Override
+    protected void closeChannel() {
+        if (!subchannels.isEmpty()) {
+            subchannels.values().forEach(CloseableChannel::close);
+            subchannels.clear();
+        }
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
@@ -26,17 +26,14 @@ public class LoadBalancer {
 
     private static final CompoundName QUERY_NODE_GROUP_AFFINITY = new CompoundName("dispatch.group.affinity");
 
-    private final boolean isInternallyDispatchable;
     private final List<GroupSchedule> scoreboard;
     private int needle = 0;
 
     public LoadBalancer(SearchCluster searchCluster) {
         if (searchCluster == null) {
-            this.isInternallyDispatchable = false;
             this.scoreboard = null;
             return;
         }
-        this.isInternallyDispatchable = (searchCluster.groupSize() == 1);
         this.scoreboard = new ArrayList<>(searchCluster.groups().size());
 
         for (Group group : searchCluster.groups().values()) {
@@ -53,7 +50,7 @@ public class LoadBalancer {
      * @return The node group to target, or <i>empty</i> if the internal dispatch logic cannot be used
      */
     public Optional<Group> takeGroupForQuery(Query query) {
-        if (!isInternallyDispatchable) {
+        if (scoreboard == null) {
             return Optional.empty();
         }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -47,18 +47,7 @@ public class LoadBalancerTest {
     }
 
     @Test
-    public void requreThatLoadBalancerIgnoresClusteredSingleGroup() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 0);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 2, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
-
-        Optional<Group> grp = lb.takeGroupForQuery(new Query());
-        assertThat(grp.isPresent(), is(false));
-    }
-
-    @Test
-    public void requreThatLoadBalancerIgnoresClusteredGroups() {
+    public void requreThatLoadBalancerServesClusteredGroups() {
         Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
         Node n2 = new SearchCluster.Node(1, "test-node2", 1, 0);
         Node n3 = new SearchCluster.Node(0, "test-node3", 0, 1);
@@ -67,7 +56,7 @@ public class LoadBalancerTest {
         LoadBalancer lb = new LoadBalancer(cluster);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query());
-        assertThat(grp.isPresent(), is(false));
+        assertThat(grp.isPresent(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Adds multiple-node support in the java dispatcher in the most trivial case (i.e. no grouping). Merging the results from multiple nodes is implemented in `FastSearcher` to keep it away from the interfacing level.

The search & fill operations should probably be split into two interfaces since they don't really share all that much and even now might use different protocols, but I didn't do that now. Next is either that or (more likely) grouping support.