### PR TITLE
Always use a fallback provisioner in hosted Vespa

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/provision/StaticProvisioner.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/provision/StaticProvisioner.java
@@ -5,7 +5,6 @@ import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.provision.*;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -19,13 +18,6 @@ public class StaticProvisioner implements HostProvisioner {
     
     /** The fallback provisioner to use for unknown clusters, or null to not fall back */
     private final HostProvisioner fallback;
-
-    /**
-     * Creates a static host provisioner with no fallback
-     */
-    public StaticProvisioner(AllocatedHosts allocatedHosts) {
-        this(allocatedHosts, null);
-    }
 
     /**
      * Creates a static host provisioner which will fall back to using the given provisioner

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
@@ -30,7 +30,7 @@ public class StaticProvisionerTest {
         InMemoryProvisioner inMemoryHostProvisioner = new InMemoryProvisioner(false, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com", "host4.yahoo.com");
         VespaModel firstModel = createModel(app, inMemoryHostProvisioner);
 
-        StaticProvisioner staticProvisioner = new StaticProvisioner(firstModel.allocatedHosts());
+        StaticProvisioner staticProvisioner = new StaticProvisioner(firstModel.allocatedHosts(), null);
         VespaModel secondModel = createModel(app, staticProvisioner);
 
         assertModelConfig(firstModel, secondModel);


### PR DESCRIPTION
If we introduce a new cluster or change the number of nodes in an
application between versions we will try to load the model (at startup,
so ActivatedModelsBuilder will be used) and discover that we need to provision
additional nodes. Since ActivatedModelsBuilder had set the fallback provisioner
to null this failed spectacularly. Make sure to always use node repository
provisioner as fallback in this case.