### PR TITLE
DockerApi: Fix immediate deleting of re-downloaded image

### DIFF
--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollectionTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImageGarbageCollectionTest.java
@@ -118,6 +118,14 @@ public class DockerImageGarbageCollectionTest {
                 .expectDeletedImages("image"); // 1h after re-download it is deleted again
     }
 
+    @Test
+    public void reDownloadingImageIsNotImmediatelyDeletedWhenDeletingByTag() {
+        gcTester.withExistingImages(ImageBuilder.forId("image").withTags("image-1", "my-tag"))
+                .expectDeletedImages("image-1", "my-tag") // After 1h we delete image
+                .expectDeletedImagesAfterMinutes(0) // image is immediately re-downloaded, but is not deleted
+                .expectDeletedImagesAfterMinutes(10)
+                .expectDeletedImages("image-1", "my-tag"); // 1h after re-download it is deleted again
+    }
 
     /** Same scenario as in {@link #multipleUnusedImagesAreIdentified()} */
     @Test


### PR DESCRIPTION
We cannot delete a docker image by its ID if there are multiple tags reffering to it, therefore the previous code first mapped the ID to all the tags and then deleted by tags if there were any. However, the map that stores images by last used time uses image ID as key, not tag - so the entry would not be reset.

This fixes the bug by always resetting last used time by image ID, but deletes by tags if there are any.