### PR TITLE
fix lost handler metrics

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerStatus.java
@@ -9,6 +9,7 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.document.config.DocumentmanagerConfig;
+import com.yahoo.jdisc.Metric;
 import com.yahoo.vespa.config.content.LoadTypeConfig;
 import com.yahoo.feedapi.FeedContext;
 import com.yahoo.metrics.MetricManager;
@@ -28,9 +29,12 @@ public class VespaFeedHandlerStatus extends ThreadedHttpRequestHandler {
                                   DocumentmanagerConfig documentmanagerConfig, 
                                   SlobroksConfig slobroksConfig,
                                   ClusterListConfig clusterListConfig,
-                                  Executor executor) {
-        this(FeedContext.getInstance(feederConfig, loadTypeConfig, documentmanagerConfig, slobroksConfig, 
-                                     clusterListConfig, new NullFeedMetric()), true, true, executor);
+                                  Executor executor,
+                                  Metric metric) {
+        this(FeedContext.getInstance(feederConfig, loadTypeConfig,
+                                     documentmanagerConfig, slobroksConfig, 
+                                     clusterListConfig, metric),
+             true, true, executor);
     }
 
     VespaFeedHandlerStatus(FeedContext context, boolean doLog, boolean makeSnapshots, Executor executor) {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/storage/searcher/GetSearcher.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/storage/searcher/GetSearcher.java
@@ -6,7 +6,7 @@ import com.yahoo.cloud.config.ClusterListConfig;
 import com.yahoo.cloud.config.SlobroksConfig;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.document.config.DocumentmanagerConfig;
-import com.yahoo.feedhandler.NullFeedMetric;
+import com.yahoo.jdisc.Metric;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.vespa.config.content.LoadTypeConfig;
 import com.yahoo.document.DataType;
@@ -199,9 +199,14 @@ public class GetSearcher extends Searcher {
                        LoadTypeConfig loadTypeConfig,
                        DocumentmanagerConfig documentmanagerConfig,
                        SlobroksConfig slobroksConfig,
-                       ClusterListConfig clusterListConfig) throws Exception {
-        this(FeedContext.getInstance(feederConfig, loadTypeConfig, documentmanagerConfig, slobroksConfig, 
-                                     clusterListConfig, new NullFeedMetric()), (long)(feederConfig.timeout() * 1000));
+                       ClusterListConfig clusterListConfig,
+                       Metric metric)
+        throws Exception
+    {
+        this(FeedContext.getInstance(feederConfig, loadTypeConfig,
+                                     documentmanagerConfig, slobroksConfig, 
+                                     clusterListConfig, metric),
+             (long)(feederConfig.timeout() * 1000));
     }
 
     GetSearcher(FeedContext context) throws Exception {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/storage/searcher/VisitSearcher.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/storage/searcher/VisitSearcher.java
@@ -4,7 +4,6 @@ package com.yahoo.storage.searcher;
 import com.yahoo.cloud.config.ClusterListConfig;
 import com.yahoo.cloud.config.SlobroksConfig;
 import com.yahoo.document.config.DocumentmanagerConfig;
-import com.yahoo.feedhandler.NullFeedMetric;
 import com.yahoo.vespa.config.content.LoadTypeConfig;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
@@ -14,6 +13,7 @@ import com.yahoo.documentapi.*;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.feedapi.FeedContext;
 import com.yahoo.feedapi.MessagePropertyProcessor;
+import com.yahoo.jdisc.Metric;
 import com.yahoo.messagebus.StaticThrottlePolicy;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -37,9 +37,13 @@ public class VisitSearcher extends Searcher {
                          LoadTypeConfig loadTypeConfig,
                          DocumentmanagerConfig documentmanagerConfig,
                          SlobroksConfig slobroksConfig,
-                         ClusterListConfig clusterListConfig) throws Exception {
-        this(FeedContext.getInstance(feederConfig, loadTypeConfig, documentmanagerConfig, 
-                                     slobroksConfig, clusterListConfig, new NullFeedMetric()));
+                         ClusterListConfig clusterListConfig,
+                         Metric metric)
+        throws Exception
+    {
+        this(FeedContext.getInstance(feederConfig, loadTypeConfig,
+                                     documentmanagerConfig, slobroksConfig,
+                                     clusterListConfig, metric));
     }
 
     VisitSearcher(FeedContext context) throws Exception {

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/VespaFeedHandlerTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/VespaFeedHandlerTestCase.java
@@ -67,7 +67,7 @@ public class VespaFeedHandlerTestCase {
             factory = DummySessionFactory.createDefault();
         }
 
-        context = new FeedContext(new MessagePropertyProcessor(new FeederConfig(new FeederConfig.Builder()), loadTypeCfg), factory, docMan, new ClusterList(), new NullFeedMetric());
+        context = new FeedContext(new MessagePropertyProcessor(new FeederConfig(new FeederConfig.Builder()), loadTypeCfg), factory, docMan, new ClusterList(), new NullFeedMetric(true));
 
         Executor threadPool = Executors.newCachedThreadPool();
         feedHandler = new VespaFeedHandler(context, threadPool);
@@ -918,7 +918,7 @@ public class VespaFeedHandlerTestCase {
                 new FeedContext(new MessagePropertyProcessor(
                         new FeederConfig(new FeederConfig.Builder()),
                         new LoadTypeConfig(new LoadTypeConfig.Builder())),
-                        factory, null, new ClusterList(), new NullFeedMetric()),
+                        factory, null, new ClusterList(), new NullFeedMetric(true)),
                 true, true,
                 Executors.newCachedThreadPool());
     }

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/v3/FeedTesterV3.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/feedhandler/v3/FeedTesterV3.java
@@ -101,7 +101,7 @@ public class FeedTesterV3 {
         Executor threadPool = Executors.newCachedThreadPool();
         DocumentmanagerConfig docMan = new DocumentmanagerConfig(new DocumentmanagerConfig.Builder().enablecompression(true));
         FeedHandlerV3 feedHandlerV3 = new FeedHandlerV3(
-                new FeedHandlerV3.Context(threadPool, AccessLog.voidAccessLog(), new NullFeedMetric()),
+                new FeedHandlerV3.Context(threadPool, AccessLog.voidAccessLog(), new NullFeedMetric(true)),
                 docMan,
                 null /* session cache */,
                 null /* thread pool config */, 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/storage/searcher/GetSearcherTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/storage/searcher/GetSearcherTestCase.java
@@ -78,7 +78,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType); // Needs auto-reply
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(newQuery("?id=userdoc:kittens:1:2"));
@@ -105,7 +105,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Query query = newQuery("?id[0]=userdoc:kittens:1:2&id[1]=userdoc:kittens:3:4");
@@ -141,7 +141,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         String data = "userdoc:kittens:5:6\nuserdoc:kittens:7:8\nuserdoc:kittens:9:10";
@@ -161,7 +161,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         String data = "userdoc:kittens:5:6\nuserdoc:kittens:7:8\nuserdoc:kittens:9:10";
@@ -184,7 +184,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         HitGroup hits = new HitGroup("mock");
         hits.add(new Hit("blernsball"));
         Chain<Searcher> searchChain = new Chain<>(searcher, new MockBackend(hits));
@@ -212,7 +212,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType, null, false, replies);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         DocumentHit backendHit = new DocumentHit(new Document(docType, new DocumentId("userdoc:kittens:5678:bar")), 5);
         Chain<Searcher> searchChain = new Chain<>(searcher, new MockBackend(backendHit));
 
@@ -229,7 +229,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         HitGroup hits = new HitGroup("mock");
         hits.add(new Hit("blernsball"));
         Chain<Searcher> searchChain = new Chain<>(searcher, new MockBackend(hits));
@@ -257,7 +257,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(new FeederConfig(new FeederConfig.Builder().timeout(58).route("route66").retryenabled(false)), defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(newQuery("?id=doc:batman:dahnahnahnah"));
@@ -283,7 +283,7 @@ public class GetSearcherTestCase {
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(new FeederConfig(new FeederConfig.Builder().timeout(58).route("riksveg18").retryenabled(true)),
                             defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         new Execution(searchChain, Execution.Context.createContextStub()).search(newQuery("?id=doc:batman:dahnahnahnah"));
@@ -336,7 +336,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -376,7 +376,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -415,7 +415,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -441,7 +441,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         {
@@ -513,7 +513,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType); // Needs auto-reply
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -548,7 +548,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType, null, false, replies);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -570,7 +570,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType, err, true);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -618,7 +618,7 @@ public class GetSearcherTestCase {
         factory.setNullReply(true);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -782,7 +782,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -831,7 +831,7 @@ public class GetSearcherTestCase {
         factory.setNullReply(true);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Result result = new Execution(searchChain, Execution.Context.createContextStub()).search(
@@ -978,7 +978,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType); // Needs auto-reply
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         Chain<Searcher> searchChain = new Chain<>(searcher);
 
         Query query = newQuery("?id=userdoc:kittens:1:2&format=json");
@@ -994,7 +994,7 @@ public class GetSearcherTestCase {
         DocumentSessionFactory factory = new DocumentSessionFactory(docType, null, false, replies);
         GetSearcher searcher = new GetSearcher(new FeedContext(
                 new MessagePropertyProcessor(defFeedCfg, defLoadTypeCfg),
-                factory, docMan, new ClusterList(), new NullFeedMetric()));
+                factory, docMan, new ClusterList(), new NullFeedMetric(true)));
         return new Chain<>(searcher);
     }
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/storage/searcher/VisitorSearcherTestCase.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/storage/searcher/VisitorSearcherTestCase.java
@@ -61,7 +61,7 @@ public class VisitorSearcherTestCase {
         return new VisitSearcher(new FeedContext(
                 new MessagePropertyProcessor(new FeederConfig(new FeederConfig.Builder().timeout(458).route("riksveg18").retryenabled(true)),
                         new LoadTypeConfig(new LoadTypeConfig.Builder())),
-                factory, docMan, clusterList, new NullFeedMetric()));
+                factory, docMan, clusterList, new NullFeedMetric(true)));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class VisitorSearcherTestCase {
         VisitSearcher searcher = new VisitSearcher(new FeedContext(
                 new MessagePropertyProcessor(new FeederConfig(new FeederConfig.Builder().timeout(100).route("whatever").retryenabled(true)),
                         new LoadTypeConfig(new LoadTypeConfig.Builder())),
-                factory, docMan, clusterList, new NullFeedMetric()));
+                factory, docMan, clusterList, new NullFeedMetric(true)));
 
             searcher.getVisitorParameters(newQuery("visit?visit.selection=id.user=1234"), null);
     }

--- a/vespaclient-core/src/main/java/com/yahoo/feedhandler/NullFeedMetric.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedhandler/NullFeedMetric.java
@@ -9,6 +9,13 @@ import java.util.Map;
  * @since 5.1.20
  */
 public final class NullFeedMetric implements Metric {
+
+    public NullFeedMetric(boolean flag) {
+        if (!flag) {
+            throw new IllegalArgumentException("must set flag allowing to throw away metrics");
+        }
+    }
+
     @Override
     public void set(String key, Number val, Context ctx) {
     }

--- a/vespaclient-java/src/main/java/com/yahoo/vespafeeder/VespaFeeder.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespafeeder/VespaFeeder.java
@@ -74,7 +74,7 @@ public class VespaFeeder {
                 args.getPropertyProcessor(),
                 args.getSessionFactory(),
                 manager,
-                new ClusterList(), new NullFeedMetric());
+                new ClusterList(), new NullFeedMetric(true));
 
         final BufferedInputStream input = new BufferedInputStream(stdin);
         VespaFeedHandler handler = VespaFeedHandler.createFromContext(context, threadPool);


### PR DESCRIPTION
* since all these classes use a shared FeedContext instance we must make
  sure that nobody ever uses NullFeedMetric (except unit tests & VespaFeeder).

@vekterli please review and merge

NOTE: it's impossible to guess why NullFeedMetric was used originally for some of this, so therefore also impossible to guess what the possible side effects of this change are.