### PR TITLE
Remove deprecated GDFLAG_ALLOW_SLIME flag from getdocsum packets.

### DIFF
--- a/container-search/src/main/java/com/yahoo/fs4/GetDocSumsPacket.java
+++ b/container-search/src/main/java/com/yahoo/fs4/GetDocSumsPacket.java
@@ -69,7 +69,6 @@ public class GetDocSumsPacket extends Packet {
      * definition of enum getdocsums_flags
      */
     public static final int GDFLAG_IGNORE_ROW  = 0x00000001;
-    public static final int GDFLAG_ALLOW_SLIME = 0x00000002;
 
     public void encodeBody(ByteBuffer buffer) {
         setFieldsFromHits();
@@ -79,9 +78,6 @@ public class GetDocSumsPacket extends Packet {
         if (useQueryCache) { // TODO: Move this decision (and the key) to ranking
             query.getRanking().getProperties().put(sessionIdKey, query.getSessionId(false).toString());
         }
-
-        // always allow slime docsums
-        flags |= GDFLAG_ALLOW_SLIME;
 
         // set the default features
         long features = GDF_MLD;

--- a/container-search/src/test/java/com/yahoo/fs4/test/GetDocSumsPacketTestCase.java
+++ b/container-search/src/test/java/com/yahoo/fs4/test/GetDocSumsPacketTestCase.java
@@ -34,16 +34,16 @@ public class GetDocSumsPacketTestCase {
     @Test
     public void testEncodingWithQuery() throws BufferTooSmallException {
         Hit hit = new FastHit();
-        assertPacket(true, hit, new byte[] {0, 0, 0, 57, 0, 0, 0, -37, 0, 0, 40, 21, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
+        assertPacket(true, hit, new byte[] {0, 0, 0, 53, 0, 0, 0, -37, 0, 0, 8, 21, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
                 IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x03, 0, 0, 0, 7,
-                100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1, 0, 0, 0, 6, 4, 0, 3, 102, 111, 111, 0, 0, 0, 2});
+                100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 1, 0, 0, 0, 6, 4, 0, 3, 102, 111, 111});
     }
 
     @Test
     public void testEncodingWithoutQuery() throws BufferTooSmallException {
         Hit hit = new FastHit();
-        assertPacket(false, hit, new byte[] { 0, 0, 0, 43, 0, 0, 0, -37, 0, 0, 40, 17, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
-                IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x03, 0, 0, 0, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 2
+        assertPacket(false, hit, new byte[] { 0, 0, 0, 39, 0, 0, 0, -37, 0, 0, 8, 17, 0, 0, 0, 0, IGNORE, IGNORE, IGNORE,
+                IGNORE, 7, 100, 101, 102, 97, 117, 108, 116, 0, 0, 0, 0x03, 0, 0, 0, 7, 100, 101, 102, 97, 117, 108, 116
         });
     }
 
@@ -56,7 +56,7 @@ public class GetDocSumsPacketTestCase {
         result.hits().add(hit);
         ByteBuffer answer = ByteBuffer.allocate(1024);
         //assertEquals(0, sessionId.asUtf8String().getByteLength());
-        answer.put(new byte[] { 0, 0, 0, (byte)(107+sessionId.asUtf8String().getByteLength()), 0, 0, 0, -37, 0, 0, 56, 17, 0, 0, 0, 0,
+        answer.put(new byte[] { 0, 0, 0, (byte)(103+sessionId.asUtf8String().getByteLength()), 0, 0, 0, -37, 0, 0, 24, 17, 0, 0, 0, 0,
                 // query timeout
                 IGNORE, IGNORE, IGNORE, IGNORE,
                 // "default" - rank profile
@@ -72,9 +72,7 @@ public class GetDocSumsPacketTestCase {
         answer.put(new byte [] {
                 // caches: features => true
                 0, 0, 0, 6, 'c', 'a', 'c', 'h', 'e', 's',
-                0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e',
-                // flags
-                0, 0, 0, 2});
+                0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e'});
         byte [] expected = new byte [answer.position()];
         answer.flip();
         answer.get(expected);

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
@@ -316,7 +316,7 @@ public class FastSearcherTestCase {
         SessionId sessionId = query.getSessionId(false);
         byte IGNORE = 69;
         ByteBuffer answer = ByteBuffer.allocate(1024);
-        answer.put(new byte[] { 0, 0, 0, (byte)(145+sessionId.asUtf8String().getByteLength()), 0, 0, 0, -37, 0, 0, 48, 17, 0, 0, 0, 0,
+        answer.put(new byte[] { 0, 0, 0, (byte)(141+sessionId.asUtf8String().getByteLength()), 0, 0, 0, -37, 0, 0, 16, 17, 0, 0, 0, 0,
                 // query timeout
                 IGNORE, IGNORE, IGNORE, IGNORE,
                 // "default" - rank profile
@@ -331,9 +331,7 @@ public class FastSearcherTestCase {
                 // match: documentdb.searchdoctype => test
                 0, 0, 0, 5, 'm', 'a', 't', 'c', 'h', 0, 0, 0, 1, 0, 0, 0, 24, 'd', 'o', 'c', 'u', 'm', 'e', 'n', 't', 'd', 'b', '.', 's', 'e', 'a', 'r', 'c', 'h', 'd', 'o', 'c', 't', 'y', 'p', 'e', 0, 0, 0, 4, 't', 'e', 's', 't',
                 // sessionId => qrserver.0.XXXXXXXXXXXXX.0
-                0, 0, 0, 6, 'c', 'a', 'c', 'h', 'e', 's', 0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e',
-                // flags
-                0, 0, 0, 2});
+                0, 0, 0, 6, 'c', 'a', 'c', 'h', 'e', 's', 0, 0, 0, 1, 0, 0, 0, 5, 'q', 'u', 'e', 'r', 'y', 0, 0, 0, 4, 't', 'r', 'u', 'e'});
         byte [] expected = new byte [answer.position()];
         answer.flip();
         answer.get(expected);

--- a/searchlib/src/vespa/searchlib/common/transport.h
+++ b/searchlib/src/vespa/searchlib/common/transport.h
@@ -106,8 +106,7 @@ enum getdocsums_features {
 
 
 enum getdocsums_flags {
-    GDFLAG_IGNORE_ROW         = 0x00000001,
-    GDFLAG_ALLOW_SLIME_NOTUSED = 0x00000002 // TODO: remove in Vespa 7
+    GDFLAG_IGNORE_ROW         = 0x00000001
 };
 
 // docsum class for slime tunneling


### PR DESCRIPTION
It is ignored by backend (slime is always allowed).

@baldersheim: please review
@arnej27959, @gjoranv, @geirst: FYI
