### PR TITLE
Set useDedicatedNodeForLogserver to true, but enable only for dev in CD

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
@@ -6,6 +6,7 @@ import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.model.HostResource;
@@ -98,7 +99,8 @@ public class DomAdminV4Builder extends DomAdminBuilderBase {
         if (deployState.getProperties().useDedicatedNodeForLogserver() &&
                 context.getApplicationType() == ConfigModelContext.ApplicationType.DEFAULT &&
                 deployState.isHosted() &&
-                deployState.zone().system() == SystemName.cd)
+                deployState.zone().system() == SystemName.cd &&
+                deployState.zone().environment() == Environment.dev)
             return NodesSpecification.dedicated(1, context);
         else
             return NodesSpecification.nonDedicated(1, context);

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
-import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsIn.isIn;
 import static org.hamcrest.core.Every.everyItem;
@@ -1758,7 +1757,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.useDedicatedNodeForLogserver(useDedicatedNodeForLogserver);
         tester.addHosts(numberOfHosts);
-        Zone zone = new Zone(SystemName.cd, Environment.prod, RegionName.defaultName());
+        Zone zone = new Zone(SystemName.cd, Environment.dev, RegionName.defaultName());
 
         VespaModel model = tester.createModel(zone, services, true);
         assertThat(model.getRoot().getHostSystem().getHosts().size(), is(numberOfHosts));

--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -68,4 +68,4 @@ sleepTimeWhenRedeployingFails long default=30
 # Feature Flags (poor man's feature flags, to be overridden in configserver-config.xml if needed)
 deleteApplicationLegacy bool default=false
 buildMinimalSetOfConfigModels bool default=true
-useDedicatedNodeForLogserver bool default=false
+useDedicatedNodeForLogserver bool default=true


### PR DESCRIPTION
Failed when enabled for other environments (too few nodes, test assumptions etc.). 