### PR TITLE
Let successful revision finish when in block window

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -455,6 +455,9 @@ public class DeploymentTrigger {
     // ---------- Change management o_O ----------
 
     private boolean acceptNewApplicationVersion(Application application) {
+        if (    ! application.deploymentSpec().canChangeRevisionAt(clock.instant()) // If rolling out revision
+             &&   application.changeAt(clock.instant()).application().isPresent()   // which isn't complete, but in prod
+             && ! application.deploymentJobs().hasFailures()) return false;         // and isn't failing, delay the new submission.
         if (application.change().application().isPresent()) return true; // More application changes are ok.
         if (application.deploymentJobs().hasFailures()) return true; // Allow changes to fix upgrade problems.
         return ! application.changeAt(clock.instant()).platform().isPresent();


### PR DESCRIPTION
@bratseth please review. 

A recent change, to allow revision to complete roll-out, was flawed, because new revisions would be accepted as the new target, stopping the previous revision. 

By storing new revisions as outstanding changes when we are in a revision block window *and* are stil rolling out a previous revision *and* are not failing (in which case it makes sense to immediately allow new revisions, for testing in system and staging tests), this problem is alleviated. 