### PR TITLE
Create separate packages for activator test bundles.

### DIFF
--- a/jdisc_core_test/integration_test/src/test/java/com/yahoo/jdisc/application/BundleActivatorIntegrationTest.java
+++ b/jdisc_core_test/integration_test/src/test/java/com/yahoo/jdisc/application/BundleActivatorIntegrationTest.java
@@ -22,7 +22,7 @@ public class BundleActivatorIntegrationTest {
         OsgiFramework osgi = driver.osgiFramework();
         BundleInstaller installer = new BundleInstaller(driver.osgiFramework());
         Bundle bundle = installer.installAndStart("my-bundle-activator.jar").get(0);
-        Class<?> serviceClass = bundle.loadClass("com.yahoo.jdisc.bundle.MyService");
+        Class<?> serviceClass = bundle.loadClass("com.yahoo.jdisc.bundle.my_act.MyService");
         assertNotNull(serviceClass);
         BundleContext ctx = osgi.bundleContext();
         ServiceReference<?> serviceRef = ctx.getServiceReference(serviceClass.getName());
@@ -37,7 +37,7 @@ public class BundleActivatorIntegrationTest {
     public void requireThatApplicationBundleActivatorHasAccessToCurrentContainer() throws Exception {
         TestDriver driver = TestDriver.newApplicationBundleInstance("app-g-act.jar", false);
         OsgiFramework osgi = driver.osgiFramework();
-        Class<?> serviceClass = osgi.bundles().get(1).loadClass("com.yahoo.jdisc.bundle.MyService");
+        Class<?> serviceClass = osgi.bundles().get(1).loadClass("com.yahoo.jdisc.bundle.g_act.MyService");
         assertNotNull(serviceClass);
         BundleContext ctx = osgi.bundleContext();
         ServiceReference<?> serviceRef = ctx.getServiceReference(serviceClass.getName());

--- a/jdisc_core_test/test_bundles/app-g-act/pom.xml
+++ b/jdisc_core_test/test_bundles/app-g-act/pom.xml
@@ -23,13 +23,13 @@
                 <configuration>
                     <instructions>
                         <X-JDisc-Application>
-                            com.yahoo.jdisc.bundle.ApplicationG
+                            com.yahoo.jdisc.bundle.g_act.ApplicationG
                         </X-JDisc-Application>
                         <Bundle-Activator>
-                            com.yahoo.jdisc.bundle.MyBundleActivator
+                            com.yahoo.jdisc.bundle.g_act.MyBundleActivator
                         </Bundle-Activator>
                         <Export-Package>
-                            com.yahoo.jdisc.bundle
+                            com.yahoo.jdisc.bundle.g_act
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/jdisc_core_test/test_bundles/app-g-act/src/main/java/com/yahoo/jdisc/bundle/g_act/ApplicationG.java
+++ b/jdisc_core_test/test_bundles/app-g-act/src/main/java/com/yahoo/jdisc/bundle/g_act/ApplicationG.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.jdisc.bundle;
+package com.yahoo.jdisc.bundle.g_act;
 
 import com.yahoo.jdisc.application.Application;
 

--- a/jdisc_core_test/test_bundles/app-g-act/src/main/java/com/yahoo/jdisc/bundle/g_act/MyBundleActivator.java
+++ b/jdisc_core_test/test_bundles/app-g-act/src/main/java/com/yahoo/jdisc/bundle/g_act/MyBundleActivator.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.jdisc.bundle;
+package com.yahoo.jdisc.bundle.g_act;
 
 import com.yahoo.jdisc.service.CurrentContainer;
 import org.osgi.framework.BundleActivator;

--- a/jdisc_core_test/test_bundles/app-g-act/src/main/java/com/yahoo/jdisc/bundle/g_act/MyService.java
+++ b/jdisc_core_test/test_bundles/app-g-act/src/main/java/com/yahoo/jdisc/bundle/g_act/MyService.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.jdisc.bundle;
+package com.yahoo.jdisc.bundle.g_act;
 
 import com.yahoo.jdisc.service.AbstractServerProvider;
 import com.yahoo.jdisc.service.CurrentContainer;

--- a/jdisc_core_test/test_bundles/my-bundle-activator/pom.xml
+++ b/jdisc_core_test/test_bundles/my-bundle-activator/pom.xml
@@ -23,10 +23,10 @@
                 <configuration>
                     <instructions>
                         <Bundle-Activator>
-                            com.yahoo.jdisc.bundle.MyBundleActivator
+                            com.yahoo.jdisc.bundle.my_act.MyBundleActivator
                         </Bundle-Activator>
                         <Export-Package>
-                            com.yahoo.jdisc.bundle
+                            com.yahoo.jdisc.bundle.my_act
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/jdisc_core_test/test_bundles/my-bundle-activator/src/main/java/com/yahoo/jdisc/bundle/my_act/MyBundleActivator.java
+++ b/jdisc_core_test/test_bundles/my-bundle-activator/src/main/java/com/yahoo/jdisc/bundle/my_act/MyBundleActivator.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.jdisc.bundle;
+package com.yahoo.jdisc.bundle.my_act;
 
 import com.yahoo.jdisc.service.CurrentContainer;
 import org.osgi.framework.BundleActivator;

--- a/jdisc_core_test/test_bundles/my-bundle-activator/src/main/java/com/yahoo/jdisc/bundle/my_act/MyService.java
+++ b/jdisc_core_test/test_bundles/my-bundle-activator/src/main/java/com/yahoo/jdisc/bundle/my_act/MyService.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.jdisc.bundle;
+package com.yahoo.jdisc.bundle.my_act;
 
 /**
  * @author Simon Thoresen Hult


### PR DESCRIPTION
- When running tests in IntelliJ, classes from the two bundles
  are confused.