### PR TITLE
Reuse Jersey client

### DIFF
--- a/jaxrs_client_utils/src/main/java/com/yahoo/vespa/jaxrs/client/JerseyJaxRsClientFactory.java
+++ b/jaxrs_client_utils/src/main/java/com/yahoo/vespa/jaxrs/client/JerseyJaxRsClientFactory.java
@@ -8,6 +8,7 @@ import org.glassfish.jersey.client.proxy.WebResourceFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.WebTarget;
@@ -16,17 +17,17 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.Collections;
 
 /**
- * @author bakksjo
+ * Factory for creating Jersey clients from a JAX-RS resource interface.
+ *
+ * @author Oyvind Bakksjo
  */
 public class JerseyJaxRsClientFactory implements JaxRsClientFactory {
+
     private static final int DEFAULT_CONNECT_TIMEOUT_MS = 30000;
     private static final int DEFAULT_READ_TIMEOUT_MS = 30000;
 
-    private final int connectTimeoutMs;
-    private final int readTimeoutMs;
-    private final SSLContext sslContext;
-    private final String userAgent;
-    private final HostnameVerifier hostnameVerifier;
+    // Client is a heavy-weight object with a finalizer so we create only one and re-use it
+    private final Client client;
 
     public JerseyJaxRsClientFactory() {
         this(DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
@@ -36,33 +37,23 @@ public class JerseyJaxRsClientFactory implements JaxRsClientFactory {
         this(DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS, sslContext, hostnameVerifier, userAgent);
     }
 
-    public JerseyJaxRsClientFactory(final int connectTimeoutMs, final int readTimeoutMs) {
+    public JerseyJaxRsClientFactory(int connectTimeoutMs, int readTimeoutMs) {
         this(connectTimeoutMs, readTimeoutMs, null, null, null);
     }
 
     public JerseyJaxRsClientFactory(int connectTimeoutMs, int readTimeoutMs, SSLContext sslContext,
                                     HostnameVerifier hostnameVerifier, String userAgent) {
-        this.connectTimeoutMs = connectTimeoutMs;
-        this.readTimeoutMs = readTimeoutMs;
-        this.sslContext = sslContext;
-        this.hostnameVerifier = hostnameVerifier;
-        this.userAgent = userAgent;
-    }
-
-    /**
-     * Contains some workarounds for HTTP/JAX-RS/Jersey issues. See:
-     *   https://jersey.java.net/apidocs/latest/jersey/org/glassfish/jersey/client/ClientProperties.html#SUPPRESS_HTTP_COMPLIANCE_VALIDATION
-     *   https://jersey.java.net/apidocs/latest/jersey/org/glassfish/jersey/client/HttpUrlConnectorProvider.html#SET_METHOD_WORKAROUND
-     */
-    @Override
-    public <T> T createClient(final Class<T> apiClass, final HostName hostName, final int port, final String pathPrefix, String scheme) {
-        final UriBuilder uriBuilder = UriBuilder.fromPath(pathPrefix).host(hostName.s()).port(port).scheme(scheme);
+        /*
+         * Configure client with some workarounds for HTTP/JAX-RS/Jersey issues. See:
+         *   https://jersey.java.net/apidocs/latest/jersey/org/glassfish/jersey/client/ClientProperties.html#SUPPRESS_HTTP_COMPLIANCE_VALIDATION
+         *   https://jersey.java.net/apidocs/latest/jersey/org/glassfish/jersey/client/HttpUrlConnectorProvider.html#SET_METHOD_WORKAROUND
+         */
         ClientBuilder builder = ClientBuilder.newBuilder()
-                .property(ClientProperties.CONNECT_TIMEOUT, connectTimeoutMs)
-                .property(ClientProperties.READ_TIMEOUT, readTimeoutMs)
-                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // Allow empty PUT. TODO: Fix API.
-                .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true) // Allow e.g. PATCH method.
-                .property(ClientProperties.FOLLOW_REDIRECTS, true);
+                                             .property(ClientProperties.CONNECT_TIMEOUT, connectTimeoutMs)
+                                             .property(ClientProperties.READ_TIMEOUT, readTimeoutMs)
+                                             .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // Allow empty PUT. TODO: Fix API.
+                                             .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true) // Allow e.g. PATCH method.
+                                             .property(ClientProperties.FOLLOW_REDIRECTS, true);
         if (sslContext != null) {
             builder.sslContext(sslContext);
         }
@@ -70,11 +61,16 @@ public class JerseyJaxRsClientFactory implements JaxRsClientFactory {
             builder.hostnameVerifier(hostnameVerifier);
         }
         if (userAgent != null) {
-            builder.register((ClientRequestFilter) context ->
-                    context.getHeaders().put(HttpHeaders.USER_AGENT, Collections.singletonList(userAgent)));
+            builder.register((ClientRequestFilter) context -> context.getHeaders().put(HttpHeaders.USER_AGENT, Collections.singletonList(userAgent)));
         }
-        final WebTarget target = builder.build().target(uriBuilder);
-        // TODO: Check if this fills up non-heap memory with loaded classes.
+        this.client = builder.build();
+    }
+
+    @Override
+    public <T> T createClient(Class<T> apiClass, HostName hostName, int port, String pathPrefix, String scheme) {
+        UriBuilder uriBuilder = UriBuilder.fromPath(pathPrefix).host(hostName.s()).port(port).scheme(scheme);
+        WebTarget target = client.target(uriBuilder);
         return WebResourceFactory.newResource(apiClass, target);
     }
+
 }


### PR DESCRIPTION
This should avoid creating an excessive amount of
`org.glassfish.jersey.client.ClientRuntime` instances and thus finalizers.
Reusing the client should be safe (it's the expected pattern?) and matches what
we do in our internal code.

The old pattern may have contributed to the high full GC frequency we see on CD
controllers, as the object graph of `org.glassfish.jersey.client.ClientRuntime`
is quite large.

FYI @jobergum