### PR TITLE
Use a more robust method for retrieving system packages.

### DIFF
--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -232,6 +232,7 @@
                         <configuration>
                             <mainClass>com.yahoo.jdisc.core.ExportPackages</mainClass>
                             <classpathScope>test</classpathScope>
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
                             <arguments>
                                 <argument>${exportPackagesFile}</argument>
                                 <argument>${project.build.directory}/dependency/commons-daemon.jar</argument>

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/core/FelixParamsTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/core/FelixParamsTestCase.java
@@ -29,17 +29,19 @@ public class FelixParamsTestCase {
 
     @Test
     public void requireThatSystemPackagesAreNotReplaced() {
+        String systemPackages = ExportPackages.getSystemPackages();
+
         FelixParams params = new FelixParams();
         Map<String, String> config = params.toConfig();
         assertNotNull(config);
         String str = config.get(Constants.FRAMEWORK_SYSTEMPACKAGES);
         assertNotNull(str);
-        assertTrue(str.contains(ExportPackages.getSystemPackages()));
+        assertTrue(str.contains(systemPackages));
 
         params.exportPackage("foo");
         assertNotNull(config = params.toConfig());
         assertNotNull(str = config.get(Constants.FRAMEWORK_SYSTEMPACKAGES));
-        assertTrue(str.contains(ExportPackages.getSystemPackages()));
+        assertTrue(str.contains(systemPackages));
         assertTrue(str.contains("foo"));
     }
 


### PR DESCRIPTION
- Start the framework and retrieve properties from the system
  bundle.
- The static 'org.osgi.framework.system.packages' property only
  returns org.osgi packages on Felix 6, and was based on a static
  list in felix/framework/src/main/resources/default (not good).