### PR TITLE
NodeAdmin: Only start services if stopped

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -89,7 +89,7 @@ public class NodeAgentImpl implements NodeAgent {
     private Optional<Future<?>> currentFilebeatRestarter = Optional.empty();
 
     private boolean hasResumedNode = false;
-    private boolean hasStartedServices = false;
+    private boolean hasStartedServices = true;
 
     /**
      * ABSENT means container is definitely absent - A container that was absent will not suddenly appear without

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -131,7 +131,7 @@ public class NodeAgentImplTest {
 
         final InOrder inOrder = inOrder(dockerOperations, orchestrator, nodeRepository);
         // TODO: Verify this isn't run unless 1st time
-        inOrder.verify(dockerOperations, times(1)).startServices(eq(containerName));
+        inOrder.verify(dockerOperations, never()).startServices(eq(containerName));
         inOrder.verify(dockerOperations, times(1)).resumeNode(eq(containerName));
         inOrder.verify(orchestrator).resume(hostName);
     }
@@ -176,7 +176,7 @@ public class NodeAgentImplTest {
         when(storageMaintainer.getDiskUsageFor(eq(containerName))).thenReturn(Optional.of(187500000000L));
 
         nodeAgent.converge();
-        inOrder.verify(dockerOperations, times(1)).startServices(eq(containerName));
+        inOrder.verify(dockerOperations, never()).startServices(eq(containerName));
         inOrder.verify(dockerOperations, times(1)).resumeNode(eq(containerName));
 
         nodeAgent.suspend();


### PR DESCRIPTION
This change will make it so that when node-admin comes up, any existing container will be assumed to have services started. Start will therefore only be called if this specific instance of node-admin has stopped services.