### PR TITLE
Stop emitting proton config for search io tuning.  Files are memory mapped.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
@@ -153,9 +153,6 @@ public class Tuning extends AbstractConfigProducer implements PartitionsConfig.P
                     if (read != null) {
                         builder.indexing.read.io(ProtonConfig.Indexing.Read.Io.Enum.valueOf(read.name));
                     }
-                    if (search != null) {
-                        builder.search.io(ProtonConfig.Search.Io.Enum.valueOf(search.name));
-                    }
                 }
 
             }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilderTest.java
@@ -152,7 +152,6 @@ public class DomSearchTuningBuilderTest extends DomBuilderTest {
         String cfg = getProtonCfg(t);
         assertThat(cfg, containsString("indexing.write.io DIRECTIO"));
         assertThat(cfg, containsString("indexing.read.io NORMAL"));
-        assertThat(cfg, containsString("search.io MMAP"));
     }
 
     @Test


### PR DESCRIPTION
@geirst: please review
