### PR TITLE
Allow component construction to take a long time

### DIFF
--- a/container-di/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-di/src/main/java/com/yahoo/container/di/Container.java
@@ -117,7 +117,7 @@ public class Container {
     }
 
     private void invalidateGeneration(long generation, Throwable cause) {
-        Duration maxWaitToExit = Duration.ofSeconds(60);
+        Duration maxWaitToExit = Duration.ofDays(1);
         leastGeneration = Math.max(configurer.getComponentsGeneration(), configurer.getBootstrapGeneration()) + 1;
         if (!(cause instanceof InterruptedException) && !(cause instanceof ConfigInterruptedException)) {
             log.log(Level.WARNING, newGraphErrorMessage(generation, cause, maxWaitToExit), cause);


### PR DESCRIPTION
Most components should be read only and eagerly set up to achieve
low latency. Therefore we should allow construction to take a long
time.

@gjoranv please review