### PR TITLE
HW verification of IP

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.dockerapi.metrics.Dimensions;
 import com.yahoo.vespa.hosted.dockerapi.metrics.GaugeWrapper;
 import com.yahoo.vespa.hosted.dockerapi.metrics.MetricReceiverWrapper;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
+import com.yahoo.vespa.hosted.node.admin.docker.DockerNetworking;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.logging.FilebeatConfigProvider;
 import com.yahoo.vespa.hosted.node.admin.component.Environment;
@@ -423,6 +424,10 @@ public class StorageMaintainer {
                 "--is_ssd", Boolean.toString(node.isFastDisk()),
                 "--bandwidth", Double.toString(node.getBandwidth()),
                 "--ips", String.join(",", node.getIpAddresses())));
+
+        if (environment.getDockerNetworking() == DockerNetworking.HOST_NETWORK) {
+            arguments.add("--skip-reverse-lookup");
+        }
 
         node.getHardwareDivergence().ifPresent(hardwareDivergence -> {
             arguments.add("--divergence");

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterImpl.java
@@ -137,6 +137,7 @@ public class NodeAdminStateUpdaterImpl implements NodeAdminStateUpdater {
             // Only update hardware divergence if there is a change.
             if (!node.getHardwareDivergence().orElse("null").equals(hardwareDivergence)) {
                 NodeAttributes nodeAttributes = new NodeAttributes().withHardwareDivergence(hardwareDivergence);
+                log.info("Updating hardware divergence to " + hardwareDivergence);
                 nodeRepository.updateNodeAttributes(dockerHostHostName, nodeAttributes);
             }
         } catch (RuntimeException e) {

--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/verification/spec/SpecVerifier.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/verification/spec/SpecVerifier.java
@@ -45,6 +45,9 @@ public class SpecVerifier extends Main.VerifierCommand {
     @Option(name = {"-i", "--ips"}, description = "Comma separated list of IP addresses assigned to this node")
     private String ipAddresses;
 
+    @Option(name = {"-S", "--skip-reverse-lookup"}, required = false, description = "Skip verification of reverse lookup of IP addresses")
+    private boolean skipReverseLookup = false;
+
     @Override
     public void run(HardwareDivergenceReport hardwareDivergenceReport, CommandExecutor commandExecutor) {
         String[] ips = Optional.ofNullable(ipAddresses)
@@ -61,12 +64,12 @@ public class SpecVerifier extends Main.VerifierCommand {
     private SpecVerificationReport verifySpec(NodeSpec nodeSpec, CommandExecutor commandExecutor) {
         VerifierSettings verifierSettings = new VerifierSettings(false);
         HardwareInfo actualHardware = HardwareInfoRetriever.retrieve(commandExecutor, verifierSettings);
-        return makeVerificationReport(actualHardware, nodeSpec);
+        return makeVerificationReport(actualHardware, nodeSpec, skipReverseLookup);
     }
 
-    private static SpecVerificationReport makeVerificationReport(HardwareInfo actualHardware, NodeSpec nodeSpec) {
+    private static SpecVerificationReport makeVerificationReport(HardwareInfo actualHardware, NodeSpec nodeSpec, boolean skipReverseLookup) {
         SpecVerificationReport specVerificationReport = HardwareNodeComparator.compare(NodeJsonConverter.convertJsonModelToHardwareInfo(nodeSpec), actualHardware);
-        IPAddressVerifier ipAddressVerifier = new IPAddressVerifier(Defaults.getDefaults().vespaHostname());
+        IPAddressVerifier ipAddressVerifier = new IPAddressVerifier(Defaults.getDefaults().vespaHostname(), skipReverseLookup);
         ipAddressVerifier.reportFaultyIpAddresses(nodeSpec, specVerificationReport);
         return specVerificationReport;
     }

--- a/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/verification/commons/noderepo/IPAddressVerifierTest.java
+++ b/node-maintainer/src/test/java/com/yahoo/vespa/hosted/node/verification/commons/noderepo/IPAddressVerifierTest.java
@@ -4,9 +4,14 @@ package com.yahoo.vespa.hosted.node.verification.commons.noderepo;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -20,7 +25,7 @@ public class IPAddressVerifierTest {
     private final NodeSpec nodeSpec = new NodeSpec(1920, 256, 48, true, 10_000, new String[]{ipv4Address, ipv6Address});
     private final String hostname = "test123.region.domain.tld";
 
-    private IPAddressVerifier ipAddressVerifier = spy(new IPAddressVerifier(hostname));
+    private IPAddressVerifier ipAddressVerifier = spy(new IPAddressVerifier(hostname, false));
     private String ipv4LookupFormat;
     private String ipv6LookupFormat;
 
@@ -31,8 +36,43 @@ public class IPAddressVerifierTest {
     }
 
     @Test
+    public void getFaultyIpAddresses_with_hostname_resolving_to_other_ips() throws Exception {
+        doReturn(Arrays.asList(InetAddress.getByName("1.2.3.4"), InetAddress.getByName("fd00::1"))).when(ipAddressVerifier).mockableGetAllByName(hostname);
+        String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
+        String[] expectedFaultyIpAddresses = new String[]{ipv4Address, ipv6Address};
+        assertArrayEquals(expectedFaultyIpAddresses, faultyIpAddresses);
+    }
+
+    @Test
+    public void getFaultyIpAddresses_with_hostname_not_resolving_to_ipv4_address() throws Exception {
+        doReturn(Arrays.asList(InetAddress.getByName(ipv6Address))).when(ipAddressVerifier).mockableGetAllByName(hostname);
+        doReturn(hostname).when(ipAddressVerifier).reverseLookUp(ipv6LookupFormat);
+        String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
+        String[] expectedFaultyIpAddresses = new String[]{ipv4Address};
+        assertArrayEquals(expectedFaultyIpAddresses, faultyIpAddresses);
+    }
+
+    @Test
+    public void getFaultyIpAddresses_with_failing_hostname_resolution() throws Exception {
+        doThrow(new UnknownHostException("bad hostname")).when(ipAddressVerifier).mockableGetAllByName(hostname);
+        String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
+        String[] expectedFaultyIpAddresses = new String[]{ipv4Address, ipv6Address};
+        assertArrayEquals(expectedFaultyIpAddresses, faultyIpAddresses);
+    }
+
+    @Test
+    public void getFaultyIpAddresses_with_hostname_not_resolving_to_ipv6_address() throws Exception {
+        doReturn(Arrays.asList(InetAddress.getByName(ipv4Address))).when(ipAddressVerifier).mockableGetAllByName(hostname);
+        doReturn(hostname).when(ipAddressVerifier).reverseLookUp(ipv4LookupFormat);
+        String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
+        String[] expectedFaultyIpAddresses = new String[]{ipv6Address};
+        assertArrayEquals(expectedFaultyIpAddresses, faultyIpAddresses);
+    }
+
+    @Test
     public void getFaultyIpAddresses_should_return_IP_address_when_different_hostname() throws Exception {
         String wrongHostName = "www.yahoo.com";
+        doReturn(Arrays.asList(InetAddress.getByName(ipv4Address), InetAddress.getByName(ipv6Address))).when(ipAddressVerifier).mockableGetAllByName(hostname);
         doReturn(hostname).when(ipAddressVerifier).reverseLookUp(ipv4LookupFormat);
         doReturn(wrongHostName).when(ipAddressVerifier).reverseLookUp(ipv6LookupFormat);
         String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
@@ -42,8 +82,18 @@ public class IPAddressVerifierTest {
 
     @Test
     public void getFaultyIpAddresses_should_return_empty_array_when_all_addresses_point_to_correct_hostname() throws Exception {
+        doReturn(Arrays.asList(InetAddress.getByName(ipv4Address), InetAddress.getByName(ipv6Address))).when(ipAddressVerifier).mockableGetAllByName(hostname);
         doReturn(hostname).when(ipAddressVerifier).reverseLookUp(ipv4LookupFormat);
         doReturn(hostname).when(ipAddressVerifier).reverseLookUp(ipv6LookupFormat);
+        String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
+        String[] expectedFaultyIpAddresses = new String[]{};
+        assertArrayEquals(expectedFaultyIpAddresses, faultyIpAddresses);
+    }
+
+    @Test
+    public void getFaultyIpAddresses_should_return_empty_array_when_reverse_lookup_is_skipped() throws Exception {
+        ipAddressVerifier = spy(new IPAddressVerifier(hostname, true));
+        doReturn(Arrays.asList(InetAddress.getByName(ipv4Address), InetAddress.getByName(ipv6Address))).when(ipAddressVerifier).mockableGetAllByName(hostname);
         String[] faultyIpAddresses = ipAddressVerifier.getFaultyIpAddresses(nodeSpec);
         String[] expectedFaultyIpAddresses = new String[]{};
         assertArrayEquals(expectedFaultyIpAddresses, faultyIpAddresses);


### PR DESCRIPTION
Hosts with HOST_NETWORK fails hardware divergence check of IP addresses because
the reverse lookup returns the node hostname (this is the whole point of the
host network - the container requires reverse lookup to pass, but not the
host). For HOST_NETWORK we'll disable this check.

We may want to add verification of reverse lookup of container IP addresses
later.

To compensate, forward resolution (hostname -> IP addresses) has been added.