### PR TITLE
Throw exception when ConfigFetcher::start() fails to get initial config.

### DIFF
--- a/config/src/vespa/config/helper/configfetcher.cpp
+++ b/config/src/vespa/config/helper/configfetcher.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "configfetcher.h"
+#include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/util/thread.h>
 #include <vespa/log/log.h>
 LOG_SETUP(".config.helper.configfetcher");
@@ -34,6 +35,9 @@ ConfigFetcher::start()
     if (!_closed) {
         LOG(debug, "Polling for config");
         _poller.poll();
+        if (_poller.getGeneration() == -1) {
+            throw ConfigTimeoutException("ConfigFetcher::start timed out getting initial config");
+        }
         LOG(debug, "Starting fetcher thread...");
         _thread->start();
         _started = true;


### PR DESCRIPTION
@baldersheim: please review
@geirst: FYI
