### PR TITLE
Skip running HW divg in parked

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterImpl.java
@@ -132,6 +132,7 @@ public class NodeAdminStateUpdaterImpl implements NodeAdminStateUpdater {
 
         try {
             NodeSpec node = nodeRepository.getNode(dockerHostHostName);
+            if (node.getState() == Node.State.parked) return;
             String hardwareDivergence = maintainer.getHardwareDivergence(node);
 
             // Only update hardware divergence if there is a change.


### PR DESCRIPTION
The fix itself is easy, but in this case there is something wrong with DNS DB as the PTR record is missing.