### PR TITLE
Add passthrough mode to AthenzPrincipalFilter

### DIFF
--- a/jdisc-security-filters/src/main/resources/configdefinitions/athenz-principal-filter.def
+++ b/jdisc-security-filters/src/main/resources/configdefinitions/athenz-principal-filter.def
@@ -6,3 +6,6 @@ principalHeaderName             string  default="Athenz-Principal-Auth"
 
 # Path to athenz.conf file
 athenzConfFile                  string
+
+# Pass-through mode
+passthroughMode                 bool    default=false


### PR DESCRIPTION
- No http response when passthrough mode is enable
- Introduce attributes for error code and message
- Introduce attribute for AthenzPrincipal instance