### PR TITLE
Let CreateIterator inherit priority of parent visitor

### DIFF
--- a/storage/src/tests/visiting/visitortest.cpp
+++ b/storage/src/tests/visiting/visitortest.cpp
@@ -119,6 +119,8 @@ public:
         }
     };
 
+    constexpr static api::StorageMessage::Priority DefaultPriority = 123;
+
     std::shared_ptr<api::CreateVisitorCommand> makeCreateVisitor(
             const VisitorOptions& options = VisitorOptions());
     void tearDown() override;
@@ -495,6 +497,7 @@ VisitorTest::makeCreateVisitor(const VisitorOptions& options)
     cmd->setAddress(address);
     cmd->setMaximumPendingReplyCount(UINT32_MAX);
     cmd->setControlDestination("foo/bar");
+    cmd->setPriority(DefaultPriority);
     return cmd;
 }
 
@@ -519,7 +522,8 @@ VisitorTest::testNormalUsage()
 
     CreateIteratorCommand::SP createCmd(
             fetchSingleCommand<CreateIteratorCommand>(*_bottom));
-    CPPUNIT_ASSERT_EQUAL(uint8_t(0), createCmd->getPriority()); // Highest pri
+    CPPUNIT_ASSERT_EQUAL(static_cast<int>(DefaultPriority),
+                         static_cast<int>(createCmd->getPriority())); // Inherit pri
     spi::IteratorId id(1234);
     api::StorageReply::SP reply(
             new CreateIteratorReply(*createCmd, id));

--- a/storage/src/vespa/storage/visiting/visitor.cpp
+++ b/storage/src/vespa/storage/visiting/visitor.cpp
@@ -1257,7 +1257,7 @@ Visitor::getIterators()
 
         cmd->setLoadType(_initiatingCmd->getLoadType());
         cmd->getTrace().setLevel(_traceLevel);
-        cmd->setPriority(0);
+        cmd->setPriority(_initiatingCmd->getPriority());
         cmd->setReadConsistency(getRequiredReadConsistency());
         _bucketStates.push_back(newBucketState.release());
         _messageHandler->send(cmd, *this);


### PR DESCRIPTION
@baldersheim please review

Since `CreateIterator` now does more than just in-memory metadata work (i.e. it
may hit the disk), it should not be given a fixed, very high priority.