### PR TITLE
Change handling of populating document from multivalue attribute

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_retriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_retriever.cpp
@@ -55,7 +55,8 @@ setValue(DocumentIdT lid,
         AttributeContent<T> content;
         content.fill(attr, lid);
         Field f = doc.getField(fieldName);
-        if (!doc.getValue(f) && content.size() == 0) {
+        if (content.size() == 0) {
+            doc.remove(f);
             break;
         }
         FieldValue::UP fv = f.getDataType().createFieldValue();
@@ -75,7 +76,8 @@ setValue(DocumentIdT lid,
         AttributeContent<WeightedType<T> > content;
         content.fill(attr, lid);
         Field f = doc.getField(fieldName);
-        if (!doc.getValue(f) && content.size() == 0) {
+        if (content.size() == 0) {
+            doc.remove(f);
             break;
         }
         FieldValue::UP fv = f.getDataType().createFieldValue();


### PR DESCRIPTION
with zero values for the document.

Old behavior:
The field was set to an empty array/set if it was present in the document.

New behavior:
The field is removed from the document.

@baldersheim: please review
@geirst, @jobergum, @bratseth: FYI
