### PR TITLE
Support cross-document type visiting via /document/v1/ root

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandler.java
@@ -29,6 +29,7 @@ public interface OperationHandler {
         public final Optional<Integer> wantedDocumentCount;
         public final Optional<String> fieldSet;
         public final Optional<Integer> concurrency;
+        public final Optional<String> bucketSpace;
 
         /** @deprecated Use a VisitOptions.Builder instead */
         @Deprecated
@@ -38,6 +39,7 @@ public interface OperationHandler {
             this.wantedDocumentCount = wantedDocumentCount;
             this.fieldSet = Optional.empty();
             this.concurrency = Optional.empty();
+            this.bucketSpace = Optional.empty();
         }
 
         private VisitOptions(Builder builder) {
@@ -46,6 +48,7 @@ public interface OperationHandler {
             this.wantedDocumentCount = Optional.ofNullable(builder.wantedDocumentCount);
             this.fieldSet = Optional.ofNullable(builder.fieldSet);
             this.concurrency = Optional.ofNullable(builder.concurrency);
+            this.bucketSpace = Optional.ofNullable(builder.bucketSpace);
         }
 
         public static class Builder {
@@ -54,6 +57,7 @@ public interface OperationHandler {
             Integer wantedDocumentCount;
             String fieldSet;
             Integer concurrency;
+            String bucketSpace;
 
             public Builder cluster(String cluster) {
                 this.cluster = cluster;
@@ -77,6 +81,11 @@ public interface OperationHandler {
 
             public Builder concurrency(Integer concurrency) {
                 this.concurrency = concurrency;
+                return this;
+            }
+
+            public Builder bucketSpace(String bucketSpace) {
+                this.bucketSpace = bucketSpace;
                 return this;
             }
 

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
@@ -24,7 +24,9 @@ public class MockedOperationHandler implements OperationHandler {
                 + documentSelection + "'"
                 + options.wantedDocumentCount.map(n -> String.format(", min docs returned: %d", n)).orElse("")
                 + options.fieldSet.map(s -> String.format(", field set: '%s'", s)).orElse("")
-                + options.concurrency.map(n -> String.format(", concurrency: %d", n)).orElse(""));
+                + options.concurrency.map(n -> String.format(", concurrency: %d", n)).orElse("")
+                + options.bucketSpace.map(s -> String.format(", bucket space: '%s'", s)).orElse("")
+                + options.cluster.map(s -> String.format(", cluster: '%s'", s)).orElse(""));
     }
 
     @Override


### PR DESCRIPTION
@freva please review 🦄
@bratseth @jonmv FYI, this plugs an API hole, although with some caveats (fieldset)

Requires `cluster` to be set since we don't have a document type to
auto-infer the target cluster from. Can use `bucketSpace` parameter
to explicitly state the target bucket space to visit (if not given,
implicitly visits the 'default' space).

Note: since we are not bound to a single document type, the field set
used is `[all]`, not `doctype:[document]`. This means that this does
_not_ have parity with non-root Document V1 visitor requests, though
it _does_ have parity with legacy `/visit` and `vespa-visit`. To
have same behavior for a single document type, use an explicit document
`selection=mydoctype` parameter combined with a `fieldSet` parameter
of `mydoctype:[document]`.

Don't want to publicly document this before we've done some in-house testing
to ensure it gives us desired API parity, as well as adding system tests for it.

This fixes #5794