### PR TITLE
Upgrade guava to 20.

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -463,7 +463,7 @@
         <bouncycastle.version>1.58</bouncycastle.version>
         <felix.version>6.0.1</felix.version>
         <findbugs.version>1.3.9</findbugs.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>20.0</guava.version>
         <guice.version>3.0</guice.version>
         <jaxb.version>2.3.0</jaxb.version>
         <jetty.version>9.4.12.v20180830</jetty.version>


### PR DESCRIPTION
- guava 21.0 removes apis used by curator/zookeeper (and hadoop).
  We could embed the older version in zkfacade bundle, but
  it requires more pom maintenance. Also, upgrading beyond 23 will
  require changes in OsgiUtil, causing a non-resolvable conflict
  in orchestrator unit tests which will then require old and new
  guava at the same time. (This can probably be solved by moving
  application based unit tests to container-integration-test.)