### PR TITLE
Inline init method.

### DIFF
--- a/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
+++ b/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
@@ -106,10 +106,6 @@ public class LogFileHandler extends StreamHandler {
     {
         super();
         this.compressOnRotation = compressOnRotation;
-        init();
-    }
-    
-    private void init() {
         logThread = new LogThread(this);
         logThread.start();
     }


### PR DESCRIPTION
- Failed on assignment to final field.

@geirst Probably a bug introduced in our last rebase.