### PR TITLE
Java dispatch fixes for coverage and query profiles

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
@@ -43,7 +43,7 @@ public class FS4InvokerFactory {
     }
 
     public SearchInvoker getSearchInvoker(Query query, SearchCluster.Node node) {
-        return new FS4SearchInvoker(searcher, query, fs4ResourcePool, node.hostname(), node.fs4port(), node.key());
+        return new FS4SearchInvoker(searcher, query, fs4ResourcePool, node);
     }
 
     public Optional<SearchInvoker> getSearchInvoker(Query query, List<SearchCluster.Node> nodes) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
@@ -155,7 +155,7 @@ public class SearchCluster implements NodeManager<SearchCluster.Node> {
 
     /** Returns the n'th (zero-indexed) group in the cluster if possible */
     public Optional<Group> group(int n) {
-        if (orderedGroups.size() < n) {
+        if (orderedGroups.size() > n) {
             return Optional.of(orderedGroups.get(n));
         } else {
             return Optional.empty();

--- a/container-search/src/main/java/com/yahoo/search/result/Coverage.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Coverage.java
@@ -46,4 +46,16 @@ public class Coverage extends com.yahoo.container.handler.Coverage {
 
     public Coverage setNodesTried(int nodesTried) { super.setNodesTried(nodesTried); return this; }
 
+    public void mergeWithPartition(Coverage other) {
+        if (other == null) {
+            return;
+        }
+        int newResultSets = Integer.max(this.resultSets, other.resultSets);
+        int newFullResultSets = Integer.min(this.fullResultSets, other.fullResultSets);
+
+        merge(other);
+
+        this.resultSets = newResultSets;
+        this.fullResultSets = newFullResultSets;
+    }
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -80,27 +80,6 @@ public class LoadBalancerTest {
     }
 
     @Test
-    public void requreThatLoadBalancerReturnsSameGroupForSameQuery() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 1, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
-
-        Query q = new Query();
-        // get first group
-        Optional<Group> grp = lb.takeGroupForQuery(q);
-        Group group = grp.get();
-        int id1 = group.id();
-        // release allocation
-        lb.releaseGroup(group);
-
-        // continue with same query
-        grp = lb.takeGroupForQuery(q);
-        group = grp.get();
-        assertThat(group.id(), equalTo(id1));
-    }
-
-    @Test
     public void requreThatLoadBalancerReturnsGroupWithShortestQueue() {
         Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
         Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);


### PR DESCRIPTION
- More precise reporting of query coverage in incomplete situations
- LoadBalancer group affinity removed; it conflicts with query profiles and didn't really bring much to the table
- LoadBalancer now prefers partial coverage over no coverage at all
- Comparison direction in SearchCluster corrected, oops.