### PR TITLE
Prevent XXE attacks

### DIFF
--- a/libmlr/pom.xml
+++ b/libmlr/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <version>1.0.0-SNAPSHOT</version>
   <name>xml2cpp</name>
-  <description>Fork of xml2cppConverver with support for SS3 models.</description>
+  <description>Fork of xml2cppConverter with support for SS3 models.</description>
   <dependencies>
   </dependencies>
   <build>

--- a/libmlr/src/main/java/com/yahoo/yst/libmlr/converter/parser/MlrXmlParser.java
+++ b/libmlr/src/main/java/com/yahoo/yst/libmlr/converter/parser/MlrXmlParser.java
@@ -17,7 +17,6 @@ import java.util.logging.Logger;
  * Parses Treenet output V5 into Abstract Treenet XML File format.
  *
  * @author allenwei
- *
  */
 public class MlrXmlParser {
 
@@ -30,16 +29,21 @@ public class MlrXmlParser {
     private HashSet<String> respIdSet = new HashSet<String>(10000);
 
     public MlrFunction parseXmlFile(String fileName) throws DecisionTreeXmlException {
-
         File file = new File(fileName);
-        if (!file.exists()) {
+        if ( ! file.exists()) {
             String errMsg = fileName + " does not exist.";
             logErrors(errMsg);
             throw new DecisionTreeXmlException(errMsg);
         }
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder docBuilder = null;
+        try { // XXE prevention
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        }
+        catch (ParserConfigurationException e) {
+            throw new IllegalStateException("Could not disallow-doctype-decl", e);
+        }
+        DocumentBuilder docBuilder;
 
         try {
             docBuilder = dbf.newDocumentBuilder();


### PR DESCRIPTION
@lesters this is to avoid a potential attack

Separate from this OPR: This module has a nonstandard pom file. Do we need this module any more given that we have XGBoost support? If we do, I suggest we move this into searchlib.