### PR TITLE
NodeAdmin: Fix Yamas check permissions

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -41,6 +42,7 @@ import java.util.stream.Stream;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.nameMatches;
 import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.olderThan;
+import static com.yahoo.vespa.hosted.node.admin.task.util.file.IOExceptionUtil.ifExists;
 import static com.yahoo.vespa.hosted.node.admin.task.util.file.IOExceptionUtil.uncheck;
 
 /**
@@ -137,6 +139,10 @@ public class StorageMaintainer {
 
         // Write config and restart yamas-agent
         Path yamasAgentFolder = context.pathOnHostFromPathInNode("/etc/yamas-agent");
+
+        // TODO: Remove after 6.301
+        ifExists(() -> Files.setPosixFilePermissions(yamasAgentFolder, PosixFilePermissions.fromString("rw-r--r--")));
+
         configs.forEach(s -> uncheck(() -> s.writeTo(yamasAgentFolder)));
         dockerOperations.executeCommandInContainerAsRoot(context, "service", "yamas-agent", "restart");
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/SecretAgentCheckConfig.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/util/SecretAgentCheckConfig.java
@@ -7,6 +7,7 @@ import com.yahoo.vespa.hosted.node.admin.task.util.file.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -49,6 +50,9 @@ public class SecretAgentCheckConfig {
         Files.createDirectories(yamasAgentDirectory);
         Path scheduleFilePath = yamasAgentDirectory.resolve(id + ".yaml");
         Files.write(scheduleFilePath, render().getBytes());
+
+        // TODO: Remove after 6.301
+        Files.setPosixFilePermissions(scheduleFilePath, PosixFilePermissions.fromString("rw-r--r--"));
     }
 
     public FileWriter getFileWriterTo(Path destinationPath) {


### PR DESCRIPTION
The core issue fixed in #7295, this PR serves to fix permission on checks created on previous versions.