### PR TITLE
Make AthenzCredentialsMaintainer shared

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/ConfigServerInfo.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/ConfigServerInfo.java
@@ -24,14 +24,18 @@ public class ConfigServerInfo {
     private final Map<String, URI> configServerURIs;
     private final AthenzService configServerIdentity;
 
+    // TODO: Remove
     public ConfigServerInfo(ConfigServerConfig config) {
-        this.configServerHostNames = config.hosts();
-        this.configServerURIs = createConfigServerUris(
-                config.scheme(),
-                config.hosts(),
-                config.port());
-        this.loadBalancerEndpoint = createLoadBalancerEndpoint(config.loadBalancerHost(), config.scheme(), config.port());
-        this.configServerIdentity = (AthenzService) AthenzIdentities.from(config.configserverAthenzIdentity());
+        this(config.loadBalancerHost(), config.hosts(), config.scheme(), config.port(),
+                (AthenzService) AthenzIdentities.from(config.configserverAthenzIdentity()));
+    }
+
+    public ConfigServerInfo(String loadBalancerHostName, List<String> configServerHostNames,
+                            String scheme, int port, AthenzService configServerAthenzIdentity) {
+        this.configServerHostNames = configServerHostNames;
+        this.configServerURIs = createConfigServerUris(scheme, configServerHostNames, port);
+        this.loadBalancerEndpoint = createLoadBalancerEndpoint(loadBalancerHostName, scheme, port);
+        this.configServerIdentity = configServerAthenzIdentity;
     }
 
     private static URI createLoadBalancerEndpoint(String loadBalancerHost, String scheme, int port) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/Environment.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/component/Environment.java
@@ -41,7 +41,7 @@ public class Environment {
     private final Path trustStorePath;
     private final DockerNetworking dockerNetworking;
 
-    private Environment(ConfigServerConfig configServerConfig,
+    private Environment(ConfigServerInfo configServerInfo,
                         Path trustStorePath,
                         String environment,
                         String region,
@@ -58,9 +58,7 @@ public class Environment {
                         AthenzService nodeAthenzIdentity,
                         boolean nodeAgentCertEnabled,
                         DockerNetworking dockerNetworking) {
-        Objects.requireNonNull(configServerConfig, "configServerConfig cannot be null");
-
-        this.configServerInfo = new ConfigServerInfo(configServerConfig);
+        this.configServerInfo = Objects.requireNonNull(configServerInfo, "configServerConfig cannot be null");
         this.environment = Objects.requireNonNull(environment, "environment cannot be null");;
         this.region = Objects.requireNonNull(region, "region cannot be null");;
         this.system = Objects.requireNonNull(system, "system cannot be null");;
@@ -189,7 +187,7 @@ public class Environment {
     }
 
     public static class Builder {
-        private ConfigServerConfig configServerConfig;
+        private ConfigServerInfo configServerInfo;
         private String environment;
         private String region;
         private String system;
@@ -208,7 +206,12 @@ public class Environment {
         private DockerNetworking dockerNetworking;
 
         public Builder configServerConfig(ConfigServerConfig configServerConfig) {
-            this.configServerConfig = configServerConfig;
+            this.configServerInfo = new ConfigServerInfo(configServerConfig);
+            return this;
+        }
+
+        public Builder configServerInfo(ConfigServerInfo configServerInfo) {
+            this.configServerInfo = configServerInfo;
             return this;
         }
 
@@ -293,7 +296,7 @@ public class Environment {
         }
 
         public Environment build() {
-            return new Environment(configServerConfig,
+            return new Environment(configServerInfo,
                                    trustStorePath,
                                    environment,
                                    region,

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -516,7 +516,7 @@ public class NodeAgentImpl implements NodeAgent {
                 startServicesIfNeeded();
                 resumeNodeIfNeeded(node);
 
-                athenzCredentialsMaintainer.converge();
+                athenzCredentialsMaintainer.converge(context);
 
                 doBeforeConverge(node);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -76,7 +76,7 @@ public class NodeAgentImpl implements NodeAgent {
     private final Environment environment;
     private final Clock clock;
     private final Duration timeBetweenEachConverge;
-    private final AthenzCredentialsMaintainer athenzCredentialsMaintainer;
+    private final Optional<AthenzCredentialsMaintainer> athenzCredentialsMaintainer;
 
     private int numberOfUnhandledException = 0;
     private Instant lastConverge;
@@ -120,7 +120,7 @@ public class NodeAgentImpl implements NodeAgent {
             final Environment environment,
             final Clock clock,
             final Duration timeBetweenEachConverge,
-            final AthenzCredentialsMaintainer athenzCredentialsMaintainer) {
+            final Optional<AthenzCredentialsMaintainer> athenzCredentialsMaintainer) {
         this.context = context;
         this.nodeRepository = nodeRepository;
         this.orchestrator = orchestrator;
@@ -516,7 +516,7 @@ public class NodeAgentImpl implements NodeAgent {
                 startServicesIfNeeded();
                 resumeNodeIfNeeded(node);
 
-                athenzCredentialsMaintainer.converge(context);
+                athenzCredentialsMaintainer.ifPresent(maintainer -> maintainer.converge(context));
 
                 doBeforeConverge(node);
 
@@ -544,7 +544,7 @@ public class NodeAgentImpl implements NodeAgent {
             case dirty:
                 removeContainerIfNeededUpdateContainerState(node, container);
                 context.log(logger, "State is " + node.getState() + ", will delete application storage and mark node as ready");
-                athenzCredentialsMaintainer.clearCredentials();
+                athenzCredentialsMaintainer.ifPresent(maintainer -> maintainer.clearCredentials(context));
                 storageMaintainer.archiveNodeStorage(context);
                 updateNodeRepoWithCurrentAttributes(node);
                 nodeRepository.setNodeState(context.hostname().value(), Node.State.ready);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -14,7 +14,6 @@ import com.yahoo.vespa.hosted.node.admin.docker.DockerNetworking;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
 import com.yahoo.vespa.hosted.node.admin.maintenance.acl.AclMaintainer;
-import com.yahoo.vespa.hosted.node.admin.maintenance.identity.AthenzCredentialsMaintainer;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminImpl;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdaterImpl;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgent;
@@ -93,13 +92,12 @@ public class DockerTester implements AutoCloseable {
         DockerOperations dockerOperations = new DockerOperationsImpl(dockerMock, environment, processExecuter);
         StorageMaintainerMock storageMaintainer = new StorageMaintainerMock(dockerOperations, null, environment, callOrderVerifier);
         AclMaintainer aclMaintainer = mock(AclMaintainer.class);
-        AthenzCredentialsMaintainer athenzCredentialsMaintainer = mock(AthenzCredentialsMaintainer.class);
 
 
         MetricReceiverWrapper mr = new MetricReceiverWrapper(MetricReceiver.nullImplementation);
         Function<String, NodeAgent> nodeAgentFactory = (hostName) -> new NodeAgentImpl(
                 NodeAgentContextImplTest.nodeAgentFromHostname(fileSystem, hostName), nodeRepositoryMock,
-                orchestratorMock, dockerOperations, storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL, athenzCredentialsMaintainer);
+                orchestratorMock, dockerOperations, storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL, Optional.empty());
         nodeAdmin = new NodeAdminImpl(nodeAgentFactory, aclMaintainer, mr, Clock.systemUTC());
         nodeAdminStateUpdater = new NodeAdminStateUpdaterImpl(nodeRepositoryMock, orchestratorMock, storageMaintainer,
                 nodeAdmin, DOCKER_HOST_HOSTNAME, clock, NODE_ADMIN_CONVERGE_STATE_INTERVAL,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.hosted.dockerapi.Container;
-import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.dockerapi.ContainerResources;
 import com.yahoo.vespa.hosted.dockerapi.ContainerStats;
 import com.yahoo.vespa.hosted.dockerapi.exception.DockerException;
@@ -761,7 +760,7 @@ public class NodeAgentImplTest {
         doNothing().when(storageMaintainer).writeMetricsConfig(any(), any());
 
         return new NodeAgentImpl(context, nodeRepository, orchestrator, dockerOperations,
-                storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL, athenzCredentialsMaintainer);
+                storageMaintainer, aclMaintainer, environment, clock, NODE_AGENT_SCAN_INTERVAL, Optional.of(athenzCredentialsMaintainer));
     }
 
     private void mockGetContainer(DockerImage dockerImage, boolean isRunning) {


### PR DESCRIPTION
This makes `AthenzCredentialsMaintainer` shareable between all `NodeAgent`s.

By using `NodeAgentContext` this also follows the general pattern used in host-admin and other node-admin components.

Most of the changes are straightforward, only special case is `lastRefreshAttempt` which is now a `Map`.