### PR TITLE
Fix BinaryUnit not checking if the input matches the expected pattern

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/BinaryUnit.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/BinaryUnit.java
@@ -16,7 +16,9 @@ public class BinaryUnit {
     public static double valueOf(String valueString) {
         Matcher matcher = pattern.matcher(valueString);
 
-        matcher.matches();
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Value '" + valueString + "' does not match the pattern for binary unit");
+        }
         double value = Double.valueOf(matcher.group(1));
         String unit = matcher.group(3);
         if (unit != null) {


### PR DESCRIPTION
It fails with a cryptic error when calling matcher.group() if the input is not a valid BinaryUnit.