### PR TITLE
Remove Vespa 7 TODO

### DIFF
--- a/metrics/src/main/java/com/yahoo/metrics/MetricManager.java
+++ b/metrics/src/main/java/com/yahoo/metrics/MetricManager.java
@@ -37,7 +37,6 @@ import java.util.logging.Logger;
  *
  * If multiple locks is taken, the allowed locking order is: 1. Thread monitor. 2. Metric lock. 3. Config lock.
  */
-// TODO: Remove on Vespa 7
 public class MetricManager implements Runnable {
 
     private static final int STATE_CREATED = 0;


### PR DESCRIPTION
We cannot remove this module yet because vespa-feeder depends on it
to generate client-side metrics. However, since it is not a public
API we can do this later by moving the small part that vespa-feeder
needs into feed-client.

@vekterli please review