### PR TITLE
Gv7/add opens for felix

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -194,6 +194,10 @@ exec_jsvc () {
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="${VESPA_HOME}/var/crash" \
         -XX:+ExitOnOutOfMemoryError \
+        --illegal-access=warn \
+        --add-opens=java.base/java.lang=ALL-UNNAMED \
+        --add-opens=java.base/java.net=ALL-UNNAMED \
+        --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
         -Djava.library.path="${VESPA_HOME}/lib64" \
         -Djava.awt.headless=true \
         -Djavax.net.ssl.keyStoreType=JKS \
@@ -266,6 +270,10 @@ exec $numactlcmd $envcmd java \
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="${VESPA_HOME}/var/crash" \
         -XX:+ExitOnOutOfMemoryError \
+        --illegal-access=warn \
+        --add-opens=java.base/java.lang=ALL-UNNAMED \
+        --add-opens=java.base/java.net=ALL-UNNAMED \
+        --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
         -Djava.library.path="${VESPA_HOME}/lib64" \
         -Djava.awt.headless=true \
         -Djavax.net.ssl.keyStoreType=JKS \

--- a/jdisc_core_test/integration_test/pom.xml
+++ b/jdisc_core_test/integration_test/pom.xml
@@ -243,8 +243,11 @@
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
-                                <!-- Allow installing fragment bundles, see felix.framework:ExtensionManager.addExtensionBundle -->
+                                <!-- java.lang + java.net are opened to avoid "WARNING: Illegal reflective access ... "-->
+                                <!-- jdk.internal.loader is opened to allow installing extension bundles, see felix.framework:ExtensionManager.addExtensionBundle -->
                                 <argLine>
+                                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                                    --add-opens=java.base/java.net=ALL-UNNAMED
                                     --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
                                 </argLine>
                              </configuration>


### PR DESCRIPTION
@arnej27959 `jdisc_container_start` (the standalone container start script) sources a script in vespa-yahoo, so I assume we don't have a working script to start the standalone container from an open source installation?

FYI: @geirst 
