### PR TITLE
Bring the .search.ClusterSearcher to a known state during construction.

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterMonitor.java
@@ -106,7 +106,7 @@ public class ClusterMonitor implements Runnable, Freezable {
         }
     }
 
-    private boolean hasInformationAboutAllNodes() {
+    boolean hasInformationAboutAllNodes() {
         for (NodeMonitor monitor : nodeMonitors.values()) {
             if ( ! monitor.statusIsKnown())
                 return false;

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -67,7 +67,7 @@ import static com.yahoo.container.QrSearchersConfig.Searchcluster.Indexingmode.S
  * @author geirst
  */
 @After("*")
-public class ClusterSearcher extends Searcher {
+public final class ClusterSearcher extends Searcher {
 
     private final static Logger log = Logger.getLogger(ClusterSearcher.class.getName());
 
@@ -169,6 +169,15 @@ public class ClusterSearcher extends Searcher {
         }
         monitor.freeze();
         monitor.startPingThread();
+        waitUntilStateIsDetermined();
+    }
+
+    private void waitUntilStateIsDetermined() {
+        try {
+            while (!monitor.hasInformationAboutAllNodes()) {
+                Thread.sleep(1);
+            }
+        } catch (InterruptedException e) { }
     }
 
     private static QrSearchersConfig.Searchcluster getSearchClusterConfigFromClusterName(QrSearchersConfig config, String name) {

--- a/container-search/src/main/java/com/yahoo/search/cluster/BaseNodeMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/BaseNodeMonitor.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.cluster;
 
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import com.yahoo.search.result.ErrorMessage;
@@ -26,7 +27,7 @@ public abstract class BaseNodeMonitor<T> {
     /** The object representing the monitored node */
     protected T node;
 
-    protected boolean isWorking=true;
+    protected boolean isWorking=false;
 
     /** Whether this node is quarantined for unstability */
     protected boolean isQuarantined=false;
@@ -90,5 +91,16 @@ public abstract class BaseNodeMonitor<T> {
 
     /** Returns whether or not this is monitoring an internal node. Default is false. */
     public boolean isInternal() { return internal; }
+
+    /** Wait until we know the state of the node. */
+    public boolean waitUntilStateIsDetermined(long timeout, TimeUnit timeUnit) {
+        long doom = System.currentTimeMillis() + timeUnit.toMillis(timeout);
+        while ((respondedAt == 0) && (System.currentTimeMillis() < doom) ) {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) { }
+        }
+        return isWorking();
+    }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/cluster/NodeManager.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/NodeManager.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.cluster;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Must be implemented by a node collection which wants
@@ -25,5 +26,8 @@ public interface NodeManager<T> {
     
     /** Called right after a ping has been issued to each node. This default implementation does nothing. */
     default void pingIterationCompleted() {}
+
+    // Must be called after children are fully constructed.
+    void waitUntilStateIsKnown(long timeout, TimeUnit timeUnit);
 
 }

--- a/container-search/src/main/java/com/yahoo/search/federation/http/ConfiguredHTTPProviderSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/http/ConfiguredHTTPProviderSearcher.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.federation.http;
 
+import com.sun.net.httpserver.HttpsParameters;
 import com.yahoo.component.ComponentId;
 import com.yahoo.search.federation.ProviderConfig;
 import com.yahoo.search.cache.QrBinaryCacheConfig;
@@ -50,9 +51,13 @@ public abstract class ConfiguredHTTPProviderSearcher extends HTTPProviderSearche
         configureCache(cacheConfig,regionConfig);
     }
 
+    private static HTTPParameters disablePing(HTTPParameters params) {
+        params.setPingOption(ProviderConfig.PingOption.Enum.DISABLE);
+        return params;
+    }
     /** Create an instance from direct parameters having a single connection. Useful for testing */
     public ConfiguredHTTPProviderSearcher(String idString,String host,int port,String path, Statistics manager) {
-        super(new ComponentId(idString), Collections.singletonList(new Connection(host,port)),path, manager);
+        super(new ComponentId(idString), Collections.singletonList(new Connection(host,port)),disablePing(new HTTPParameters(path)), manager);
     }
 
     /** Create an instance from direct parameters having a single connection. Useful for testing */

--- a/container-search/src/main/java/com/yahoo/search/federation/http/HTTPSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/http/HTTPSearcher.java
@@ -279,6 +279,7 @@ public abstract class HTTPSearcher extends ClusterSearcher<Connection> {
         }
 
         initializeCertificate(httpParameters, certificateStore);
+        waitUntilStateIsKnown(5*httpParameters.getConnectionTimeout(), TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/DirectSearchTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/DirectSearchTestCase.java
@@ -73,6 +73,7 @@ public class DirectSearchTestCase {
     public void testNoDirectSearchWhenLocalNodeIsDown() {
         FastSearcherTester tester = new FastSearcherTester(2, FastSearcherTester.selfHostname + ":9999:0", "otherhost:9999:1");
         assertTrue(tester.vipStatus().isInRotation());
+        tester.dispatcher().searchCluster().getMonitorConfiguration().setFailLimit(0);
         tester.setResponding(FastSearcherTester.selfHostname, false);
         assertFalse(tester.vipStatus().isInRotation());
         assertEquals("1 ping request, 0 search requests", 1, tester.requestCount(FastSearcherTester.selfHostname, 9999));

--- a/container-search/src/test/java/com/yahoo/search/cluster/test/ClusterSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/cluster/test/ClusterSearcherTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.search.cluster.test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.yahoo.component.ComponentId;
 import com.yahoo.prelude.Ping;
@@ -121,10 +122,11 @@ public class ClusterSearcherTestCase {
     }
 
     /** A cluster searcher which clusters over a set of alternative searchers (search chains would be more realistic) */
-    static class SearcherClusterSearcher extends ClusterSearcher<Searcher> {
+    static final class SearcherClusterSearcher extends ClusterSearcher<Searcher> {
 
         public SearcherClusterSearcher(ComponentId id,List<Searcher> searchers,Hasher<Searcher> hasher) {
             super(id,searchers,hasher,false);
+            waitUntilStateIsKnown(-1, TimeUnit.MILLISECONDS);
         }
 
         @Override

--- a/container-search/src/test/java/com/yahoo/search/federation/http/PingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/federation/http/PingTestCase.java
@@ -109,7 +109,7 @@ public class PingTestCase {
     public void testPassiveAggressiveCase() throws Exception {
         PassiveAggressiveStupidServer server = new PassiveAggressiveStupidServer();
         server.start();
-        checkSearchAndPing(true, false, true, server.getServerPort());
+        checkSearchAndPing(false, false, false, server.getServerPort());
         server.stop();
     }
 

--- a/container-search/src/test/java/com/yahoo/search/federation/http/QueryParametersTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/federation/http/QueryParametersTestCase.java
@@ -2,6 +2,8 @@
 package com.yahoo.search.federation.http;
 
 import com.yahoo.component.ComponentId;
+import com.yahoo.prelude.Ping;
+import com.yahoo.prelude.Pong;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.searchchain.Execution;
@@ -52,6 +54,10 @@ public class QueryParametersTestCase {
             super(new ComponentId("test"), Collections.singletonList(new Connection("host", Defaults.getDefaults().vespaWebServicePort())), "path", Statistics.nullImplementation);
         }
 
+        @Override
+        public Pong ping(Ping ping, Connection connection) {
+            return new Pong();
+        }
         @Override
         public Map<String, String> getCacheKey(Query q) {
             return Collections.singletonMap("nocaching", String.valueOf(Math.random()));


### PR DESCRIPTION
Also wait until SearchCluster knows the cluster state.
And the .prelude.ClusterSearcher should also wait for known state in constructor.
Update tests
@bratseth and @arnej27959 PR
I am a bit uncertain about the state for the PingTest of the .search.ClusterSearcher. The grumpy server and the passive aggresive, can not work as the test is today.