### PR TITLE
Revert "Balder/avoid caching stuff you already have access t"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -33,6 +33,7 @@ import com.yahoo.container.logging.AccessLog;
 import com.yahoo.container.usability.BindingsOverviewHandler;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.jdisc.http.ServletPathsConfig;
+import com.yahoo.lang.SettableOptional;
 import com.yahoo.metrics.simple.runtime.MetricProperties;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.prelude.semantics.SemanticRulesConfig;
@@ -166,7 +167,7 @@ public final class ContainerCluster
 
     private final List<String> serviceAliases = new ArrayList<>();
     private final List<String> endpointAliases = new ArrayList<>();
-    private final ComponentGroup<Component<?, ?>> componentGroup;
+    protected final ComponentGroup<Component<?, ?>> componentGroup;
     private final ConfigProducerGroup<RestApi> restApiGroup;
     private final ConfigProducerGroup<Servlet> servletGroup;
     private final ContainerClusterVerifier clusterVerifier;
@@ -180,8 +181,8 @@ public final class ContainerCluster
     /** The zone this is deployed in, or the default zone if not on hosted Vespa */
     private Zone zone;
     
-    private String hostClusterId = null;
-    private Integer memoryPercentage = null;
+    private Optional<String> hostClusterId = Optional.empty();
+    private final SettableOptional<Integer> memoryPercentage = new SettableOptional<>();
 
     private static class AcceptAllVerifier implements ContainerClusterVerifier {
         @Override
@@ -325,7 +326,7 @@ public final class ContainerCluster
         return componentGroup.removeComponent(componentId);
     }
 
-    private void addSimpleComponent(Class<?> clazz) {
+    public void addSimpleComponent(Class<?> clazz) {
         addSimpleComponent(clazz.getName());
     }
 
@@ -412,7 +413,7 @@ public final class ContainerCluster
         addComponent(processingHandler);
     }
 
-    ProcessingChains getProcessingChains() {
+    public ProcessingChains getProcessingChains() {
         return processingChains;
     }
 
@@ -774,22 +775,22 @@ public final class ContainerCluster
     /** The configured endpoint aliases (fqdn) for the service in this cluster */
     public List<String> endpointAliases() { return endpointAliases; }
     
-    public void setHostClusterId(String clusterId) { hostClusterId = clusterId; }
+    public void setHostClusterId(String clusterId) { hostClusterId = Optional.ofNullable(clusterId); }
 
     /** 
      * Returns the id of the content cluster which hosts this container cluster, if any.
      * This is only set with hosted clusters where this container cluster is set up to run on the nodes
      * of a content cluster.
      */
-    public Optional<String> getHostClusterId() { return Optional.ofNullable(hostClusterId); }
+    public Optional<String> getHostClusterId() { return hostClusterId; }
 
-    public void setMemoryPercentage(Integer memoryPercentage) { this.memoryPercentage = memoryPercentage; }
+    public void setMemoryPercentage(Optional<Integer> memoryPercentage) { this.memoryPercentage.set(memoryPercentage); }
 
     /** 
      * Returns the percentage of host physical memory this application has specified for nodes in this cluster,
      * or empty if this is not specified by the application.
      */
-    public Optional<Integer> getMemoryPercentage() { return Optional.ofNullable(memoryPercentage); }
+    public SettableOptional<Integer> getMemoryPercentage() { return memoryPercentage; }
 
     boolean messageBusEnabled() { return messageBusEnabled; }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
@@ -1,7 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.search;
 
+import com.yahoo.binaryprefix.BinaryPrefix;
+import com.yahoo.binaryprefix.BinaryScaledAmount;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
+import com.yahoo.lang.SettableOptional;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.prelude.fastsearch.FS4ResourcePool;
 import com.yahoo.prelude.semantics.SemanticRulesConfig;
@@ -11,21 +14,15 @@ import com.yahoo.vespa.model.container.component.ContainerSubsystem;
 import com.yahoo.vespa.model.container.search.searchchain.HttpProvider;
 import com.yahoo.vespa.model.container.search.searchchain.LocalProvider;
 import com.yahoo.vespa.model.container.search.searchchain.SearchChains;
+import com.yahoo.vespa.model.search.*;
 import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.search.query.profile.config.QueryProfilesConfig;
 import com.yahoo.search.pagetemplates.PageTemplatesConfig;
-import com.yahoo.vespa.model.search.AbstractSearchCluster;
-import com.yahoo.vespa.model.search.Dispatch;
-import com.yahoo.vespa.model.search.IndexedSearchCluster;
-import com.yahoo.vespa.model.search.StreamingSearchCluster;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author gjoranv
@@ -44,15 +41,20 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
     private final List<AbstractSearchCluster> systems = new LinkedList<>();
     private final Options options;
 
+    // For legacy qrs clusters only.
+    private BinaryScaledAmount totalCacheSize = new BinaryScaledAmount();
+
     private QueryProfiles queryProfiles;
     private SemanticRules semanticRules;
     private PageTemplates pageTemplates;
     private final ContainerCluster owningCluster;
+    private final SettableOptional<Integer> memoryPercentage;
 
     public ContainerSearch(ContainerCluster cluster, SearchChains chains, Options options) {
         super(chains);
         this.options = options;
         this.owningCluster = cluster;
+        this.memoryPercentage = cluster.getMemoryPercentage();
         cluster.addComponent(getFS4ResourcePool());
     }
 
@@ -69,7 +71,7 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
 
     // public for testing
     public void initializeSearchChains(Map<String, ? extends AbstractSearchCluster> searchClusters) {
-        getChains().initialize(searchClusters);
+        getChains().initialize(searchClusters, totalCacheSize);
 
         QrsCache defaultCacheOptions = getOptions().cacheSettings.get("");
         if (defaultCacheOptions != null) {
@@ -84,6 +86,10 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
                 localProvider.setCacheSize(cacheOptions.size);
             }
         }
+    }
+
+    public void setTotalCacheSize(BinaryScaledAmount totalCacheSize) {
+        this.totalCacheSize = totalCacheSize;
     }
 
     public void setQueryProfiles(QueryProfiles queryProfiles) {
@@ -116,16 +122,24 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
     @Override
     public void getConfig(QrStartConfig.Builder qsB) {
     	QrStartConfig.Jvm.Builder internalBuilder = new QrStartConfig.Jvm.Builder();
-        if (owningCluster.getMemoryPercentage().isPresent()) {
-            internalBuilder.heapSizeAsPercentageOfPhysicalMemory(owningCluster.getMemoryPercentage().get());
-        } else if (owningCluster.isHostedVespa()) {
-            internalBuilder.heapSizeAsPercentageOfPhysicalMemory(owningCluster.getHostClusterId().isPresent() ? 17 : 60);
+        if (memoryPercentage.isPresent()) {
+            internalBuilder.heapSizeAsPercentageOfPhysicalMemory(memoryPercentage.get());
+        }
+    	else if (owningCluster.isHostedVespa()) {
+            if (owningCluster.getHostClusterId().isPresent())
+                internalBuilder.heapSizeAsPercentageOfPhysicalMemory(17);
+            else
+                internalBuilder.heapSizeAsPercentageOfPhysicalMemory(60);
         }
         qsB.jvm(internalBuilder.directMemorySizeCache(totalCacheSizeMb()));
     }
 
     private int totalCacheSizeMb() {
-        return totalHttpProviderCacheSize();
+        if (!totalCacheSize.equals(new BinaryScaledAmount())) {
+            return (int) totalCacheSize.as(BinaryPrefix.mega);
+        } else {
+            return totalHttpProviderCacheSize();
+        }
     }
 
     private int totalHttpProviderCacheSize() {
@@ -187,6 +201,7 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
     public Options getOptions() {
         return options;
     }
+    public Optional<Integer> getMemoryPercentage() { return memoryPercentage.asOptional(); }
 
     /**
      * Struct that encapsulates qrserver options.

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/SearchChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/SearchChains.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.search.searchchain;
 
+import com.yahoo.binaryprefix.BinaryScaledAmount;
 import com.yahoo.collections.CollectionUtil;
 import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
@@ -25,17 +26,31 @@ public class SearchChains extends Chains<SearchChain> {
         super(parent, subId);
     }
 
-    public void initialize(Map<String, ? extends AbstractSearchCluster> searchClustersByName) {
+    public void initialize(Map<String, ? extends AbstractSearchCluster> searchClustersByName, BinaryScaledAmount totalProviderCacheSize) {
         LocalClustersCreator.addDefaultLocalProviders(this, searchClustersByName.keySet());
         VespaSearchChainsCreator.addVespaSearchChains(this);
 
         validateSourceGroups(); //must be done before initializing searchers since they are used by FederationSearchers.
-        initializeComponents(searchClustersByName);
+        initializeComponents(searchClustersByName, totalProviderCacheSize);
     }
 
-    private void initializeComponents(Map<String, ? extends AbstractSearchCluster> searchClustersByName) {
+    private void initializeComponents(Map<String, ? extends AbstractSearchCluster> searchClustersByName,
+                                      BinaryScaledAmount totalProviderCacheSize) {
         setSearchClusterForLocalProvider(searchClustersByName);
+        setCacheSizeForHttpProviders(totalProviderCacheSize);
         initializeComponents();
+    }
+
+    private void setCacheSizeForHttpProviders(BinaryScaledAmount totalProviderCacheSize) {
+        double totalCacheWeight = 0;
+        for (HttpProvider provider : httpProviders()) {
+            totalCacheWeight += provider.getCacheWeight();
+        }
+
+        final BinaryScaledAmount cacheUnit = totalProviderCacheSize.divide(totalCacheWeight);
+        for (HttpProvider provider : httpProviders()) {
+            provider.setCacheSize(cacheUnit.multiply(provider.getCacheWeight()));
+        }
     }
 
     private void setSearchClusterForLocalProvider(Map<String, ? extends AbstractSearchCluster> clusterIndexByName) {
@@ -66,7 +81,7 @@ public class SearchChains extends Chains<SearchChain> {
         super.validate();
     }
 
-    SourceGroupRegistry allSourceGroups() {
+    public SourceGroupRegistry allSourceGroups() {
         return sourceGroups;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -136,7 +136,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         model.setCluster(cluster);
     }
 
-    private void addBundlesForPlatformComponents(ContainerCluster cluster) {
+    protected void addBundlesForPlatformComponents(ContainerCluster cluster) {
         for (Component<?, ?> component : cluster.getAllComponents()) {
             String componentClass = component.model.bundleInstantiationSpec.getClassName();
             BundleMapper.getBundlePath(componentClass).
@@ -252,15 +252,15 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         addConfiguredComponents(deployState, cluster, spec, "component");
     }
 
-    private void setDefaultMetricConsumerFactory(ContainerCluster cluster) {
+    protected void setDefaultMetricConsumerFactory(ContainerCluster cluster) {
         cluster.setDefaultMetricConsumerFactory(MetricDefaultsConfig.Factory.Enum.STATE_MONITOR);
     }
 
-    private void addDefaultHandlers(ContainerCluster cluster) {
+    protected void addDefaultHandlers(ContainerCluster cluster) {
         addDefaultHandlersExceptStatus(cluster);
     }
 
-    private void addStatusHandlers(ContainerCluster cluster, ConfigModelContext configModelContext) {
+    protected void addStatusHandlers(ContainerCluster cluster, ConfigModelContext configModelContext) {
         if (configModelContext.getDeployState().isHosted()) {
             String name = "status.html";
             Optional<String> statusFile = Optional.ofNullable(System.getenv(HOSTED_VESPA_STATUS_FILE_INSTALL_SETTING));
@@ -281,7 +281,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         cluster.addVipHandler();
     }
 
-    private static void addDefaultHandlersExceptStatus(ContainerCluster cluster) {
+    protected static void addDefaultHandlersExceptStatus(ContainerCluster cluster) {
         cluster.addDefaultRootHandler();
         cluster.addMetricStateHandler();
         cluster.addApplicationStatusHandler();
@@ -313,7 +313,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         return components;
     }
 
-    private void addAccessLogs(DeployState deployState, ContainerCluster cluster, Element spec) {
+    protected void addAccessLogs(DeployState deployState, ContainerCluster cluster, Element spec) {
         List<Element> accessLogElements = getAccessLogElements(spec);
 
         for (Element accessLog : accessLogElements) {
@@ -324,12 +324,12 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             cluster.addDefaultSearchAccessLog();
     }
 
-    private List<Element> getAccessLogElements(Element spec) {
+    protected final List<Element> getAccessLogElements(Element spec) {
         return XML.getChildren(spec, "accesslog");
     }
 
 
-    private void addHttp(DeployState deployState, Element spec, ContainerCluster cluster) {
+    protected final void addHttp(DeployState deployState, Element spec, ContainerCluster cluster) {
         Element httpElement = XML.getChild(spec, "http");
         if (httpElement != null) {
             cluster.setHttp(buildHttp(deployState, cluster, httpElement));
@@ -345,7 +345,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         return http;
     }
 
-    private void addRestApis(DeployState deployState, Element spec, ContainerCluster cluster) {
+    protected void addRestApis(DeployState deployState, Element spec, ContainerCluster cluster) {
         for (Element restApiElem : XML.getChildren(spec, "rest-api")) {
             cluster.addRestApi(
                     new RestApiBuilder().build(deployState, cluster, restApiElem));
@@ -505,7 +505,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         memoryPercentage = memoryPercentage.substring(0, memoryPercentage.length()-1).trim();
 
         try {
-            cluster.setMemoryPercentage(Integer.parseInt(memoryPercentage));
+            cluster.setMemoryPercentage(Optional.of(Integer.parseInt(memoryPercentage)));
         }
         catch (NumberFormatException e) {
             throw new IllegalArgumentException("The memory percentage given for nodes in " + cluster +
@@ -758,13 +758,13 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
     }
 
-    private static void addConfiguredComponents(DeployState deployState, ContainerCluster cluster, Element spec, String componentName) {
+    public static void addConfiguredComponents(DeployState deployState, ContainerCluster cluster, Element spec, String componentName) {
         for (Element node : XML.getChildren(spec, componentName)) {
             cluster.addComponent(new DomComponentBuilder().build(deployState, cluster, node));
         }
     }
 
-    private static void validateAndAddConfiguredComponents(DeployState deployState, ContainerCluster cluster, Element spec, String componentName, Consumer<Element> elementValidator) {
+    public static void validateAndAddConfiguredComponents(DeployState deployState, ContainerCluster cluster, Element spec, String componentName, Consumer<Element> elementValidator) {
         for (Element node : XML.getChildren(spec, componentName)) {
             elementValidator.accept(node); // throws exception here if something is wrong
             cluster.addComponent(new DomComponentBuilder().build(deployState, cluster, node));

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -132,13 +132,13 @@ public class ModelProvisioningTest {
         assertThat(model.getContainerClusters().get("mydisc").getContainers().get(0).getPreLoad(), is(getDefaults().underVespaHome("lib64/vespa/malloc/libvespamalloc.so")));
         assertThat(model.getContainerClusters().get("mydisc").getContainers().get(1).getPreLoad(), is(getDefaults().underVespaHome("lib64/vespa/malloc/libvespamalloc.so")));
         assertThat(model.getContainerClusters().get("mydisc").getContainers().get(2).getPreLoad(), is(getDefaults().underVespaHome("lib64/vespa/malloc/libvespamalloc.so")));
-        assertThat(model.getContainerClusters().get("mydisc").getMemoryPercentage(), is(Optional.empty()));
+        assertThat(model.getContainerClusters().get("mydisc").getMemoryPercentage().asOptional(), is(Optional.empty()));
 
         assertThat(model.getContainerClusters().get("mydisc2").getContainers().get(0).getJvmArgs(), is("-verbosegc"));
         assertThat(model.getContainerClusters().get("mydisc2").getContainers().get(1).getJvmArgs(), is("-verbosegc"));
         assertThat(model.getContainerClusters().get("mydisc2").getContainers().get(0).getPreLoad(), is("lib/blablamalloc.so"));
         assertThat(model.getContainerClusters().get("mydisc2").getContainers().get(1).getPreLoad(), is("lib/blablamalloc.so"));
-        assertThat(model.getContainerClusters().get("mydisc2").getMemoryPercentage(), is(Optional.of(45)));
+        assertThat(model.getContainerClusters().get("mydisc2").getMemoryPercentage().asOptional(), is(Optional.of(45)));
         QrStartConfig.Builder qrStartBuilder = new QrStartConfig.Builder();
         model.getContainerClusters().get("mydisc2").getConfig(qrStartBuilder);
         QrStartConfig qrsStartConfig = new QrStartConfig(qrStartBuilder);

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -89,7 +89,7 @@ public class ContainerClusterTest {
     }
 
     private ContainerCluster createContainerCluster(MockRoot root, boolean isCombinedCluster) {
-        return createContainerCluster(root, isCombinedCluster, null, Optional.empty());
+        return createContainerCluster(root, isCombinedCluster, Optional.empty(), Optional.empty());
     }
 
     private ContainerCluster createClusterControllerCluster(MockRoot root) {
@@ -97,10 +97,11 @@ public class ContainerClusterTest {
     }
 
     private ContainerCluster createContainerCluster(MockRoot root, boolean isCombinedCluster, ContainerClusterVerifier extraComponents) {
-        return createContainerCluster(root, isCombinedCluster, null, Optional.of(extraComponents));
+        return createContainerCluster(root, isCombinedCluster, Optional.empty(), Optional.of(extraComponents));
     }
 
-    private ContainerCluster createContainerCluster(MockRoot root, boolean isCombinedCluster, Integer memoryPercentage) {
+    private ContainerCluster createContainerCluster(MockRoot root, boolean isCombinedCluster,
+                                                    Optional<Integer> memoryPercentage) {
         return createContainerCluster(root, isCombinedCluster, memoryPercentage, Optional.empty());
     }
     private MockRoot createRoot(boolean isHosted) {
@@ -108,7 +109,7 @@ public class ContainerClusterTest {
         return new MockRoot("foo", state);
     }
     private ContainerCluster createContainerCluster(MockRoot root, boolean isCombinedCluster,
-                                                    Integer memoryPercentage, Optional<ContainerClusterVerifier> extraComponents) {
+                                                    Optional<Integer> memoryPercentage, Optional<ContainerClusterVerifier> extraComponents) {
 
         ContainerCluster cluster = extraComponents.isPresent()
                 ? new ContainerCluster(root, "container0", "container1", extraComponents.get(), root.getDeployState())
@@ -120,7 +121,7 @@ public class ContainerClusterTest {
         return cluster;
     }
     private void verifyHeapSizeAsPercentageOfPhysicalMemory(boolean isHosted, boolean isCombinedCluster, 
-                                                            Integer explicitMemoryPercentage,
+                                                            Optional<Integer> explicitMemoryPercentage, 
                                                             int expectedMemoryPercentage) {
         ContainerCluster cluster = createContainerCluster(createRoot(isHosted), isCombinedCluster, explicitMemoryPercentage);
         QrStartConfig.Builder qsB = new QrStartConfig.Builder();
@@ -133,14 +134,14 @@ public class ContainerClusterTest {
     public void requireThatHeapSizeAsPercentageOfPhysicalMemoryForHostedAndNot() {
         boolean hosted = true;
         boolean combined = true; // a cluster running on content nodes (only relevant with hosted)
-        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted, ! combined, null, 60);
-        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted,   combined, null, 17);
-        verifyHeapSizeAsPercentageOfPhysicalMemory(! hosted, ! combined, null, 0);
+        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted, ! combined, Optional.empty(), 60);
+        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted,   combined, Optional.empty(), 17);
+        verifyHeapSizeAsPercentageOfPhysicalMemory(! hosted, ! combined, Optional.empty(), 0);
         
         // Explicit value overrides all defaults
-        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted, ! combined, 67, 67);
-        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted,   combined, 68, 68);
-        verifyHeapSizeAsPercentageOfPhysicalMemory(! hosted, ! combined, 69, 69);
+        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted, ! combined, Optional.of(67), 67);
+        verifyHeapSizeAsPercentageOfPhysicalMemory(  hosted,   combined, Optional.of(68), 68);
+        verifyHeapSizeAsPercentageOfPhysicalMemory(! hosted, ! combined, Optional.of(69), 69);
     }
 
     private void verifyJvmArgs(boolean isHosted, boolean hasDocproc, String expectedArgs, String jvmArgs) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/search/searchchain/SearchChainsTestBase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/search/searchchain/SearchChainsTestBase.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.search.searchchain;
 
+import com.yahoo.binaryprefix.BinaryPrefix;
 import com.yahoo.binaryprefix.BinaryScaledAmount;
 import com.yahoo.config.model.builder.xml.test.DomBuilderTest;
 import com.yahoo.vespa.model.builder.xml.dom.chains.search.DomSearchChainsBuilder;
@@ -15,7 +16,8 @@ public abstract class SearchChainsTestBase extends DomBuilderTest {
     @Before
     public void setupSearchChains() {
         SearchChains searchChains = new DomSearchChainsBuilder().build(root.getDeployState(), root, servicesXml());
-        searchChains.initialize(MockSearchClusters.twoMockClusterSpecsByName(root));
+        searchChains.initialize(MockSearchClusters.twoMockClusterSpecsByName(root),
+                                new BinaryScaledAmount(100, BinaryPrefix.mega));
         root.freezeModelTopology();
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#7391

Broke some system tests:
`2018-10-22 09:43:24.914] ERROR   : configserver     Container.com.yahoo.vespa.config.server.rpc.GetConfigProcessor
	Unexpected error handling config request
	exception=
	java.lang.NullPointerException
	at com.yahoo.vespa.model.container.search.searchchain.HttpProvider.cacheSizeMB(HttpProvider.java:106)
	at com.yahoo.vespa.model.container.search.searchchain.HttpProvider.getConfig(HttpProvider.java:111)
	at com.yahoo.search.cache.QrBinaryCacheConfig$Builder.dispatchGetConfig(QrBinaryCacheConfig.java:166)
	at com.yahoo.config.model.producer.AbstractConfigProducer.cascadeConfig(AbstractConfigProducer.java:208)
	at com.yahoo.config.model.producer.AbstractConfigProducer.cascadeConfig(AbstractConfigProducer.java:206)
	at com.yahoo.config.model.producer.AbstractConfigProducer.cascadeConfig(AbstractConfigProducer.java:206)
	at com.yahoo.vespa.model.VespaModel.populateConfigBuilder(VespaModel.java:367)`