### PR TITLE
Check that assumption of struct data type is correct

### DIFF
--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/DisallowComplexMapAndWsetKeyTypesTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/DisallowComplexMapAndWsetKeyTypesTestCase.java
@@ -26,6 +26,11 @@ public class DisallowComplexMapAndWsetKeyTypesTestCase {
         testFieldType("array<map<mystruct,string>>");
     }
 
+    @Test
+    public void requireThatNestedComplexValuesForMapSucceed() throws ParseException {
+        testFieldType("array<map<string,mystruct>>");
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void requireThatNestedComplexTypesForWsetFail() throws ParseException {
         testFieldType("array<weightedset<mystruct>>");


### PR DESCRIPTION
@bratseth Please review.

This fixes the current error of some VDS systemtests failing deployment due to the search definition containing a field with type "array<map<string,struct>>". 

@aressem FYI.