### PR TITLE
Fixes to java dispatcher load distribution

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -3,16 +3,17 @@ package com.yahoo.vespa.model.search;
 
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.log.LogLevel;
-import com.yahoo.vespa.config.search.AttributesConfig;
-import com.yahoo.vespa.config.search.DispatchConfig;
-import com.yahoo.vespa.config.search.core.ProtonConfig;
-import com.yahoo.vespa.config.search.RankProfilesConfig;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.log.LogLevel;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.searchdefinition.DocumentOnlySearch;
 import com.yahoo.searchdefinition.derived.DerivedConfiguration;
+import com.yahoo.vespa.config.search.AttributesConfig;
+import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.config.search.DispatchConfig.DistributionPolicy;
+import com.yahoo.vespa.config.search.RankProfilesConfig;
+import com.yahoo.vespa.config.search.core.ProtonConfig;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.SimpleConfigProducer;
@@ -23,8 +24,11 @@ import com.yahoo.vespa.model.content.DispatchSpec;
 import com.yahoo.vespa.model.content.SearchCoverage;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -316,17 +320,17 @@ public class IndexedSearchCluster extends SearchCluster
 
     @Override
     public DerivedConfiguration getSdConfig() { return null; }
-    
+
     @Override
     public void getConfig(IndexInfoConfig.Builder builder) {
         unionCfg.getConfig(builder);
     }
-    
+
     @Override
     public void getConfig(IlscriptsConfig.Builder builder) {
         unionCfg.getConfig(builder);
     }
-    
+
     @Override
     public void getConfig(AttributesConfig.Builder builder) {
         unionCfg.getConfig(builder);
@@ -402,6 +406,19 @@ public class IndexedSearchCluster extends SearchCluster
             nodeBuilder.fs4port(node.getDispatchPort());
             if (tuning.dispatch.minActiveDocsCoverage != null)
                 builder.minActivedocsPercentage(tuning.dispatch.minActiveDocsCoverage);
+            if (tuning.dispatch.minGroupCoverage != null)
+                builder.minGroupCoverage(tuning.dispatch.minGroupCoverage);
+            if (tuning.dispatch.policy != null) {
+                switch(tuning.dispatch.policy) {
+                case RANDOM:
+                    builder.distributionPolicy(DistributionPolicy.RANDOM);
+                    break;
+                case ROUNDROBIN:
+                    builder.distributionPolicy(DistributionPolicy.ROUNDROBIN);
+                    break;
+                }
+            }
+            builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());
             builder.node(nodeBuilder);
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -409,13 +409,13 @@ public class IndexedSearchCluster extends SearchCluster
             if (tuning.dispatch.minGroupCoverage != null)
                 builder.minGroupCoverage(tuning.dispatch.minGroupCoverage);
             if (tuning.dispatch.policy != null) {
-                switch(tuning.dispatch.policy) {
-                case RANDOM:
-                    builder.distributionPolicy(DistributionPolicy.RANDOM);
-                    break;
-                case ROUNDROBIN:
-                    builder.distributionPolicy(DistributionPolicy.ROUNDROBIN);
-                    break;
+                switch (tuning.dispatch.policy) {
+                    case RANDOM:
+                        builder.distributionPolicy(DistributionPolicy.RANDOM);
+                        break;
+                    case ROUNDROBIN:
+                        builder.distributionPolicy(DistributionPolicy.ROUNDROBIN);
+                        break;
                 }
             }
             builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());

--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -7,6 +7,15 @@ namespace=vespa.config.search
 # for that group to be included in queries
 minActivedocsPercentage double default=97.0
 
+# Minimum coverage for allowing a group to be considered for serving
+minGroupCoverage double default=100
+
+# Maximum number of nodes allowed to be down for group to be considered for serving
+maxNodesDownPerGroup int default=0
+
+# Distribution policy for group selection
+distributionPolicy enum { ROUNDROBIN, RANDOM } default=ROUNDROBIN
+
 # The unique key of a search node
 node[].key int
 

--- a/container-search/src/main/java/com/yahoo/fs4/mplex/Backend.java
+++ b/container-search/src/main/java/com/yahoo/fs4/mplex/Backend.java
@@ -354,6 +354,31 @@ public class Backend implements ConnectionFactory {
     }
 
     /**
+     * Attempt to establish a connection without sending messages and then
+     * return it to the pool. The assumption is that if the probing is
+     * successful, the connection will be used soon after. There should be
+     * minimal overhead since the connection is cached.
+     */
+    public boolean probeConnection() {
+        if (shutdownInitiated) {
+            return false;
+        }
+
+        FS4Connection connection = null;
+        try {
+            connection = getConnection();
+        } catch (IOException ignored) {
+            // connection is null
+        } finally {
+            if (connection != null) {
+                returnConnection(connection);
+            }
+        }
+
+        return connection != null;
+    }
+
+    /**
      * This method should be used to ensure graceful shutdown of the backend.
      */
     public void shutdown() {

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
@@ -46,6 +46,13 @@ public class FS4InvokerFactory {
         return new FS4SearchInvoker(searcher, query, backend.openChannel(), node);
     }
 
+    /**
+     * Create a {@link SearchInvoker} for a list of content nodes.
+     *
+     * @param query the search query being processed
+     * @param nodes pre-selected list of content nodes
+     * @return Optional containing the SearchInvoker or <i>empty</i> if some node in the list is invalid
+     */
     public Optional<SearchInvoker> getSearchInvoker(Query query, List<SearchCluster.Node> nodes) {
         Map<Integer, SearchInvoker> invokers = new HashMap<>();
         for (SearchCluster.Node node : nodes) {
@@ -69,6 +76,12 @@ public class FS4InvokerFactory {
         return new FS4FillInvoker(searcher, query, fs4ResourcePool, node.hostname(), node.fs4port(), node.key());
     }
 
+    /**
+     * Create a {@link FillInvoker} for a the hits in a {@link Result}.
+     *
+     * @param result the Result containing hits that need to be filled
+     * @return Optional containing the FillInvoker or <i>empty</i> if some hit is from an unknown content node
+     */
     public Optional<FillInvoker> getFillInvoker(Result result) {
         Collection<Integer> requiredNodes = requiredFillNodes(result);
 

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
@@ -2,9 +2,9 @@
 package com.yahoo.prelude.fastsearch;
 
 import com.google.common.collect.ImmutableMap;
+import com.yahoo.fs4.mplex.Backend;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
-import com.yahoo.search.dispatch.CloseableInvoker;
 import com.yahoo.search.dispatch.FillInvoker;
 import com.yahoo.search.dispatch.InterleavedFillInvoker;
 import com.yahoo.search.dispatch.InterleavedSearchInvoker;
@@ -12,7 +12,6 @@ import com.yahoo.search.dispatch.SearchCluster;
 import com.yahoo.search.dispatch.SearchInvoker;
 import com.yahoo.search.result.Hit;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,11 +42,27 @@ public class FS4InvokerFactory {
     }
 
     public SearchInvoker getSearchInvoker(Query query, SearchCluster.Node node) {
-        return new FS4SearchInvoker(searcher, query, fs4ResourcePool, node);
+        Backend backend = fs4ResourcePool.getBackend(node.hostname(), node.fs4port());
+        return new FS4SearchInvoker(searcher, query, backend.openChannel(), node);
     }
 
     public Optional<SearchInvoker> getSearchInvoker(Query query, List<SearchCluster.Node> nodes) {
-        return getInvoker(nodes, node -> getSearchInvoker(query, node), InterleavedSearchInvoker::new);
+        Map<Integer, SearchInvoker> invokers = new HashMap<>();
+        for (SearchCluster.Node node : nodes) {
+            if (node.isWorking()) {
+                Backend backend = fs4ResourcePool.getBackend(node.hostname(), node.fs4port());
+                if (backend.probeConnection()) {
+                    invokers.put(node.key(), new FS4SearchInvoker(searcher, query, backend.openChannel(), node));
+                } else {
+                    return Optional.empty();
+                }
+            }
+        }
+        if (invokers.size() == 1) {
+            return Optional.of(invokers.values().iterator().next());
+        } else {
+            return Optional.of(new InterleavedSearchInvoker(invokers));
+        }
     }
 
     public FillInvoker getFillInvoker(Query query, SearchCluster.Node node) {
@@ -56,18 +71,22 @@ public class FS4InvokerFactory {
 
     public Optional<FillInvoker> getFillInvoker(Result result) {
         Collection<Integer> requiredNodes = requiredFillNodes(result);
-        List<SearchCluster.Node> nodes = new ArrayList<>(requiredNodes.size());
 
+        Query query = result.getQuery();
+        Map<Integer, FillInvoker> invokers = new HashMap<>();
         for (Integer distKey : requiredNodes) {
             SearchCluster.Node node = nodesByKey.get(distKey);
             if (node == null) {
                 return Optional.empty();
             }
-            nodes.add(node);
+            invokers.put(distKey, getFillInvoker(query, node));
         }
 
-        Query query = result.getQuery();
-        return getInvoker(nodes, node -> getFillInvoker(query, node), InterleavedFillInvoker::new);
+        if (invokers.size() == 1) {
+            return Optional.of(invokers.values().iterator().next());
+        } else {
+            return Optional.of(new InterleavedFillInvoker(invokers));
+        }
     }
 
     private static Collection<Integer> requiredFillNodes(Result result) {
@@ -80,41 +99,5 @@ public class FS4InvokerFactory {
             }
         }
         return requiredNodes;
-    }
-
-    @FunctionalInterface
-    private interface InvokerConstructor<INVOKER> {
-        INVOKER construct(SearchCluster.Node node);
-    }
-
-    @FunctionalInterface
-    private interface ClusterInvokerConstructor<CLUSTERINVOKER extends INVOKER, INVOKER> {
-        CLUSTERINVOKER construct(Map<Integer, INVOKER> subinvokers);
-    }
-
-    /* Get an invocation object for the provided collection of nodes. If only one
-       node is used, only the single-node invoker is used. For multiple nodes, each
-       gets a single-node invoker and they are all wrapped into a cluster invoker.
-       The functional interfaces are used to allow code reuse with SearchInvokers
-       and FillInvokers even though they don't share much class hierarchy. */
-    private <INVOKER extends CloseableInvoker, CLUSTERINVOKER extends INVOKER> Optional<INVOKER> getInvoker(
-            Collection<SearchCluster.Node> nodes, InvokerConstructor<INVOKER> singleNodeCtor,
-            ClusterInvokerConstructor<CLUSTERINVOKER, INVOKER> clusterCtor) {
-        if (nodes.size() == 1) {
-            SearchCluster.Node node = nodes.iterator().next();
-            return Optional.of(singleNodeCtor.construct(node));
-        } else {
-            Map<Integer, INVOKER> nodeInvokers = new HashMap<>();
-            for (SearchCluster.Node node : nodes) {
-                if (node.isWorking()) {
-                    nodeInvokers.put(node.key(), singleNodeCtor.construct(node));
-                }
-            }
-            if (nodeInvokers.size() == 1) {
-                return Optional.of(nodeInvokers.values().iterator().next());
-            } else {
-                return Optional.of(clusterCtor.construct(nodeInvokers));
-            }
-        }
     }
 }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
@@ -39,12 +39,11 @@ public class FS4SearchInvoker extends SearchInvoker {
     private Query query = null;
     private QueryPacket queryPacket = null;
 
-    public FS4SearchInvoker(VespaBackEndSearcher searcher, Query query, FS4ResourcePool fs4ResourcePool, SearchCluster.Node node) {
+    public FS4SearchInvoker(VespaBackEndSearcher searcher, Query query, FS4Channel channel, SearchCluster.Node node) {
         this.searcher = searcher;
         this.node = Optional.of(node);
+        this.channel = channel;
 
-        Backend backend = fs4ResourcePool.getBackend(node.hostname(), node.fs4port());
-        this.channel = backend.openChannel();
         channel.setQuery(query);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -44,14 +44,15 @@ public class Dispatcher extends AbstractComponent {
 
     public Dispatcher(DispatchConfig dispatchConfig, FS4ResourcePool fs4ResourcePool, int containerClusterSize, VipStatus vipStatus) {
         this.searchCluster = new SearchCluster(dispatchConfig, fs4ResourcePool, containerClusterSize, vipStatus);
-        this.loadBalancer = new LoadBalancer(searchCluster);
+        this.loadBalancer = new LoadBalancer(searchCluster,
+                dispatchConfig.distributionPolicy() == DispatchConfig.DistributionPolicy.ROUNDROBIN);
         this.rpcResourcePool = new RpcResourcePool(dispatchConfig);
     }
 
     /** For testing */
     public Dispatcher(Map<Integer, Client.NodeConnection> nodeConnections, Client client) {
         this.searchCluster = null;
-        this.loadBalancer = new LoadBalancer(searchCluster);
+        this.loadBalancer = new LoadBalancer(searchCluster, true);
         this.rpcResourcePool = new RpcResourcePool(client, nodeConnections);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -145,6 +145,7 @@ public class Dispatcher extends AbstractComponent {
                 return invoker;
             } else {
                 // invoker could not be produced (likely connectivity issue)
+                searchCluster.groupConnectionFailure(group);
                 loadBalancer.releaseGroup(group);
                 if (tried == null) {
                     tried = new HashSet<>();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
@@ -5,6 +5,7 @@ import com.yahoo.search.Query;
 import com.yahoo.search.dispatch.SearchCluster.Group;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -18,14 +19,13 @@ import java.util.logging.Logger;
  */
 public class LoadBalancer {
     // The implementation here is a simplistic least queries in flight + round-robin load balancer
-    // TODO: consider the options in com.yahoo.vespa.model.content.TuningDispatch
 
     private static final Logger log = Logger.getLogger(LoadBalancer.class.getName());
 
     private final List<GroupSchedule> scoreboard;
     private int needle = 0;
 
-    public LoadBalancer(SearchCluster searchCluster) {
+    public LoadBalancer(SearchCluster searchCluster, boolean roundRobin) {
         if (searchCluster == null) {
             this.scoreboard = null;
             return;
@@ -34,6 +34,11 @@ public class LoadBalancer {
 
         for (Group group : searchCluster.orderedGroups()) {
             scoreboard.add(new GroupSchedule(group));
+        }
+
+        if(! roundRobin) {
+            // TODO - More randomness could be desirable
+            Collections.shuffle(scoreboard);
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
@@ -153,6 +153,9 @@ public class SearchCluster implements NodeManager<SearchCluster.Node> {
     /** Returns the groups of this cluster as an immutable map indexed by group id */
     public ImmutableMap<Integer, Group> groups() { return groups; }
 
+    /** Returns the groups of this cluster as an immutable list in introduction order */
+    public ImmutableList<Group> orderedGroups() { return orderedGroups; }
+
     /** Returns the n'th (zero-indexed) group in the cluster if possible */
     public Optional<Group> group(int n) {
         if (orderedGroups.size() > n) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
@@ -46,9 +46,9 @@ public class SearchCluster implements NodeManager<SearchCluster.Node> {
     private static final Logger log = Logger.getLogger(SearchCluster.class.getName());
 
     /** The min active docs a group must have to be considered up, as a % of the average active docs of the other groups */
-    public final double minActivedocsCoveragePercentage;
-    public final double minGroupCoverage;
-    public final int maxNodesDownPerGroup;
+    private final double minActivedocsCoveragePercentage;
+    private final double minGroupCoverage;
+    private final int maxNodesDownPerGroup;
     private final int size;
     private final ImmutableMap<Integer, Group> groups;
     private final ImmutableMultimap<String, Node> nodesByHost;

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchCluster.java
@@ -216,6 +216,10 @@ public class SearchCluster implements NodeManager<SearchCluster.Node> {
             vipStatus.removeFromRotation(this);
     }
 
+    public void groupConnectionFailure(Group group) {
+        group.setHasSufficientCoverage(false); // will be reset after next ping iteration
+    }
+
     private void updateSufficientCoverage(Group group, boolean sufficientCoverage) {
         // update VIP status if we direct dispatch to this group and coverage status changed
         if (usesDirectDispatchTo(group) && sufficientCoverage != group.hasSufficientCoverage()) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -22,8 +22,8 @@ public class LoadBalancerTest {
     @Test
     public void requreThatLoadBalancerServesSingleNodeSetups() {
         Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1), null, 1, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
+        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1), null, 1, null);
+        LoadBalancer lb = new LoadBalancer(cluster, true);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query());
         Group group = grp.orElseGet(() -> {
@@ -36,8 +36,8 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerServesMultiGroupSetups() {
         Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
         Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 1, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
+        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        LoadBalancer lb = new LoadBalancer(cluster, true);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query());
         Group group = grp.orElseGet(() -> {
@@ -52,8 +52,8 @@ public class LoadBalancerTest {
         Node n2 = new SearchCluster.Node(1, "test-node2", 1, 0);
         Node n3 = new SearchCluster.Node(0, "test-node3", 0, 1);
         Node n4 = new SearchCluster.Node(1, "test-node4", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
+        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
+        LoadBalancer lb = new LoadBalancer(cluster, true);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query());
         assertThat(grp.isPresent(), is(true));
@@ -63,8 +63,8 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerReturnsDifferentGroups() {
         Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
         Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 1, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
+        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
         Optional<Group> grp = lb.takeGroupForQuery(new Query());
@@ -83,8 +83,8 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerReturnsGroupWithShortestQueue() {
         Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
         Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, Arrays.asList(n1, n2), null, 1, null);
-        LoadBalancer lb = new LoadBalancer(cluster);
+        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
         Optional<Group> grp = lb.takeGroupForQuery(new Query());

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
@@ -19,7 +19,7 @@ public class MockSearchCluster extends SearchCluster {
     private final ImmutableMultimap<String, Node> nodesByHost;
 
     public MockSearchCluster(int groups, int nodesPerGroup) {
-        super(100, Collections.emptyList(), null, 1, null);
+        super(100, 100, 0, Collections.emptyList(), null, 1, null);
 
         ImmutableMap.Builder<Integer, Group> groupBuilder = ImmutableMap.builder();
         ImmutableMultimap.Builder<String, Node> hostBuilder = ImmutableMultimap.builder();


### PR DESCRIPTION
- fixes coverage/no-coverage comparison in load balancer
- reject load balancer's offered content group if connections to it fail immediately (this will likely need more tweaking when no content group is fully functional)
- use more dispatch/distribution configuration parameters from the config model to better determine when a partially working group can be used
- take group out of rotation on connection error to avoid a race condition when one node in a group goes down and the remaining start to report higher active document numbers before the downed node is marked dead. The group will momentarily be counted as having an active document count higher than others.

(Edit: last entry added to this PR as the patch is smaller than I originally expected)