### PR TITLE
Coredump fixes

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
@@ -162,6 +162,14 @@ public class CoredumpHandlerTest {
         coredumpHandler.getMetadata(context, fileSystem.getPath("/fake/path"), Collections.emptyMap());
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void fails_to_get_core_file_if_only_compressed() throws IOException {
+        Path coredumpDirectory = fileSystem.getPath("/path/to/coredump/proccessing/id-123");
+        Files.createDirectories(coredumpDirectory);
+        Files.createFile(coredumpDirectory.resolve("dump_bash.core.431.lz4"));
+        coredumpHandler.findCoredumpFileInProcessingDirectory(coredumpDirectory);
+    }
+
     @Test
     public void process_single_coredump_test() throws IOException {
         Path coredumpDirectory = fileSystem.getPath("/path/to/coredump/proccessing/id-123");


### PR DESCRIPTION
* Increases the timeout on `lz4` compression of coredumps, default is 10m which is not enough for a 180GB core.
* Only find uncompressed coredump - this makes the compression retryable. Without it, one can start compressing a core file which may fail for whatever reason, then we have the original core file and a (corrupted) compressed core. Next iteration we could randomly select the corrupted compressed core and compress it again.