### PR TITLE
Use G1GC by default on Vespa 7 (JDK 9+).

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -144,7 +144,7 @@ public final class ContainerCluster
     public static final String STATISTICS_HANDLER_CLASS = "com.yahoo.container.config.StatisticsRequestHandler";
     public static final String SIMPLE_LINGUISTICS_PROVIDER = "com.yahoo.language.provider.SimpleLinguisticsProvider";
     public static final String CMS = "-XX:+UseConcMarkSweepGC -XX:MaxTenuringThreshold=15 -XX:NewRatio=1";
-    static final String G1GC = "-XX:+UseG1GC -XX:MaxTenuringThreshold=15";
+    public static final String G1GC = "-XX:+UseG1GC -XX:MaxTenuringThreshold=15";
 
     public static final String ROOT_HANDLER_BINDING = "*://*/";
 
@@ -639,7 +639,7 @@ public final class ContainerCluster
             return ((zone.environment() != Environment.prod) || RegionName.from("us-east-3").equals(zone.region()))
                     ? G1GC : CMS;
         } else {
-            return CMS;
+            return G1GC;
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static com.yahoo.vespa.model.container.ContainerCluster.G1GC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -195,7 +196,7 @@ public class ContainerClusterTest {
         verifyGCOpts(isHosted, null, zone, expected);
         verifyGCOpts(isHosted, "-XX:+UseG1GC", zone, "-XX:+UseG1GC");
         Zone DEV = new Zone(SystemName.dev, zone.environment(), zone.region());
-        verifyGCOpts(isHosted, null, DEV, ContainerCluster.G1GC);
+        verifyGCOpts(isHosted, null, DEV, G1GC);
         verifyGCOpts(isHosted, "-XX:+UseConcMarkSweepGC", DEV, "-XX:+UseConcMarkSweepGC");
 
     }
@@ -203,10 +204,10 @@ public class ContainerClusterTest {
     @Test
     public void requireThatGCOptsIsHonoured() {
         final Zone US_EAST_3 = new Zone(Environment.prod, RegionName.from("us-east-3"));
-        verifyGCOpts(false, Zone.defaultZone(),ContainerCluster.CMS);
-        verifyGCOpts(false, US_EAST_3, ContainerCluster.CMS);
+        verifyGCOpts(false, Zone.defaultZone(),G1GC);
+        verifyGCOpts(false, US_EAST_3, G1GC);
         verifyGCOpts(true, Zone.defaultZone(), ContainerCluster.CMS);
-        verifyGCOpts(true, US_EAST_3, ContainerCluster.G1GC);
+        verifyGCOpts(true, US_EAST_3, G1GC);
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -105,7 +105,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         QrStartConfig.Builder qrStartBuilder = new QrStartConfig.Builder();
         root.getConfig(qrStartBuilder, "jdisc/container.0");
         QrStartConfig qrStartConfig = new QrStartConfig(qrStartBuilder);
-        assertEquals(ContainerCluster.CMS, qrStartConfig.jvm().gcopts());
+        assertEquals(ContainerCluster.G1GC, qrStartConfig.jvm().gcopts());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
@@ -217,7 +217,7 @@ public class DocprocBuilderTest extends DomBuilderTest {
         QrStartConfig.Jvm jvm = qrStartConfig.jvm();
         assertThat(jvm.server(), is(true));
         assertThat(jvm.verbosegc(), is(true));
-        assertThat(jvm.gcopts(), is("-XX:+UseConcMarkSweepGC -XX:MaxTenuringThreshold=15 -XX:NewRatio=1"));
+        assertThat(jvm.gcopts(), is("-XX:+UseG1GC -XX:MaxTenuringThreshold=15"));
         assertThat(jvm.heapsize(), is(1536));
         assertThat(jvm.stacksize(), is(512));
         assertThat(qrStartConfig.ulimitv(), is(""));

--- a/container-search/src/main/resources/configdefinitions/qr-start.def
+++ b/container-search/src/main/resources/configdefinitions/qr-start.def
@@ -9,7 +9,7 @@ jvm.server bool default=true restart
 jvm.verbosegc bool default=true restart
 
 ## Garbage Collection tuning parameters
-jvm.gcopts string default="-XX:+UseConcMarkSweepGC -XX:MaxTenuringThreshold=15 -XX:NewRatio=1" restart
+jvm.gcopts string default="-XX:MaxTenuringThreshold=15 -XX:NewRatio=1" restart
 
 ## Heap size (in megabytes) for the Java VM
 jvm.heapsize int default=1536 restart


### PR DESCRIPTION
Alternatively, we'll add a new expected warning in the system tests.