### PR TITLE
Increase stack size to fix unstable test in bundle-plugin

### DIFF
--- a/travis/travis-build-full.sh
+++ b/travis/travis-build-full.sh
@@ -5,7 +5,7 @@ set -e
 export SOURCE_DIR=/source
 export NUM_THREADS=6
 export MALLOC_ARENA_MAX=1
-export MAVEN_OPTS="-Xms128m -Xmx2g"
+export MAVEN_OPTS="-Xss1m -Xms128m -Xmx2g"
 source /etc/profile.d/devtoolset-7.sh || true
 
 ccache --max-size=1250M


### PR DESCRIPTION
ExportPackageParserTest.require_that_long_string_literals_do_not_cause_stack_overflow_error() fails on Travis-CI for Vespa 7 build