### PR TITLE
vespa-http-client: Throw on missing document ID

### DIFF
--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/runner/JsonReaderTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/runner/JsonReaderTest.java
@@ -101,9 +101,9 @@ public class JsonReaderTest {
     final AtomicInteger numSent = new AtomicInteger(0);
 
     @Test
-    public void testReadNoocument() throws Exception {
+    public void testReadNoDocument() throws Exception {
         InputStream inputStream = new ByteArrayInputStream(
-                ("  " ).getBytes(StandardCharsets.UTF_8));
+                "  ".getBytes(StandardCharsets.UTF_8));
         JsonReader.read(inputStream, session, numSent);
         inputStream.close();
         assertThat(session.documentIds.size(), is(0));
@@ -186,20 +186,20 @@ public class JsonReaderTest {
     }
 
     @Test(expected=RuntimeException.class)
-    public void testBadJsonCommaAfterLastElement() throws Exception {
+    public void testBadJsonCommaAfterLastElement() {
         InputStream inputStream = new ByteArrayInputStream(
                 ("["+ doc1 +  ",]" ).getBytes(StandardCharsets.UTF_8));
         JsonReader.read(inputStream, session, numSent);
     }
 
     @Test(expected=RuntimeException.class)
-    public void testTotalGarbage() throws Exception {
+    public void testTotalGarbage() {
         InputStream inputStream = new ByteArrayInputStream(("garbage" ).getBytes(StandardCharsets.UTF_8));
         JsonReader.read(inputStream, session, numSent);
     }
 
     @Test(expected=RuntimeException.class)
-    public void testTwoDocIds() throws Exception {
+    public void testTwoDocIds() {
         InputStream inputStream = new ByteArrayInputStream(("[{\"remove\": \"id\", \"update\": \"id:\"}]"
                 .getBytes(StandardCharsets.UTF_8)));
         JsonReader.read(inputStream, session, numSent);

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/runner/JsonReaderTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/runner/JsonReaderTest.java
@@ -205,6 +205,13 @@ public class JsonReaderTest {
         JsonReader.read(inputStream, session, numSent);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsOnMissingId() {
+        InputStream inputStream = new ByteArrayInputStream(
+                inputJson("[{'fields':{ 'something': 'smoketest', 'nalle': 'bamse' }}]").getBytes(StandardCharsets.UTF_8));
+        JsonReader.read(inputStream, session, numSent);
+    }
+
     @Test
     public void testFullDocument() throws Exception {
         InputStream inputStream = new ByteArrayInputStream((


### PR DESCRIPTION
This fixes VESPA-13625.

Most of this code is to generate a helpful error message by printing (the start of) of the offending document.

Also removed a case where `data` could be `null`: I'm not quite sure how this is possible, as long as we find a document id, `charSize` should be `> 2`?