### PR TITLE
Jvenstad/snooze jobs

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
@@ -113,6 +113,12 @@ public class LockedApplication {
                                      ownershipIssueId, metrics, rotation, rotationStatus);
     }
 
+    public LockedApplication withJobPause(JobType jobType, OptionalLong pausedUntil) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.withPause(jobType, pausedUntil), change, outstandingChange,
+                                     ownershipIssueId, metrics, rotation, rotationStatus);
+    }
+
     public LockedApplication withJobCompletion(long projectId, JobType jobType, JobStatus.JobRun completion,
                                                Optional<DeploymentJobs.JobError> jobError) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Change.java
@@ -69,6 +69,15 @@ public final class Change {
         return new Change(platform, Optional.of(applicationVersion));
     }
 
+    /** Returns the change obtained when overwriting elements of the given change with any present in this */
+    public Change onTopOf(Change other) {
+        if (platform.isPresent())
+            other = other.with(platform.get());
+        if (application.isPresent())
+            other = other.with(application.get());
+        return other;
+    }
+
     @Override
     public int hashCode() { return Objects.hash(platform, application); }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/DeploymentJobs.java
@@ -71,6 +71,15 @@ public class DeploymentJobs {
         return new DeploymentJobs(projectId, status, issueId, builtInternally);
     }
 
+    public DeploymentJobs withPause(JobType jobType, OptionalLong pausedUntil) {
+        Map<JobType, JobStatus> status = new LinkedHashMap<>(this.status);
+        status.compute(jobType, (__, job) -> {
+            if (job == null) job = JobStatus.initial(jobType);
+            return job.withPause(pausedUntil);
+        });
+        return new DeploymentJobs(projectId, status, issueId, builtInternally);
+    }
+
     public DeploymentJobs withProjectId(OptionalLong projectId) {
         return new DeploymentJobs(projectId, status, issueId, builtInternally);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobStatus.java
@@ -60,7 +60,7 @@ public class JobStatus {
     }
 
     public JobStatus withTriggering(JobRun jobRun) {
-        return new JobStatus(type, jobError, Optional.of(jobRun), lastCompleted, firstFailing, lastSuccess, pausedUntil);
+        return new JobStatus(type, jobError, Optional.of(jobRun), lastCompleted, firstFailing, lastSuccess, OptionalLong.empty());
     }
 
     public JobStatus withCompletion(long runId, Optional<DeploymentJobs.JobError> jobError, Instant completion) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -95,6 +95,7 @@ public class ApplicationSerializer {
     private final String lastCompletedField = "lastCompleted";
     private final String firstFailingField = "firstFailing";
     private final String lastSuccessField = "lastSuccess";
+    private final String pausedUntilField = "pausedUntil";
 
     // JobRun fields
     private final String jobRunIdField = "id";
@@ -252,6 +253,7 @@ public class ApplicationSerializer {
         jobStatus.lastCompleted().ifPresent(run -> jobRunToSlime(run, object, lastCompletedField));
         jobStatus.lastSuccess().ifPresent(run -> jobRunToSlime(run, object, lastSuccessField));
         jobStatus.firstFailing().ifPresent(run -> jobRunToSlime(run, object, firstFailingField));
+        jobStatus.pausedUntil().ifPresent(until -> object.setLong(pausedUntilField, until));
     }
 
     private void jobRunToSlime(JobStatus.JobRun jobRun, Cursor parent, String jobRunObjectName) {
@@ -440,11 +442,13 @@ public class ApplicationSerializer {
         if (object.field(errorField).valid())
             jobError = Optional.of(JobError.valueOf(object.field(errorField).asString()));
 
-        return Optional.of(new JobStatus(jobType.get(), jobError,
-                             jobRunFromSlime(object.field(lastTriggeredField)),
-                             jobRunFromSlime(object.field(lastCompletedField)),
-                             jobRunFromSlime(object.field(firstFailingField)),
-                             jobRunFromSlime(object.field(lastSuccessField))));
+        return Optional.of(new JobStatus(jobType.get(),
+                                         jobError,
+                                         jobRunFromSlime(object.field(lastTriggeredField)),
+                                         jobRunFromSlime(object.field(lastCompletedField)),
+                                         jobRunFromSlime(object.field(firstFailingField)),
+                                         jobRunFromSlime(object.field(lastSuccessField)),
+                                         optionalLong(object.field(pausedUntilField))));
     }
 
     private Optional<JobStatus.JobRun> jobRunFromSlime(Inspector object) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilter.java
@@ -117,8 +117,7 @@ public class ControllerAuthorizationFilter extends CorsRequestFilterBase {
 
     private static boolean isHostedOperatorOperation(Path path, Method method) {
         if (isWhiteListedOperation(path, method)) return false;
-        return path.matches("/application/v4/tenant/{tenant}/application/{application}/deploying") ||
-               path.matches("/controller/v1/{*}") ||
+        return path.matches("/controller/v1/{*}") ||
                path.matches("/provision/v2/{*}") ||
                path.matches("/screwdriver/v1/trigger/tenant/{*}") ||
                path.matches("/os/v1/{*}") ||
@@ -131,6 +130,7 @@ public class ControllerAuthorizationFilter extends CorsRequestFilterBase {
         if (isHostedOperatorOperation(path, method)) return false;
         return path.matches("/application/v4/tenant/{tenant}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}") ||
+               path.matches("/application/v4/tenant/{tenant}/application/{application}/deploying") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/job/{job}/{*}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/dev/{*}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/perf/{*}") ||

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilter.java
@@ -131,7 +131,7 @@ public class ControllerAuthorizationFilter extends CorsRequestFilterBase {
         if (isHostedOperatorOperation(path, method)) return false;
         return path.matches("/application/v4/tenant/{tenant}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}") ||
-               path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/job/{job}") ||
+               path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/job/{job}/{*}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/dev/{*}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/perf/{*}") ||
                path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/global-rotation/override");

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/screwdriver/ScrewdriverApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/screwdriver/ScrewdriverApiHandler.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 
 import static java.util.stream.Collectors.joining;
 
+// TODO jvenstad: Only useful method has been moved to application API. Delete this when users have updated.
 /**
  * This API lists deployment jobs that are queued for execution on Screwdriver.
  * 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -530,8 +530,8 @@ public class DeploymentTriggerTest {
         Application app = tester.createAndDeploy("app", 3, "default");
         tester.upgradeSystem(new Version("9.8.7"));
 
-        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsWest1, tester.clock().millis() + 1000);
-        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsEast3, tester.clock().millis() + 3000);
+        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsWest1, tester.clock().instant().plus(Duration.ofSeconds(1)));
+        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsEast3, tester.clock().instant().plus(Duration.ofSeconds(3)));
 
         // us-west-1 does not trigger when paused.
         tester.deployAndNotify(app, true, systemTest);
@@ -542,7 +542,7 @@ public class DeploymentTriggerTest {
         tester.clock().advance(Duration.ofMillis(1500));
         tester.readyJobTrigger().run();
         tester.assertRunning(productionUsWest1, app.id());
-        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsWest1, tester.clock().millis() + 1000);
+        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsWest1, tester.clock().instant().plus(Duration.ofSeconds(1)));
         tester.deployAndNotify(app, false, productionUsWest1);
         tester.assertNotRunning(productionUsWest1, app.id());
         tester.clock().advance(Duration.ofMillis(1000));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -526,6 +526,37 @@ public class DeploymentTriggerTest {
     }
 
     @Test
+    public void testJobPause() {
+        Application app = tester.createAndDeploy("app", 3, "default");
+        tester.upgradeSystem(new Version("9.8.7"));
+
+        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsWest1, tester.clock().millis() + 1000);
+        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsEast3, tester.clock().millis() + 3000);
+
+        // us-west-1 does not trigger when paused.
+        tester.deployAndNotify(app, true, systemTest);
+        tester.deployAndNotify(app, true, stagingTest);
+        tester.assertNotRunning(productionUsWest1, app.id());
+
+        // us-west-1 triggers when no longer paused, but does not retry when paused again.
+        tester.clock().advance(Duration.ofMillis(1500));
+        tester.readyJobTrigger().run();
+        tester.assertRunning(productionUsWest1, app.id());
+        tester.applications().deploymentTrigger().pauseJob(app.id(), productionUsWest1, tester.clock().millis() + 1000);
+        tester.deployAndNotify(app, false, productionUsWest1);
+        tester.assertNotRunning(productionUsWest1, app.id());
+        tester.clock().advance(Duration.ofMillis(1000));
+        tester.readyJobTrigger().run();
+        tester.deployAndNotify(app, true, productionUsWest1);
+
+        // us-east-3 does not automatically trigger when paused, but does when forced.
+        tester.assertNotRunning(productionUsEast3, app.id());
+        tester.deploymentTrigger().forceTrigger(app.id(), productionUsEast3, "mrTrigger");
+        tester.assertRunning(productionUsEast3, app.id());
+        assertFalse(tester.application(app.id()).deploymentJobs().jobStatus().get(productionUsEast3).pausedUntil().isPresent());
+    }
+
+    @Test
     public void testUpgradingButNoJobStarted() {
         ReadyJobsTrigger readyJobsTrigger = new ReadyJobsTrigger(tester.controller(),
                                                                  Duration.ofHours(1),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -83,7 +83,8 @@ public class ApplicationSerializerTest {
 
         statusList.add(JobStatus.initial(JobType.systemTest)
                                 .withTriggering(Version.fromString("5.6.7"), ApplicationVersion.unknown, empty(), "Test", Instant.ofEpochMilli(7))
-                                .withCompletion(30, empty(), Instant.ofEpochMilli(8)));
+                                .withCompletion(30, empty(), Instant.ofEpochMilli(8))
+                                .withPause(OptionalLong.of(1L << 32)));
         statusList.add(JobStatus.initial(JobType.stagingTest)
                                 .withTriggering(Version.fromString("5.6.6"), ApplicationVersion.unknown, empty(), "Test 2", Instant.ofEpochMilli(5))
                                 .withCompletion(11, Optional.of(JobError.unknown), Instant.ofEpochMilli(6)));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -49,6 +49,7 @@ import com.yahoo.vespa.hosted.controller.athenz.mock.AthenzDbMock;
 import com.yahoo.vespa.hosted.controller.authority.config.ApiAuthorityConfig;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.BuildJob;
+import com.yahoo.vespa.hosted.controller.deployment.DeploymentTrigger;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerMock;
 import com.yahoo.vespa.hosted.controller.integration.MetricsServiceMock;
 import com.yahoo.vespa.hosted.controller.maintenance.DeploymentMetricsMaintainer;
@@ -355,6 +356,11 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                       .userIdentity(HOSTED_VESPA_OPERATOR)
                                       .data("6.1.0"),
                               new File("application-deployment.json"));
+
+        // POST a pause to a production job
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/instance/default/job/production-us-west-1/pause", POST)
+                             .userIdentity(USER_ID),
+                              "{\"message\":\"productionUsWest1 for tenant1.application1 paused for " + DeploymentTrigger.maxPause + "\"}");
 
         // POST a 'restart application' command
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/restart", POST)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -359,8 +359,13 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
         // POST a pause to a production job
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/instance/default/job/production-us-west-1/pause", POST)
-                             .userIdentity(USER_ID),
-                              "{\"message\":\"productionUsWest1 for tenant1.application1 paused for " + DeploymentTrigger.maxPause + "\"}");
+                                      .userIdentity(USER_ID),
+                              "{\"message\":\"production-us-west-1 for tenant1.application1 paused for " + DeploymentTrigger.maxPause + "\"}");
+
+        // POST a triggering to the same production job
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/instance/default/job/production-us-west-1", POST)
+                                      .userIdentity(USER_ID),
+                              "{\"message\":\"Triggered production-us-west-1 for tenant1.application1\"}");
 
         // POST a 'restart application' command
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/restart", POST)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -497,9 +497,8 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
     private void addIssues(ContainerControllerTester tester, ApplicationId id) {
         tester.controller().applications().lockOrThrow(id, application ->
-                tester.controller().applications().store(application
-                                                                 .withDeploymentIssueId(IssueId.from("123"))
-                                                                 .withOwnershipIssueId(IssueId.from("321"))));
+                tester.controller().applications().store(application.withDeploymentIssueId(IssueId.from("123"))
+                                                                    .withOwnershipIssueId(IssueId.from("321"))));
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -348,12 +348,12 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
         // DELETE (cancel) again is a no-op
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/deploying", DELETE)
-                                      .userIdentity(HOSTED_VESPA_OPERATOR),
+                                      .userIdentity(USER_ID),
                               new File("application-deployment-cancelled-no-op.json"));
 
         // POST triggering of a full deployment to an application (if version is omitted, current system version is used)
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/deploying", POST)
-                                      .userIdentity(HOSTED_VESPA_OPERATOR)
+                                      .userIdentity(USER_ID)
                                       .data("6.1.0"),
                               new File("application-deployment.json"));
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-deployment.json
@@ -1,1 +1,1 @@
-{"message":"Triggered upgrade to 6.1 for application 'tenant1.application1'"}
+{"message":"Triggered upgrade to 6.1 for tenant1.application1"}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilterTest.java
@@ -70,7 +70,7 @@ public class ControllerAuthorizationFilterTest {
         List<AthenzIdentity> allowed = singletonList(HOSTED_OPERATOR);
         List<AthenzIdentity> forbidden = singletonList(USER);
 
-        testApiAccess(PUT, "/application/v4/tenant/mytenant/application/myapp/deploying",
+        testApiAccess(PUT, "/zone/v2/hello-proxy-path",
                       allowed, forbidden, filter);
         testApiAccess(POST, "/screwdriver/v1/trigger/tenant/mytenant/application/myapp/",
                       allowed, forbidden, filter);


### PR DESCRIPTION
@bratseth please review.

@kkraune FYI. 

This lets tenants set their latest commit or any Vespa version as current Change, or cancel it. I will provide buttons for setting the latest commit and the latest Vespa version as targets, but nothing else.
This also lets tenants pause any of their jobs, up to 3 days ahead of now, and also lets them trigger jobs, as we have been able to for some time (production jobs trigger tests unless they are verified). Triggering a job cancels any pause it has left. There will be buttons also for this. 