### PR TITLE
Java dispatcher refactoring and cluster monitoring improvements

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
@@ -11,8 +11,8 @@ import com.yahoo.fs4.mplex.FS4Channel;
 import com.yahoo.fs4.mplex.InvalidChannelException;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
-import com.yahoo.search.dispatch.SearchCluster;
 import com.yahoo.search.dispatch.SearchInvoker;
+import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
 
@@ -33,13 +33,13 @@ import static java.util.Arrays.asList;
 public class FS4SearchInvoker extends SearchInvoker {
     private final VespaBackEndSearcher searcher;
     private FS4Channel channel;
-    private final Optional<SearchCluster.Node> node;
+    private final Optional<Node> node;
 
     private ErrorMessage pendingSearchError = null;
     private Query query = null;
     private QueryPacket queryPacket = null;
 
-    public FS4SearchInvoker(VespaBackEndSearcher searcher, Query query, FS4Channel channel, SearchCluster.Node node) {
+    public FS4SearchInvoker(VespaBackEndSearcher searcher, Query query, FS4Channel channel, Node node) {
         this.searcher = searcher;
         this.node = Optional.of(node);
         this.channel = channel;
@@ -115,7 +115,7 @@ public class FS4SearchInvoker extends SearchInvoker {
 
         searcher.addMetaInfo(query, queryPacket.getQueryPacketData(), resultPacket, result);
 
-        searcher.addUnfilledHits(result, resultPacket.getDocuments(), false, queryPacket.getQueryPacketData(), cacheKey, node.map(SearchCluster.Node::key));
+        searcher.addUnfilledHits(result, resultPacket.getDocuments(), false, queryPacket.getQueryPacketData(), cacheKey, node.map(Node::key));
         Packet[] packets;
         CacheControl cacheControl = searcher.getCacheControl();
         PacketWrapper packetWrapper = cacheControl.lookup(cacheKey, query);
@@ -130,7 +130,7 @@ public class FS4SearchInvoker extends SearchInvoker {
             } else {
                 packets = new Packet[1];
                 packets[0] = resultPacket;
-                cacheControl.cache(cacheKey, query, new DocsumPacketKey[0], packets, node.map(SearchCluster.Node::key));
+                cacheControl.cache(cacheKey, query, new DocsumPacketKey[0], packets, node.map(Node::key));
             }
         }
         return asList(result);

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -17,8 +17,8 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.Dispatcher;
 import com.yahoo.search.dispatch.FillInvoker;
-import com.yahoo.search.dispatch.SearchCluster;
 import com.yahoo.search.dispatch.SearchInvoker;
+import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.grouping.GroupingRequest;
 import com.yahoo.search.grouping.request.GroupingOperation;
 import com.yahoo.search.query.Ranking;
@@ -218,7 +218,7 @@ public class FastSearcher extends VespaBackEndSearcher {
             return invoker.get();
         }
 
-        Optional<SearchCluster.Node> direct = getDirectNode(query);
+        Optional<Node> direct = getDirectNode(query);
         if(direct.isPresent()) {
             return fs4InvokerFactory.getSearchInvoker(query, direct.get());
         }
@@ -237,7 +237,7 @@ public class FastSearcher extends VespaBackEndSearcher {
             return invoker.get();
         }
 
-        Optional<SearchCluster.Node> direct = getDirectNode(query);
+        Optional<Node> direct = getDirectNode(query);
         if (direct.isPresent()) {
             return fs4InvokerFactory.getFillInvoker(query, direct.get());
         }
@@ -248,18 +248,18 @@ public class FastSearcher extends VespaBackEndSearcher {
      * If the query can be directed to a single local content node, returns that node. Otherwise,
      * returns an empty value.
      */
-    private Optional<SearchCluster.Node> getDirectNode(Query query) {
+    private Optional<Node> getDirectNode(Query query) {
         if (!query.properties().getBoolean(dispatchDirect, true))
             return Optional.empty();
         if (query.properties().getBoolean(com.yahoo.search.query.Model.ESTIMATE))
             return Optional.empty();
 
-        Optional<SearchCluster.Node> directDispatchRecipient = dispatcher.searchCluster().directDispatchTarget();
+        Optional<Node> directDispatchRecipient = dispatcher.searchCluster().directDispatchTarget();
         if (!directDispatchRecipient.isPresent())
             return Optional.empty();
 
         // Dispatch directly to the single, local search node
-        SearchCluster.Node local = directDispatchRecipient.get();
+        Node local = directDispatchRecipient.get();
         query.trace(false, 2, "Dispatching directly to ", local);
         return Optional.of(local);
     }

--- a/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
@@ -1,8 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.cluster;
 
-
-import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.search.result.ErrorMessage;
 
@@ -43,7 +41,7 @@ public class ClusterMonitor<T> {
     public ClusterMonitor(NodeManager<T> manager, String ignored) {
         this(manager);
     }
-    
+
     public ClusterMonitor(NodeManager<T> manager) {
         nodeManager = manager;
         monitorThread = new MonitorThread("search.clustermonitor");

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchPath.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchPath.java
@@ -3,7 +3,9 @@ package com.yahoo.search.dispatch;
 
 import com.google.common.collect.ImmutableCollection;
 import com.yahoo.collections.Pair;
-import com.yahoo.search.dispatch.SearchCluster.Group;
+import com.yahoo.search.dispatch.searchcluster.Group;
+import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,7 +39,7 @@ public class SearchPath {
      * @return list of nodes chosen with the search path, or an empty list in which
      *         case some other node selection logic should be used
      */
-    public static List<SearchCluster.Node> selectNodes(String searchPath, SearchCluster cluster) {
+    public static List<Node> selectNodes(String searchPath, SearchCluster cluster) {
         Optional<SearchPath> sp = SearchPath.fromString(searchPath);
         if (sp.isPresent()) {
             return sp.get().mapToNodes(cluster);
@@ -46,7 +48,7 @@ public class SearchPath {
         }
     }
 
-    public static Optional<SearchPath> fromString(String path) {
+    static Optional<SearchPath> fromString(String path) {
         if (path == null || path.isEmpty()) {
             return Optional.empty();
         }
@@ -73,23 +75,23 @@ public class SearchPath {
         this.group = group;
     }
 
-    private List<SearchCluster.Node> mapToNodes(SearchCluster cluster) {
+    private List<Node> mapToNodes(SearchCluster cluster) {
         if (cluster.groups().isEmpty()) {
             return Collections.emptyList();
         }
 
-        SearchCluster.Group selectedGroup = selectGroup(cluster);
+        Group selectedGroup = selectGroup(cluster);
 
         if (nodes.isEmpty()) {
             return selectedGroup.nodes();
         }
-        List<SearchCluster.Node> groupNodes = selectedGroup.nodes();
+        List<Node> groupNodes = selectedGroup.nodes();
         Set<Integer> wanted = new HashSet<>();
         int max = groupNodes.size();
         for (NodeSelection node : nodes) {
             wanted.addAll(node.matches(max));
         }
-        List<SearchCluster.Node> ret = new ArrayList<>();
+        List<Node> ret = new ArrayList<>();
         for (int idx : wanted) {
             ret.add(groupNodes.get(idx));
         }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -1,0 +1,75 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.searchcluster;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A group in a search cluster. This class is multithread safe.
+ *
+ * @author bratseth
+ * @author ollivir
+ */
+public class Group {
+
+    private final int id;
+    private final ImmutableList<Node> nodes;
+
+    private final AtomicBoolean hasSufficientCoverage = new AtomicBoolean(true);
+    private final AtomicLong activeDocuments = new AtomicLong(0);
+
+    public Group(int id, List<Node> nodes) {
+        this.id = id;
+        this.nodes = ImmutableList.copyOf(nodes);
+    }
+
+    /** Returns the unique identity of this group */
+    public int id() { return id; }
+
+    /** Returns the nodes in this group as an immutable list */
+    public ImmutableList<Node> nodes() { return nodes; }
+
+    /**
+     * Returns whether this group has sufficient active documents
+     * (compared to other groups) that is should receive traffic
+     */
+    public boolean hasSufficientCoverage() {
+        return hasSufficientCoverage.get();
+    }
+
+    void setHasSufficientCoverage(boolean sufficientCoverage) {
+        hasSufficientCoverage.lazySet(sufficientCoverage);
+    }
+
+    void aggregateActiveDocuments() {
+        long activeDocumentsInGroup = 0;
+        for (Node node : nodes) {
+            if (node.isWorking()) {
+                activeDocumentsInGroup += node.getActiveDocuments();
+            }
+        }
+        activeDocuments.set(activeDocumentsInGroup);
+
+    }
+
+    /** Returns the active documents on this node. If unknown, 0 is returned. */
+    long getActiveDocuments() {
+        return this.activeDocuments.get();
+    }
+
+    @Override
+    public String toString() { return "search group " + id; }
+
+    @Override
+    public int hashCode() { return id; }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) return true;
+        if (!(other instanceof Group)) return false;
+        return ((Group) other).id == this.id;
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
@@ -1,0 +1,73 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.searchcluster;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A node in a search cluster. This class is multithread safe.
+ *
+ * @author bratseth
+ * @author ollivir
+ */
+public class Node {
+
+    private final int key;
+    private final String hostname;
+    private final int fs4port;
+    final int group;
+
+    private final AtomicBoolean working = new AtomicBoolean(true);
+    private final AtomicLong activeDocuments = new AtomicLong(0);
+
+    public Node(int key, String hostname, int fs4port, int group) {
+        this.key = key;
+        this.hostname = hostname;
+        this.fs4port = fs4port;
+        this.group = group;
+    }
+
+    /** Returns the unique and stable distribution key of this node */
+    public int key() { return key; }
+
+    public String hostname() { return hostname; }
+
+    public int fs4port() { return fs4port; }
+
+    /** Returns the id of this group this node belongs to */
+    public int group() { return group; }
+
+    public void setWorking(boolean working) {
+        this.working.lazySet(working);
+    }
+
+    /** Returns whether this node is currently responding to requests */
+    public boolean isWorking() { return working.get(); }
+
+    /** Updates the active documents on this node */
+    void setActiveDocuments(long activeDocuments) {
+        this.activeDocuments.set(activeDocuments);
+    }
+
+    /** Returns the active documents on this node. If unknown, 0 is returned. */
+    public long getActiveDocuments() {
+        return this.activeDocuments.get();
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(hostname, fs4port); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if ( ! (o instanceof Node)) return false;
+        Node other = (Node)o;
+        if ( ! Objects.equals(this.hostname, other.hostname)) return false;
+        if ( ! Objects.equals(this.fs4port, other.fs4port)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() { return "search node " + hostname + ":" + fs4port + " in group " + group; }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Pinger.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Pinger.java
@@ -1,0 +1,42 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.searchcluster;
+
+import com.yahoo.prelude.Ping;
+import com.yahoo.prelude.Pong;
+import com.yahoo.prelude.fastsearch.FS4ResourcePool;
+import com.yahoo.prelude.fastsearch.FastSearcher;
+import com.yahoo.search.cluster.ClusterMonitor;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.yolean.Exceptions;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author bratseth
+ * @author ollivir
+ */
+class Pinger implements Callable<Pong> {
+    private final Node node;
+    private final ClusterMonitor<Node> clusterMonitor;
+    private final FS4ResourcePool fs4ResourcePool;
+
+    public Pinger(Node node, ClusterMonitor<Node> clusterMonitor, FS4ResourcePool fs4ResourcePool) {
+        this.node = node;
+        this.clusterMonitor = clusterMonitor;
+        this.fs4ResourcePool = fs4ResourcePool;
+    }
+
+    public Pong call() {
+        try {
+            Pong pong = FastSearcher.ping(new Ping(clusterMonitor.getConfiguration().getRequestTimeout()),
+                                          fs4ResourcePool.getBackend(node.hostname(), node.fs4port()), node.toString());
+            if (pong.activeDocuments().isPresent())
+                node.setActiveDocuments(pong.activeDocuments().get());
+            return pong;
+        } catch (RuntimeException e) {
+            return new Pong(ErrorMessage.createBackendCommunicationError("Exception when pinging " + node + ": "
+                            + Exceptions.toMessageString(e)));
+        }
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
@@ -12,16 +12,14 @@ import com.yahoo.prelude.fastsearch.FastSearcher;
 import com.yahoo.prelude.fastsearch.SummaryParameters;
 import com.yahoo.prelude.fastsearch.test.fs4mock.MockBackend;
 import com.yahoo.prelude.fastsearch.test.fs4mock.MockFS4ResourcePool;
-import com.yahoo.prelude.fastsearch.test.fs4mock.MockFSChannel;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
-import com.yahoo.search.dispatch.SearchCluster;
+import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.searchchain.Execution;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -38,7 +36,7 @@ class FastSearcherTester {
     private final MockDispatcher mockDispatcher;
     private final VipStatus vipStatus;
 
-    public FastSearcherTester(int containerClusterSize, SearchCluster.Node searchNode) {
+    public FastSearcherTester(int containerClusterSize, Node searchNode) {
         this(containerClusterSize, Collections.singletonList(searchNode));
     }
 
@@ -46,7 +44,7 @@ class FastSearcherTester {
         this(containerClusterSize, toNodes(hostAndPortAndGroupStrings));
     }
 
-    public FastSearcherTester(int containerClusterSize, List<SearchCluster.Node> searchNodes) {
+    public FastSearcherTester(int containerClusterSize, List<Node> searchNodes) {
         ClustersStatus clustersStatus = new ClustersStatus();
         clustersStatus.setContainerHasClusters(true);
         vipStatus = new VipStatus(clustersStatus);
@@ -61,12 +59,12 @@ class FastSearcherTester {
                                         new DocumentdbInfoConfig(new DocumentdbInfoConfig.Builder()));
     }
 
-    private static List<SearchCluster.Node> toNodes(String... hostAndPortAndGroupStrings) {
-        List<SearchCluster.Node> nodes = new ArrayList<>();
+    private static List<Node> toNodes(String... hostAndPortAndGroupStrings) {
+        List<Node> nodes = new ArrayList<>();
         int key = 0;
         for (String s : hostAndPortAndGroupStrings) {
             String[] parts = s.split(":");
-            nodes.add(new SearchCluster.Node(key++, parts[0], Integer.parseInt(parts[1]), Integer.parseInt(parts[2])));
+            nodes.add(new Node(key++, parts[0], Integer.parseInt(parts[1]), Integer.parseInt(parts[2])));
         }
         return nodes;
     }
@@ -90,7 +88,7 @@ class FastSearcherTester {
         mockFS4ResourcePool.setResponding(hostname, responding);
 
         // Make the search cluster monitor notice right now in this thread
-        SearchCluster.Node node = mockDispatcher.searchCluster().nodesByHost().get(hostname).iterator().next();
+        Node node = mockDispatcher.searchCluster().nodesByHost().get(hostname).iterator().next();
         mockDispatcher.searchCluster().ping(node, MoreExecutors.directExecutor());
     }
 
@@ -99,7 +97,7 @@ class FastSearcherTester {
         mockFS4ResourcePool.setActiveDocuments(hostname, activeDocuments);
 
         // Make the search cluster monitor notice right now in this thread
-        SearchCluster.Node node = mockDispatcher.searchCluster().nodesByHost().get(hostname).iterator().next();
+        Node node = mockDispatcher.searchCluster().nodesByHost().get(hostname).iterator().next();
         mockDispatcher.searchCluster().ping(node, MoreExecutors.directExecutor());
         mockDispatcher.searchCluster().pingIterationCompleted();
     }

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
@@ -5,7 +5,7 @@ import com.yahoo.container.handler.VipStatus;
 import com.yahoo.prelude.fastsearch.FS4ResourcePool;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.Dispatcher;
-import com.yahoo.search.dispatch.SearchCluster;
+import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.vespa.config.search.DispatchConfig;
 
 import java.util.Collections;
@@ -13,27 +13,27 @@ import java.util.List;
 
 class MockDispatcher extends Dispatcher {
 
-    public MockDispatcher(SearchCluster.Node node) {
+    public MockDispatcher(Node node) {
         this(Collections.singletonList(node));
     }
 
-    public MockDispatcher(List<SearchCluster.Node> nodes) {
+    public MockDispatcher(List<Node> nodes) {
         super(toDispatchConfig(nodes), new FS4ResourcePool(1), 1, new VipStatus());
     }
 
-    public MockDispatcher(List<SearchCluster.Node> nodes, VipStatus vipStatus) {
+    public MockDispatcher(List<Node> nodes, VipStatus vipStatus) {
         super(toDispatchConfig(nodes), new FS4ResourcePool(1), 1, vipStatus);
     }
 
-    public MockDispatcher(List<SearchCluster.Node> nodes, FS4ResourcePool fs4ResourcePool, 
+    public MockDispatcher(List<Node> nodes, FS4ResourcePool fs4ResourcePool,
                           int containerClusterSize, VipStatus vipStatus) {
         super(toDispatchConfig(nodes), fs4ResourcePool, containerClusterSize, vipStatus);
     }
 
-    private static DispatchConfig toDispatchConfig(List<SearchCluster.Node> nodes) {
+    private static DispatchConfig toDispatchConfig(List<Node> nodes) {
         DispatchConfig.Builder dispatchConfigBuilder = new DispatchConfig.Builder();
         int key = 0;
-        for (SearchCluster.Node node : nodes) {
+        for (Node node : nodes) {
             DispatchConfig.Node.Builder dispatchConfigNodeBuilder = new DispatchConfig.Node.Builder();
             dispatchConfigNodeBuilder.host(node.hostname());
             dispatchConfigNodeBuilder.fs4port(node.fs4port());
@@ -44,7 +44,7 @@ class MockDispatcher extends Dispatcher {
         }
         return new DispatchConfig(dispatchConfigBuilder);
     }
-    
+
     public void fill(Result result, String summaryClass) {
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -2,8 +2,9 @@
 package com.yahoo.search.dispatch;
 
 import com.yahoo.search.Query;
-import com.yahoo.search.dispatch.SearchCluster.Group;
-import com.yahoo.search.dispatch.SearchCluster.Node;
+import com.yahoo.search.dispatch.searchcluster.Group;
+import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 import junit.framework.AssertionFailedError;
 import org.junit.Test;
 
@@ -21,11 +22,11 @@ import static org.junit.Assert.assertThat;
 public class LoadBalancerTest {
     @Test
     public void requreThatLoadBalancerServesSingleNodeSetups() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
+        Node n1 = new Node(0, "test-node1", 0, 0);
         SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
-        Optional<Group> grp = lb.takeGroupForQuery(new Query());
+        Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
         Group group = grp.orElseGet(() -> {
             throw new AssertionFailedError("Expected a SearchCluster.Group");
         });
@@ -34,12 +35,12 @@ public class LoadBalancerTest {
 
     @Test
     public void requreThatLoadBalancerServesMultiGroupSetups() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
+        Node n1 = new Node(0, "test-node1", 0, 0);
+        Node n2 = new Node(1, "test-node2", 1, 1);
         SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
-        Optional<Group> grp = lb.takeGroupForQuery(new Query());
+        Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
         Group group = grp.orElseGet(() -> {
             throw new AssertionFailedError("Expected a SearchCluster.Group");
         });
@@ -48,51 +49,51 @@ public class LoadBalancerTest {
 
     @Test
     public void requreThatLoadBalancerServesClusteredGroups() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 0);
-        Node n3 = new SearchCluster.Node(0, "test-node3", 0, 1);
-        Node n4 = new SearchCluster.Node(1, "test-node4", 1, 1);
+        Node n1 = new Node(0, "test-node1", 0, 0);
+        Node n2 = new Node(1, "test-node2", 1, 0);
+        Node n3 = new Node(0, "test-node3", 0, 1);
+        Node n4 = new Node(1, "test-node4", 1, 1);
         SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
-        Optional<Group> grp = lb.takeGroupForQuery(new Query());
+        Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
         assertThat(grp.isPresent(), is(true));
     }
 
     @Test
     public void requreThatLoadBalancerReturnsDifferentGroups() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
+        Node n1 = new Node(0, "test-node1", 0, 0);
+        Node n2 = new Node(1, "test-node2", 1, 1);
         SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
-        Optional<Group> grp = lb.takeGroupForQuery(new Query());
+        Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
         Group group = grp.get();
         int id1 = group.id();
         // release allocation
         lb.releaseGroup(group);
 
         // get second group
-        grp = lb.takeGroupForQuery(new Query());
+        grp = lb.takeGroupForQuery(new Query(), null);
         group = grp.get();
         assertThat(group.id(), not(equalTo(id1)));
     }
 
     @Test
     public void requreThatLoadBalancerReturnsGroupWithShortestQueue() {
-        Node n1 = new SearchCluster.Node(0, "test-node1", 0, 0);
-        Node n2 = new SearchCluster.Node(1, "test-node2", 1, 1);
+        Node n1 = new Node(0, "test-node1", 0, 0);
+        Node n2 = new Node(1, "test-node2", 1, 1);
         SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
-        Optional<Group> grp = lb.takeGroupForQuery(new Query());
+        Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
         Group group = grp.get();
         int id1 = group.id();
 
         // get second group
-        grp = lb.takeGroupForQuery(new Query());
+        grp = lb.takeGroupForQuery(new Query(), null);
         group = grp.get();
         int id2 = group.id();
         assertThat(id2, not(equalTo(id1)));
@@ -100,7 +101,7 @@ public class LoadBalancerTest {
         lb.releaseGroup(group);
 
         // get third group
-        grp = lb.takeGroupForQuery(new Query());
+        grp = lb.takeGroupForQuery(new Query(), null);
         group = grp.get();
         assertThat(group.id(), equalTo(id2));
     }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
@@ -3,6 +3,9 @@ package com.yahoo.search.dispatch;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.yahoo.search.dispatch.searchcluster.Group;
+import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/SearchPathTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/SearchPathTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.dispatch;
 
 import com.yahoo.search.dispatch.SearchPath.InvalidSearchPathException;
+import com.yahoo.search.dispatch.searchcluster.Node;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -77,7 +78,7 @@ public class SearchPathTest {
         assertThat(distKeysAsString(SearchPath.selectNodes("[1,88>/1", cluster)), equalTo("5,6"));
     }
 
-    private static String distKeysAsString(Collection<SearchCluster.Node> nodes) {
-        return nodes.stream().map(SearchCluster.Node::key).map(Object::toString).collect(Collectors.joining(","));
+    private static String distKeysAsString(Collection<Node> nodes) {
+        return nodes.stream().map(Node::key).map(Object::toString).collect(Collectors.joining(","));
     }
 }


### PR DESCRIPTION
- TrafficMonitor changed to handle connection failures and no-answers differently (should be more in line with fdispatch and in general more responsive)
- SearchCluster moved to its own package and inner classes extracted to separate files
- retry logic in Dispatcher.getInternalInvoker has now a fixed limit of retries and works in cooperation with LoadBalancer to always get "good" candidates.
- FS4InvokerFactory now considers coverage when some node is inaccessible and can return an invoker without full coverage as a last resort