### PR TITLE
Send probe when suspending many nodes

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorContext.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorContext.java
@@ -22,16 +22,16 @@ public class OrchestratorContext {
 
     private final Clock clock;
     private final TimeBudget timeBudget;
-    private boolean probe;
+    private final boolean probe;
 
     /** Create an OrchestratorContext for operations on multiple applications. */
     public static OrchestratorContext createContextForMultiAppOp(Clock clock) {
-        return new OrchestratorContext(clock, TimeBudget.fromNow(clock, DEFAULT_TIMEOUT_FOR_BATCH_OP), true);
+        return new OrchestratorContext(clock, TimeBudget.fromNow(clock, DEFAULT_TIMEOUT_FOR_BATCH_OP), false);
     }
 
     /** Create an OrchestratorContext for an operation on a single application. */
     public static OrchestratorContext createContextForSingleAppOp(Clock clock) {
-        return new OrchestratorContext(clock, TimeBudget.fromNow(clock, DEFAULT_TIMEOUT_FOR_SINGLE_OP), true);
+        return new OrchestratorContext(clock, TimeBudget.fromNow(clock, DEFAULT_TIMEOUT_FOR_SINGLE_OP), false);
     }
 
     private OrchestratorContext(Clock clock, TimeBudget timeBudget, boolean probe) {
@@ -48,13 +48,6 @@ public class OrchestratorContext {
         return new ClusterControllerClientTimeouts(timeBudget.timeLeftAsTimeBudget());
     }
 
-
-    /** Mark this operation as a non-committal probe. */
-    public OrchestratorContext markAsProbe() {
-        this.probe = true;
-        return this;
-    }
-
     /** Whether the operation is a no-op probe to test whether it would have succeeded, if it had been committal. */
     public boolean isProbe() {
         return probe;
@@ -69,7 +62,7 @@ public class OrchestratorContext {
     }
 
     /** Create an OrchestratorContext for an operation on a single application, but limited to current timeout. */
-    public OrchestratorContext createSubcontextForSingleAppOp() {
+    public OrchestratorContext createSubcontextForSingleAppOp(boolean probe) {
         Instant now = clock.instant();
         Instant deadline = timeBudget.deadline().get();
         Instant maxDeadline = now.plus(DEFAULT_TIMEOUT_FOR_SINGLE_OP);

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerClientImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerClientImpl.java
@@ -35,7 +35,10 @@ public class ClusterControllerClientImpl implements ClusterControllerClient{
                                                        int storageNodeIndex,
                                                        ClusterControllerNodeState wantedState) throws IOException {
         ClusterControllerStateRequest.State state = new ClusterControllerStateRequest.State(wantedState, REQUEST_REASON);
-        ClusterControllerStateRequest stateRequest = new ClusterControllerStateRequest(state, ClusterControllerStateRequest.Condition.SAFE);
+        ClusterControllerStateRequest stateRequest = new ClusterControllerStateRequest(
+                state,
+                ClusterControllerStateRequest.Condition.SAFE,
+                context.isProbe() ? true : null);
         ClusterControllerClientTimeouts timeouts = context.getClusterControllerTimeouts();
 
         try {
@@ -67,7 +70,8 @@ public class ClusterControllerClientImpl implements ClusterControllerClient{
             OrchestratorContext context,
             ClusterControllerNodeState wantedState) throws IOException {
         ClusterControllerStateRequest.State state = new ClusterControllerStateRequest.State(wantedState, REQUEST_REASON);
-        ClusterControllerStateRequest stateRequest = new ClusterControllerStateRequest(state, ClusterControllerStateRequest.Condition.FORCE);
+        ClusterControllerStateRequest stateRequest = new ClusterControllerStateRequest(
+                state, ClusterControllerStateRequest.Condition.FORCE, null);
         ClusterControllerClientTimeouts timeouts = context.getClusterControllerTimeouts();
 
         try {

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerStateRequest.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/controller/ClusterControllerStateRequest.java
@@ -1,8 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.controller;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -10,6 +12,8 @@ import java.util.Objects;
 /**
  * @author hakonhall
  */
+@Immutable
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ClusterControllerStateRequest {
 
     @JsonProperty("state")
@@ -18,26 +22,29 @@ public class ClusterControllerStateRequest {
     @JsonProperty("condition")
     public final Condition condition;
 
-    public ClusterControllerStateRequest(State currentState, Condition condition) {
+    @JsonProperty("probe")
+    public final Boolean probe;
+
+    public ClusterControllerStateRequest(State currentState, Condition condition, Boolean probe) {
         Map<String, State> state = Collections.singletonMap("user", currentState);
         this.state = Collections.unmodifiableMap(state);
         this.condition = condition;
+        this.probe = probe;
     }
 
     @Override
-    public boolean equals(Object object) {
-        if (!(object instanceof ClusterControllerStateRequest)) {
-            return false;
-        }
-
-        final ClusterControllerStateRequest that = (ClusterControllerStateRequest) object;
-        return Objects.equals(this.state, that.state)
-                && Objects.equals(this.condition, that.condition);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClusterControllerStateRequest that = (ClusterControllerStateRequest) o;
+        return Objects.equals(state, that.state) &&
+                condition == that.condition &&
+                Objects.equals(probe, that.probe);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, condition);
+        return Objects.hash(state, condition, probe);
     }
 
     @Override

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ApplicationApi.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ApplicationApi.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.orchestrator.model;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.orchestrator.OrchestratorContext;
 import com.yahoo.vespa.orchestrator.status.ApplicationInstanceStatus;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 
@@ -26,7 +27,7 @@ public interface ApplicationApi {
 
     ApplicationInstanceStatus getApplicationStatus();
 
-    void setHostState(HostName hostName, HostStatus status);
+    void setHostState(OrchestratorContext context, HostName hostName, HostStatus status);
     List<HostName> getNodesInGroupWithStatus(HostStatus status);
 
     List<StorageNode> getStorageNodesInGroupInClusterOrder();

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/StorageNodeImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/StorageNodeImpl.java
@@ -104,6 +104,12 @@ public class StorageNodeImpl implements StorageNode {
                     HostedVespaPolicy.SET_NODE_STATE_CONSTRAINT,
                     "Failed to set state to " + wantedNodeState + " in cluster controller: " + response.reason);
         }
+
+        String logSuffix = context.isProbe() ?
+                " has been set to " + wantedNodeState:
+                " would have been set to " + wantedNodeState + " (this is a probe)";
+        logger.log(LogLevel.INFO, "Storage node " + nodeIndex + " in cluster " + clusterId +
+                " application " + applicationInstance.reference().asString() + " on host " + hostName() + logSuffix);
     }
 
     @Override

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/StorageNodeImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/StorageNodeImpl.java
@@ -106,8 +106,8 @@ public class StorageNodeImpl implements StorageNode {
         }
 
         String logSuffix = context.isProbe() ?
-                " has been set to " + wantedNodeState:
-                " would have been set to " + wantedNodeState + " (this is a probe)";
+                " would have been set to " + wantedNodeState + " (this is a probe)" :
+                " has been set to " + wantedNodeState;
         logger.log(LogLevel.INFO, "Storage node " + nodeIndex + " in cluster " + clusterId +
                 " application " + applicationInstance.reference().asString() + " on host " + hostName() + logSuffix);
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicy.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.policy;
 
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.applicationmodel.ApplicationInstance;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.orchestrator.OrchestratorContext;
@@ -52,13 +51,11 @@ public class HostedVespaPolicy implements Policy {
         // These storage nodes are guaranteed to be NO_REMARKS
         for (StorageNode storageNode : application.getUpStorageNodesInGroupInClusterOrder()) {
             storageNode.setNodeState(context, ClusterControllerNodeState.MAINTENANCE);
-            log.log(LogLevel.INFO, "The storage node on " + storageNode.hostName() + " has been set to MAINTENANCE");
         }
 
         // Ensure all nodes in the group are marked as allowed to be down
         for (HostName hostName : application.getNodesInGroupWithStatus(HostStatus.NO_REMARKS)) {
-            application.setHostState(hostName, HostStatus.ALLOWED_TO_BE_DOWN);
-            log.log(LogLevel.INFO, hostName + " is now allowed to be down (suspended)");
+            application.setHostState(context, hostName, HostStatus.ALLOWED_TO_BE_DOWN);
         }
     }
 
@@ -68,12 +65,10 @@ public class HostedVespaPolicy implements Policy {
         // Always defer to Cluster Controller whether it's OK to resume storage node
         for (StorageNode storageNode : application.getStorageNodesAllowedToBeDownInGroupInReverseClusterOrder()) {
             storageNode.setNodeState(context, ClusterControllerNodeState.UP);
-            log.log(LogLevel.INFO, "The storage node on " + storageNode.hostName() + " has been set to UP");
         }
 
         for (HostName hostName : application.getNodesInGroupWithStatus(HostStatus.ALLOWED_TO_BE_DOWN)) {
-            application.setHostState(hostName, HostStatus.NO_REMARKS);
-            log.log(LogLevel.INFO, hostName + " is no longer allowed to be down (resumed)");
+            application.setHostState(context, hostName, HostStatus.NO_REMARKS);
         }
     }
 
@@ -98,13 +93,11 @@ public class HostedVespaPolicy implements Policy {
         // These storage nodes are guaranteed to be NO_REMARKS
         for (StorageNode storageNode : applicationApi.getStorageNodesInGroupInClusterOrder()) {
             storageNode.setNodeState(context, ClusterControllerNodeState.DOWN);
-            log.log(LogLevel.INFO, "The storage node on " + storageNode.hostName() + " has been set DOWN");
         }
 
         // Ensure all nodes in the group are marked as allowed to be down
         for (HostName hostName : applicationApi.getNodesInGroupWithStatus(HostStatus.NO_REMARKS)) {
-            applicationApi.setHostState(hostName, HostStatus.ALLOWED_TO_BE_DOWN);
-            log.log(LogLevel.INFO, hostName + " is now allowed to be down (suspended)");
+            applicationApi.setHostState(context, hostName, HostStatus.ALLOWED_TO_BE_DOWN);
         }
     }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/InMemoryStatusService.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/InMemoryStatusService.java
@@ -3,8 +3,8 @@ package com.yahoo.vespa.orchestrator.status;
 
 import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.orchestrator.OrchestratorContext;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -46,8 +46,8 @@ public class InMemoryStatusService implements StatusService {
 
     @Override
     public MutableStatusRegistry lockApplicationInstance_forCurrentThreadOnly(
-            ApplicationInstanceReference applicationInstanceReference,
-            Duration timeout) {
+            OrchestratorContext context,
+            ApplicationInstanceReference applicationInstanceReference) {
         Lock lock = instanceLockService.get(applicationInstanceReference);
         return new InMemoryMutableStatusRegistry(lock, applicationInstanceReference);
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/StatusService.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/StatusService.java
@@ -2,8 +2,8 @@
 package com.yahoo.vespa.orchestrator.status;
 
 import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
+import com.yahoo.vespa.orchestrator.OrchestratorContext;
 
-import java.time.Duration;
 import java.util.Set;
 
 /**
@@ -25,7 +25,7 @@ public interface StatusService {
      * possibly inconsistent snapshot values. It is not recommended that this method is used for anything other
      * than monitoring, logging, debugging, etc. It should never be used for multi-step operations (e.g.
      * read-then-write) where consistency is required. For those cases, use
-     * {@link #lockApplicationInstance_forCurrentThreadOnly(ApplicationInstanceReference, Duration)}.
+     * {@link #lockApplicationInstance_forCurrentThreadOnly(OrchestratorContext, ApplicationInstanceReference)}.
      */
     ReadOnlyStatusRegistry forApplicationInstance(ApplicationInstanceReference applicationInstanceReference);
 
@@ -54,8 +54,8 @@ public interface StatusService {
      * This may leave the registry in an inconsistent state (as judged by the client code).
      */
     MutableStatusRegistry lockApplicationInstance_forCurrentThreadOnly(
-            ApplicationInstanceReference applicationInstanceReference,
-            Duration timeout);
+            OrchestratorContext context,
+            ApplicationInstanceReference applicationInstanceReference);
 
     /**
      * Returns all application instances that are allowed to be down. The intention is to use this

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicyTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicyTest.java
@@ -84,9 +84,9 @@ public class HostedVespaPolicyTest {
         order.verify(storageNode3).setNodeState(context, ClusterControllerNodeState.MAINTENANCE);
 
         order.verify(applicationApi).getNodesInGroupWithStatus(HostStatus.NO_REMARKS);
-        order.verify(applicationApi).setHostState(hostName1, HostStatus.ALLOWED_TO_BE_DOWN);
-        order.verify(applicationApi).setHostState(hostName2, HostStatus.ALLOWED_TO_BE_DOWN);
-        order.verify(applicationApi).setHostState(hostName3, HostStatus.ALLOWED_TO_BE_DOWN);
+        order.verify(applicationApi).setHostState(context, hostName1, HostStatus.ALLOWED_TO_BE_DOWN);
+        order.verify(applicationApi).setHostState(context, hostName2, HostStatus.ALLOWED_TO_BE_DOWN);
+        order.verify(applicationApi).setHostState(context, hostName3, HostStatus.ALLOWED_TO_BE_DOWN);
 
         order.verifyNoMoreInteractions();
     }
@@ -135,9 +135,9 @@ public class HostedVespaPolicyTest {
         order.verify(storageNode3).setNodeState(context, ClusterControllerNodeState.DOWN);
 
         order.verify(applicationApi).getNodesInGroupWithStatus(HostStatus.NO_REMARKS);
-        order.verify(applicationApi).setHostState(hostName1, HostStatus.ALLOWED_TO_BE_DOWN);
-        order.verify(applicationApi).setHostState(hostName2, HostStatus.ALLOWED_TO_BE_DOWN);
-        order.verify(applicationApi).setHostState(hostName3, HostStatus.ALLOWED_TO_BE_DOWN);
+        order.verify(applicationApi).setHostState(context, hostName1, HostStatus.ALLOWED_TO_BE_DOWN);
+        order.verify(applicationApi).setHostState(context, hostName2, HostStatus.ALLOWED_TO_BE_DOWN);
+        order.verify(applicationApi).setHostState(context, hostName3, HostStatus.ALLOWED_TO_BE_DOWN);
 
         order.verifyNoMoreInteractions();
     }

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
@@ -75,7 +75,7 @@ public class HostResourceTest {
     static {
         when(EVERY_HOST_IS_UP_HOST_STATUS_SERVICE.forApplicationInstance(eq(APPLICATION_INSTANCE_REFERENCE)))
                 .thenReturn(EVERY_HOST_IS_UP_MUTABLE_HOST_STATUS_REGISTRY);
-        when(EVERY_HOST_IS_UP_HOST_STATUS_SERVICE.lockApplicationInstance_forCurrentThreadOnly(eq(APPLICATION_INSTANCE_REFERENCE), any()))
+        when(EVERY_HOST_IS_UP_HOST_STATUS_SERVICE.lockApplicationInstance_forCurrentThreadOnly(any(), eq(APPLICATION_INSTANCE_REFERENCE)))
                 .thenReturn(EVERY_HOST_IS_UP_MUTABLE_HOST_STATUS_REGISTRY);
         when(EVERY_HOST_IS_UP_MUTABLE_HOST_STATUS_REGISTRY.getHostStatus(any()))
                 .thenReturn(HostStatus.NO_REMARKS);


### PR DESCRIPTION
When suspending all nodes on a host, first do a suspend-all probe that will try
to suspend the nodes as normal in Orchestrator and cluster controller, but
actually not commit anything. A probe failure will result in the same failure
as a non-probe failure: A 409 response with description is sent back to the
client.