### PR TITLE
Avoid Query.clone which changes the sessionId (and the cache key)

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -33,13 +33,15 @@ public class InterleavedSearchInvoker extends SearchInvoker {
      */
     @Override
     protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+        int originalHits = query.getHits();
+        int originalOffset = query.getOffset();
+        query.setHits(query.getHits() + query.getOffset());
+        query.setOffset(0);
         for (SearchInvoker invoker : invokers) {
-            Query subquery = query.clone();
-
-            subquery.setHits(subquery.getHits() + subquery.getOffset());
-            subquery.setOffset(0);
-            invoker.sendSearchRequest(subquery, null);
+            invoker.sendSearchRequest(query, null);
         }
+        query.setHits(originalHits);
+        query.setOffset(originalOffset);
     }
 
     @Override


### PR DESCRIPTION
This was the cause for `groupingSessionCache` not working