### PR TITLE
Remove support for vespa http client protocol v2.  Always use protocol v3.

### DIFF
--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaRecordWriter.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/VespaRecordWriter.java
@@ -102,7 +102,6 @@ public class VespaRecordWriter extends RecordWriter {
         ConnectionParams.Builder connParamsBuilder = new ConnectionParams.Builder();
         connParamsBuilder.setDryRun(configuration.dryrun());
         connParamsBuilder.setUseCompression(configuration.useCompression());
-        connParamsBuilder.setEnableV3Protocol(configuration.useV3Protocol());
         connParamsBuilder.setNumPersistentConnectionsPerEndpoint(configuration.numConnections());
         connParamsBuilder.setMaxRetries(configuration.numRetries());
         if (configuration.proxyHost() != null) {

--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/util/VespaConfiguration.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/mapreduce/util/VespaConfiguration.java
@@ -19,7 +19,6 @@ public class VespaConfiguration {
     public static final String USE_COMPRESSION = "vespa.feed.usecompression";
     public static final String DATA_FORMAT = "vespa.feed.data.format";
     public static final String PROGRESS_REPORT = "vespa.feed.progress.interval";
-    public static final String V3_PROTOCOL = "vespa.feed.v3.protocol";
     public static final String CONNECTIONS = "vespa.feed.connections";
     public static final String THROTTLER_MIN_SIZE = "vespa.feed.throttler.min.size";
     public static final String QUERY_CONNECTION_TIMEOUT = "vespa.query.connection.timeout";
@@ -75,11 +74,6 @@ public class VespaConfiguration {
 
     public boolean useCompression() {
         return getBoolean(USE_COMPRESSION, true);
-    }
-
-
-    public boolean useV3Protocol() {
-        return getBoolean(V3_PROTOCOL, true);
     }
 
 
@@ -187,7 +181,6 @@ public class VespaConfiguration {
         sb.append(USE_COMPRESSION + ": " +  useCompression() +"\n");
         sb.append(DATA_FORMAT + ": " +  dataFormat() +"\n");
         sb.append(PROGRESS_REPORT + ": " +  progressInterval() +"\n");
-        sb.append(V3_PROTOCOL + ": " +  useV3Protocol() +"\n");
         sb.append(CONNECTIONS + ": " +  numConnections() +"\n");
         sb.append(THROTTLER_MIN_SIZE + ": " +  throttlerMinSize() +"\n");
         sb.append(QUERY_CONNECTION_TIMEOUT + ": " +  queryConnectionTimeout() +"\n");

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/ConnectionParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/ConnectionParams.java
@@ -46,7 +46,6 @@ public final class ConnectionParams {
         private int maxRetries = 100;
         private long minTimeBetweenRetriesMs = 700;
         private boolean dryRun = false;
-        private boolean enableV3Protocol = true;
         private int traceLevel = 0;
         private int traceEveryXOperation = 0;
         private boolean printTraceToStdErr = true;
@@ -175,12 +174,6 @@ public final class ConnectionParams {
             return this;
         }
 
-        @Beta
-        public Builder setEnableV3Protocol(boolean enableV3Protocol) {
-            this.enableV3Protocol = enableV3Protocol;
-            return this;
-        }
-
         /**
          * Set the min time between retries when temporarily failing against a gateway.
          *
@@ -245,7 +238,6 @@ public final class ConnectionParams {
                     maxRetries,
                     minTimeBetweenRetriesMs,
                     dryRun,
-                    enableV3Protocol,
                     traceLevel,
                     traceEveryXOperation,
                     printTraceToStdErr);
@@ -301,7 +293,6 @@ public final class ConnectionParams {
     private final int maxRetries;
     private final long minTimeBetweenRetriesMs;
     private final boolean dryRun;
-    private final boolean enableV3Protocol;
     private final int traceLevel;
     private final int traceEveryXOperation;
     private final boolean printTraceToStdErr;
@@ -319,7 +310,6 @@ public final class ConnectionParams {
             int maxRetries,
             long minTimeBetweenRetriesMs,
             boolean dryRun,
-            boolean enableV3Protocol,
             int traceLevel,
             int traceEveryXOperation,
             boolean printTraceToStdErr) {
@@ -335,7 +325,6 @@ public final class ConnectionParams {
         this.maxRetries = maxRetries;
         this.minTimeBetweenRetriesMs = minTimeBetweenRetriesMs;
         this.dryRun = dryRun;
-        this.enableV3Protocol = enableV3Protocol;
         this.traceLevel = traceLevel;
         this.traceEveryXOperation = traceEveryXOperation;
         this.printTraceToStdErr = printTraceToStdErr;
@@ -386,8 +375,6 @@ public final class ConnectionParams {
     public boolean isDryRun() {
         return dryRun;
     }
-
-    public boolean isEnableV3Protocol() { return enableV3Protocol; }
 
     public int getTraceLevel() {
         return traceLevel;

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ApacheGatewayConnection.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ApacheGatewayConnection.java
@@ -78,7 +78,7 @@ class ApacheGatewayConnection implements GatewayConnection {
             ConnectionParams connectionParams,
             HttpClientFactory httpClientFactory,
             String clientId) {
-        SUPPORTED_VERSIONS.add(2);
+        SUPPORTED_VERSIONS.add(3);
         this.endpoint = endpoint;
         this.feedParams = feedParams;
         this.clusterSpecificRoute = clusterSpecificRoute;
@@ -94,11 +94,8 @@ class ApacheGatewayConnection implements GatewayConnection {
             endOfFeed = END_OF_FEED_XML;
         }
         this.clientId = clientId;
-        if (connectionParams.isEnableV3Protocol()) {
-            if (this.clientId == null) {
-                throw new RuntimeException("Set to support version 3, but got no client Id.");
-            }
-            SUPPORTED_VERSIONS.add(3);
+        if (this.clientId == null) {
+            throw new RuntimeException("Got no client Id.");
         }
     }
 
@@ -343,10 +340,6 @@ class ApacheGatewayConnection implements GatewayConnection {
             if (log.isLoggable(Level.FINE)) {
                 log.log(Level.FINE, "Server decided upon protocol version " + serverVersion + ".");
             }
-        }
-        if (this.connectionParams.isEnableV3Protocol() && serverVersion != 3) {
-            throw new ServerResponseException("Client was set up to use v3 of protocol, however, gateway wants to " +
-                    "use version " + serverVersion + ". Already set up structures for v3 so can not do v2 now.");
         }
         this.negotiatedVersion = serverVersion;
     }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
@@ -79,12 +79,8 @@ public class ClusterConnection implements AutoCloseable {
                             operationProcessor.getClientId()
                     );
                 }
-                if (connectionParams.isEnableV3Protocol()) {
-                    if (documentQueue == null) {
-                        documentQueue = new DocumentQueue(clientQueueSizePerCluster);
-                    }
-                } else {
-                    documentQueue = new DocumentQueue(clientQueueSizePerCluster / cluster.getEndpoints().size());
+                if (documentQueue == null) {
+                    documentQueue = new DocumentQueue(clientQueueSizePerCluster);
                 }
                 final IOThread ioThread = new IOThread(
                         operationProcessor.getIoThreadGroup(),
@@ -95,7 +91,7 @@ public class ClusterConnection implements AutoCloseable {
                         maxInFlightPerSession,
                         feedParams.getLocalQueueTimeOut(),
                         documentQueue,
-                        connectionParams.isEnableV3Protocol() ? feedParams.getMaxSleepTimeMs() : 0);
+                        feedParams.getMaxSleepTimeMs());
                 ioThreads.add(ioThread);
             }
         }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
@@ -51,7 +51,6 @@ public class OperationProcessor {
     private final long minTimeBetweenRetriesMs;
     private final Random random = new SecureRandom();
     private final int traceEveryXOperation;
-    private final boolean blockOperationsToSameDocument;
     private int traceCounter = 0;
     private final boolean traceToStderr;
     private final ThreadGroup ioThreadGroup;
@@ -66,7 +65,6 @@ public class OperationProcessor {
         this.resultCallback = resultCallback;
         this.incompleteResultsThrottler = incompleteResultsThrottler;
         this.timeoutExecutor = timeoutExecutor;
-        this.blockOperationsToSameDocument = sessionParams.getConnectionParams().isEnableV3Protocol();
         this.ioThreadGroup = new ThreadGroup("operationprocessor");
 
         if (sessionParams.getClusters().isEmpty()) {
@@ -243,7 +241,7 @@ public class OperationProcessor {
         incompleteResultsThrottler.operationStart();
 
         synchronized (monitor) {
-            if (blockOperationsToSameDocument && inflightDocumentIds.contains(document.getDocumentId())) {
+            if (inflightDocumentIds.contains(document.getDocumentId())) {
                 blockedDocumentsByDocumentId.put(document.getDocumentId(), document);
                 return;
             }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/runner/CommandLineArguments.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/runner/CommandLineArguments.java
@@ -66,16 +66,6 @@ public class CommandLineArguments {
                 return null;
             }
         }
-        if (cmdArgs.enableV2Protocol) {
-            if (cmdArgs.enableV3Protocol) {
-                System.err.println("both --useV2Protocol and --useV3Protocol options specified, ignoring deprecated --useV2Protocol option");
-                cmdArgs.enableV2Protocol = false;
-            } else {
-                System.err.println("--useV2Protocol option is deprecated");
-            }
-        } else {
-            cmdArgs.enableV3Protocol = true;
-        }
 
         return cmdArgs;
     }
@@ -110,10 +100,7 @@ public class CommandLineArguments {
     private HelpOption helpOption;
 
     @Option(name = {"--useV3Protocol"}, description = "Use V3 protocol to gateway. This is the default protocol.")
-    private boolean enableV3Protocol = false;
-
-    @Option(name = {"--useV2Protocol"}, description = "Use old V2 protocol to gateway. This option is deprecated.")
-    private boolean enableV2Protocol = false;
+    private boolean enableV3Protocol = true;
 
     @Option(name = {"--file"},
             description = "The name of the input file to read.")
@@ -240,7 +227,6 @@ public class CommandLineArguments {
                                 .setHostnameVerifier(insecure ? NoopHostnameVerifier.INSTANCE :
                                         SSLConnectionSocketFactory.getDefaultHostnameVerifier())
                                 .setNumPersistentConnectionsPerEndpoint(16)
-                                .setEnableV3Protocol(! enableV2Protocol)
                                 .setUseCompression(useCompressionArg)
                                 .setMaxRetries(noRetryArg ? 0 : 100)
                                 .setMinTimeBetweenRetries(retrydelayArg, TimeUnit.SECONDS)

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/communication/ApacheGatewayConnectionTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/communication/ApacheGatewayConnectionTest.java
@@ -55,7 +55,6 @@ public class ApacheGatewayConnectionTest {
         final FeedParams feedParams = new FeedParams.Builder().setDataFormat(FeedParams.DataFormat.JSON_UTF8).build();
         final String clusterSpecificRoute = "";
         final ConnectionParams connectionParams = new ConnectionParams.Builder()
-                .setEnableV3Protocol(true)
                 .build();
         final List<Document> documents = new ArrayList<>();
 
@@ -90,7 +89,6 @@ public class ApacheGatewayConnectionTest {
         final FeedParams feedParams = new FeedParams.Builder().setDataFormat(FeedParams.DataFormat.JSON_UTF8).build();
         final String clusterSpecificRoute = "";
         final ConnectionParams connectionParams = new ConnectionParams.Builder()
-                .setEnableV3Protocol(true)
                 .build();
 
         // This is the fake server, returns wrong session Id.
@@ -115,7 +113,6 @@ public class ApacheGatewayConnectionTest {
         final FeedParams feedParams = new FeedParams.Builder().setDataFormat(FeedParams.DataFormat.JSON_UTF8).build();
         final String clusterSpecificRoute = "";
         final ConnectionParams connectionParams = new ConnectionParams.Builder()
-                .setEnableV3Protocol(true)
                 .build();
 
         final ApacheGatewayConnection.HttpClientFactory mockFactory =

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessorTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessorTest.java
@@ -124,7 +124,7 @@ public class OperationProcessorTest {
         SessionParams sessionParams = new SessionParams.Builder()
                 .addCluster(new Cluster.Builder().addEndpoint(Endpoint.create("host")).build())
                 .addCluster(new Cluster.Builder().addEndpoint(Endpoint.create("host")).build())
-                .setConnectionParams(new ConnectionParams.Builder().setEnableV3Protocol(true).build())
+                .setConnectionParams(new ConnectionParams.Builder().build())
                 .build();
         OperationProcessor operationProcessor = new OperationProcessor(
                 new IncompleteResultsThrottler(1000, 1000, null, null),
@@ -161,7 +161,7 @@ public class OperationProcessorTest {
     public void testBlockingOfOperationsToSameDocIdWithTwoOperations() {
         SessionParams sessionParams = new SessionParams.Builder()
                 .addCluster(new Cluster.Builder().addEndpoint(Endpoint.create("host")).build())
-                .setConnectionParams(new ConnectionParams.Builder().setEnableV3Protocol(true).build())
+                .setConnectionParams(new ConnectionParams.Builder().build())
                 .build();
 
         OperationProcessor operationProcessor = new OperationProcessor(
@@ -194,7 +194,7 @@ public class OperationProcessorTest {
     public void testBlockingOfOperationsToSameDocIdMany() {
         SessionParams sessionParams = new SessionParams.Builder()
                 .addCluster(new Cluster.Builder().addEndpoint(Endpoint.create("host")).build())
-                .setConnectionParams(new ConnectionParams.Builder().setEnableV3Protocol(true).build())
+                .setConnectionParams(new ConnectionParams.Builder().build())
                 .build();
 
         OperationProcessor operationProcessor = new OperationProcessor(
@@ -229,7 +229,7 @@ public class OperationProcessorTest {
         Endpoint endpoint = Endpoint.create("host");
         SessionParams sessionParams = new SessionParams.Builder()
                 .addCluster(new Cluster.Builder().addEndpoint(endpoint).build())
-                .setConnectionParams(new ConnectionParams.Builder().setEnableV3Protocol(true).build())
+                .setConnectionParams(new ConnectionParams.Builder().build())
                 .build();
 
         OperationProcessor operationProcessor = new OperationProcessor(

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/runner/CommandLineArgumentsTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/runner/CommandLineArgumentsTest.java
@@ -95,7 +95,6 @@ public class CommandLineArgumentsTest {
         assertThat(params.getClusters().get(0).getEndpoints().get(0).isUseSsl(), is(false));
         assertThat(params.getConnectionParams().getUseCompression(), is(false));
         assertThat(params.getConnectionParams().getNumPersistentConnectionsPerEndpoint(), is(16));
-        assertThat(params.getConnectionParams().isEnableV3Protocol(), is(true));
         assertThat(params.getFeedParams().getRoute(), is("default"));
         assertThat(params.getFeedParams().getDataFormat(), is(FeedParams.DataFormat.XML_UTF8));
         assertThat(params.getFeedParams().getLocalQueueTimeOut(), is(180000L));
@@ -176,30 +175,10 @@ public class CommandLineArgumentsTest {
     }
 
     @Test
-    public void testDeprecatedUseV2Protocol() {
-        addMinimum();
-        args.add("--useV2Protocol");
-        CommandLineArguments arguments = CommandLineArguments.build(asArray());
-        SessionParams params = arguments.createSessionParams(true /* use json */);
-        assertThat(params.getConnectionParams().isEnableV3Protocol(), is(false));
-    }
-
-    @Test
     public void testUseV3Protocol() {
         addMinimum();
         args.add("--useV3Protocol");
         CommandLineArguments arguments = CommandLineArguments.build(asArray());
         SessionParams params = arguments.createSessionParams(true /* use json */);
-        assertThat(params.getConnectionParams().isEnableV3Protocol(), is(true));
-    }
-
-    @Test
-    public void testDeprecatedUseV2ProtocolAndUseV3Protocol() {
-        addMinimum();
-        args.add("--useV2Protocol");
-        args.add("--useV3Protocol");
-        CommandLineArguments arguments = CommandLineArguments.build(asArray());
-        SessionParams params = arguments.createSessionParams(true /* use json */);
-        assertThat(params.getConnectionParams().isEnableV3Protocol(), is(true));
     }
 }


### PR DESCRIPTION
@geirst: please review
