### PR TITLE
Disable java dispatch when multi-level dispatch used; coverage reporting fixes

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -404,23 +404,24 @@ public class IndexedSearchCluster extends SearchCluster
             nodeBuilder.host(node.getHostName());
             nodeBuilder.port(node.getRpcPort());
             nodeBuilder.fs4port(node.getDispatchPort());
-            if (tuning.dispatch.minActiveDocsCoverage != null)
-                builder.minActivedocsPercentage(tuning.dispatch.minActiveDocsCoverage);
-            if (tuning.dispatch.minGroupCoverage != null)
-                builder.minGroupCoverage(tuning.dispatch.minGroupCoverage);
-            if (tuning.dispatch.policy != null) {
-                switch (tuning.dispatch.policy) {
-                    case RANDOM:
-                        builder.distributionPolicy(DistributionPolicy.RANDOM);
-                        break;
-                    case ROUNDROBIN:
-                        builder.distributionPolicy(DistributionPolicy.ROUNDROBIN);
-                        break;
-                }
-            }
-            builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());
             builder.node(nodeBuilder);
         }
+        if (tuning.dispatch.minActiveDocsCoverage != null)
+            builder.minActivedocsPercentage(tuning.dispatch.minActiveDocsCoverage);
+        if (tuning.dispatch.minGroupCoverage != null)
+            builder.minGroupCoverage(tuning.dispatch.minGroupCoverage);
+        if (tuning.dispatch.policy != null) {
+            switch (tuning.dispatch.policy) {
+                case RANDOM:
+                    builder.distributionPolicy(DistributionPolicy.RANDOM);
+                    break;
+                case ROUNDROBIN:
+                    builder.distributionPolicy(DistributionPolicy.ROUNDROBIN);
+                    break;
+            }
+        }
+        builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());
+        builder.useMultilevelDispatch(useMultilevelDispatchSetup());
     }
 
     @Override

--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -16,6 +16,9 @@ maxNodesDownPerGroup int default=0
 # Distribution policy for group selection
 distributionPolicy enum { ROUNDROBIN, RANDOM } default=ROUNDROBIN
 
+# Is multi-level dispatch configured for this cluster
+useMultilevelDispatch bool default=false
+
 # The unique key of a search node
 node[].key int
 

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -272,14 +272,20 @@ public class FastSearcher extends VespaBackEndSearcher {
         Result result = new Result(query);
         // keep a separate tally of coverage as the normal merge counts using
         // federated query rules
-        Coverage finalCoverage = new Coverage(0, 0);
+        Coverage finalCoverage = null;
 
         for (Result partialResult : results) {
-            finalCoverage.mergeWithPartition(partialResult.getCoverage(true));
+            if(finalCoverage == null) {
+                finalCoverage = partialResult.getCoverage(true);
+            } else {
+                finalCoverage.mergeWithPartition(partialResult.getCoverage(true));
+            }
             result.mergeWith(partialResult);
             result.hits().addAll(partialResult.hits().asUnorderedHits());
         }
-        result.setCoverage(finalCoverage);
+        if (finalCoverage != null) {
+            result.setCoverage(finalCoverage);
+        }
 
         if (query.getOffset() != 0 || result.hits().size() > query.getHits()) {
             // with multiple results, each partial result is expected to have

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -14,6 +14,7 @@ import com.yahoo.search.dispatch.SearchPath.InvalidSearchPathException;
 import com.yahoo.search.dispatch.searchcluster.Group;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.dispatch.searchcluster.SearchCluster;
+import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.vespa.config.search.DispatchConfig;
 
 import java.util.Arrays;
@@ -125,7 +126,7 @@ public class Dispatcher extends AbstractComponent {
                 return invokerFactory.supply(query, -1, nodes, true);
             }
         } catch (InvalidSearchPathException e) {
-            return Optional.of(new SearchErrorInvoker(e.getMessage()));
+            return Optional.of(new SearchErrorInvoker(ErrorMessage.createIllegalQuery(e.getMessage())));
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
@@ -5,6 +5,7 @@ import com.yahoo.fs4.QueryPacket;
 import com.yahoo.prelude.fastsearch.CacheKey;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
+import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
 
 import java.io.IOException;
@@ -12,17 +13,24 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * A search invoker that will immediately produce an error that occurred during invoker construction.
- * Currently used for invalid searchpath values.
+ * A search invoker that will immediately produce an error that occurred during
+ * invoker construction. Currently used for invalid searchpath values and node
+ * failure
  *
  * @author ollivir
  */
 public class SearchErrorInvoker extends SearchInvoker {
-    private final String message;
+    private final ErrorMessage message;
     private Query query;
+    private final Coverage coverage;
 
-    public SearchErrorInvoker(String message) {
+    public SearchErrorInvoker(ErrorMessage message, Coverage coverage) {
         this.message = message;
+        this.coverage = coverage;
+    }
+
+    public SearchErrorInvoker(ErrorMessage message) {
+        this(message, null);
     }
 
     @Override
@@ -32,7 +40,11 @@ public class SearchErrorInvoker extends SearchInvoker {
 
     @Override
     protected List<Result> getSearchResults(CacheKey cacheKey) throws IOException {
-        return Arrays.asList(new Result(query, ErrorMessage.createIllegalQuery(message)));
+        Result res = new Result(query, message);
+        if (coverage != null) {
+            res.setCoverage(coverage);
+        }
+        return Arrays.asList(res);
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -323,7 +323,7 @@ public class SearchCluster implements NodeManager<Node> {
      */
     public boolean isPartialGroupCoverageSufficient(int groupId, List<Node> nodes) {
         if (orderedGroups.size() == 1) {
-            return true;
+            return nodes.size() >= groupSize() - maxNodesDownPerGroup;
         }
         long sumOfActiveDocuments = 0;
         int otherGroups = 0;


### PR DESCRIPTION
- Added enough bits to DispatchConfig so that it can be disabled when multi-level dispatching is configured
- Fixed coverage reporting again, since it predictably broke with the changes to behaviour during node failures