### PR TITLE
Allow controlling major version in the upgrader

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
@@ -154,10 +154,15 @@ public class ApplicationList {
         return listOf(list.stream().filter(a -> a.deploymentSpec().canUpgradeAt(instant)));
     }
 
-    /** Returns the subset of applications that hasn't pinned to another major version than the given one */
-    public ApplicationList allowMajorVersion(int majorVersion) {
-        return listOf(list.stream().filter(a -> ! a.deploymentSpec().majorVersion().isPresent() ||
-                                                a.deploymentSpec().majorVersion().get().equals(majorVersion)));
+    /**
+     * Returns the subset of applications that hasn't pinned to an an earlier major version than the given one.
+     *
+     * @param targetMajorVersion the target major version which applications returned allows upgrading to
+     * @param defaultMajorVersion the default major version to assume for applications not specifying one
+     */
+    public ApplicationList allowMajorVersion(int targetMajorVersion, int defaultMajorVersion) {
+        return listOf(list.stream().filter(a -> a.deploymentSpec().majorVersion().orElse(defaultMajorVersion)
+                                           >= targetMajorVersion));
     }
 
     /** Returns the first n application in this (or all, if there are less than n). */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
@@ -137,7 +137,7 @@ public class Upgrader extends Maintainer {
         return curator.readTargetMajorVersion();
     }
 
-    /** Sets the number of upgrades per minute */
+    /** Sets the default target major version. Set to empty to determine target version normally (by confidence) */
     public void setTargetMajorVersion(Optional<Integer> targetMajorVersion) {
         curator.writeTargetMajorVersion(targetMajorVersion);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
@@ -98,7 +98,7 @@ public class Upgrader extends Maintainer {
     private void upgrade(ApplicationList applications, Version version) {
         applications = applications.hasProductionDeployment();
         applications = applications.onLowerVersionThan(version);
-        applications = applications.allowMajorVersion(version.getMajor());
+        applications = applications.allowMajorVersion(version.getMajor(), targetMajorVersion().orElse(version.getMajor()));
         applications = applications.notDeploying(); // wait with applications deploying an application change or already upgrading
         applications = applications.notFailingOn(version); // try to upgrade only if it hasn't failed on this version
         applications = applications.canUpgradeAt(controller().clock().instant()); // wait with applications that are currently blocking upgrades
@@ -127,7 +127,19 @@ public class Upgrader extends Maintainer {
 
     /** Sets the number of upgrades per minute */
     public void setUpgradesPerMinute(double n) {
+        if (n < 0)
+            throw new IllegalArgumentException("Upgrades per minute must be >= 0, got " + n);
         curator.writeUpgradesPerMinute(n);
+    }
+
+    /** Returns the target major version for applications not specifying one */
+    public Optional<Integer> targetMajorVersion() {
+        return curator.readTargetMajorVersion();
+    }
+
+    /** Sets the number of upgrades per minute */
+    public void setTargetMajorVersion(Optional<Integer> targetMajorVersion) {
+        curator.writeTargetMajorVersion(targetMajorVersion);
     }
 
     /** Override confidence for given version. This will cause the computed confidence to be ignored */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -227,12 +227,20 @@ public class CuratorDb {
     }
 
     public void writeUpgradesPerMinute(double n) {
-        if (n < 0) {
-            throw new IllegalArgumentException("Upgrades per minute must be >= 0");
-        }
         curator.set(upgradesPerMinutePath(), ByteBuffer.allocate(Double.BYTES).putDouble(n).array());
     }
-  
+
+    public Optional<Integer> readTargetMajorVersion() {
+        return read(targetMajorVersionPath(), ByteBuffer::wrap).map(ByteBuffer::getInt);
+    }
+
+    public void writeTargetMajorVersion(Optional<Integer> targetMajorVersion) {
+        if (targetMajorVersion.isPresent())
+            curator.set(targetMajorVersionPath(), ByteBuffer.allocate(Integer.BYTES).putInt(targetMajorVersion.get()).array());
+        else
+            curator.delete(targetMajorVersionPath());
+    }
+
     public void writeVersionStatus(VersionStatus status) {
         curator.set(versionStatusPath(), asJson(versionStatusSerializer.toSlime(status)));
     }
@@ -500,6 +508,10 @@ public class CuratorDb {
 
     private static Path upgradesPerMinutePath() {
         return root.append("upgrader").append("upgradesPerMinute");
+    }
+
+    private static Path targetMajorVersionPath() {
+        return root.append("upgrader").append("targetMajorVersion");
     }
 
     private static Path confidenceOverridesPath() {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/ControllerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/ControllerApiHandler.java
@@ -20,6 +20,7 @@ import com.yahoo.yolean.Exceptions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.Scanner;
 import java.util.logging.Level;
 
@@ -102,7 +103,7 @@ public class ControllerApiHandler extends LoggingRequestHandler {
 
     private HttpResponse configureUpgrader(HttpRequest request) {
         String upgradesPerMinuteField = "upgradesPerMinute";
-        String confidenceOverrideField = "confidenceOverride";
+        String targetMajorVersionField = "targetMajorVersion";
 
         byte[] jsonBytes = toJsonBytes(request.getData());
         Inspector inspect = SlimeUtils.jsonToSlime(jsonBytes).get();
@@ -110,6 +111,9 @@ public class ControllerApiHandler extends LoggingRequestHandler {
 
         if (inspect.field(upgradesPerMinuteField).valid()) {
             upgrader.setUpgradesPerMinute(inspect.field(upgradesPerMinuteField).asDouble());
+        } else if (inspect.field(targetMajorVersionField).valid()) {
+            int target = (int)inspect.field(targetMajorVersionField).asLong();
+            upgrader.setTargetMajorVersion(Optional.ofNullable(target == 0 ? null : target)); // 0 is the default value
         } else {
             return ErrorResponse.badRequest("No such modifiable field(s)");
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/UpgraderResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/UpgraderResponse.java
@@ -27,11 +27,14 @@ public class UpgraderResponse extends HttpResponse {
         Slime slime = new Slime();
         Cursor root = slime.setObject();
         root.setDouble("upgradesPerMinute", upgrader.upgradesPerMinute());
+        upgrader.targetMajorVersion().ifPresent(v -> root.setLong("targetMajorVersion", v));
+
         Cursor array = root.setArray("confidenceOverrides");
         upgrader.confidenceOverrides().forEach((version, confidence) -> {
             Cursor object = array.addObject();
             object.setString(version.toString(), confidence.name());
         });
+
         new JsonFormat(true).encode(outputStream, slime);
     }
 


### PR DESCRIPTION
This makes it possible to set the target major Vespa version
in the upgrader explicitly for applications that do not.

This allows us to do a more controlled rollout of new major versions.

@mpolden please review

@arnej27959 fyi