### PR TITLE
Don't set up search implicitly

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -1,29 +1,15 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.clients;
 
-import com.yahoo.component.ComponentId;
-import com.yahoo.component.ComponentSpecification;
-import com.yahoo.component.chain.Phase;
-import com.yahoo.component.chain.dependencies.Dependencies;
-import com.yahoo.component.chain.model.ChainSpecification;
-import com.yahoo.component.chain.model.ChainedComponentModel;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.component.Handler;
-import com.yahoo.vespa.model.container.component.chain.ProcessingHandler;
-import com.yahoo.vespa.model.container.search.ContainerSearch;
-import com.yahoo.vespa.model.container.search.searchchain.SearchChain;
-import com.yahoo.vespa.model.container.search.searchchain.SearchChains;
-import com.yahoo.vespa.model.container.search.searchchain.Searcher;
 import com.yahoo.vespaclient.config.FeederConfig;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * @author Einar M R Rosenvinge

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -35,7 +35,7 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
 
     public ContainerDocumentApi(ContainerCluster cluster, Options options) {
         this.options = options;
-        legacySetupSearch(cluster); // TODO: Try to not do that on Vespa 7
+        //legacySetupSearch(cluster); // TODO: Try to not do that on Vespa 7
         setupHandlers(cluster);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -35,26 +35,12 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
 
     public ContainerDocumentApi(ContainerCluster cluster, Options options) {
         this.options = options;
-        //legacySetupSearch(cluster); // TODO: Try to not do that on Vespa 7
         setupHandlers(cluster);
     }
 
     private void setupHandlers(ContainerCluster cluster) {
         cluster.addComponent(newVespaClientHandler("com.yahoo.document.restapi.resource.RestApi", "document/v1/*"));
         cluster.addComponent(newVespaClientHandler("com.yahoo.vespa.http.server.FeedHandler", ContainerCluster.RESERVED_URI_PREFIX + "/feedapi"));
-    }
-
-    private void legacySetupSearch(ContainerCluster cluster) {
-        if (cluster.getSearch() != null) return;
-
-        SearchChains chains = new SearchChains(cluster, "searchchain");
-        ContainerSearch containerSearch = new ContainerSearch(cluster, chains, new ContainerSearch.Options());
-        cluster.setSearch(containerSearch);
-
-        ProcessingHandler<SearchChains> searchHandler = new ProcessingHandler<>(chains,
-                                                                                "com.yahoo.search.handler.SearchHandler");
-        searchHandler.addServerBindings("http://*/search/*", "https://*/search/*");
-        cluster.addComponent(searchHandler);
     }
 
     private Handler newVespaClientHandler(String componentId, String bindingSuffix) {
@@ -66,12 +52,6 @@ public class ContainerDocumentApi implements FeederConfig.Producer {
                     rootBinding + bindingSuffix + '/');
         }
         return handler;
-    }
-
-    private Searcher newVespaClientSearcher(String componentSpec) {
-        return new Searcher<>(new ChainedComponentModel(
-                BundleInstantiationSpecification.getFromStrings(componentSpec, null, vespaClientBundleSpecification),
-                new Dependencies(null, null, null)));
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
@@ -37,7 +37,7 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
     }
 
     @Test
-    public void document_api_config_is_added_to_container_cluster() throws Exception {
+    public void document_api_config_is_added_to_container_cluster() {
         Element elem = DomBuilderTest.parse(
                 "<jdisc id='cluster1' version='1.0'>",
                 "  <document-api>",
@@ -60,7 +60,7 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
     }
 
     @Test
-    public void custom_bindings_are_allowed() throws Exception {
+    public void custom_bindings_are_allowed() {
         Element elem = DomBuilderTest.parse(
                 "<jdisc id='cluster1' version='1.0'>",
                 "  <document-api>",
@@ -86,7 +86,7 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
     }
 
     @Test
-    public void requireThatHandlersAreSetup() throws Exception {
+    public void requireThatHandlersAreSetup() {
         Element elem = DomBuilderTest.parse(
                 "<jdisc id='cluster1' version='1.0'>",
                 "  <document-api />",
@@ -100,11 +100,6 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
         assertThat(handlerMap.get("com.yahoo.container.handler.VipStatusHandler"), not(nullValue()));
         assertThat(handlerMap.get("com.yahoo.container.handler.observability.ApplicationStatusHandler"), not(nullValue()));
         assertThat(handlerMap.get("com.yahoo.container.jdisc.state.StateHandler"), not(nullValue()));
-
-        assertThat(handlerMap.get("com.yahoo.search.handler.SearchHandler"), not(nullValue()));
-        assertThat(handlerMap.get("com.yahoo.search.handler.SearchHandler").getServerBindings().contains("http://*/search/*"), is(true));
-        assertThat(handlerMap.get("com.yahoo.search.handler.SearchHandler").getServerBindings().contains("https://*/search/*"), is(true));
-        assertThat(handlerMap.get("com.yahoo.search.handler.SearchHandler").getServerBindings().size(), equalTo(2));
 
         assertThat(handlerMap.get("com.yahoo.vespa.http.server.FeedHandler"), not(nullValue()));
         assertThat(handlerMap.get("com.yahoo.vespa.http.server.FeedHandler").getServerBindings().contains("http://*/" + ContainerCluster.RESERVED_URI_PREFIX + "/feedapi"), is(true));


### PR DESCRIPTION
@gjoranv and @arnej27959 I don't think we need to set up search implicitly any more when document-api is specified for a container cluster