### PR TITLE
Use TF 1.11.0 everywhere

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -299,12 +299,10 @@
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>proto</artifactId>
-      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow</artifactId>
-      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -678,6 +678,16 @@
                 <artifactId>jna</artifactId>
                 <version>${jna.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.tensorflow</groupId>
+                <artifactId>proto</artifactId>
+                <version>${tensorflow.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.tensorflow</groupId>
+                <artifactId>tensorflow</artifactId>
+                <version>${tensorflow.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -686,6 +696,7 @@
         <antlr4.version>4.5</antlr4.version>
         <asm.version>6.2</asm.version>
         <jna.version>4.5.2</jna.version>
+        <tensorflow.version>1.11.0</tensorflow.version>
         <!-- Athenz dependencies. Make sure these dependencies matches those in Vespa's internal repositories -->
         <athenz.version>1.7.43</athenz.version>
         <commons-lang.version>2.6</commons-lang.version>

--- a/searchlib/pom.xml
+++ b/searchlib/pom.xml
@@ -41,12 +41,10 @@
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>proto</artifactId>
-      <version>1.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow</artifactId>
-      <version>1.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
@lesters please review

NoClassDefFoundException does not mean ClassNotFoundException, I think this is caused by TF coming from the container classpath in the head model but from the config-model classpath when loading an older model version.