### PR TITLE
When pooling ClusterMonitors and SearchClusters you will add a cluste…

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
@@ -32,7 +32,7 @@ public class ClustersStatus extends AbstractComponent {
     private final Object mutex = new Object();
 
     /** The status of clusters, when known. Note that clusters may exist for which there is no knowledge yet. */
-    private final Map<Object, Boolean> clusterStatus = new HashMap<>();
+    private final Map<String, Boolean> clusterStatus = new HashMap<>();
 
     public void setContainerHasClusters(boolean containerHasClusters) {
         synchronized (mutex) {
@@ -48,16 +48,32 @@ public class ClustersStatus extends AbstractComponent {
         }
     }
 
-    public void setUp(Object clusterIdentifier) {
+    void setUp(String clusterIdentifier) {
         synchronized (mutex) {
             clusterStatus.put(clusterIdentifier, Boolean.TRUE);
         }
     }
 
-    public void setDown(Object clusterIdentifier) {
+    void setDown(String clusterIdentifier) {
         synchronized (mutex) {
             clusterStatus.put(clusterIdentifier, Boolean.FALSE);
         }
+    }
+
+    /**
+     @deprecated Use setUp(String) instead
+     */
+    @Deprecated
+    public void setUp(Object clusterIdentifier) {
+        setUp((String) clusterIdentifier);
+    }
+
+    /**
+     @deprecated Use setDown(String) instead
+     */
+    @Deprecated
+    public void setDown(Object clusterIdentifier) {
+        setDown((String) clusterIdentifier);
     }
 
     /** Returns whether this container should receive traffic based on the state of this */

--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -1,9 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.handler;
 
-import java.util.IdentityHashMap;
-import java.util.Map;
-
 import com.google.inject.Inject;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.core.VipStatusConfig;
@@ -52,13 +49,25 @@ public class VipStatus {
     }
 
     /** Note that a cluster (which influences up/down state) is up */
-    public void addToRotation(Object clusterIdentifier) {
+    public void addToRotation(String clusterIdentifier) {
         clustersStatus.setUp(clusterIdentifier);
     }
 
     /** Note that a cluster (which influences up/down state) is down */
-    public void removeFromRotation(Object clusterIdentifier) {
+    public void removeFromRotation(String clusterIdentifier) {
         clustersStatus.setDown(clusterIdentifier);
+    }
+
+    /** @deprecated Use addToRotation(String) instead  */
+    @Deprecated
+    public void addToRotation(Object clusterIdentifier) {
+        addToRotation((String) clusterIdentifier);
+    }
+
+    /** @deprecated Use removeFromRotation(String) instead  */
+    @Deprecated
+    public void removeFromRotation(Object clusterIdentifier) {
+        removeFromRotation((String) clusterIdentifier);
     }
 
     /** Returns whether this container should receive traffic at this time */

--- a/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
@@ -18,9 +18,9 @@ public class VipStatusTestCase {
         clustersStatus.setContainerHasClusters(true);
         VipStatus v = new VipStatus(clustersStatus);
 
-        Object cluster1 = new Object();
-        Object cluster2 = new Object();
-        Object cluster3 = new Object();
+        String cluster1 = new String("a");
+        String cluster2 = new String("b");
+        String cluster3 = new String("c");
 
         // initial state
         assertFalse(v.isInRotation());

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterMonitor.java
@@ -100,9 +100,9 @@ public class ClusterMonitor implements Runnable, Freezable {
         if ( ! hasInformationAboutAllNodes()) return;
         
         if (hasWorkingNodesWithDocumentsOnline()) {
-            vipStatus.get().addToRotation(this);
+            vipStatus.get().addToRotation(nodeManager.getId().stringValue());
         } else {
-            vipStatus.get().removeFromRotation(this);
+            vipStatus.get().removeFromRotation(nodeManager.getId().stringValue());
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -110,7 +110,7 @@ public class ClusterSearcher extends Searcher {
         super(id);
         this.fs4ResourcePool = fs4ResourcePool;
 
-        Dispatcher dispatcher = new Dispatcher(dispatchConfig, fs4ResourcePool, clusterInfoConfig.nodeCount(), vipStatus);
+        Dispatcher dispatcher = new Dispatcher(id.stringValue(), dispatchConfig, fs4ResourcePool, clusterInfoConfig.nodeCount(), vipStatus);
 
         monitor = (dispatcher.searchCluster().directDispatchTarget().isPresent()) // dispatcher should decide vip status instead
                 ? new ClusterMonitor(this, monitorConfig, Optional.empty())

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -49,20 +49,12 @@ public class Dispatcher extends AbstractComponent {
     private final RpcResourcePool rpcResourcePool;
     private final boolean multilevelDispatch;
 
-    public Dispatcher(DispatchConfig dispatchConfig, FS4ResourcePool fs4ResourcePool, int containerClusterSize, VipStatus vipStatus) {
-        this.searchCluster = new SearchCluster(dispatchConfig, fs4ResourcePool, containerClusterSize, vipStatus);
+    public Dispatcher(String clusterId, DispatchConfig dispatchConfig, FS4ResourcePool fs4ResourcePool, int containerClusterSize, VipStatus vipStatus) {
+        this.searchCluster = new SearchCluster(clusterId, dispatchConfig, fs4ResourcePool, containerClusterSize, vipStatus);
         this.loadBalancer = new LoadBalancer(searchCluster,
                 dispatchConfig.distributionPolicy() == DispatchConfig.DistributionPolicy.ROUNDROBIN);
         this.rpcResourcePool = new RpcResourcePool(dispatchConfig);
         this.multilevelDispatch = dispatchConfig.useMultilevelDispatch();
-    }
-
-    /** For testing */
-    public Dispatcher(Map<Integer, Client.NodeConnection> nodeConnections, Client client) {
-        this.searchCluster = null;
-        this.loadBalancer = new LoadBalancer(searchCluster, true);
-        this.rpcResourcePool = new RpcResourcePool(client, nodeConnections);
-        this.multilevelDispatch = false;
     }
 
     /** Returns the search cluster this dispatches to */

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
@@ -83,7 +83,7 @@ public class FastSearcherTestCase {
         Logger.getLogger(FastSearcher.class.getName()).setLevel(Level.ALL);
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool(1),
-                                                     new MockDispatcher(Collections.emptyList()),
+                                                     new MockDispatcher("a", Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      new CacheParams(100, 1e64),
@@ -104,7 +104,7 @@ public class FastSearcherTestCase {
         Logger.getLogger(FastSearcher.class.getName()).setLevel(Level.ALL);
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool(1),
-                                                     new MockDispatcher(Collections.emptyList()),
+                                                     new MockDispatcher("a", Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      new CacheParams(100, 1e64),
@@ -137,7 +137,7 @@ public class FastSearcherTestCase {
         MockFS4ResourcePool mockFs4ResourcePool = new MockFS4ResourcePool();
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                 mockFs4ResourcePool,
-                new MockDispatcher(nodes, mockFs4ResourcePool, 1, new VipStatus()),
+                new MockDispatcher("a", nodes, mockFs4ResourcePool, 1, new VipStatus()),
                 new SummaryParameters(null),
                 new ClusterParams("testhittype"),
                 new CacheParams(0, 0),
@@ -177,7 +177,7 @@ public class FastSearcherTestCase {
             new DocumentdbInfoConfig(new DocumentdbInfoConfig.Builder().documentdb(new DocumentdbInfoConfig.Documentdb.Builder().name("testDb")));
         FastSearcher fastSearcher = new FastSearcher(mockBackend,
                                                      new FS4ResourcePool(1),
-                                                     new MockDispatcher(Collections.emptyList()),
+                                                     new MockDispatcher("a", Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      new CacheParams(100, 1e64),
@@ -369,7 +369,7 @@ public class FastSearcherTestCase {
         Logger.getLogger(FastSearcher.class.getName()).setLevel(Level.ALL);
         return new FastSearcher(mockBackend,
                                 new FS4ResourcePool(1),
-                                new MockDispatcher(Collections.emptyList()),
+                                new MockDispatcher("a", Collections.emptyList()),
                                 new SummaryParameters(null),
                                 new ClusterParams("testhittype"),
                                 new CacheParams(100, 1e64),
@@ -382,7 +382,7 @@ public class FastSearcherTestCase {
         MockFSChannel.resetDocstamp();
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool(1),
-                                                     new MockDispatcher(Collections.emptyList()),
+                                                     new MockDispatcher("a", Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      new CacheParams(100, 1e64),
@@ -425,7 +425,7 @@ public class FastSearcherTestCase {
         MockFSChannel.resetDocstamp();
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool(1),
-                                                     new MockDispatcher(Collections.emptyList()),
+                                                     new MockDispatcher("a", Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      new CacheParams(100, 1e64),
@@ -479,7 +479,7 @@ public class FastSearcherTestCase {
     @Test
     public void testSinglePassGroupingIsNotForcedWithSingleNodeGroups() {
         MockDispatcher dispatcher =
-                new MockDispatcher(ImmutableList.of(new Node(0, "host0", 123, 0),
+                new MockDispatcher("a", ImmutableList.of(new Node(0, "host0", 123, 0),
                                                     new Node(2, "host1", 123, 0)));
 
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
@@ -524,7 +524,7 @@ public class FastSearcherTestCase {
         Backend backend = listeners.getBackend(server.host.getHostString(),server.host.getPort());
         FastSearcher fastSearcher = new FastSearcher(backend,
                                                      new FS4ResourcePool(1),
-                                                     new MockDispatcher(Collections.emptyList()),
+                                                     new MockDispatcher("a", Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      new CacheParams(0, 0.0d),

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
@@ -49,7 +49,7 @@ class FastSearcherTester {
         clustersStatus.setContainerHasClusters(true);
         vipStatus = new VipStatus(clustersStatus);
         mockFS4ResourcePool = new MockFS4ResourcePool();
-        mockDispatcher = new MockDispatcher(searchNodes, mockFS4ResourcePool, containerClusterSize, vipStatus);
+        mockDispatcher = new MockDispatcher("a", searchNodes, mockFS4ResourcePool, containerClusterSize, vipStatus);
         fastSearcher = new FastSearcher(new MockBackend(selfHostname, 0L, true),
                                         mockFS4ResourcePool,
                                         mockDispatcher,

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
@@ -14,20 +14,16 @@ import java.util.List;
 class MockDispatcher extends Dispatcher {
 
     public MockDispatcher(Node node) {
-        this(Collections.singletonList(node));
+        this(node.hostname(), Collections.singletonList(node));
     }
 
-    public MockDispatcher(List<Node> nodes) {
-        super(toDispatchConfig(nodes), new FS4ResourcePool(1), 1, new VipStatus());
+    public MockDispatcher(String clusterId, List<Node> nodes) {
+        this(clusterId, nodes, new FS4ResourcePool(1), 1, new VipStatus());
     }
 
-    public MockDispatcher(List<Node> nodes, VipStatus vipStatus) {
-        super(toDispatchConfig(nodes), new FS4ResourcePool(1), 1, vipStatus);
-    }
-
-    public MockDispatcher(List<Node> nodes, FS4ResourcePool fs4ResourcePool,
+    public MockDispatcher(String clusterId, List<Node> nodes, FS4ResourcePool fs4ResourcePool,
                           int containerClusterSize, VipStatus vipStatus) {
-        super(toDispatchConfig(nodes), fs4ResourcePool, containerClusterSize, vipStatus);
+        super(clusterId, toDispatchConfig(nodes), fs4ResourcePool, containerClusterSize, vipStatus);
     }
 
     private static DispatchConfig toDispatchConfig(List<Node> nodes) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -23,7 +23,7 @@ public class LoadBalancerTest {
     @Test
     public void requreThatLoadBalancerServesSingleNodeSetups() {
         Node n1 = new Node(0, "test-node1", 0, 0);
-        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
@@ -37,7 +37,7 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerServesMultiGroupSetups() {
         Node n1 = new Node(0, "test-node1", 0, 0);
         Node n2 = new Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
@@ -53,7 +53,7 @@ public class LoadBalancerTest {
         Node n2 = new Node(1, "test-node2", 1, 0);
         Node n3 = new Node(0, "test-node3", 0, 1);
         Node n4 = new Node(1, "test-node4", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
+        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         Optional<Group> grp = lb.takeGroupForQuery(new Query(), null);
@@ -64,7 +64,7 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerReturnsDifferentGroups() {
         Node n1 = new Node(0, "test-node1", 0, 0);
         Node n2 = new Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
@@ -84,7 +84,7 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerReturnsGroupWithShortestQueue() {
         Node n1 = new Node(0, "test-node1", 0, 0);
         Node n2 = new Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster(88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
@@ -21,8 +21,8 @@ public class MockSearchCluster extends SearchCluster {
     private final ImmutableMap<Integer, Group> groups;
     private final ImmutableMultimap<String, Node> nodesByHost;
 
-    public MockSearchCluster(int groups, int nodesPerGroup) {
-        super(100, 100, 0, Collections.emptyList(), null, 1, null);
+    public MockSearchCluster(String clusterId, int groups, int nodesPerGroup) {
+        super(clusterId, 100, 100, 0, Collections.emptyList(), null, 1, null);
 
         ImmutableMap.Builder<Integer, Group> groupBuilder = ImmutableMap.builder();
         ImmutableMultimap.Builder<String, Node> hostBuilder = ImmutableMultimap.builder();

--- a/container-search/src/test/java/com/yahoo/search/dispatch/SearchPathTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/SearchPathTest.java
@@ -69,7 +69,7 @@ public class SearchPathTest {
 
     @Test
     public void searchPathMustFilterNodesBasedOnDefinition() {
-        MockSearchCluster cluster = new MockSearchCluster(3, 3);
+        MockSearchCluster cluster = new MockSearchCluster("a",3, 3);
 
         assertThat(distKeysAsString(SearchPath.selectNodes("1/1", cluster)), equalTo("5"));
         assertThat(distKeysAsString(SearchPath.selectNodes("/1", cluster)), equalTo("4,5,6"));


### PR DESCRIPTION
…r every time there is a reconfig.

As nothing will purge them, you both keep stuff alive forever and end up with more clusters that you have.
Hence the magic for not removing vipstatus when there are multiple clusters kick in preventing nodes being taken OOR.
Now it is using the ComponentId for identifying a cluster.
@bratseth or @ollivir PR