### PR TITLE
[predicate-search-core] Remove Cloneable from Predicate class hierarchy.

### DIFF
--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/BooleanPredicate.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/BooleanPredicate.java
@@ -22,11 +22,6 @@ public class BooleanPredicate extends PredicateValue {
     }
 
     @Override
-    public BooleanPredicate clone() throws CloneNotSupportedException {
-        return (BooleanPredicate)super.clone();
-    }
-
-    @Override
     public int hashCode() {
         return value ? Boolean.TRUE.hashCode() : Boolean.FALSE.hashCode();
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/Conjunction.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/Conjunction.java
@@ -44,16 +44,6 @@ public class Conjunction extends PredicateOperator {
     }
 
     @Override
-    public Conjunction clone() throws CloneNotSupportedException {
-        Conjunction obj = (Conjunction)super.clone();
-        obj.operands = new ArrayList<>(operands.size());
-        for (Predicate operand : operands) {
-            obj.operands.add(operand.clone());
-        }
-        return obj;
-    }
-
-    @Override
     public int hashCode() {
         return operands.hashCode();
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/Disjunction.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/Disjunction.java
@@ -44,16 +44,6 @@ public class Disjunction extends PredicateOperator {
     }
 
     @Override
-    public Disjunction clone() throws CloneNotSupportedException {
-        Disjunction obj = (Disjunction)super.clone();
-        obj.operands = new ArrayList<>(operands.size());
-        for (Predicate operand : operands) {
-            obj.operands.add(operand.clone());
-        }
-        return obj;
-    }
-
-    @Override
     public int hashCode() {
         return operands.hashCode();
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/FeatureConjunction.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/FeatureConjunction.java
@@ -77,11 +77,6 @@ public class FeatureConjunction extends PredicateOperator {
     }
 
     @Override
-    public FeatureConjunction clone() throws CloneNotSupportedException {
-        return new FeatureConjunction(operands);
-    }
-
-    @Override
     public int hashCode() {
         return operands.hashCode();
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/FeatureRange.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/FeatureRange.java
@@ -84,11 +84,6 @@ public class FeatureRange extends PredicateValue {
     }
 
     @Override
-    public FeatureRange clone() throws CloneNotSupportedException {
-        return (FeatureRange)super.clone();
-    }
-
-    @Override
     public int hashCode() {
         return ((key.hashCode() + (from != null ? from.hashCode() : 0)) * 31 + (to != null ? to.hashCode() : 0)) * 31;
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/FeatureSet.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/FeatureSet.java
@@ -67,13 +67,6 @@ public class FeatureSet extends PredicateValue {
     }
 
     @Override
-    public FeatureSet clone() throws CloneNotSupportedException {
-        FeatureSet obj = (FeatureSet)super.clone();
-        obj.values = new TreeSet<>(values);
-        return obj;
-    }
-
-    @Override
     public int hashCode() {
         return (key.hashCode() + values.hashCode()) * 31;
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/Negation.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/Negation.java
@@ -32,13 +32,6 @@ public class Negation extends PredicateOperator {
     }
 
     @Override
-    public Negation clone() throws CloneNotSupportedException {
-        Negation obj = (Negation)super.clone();
-        obj.operand = operand.clone();
-        return obj;
-    }
-
-    @Override
     public int hashCode() {
         return operand.hashCode();
     }

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/Predicate.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/Predicate.java
@@ -13,16 +13,11 @@ import java.nio.charset.StandardCharsets;
 /**
  * @author Simon Thoresen Hult
  */
-public abstract class Predicate implements Cloneable {
+public abstract class Predicate {
 
     private final static char QUOTE_CHAR = '\'';
     private final static Ascii.Encoder ASCII_ENCODER = Ascii.newEncoder(StandardCharsets.UTF_8, QUOTE_CHAR);
     private final static Ascii.Decoder ASCII_DECODER = Ascii.newDecoder(StandardCharsets.UTF_8);
-
-    @Override
-    public Predicate clone() throws CloneNotSupportedException {
-        return (Predicate)super.clone();
-    }
 
     @Override
     public final String toString() {

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/RangeEdgePartition.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/RangeEdgePartition.java
@@ -30,11 +30,6 @@ public class RangeEdgePartition extends RangePartition {
     }
 
     @Override
-    public RangeEdgePartition clone() throws CloneNotSupportedException {
-        return (RangeEdgePartition)super.clone();
-    }
-
-    @Override
     public int hashCode() {
         return super.hashCode()
                 + Long.valueOf(value).hashCode()

--- a/predicate-search-core/src/main/java/com/yahoo/document/predicate/RangePartition.java
+++ b/predicate-search-core/src/main/java/com/yahoo/document/predicate/RangePartition.java
@@ -31,11 +31,6 @@ public class RangePartition extends PredicateValue {
     }
 
     @Override
-    public RangePartition clone() throws CloneNotSupportedException {
-        return (RangePartition)super.clone();
-    }
-
-    @Override
     public int hashCode() {
         return label.hashCode();
     }

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/BooleanPredicateTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/BooleanPredicateTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -16,14 +15,6 @@ public class BooleanPredicateTest {
     @Test
     public void requireThatFalseIsAValue() {
         assertTrue(PredicateValue.class.isAssignableFrom(BooleanPredicate.class));
-    }
-
-    @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        BooleanPredicate node1 = new BooleanPredicate(true);
-        BooleanPredicate node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
     }
 
     @Test

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/ConjunctionTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/ConjunctionTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -48,15 +47,6 @@ public class ConjunctionTest {
 
         node = new Conjunction(Arrays.asList(foo, bar));
         assertEquals(Arrays.asList(foo, bar), node.getOperands());
-    }
-
-    @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        Conjunction node1 = new Conjunction(SimplePredicates.newString("a"), SimplePredicates.newString("b"));
-        Conjunction node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-        assertNotSame(node1.getOperands(), node2.getOperands());
     }
 
     @Test

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/DisjunctionTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/DisjunctionTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -48,15 +47,6 @@ public class DisjunctionTest {
 
         node = new Disjunction(Arrays.asList(foo, bar));
         assertEquals(Arrays.asList(foo, bar), node.getOperands());
-    }
-
-    @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        Disjunction node1 = new Disjunction(SimplePredicates.newString("a"), SimplePredicates.newString("b"));
-        Disjunction node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-        assertNotSame(node1.getOperands(), node2.getOperands());
     }
 
     @Test

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/FeatureRangeTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/FeatureRangeTest.java
@@ -64,14 +64,6 @@ public class FeatureRangeTest {
     }
 
     @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        FeatureRange node1 = new FeatureRange("foo", 6L, 9L);
-        FeatureRange node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-    }
-
-    @Test
     public void requireThatHashCodeIsImplemented() {
         assertEquals(new FeatureRange("key").hashCode(), new FeatureRange("key").hashCode());
     }

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/FeatureSetTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/FeatureSetTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -59,15 +58,6 @@ public class FeatureSetTest {
         node = new FeatureSet("key", Arrays.asList("valueA", "valueB"));
         assertEquals("key", node.getKey());
         assertValues(Arrays.asList("valueA", "valueB"), node);
-    }
-
-    @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        FeatureSet node1 = new FeatureSet("key", "valueA", "valueB");
-        FeatureSet node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-        assertNotSame(node1.getValues(), node2.getValues());
     }
 
     @Test

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/NegationTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/NegationTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -29,15 +28,6 @@ public class NegationTest {
         Predicate bar = SimplePredicates.newString("bar");
         node.setOperand(bar);
         assertSame(bar, node.getOperand());
-    }
-
-    @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        Negation node1 = new Negation(SimplePredicates.newString("a"));
-        Negation node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-        assertNotSame(node1.getOperand(), node2.getOperand());
     }
 
     @Test

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/PredicateTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/PredicateTest.java
@@ -8,17 +8,11 @@ import static com.yahoo.document.predicate.Predicates.feature;
 import static com.yahoo.document.predicate.Predicates.not;
 import static com.yahoo.document.predicate.Predicates.or;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Simon Thoresen Hult
  */
 public class PredicateTest {
-
-    @Test
-    public void requireThatPredicateIsCloneable() {
-        assertTrue(Cloneable.class.isAssignableFrom(Predicate.class));
-    }
 
     @Test
     public void requireThatANDConstructsAConjunction() {

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/RangeEdgePartitionTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/RangeEdgePartitionTest.java
@@ -25,14 +25,6 @@ public class RangeEdgePartitionTest {
     }
 
     @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        RangeEdgePartition node1 = new RangeEdgePartition("foo=10", 10, 0, 0);
-        RangeEdgePartition node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-    }
-
-    @Test
     public void requireThatHashCodeIsImplemented() {
         assertEquals(new RangeEdgePartition("foo=-10", 10, 2, 3).hashCode(),
                 new RangeEdgePartition("foo=-10", 10, 2, 3).hashCode());

--- a/predicate-search-core/src/test/java/com/yahoo/document/predicate/RangePartitionTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/document/predicate/RangePartitionTest.java
@@ -27,14 +27,6 @@ public class RangePartitionTest {
     }
 
     @Test
-    public void requireThatCloneIsImplemented() throws CloneNotSupportedException {
-        RangePartition node1 = new RangePartition("foo=300-399");
-        RangePartition node2 = node1.clone();
-        assertEquals(node1, node2);
-        assertNotSame(node1, node2);
-    }
-
-    @Test
     public void requireThatHashCodeIsImplemented() {
         assertEquals(new RangePartition("foo=0-9").hashCode(), new RangePartition("foo=0-9").hashCode());
     }


### PR DESCRIPTION
This patch removes the clone property of Predicates so that we do not
suffer from its design flaws. That method is not used internally at the
moment and if need be should be replaced by copy-constructor in the
future.