### PR TITLE
Gjoranv/timestamp in seconds

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/jdisc/state/MetricsPacketsHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/state/MetricsPacketsHandler.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.yahoo.container.jdisc.state.StateHandler.getSnapshotPreprocessor;
 
@@ -151,7 +152,7 @@ public class MetricsPacketsHandler extends AbstractRequestHandler {
 
     private void addMetaData(long timestamp, String application, JSONObjectWithLegibleException packet) {
         packet.put(APPLICATION_KEY, application);
-        packet.put(TIMESTAMP_KEY, timestamp);
+        packet.put(TIMESTAMP_KEY, TimeUnit.MILLISECONDS.toSeconds(timestamp));
     }
 
     private void addDimensions(MetricDimensions metricDimensions, JSONObjectWithLegibleException packet) throws JSONException {

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/MetricsPacketsHandlerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/MetricsPacketsHandlerTest.java
@@ -17,6 +17,7 @@ import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.PACKET_SEPAR
 import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.STATUS_CODE_KEY;
 import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.STATUS_MSG_KEY;
 import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.TIMESTAMP_KEY;
+import static com.yahoo.container.jdisc.state.StateHandlerTestBase.SNAPSHOT_INTERVAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -58,6 +59,15 @@ public class MetricsPacketsHandlerTest extends StateHandlerTestBase {
         assertTrue(counterPacket.has(TIMESTAMP_KEY));
         assertTrue(counterPacket.has(APPLICATION_KEY));
         assertEquals(APPLICATION_NAME, counterPacket.get(APPLICATION_KEY).asText());
+    }
+
+    @Test
+    public void timestamp_resolution_is_in_seconds() throws Exception {
+        metric.add("counter", 1, null);
+        List<JsonNode> packets = incrementTimeAndGetJsonPackets();
+        JsonNode counterPacket = packets.get(1);
+
+        assertEquals(SNAPSHOT_INTERVAL/1000L, counterPacket.get(TIMESTAMP_KEY).asLong());
     }
 
     @Test


### PR DESCRIPTION
The current user of this handler requires timestamp in seconds. If needed, we can add a config option to use millis later.