### PR TITLE
Add explicit metric for diverging timestamps on updated documents

### DIFF
--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -62,10 +62,18 @@ class ExternalOperationHandlerTest : public CppUnit::TestFixture,
                 .safe_time_not_reached.getLongValue("count");
     }
 
+    int64_t safe_time_not_reached_metric_count(const metrics::LoadMetric<UpdateMetricSet>& metrics) const {
+        return metrics[documentapi::LoadType::DEFAULT].failures.safe_time_not_reached.getLongValue("count");
+    }
+
     int64_t concurrent_mutatations_metric_count(
             const metrics::LoadMetric<PersistenceOperationMetricSet>& metrics) const {
         return metrics[documentapi::LoadType::DEFAULT].failures
                 .concurrent_mutations.getLongValue("count");
+    }
+
+    int64_t concurrent_mutatations_metric_count(const metrics::LoadMetric<UpdateMetricSet>& metrics) const {
+        return metrics[documentapi::LoadType::DEFAULT].failures.concurrent_mutations.getLongValue("count");
     }
 
     void set_up_distributor_for_sequencing_test();

--- a/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
+++ b/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
@@ -204,7 +204,7 @@ TwoPhaseUpdateOperationTest::replyToMessage(
         api::ReturnCode::Result result)
 {
     std::shared_ptr<api::StorageMessage> msg2 = sender.commands.at(index);
-    UpdateCommand& updatec = dynamic_cast<UpdateCommand&>(*msg2);
+    auto& updatec = dynamic_cast<UpdateCommand&>(*msg2);
     std::unique_ptr<api::StorageReply> reply(updatec.makeReply());
     static_cast<api::UpdateReply*>(reply.get())->setOldTimestamp(oldTimestamp);
     reply->setResult(api::ReturnCode(result, ""));
@@ -222,7 +222,7 @@ TwoPhaseUpdateOperationTest::replyToPut(
         const std::string& traceMsg)
 {
     std::shared_ptr<api::StorageMessage> msg2 = sender.commands.at(index);
-    PutCommand& putc = dynamic_cast<PutCommand&>(*msg2);
+    auto& putc = dynamic_cast<PutCommand&>(*msg2);
     std::unique_ptr<api::StorageReply> reply(putc.makeReply());
     reply->setResult(api::ReturnCode(result, ""));
     if (!traceMsg.empty()) {
@@ -240,7 +240,7 @@ TwoPhaseUpdateOperationTest::replyToCreateBucket(
         api::ReturnCode::Result result)
 {
     std::shared_ptr<api::StorageMessage> msg2 = sender.commands.at(index);
-    CreateBucketCommand& putc = dynamic_cast<CreateBucketCommand&>(*msg2);
+    auto& putc = dynamic_cast<CreateBucketCommand&>(*msg2);
     std::unique_ptr<api::StorageReply> reply(putc.makeReply());
     reply->setResult(api::ReturnCode(result, ""));
     callback.receive(sender,
@@ -257,8 +257,7 @@ TwoPhaseUpdateOperationTest::replyToGet(
         api::ReturnCode::Result result,
         const std::string& traceMsg)
 {
-    const api::GetCommand& get(
-            static_cast<const api::GetCommand&>(*sender.commands.at(index)));
+    auto& get = static_cast<const api::GetCommand&>(*sender.commands.at(index));
     std::shared_ptr<api::StorageReply> reply;
 
     if (haveDocument) {

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -34,6 +34,7 @@ vespa_add_library(storage_distributor
     statecheckers.cpp
     statusreporterdelegate.cpp
     throttlingoperationstarter.cpp
+    update_metric_set.cpp
     visitormetricsset.cpp
     $<TARGET_OBJECTS:storage_distributoroperation>
     $<TARGET_OBJECTS:storage_distributoroperationexternal>

--- a/storage/src/vespa/storage/distributor/distributormetricsset.cpp
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.cpp
@@ -10,7 +10,7 @@ using metrics::MetricSet;
 DistributorMetricSet::DistributorMetricSet(const metrics::LoadTypeSet& lt)
     : MetricSet("distributor", {{"distributor"}}, ""),
       puts(lt, PersistenceOperationMetricSet("puts"), this),
-      updates(lt, PersistenceOperationMetricSet("updates"), this),
+      updates(lt, UpdateMetricSet(), this),
       update_puts(lt, PersistenceOperationMetricSet("update_puts"), this),
       update_gets(lt, PersistenceOperationMetricSet("update_gets"), this),
       removes(lt, PersistenceOperationMetricSet("removes"), this),

--- a/storage/src/vespa/storage/distributor/distributormetricsset.h
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "persistence_operation_metric_set.h"
+#include "update_metric_set.h"
 #include "visitormetricsset.h"
 #include <vespa/metrics/metrics.h>
 #include <vespa/documentapi/loadtypes/loadtypeset.h>
@@ -12,7 +13,7 @@ class DistributorMetricSet : public metrics::MetricSet
 {
 public:
     metrics::LoadMetric<PersistenceOperationMetricSet> puts;
-    metrics::LoadMetric<PersistenceOperationMetricSet> updates;
+    metrics::LoadMetric<UpdateMetricSet> updates;
     metrics::LoadMetric<PersistenceOperationMetricSet> update_puts;
     metrics::LoadMetric<PersistenceOperationMetricSet> update_gets;
     metrics::LoadMetric<PersistenceOperationMetricSet> removes;

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -18,6 +18,8 @@ class UpdateCommand;
 class CreateBucketReply;
 }
 
+class UpdateMetricSet;
+
 namespace distributor {
 
 class DistributorBucketSpace;
@@ -120,7 +122,7 @@ private:
     void replyWithTasFailure(DistributorMessageSender& sender,
                              vespalib::stringref message);
 
-    PersistenceOperationMetricSet& _updateMetric;
+    UpdateMetricSet& _updateMetric;
     PersistenceOperationMetricSet& _putMetric;
     PersistenceOperationMetricSet& _getMetric;
     std::shared_ptr<api::UpdateCommand> _updateCmd;

--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
@@ -20,14 +20,15 @@ using document::BucketSpace;
 UpdateOperation::UpdateOperation(DistributorComponent& manager,
                                  DistributorBucketSpace &bucketSpace,
                                  const std::shared_ptr<api::UpdateCommand> & msg,
-                                 PersistenceOperationMetricSet& metric)
+                                 UpdateMetricSet& metric)
     : Operation(),
       _trackerInstance(metric, std::make_shared<api::UpdateReply>(*msg),
                        manager, msg->getTimestamp()),
       _tracker(_trackerInstance),
       _msg(msg),
       _manager(manager),
-      _bucketSpace(bucketSpace)
+      _bucketSpace(bucketSpace),
+      _metrics(metric)
 {
 }
 
@@ -149,6 +150,7 @@ UpdateOperation::onReceive(DistributorMessageSender& sender,
                                      reply.getBucket().toString().c_str(),
                                      _results[i].oldTs, _results[i].nodeId,
                                      _results[goodNode].oldTs, _results[goodNode].nodeId);
+                        _metrics.diverging_timestamp_updates.inc();
 
                         replyToSend.setNodeWithNewestTimestamp(_results[goodNode].nodeId);
                         _newestTimestampLocation.first  = _results[goodNode].bucketId;

--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
@@ -15,6 +15,8 @@ class UpdateCommand;
 class CreateBucketReply;
 }
 
+class UpdateMetricSet;
+
 namespace distributor {
 
 class DistributorBucketSpace;
@@ -25,7 +27,7 @@ public:
     UpdateOperation(DistributorComponent& manager,
                     DistributorBucketSpace &bucketSpace,
                     const std::shared_ptr<api::UpdateCommand> & msg,
-                    PersistenceOperationMetricSet& metric);
+                    UpdateMetricSet& metric);
 
     void onStart(DistributorMessageSender& sender) override;
     const char* getName() const override { return "update"; };
@@ -59,6 +61,7 @@ private:
     };
 
     std::vector<OldTimestamp> _results;
+    UpdateMetricSet& _metrics;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/update_metric_set.cpp
+++ b/storage/src/vespa/storage/distributor/update_metric_set.cpp
@@ -1,0 +1,34 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "update_metric_set.h"
+#include <vespa/metrics/loadmetric.hpp>
+#include <vespa/metrics/summetric.hpp>
+
+namespace storage {
+
+using metrics::MetricSet;
+
+UpdateMetricSet::UpdateMetricSet(MetricSet* owner)
+    : PersistenceOperationMetricSet("updates", owner),
+      diverging_timestamp_updates("diverging_timestamp_updates", {},
+                                  "Number of updates that report they were performed against "
+                                  "divergent version timestamps on different replicas", this)
+{
+}
+
+UpdateMetricSet::~UpdateMetricSet() = default;
+
+MetricSet *
+UpdateMetricSet::clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
+                        MetricSet* owner, bool includeUnused) const
+{
+    if (copyType == INACTIVE) {
+        return MetricSet::clone(ownerList, INACTIVE, owner, includeUnused);
+    }
+    return static_cast<MetricSet*>((new UpdateMetricSet(owner))->assignValues(*this));
+}
+
+}
+
+template class metrics::LoadMetric<storage::UpdateMetricSet>;
+template class metrics::SumMetric<storage::UpdateMetricSet>;

--- a/storage/src/vespa/storage/distributor/update_metric_set.cpp
+++ b/storage/src/vespa/storage/distributor/update_metric_set.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "update_metric_set.h"
 #include <vespa/metrics/loadmetric.hpp>

--- a/storage/src/vespa/storage/distributor/update_metric_set.h
+++ b/storage/src/vespa/storage/distributor/update_metric_set.h
@@ -1,0 +1,23 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "persistence_operation_metric_set.h"
+#include <vespa/documentapi/loadtypes/loadtypeset.h>
+#include <vespa/metrics/metrics.h>
+
+namespace storage {
+
+class UpdateMetricSet : public PersistenceOperationMetricSet {
+public:
+    metrics::LongCountMetric diverging_timestamp_updates;
+
+    explicit UpdateMetricSet(MetricSet* owner = nullptr);
+    ~UpdateMetricSet() override;
+
+    MetricSet* clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
+                     MetricSet* owner, bool includeUnused) const override;
+};
+
+} // storage
+
+


### PR DESCRIPTION
@geirst please review

Easier to track across nodes than hunting for log warnings.