### PR TITLE
Remove dependency on Java from RPMs

### DIFF
--- a/node-admin/vespa-node-admin.spec
+++ b/node-admin/vespa-node-admin.spec
@@ -16,7 +16,6 @@ License:        Commercial
 URL:            http://vespa.ai
 
 Requires: bash
-Requires: java-1.8.0-openjdk-headless
 Requires: vespa-base = %{version}
 Requires: vespa-standalone-container = %{version}
 Requires: vespa-node-maintainer = %{version}

--- a/node-maintainer/vespa-node-maintainer.spec
+++ b/node-maintainer/vespa-node-maintainer.spec
@@ -16,6 +16,7 @@ License:        Commercial
 URL:            http://vespa.ai
 
 Requires: bash
+Requires: java-1.8.0-openjdk-headless
 Requires: vespa-base = %{version}
 
 Conflicts: vespa

--- a/node-maintainer/vespa-node-maintainer.spec
+++ b/node-maintainer/vespa-node-maintainer.spec
@@ -16,7 +16,6 @@ License:        Commercial
 URL:            http://vespa.ai
 
 Requires: bash
-Requires: java-1.8.0-openjdk-headless
 Requires: vespa-base = %{version}
 
 Conflicts: vespa

--- a/standalone-container/vespa-standalone-container.spec
+++ b/standalone-container/vespa-standalone-container.spec
@@ -16,7 +16,6 @@ License:        Commercial
 URL:            http://vespa.ai
 
 Requires: bash
-Requires: java-1.8.0-openjdk-headless
 Requires: vespa-base = %{version}
 
 Conflicts: vespa


### PR DESCRIPTION
It will now be implementation-defined how Java is installed, and which version
is used.