### PR TITLE
Move to Python3 for test parallelization script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 # TODO: Move this to where it's actually needed
 find_package(JNI REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 include(functions.cmake)
 include(build_settings.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,11 @@ endif()
 find_package(JNI REQUIRED)
 
 # TODO move to find_package(Python3 REQUIRED COMPONENTS Interpreter) when on CMake >= 3.12
-set(Python_ADDITIONAL_VERSIONS 3.6)
+set(Python_ADDITIONAL_VERSIONS 3.6 3.7)
 find_package(PythonInterp REQUIRED)
+if (PYTHON_VERSION_MAJOR LESS 3)
+    message(FATAL_ERROR "Building Vespa requires Python 3, found ${PYTHON_VERSION_STRING}")
+endif()
 
 include(functions.cmake)
 include(build_settings.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ endif()
 
 # TODO: Move this to where it's actually needed
 find_package(JNI REQUIRED)
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+# TODO move to find_package(Python3 REQUIRED COMPONENTS Interpreter) when on CMake >= 3.12
+set(Python_ADDITIONAL_VERSIONS 3.6)
+find_package(PythonInterp REQUIRED)
 
 include(functions.cmake)
 include(build_settings.cmake)

--- a/cppunit-parallelize.py
+++ b/cppunit-parallelize.py
@@ -20,14 +20,14 @@ def parse_arguments():
     return args
 
 def take(lst, n):
-    return [ lst.pop() for i in xrange(n) ]
+    return [ lst.pop() for i in range(n) ]
 
 def chunkify(lst, chunks):
     lst = copy.copy(lst)
-    chunk_size = len(lst) / chunks
+    chunk_size = len(lst) // chunks
     chunk_surplus = len(lst) % chunks
 
-    result = [ take(lst, chunk_size) for i in xrange(chunks) ]
+    result = [ take(lst, chunk_size) for i in range(chunks) ]
     if chunk_surplus:
         result.append(lst)
 
@@ -39,13 +39,13 @@ def error_if_file_not_found(function):
             return function(*args, **kwargs)
         except OSError as e:
             if e.errno == os.errno.ENOENT: # "No such file or directory"
-                print >>sys.stderr, "Error: could not find testrunner or valgrind executable"
+                print("Error: could not find testrunner or valgrind executable", file=sys.stderr)
                 sys.exit(1)
     return wrapper
 
 @error_if_file_not_found
 def get_test_suites(testrunner):
-    return subprocess.check_output((testrunner, "--list")).strip().split("\n")
+    return subprocess.check_output((testrunner, "--list")).decode('utf-8').strip().split("\n")
 
 class Process:
     def __init__(self, cmd, group):
@@ -76,33 +76,33 @@ def cleanup_processes(processes):
             proc.handle.kill()
         except OSError as e:
             if e.errno != os.errno.ESRCH: # "No such process"
-                print >>sys.stderr, e.message
+                print(e.message, file=sys.stderr)
 
 args = parse_arguments()
 test_suites = get_test_suites(args.testrunner)
 test_suite_groups = chunkify(test_suites, args.chunks)
 processes = build_processes(test_suite_groups)
 
-print "Running %d test suites in %d parallel chunks with ~%d tests each" % (len(test_suites), len(test_suite_groups), len(test_suite_groups[0]))
+print("Running %d test suites in %d parallel chunks with ~%d tests each" % (len(test_suites), len(test_suite_groups), len(test_suite_groups[0])))
 
 processes_left = len(processes)
 while True:
     try:
         for proc in processes:
             return_code = proc.handle.poll()
-            proc.output += proc.handle.stdout.read()
+            proc.output += proc.handle.stdout.read().decode('utf-8') # Hopefully won't cross any codepoint boundaries...
 
             if return_code == 0:
                 proc.finished = True
                 processes_left -= 1
                 if processes_left > 0:
-                    print "%d test suite(s) left" % processes_left
+                    print("%d test suite(s) left" % processes_left)
                 else:
-                    print "All test suites ran successfully"
+                    print("All test suites ran successfully")
                     sys.exit(0)
             elif return_code is not None:
-                print "Error: one of '%s' test suites failed:" % ", ".join(proc.group)
-                print >>sys.stderr, proc.output
+                print("Error: one of '%s' test suites failed:" % ", ".join(proc.group))
+                print(proc.output, file=sys.stderr)
                 sys.exit(return_code)
 
             time.sleep(0.01)

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -32,6 +32,7 @@ BuildRequires: libatomic
 BuildRequires: Judy-devel
 %if 0%{?centos}
 BuildRequires: cmake3
+BuildRequires: python36
 BuildRequires: llvm5.0-devel
 BuildRequires: vespa-boost-devel >= 1.59.0-6
 BuildRequires: vespa-gtest >= 1.8.0-1

--- a/document/src/tests/CMakeLists.txt
+++ b/document/src/tests/CMakeLists.txt
@@ -38,6 +38,6 @@ vespa_add_executable(document_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME document_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
     DEPENDS document_testrunner_app
 )

--- a/document/src/tests/CMakeLists.txt
+++ b/document/src/tests/CMakeLists.txt
@@ -38,6 +38,6 @@ vespa_add_executable(document_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME document_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
     DEPENDS document_testrunner_app
 )

--- a/document/src/tests/CMakeLists.txt
+++ b/document/src/tests/CMakeLists.txt
@@ -38,6 +38,6 @@ vespa_add_executable(document_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME document_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:document_testrunner_app>
     DEPENDS document_testrunner_app
 )

--- a/metrics/src/tests/CMakeLists.txt
+++ b/metrics/src/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ vespa_add_executable(metrics_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME metrics_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
     DEPENDS metrics_testrunner_app
 )

--- a/metrics/src/tests/CMakeLists.txt
+++ b/metrics/src/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ vespa_add_executable(metrics_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME metrics_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
     DEPENDS metrics_testrunner_app
 )

--- a/metrics/src/tests/CMakeLists.txt
+++ b/metrics/src/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ vespa_add_executable(metrics_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME metrics_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:metrics_testrunner_app>
     DEPENDS metrics_testrunner_app
 )

--- a/persistence/src/tests/CMakeLists.txt
+++ b/persistence/src/tests/CMakeLists.txt
@@ -10,6 +10,6 @@ vespa_add_executable(persistence_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME persistence_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
     DEPENDS persistence_testrunner_app
 )

--- a/persistence/src/tests/CMakeLists.txt
+++ b/persistence/src/tests/CMakeLists.txt
@@ -10,6 +10,6 @@ vespa_add_executable(persistence_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME persistence_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
     DEPENDS persistence_testrunner_app
 )

--- a/persistence/src/tests/CMakeLists.txt
+++ b/persistence/src/tests/CMakeLists.txt
@@ -10,6 +10,6 @@ vespa_add_executable(persistence_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME persistence_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:persistence_testrunner_app>
     DEPENDS persistence_testrunner_app
 )

--- a/storage/src/tests/CMakeLists.txt
+++ b/storage/src/tests/CMakeLists.txt
@@ -18,6 +18,6 @@ vespa_add_executable(storage_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storage_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
     DEPENDS storage_testrunner_app
 )

--- a/storage/src/tests/CMakeLists.txt
+++ b/storage/src/tests/CMakeLists.txt
@@ -18,6 +18,6 @@ vespa_add_executable(storage_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storage_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
     DEPENDS storage_testrunner_app
 )

--- a/storage/src/tests/CMakeLists.txt
+++ b/storage/src/tests/CMakeLists.txt
@@ -18,6 +18,6 @@ vespa_add_executable(storage_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storage_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
     DEPENDS storage_testrunner_app
 )

--- a/storageapi/src/tests/CMakeLists.txt
+++ b/storageapi/src/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ vespa_add_executable(storageapi_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageapi_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
     DEPENDS storageapi_testrunner_app
 )

--- a/storageapi/src/tests/CMakeLists.txt
+++ b/storageapi/src/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ vespa_add_executable(storageapi_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageapi_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
     DEPENDS storageapi_testrunner_app
 )

--- a/storageapi/src/tests/CMakeLists.txt
+++ b/storageapi/src/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ vespa_add_executable(storageapi_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageapi_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageapi_testrunner_app>
     DEPENDS storageapi_testrunner_app
 )

--- a/storageframework/src/tests/CMakeLists.txt
+++ b/storageframework/src/tests/CMakeLists.txt
@@ -11,6 +11,6 @@ vespa_add_executable(storageframework_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageframework_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
     DEPENDS storageframework_testrunner_app
 )

--- a/storageframework/src/tests/CMakeLists.txt
+++ b/storageframework/src/tests/CMakeLists.txt
@@ -11,6 +11,6 @@ vespa_add_executable(storageframework_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageframework_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
     DEPENDS storageframework_testrunner_app
 )

--- a/storageframework/src/tests/CMakeLists.txt
+++ b/storageframework/src/tests/CMakeLists.txt
@@ -11,6 +11,6 @@ vespa_add_executable(storageframework_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageframework_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageframework_testrunner_app>
     DEPENDS storageframework_testrunner_app
 )

--- a/storageserver/src/tests/CMakeLists.txt
+++ b/storageserver/src/tests/CMakeLists.txt
@@ -14,6 +14,6 @@ vespa_add_executable(storageserver_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageserver_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
     DEPENDS storageserver_testrunner_app
 )

--- a/storageserver/src/tests/CMakeLists.txt
+++ b/storageserver/src/tests/CMakeLists.txt
@@ -14,6 +14,6 @@ vespa_add_executable(storageserver_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageserver_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
     DEPENDS storageserver_testrunner_app
 )

--- a/storageserver/src/tests/CMakeLists.txt
+++ b/storageserver/src/tests/CMakeLists.txt
@@ -14,6 +14,6 @@ vespa_add_executable(storageserver_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storageserver_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:storageserver_testrunner_app>
     DEPENDS storageserver_testrunner_app
 )

--- a/vdslib/src/tests/CMakeLists.txt
+++ b/vdslib/src/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ vespa_add_executable(vdslib_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME vdslib_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
     DEPENDS vdslib_testrunner_app
 )

--- a/vdslib/src/tests/CMakeLists.txt
+++ b/vdslib/src/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ vespa_add_executable(vdslib_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME vdslib_testrunner_app
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
     DEPENDS vdslib_testrunner_app
 )

--- a/vdslib/src/tests/CMakeLists.txt
+++ b/vdslib/src/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ vespa_add_executable(vdslib_testrunner_app TEST
 # TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME vdslib_testrunner_app
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdslib_testrunner_app>
     DEPENDS vdslib_testrunner_app
 )

--- a/vdstestlib/src/tests/cppunit/CMakeLists.txt
+++ b/vdstestlib/src/tests/cppunit/CMakeLists.txt
@@ -11,6 +11,6 @@ vespa_add_executable(vdstestlib_testrunner_app TEST
 vespa_add_test(
     NAME vdstestlib_testrunner_app
     NO_VALGRIND
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
+    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
     DEPENDS vdstestlib_testrunner_app
 )

--- a/vdstestlib/src/tests/cppunit/CMakeLists.txt
+++ b/vdstestlib/src/tests/cppunit/CMakeLists.txt
@@ -11,6 +11,6 @@ vespa_add_executable(vdstestlib_testrunner_app TEST
 vespa_add_test(
     NAME vdstestlib_testrunner_app
     NO_VALGRIND
-    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
+    COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
     DEPENDS vdstestlib_testrunner_app
 )

--- a/vdstestlib/src/tests/cppunit/CMakeLists.txt
+++ b/vdstestlib/src/tests/cppunit/CMakeLists.txt
@@ -11,6 +11,6 @@ vespa_add_executable(vdstestlib_testrunner_app TEST
 vespa_add_test(
     NAME vdstestlib_testrunner_app
     NO_VALGRIND
-    COMMAND "${Python3_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
+    COMMAND "${Python_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 1 $<TARGET_FILE:vdstestlib_testrunner_app>
     DEPENDS vdstestlib_testrunner_app
 )


### PR DESCRIPTION
@aressem please review. Script was made for ye olde python 2.7
@baldersheim FYI
@toregge FYI, will likely have to add python3 dep for Fedora as well

Require python3 as build dep and during configure step.