### PR TITLE
Remove unused settings in proton.def.

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -254,10 +254,6 @@ summary.log.chunk.maxbytes int default=65536
 ## Skip crc32 check on read.
 summary.log.chunk.skipcrconread bool default=false
 
-## Control how compation is done, write to the front or to new const file.
-## TODO: Remove, will always be false
-summary.log.compact2activefile bool default=false
-
 ## Max size per summary file.
 summary.log.maxfilesize long default=1000000000
 
@@ -265,7 +261,6 @@ summary.log.maxfilesize long default=1000000000
 summary.log.maxdiskbloatfactor double default=0.1
 
 ## Max bucket spread within a single summary file. This will trigger bucket order compacting.
-## Only used when summary.compact2buckets is true.
 summary.log.maxbucketspread double default=2.5
 
 ## If a file goes below this ratio compared to allowed max size it will be joined to the front.
@@ -285,10 +280,6 @@ summary.read.mmap.options[] enum {MLOCK, POPULATE, HUGETLB} restart
 
 ## Advise to give to os when mapping memory.
 summary.read.mmap.advise enum {NORMAL, RANDOM, SEQUENTIAL} default=NORMAL restart
-
-## Enable compact for bucket oriented access.
-## TODO: Unused, always bucket order.
-summary.compact2buckets bool default=true restart
 
 ## The name of the input document type
 documentdb[].inputdoctypename string

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -189,7 +189,7 @@ deriveConfig(const ProtonConfig::Summary & summary, const ProtonConfig::Flush::M
     logConfig.setMaxFileSize(log.maxfilesize)
             .setMaxDiskBloatFactor(std::min(flush.diskbloatfactor, flush.each.diskbloatfactor))
             .setMaxBucketSpread(log.maxbucketspread).setMinFileSizeFactor(log.minfilesizefactor)
-            .compact2ActiveFile(log.compact2activefile).compactCompression(deriveCompression(log.compact.compression))
+            .compactCompression(deriveCompression(log.compact.compression))
             .setFileConfig(fileConfig).disableCrcOnRead(chunk.skipcrconread);
     return LogDocumentStore::Config(config, logConfig);
 }

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -206,7 +206,7 @@ TEST("testGrowing") {
     LogDataStore::Config config; //(100000, 0.1, 3.0, 0.2, 8, true, CompressionConfig::LZ4,
                                 // WriteableFileChunk::Config(CompressionConfig(CompressionConfig::LZ4, 9, 60), 1000));
     config.setMaxFileSize(100000).setMaxDiskBloatFactor(0.1).setMaxBucketSpread(3.0).setMinFileSizeFactor(0.2)
-            .compact2ActiveFile(true).compactCompression({CompressionConfig::LZ4})
+            .compactCompression({CompressionConfig::LZ4})
             .setFileConfig({{CompressionConfig::LZ4, 9, 60}, 1000});
     vespalib::ThreadStackExecutor executor(8, 128*1024);
     DummyFileHeaderContext fileHeaderContext;
@@ -1054,7 +1054,6 @@ TEST("require that config equality operator detects inequality") {
     EXPECT_FALSE(C() == C().setMinFileSizeFactor(0.3));
     EXPECT_FALSE(C() == C().setFileConfig(WriteableFileChunk::Config({}, 70)));
     EXPECT_FALSE(C() == C().disableCrcOnRead(true));
-    EXPECT_FALSE(C() == C().compact2ActiveFile(false));
     EXPECT_FALSE(C() == C().compactCompression({CompressionConfig::ZSTD}));
 }
 

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -52,12 +52,10 @@ public:
         double getMinFileSizeFactor() const { return _minFileSizeFactor; }
 
         bool crcOnReadDisabled() const { return _skipCrcOnRead; }
-        bool compact2ActiveFile() const { return _compact2ActiveFile; }
         const CompressionConfig & compactCompression() const { return _compactCompression; }
 
         const WriteableFileChunk::Config & getFileConfig() const { return _fileConfig; }
         Config & disableCrcOnRead(bool v) { _skipCrcOnRead = v; return *this;}
-        Config & compact2ActiveFile(bool v) { _compact2ActiveFile = v; return *this; }
 
         bool operator == (const Config &) const;
     private:
@@ -66,7 +64,6 @@ public:
         double                      _maxBucketSpread;
         double                      _minFileSizeFactor;
         bool                        _skipCrcOnRead;
-        bool                        _compact2ActiveFile;
         CompressionConfig           _compactCompression;
         WriteableFileChunk::Config  _fileConfig;
     };


### PR DESCRIPTION
summary.log.compact2activefile is always false.
summary.compact2buckets is always true.

@baldersheim please review