### PR TITLE
Exclude tensorflow when depending on searchlib

### DIFF
--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -128,6 +128,10 @@
           <groupId>com.yahoo.vespa</groupId>
           <artifactId>config</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
See https://github.com/vespa-engine/vespa/pull/7744, this might not be necessary/correct anymore