### PR TITLE
Adaptive timeout support in java dispatch

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -422,6 +422,15 @@ public class IndexedSearchCluster extends SearchCluster
         }
         builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());
         builder.useMultilevelDispatch(useMultilevelDispatchSetup());
+        builder.searchableCopies(rootDispatch.getSearchableCopies());
+        if (searchCoverage != null) {
+            if (searchCoverage.getMinimum() != null)
+                builder.minSearchCoverage(searchCoverage.getMinimum());
+            if (searchCoverage.getMinWaitAfterCoverageFactor() != null)
+                builder.minWaitAfterCoverageFactor(searchCoverage.getMinWaitAfterCoverageFactor());
+            if (searchCoverage.getMaxWaitAfterCoverageFactor() != null)
+                builder.maxWaitAfterCoverageFactor(searchCoverage.getMaxWaitAfterCoverageFactor());
+        }
     }
 
     @Override

--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -19,6 +19,18 @@ distributionPolicy enum { ROUNDROBIN, ADAPTIVE } default=ROUNDROBIN
 # Is multi-level dispatch configured for this cluster
 useMultilevelDispatch bool default=false
 
+# Number of document copies
+searchableCopies long default=1
+
+# Minimum search coverage required before returning the results of a query
+minSearchCoverage double default=100
+
+# Minimum wait time for full coverage after minimum coverage is achieved, factored based on time left at minimum coverage
+minWaitAfterCoverageFactor double default=0
+
+# Maximum wait time for full coverage after minimum coverage is achieved, factored based on time left at minimum coverage
+maxWaitAfterCoverageFactor double default=1
+
 # The unique key of a search node
 node[].key int
 

--- a/container-core/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -28,9 +28,9 @@ public class Coverage {
         EXPLICITLY_FULL, EXPLICITLY_INCOMPLETE, DOCUMENT_COUNT;
     }
 
-    private final static int DEGRADED_BY_MATCH_PHASE = 1;
-    private final static int DEGRADED_BY_TIMEOUT = 2;
-    private final static int DEGRADED_BY_ADAPTIVE_TIMEOUT = 4;
+    public final static int DEGRADED_BY_MATCH_PHASE = 1;
+    public final static int DEGRADED_BY_TIMEOUT = 2;
+    public final static int DEGRADED_BY_ADAPTIVE_TIMEOUT = 4;
 
     /**
      * Build an invalid instance to initiate manually.

--- a/container-search/src/main/java/com/yahoo/fs4/mplex/FS4Channel.java
+++ b/container-search/src/main/java/com/yahoo/fs4/mplex/FS4Channel.java
@@ -1,6 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.fs4.mplex;
 
+import com.yahoo.concurrent.SystemTimer;
+import com.yahoo.fs4.BasicPacket;
+import com.yahoo.fs4.ChannelTimeoutException;
+import com.yahoo.fs4.Packet;
+import com.yahoo.search.Query;
+import com.yahoo.search.dispatch.ResponseMonitor;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -8,12 +15,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-
-import com.yahoo.concurrent.SystemTimer;
-import com.yahoo.fs4.BasicPacket;
-import com.yahoo.fs4.ChannelTimeoutException;
-import com.yahoo.fs4.Packet;
-import com.yahoo.search.Query;
 
 /**
  * This class is used to represent a "channel" in the FS4 protocol.
@@ -34,6 +35,7 @@ public class FS4Channel {
     volatile private BlockingQueue<BasicPacket> responseQueue;
     private Query query;
     private boolean isPingChannel = false;
+    private ResponseMonitor<FS4Channel> monitor;
 
     /** for unit testing.  do not use */
     protected FS4Channel () {
@@ -197,6 +199,9 @@ public class FS4Channel {
         throws InterruptedException, InvalidChannelException
     {
         ensureValidQ().put(packet);
+        if(monitor != null) {
+            monitor.responseAvailable(this);
+        }
     }
 
     /**
@@ -241,4 +246,7 @@ public class FS4Channel {
         return "fs4 channel " + channelId + (isValid() ? " [valid]" : " [invalid]");
     }
 
+    public void setResponseMonitor(ResponseMonitor<FS4Channel> monitor) {
+        this.monitor = monitor;
+    }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -20,7 +20,6 @@ import com.yahoo.vespa.config.search.DispatchConfig;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -134,7 +133,7 @@ public class Dispatcher extends AbstractComponent {
         int max = Integer.min(searchCluster.orderedGroups().size(), MAX_GROUP_SELECTION_ATTEMPTS);
         Set<Integer> rejected = null;
         for (int i = 0; i < max; i++) {
-            Optional<Group> groupInCluster = loadBalancer.takeGroupForQuery(rejected);
+            Optional<Group> groupInCluster = loadBalancer.takeGroup(rejected);
             if (!groupInCluster.isPresent()) {
                 // No groups available
                 break;

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -5,12 +5,25 @@ import com.yahoo.fs4.QueryPacket;
 import com.yahoo.prelude.fastsearch.CacheKey;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
+import com.yahoo.search.dispatch.searchcluster.SearchCluster;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.vespa.config.search.DispatchConfig;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.yahoo.container.handler.Coverage.DEGRADED_BY_ADAPTIVE_TIMEOUT;
+import static com.yahoo.container.handler.Coverage.DEGRADED_BY_TIMEOUT;
 
 /**
  * InterleavedSearchInvoker uses multiple {@link SearchInvoker} objects to interface with content
@@ -19,11 +32,25 @@ import java.util.Map;
  *
  * @author ollivir
  */
-public class InterleavedSearchInvoker extends SearchInvoker {
-    private final Collection<SearchInvoker> invokers;
+public class InterleavedSearchInvoker extends SearchInvoker implements ResponseMonitor<SearchInvoker> {
+    private static final Logger log = Logger.getLogger(InterleavedSearchInvoker.class.getName());
 
-    public InterleavedSearchInvoker(Map<Integer, SearchInvoker> invokers) {
-        this.invokers = new ArrayList<>(invokers.values());
+    private final Set<SearchInvoker> invokers;
+    private final SearchCluster searchCluster;
+    private final LinkedBlockingQueue<SearchInvoker> availableForProcessing;
+    private Query query;
+
+    private boolean adaptiveTimeoutCalculated = false;
+    private long adaptiveTimeoutMin = 0;
+    private long adaptiveTimeoutMax = 0;
+    private long deadline = 0;
+
+    public InterleavedSearchInvoker(Collection<SearchInvoker> invokers, SearchCluster searchCluster) {
+        super(Optional.empty());
+        this.invokers = Collections.newSetFromMap(new IdentityHashMap<>());
+        this.invokers.addAll(invokers);
+        this.searchCluster = searchCluster;
+        this.availableForProcessing = newQueue();
     }
 
     /**
@@ -33,25 +60,107 @@ public class InterleavedSearchInvoker extends SearchInvoker {
      */
     @Override
     protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+        this.query = query;
+        invokers.forEach(invoker -> invoker.setMonitor(this));
+        deadline = currentTime() + query.getTimeLeft();
+
         int originalHits = query.getHits();
         int originalOffset = query.getOffset();
         query.setHits(query.getHits() + query.getOffset());
         query.setOffset(0);
+
         for (SearchInvoker invoker : invokers) {
             invoker.sendSearchRequest(query, null);
         }
+
         query.setHits(originalHits);
         query.setOffset(originalOffset);
     }
 
     @Override
     protected List<Result> getSearchResults(CacheKey cacheKey) throws IOException {
+        int requests = invokers.size();
+        int responses = 0;
         List<Result> results = new ArrayList<>();
 
-        for (SearchInvoker invoker : invokers) {
-            results.addAll(invoker.getSearchResults(cacheKey));
+        long nextTimeout = query.getTimeLeft();
+        try {
+            while (!invokers.isEmpty() && nextTimeout >= 0) {
+                SearchInvoker invoker = availableForProcessing.poll(nextTimeout, TimeUnit.MILLISECONDS);
+                if (invoker == null) {
+                    if (log.isLoggable(Level.FINE)) {
+                        log.fine("Search timed out with " + requests + " requests made, " + responses + " responses received");
+                    }
+                    break;
+                } else {
+                    invokers.remove(invoker);
+                    results.addAll(invoker.getSearchResults(cacheKey));
+                    responses++;
+                }
+                nextTimeout = nextTimeout(requests, responses);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while waiting for search results", e);
         }
+
+        insertTimeoutErrors(results);
         return results;
+    }
+
+    private void insertTimeoutErrors(List<Result> results) {
+        int degradedReason = adaptiveTimeoutCalculated ? DEGRADED_BY_ADAPTIVE_TIMEOUT : DEGRADED_BY_TIMEOUT;
+
+        for (SearchInvoker invoker : invokers) {
+            Optional<Integer> dk = invoker.distributionKey();
+            String message;
+            if (dk.isPresent()) {
+                message = "Backend communication timeout on node with distribution-key " + dk.get();
+            } else {
+                message = "Backend communication timeout";
+            }
+            Result error = new Result(query, ErrorMessage.createBackendCommunicationError(message));
+            invoker.getErrorCoverage().ifPresent(coverage -> {
+                coverage.setDegradedReason(degradedReason);
+                error.setCoverage(coverage);
+            });
+            results.add(error);
+        }
+    }
+
+    private long nextTimeout(int requests, int responses) {
+        DispatchConfig config = searchCluster.dispatchConfig();
+        double minimumCoverage = config.minSearchCoverage();
+
+        if (requests == responses || minimumCoverage >= 100.0) {
+            return query.getTimeLeft();
+        }
+        int minimumResponses = (int) (requests * minimumCoverage / 100.0);
+
+        if (responses < minimumResponses) {
+            return query.getTimeLeft();
+        }
+
+        long timeLeft = query.getTimeLeft();
+        if (!adaptiveTimeoutCalculated) {
+            adaptiveTimeoutMin = (long) (timeLeft * config.minWaitAfterCoverageFactor());
+            adaptiveTimeoutMax = (long) (timeLeft * config.maxWaitAfterCoverageFactor());
+            adaptiveTimeoutCalculated = true;
+        }
+
+        long now = currentTime();
+        int pendingQueries = requests - responses;
+        double missWidth = ((100.0 - config.minSearchCoverage()) * requests) / 100.0 - 1.0;
+        double slopedWait = adaptiveTimeoutMin;
+        if (pendingQueries > 1 && missWidth > 0.0) {
+            slopedWait += ((adaptiveTimeoutMax - adaptiveTimeoutMin) * (pendingQueries - 1)) / missWidth;
+        }
+        long nextAdaptive = (long) slopedWait;
+        if (now + nextAdaptive >= deadline) {
+            return deadline - now;
+        }
+        deadline = now + nextAdaptive;
+
+        return nextAdaptive;
     }
 
     @Override
@@ -60,5 +169,27 @@ public class InterleavedSearchInvoker extends SearchInvoker {
             invokers.forEach(SearchInvoker::close);
             invokers.clear();
         }
+    }
+
+    @Override
+    public void responseAvailable(SearchInvoker from) {
+        if (availableForProcessing != null) {
+            availableForProcessing.add(from);
+        }
+    }
+
+    @Override
+    protected void setMonitor(ResponseMonitor<SearchInvoker> monitor) {
+        // never to be called
+    }
+
+    // For overriding in tests
+    protected long currentTime() {
+        return System.currentTimeMillis();
+    }
+
+    // For overriding in tests
+    protected LinkedBlockingQueue<SearchInvoker> newQueue() {
+        return new LinkedBlockingQueue<>();
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
-import com.yahoo.search.Query;
 import com.yahoo.search.dispatch.searchcluster.Group;
 import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 
@@ -45,13 +44,13 @@ public class LoadBalancer {
     }
 
     /**
-     * Select and allocate the search cluster group which is to be used for the provided query. Callers <b>must</b> call
+     * Select and allocate the search cluster group which is to be used for the next search query. Callers <b>must</b> call
      * {@link #releaseGroup} symmetrically for each taken allocation.
      *
      * @param rejectedGroups if not null, the load balancer will only return groups with IDs not in the set
      * @return The node group to target, or <i>empty</i> if the internal dispatch logic cannot be used
      */
-    public Optional<Group> takeGroupForQuery(Set<Integer> rejectedGroups) {
+    public Optional<Group> takeGroup(Set<Integer> rejectedGroups) {
         if (scoreboard == null) {
             return Optional.empty();
         }
@@ -60,7 +59,7 @@ public class LoadBalancer {
     }
 
     /**
-     * Release an allocation given by {@link #takeGroupForQuery}. The release must be done exactly once for each allocation.
+     * Release an allocation given by {@link #takeGroup}. The release must be done exactly once for each allocation.
      *
      * @param group
      *            previously allocated group

--- a/container-search/src/main/java/com/yahoo/search/dispatch/ResponseMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/ResponseMonitor.java
@@ -1,0 +1,13 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+/**
+ * Classes implementing ResponseMonitor can be informed by monitored objects
+ * that a response is available for processing. The responseAvailable method
+ * must be thread-safe.
+ *
+ * @author ollivir
+ */
+public interface ResponseMonitor<T> {
+    void responseAvailable(T from);
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
@@ -11,6 +11,7 @@ import com.yahoo.search.result.ErrorMessage;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A search invoker that will immediately produce an error that occurred during
@@ -23,8 +24,10 @@ public class SearchErrorInvoker extends SearchInvoker {
     private final ErrorMessage message;
     private Query query;
     private final Coverage coverage;
+    private ResponseMonitor<SearchInvoker> monitor;
 
     public SearchErrorInvoker(ErrorMessage message, Coverage coverage) {
+        super(Optional.empty());
         this.message = message;
         this.coverage = coverage;
     }
@@ -36,6 +39,9 @@ public class SearchErrorInvoker extends SearchInvoker {
     @Override
     protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
         this.query = query;
+        if(monitor != null) {
+            monitor.responseAvailable(this);
+        }
     }
 
     @Override
@@ -52,4 +58,8 @@ public class SearchErrorInvoker extends SearchInvoker {
         // nothing to do
     }
 
+    @Override
+    protected void setMonitor(ResponseMonitor<SearchInvoker> monitor) {
+        this.monitor = monitor;
+    }
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -1,0 +1,180 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+import com.yahoo.fs4.QueryPacket;
+import com.yahoo.prelude.fastsearch.CacheKey;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.dispatch.searchcluster.SearchCluster;
+import com.yahoo.test.ManualClock;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.yahoo.search.dispatch.MockSearchCluster.createDispatchConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author ollivir
+ */
+public class InterleavedSearchInvokerTest {
+    private ManualClock clock = new ManualClock(Instant.now());
+    private Query query = new TestQuery();
+    private LinkedList<Event> expectedEvents = new LinkedList<>();
+    private List<SearchInvoker> invokers = new ArrayList<>();
+
+    @Test
+    public void requireThatAdaptiveTimeoutsAreNotUsedWithFullCoverageRequirement() throws IOException {
+        SearchCluster cluster = new MockSearchCluster("!", createDispatchConfig(100.0), 1, 3);
+        SearchInvoker invoker = createInterleavedInvoker(cluster, 3);
+
+        expectedEvents.add(new Event(5000, 100, 0));
+        expectedEvents.add(new Event(4900, 100, 1));
+        expectedEvents.add(new Event(4800, 100, 2));
+
+        invoker.search(query, null, null);
+
+        assertTrue("All test scenario events processed", expectedEvents.isEmpty());
+    }
+
+    @Test
+    public void requireThatTimeoutsAreNotMarkedAsAdaptive() throws IOException {
+        SearchCluster cluster = new MockSearchCluster("!", createDispatchConfig(100.0), 1, 3);
+        SearchInvoker invoker = createInterleavedInvoker(cluster, 3);
+
+        expectedEvents.add(new Event(5000, 300, 0));
+        expectedEvents.add(new Event(4700, 300, 1));
+        expectedEvents.add(null);
+
+        List<Result> results = invoker.search(query, null, null);
+
+        assertTrue("All test scenario events processed", expectedEvents.isEmpty());
+        assertNotNull("Last invoker is marked as an error", results.get(2).hits().getErrorHit());
+        assertTrue("Timed out invoker is a normal timeout", results.get(2).getCoverage(false).isDegradedByTimeout());
+    }
+
+    @Test
+    public void requireThatAdaptiveTimeoutDecreasesTimeoutWhenCoverageIsReached() throws IOException {
+        SearchCluster cluster = new MockSearchCluster("!", createDispatchConfig(50.0), 1, 4);
+        SearchInvoker invoker = createInterleavedInvoker(cluster, 4);
+
+        expectedEvents.add(new Event(5000, 100, 0));
+        expectedEvents.add(new Event(4900, 100, 1));
+        expectedEvents.add(new Event(2400, 100, 2));
+        expectedEvents.add(new Event(0, 0, null));
+
+        List<Result> results = invoker.search(query, null, null);
+
+        assertTrue("All test scenario events processed", expectedEvents.isEmpty());
+        assertNotNull("Last invoker is marked as an error", results.get(3).hits().getErrorHit());
+        assertTrue("Timed out invoker is an adaptive timeout", results.get(3).getCoverage(false).isDegradedByAdapativeTimeout());
+    }
+
+    private InterleavedSearchInvoker createInterleavedInvoker(SearchCluster searchCluster, int numInvokers) {
+        for (int i = 0; i < numInvokers; i++) {
+            invokers.add(new TestInvoker());
+        }
+
+        return new InterleavedSearchInvoker(invokers, searchCluster) {
+            @Override
+            protected long currentTime() {
+                return clock.millis();
+            }
+
+            @Override
+            protected LinkedBlockingQueue<SearchInvoker> newQueue() {
+                return new LinkedBlockingQueue<SearchInvoker>() {
+                    @Override
+                    public SearchInvoker poll(long timeout, TimeUnit timeUnit) throws InterruptedException {
+                        assertFalse(expectedEvents.isEmpty());
+                        Event ev = expectedEvents.removeFirst();
+                        if (ev == null) {
+                            return null;
+                        } else {
+                            return ev.process(query, timeout);
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    private class Event {
+        Long expectedTimeout;
+        long delay;
+        Integer invokerIndex;
+
+        public Event(Integer expectedTimeout, int delay, Integer invokerIndex) {
+            this.expectedTimeout = (long) expectedTimeout;
+            this.delay = delay;
+            this.invokerIndex = invokerIndex;
+        }
+
+        public SearchInvoker process(Query query, long currentTimeout) {
+            if (expectedTimeout != null) {
+                assertEquals("Expecting timeout to be " + expectedTimeout, (long) expectedTimeout, currentTimeout);
+            }
+            clock.advance(Duration.ofMillis(delay));
+            if (query.getTimeLeft() < 0) {
+                fail("Test sequence ran out of time window");
+            }
+            if (invokerIndex == null) {
+                return null;
+            } else {
+                return invokers.get(invokerIndex);
+            }
+        }
+    }
+
+    private class TestInvoker extends SearchInvoker {
+        protected TestInvoker() {
+            super(Optional.of(new Node(42, "?", 0, 0)));
+        }
+
+        @Override
+        protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+        }
+
+        @Override
+        protected List<Result> getSearchResults(CacheKey cacheKey) throws IOException {
+            return Collections.singletonList(new Result(query));
+        }
+
+        @Override
+        protected void release() {
+        }
+    }
+
+    public class TestQuery extends Query {
+        private long start = clock.millis();
+
+        public TestQuery() {
+            super();
+            setTimeout(5000);
+        }
+
+        @Override
+        public long getStartTime() {
+            return start;
+        }
+
+        @Override
+        public long getDurationTime() {
+            return clock.millis() - start;
+        }
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerTest.java
@@ -7,9 +7,9 @@ import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 import junit.framework.AssertionFailedError;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Optional;
 
+import static com.yahoo.search.dispatch.MockSearchCluster.createDispatchConfig;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -22,10 +22,10 @@ public class LoadBalancerTest {
     @Test
     public void requreThatLoadBalancerServesSingleNodeSetups() {
         Node n1 = new Node(0, "test-node1", 0, 0);
-        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", createDispatchConfig(n1), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
-        Optional<Group> grp = lb.takeGroupForQuery(null);
+        Optional<Group> grp = lb.takeGroup(null);
         Group group = grp.orElseGet(() -> {
             throw new AssertionFailedError("Expected a SearchCluster.Group");
         });
@@ -36,10 +36,10 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerServesMultiGroupSetups() {
         Node n1 = new Node(0, "test-node1", 0, 0);
         Node n2 = new Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", createDispatchConfig(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
-        Optional<Group> grp = lb.takeGroupForQuery(null);
+        Optional<Group> grp = lb.takeGroup(null);
         Group group = grp.orElseGet(() -> {
             throw new AssertionFailedError("Expected a SearchCluster.Group");
         });
@@ -52,10 +52,10 @@ public class LoadBalancerTest {
         Node n2 = new Node(1, "test-node2", 1, 0);
         Node n3 = new Node(0, "test-node3", 0, 1);
         Node n4 = new Node(1, "test-node4", 1, 1);
-        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2, n3, n4), null, 2, null);
+        SearchCluster cluster = new SearchCluster("a", createDispatchConfig(n1, n2, n3, n4), null, 2, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
-        Optional<Group> grp = lb.takeGroupForQuery(null);
+        Optional<Group> grp = lb.takeGroup(null);
         assertThat(grp.isPresent(), is(true));
     }
 
@@ -63,18 +63,18 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerReturnsDifferentGroups() {
         Node n1 = new Node(0, "test-node1", 0, 0);
         Node n2 = new Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", createDispatchConfig(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
-        Optional<Group> grp = lb.takeGroupForQuery(null);
+        Optional<Group> grp = lb.takeGroup(null);
         Group group = grp.get();
         int id1 = group.id();
         // release allocation
         lb.releaseGroup(group);
 
         // get second group
-        grp = lb.takeGroupForQuery(null);
+        grp = lb.takeGroup(null);
         group = grp.get();
         assertThat(group.id(), not(equalTo(id1)));
     }
@@ -83,16 +83,16 @@ public class LoadBalancerTest {
     public void requreThatLoadBalancerReturnsGroupWithShortestQueue() {
         Node n1 = new Node(0, "test-node1", 0, 0);
         Node n2 = new Node(1, "test-node2", 1, 1);
-        SearchCluster cluster = new SearchCluster("a", 88.0, 99.0, 0, Arrays.asList(n1, n2), null, 1, null);
+        SearchCluster cluster = new SearchCluster("a", createDispatchConfig(n1, n2), null, 1, null);
         LoadBalancer lb = new LoadBalancer(cluster, true);
 
         // get first group
-        Optional<Group> grp = lb.takeGroupForQuery(null);
+        Optional<Group> grp = lb.takeGroup(null);
         Group group = grp.get();
         int id1 = group.id();
 
         // get second group
-        grp = lb.takeGroupForQuery(null);
+        grp = lb.takeGroup(null);
         group = grp.get();
         int id2 = group.id();
         assertThat(id2, not(equalTo(id1)));
@@ -100,7 +100,7 @@ public class LoadBalancerTest {
         lb.releaseGroup(group);
 
         // get third group
-        grp = lb.takeGroupForQuery(null);
+        grp = lb.takeGroup(null);
         group = grp.get();
         assertThat(group.id(), equalTo(id2));
     }


### PR DESCRIPTION
Preliminary support for adaptive timeouts. Fixes a related issue with reporting timeouts in query coverage data. The main changes here are the modifications in `InterleavedSearchInvoker` to make it process responses as they arrive instead of in order of invocation.