### PR TITLE
Support test-and-set for auto-create document updates

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -378,7 +378,7 @@ TwoPhaseUpdateOperation::handleSafePathReceivedGet(DistributorMessageSender& sen
         }
         docToUpdate = reply.getDocument();
         setUpdatedForTimestamp(receivedTimestamp);
-    } else if (hasTasCondition()) {
+    } else if (hasTasCondition() && !shouldCreateIfNonExistent()) {
         replyWithTasFailure(sender, "Document did not exist");
         return;
     } else if (shouldCreateIfNonExistent()) {

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -85,9 +85,10 @@ bool PersistenceThread::tasConditionExists(const api::TestAndSetCommand & cmd) {
     return cmd.getCondition().isPresent();
 }
 
-bool PersistenceThread::tasConditionMatches(const api::TestAndSetCommand & cmd, MessageTracker & tracker) {
+bool PersistenceThread::tasConditionMatches(const api::TestAndSetCommand & cmd, MessageTracker & tracker,
+                                            bool missingDocumentImpliesMatch) {
     try {
-        TestAndSetHelper helper(*this, cmd);
+        TestAndSetHelper helper(*this, cmd, missingDocumentImpliesMatch);
 
         auto code = helper.retrieveAndMatch();
         if (code.failed()) {
@@ -149,7 +150,7 @@ PersistenceThread::handleUpdate(api::UpdateCommand& cmd)
     auto tracker = std::make_unique<MessageTracker>(metrics, _env._component.getClock());
     metrics.request_size.addValue(cmd.getApproxByteSize());
 
-    if (tasConditionExists(cmd) && !tasConditionMatches(cmd, *tracker)) {
+    if (tasConditionExists(cmd) && !tasConditionMatches(cmd, *tracker, cmd.getUpdate()->getCreateIfNonExistent())) {
         return tracker;
     }
     

--- a/storage/src/vespa/storage/persistence/persistencethread.h
+++ b/storage/src/vespa/storage/persistence/persistencethread.h
@@ -87,7 +87,8 @@ private:
 
     friend class TestAndSetHelper;
     bool tasConditionExists(const api::TestAndSetCommand & cmd);
-    bool tasConditionMatches(const api::TestAndSetCommand & cmd, MessageTracker & tracker);
+    bool tasConditionMatches(const api::TestAndSetCommand & cmd, MessageTracker & tracker,
+                             bool missingDocumentImpliesMatch = false);
 };
 
 } // storage

--- a/storage/src/vespa/storage/persistence/testandsethelper.cpp
+++ b/storage/src/vespa/storage/persistence/testandsethelper.cpp
@@ -39,11 +39,13 @@ spi::GetResult TestAndSetHelper::retrieveDocument(const document::FieldSet & fie
         _thread._context);
 }
 
-TestAndSetHelper::TestAndSetHelper(PersistenceThread & thread, const api::TestAndSetCommand & cmd)
+TestAndSetHelper::TestAndSetHelper(PersistenceThread & thread, const api::TestAndSetCommand & cmd,
+                                   bool missingDocumentImpliesMatch)
     : _thread(thread),
       _component(thread._env._component),
       _cmd(cmd),
-      _docId(cmd.getDocumentId())
+      _docId(cmd.getDocumentId()),
+      _missingDocumentImpliesMatch(missingDocumentImpliesMatch)
 {
     getDocumentType();
     parseDocumentSelection();
@@ -68,6 +70,8 @@ api::ReturnCode TestAndSetHelper::retrieveAndMatch() {
         }
 
         // Document matches
+        return api::ReturnCode();
+    } else if (_missingDocumentImpliesMatch) {
         return api::ReturnCode();
     }
 

--- a/storage/src/vespa/storage/persistence/testandsethelper.h
+++ b/storage/src/vespa/storage/persistence/testandsethelper.h
@@ -26,13 +26,15 @@ class TestAndSetHelper {
     const document::DocumentId _docId;
     const document::DocumentType * _docTypePtr;
     std::unique_ptr<document::select::Node> _docSelectionUp;
+    bool _missingDocumentImpliesMatch;
 
     void getDocumentType();
     void parseDocumentSelection();
     spi::GetResult retrieveDocument(const document::FieldSet & fieldSet);
 
 public:
-    TestAndSetHelper(PersistenceThread & thread, const api::TestAndSetCommand & cmd);
+    TestAndSetHelper(PersistenceThread & thread, const api::TestAndSetCommand & cmd,
+                     bool missingDocumentImpliesMatch = false);
     ~TestAndSetHelper();
     api::ReturnCode retrieveAndMatch();
 };


### PR DESCRIPTION
@geirst please review

Has the obvious consistency caveats that if all your existing replicas are
down, the update will go through since the document from an weak consistency
perspective does not exist anywhere. But can be a useful feature if this
is an acceptable tradeoff.