### PR TITLE
Balder/make entryref constructor explicit

### DIFF
--- a/searchcommon/src/vespa/searchcommon/common/growstrategy.h
+++ b/searchcommon/src/vespa/searchcommon/common/growstrategy.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace search {
 

--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -40,9 +40,11 @@
 #include <vespa/searchlib/test/directory_handler.h>
 #include <vespa/searchlib/util/filekit.h>
 #include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchcommon/attribute/iattributevector.h>
+#include <vespa/searchlib/btree/btreeroot.hpp>
 
 #include <vespa/log/log.h>
 LOG_SETUP("attribute_test");

--- a/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
+++ b/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
@@ -16,6 +16,7 @@
 #include <vespa/searchlib/test/mock_attribute_manager.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <unordered_set>
 
 #include <vespa/log/log.h>
 LOG_SETUP("document_iterator_test");
@@ -50,7 +51,6 @@ using storage::spi::Timestamp;
 using storage::spi::test::makeSpiBucket;
 
 using namespace proton;
-using namespace search::index;
 
 const uint64_t largeNum = 10000000;
 

--- a/searchcore/src/tests/proton/server/documentretriever_test.cpp
+++ b/searchcore/src/tests/proton/server/documentretriever_test.cpp
@@ -31,7 +31,10 @@
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/searchlib/attribute/stringbase.h>
+#include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/stringfmt.h>
+
 
 #include <vespa/log/log.h>
 LOG_SETUP("document_retriever_test");

--- a/searchcore/src/vespa/searchcore/grouping/groupingmanager.cpp
+++ b/searchcore/src/vespa/searchcore/grouping/groupingmanager.cpp
@@ -52,7 +52,7 @@ GroupingManager::init(const IAttributeContext &attrCtx)
                     an.useEnumOptimization();
                 }
             }
-            ConfigureStaticParams stuff(&attrCtx, NULL);
+            ConfigureStaticParams stuff(&attrCtx, nullptr);
             grouping.configureStaticStuff(stuff);
             list.push_back(groupingList[i]);
         } catch (const std::exception & e) {

--- a/searchcore/src/vespa/searchcore/proton/common/attrupdate.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/attrupdate.cpp
@@ -17,8 +17,10 @@
 #include <vespa/searchlib/common/base.h>
 #include <vespa/searchlib/tensor/tensor_attribute.h>
 #include <vespa/searchlib/attribute/reference_attribute.h>
+#include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/searchlib/attribute/attributevector.hpp>
 #include <vespa/searchlib/attribute/changevector.hpp>
+#include <vespa/vespalib/util/stringfmt.h>
 #include <sstream>
 
 #include <vespa/log/log.h>

--- a/searchcore/src/vespa/searchcore/proton/common/attrupdate.h
+++ b/searchcore/src/vespa/searchcore/proton/common/attrupdate.h
@@ -4,13 +4,14 @@
 #include <vespa/document/fieldvalue/fieldvalue.h>
 #include <vespa/document/update/documentupdate.h>
 #include <vespa/searchlib/attribute/attribute.h>
-#include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/vespalib/util/exception.h>
 
 namespace search {
 
+class PredicateAttribute;
+
 namespace tensor { class TensorAttribute; }
-namespace attribute { class ReferenceAttribute; }
+namespace attribute {class ReferenceAttribute; }
 
 VESPA_DEFINE_EXCEPTION(UpdateException, vespalib::Exception);
 

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -14,6 +14,7 @@
 #include <vespa/searchlib/attribute/singlenumericattribute.h>
 #include <vespa/searchlib/attribute/singlenumericattribute.hpp>
 #include <vespa/searchlib/attribute/singlenumericpostattribute.hpp>
+#include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/fef/fef.h>
 #include <vespa/searchlib/query/tree/location.h>
 #include <vespa/searchlib/query/tree/point.h>

--- a/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
+++ b/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
@@ -19,6 +19,7 @@ namespace search {
 
 using attribute::CollectionType;
 using attribute::IAttributeVector;
+using datastore::EntryRef;
 
 class StringAttributeTest : public vespalib::TestApp
 {
@@ -333,12 +334,12 @@ void StringAttributeTest::testDefaultValueOnAddDoc(AttributeVector & v)
     EXPECT_EQUAL(0u, v.getNumDocs());
     v.addReservedDoc();
     EXPECT_EQUAL(1u, v.getNumDocs());
-    EXPECT_TRUE( EnumStoreBase::Index(v.getEnum(0)).valid() );
+    EXPECT_TRUE( EnumStoreBase::Index(EntryRef(v.getEnum(0))).valid() );
     uint32_t doc(7);
     EXPECT_TRUE( v.addDoc(doc) );
     EXPECT_EQUAL(1u, doc);
     EXPECT_EQUAL(2u, v.getNumDocs());
-    EXPECT_TRUE( EnumStoreBase::Index(v.getEnum(doc)).valid() );
+    EXPECT_TRUE( EnumStoreBase::Index(EntryRef(v.getEnum(doc))).valid() );
     EXPECT_EQUAL(0u, strlen(v.getString(doc, NULL, 0)));
 }
 
@@ -360,7 +361,7 @@ StringAttributeTest::testSingleValue(Attribute & svsa, Config &cfg)
         EXPECT_TRUE( doc == i );
         EXPECT_TRUE( v.getNumDocs() == i + 1 );
         EXPECT_TRUE( v.getValueCount(doc) == 1 );
-        EXPECT_TRUE( ! EnumStoreBase::Index(v.getEnum(doc)).valid() );
+        EXPECT_TRUE( ! EnumStoreBase::Index(EntryRef(v.getEnum(doc))).valid() );
     }
 
     std::map<vespalib::string, uint32_t> enums;
@@ -369,7 +370,7 @@ StringAttributeTest::testSingleValue(Attribute & svsa, Config &cfg)
         sprintf(tmp, "enum%u", i % 10);
         EXPECT_TRUE( v.update(i, tmp) );
         EXPECT_TRUE( v.getValueCount(i) == 1 );
-        EXPECT_TRUE( ! EnumStoreBase::Index(v.getEnum(i)).valid() );
+        EXPECT_TRUE( ! EnumStoreBase::Index(EntryRef(v.getEnum(i))).valid() );
         if ((i % 10) == 9) {
             v.commit();
             for (uint32_t j = i - 9; j <= i; ++j) {

--- a/searchlib/src/tests/memoryindex/compact_document_words_store/compact_document_words_store_test.cpp
+++ b/searchlib/src/tests/memoryindex/compact_document_words_store/compact_document_words_store_test.cpp
@@ -104,7 +104,7 @@ TEST("require that a lot of words can be inserted, retrieved and removed")
     for (uint32_t docId = 0; docId < 50; ++docId) {
         Builder b(docId);
         for (uint32_t wordRef = 0; wordRef < 20000; ++wordRef) {
-            b.insert(wordRef);
+            b.insert(EntryRef(wordRef));
         }
         store.insert(b);
         MemoryUsage usage = store.getMemoryUsage();

--- a/searchlib/src/tests/predicate/predicate_bounds_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_bounds_posting_list_test.cpp
@@ -1,12 +1,15 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for predicate_bounds_posting_list.
 
-#include <vespa/log/log.h>
-LOG_SETUP("predicate_bounds_posting_list_test");
-
+#include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/predicate/predicate_tree_annotator.h>
 #include <vespa/searchlib/predicate/predicate_bounds_posting_list.h>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
 #include <vespa/vespalib/testkit/testapp.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("predicate_bounds_posting_list_test");
 
 using namespace search;
 using namespace search::predicate;

--- a/searchlib/src/tests/predicate/predicate_index_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_index_test.cpp
@@ -1,13 +1,17 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for predicate_index.
 
-#include <vespa/log/log.h>
-LOG_SETUP("predicate_index_test");
-
 #include <vespa/searchlib/predicate/predicate_index.h>
+#include <vespa/searchlib/predicate/simple_index.hpp>
 #include <vespa/searchlib/predicate/predicate_tree_annotator.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
+#include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
+
+#include <vespa/log/log.h>
+LOG_SETUP("predicate_index_test");
 
 using namespace search;
 using namespace search::predicate;

--- a/searchlib/src/tests/predicate/predicate_interval_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_interval_posting_list_test.cpp
@@ -1,12 +1,15 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for predicate_interval_posting_list.
 
-#include <vespa/log/log.h>
-LOG_SETUP("predicate_interval_posting_list_test");
-
+#include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/predicate/predicate_tree_annotator.h>
 #include <vespa/searchlib/predicate/predicate_interval_posting_list.h>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
 #include <vespa/vespalib/testkit/testapp.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("predicate_interval_posting_list_test");
 
 using namespace search;
 using namespace search::predicate;

--- a/searchlib/src/tests/predicate/predicate_tree_annotator_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_tree_annotator_test.cpp
@@ -141,7 +141,7 @@ TEST("require that NOTs get correct intervals") {
     EXPECT_EQUAL(2u, result.interval_map.size());
     checkInterval(result, "key=value",
                   {0x00010001, 0x00020002, 0x00040004, 0x00050005});
-    checkInterval(result, PredicateIndex::z_star_compressed_attribute_name,
+    checkInterval(result, Constants::z_star_compressed_attribute_name,
                   {0x00020001, 0x00050004});
 }
 
@@ -156,7 +156,7 @@ TEST("require that NOT inverts ANDs and ORs") {
     EXPECT_EQUAL(2u, result.interval_map.size());
     checkInterval(result, "key=value",
                   {0x00010002, 0x00010003});
-    checkInterval(result, PredicateIndex::z_star_compressed_attribute_name,
+    checkInterval(result, Constants::z_star_compressed_attribute_name,
                   {0x00020000});
 }
 
@@ -168,7 +168,7 @@ TEST("require that final first NOT-interval is extended") {
     EXPECT_EQUAL(2u, result.interval_range);
     EXPECT_EQUAL(2u, result.interval_map.size());
     checkInterval(result, "key=A", {0x00010001});
-    checkInterval(result, PredicateIndex::z_star_compressed_attribute_name,
+    checkInterval(result, Constants::z_star_compressed_attribute_name,
                   {0x00010000});
 }
 
@@ -188,7 +188,7 @@ TEST("show different types of NOT-intervals") {
     checkInterval(result, "key=B", {0x00020002});
     checkInterval(result, "key=C", {0x00010004});
     checkInterval(result, "key=D", {0x00060006});
-    checkInterval(result, PredicateIndex::z_star_compressed_attribute_name,
+    checkInterval(result, Constants::z_star_compressed_attribute_name,
                   {0x00020001, 0x00000006, 0x00040000});
 
     slime = orNode({neg(featureSet("key", {"A"})),
@@ -200,7 +200,7 @@ TEST("show different types of NOT-intervals") {
     EXPECT_EQUAL(3u, result.interval_map.size());
     checkInterval(result, "key=A", {0x00010003});
     checkInterval(result, "key=B", {0x00010003});
-    checkInterval(result, PredicateIndex::z_star_compressed_attribute_name,
+    checkInterval(result, Constants::z_star_compressed_attribute_name,
                   {0x00030000, 0x00030000});
 
     slime = orNode({andNode({neg(featureSet("key", {"A"})),
@@ -216,7 +216,7 @@ TEST("show different types of NOT-intervals") {
     checkInterval(result, "key=B", {0x00030007});
     checkInterval(result, "key=C", {0x00010005});
     checkInterval(result, "key=D", {0x00070007});
-    checkInterval(result, PredicateIndex::z_star_compressed_attribute_name,
+    checkInterval(result, Constants::z_star_compressed_attribute_name,
                   {0x00010000, 0x00070002, 0x00050000,
                    0x00070006});
 
@@ -333,7 +333,7 @@ TEST("require that z-star feature is only registered once") {
     EXPECT_EQUAL(4u, result.interval_range);
     ASSERT_EQUAL(3u, result.features.size());
     EXPECT_EQUAL(PredicateHash::hash64("key1=value1"), result.features[0]);
-    EXPECT_EQUAL(PredicateIndex::z_star_compressed_hash, result.features[1]);
+    EXPECT_EQUAL(Constants::z_star_compressed_hash, result.features[1]);
     EXPECT_EQUAL(PredicateHash::hash64("key2=10-19"), result.features[2]);
     ASSERT_EQUAL(0u, result.range_features.size());
 }

--- a/searchlib/src/tests/predicate/predicate_zero_constraint_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_zero_constraint_posting_list_test.cpp
@@ -1,11 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for predicate_zero_constraint_posting_list.
 
+#include <vespa/searchlib/predicate/predicate_zero_constraint_posting_list.h>
+#include <vespa/searchlib/predicate/predicate_index.h>
+
+#include <vespa/vespalib/testkit/testapp.h>
+
 #include <vespa/log/log.h>
 LOG_SETUP("predicate_zero_constraint_posting_list_test");
-
-#include <vespa/searchlib/predicate/predicate_zero_constraint_posting_list.h>
-#include <vespa/vespalib/testkit/testapp.h>
 
 using namespace search;
 using namespace search::predicate;

--- a/searchlib/src/tests/predicate/predicate_zstar_compressed_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_zstar_compressed_posting_list_test.cpp
@@ -1,12 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for predicate_zstar_compressed_posting_list.
 
+#include <vespa/searchlib/predicate/predicate_zstar_compressed_posting_list.h>
+#include <vespa/searchlib/predicate/predicate_index.h>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
+#include <vespa/vespalib/testkit/testapp.h>
+
 #include <vespa/log/log.h>
 LOG_SETUP("predicate_zstar_compressed_posting_list_test");
-
-#include <vespa/searchlib/predicate/predicate_tree_annotator.h>
-#include <vespa/searchlib/predicate/predicate_zstar_compressed_posting_list.h>
-#include <vespa/vespalib/testkit/testapp.h>
 
 using namespace search;
 using namespace search::predicate;

--- a/searchlib/src/tests/predicate/simple_index_test.cpp
+++ b/searchlib/src/tests/predicate/simple_index_test.cpp
@@ -4,6 +4,12 @@
 #include <vespa/searchlib/predicate/simple_index.hpp>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
+#include <vespa/searchlib/btree/btree.hpp>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
+#include <vespa/searchlib/btree/btreestore.hpp>
+#include <vespa/searchlib/btree/btreenodeallocator.hpp>
+#include <map>
 
 #include <vespa/log/log.h>
 LOG_SETUP("simple_index_test");

--- a/searchlib/src/tests/queryeval/predicate/predicate_blueprint_test.cpp
+++ b/searchlib/src/tests/queryeval/predicate/predicate_blueprint_test.cpp
@@ -1,12 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for predicate_blueprint.
 
-#include <vespa/log/log.h>
-LOG_SETUP("predicate_blueprint_test");
-
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/searchlib/predicate/predicate_tree_annotator.h>
+#include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>
 #include <vespa/searchlib/query/tree/predicate_query_term.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
@@ -15,6 +13,9 @@ LOG_SETUP("predicate_blueprint_test");
 #include <vespa/searchlib/queryeval/predicate_blueprint.h>
 #include <vespa/searchlib/predicate/predicate_hash.h>
 #include <vespa/vespalib/testkit/testapp.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("predicate_blueprint_test");
 
 using namespace search;
 using namespace search::predicate;
@@ -123,8 +124,7 @@ TEST_F("require that blueprint with 'bounds' posting list entry estimates "
 TEST_F("require that blueprint with zstar-compressed estimates non-empty.",
        Fixture) {
     PredicateTreeAnnotations annotations(1);
-    annotations.interval_map[PredicateIndex::z_star_compressed_hash] =
-        std::vector<Interval>{{0xfffe0000}};
+    annotations.interval_map[Constants::z_star_compressed_hash] =std::vector<Interval>{{0xfffe0000}};
     f.indexDocument(doc_id, annotations);
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
     EXPECT_FALSE(blueprint.getState().estimate().empty);
@@ -133,8 +133,7 @@ TEST_F("require that blueprint with zstar-compressed estimates non-empty.",
 
 TEST_F("require that blueprint can create search", Fixture) {
     PredicateTreeAnnotations annotations(1);
-    annotations.interval_map[PredicateHash::hash64("key=value")] =
-        std::vector<Interval>{{interval}};
+    annotations.interval_map[PredicateHash::hash64("key=value")] =std::vector<Interval>{{interval}};
     f.indexDocument(doc_id, annotations);
 
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
@@ -181,8 +180,7 @@ TEST_F("require that blueprint can create more advanced search", Fixture) {
 
 TEST_F("require that blueprint can create NOT search", Fixture) {
     PredicateTreeAnnotations annotations(1);
-    annotations.interval_map[PredicateIndex::z_star_hash] =
-        std::vector<Interval>{{0x00010000}, {0xffff0001}};
+    annotations.interval_map[Constants::z_star_hash] =std::vector<Interval>{{0x00010000}, {0xffff0001}};
     f.indexDocument(doc_id, annotations);
 
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
@@ -198,8 +196,7 @@ TEST_F("require that blueprint can create NOT search", Fixture) {
 
 TEST_F("require that blueprint can create compressed NOT search", Fixture) {
     PredicateTreeAnnotations annotations(1);
-    annotations.interval_map[PredicateIndex::z_star_compressed_hash] =
-        std::vector<Interval>{{0xfffe0000}};
+    annotations.interval_map[Constants::z_star_compressed_hash] =std::vector<Interval>{{0xfffe0000}};
     f.indexDocument(doc_id, annotations);
 
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);

--- a/searchlib/src/vespa/searchlib/attribute/attributefilebufferwriter.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributefilebufferwriter.h
@@ -5,8 +5,7 @@
 #include "iattributefilewriter.h"
 #include <vespa/searchlib/util/bufferwriter.h>
 
-namespace search
-{
+namespace search {
 
 /*
  * BufferWriter implementation that passes full buffers on to
@@ -27,10 +26,9 @@ public:
     static constexpr size_t BUFFER_SIZE = 4 * 1024 * 1024;
 
     AttributeFileBufferWriter(IAttributeFileWriter &fileWriter);
+    ~AttributeFileBufferWriter() override;
 
-    virtual ~AttributeFileBufferWriter();
-
-    virtual void flush() override;
+    void flush() override;
 
     size_t getBytesWritten() const { return _bytesWritten; }
 };

--- a/searchlib/src/vespa/searchlib/attribute/attributememorysavetarget.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributememorysavetarget.h
@@ -3,21 +3,14 @@
 #pragma once
 
 #include "iattributesavetarget.h"
+#include "attributememoryfilewriter.h"
 #include <vespa/searchlib/util/rawbuf.h>
 #include <memory>
 #include <vespa/searchlib/common/tunefileinfo.h>
-#include "attributememoryfilewriter.h"
 
-namespace search
-{
+namespace search::common { class FileHeaderContext; }
 
-namespace common
-{
-
-class FileHeaderContext;
-
-}
-
+namespace search {
 class AttributeVector;
 
 /**
@@ -39,7 +32,7 @@ public:
      * Write the underlying buffer(s) to file(s).
      **/
     bool writeToFile(const TuneFileAttributes &tuneFileAttributes,
-                     const search::common::FileHeaderContext &fileHeaderContext);
+                     const common::FileHeaderContext &fileHeaderContext);
 
     bool setup() override { return true; }
     void close() override {}

--- a/searchlib/src/vespa/searchlib/attribute/enumattributesaver.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattributesaver.h
@@ -21,13 +21,10 @@ class EnumAttributeSaver
 
 public:
     EnumAttributeSaver(const EnumStoreBase &enumStore, bool disableReEnumerate);
-
     ~EnumAttributeSaver();
 
     void enableReEnumerate();
-
     void writeUdat(IAttributeSaveTarget &saveTarget);
-
     const EnumStoreBase &getEnumStore() const { return _enumStore; }
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/enumstore.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumstore.hpp
@@ -110,15 +110,12 @@ EnumStoreT<EntryType>::printValue(vespalib::asciistream & os, Type value) const
 
 template <class EntryType>
 void
-EnumStoreT<EntryType>::writeValues(BufferWriter &writer,
-                                   const Index *idxs, size_t count) const
+EnumStoreT<EntryType>::writeValues(BufferWriter &writer, const Index *idxs, size_t count) const
 {
     size_t sz(EntryType::fixedSize());
     for (uint32_t i = 0; i < count; ++i) {
         Index idx = idxs[i];
-        const char *src(_store.getBufferEntry<char>(idx.bufferId(),
-                                                    idx.offset()) +
-                        EntryBase::size());
+        const char *src(_store.getBufferEntry<char>(idx.bufferId(), idx.offset()) + EntryBase::size());
         writer.write(src, sz);
     }
 }
@@ -126,9 +123,7 @@ EnumStoreT<EntryType>::writeValues(BufferWriter &writer,
 
 template <class EntryType>
 ssize_t
-EnumStoreT<EntryType>::deserialize(const void *src,
-                                      size_t available,
-                                      size_t &initSpace)
+EnumStoreT<EntryType>::deserialize(const void *src, size_t available, size_t &initSpace)
 {
     (void) src;
     size_t sz(EntryType::fixedSize());
@@ -141,9 +136,7 @@ EnumStoreT<EntryType>::deserialize(const void *src,
 
 template <class EntryType>
 ssize_t
-EnumStoreT<EntryType>::deserialize(const void *src,
-                                      size_t available,
-                                      Index &idx)
+EnumStoreT<EntryType>::deserialize(const void *src, size_t available, Index &idx)
 {
     size_t sz(EntryType::fixedSize());
     if (available < sz)
@@ -166,8 +159,7 @@ EnumStoreT<EntryType>::deserialize(const void *src,
     ++_nextEnum;
 
     if (idx.valid()) {
-        assert(ComparatorType::compare(getValue(idx),
-                                       Entry(dst).getValue()) < 0);
+        assert(ComparatorType::compare(getValue(idx), Entry(dst).getValue()) < 0);
     }
     idx = Index(offset, activeBufferId);
     return sz;
@@ -178,8 +170,7 @@ template <class EntryType>
 bool
 EnumStoreT<EntryType>::foldedChange(const Index &idx1, const Index &idx2)
 {
-    int cmpres = FoldedComparatorType::compareFolded(getValue(idx1),
-                                                     getValue(idx2));
+    int cmpres = FoldedComparatorType::compareFolded(getValue(idx1), getValue(idx2));
     assert(cmpres <= 0);
     return cmpres < 0;
 }
@@ -187,8 +178,7 @@ EnumStoreT<EntryType>::foldedChange(const Index &idx1, const Index &idx2)
 
 template <typename EntryType>
 bool
-EnumStoreT<EntryType>::findEnum(Type value,
-                                   EnumStoreBase::EnumHandle &e) const
+EnumStoreT<EntryType>::findEnum(Type value, EnumStoreBase::EnumHandle &e) const
 {
     ComparatorType cmp(*this, value);
     Index idx;
@@ -248,9 +238,7 @@ EnumStoreT<EntryType>::freeUnusedEnums(const IndexVector &toRemove)
 template <typename EntryType>
 template <typename Dictionary>
 void
-EnumStoreT<EntryType>::addEnum(Type value,
-                                  Index &newIdx,
-                                  Dictionary &dict)
+EnumStoreT<EntryType>::addEnum(Type value, Index &newIdx, Dictionary &dict)
 {
     typedef typename Dictionary::Iterator DictionaryIterator;
     uint32_t entrySize = this->getEntrySize(value);
@@ -321,16 +309,12 @@ template <typename EntryType>
 void
 EnumStoreT<EntryType>::addEnum(Type value, Index & newIdx)
 {
-    if (_enumDict->hasData())
-        addEnum(value, newIdx,
-                static_cast<EnumStoreDict<EnumPostingTree> *>(_enumDict)->
-                getDictionary());
-    else
-        addEnum(value, newIdx,
-                static_cast<EnumStoreDict<EnumTree> *>(_enumDict)->
-                getDictionary());
+    if (_enumDict->hasData()) {
+        addEnum(value, newIdx, static_cast<EnumStoreDict<EnumPostingTree> *>(_enumDict)->getDictionary());
+    } else {
+        addEnum(value, newIdx, static_cast<EnumStoreDict<EnumTree> *>(_enumDict)->getDictionary());
+    }
 }
-
 
 template <typename DictionaryType>
 struct TreeBuilderInserter {
@@ -508,15 +492,11 @@ template <typename EntryType>
 void
 EnumStoreT<EntryType>::printCurrentContent(vespalib::asciistream &os) const
 {
-    if (_enumDict->hasData())
-        printCurrentContent(os,
-                            static_cast<EnumStoreDict<EnumPostingTree> *>
-                            (_enumDict)->getDictionary());
-    else
-        printCurrentContent(os,
-                            static_cast<EnumStoreDict<EnumTree> *>
-                            (_enumDict)->getDictionary());
+    if (_enumDict->hasData()) {
+        printCurrentContent(os, static_cast<EnumStoreDict<EnumPostingTree> *>(_enumDict)->getDictionary());
+    } else {
+        printCurrentContent(os, static_cast<EnumStoreDict<EnumTree> *>(_enumDict)->getDictionary());
+    }
 }
 
 } // namespace search
-

--- a/searchlib/src/vespa/searchlib/attribute/enumstore.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumstore.hpp
@@ -25,7 +25,7 @@ void EnumStoreT<EntryType>::freeUnusedEnum(Index idx, IndexSet & unused)
     if (e.getRefCount() == 0) {
         Type value = e.getValue();
         if (unused.insert(idx).second) {
-            _store.incDead(idx.bufferId(), getEntrySize(value));
+            _store.incDead(idx, getEntrySize(value));
         }
     }
 }

--- a/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
@@ -9,6 +9,8 @@
 #include <vespa/searchlib/common/rcuvector.hpp>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/stllike/hash_map.hpp>
+
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.attribute.enumstorebase");
@@ -626,37 +628,28 @@ EnumStoreBase::reEnumerate<EnumPostingTree>(const EnumPostingTree &tree);
 
 template
 ssize_t
-EnumStoreBase::deserialize<EnumTree>(const void *src,
-                                     size_t available,
-                                     IndexVector &idx,
-                                     EnumTree &tree);
+EnumStoreBase::deserialize<EnumTree>(const void *src, size_t available, IndexVector &idx, EnumTree &tree);
 
 template
 ssize_t
-EnumStoreBase::deserialize<EnumPostingTree>(const void *src,
-                                            size_t available,
-                                            IndexVector &idx,
-                                            EnumPostingTree &tree);
+EnumStoreBase::deserialize<EnumPostingTree>(const void *src, size_t available, IndexVector &idx, EnumPostingTree &tree);
 
 template
 void
-EnumStoreBase::fixupRefCounts<EnumTree>(const EnumVector &hist,
-                                        EnumTree &tree);
+EnumStoreBase::fixupRefCounts<EnumTree>(const EnumVector &hist, EnumTree &tree);
 
 template
 void
-EnumStoreBase::fixupRefCounts<EnumPostingTree>(
-        const EnumVector &hist,
-        EnumPostingTree &tree);
+EnumStoreBase::fixupRefCounts<EnumPostingTree>(const EnumVector &hist, EnumPostingTree &tree);
 
 template class EnumStoreDict<EnumTree>;
 
 template class EnumStoreDict<EnumPostingTree>;
 
 namespace attribute {
-
     template class RcuVectorBase<EnumStoreIndex>;
-
 }
 
 }
+
+template class vespalib::hash_map<search::EnumStoreIndex, search::EnumStoreIndex>;

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
@@ -6,7 +6,6 @@
 #include "multivalueattribute.hpp"
 #include "multienumattributesaver.h"
 #include "load_utils.h"
-
 namespace search {
 
 template <typename B, typename M>
@@ -16,7 +15,7 @@ MultiValueEnumAttribute<B, M>::extractChangeData(const Change & c, EnumIndex & i
     if (c._enumScratchPad == Change::UNSET_ENUM) {
         return this->_enumStore.findIndex(c._data.raw(), idx);
     }
-    idx = EnumIndex(c._enumScratchPad);
+    idx = EnumIndex(datastore::EntryRef(c._enumScratchPad));
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.cpp
@@ -82,9 +82,7 @@ MultiValueEnumAttributeSaver(GenerationHandler::Guard &&guard,
 
 
 template <typename MultiValueT>
-MultiValueEnumAttributeSaver<MultiValueT>::~MultiValueEnumAttributeSaver()
-{
-}
+MultiValueEnumAttributeSaver<MultiValueT>::~MultiValueEnumAttributeSaver() = default;
 
 template <typename MultiValueT>
 bool

--- a/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.h
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.h
@@ -26,12 +26,12 @@ class MultiValueEnumAttributeSaver : public MultiValueAttributeSaver
     const MultiValueMapping &_mvMapping;
     EnumAttributeSaver      _enumSaver;
 public:
-    virtual bool onSave(IAttributeSaveTarget &saveTarget) override;
+    bool onSave(IAttributeSaveTarget &saveTarget) override;
     MultiValueEnumAttributeSaver(GenerationHandler::Guard &&guard,
                                  const attribute::AttributeHeader &header,
                                  const MultiValueMapping &mvMapping,
                                  const EnumStoreBase &enumStore);
-    virtual ~MultiValueEnumAttributeSaver();
+    ~MultiValueEnumAttributeSaver() override;
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/postingchange.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postingchange.cpp
@@ -126,9 +126,9 @@ PostingChange<AttributeWeightPosting>::removeDups()
 }
 
 template <typename P>
-PostingChange<P>::PostingChange() { }
+PostingChange<P>::PostingChange() = default;
 template <typename P>
-PostingChange<P>::~PostingChange() { }
+PostingChange<P>::~PostingChange() = default;
 
 template <typename P>
 void
@@ -191,7 +191,7 @@ private:
         if (itr.second) {
             itr.first->second = _mapper.map(unmapped, _compare).ref();
         }
-        return EnumIndex(itr.first->second);
+        return EnumIndex(datastore::EntryRef(itr.first->second));
     }
 
 
@@ -273,7 +273,7 @@ ActualChangeComputer<WeightedIndex>::ActualChangeComputer(const EnumStoreCompara
 { }
 
 template <typename WeightedIndex>
-ActualChangeComputer<WeightedIndex>::~ActualChangeComputer() { }
+ActualChangeComputer<WeightedIndex>::~ActualChangeComputer() = default;
 
 template <typename WeightedIndex>
 void

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.cpp
@@ -15,8 +15,7 @@ using btree::BTreeNoLeafData;
 // #define FORCE_BITVECTORS
 
 
-PostingStoreBase2::PostingStoreBase2(EnumPostingTree &dict, Status &status,
-                                     const Config &config)
+PostingStoreBase2::PostingStoreBase2(EnumPostingTree &dict, Status &status, const Config &config)
     :
 #ifdef FORCE_BITVECTORS
       _enableBitVectors(true),
@@ -91,7 +90,7 @@ PostingStore<DataT>::removeSparseBitVectors()
     bool res = false;
     bool needscan = false;
     for (auto &i : _bvs) {
-        RefType iRef(i);
+        RefType iRef = EntryRef(i);
         uint32_t typeId = getTypeId(iRef);
         (void) typeId;
         assert(isBitVector(typeId));

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
@@ -3,6 +3,7 @@
 #include "predicate_attribute.h"
 #include "iattributesavetarget.h"
 #include "attribute_header.h"
+#include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/util/fileutil.h>
 #include <vespa/document/fieldvalue/predicatefieldvalue.h>
 #include <vespa/document/predicate/predicate.h>
@@ -80,6 +81,10 @@ PredicateAttribute::PredicateAttribute(const vespalib::string &base_file_name,
 PredicateAttribute::~PredicateAttribute()
 {
     getGenerationHolder().clearHoldLists();
+}
+
+void PredicateAttribute::populateIfNeeded() {
+    _index->populateIfNeeded(getNumDocs());
 }
 
 uint32_t

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
@@ -3,10 +3,12 @@
 #pragma once
 
 #include "not_implemented_attribute.h"
-#include <vespa/searchlib/predicate/predicate_index.h>
+#include <vespa/searchlib/predicate/common.h>
 #include <vespa/searchlib/common/rcuvector.h>
 
 namespace document { class PredicateFieldValue; }
+
+namespace search::predicate { class PredicateIndex; }
 
 namespace search {
 
@@ -38,10 +40,9 @@ public:
 
     DECLARE_IDENTIFIABLE_ABSTRACT(PredicateAttribute);
 
-    PredicateAttribute(const vespalib::string &base_file_name,
-                       const Config &config);
+    PredicateAttribute(const vespalib::string &base_file_name, const Config &config);
 
-    virtual ~PredicateAttribute();
+    ~PredicateAttribute() override;
 
     predicate::PredicateIndex &getIndex() { return *_index; }
 
@@ -77,13 +78,11 @@ public:
         _max_interval_range = std::max(intervalRange, _max_interval_range);
     }
 
-    void populateIfNeeded() {
-        _index->populateIfNeeded(getNumDocs());
-    }
+    void populateIfNeeded();
 private:
     vespalib::string _base_file_name;
     const AttributeVectorDocIdLimitProvider _limit_provider;
-    predicate::PredicateIndex::UP _index;
+    std::unique_ptr<predicate::PredicateIndex> _index;
     int64_t _lower_bound;
     int64_t _upper_bound;
 

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -272,7 +272,7 @@ template <typename B>
 void
 SingleValueEnumAttribute<B>::clearDocs(DocId lidLow, DocId lidLimit)
 {
-    EnumHandle e;
+    EnumHandle e(0);
     bool findDefaultEnumRes(this->findEnum(this->getDefaultEnumTypeValue(), e));
     if (!findDefaultEnumRes) {
         e = EnumHandle();
@@ -280,7 +280,7 @@ SingleValueEnumAttribute<B>::clearDocs(DocId lidLow, DocId lidLimit)
     assert(lidLow <= lidLimit);
     assert(lidLimit <= this->getNumDocs());
     for (DocId lid = lidLow; lid < lidLimit; ++lid) {
-        if (_enumIndices[lid] != e) {
+        if (_enumIndices[lid] != datastore::EntryRef(e)) {
             this->clearDoc(lid);
         }
     }
@@ -291,14 +291,13 @@ template <typename B>
 void
 SingleValueEnumAttribute<B>::onShrinkLidSpace()
 {
-    EnumHandle e;
+    EnumHandle e(0);
     bool findDefaultEnumRes(this->findEnum(this->getDefaultEnumTypeValue(), e));
     assert(findDefaultEnumRes);
     uint32_t committedDocIdLimit = this->getCommittedDocIdLimit();
     assert(_enumIndices.size() >= committedDocIdLimit);
-    attribute::IPostingListAttributeBase *pab = 
-        this->getIPostingListAttributeBase();
-    if (pab != NULL) {
+    attribute::IPostingListAttributeBase *pab = this->getIPostingListAttributeBase();
+    if (pab != nullptr) {
         pab->clearPostings(e, committedDocIdLimit, _enumIndices.size());
     }
     _enumIndices.shrink(committedDocIdLimit);
@@ -318,6 +317,4 @@ SingleValueEnumAttribute<B>::onInitSave(vespalib::stringref fileName)
          this->_enumStore);
 }
 
-
 } // namespace search
-

--- a/searchlib/src/vespa/searchlib/btree/btree.h
+++ b/searchlib/src/vespa/searchlib/btree/btree.h
@@ -6,8 +6,7 @@
 #include "noaggrcalc.h"
 #include <vespa/vespalib/util/generationhandler.h>
 
-namespace search {
-namespace btree {
+namespace search::btree {
 
 /**
  * Class that wraps a btree root and an allocator and that provides the same API as
@@ -165,6 +164,4 @@ public:
     }
 };
 
-} // namespace search::btree
-} // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/datastore/datastorebase.h
+++ b/searchlib/src/vespa/searchlib/datastore/datastorebase.h
@@ -341,5 +341,4 @@ public:
     std::vector<uint32_t> startCompactWorstBuffers(bool compactMemory, bool compactAddressSpace);
 };
 
-
 }

--- a/searchlib/src/vespa/searchlib/datastore/entryref.h
+++ b/searchlib/src/vespa/searchlib/datastore/entryref.h
@@ -13,6 +13,7 @@ public:
     EntryRef() : _ref(0u) { }
     explicit EntryRef(uint32_t ref_) : _ref(ref_) { }
     uint32_t ref() const { return _ref; }
+    uint32_t hash() const { return _ref; }
     bool valid() const { return _ref != 0u; }
     bool operator==(const EntryRef &rhs) const { return _ref == rhs._ref; }
     bool operator!=(const EntryRef &rhs) const { return _ref != rhs._ref; }

--- a/searchlib/src/vespa/searchlib/datastore/entryref.h
+++ b/searchlib/src/vespa/searchlib/datastore/entryref.h
@@ -11,7 +11,7 @@ protected:
     uint32_t _ref;
 public:
     EntryRef() : _ref(0u) { }
-    EntryRef(uint32_t ref_) : _ref(ref_) { }
+    explicit EntryRef(uint32_t ref_) : _ref(ref_) { }
     uint32_t ref() const { return _ref; }
     bool valid() const { return _ref != 0u; }
     bool operator==(const EntryRef &rhs) const { return _ref == rhs._ref; }

--- a/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/attribute_map_lookup_node.cpp
@@ -99,9 +99,7 @@ public:
 };
 
 template <typename T, typename KeyType>
-KeyHandlerT<T,KeyType>::~KeyHandlerT()
-{
-}
+KeyHandlerT<T,KeyType>::~KeyHandlerT() = default;
 
 using IntegerKeyHandler = KeyHandlerT<IAttributeVector::largeint_t>;
 using FloatKeyHandler   = KeyHandlerT<double>;
@@ -150,9 +148,7 @@ public:
 };
 
 template <typename T>
-IndirectKeyHandlerT<T>::~IndirectKeyHandlerT()
-{
-}
+IndirectKeyHandlerT<T>::~IndirectKeyHandlerT() = default;
 
 using IndirectIntegerKeyHandler = IndirectKeyHandlerT<IAttributeVector::largeint_t>;
 using IndirectFloatKeyHandler = IndirectKeyHandlerT<double>;

--- a/searchlib/src/vespa/searchlib/expression/attributenode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/attributenode.cpp
@@ -74,7 +74,7 @@ namespace {
 
 std::unique_ptr<AttributeResult> createResult(const IAttributeVector * attribute)
 {
-    return (dynamic_cast<const SingleValueEnumAttributeBase *>(attribute) != NULL)
+    return (dynamic_cast<const SingleValueEnumAttributeBase *>(attribute) != nullptr)
         ? std::make_unique<EnumAttributeResult>(attribute, 0)
         : std::make_unique<AttributeResult>(attribute, 0);
 }
@@ -83,18 +83,18 @@ std::unique_ptr<AttributeResult> createResult(const IAttributeVector * attribute
 
 AttributeNode::AttributeNode() :
     FunctionNode(),
-    _scratchResult(new AttributeResult()),
+    _scratchResult(std::make_unique<AttributeResult>()),
     _hasMultiValue(false),
     _useEnumOptimization(false),
     _handler(),
     _attributeName()
 {}
 
-AttributeNode::~AttributeNode() {}
+AttributeNode::~AttributeNode() = default;
 
 AttributeNode::AttributeNode(vespalib::stringref name) :
     FunctionNode(),
-    _scratchResult(new AttributeResult()),
+    _scratchResult(std::make_unique<AttributeResult>()),
     _hasMultiValue(false),
     _useEnumOptimization(false),
     _handler(),
@@ -136,7 +136,7 @@ AttributeNode & AttributeNode::operator = (const AttributeNode & attr)
 void AttributeNode::onPrepare(bool preserveAccurateTypes)
 {
     const IAttributeVector * attribute = _scratchResult->getAttribute();
-    if (attribute != NULL) {
+    if (attribute != nullptr) {
         BasicType::Type basicType = attribute->getBasicType();
         if (attribute->isIntegerType()) {
             if (_hasMultiValue) {
@@ -277,13 +277,13 @@ bool AttributeNode::onExecute() const
 void AttributeNode::wireAttributes(const IAttributeContext & attrCtx)
 {
     const IAttributeVector * attribute(_scratchResult ? _scratchResult->getAttribute() : nullptr);
-    if (attribute == NULL) {
+    if (attribute == nullptr) {
         if (_useEnumOptimization) {
             attribute = attrCtx.getAttributeStableEnum(_attributeName);
         } else {
             attribute = attrCtx.getAttribute(_attributeName);
         }
-        if (attribute == NULL) {
+        if (attribute == nullptr) {
             throw std::runtime_error(make_string("Failed locating attribute vector '%s'", _attributeName.c_str()));
         }
         _hasMultiValue = attribute->hasMultiValue();

--- a/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
@@ -19,8 +19,7 @@ using namespace search::attribute;
 using namespace search::fef;
 using vespalib::hwaccelrated::IAccelrated;
 
-namespace search {
-namespace features {
+namespace search::features {
 namespace dotproduct {
 namespace wset {
 
@@ -679,5 +678,4 @@ DotProductBlueprint::createExecutor(const IQueryEnvironment & env, vespalib::Sta
     return stash.create<SingleZeroValueExecutor>();
 }
 
-} // namespace features
-} // namespace search
+}

--- a/searchlib/src/vespa/searchlib/memoryindex/compact_document_words_store.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/compact_document_words_store.h
@@ -7,8 +7,7 @@
 #include <vespa/vespalib/util/array.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 
-namespace search {
-namespace memoryindex {
+namespace search::memoryindex {
 
 /**
  * Class used to store the {wordRef, fieldId, docId} tuples that are inserted
@@ -57,7 +56,7 @@ public:
         Iterator(const uint32_t *buf);
         bool valid() const { return _valid; }
         Iterator &operator++();
-        datastore::EntryRef wordRef() const { return _wordRef; }
+        datastore::EntryRef wordRef() const { return datastore::EntryRef(_wordRef); }
         bool hasBackingBuf() const { return _buf != nullptr; }
     };
 
@@ -98,6 +97,4 @@ public:
     MemoryUsage getMemoryUsage() const;
 };
 
-} // namespace memoryindex
-} // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/memoryindex/wordstore.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/wordstore.cpp
@@ -3,8 +3,7 @@
 #include "wordstore.h"
 #include <vespa/searchlib/datastore/datastore.hpp>
 
-namespace search {
-namespace memoryindex {
+namespace search::memoryindex {
 
 constexpr size_t MIN_CLUSTERS = 1024;
 
@@ -44,7 +43,4 @@ WordStore::addWord(const vespalib::stringref word)
     return result.ref;
 }
 
-
-} // namespace search::memoryindex
-} // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/memoryindex/wordstore.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/wordstore.h
@@ -5,8 +5,7 @@
 #include <vespa/searchlib/datastore/datastore.h>
 #include <vespa/vespalib/stllike/string.h>
 
-namespace search {
-namespace memoryindex {
+namespace search::memoryindex {
 
 class WordStore
 {
@@ -36,6 +35,4 @@ public:
     }
 };
 
-} // namespace search::memoryindex
-} // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/predicate/CMakeLists.txt
@@ -10,5 +10,6 @@ vespa_add_library(searchlib_predicate OBJECT
     predicate_tree_annotator.cpp
     predicate_zero_constraint_posting_list.cpp
     simple_index.cpp
+    common.cpp
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/predicate/common.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/common.cpp
@@ -1,0 +1,13 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "common.h"
+#include "predicate_hash.h"
+
+namespace search::predicate {
+
+const vespalib::string Constants::z_star_attribute_name = "z-star";
+const uint64_t Constants::z_star_hash = PredicateHash::hash64(Constants::z_star_attribute_name);
+const vespalib::string Constants::z_star_compressed_attribute_name = "z-star-compressed";
+const uint64_t Constants::z_star_compressed_hash = PredicateHash::hash64(Constants::z_star_compressed_attribute_name);
+
+}

--- a/searchlib/src/vespa/searchlib/predicate/common.h
+++ b/searchlib/src/vespa/searchlib/predicate/common.h
@@ -1,0 +1,25 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/btree/btree.h>
+
+namespace search::predicate {
+
+using BTreeSet = btree::BTree<uint32_t, btree::BTreeNoLeafData>;
+using ZeroConstraintDocs = BTreeSet::FrozenView;
+
+struct Constants {
+    static const vespalib::string z_star_attribute_name;
+    static const uint64_t         z_star_hash;
+    static const vespalib::string z_star_compressed_attribute_name;
+    static const uint64_t         z_star_compressed_hash;
+};
+
+struct DocIdLimitProvider {
+    virtual uint32_t getDocIdLimit() const = 0;
+    virtual uint32_t getCommittedDocIdLimit() const = 0;
+    virtual ~DocIdLimitProvider() {}
+};
+
+}

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.cpp
@@ -1,17 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "document_features_store.h"
-#include "predicate_index.h"
 #include "predicate_range_expander.h"
-#include "predicate_tree_annotator.h"
-#include <vespa/searchlib/btree/btreenode.h>
-#include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
-#include <unordered_map>
-#include <vector>
+#include <vespa/searchlib/btree/btree.hpp>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreenodeallocator.hpp>
 
-#include <vespa/log/log.h>
-LOG_SETUP(".searchlib.predicate.document_features_store");
+//#include "predicate_index.h"
 
 using search::btree::BTreeNoLeafData;
 using search::datastore::EntryRef;
@@ -20,8 +16,7 @@ using vespalib::stringref;
 using std::unordered_map;
 using std::vector;
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 void
 DocumentFeaturesStore::setCurrent(uint32_t docId, FeatureVector *features) {
@@ -288,5 +283,4 @@ void DocumentFeaturesStore::serialize(DataBuffer &buffer) const {
     serializeDocs(buffer, _docs);
 }
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.h
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.h
@@ -5,14 +5,11 @@
 #include "predicate_tree_annotator.h"
 #include <vespa/searchlib/btree/btree.h>
 #include <vespa/searchlib/memoryindex/wordstore.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/stllike/hash_map.h>
-#include <vespa/vespalib/util/array.h>
 #include <unordered_set>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * Class used to track the {featureId, docId} pairs that are inserted
@@ -84,6 +81,4 @@ public:
     void serialize(vespalib::DataBuffer &buffer) const;
 };
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_bounds_posting_list.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_bounds_posting_list.h
@@ -3,10 +3,9 @@
 #pragma once
 
 #include "predicate_posting_list.h"
-#include "predicate_index.h"
+#include "predicate_interval_store.h"
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * PredicatePostingList implementation for range query edge iterators (bounds)
@@ -22,9 +21,7 @@ class PredicateBoundsPostingList : public PredicatePostingList {
     IntervalWithBounds _single_buf;
 
 public:
-    PredicateBoundsPostingList(const PredicateIntervalStore &interval_store,
-                               Iterator it,
-                               uint32_t value_diff);
+    PredicateBoundsPostingList(const PredicateIntervalStore &interval_store,Iterator it,uint32_t value_diff);
     bool next(uint32_t doc_id) override;
     bool nextInterval() override;
     VESPA_DLL_LOCAL uint32_t getInterval() const override {
@@ -64,8 +61,7 @@ bool PredicateBoundsPostingList<Iterator>::next(uint32_t doc_id) {
         if (!_iterator.valid()) {
             return false;
         }
-        _current_interval = _interval_store.get(_iterator.getData(),
-                                                _interval_count, &_single_buf);
+        _current_interval = _interval_store.get(_iterator.getData(), _interval_count, &_single_buf);
         if (checkBounds(_current_interval->bounds, _value_diff)) {
             break;
         }
@@ -91,6 +87,4 @@ bool PredicateBoundsPostingList<Iterator>::nextInterval() {
     return true;
 }
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_hash.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_hash.h
@@ -4,8 +4,7 @@
 
 #include <vespa/vespalib/stllike/string.h>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 /**
  * Hash function used for predicate fields.
  */
@@ -120,6 +119,5 @@ struct PredicateHash {
         return static_cast<uint64_t>(c);
     }
 };
-}  // namespace predicate
-}  // namespace search
 
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.cpp
@@ -2,38 +2,30 @@
 
 #include "predicate_index.h"
 #include "predicate_hash.h"
+#include <vespa/searchlib/btree/btree.hpp>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
+#include <vespa/searchlib/btree/btreestore.hpp>
+#include <vespa/searchlib/btree/btreenodeallocator.hpp>
 
-#include <vespa/log/log.h>
-LOG_SETUP(".searchlib.predicate.predicate_index");
 
 using search::datastore::EntryRef;
 using vespalib::DataBuffer;
 using std::vector;
 
-namespace search {
-namespace predicate {
-
-const vespalib::string PredicateIndex::z_star_attribute_name("z-star");
-const uint64_t PredicateIndex::z_star_hash(
-        PredicateHash::hash64(PredicateIndex::z_star_attribute_name));
-const vespalib::string PredicateIndex::z_star_compressed_attribute_name("z-star-compressed");
-const uint64_t PredicateIndex::z_star_compressed_hash(
-        PredicateHash::hash64(PredicateIndex::z_star_compressed_attribute_name));
+namespace search::predicate {
 
 template <>
-void PredicateIndex::addPosting<Interval>(
-        uint64_t feature, uint32_t doc_id, EntryRef ref) {
+void PredicateIndex::addPosting<Interval>(uint64_t feature, uint32_t doc_id, EntryRef ref) {
     _interval_index.addPosting(feature, doc_id, ref);
 }
 template <>
-void PredicateIndex::addPosting<IntervalWithBounds>(
-        uint64_t feature, uint32_t doc_id, EntryRef ref) {
+void PredicateIndex::addPosting<IntervalWithBounds>(uint64_t feature, uint32_t doc_id, EntryRef ref) {
     _bounds_index.addPosting(feature, doc_id, ref);
 }
 
 template <typename IntervalT>
-void PredicateIndex::indexDocumentFeatures(
-        uint32_t doc_id, const PredicateIndex::FeatureMap<IntervalT> &interval_map) {
+void PredicateIndex::indexDocumentFeatures(uint32_t doc_id, const PredicateIndex::FeatureMap<IntervalT> &interval_map) {
     if (interval_map.empty()) {
         return;
     }
@@ -134,7 +126,7 @@ PredicateIndex::PredicateIndex(GenerationHandler &generation_handler, Generation
     commit();
 }
 
-PredicateIndex::~PredicateIndex() {}
+PredicateIndex::~PredicateIndex() = default;
 
 void PredicateIndex::serialize(DataBuffer &buffer) const {
     _features_store.serialize(buffer);
@@ -295,5 +287,4 @@ PredicateIndex::adjustDocIdLimit(uint32_t docId)
     _cache.adjustDocIdLimit(docId);
 }
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "common.h"
 #include "document_features_store.h"
 #include "predicate_interval_store.h"
 #include "simple_index.h"
@@ -11,8 +12,8 @@
 #include <vespa/vespalib/stllike/string.h>
 #include <unordered_map>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
+
 class PredicateTreeAnnotations;
 
 /**
@@ -24,7 +25,6 @@ class PredicateTreeAnnotations;
 class PredicateIndex : public PopulateInterface {
     typedef SimpleIndex<datastore::EntryRef> IntervalIndex;
     typedef SimpleIndex<datastore::EntryRef> BoundsIndex;
-    typedef btree::BTree<uint32_t, btree::BTreeNoLeafData> BTreeSet;
     template <typename IntervalT>
     using FeatureMap = std::unordered_map<uint64_t, std::vector<IntervalT>>;
     using generation_t = vespalib::GenerationHandler::generation_t;
@@ -32,17 +32,11 @@ class PredicateIndex : public PopulateInterface {
     using optional = std::experimental::optional<T>;
 
 public:
-    using ZeroConstraintDocs = BTreeSet::FrozenView;
     typedef std::unique_ptr<PredicateIndex> UP;
     typedef vespalib::GenerationHandler GenerationHandler;
     typedef vespalib::GenerationHolder GenerationHolder;
     using BTreeIterator = SimpleIndex<datastore::EntryRef>::BTreeIterator;
     using VectorIterator = SimpleIndex<datastore::EntryRef>::VectorIterator;
-    static const vespalib::string z_star_attribute_name;
-    static const uint64_t z_star_hash;
-    static const vespalib::string z_star_compressed_attribute_name;
-    static const uint64_t z_star_compressed_hash;
-
 private:
     uint32_t _arity;
     GenerationHandler &_generation_handler;
@@ -56,8 +50,7 @@ private:
     mutable BitVectorCache  _cache;
 
     template <typename IntervalT>
-    void addPosting(uint64_t feature, uint32_t doc_id,
-                    datastore::EntryRef ref);
+    void addPosting(uint64_t feature, uint32_t doc_id, datastore::EntryRef ref);
 
     template <typename IntervalT>
     void indexDocumentFeatures(uint32_t doc_id, const FeatureMap<IntervalT> &interval_map);
@@ -75,7 +68,7 @@ public:
                    const SimpleIndexConfig &simple_index_config, vespalib::DataBuffer &buffer,
                    SimpleIndexDeserializeObserver<> & observer, uint32_t version);
 
-    ~PredicateIndex();
+    ~PredicateIndex() override;
     void serialize(vespalib::DataBuffer &buffer) const;
     void onDeserializationCompleted();
 
@@ -117,6 +110,4 @@ public:
 
 extern template class SimpleIndex<datastore::EntryRef>;
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval.cpp
@@ -3,8 +3,7 @@
 #include "predicate_interval.h"
 #include <ostream>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 std::ostream &operator<<(std::ostream &out, const Interval &i) {
     std::ios_base::fmtflags flags = out.flags();
@@ -20,5 +19,4 @@ std::ostream &operator<<(std::ostream &out, const IntervalWithBounds &i) {
     return out;
 }
 
-}  // namespace predicate
 }

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval.h
@@ -4,8 +4,7 @@
 
 #include <vespa/vespalib/data/databuffer.h>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * Stores a simple interval for the boolean constraint interval algorithm.
@@ -60,5 +59,4 @@ struct IntervalWithBounds {
 };
 std::ostream &operator<<(std::ostream &out, const IntervalWithBounds &i);
 
-}  // namespace predicate
 }

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval_posting_list.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval_posting_list.h
@@ -3,10 +3,9 @@
 #pragma once
 
 #include "predicate_posting_list.h"
-#include "predicate_index.h"
+#include "predicate_interval_store.h"
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * PredicatePostingList implementation for regular interval iterators
@@ -57,12 +56,9 @@ bool PredicateIntervalPostingList<Iterator>::next(uint32_t doc_id) {
             return false;
         }
     }
-    _current_interval =
-            _interval_store.get(_iterator.getData(), _interval_count, &_single_buf);
+    _current_interval = _interval_store.get(_iterator.getData(), _interval_count, &_single_buf);
     setDocId(_iterator.getKey());
     return true;
 }
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval_store.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval_store.cpp
@@ -1,20 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "predicate_interval_store.h"
-#include "predicate_index.h"
-#include <vespa/searchlib/datastore/bufferstate.h>
+#include "predicate_interval.h"
 #include <vespa/searchlib/datastore/datastore.hpp>
-#include <vespa/searchlib/datastore/entryref.h>
-
-#include <vespa/log/log.h>
-LOG_SETUP(".searchlib.predicate.predicate_interval_store");
 
 using search::datastore::BufferState;
 using search::datastore::EntryRef;
 using std::vector;
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 template <typename T>
 PredicateIntervalStore::Entry<T> PredicateIntervalStore::allocNewEntry(uint32_t type_id, uint32_t size)
@@ -52,31 +46,29 @@ PredicateIntervalStore::~PredicateIntervalStore() {
 // anyway.
 //
 template <typename IntervalT>
-datastore::EntryRef PredicateIntervalStore::insert(
-        const vector<IntervalT> &intervals) {
+EntryRef PredicateIntervalStore::insert(const vector<IntervalT> &intervals) {
     const uint32_t size = entrySize<IntervalT>() * intervals.size();
     if (size == 0) {
-        return datastore::EntryRef();
+        return EntryRef();
     }
     uint32_t *buffer;
-    datastore::EntryRef ref;
+    EntryRef ref;
     if (size == 1 && intervals[0].interval <= RefCacheType::DATA_REF_MASK) {
-        return datastore::EntryRef(intervals[0].interval);
+        return EntryRef(intervals[0].interval);
     }
-    uint32_t cached_ref = _ref_cache.find(
-            reinterpret_cast<const uint32_t *>(&intervals[0]), size);
+    uint32_t cached_ref = _ref_cache.find(reinterpret_cast<const uint32_t *>(&intervals[0]), size);
     if (cached_ref) {
-        return cached_ref;
+        return EntryRef(cached_ref);
     }
 
     if (size < RefCacheType::MAX_SIZE) {
         auto entry = allocNewEntry<uint32_t>(0, size);
         buffer = entry.buffer;
-        ref = entry.ref.ref() | (size << RefCacheType::SIZE_SHIFT);
+        ref = EntryRef(entry.ref.ref() | (size << RefCacheType::SIZE_SHIFT));
     } else {
         auto entry = allocNewEntry<uint32_t>(0, size + 1);
         buffer = entry.buffer;
-        ref = entry.ref.ref() | RefCacheType::SIZE_MASK;
+        ref = EntryRef(entry.ref.ref() | RefCacheType::SIZE_MASK);
         *buffer++ = size;
     }
     memcpy(buffer, &intervals[0], size * sizeof(uint32_t));
@@ -112,5 +104,4 @@ void PredicateIntervalStore::transferHoldLists(generation_t generation) {
     _store.transferHoldLists(generation);
 }
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval_store.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval_store.h
@@ -5,11 +5,9 @@
 #include "predicate_ref_cache.h"
 #include <vespa/searchlib/datastore/bufferstate.h>
 #include <vespa/searchlib/datastore/datastore.h>
-#include <vespa/searchlib/datastore/entryref.h>
 #include <vector>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 class Interval;
 
 /**
@@ -31,9 +29,8 @@ class PredicateIntervalStore {
     public:
         DataStoreAdapter(const DataStoreType &store) : _store(store) {}
         const uint32_t *getBuffer(uint32_t ref) const {
-            RefType entry_ref(ref);
-            return _store.getBufferEntry<uint32_t>(
-                    entry_ref.bufferId(), entry_ref.offset());
+            RefType entry_ref = datastore::EntryRef(ref);
+            return _store.getBufferEntry<uint32_t>(entry_ref.bufferId(), entry_ref.offset());
         }
     };
     DataStoreAdapter _store_adapter;
@@ -97,16 +94,14 @@ public:
                          IntervalT *single_buf) const
     {
         uint32_t size = btree_ref.ref() >> RefCacheType::SIZE_SHIFT;
-        RefType data_ref(btree_ref.ref() & RefCacheType::DATA_REF_MASK);
+        RefType data_ref(datastore::EntryRef(btree_ref.ref() & RefCacheType::DATA_REF_MASK));
         if (__builtin_expect(size == 0, true)) {  // single-interval optimization
             *single_buf = IntervalT();
             single_buf->interval = data_ref.ref();
             size_out = 1;
             return single_buf;
         }
-        const uint32_t *buf =
-            _store.getBufferEntry<uint32_t>(data_ref.bufferId(),
-                                            data_ref.offset());
+        const uint32_t *buf = _store.getBufferEntry<uint32_t>(data_ref.bufferId(), data_ref.offset());
         if (size == RefCacheType::MAX_SIZE) {
             size = *buf++;
         }
@@ -114,6 +109,5 @@ public:
         return reinterpret_cast<const IntervalT *>(buf);
     }
 };
-}  // namespace predicate
-}  // namespace search
 
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_posting_list.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_posting_list.h
@@ -8,8 +8,7 @@
 /**
  * Interface for posting lists used by PredicateSearch.
  */
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 class PredicatePostingList {
     uint32_t _docId;
@@ -48,5 +47,4 @@ public:
     uint64_t getSubquery() const { return _subquery; }
 };
 
-}
 }

--- a/searchlib/src/vespa/searchlib/predicate/predicate_range_expander.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_range_expander.cpp
@@ -6,12 +6,10 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".predicate_range_expander");
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 void PredicateRangeExpander::debugLog(const char *fmt, const char *msg) {
     LOG(debug, fmt, msg);
 }
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_range_expander.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_range_expander.h
@@ -3,11 +3,9 @@
 #pragma once
 
 #include "predicate_hash.h"
-#include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * Helper class for expanding ranges. This functionality is ported from
@@ -117,6 +115,4 @@ public:
     }
 };
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_ref_cache.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_ref_cache.h
@@ -7,8 +7,7 @@
 #include <cstdint>
 #include <cassert>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * Holds the data used in a cache lookup operation.
@@ -158,5 +157,4 @@ public:
     }
 };
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_tree_analyzer.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_tree_analyzer.cpp
@@ -3,7 +3,6 @@
 #include "predicate_tree_analyzer.h"
 #include <vespa/document/predicate/predicate.h>
 #include <algorithm>
-#include <iostream>
 #include <cmath>
 
 using document::Predicate;
@@ -13,8 +12,8 @@ using std::string;
 using vespalib::slime::Inspector;
 using vespalib::Memory;
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
+
 namespace {
 long getType(const Inspector &in, bool negated) {
     long type = in[Predicate::NODE_TYPE].asLong();
@@ -163,7 +162,6 @@ PredicateTreeAnalyzer::PredicateTreeAnalyzer(const Inspector &in)
     _min_feature = static_cast<int>(std::ceil(float(findMinFeature(in)) + (_has_not? 1.0 : 0.0)));
 }
 
-PredicateTreeAnalyzer::~PredicateTreeAnalyzer() { }
+PredicateTreeAnalyzer::~PredicateTreeAnalyzer() = default;
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_tree_analyzer.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_tree_analyzer.h
@@ -5,10 +5,8 @@
 #include "tree_crumbs.h"
 #include <vespa/vespalib/data/slime/slime.h>
 #include <map>
-#include <string>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * Analyzes a predicate tree, in the form of a slime object, to find
@@ -39,6 +37,4 @@ public:
     const std::map<std::string, int> &getSizeMap() const { return _size_map; }
 };
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_tree_annotator.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_tree_annotator.cpp
@@ -1,13 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "predicate_tree_annotator.h"
-#include "predicate_index.h"
 #include "predicate_range_expander.h"
 #include "predicate_tree_analyzer.h"
+#include "common.h"
 #include <vespa/document/predicate/predicate.h>
-
-#include <vespa/log/log.h>
-LOG_SETUP(".searchlib.predicate.predicate_tree_annotator");
 
 using document::Predicate;
 using std::map;
@@ -15,8 +12,7 @@ using std::string;
 using vespalib::slime::Inspector;
 using vespalib::Memory;
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 using predicate::MIN_INTERVAL;
 using predicate::MAX_INTERVAL;
@@ -83,7 +79,7 @@ PredicateTreeAnnotatorImpl::PredicateTreeAnnotatorImpl(
       _end(interval_range),
       _left_weight(0),
       _result(result),
-      _zStar_hash(PredicateIndex::z_star_compressed_hash),
+      _zStar_hash(Constants::z_star_compressed_hash),
       _negated(false),
       _final_range_used(false),
       _size_map(size_map),
@@ -232,7 +228,8 @@ void PredicateTreeAnnotatorImpl::assignIntervalMarkers(const Inspector &in) {
 PredicateTreeAnnotations::PredicateTreeAnnotations(uint32_t mf, uint16_t ir)
     : min_feature(mf), interval_range(ir)
 {}
-PredicateTreeAnnotations::~PredicateTreeAnnotations(){}
+
+PredicateTreeAnnotations::~PredicateTreeAnnotations() = default;
 
 void PredicateTreeAnnotator::annotate(const Inspector &in,
                                       PredicateTreeAnnotations &result,
@@ -244,12 +241,10 @@ void PredicateTreeAnnotator::annotate(const Inspector &in,
     assert(size <= UINT16_MAX && size > 0);
     uint16_t interval_range = static_cast<uint16_t>(size);
 
-    PredicateTreeAnnotatorImpl
-        annotator(analyzer.getSizeMap(), result, lower, upper, interval_range);
+    PredicateTreeAnnotatorImpl annotator(analyzer.getSizeMap(), result, lower, upper, interval_range);
     annotator.assignIntervalMarkers(in);
     result.min_feature = min_feature;
     result.interval_range = interval_range;
 }
 
-}  // namespace predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_tree_annotator.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_tree_annotator.h
@@ -4,7 +4,6 @@
 
 #include "predicate_interval.h"
 #include <vespa/vespalib/data/memory.h>
-#include <vespa/vespalib/stllike/string.h>
 #include <climits>
 #include <vector>
 #include <unordered_map>

--- a/searchlib/src/vespa/searchlib/predicate/predicate_zero_constraint_posting_list.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_zero_constraint_posting_list.cpp
@@ -2,11 +2,7 @@
 
 #include "predicate_zero_constraint_posting_list.h"
 
-#include <vespa/log/log.h>
-LOG_SETUP(".searchlib.predicate.predicate_zero_constraint_posting_list");
-
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 PredicateZeroConstraintPostingList::PredicateZeroConstraintPostingList(Iterator it)
     : _iterator(it) {}
@@ -22,5 +18,4 @@ bool PredicateZeroConstraintPostingList::next(uint32_t doc_id) {
     return true;
 }
 
-}  // namespace search::predicate
-}  // namespace search
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_zero_constraint_posting_list.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_zero_constraint_posting_list.h
@@ -3,17 +3,16 @@
 #pragma once
 
 #include "predicate_posting_list.h"
-#include "predicate_index.h"
+#include "common.h"
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * PredicatePostingList implementation for zero constraint documents
  * from PredicateIndex.
  */
 class PredicateZeroConstraintPostingList : public PredicatePostingList {
-    using Iterator = PredicateIndex::ZeroConstraintDocs::Iterator;
+    using Iterator = ZeroConstraintDocs::Iterator;
     Iterator _iterator;
 
 public:
@@ -23,6 +22,4 @@ public:
     VESPA_DLL_LOCAL uint32_t getInterval() const override { return 0x00010001; }
 };
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/predicate_zstar_compressed_posting_list.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_zstar_compressed_posting_list.h
@@ -3,10 +3,10 @@
 #pragma once
 
 #include "predicate_posting_list.h"
-#include "predicate_index.h"
+#include "predicate_interval_store.h"
+#include "predicate_interval.h"
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * PredicatePostingList implementation for zstar iterators from
@@ -49,8 +49,7 @@ bool PredicateZstarCompressedPostingList<Iterator>::next(uint32_t doc_id) {
         return false;
     }
     Interval single_buf;
-    _current_interval =
-            _interval_store.get(_iterator.getData(), _interval_count, &single_buf);
+    _current_interval = _interval_store.get(_iterator.getData(), _interval_count, &single_buf);
     setDocId(_iterator.getKey());
     setInterval(_current_interval[0].interval);
     _prev_interval = getInterval();
@@ -84,6 +83,4 @@ bool PredicateZstarCompressedPostingList<Iterator>::nextInterval() {
     return false;
 }
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.cpp
@@ -2,13 +2,17 @@
 
 #include "simple_index.hpp"
 #include <vespa/vespalib/util/array.hpp>
+#include <vespa/searchlib/btree/btree.hpp>
+#include <vespa/searchlib/btree/btreeroot.hpp>
+#include <vespa/searchlib/btree/btreeiterator.hpp>
+#include <vespa/searchlib/btree/btreestore.hpp>
+#include <vespa/searchlib/btree/btreenodeallocator.hpp>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.predicate.simple_index");
 
-namespace search {
-namespace predicate {
-namespace simpleindex {
+namespace search::predicate {
+ namespace simpleindex {
 
 bool log_enabled() {
     return LOG_WOULD_LOG(debug);
@@ -22,6 +26,5 @@ void log_debug(vespalib::string &str) {
 
 template class SimpleIndex<datastore::EntryRef>;
 
-}  // namespace predicate
-} // namespace search
+}
 

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.h
@@ -2,25 +2,13 @@
 
 #pragma once
 
+#include "common.h"
 #include <vespa/searchlib/common/rcuvector.h>
-#include <vespa/searchlib/btree/btree.hpp>
-#include <vespa/searchlib/btree/btreeiterator.hpp>
-#include <vespa/searchlib/btree/btreenode.hpp>
-#include <vespa/searchlib/btree/btreenodeallocator.hpp>
-#include <vespa/searchlib/btree/btreenodestore.hpp>
-#include <vespa/searchlib/btree/btreeroot.hpp>
-#include <vespa/searchlib/btree/btreestore.hpp>
+#include <vespa/searchlib/btree/btreestore.h>
 #include <vespa/vespalib/data/databuffer.h>
-#include <vespa/vespalib/stllike/string.h>
-#include <vespa/vespalib/util/exceptions.h>
-#include <vespa/vespalib/util/macro.h>
-#include <vespa/vespalib/util/generationholder.h>
 #include <experimental/optional>
 
-
-namespace search {
-namespace predicate {
-
+namespace search::predicate {
 
 template <typename Key = uint64_t, typename DocId = uint32_t>
 struct SimpleIndexDeserializeObserver {
@@ -31,8 +19,7 @@ struct SimpleIndexDeserializeObserver {
 template <typename Posting>
 struct PostingSerializer {
     virtual ~PostingSerializer() {}
-    virtual void serialize(const Posting &posting,
-                           vespalib::DataBuffer &buffer) const = 0;
+    virtual void serialize(const Posting &posting, vespalib::DataBuffer &buffer) const = 0;
 };
 
 template <typename Posting>
@@ -41,19 +28,11 @@ struct PostingDeserializer {
     virtual Posting deserialize(vespalib::DataBuffer &buffer) = 0;
 };
 
-struct DocIdLimitProvider {
-    virtual uint32_t getDocIdLimit() const = 0;
-    virtual uint32_t getCommittedDocIdLimit() const = 0;
-    virtual ~DocIdLimitProvider() {}
-};
-
 struct SimpleIndexConfig {
     static constexpr double DEFAULT_UPPER_DOCID_FREQ_THRESHOLD = 0.40;
-    static constexpr double DEFAULT_LOWER_DOCID_FREQ_THRESHOLD =
-            0.8 * DEFAULT_UPPER_DOCID_FREQ_THRESHOLD;
+    static constexpr double DEFAULT_LOWER_DOCID_FREQ_THRESHOLD = 0.8 * DEFAULT_UPPER_DOCID_FREQ_THRESHOLD;
     static constexpr size_t DEFAULT_UPPER_VECTOR_SIZE_THRESHOLD = 10000;
-    static constexpr size_t DEFAULT_LOWER_VECTOR_SIZE_THRESHOLD =
-            static_cast<size_t>(0.8 * DEFAULT_UPPER_VECTOR_SIZE_THRESHOLD);
+    static constexpr size_t DEFAULT_LOWER_VECTOR_SIZE_THRESHOLD = static_cast<size_t>(0.8 * DEFAULT_UPPER_VECTOR_SIZE_THRESHOLD);
     static constexpr size_t DEFAULT_VECTOR_PRUNE_FREQUENCY = 20000;
     static constexpr double DEFAULT_FOREACH_VECTOR_THRESHOLD = 0.25;
 
@@ -257,6 +236,4 @@ void SimpleIndex<Posting, Key, DocId>::foreach_frozen_key(
     }
 }
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.hpp
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "simple_index.h"
+#include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/searchlib/common/rcuvector.hpp>
 
 namespace search::predicate {

--- a/searchlib/src/vespa/searchlib/predicate/tree_crumbs.h
+++ b/searchlib/src/vespa/searchlib/predicate/tree_crumbs.h
@@ -5,8 +5,7 @@
 #include <string>
 #include <vector>
 
-namespace search {
-namespace predicate {
+namespace search::predicate {
 
 /**
  * Builds a path from the root of a tree, to be able to describe a
@@ -39,6 +38,4 @@ public:
     }
 };
 
-}  // namespace predicate
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
@@ -4,16 +4,14 @@
 
 #include "blueprint.h"
 #include "predicate_search.h"
+#include <vespa/searchlib/common/bitvectorcache.h>
+#include <vespa/searchlib/predicate/simple_index.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
-#include <vespa/searchlib/datastore/entryref.h>
-#include <vector>
-#include <memory>
 
-namespace search {
-namespace query { class PredicateQuery; }
+namespace search::query { class PredicateQuery; }
 
-namespace queryeval {
+namespace search::queryeval {
 /**
  * Blueprint for building predicate searches. It builds search
  * iterators based on PredicateSearch.
@@ -91,6 +89,4 @@ private:
     optional<VectorIterator> _zstar_vector_iterator;
 };
 
-}  // namespace search::queryeval
-}  // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/util/bufferwriter.cpp
+++ b/searchlib/src/vespa/searchlib/util/bufferwriter.cpp
@@ -11,11 +11,7 @@ BufferWriter::BufferWriter()
 {
 }
 
-
-BufferWriter::~BufferWriter()
-{
-}
-
+BufferWriter::~BufferWriter() = default;
 
 void
 BufferWriter::writeSlow(const void *src, size_t len)
@@ -36,6 +32,5 @@ BufferWriter::writeSlow(const void *src, size_t len)
         flush();
     }
 }
-
 
 } // namespace search

--- a/vespalib/src/vespa/vespalib/stllike/hash_set.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/hash_set.hpp
@@ -24,7 +24,7 @@ hash_set<K, H, EQ, M>::hash_set(std::initializer_list<K> input)
 }
 
 template<typename K, typename H, typename EQ, typename M>
-hash_set<K, H, EQ, M>::~hash_set() {}
+hash_set<K, H, EQ, M>::~hash_set() = default;
 
 template<typename K, typename H, typename EQ, typename M>
 bool

--- a/vespalib/src/vespa/vespalib/stllike/hashtable.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.hpp
@@ -42,25 +42,14 @@ hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::hashtable(size_t rese
 }
 
 template< typename Key, typename Value, typename Hash, typename Equal, typename KeyExtract, typename Modulator >
-hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::hashtable(const hashtable & rhs)
-    : _modulator(rhs._modulator),
-      _count(rhs._count),
-      _nodes(rhs._nodes),
-      _hasher(rhs._hasher),
-      _equal(rhs._equal)
-{ }
+hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::hashtable(const hashtable &) = default;
 
 template< typename Key, typename Value, typename Hash, typename Equal, typename KeyExtract, typename Modulator >
 hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator> &
-hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::operator = (const hashtable & rhs) {
-    hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>(rhs).swap(*this);
-    return *this;
-}
+hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::operator = (const hashtable &) = default;
 
 template< typename Key, typename Value, typename Hash, typename Equal, typename KeyExtract, typename Modulator >
-hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::~hashtable()
-{
-}
+hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::~hashtable() = default;
 
 template< typename Key, typename Value, typename Hash, typename Equal, typename KeyExtract, typename Modulator >
 typename hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::iterator


### PR DESCRIPTION
@toregge PR
This is just cleanup. The last commit fixes a bug that will reveal itself when swapping the bits in the EntryRef