### PR TITLE
Run tester on same platform as deployment target

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunner.java
@@ -8,13 +8,11 @@ import com.yahoo.vespa.hosted.controller.deployment.InternalStepRunner;
 import com.yahoo.vespa.hosted.controller.deployment.JobController;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.RunId;
 import com.yahoo.vespa.hosted.controller.deployment.Run;
-import com.yahoo.vespa.hosted.controller.deployment.RunStatus;
 import com.yahoo.vespa.hosted.controller.deployment.Step;
 import com.yahoo.vespa.hosted.controller.deployment.StepRunner;
 import org.jetbrains.annotations.TestOnly;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
@bratseth please review.

Tester application has no application code, but uses only Vespa bundles, so versions there are OK. 

However, the JDK it runs on, and also uses for `mvn test`, is determined by the major version, so this lets applications remaining on 6 have a JDK 8 run their tests, to ensure compatibility. 

I'm not sure this would break anyone, as I believe the system and staging tests are 8-11-compatible, but shouldn't hurt to be safe. 