### PR TITLE
Reduce locked section by using a hashmap to reduce cachemisses during…

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.h
@@ -48,7 +48,8 @@ protected:
 public:
     typedef EnumStoreT<EnumEntryType>                  EnumStore;
 protected:
-    typedef EnumStoreBase::Index                     EnumIndex;
+    using EnumIndex = EnumStoreBase::Index;
+    using EnumIndexMap = EnumStoreBase::EnumIndexMap;
 
     EnumStore _enumStore;
 
@@ -72,7 +73,7 @@ protected:
      */
     void insertNewUniqueValues(EnumStoreBase::IndexVector & newIndexes);
     virtual void considerAttributeChange(const Change & c, UniqueSet & newUniques) = 0;
-    virtual void reEnumerate() = 0;
+    virtual void reEnumerate(const EnumIndexMap &) = 0;
     AddressSpace getEnumStoreAddressSpaceUsage() const override;
 public:
     EnumAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);

--- a/searchlib/src/vespa/searchlib/attribute/enumstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumstore.h
@@ -172,7 +172,7 @@ public:
     void freeUnusedEnums(bool movePostingidx) override;
     void freeUnusedEnums(const IndexVector &toRemove) override;
     void reset(Builder &builder);
-    bool performCompaction(uint64_t bytesNeeded) override;
+    bool performCompaction(uint64_t bytesNeeded, EnumIndexMap & old2New) override;
     void printCurrentContent(vespalib::asciistream &os) const;
 
 private:
@@ -183,7 +183,7 @@ private:
     void addEnum(Type value, Index &newIdx, Dictionary &dict);
 
     template <typename Dictionary>
-    void performCompaction(Dictionary &dict);
+    void performCompaction(Dictionary &dict, EnumIndexMap & old2New);
 
     template <typename Dictionary>
     void printCurrentContent(vespalib::asciistream &os, const Dictionary &dict) const;

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.h
@@ -41,13 +41,14 @@ protected:
     typedef typename MultiValueAttribute<B, M>::DocumentValues DocIndices;
     typedef attribute::LoadedEnumAttributeVector  LoadedEnumAttributeVector;
     typedef attribute::LoadedEnumAttribute        LoadedEnumAttribute;
+    using EnumIndexMap = EnumStoreBase::EnumIndexMap;
 
     // from MultiValueAttribute
     bool extractChangeData(const Change & c, EnumIndex & idx) override; // EnumIndex is ValueType. Use EnumStore
 
     // from EnumAttribute
     void considerAttributeChange(const Change & c, UniqueSet & newUniques) override; // same for both string and numeric
-    void reEnumerate() override; // same for both string and numeric
+    void reEnumerate(const EnumIndexMap &) override; // same for both string and numeric
 
     virtual void applyValueChanges(const DocIndices & docIndices, EnumStoreBase::IndexVector & unused);
 

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
@@ -57,6 +57,7 @@ protected:
     typedef attribute::LoadedEnumAttributeVector LoadedEnumAttributeVector;
     typedef attribute::LoadedEnumAttribute LoadedEnumAttribute;
     using B::getGenerationHolder;
+    using EnumIndexMap = EnumStoreBase::EnumIndexMap;
 
 private:
     void considerUpdateAttributeChange(const Change & c, UniqueSet & newUniques);
@@ -65,7 +66,7 @@ private:
 protected:
     // from EnumAttribute
     void considerAttributeChange(const Change & c, UniqueSet & newUniques) override;
-    void reEnumerate() override;
+    void reEnumerate(const EnumIndexMap & old2New) override;
 
     // implemented by single value numeric enum attribute.
     virtual void considerUpdateAttributeChange(const Change & c) { (void) c; }

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -135,7 +135,7 @@ SingleValueEnumAttribute<B>::considerAttributeChange(const Change & c, UniqueSet
 
 template <typename B>
 void
-SingleValueEnumAttribute<B>::reEnumerate()
+SingleValueEnumAttribute<B>::reEnumerate(const EnumIndexMap & old2New)
 {
     auto newIndexes = std::make_unique<vespalib::Array<EnumIndex>>();
     newIndexes->reserve(_enumIndices.capacity());
@@ -143,7 +143,7 @@ SingleValueEnumAttribute<B>::reEnumerate()
         EnumIndex oldIdx = _enumIndices[i];
         EnumIndex newIdx;
         if (oldIdx.valid()) {
-            this->_enumStore.getCurrentIndex(oldIdx, newIdx);
+            newIdx = old2New[oldIdx];
         }
         newIndexes->push_back_fast(newIdx);
     }


### PR DESCRIPTION
… repopulation.

Create the old2New mapping during compaction
No more precompute phase.

Conflicts:
	searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
@geirst or @toregge PR
This is a rebase of #7765 so you know it already