### PR TITLE
Do not provide commons-codec at build time.

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -90,7 +90,6 @@
                                                 <include>com.sun.activation:javax.activation:[1.2.0]:jar:provided</include>
                                                 <include>com.sun.xml.bind:jaxb-core:[${jaxb.version}]:jar:provided</include>
                                                 <include>com.sun.xml.bind:jaxb-impl:[${jaxb.version}]:jar:provided</include>
-                                                <include>commons-codec:commons-codec:[1.4]:jar:provided</include>
                                                 <include>commons-daemon:commons-daemon:[1.0.3]:jar:provided</include>
                                                 <include>commons-logging:commons-logging:[1.1.1]:jar:provided</include>
                                                 <include>javax.annotation:javax.annotation-api:[${javax.annotation-api.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -144,11 +144,6 @@
                 <version>${guice.version}</version>
                 <classifier>no_aop</classifier>
             </dependency>
-           <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.4</version>
-            </dependency>
             <dependency>
                 <groupId>commons-daemon</groupId>
                 <artifactId>commons-daemon</artifactId>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -147,6 +147,10 @@
           <artifactId>icu4j</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
@@ -178,6 +182,10 @@
       <artifactId>document</artifactId>
       <version>${project.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -408,6 +408,11 @@
                 <version>1.3.1</version>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.4</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>3.2.1</version>


### PR DESCRIPTION
- We effectively stopped providing it runtime since
  https://github.com/vespa-engine/vespa/pull/7696

FYI: @bratseth, @arnej27959 