### PR TITLE
Don't allow function argument list to start with comma.

### DIFF
--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -316,7 +316,7 @@ List<ExpressionNode> args() :
     ExpressionNode argument;
 }
 {
-    ( ( argument = arg() { arguments.add(argument); })? ( <COMMA> argument = arg() { arguments.add(argument); } )* )
+    ( ( argument = arg() { arguments.add(argument); } ( <COMMA> argument = arg() { arguments.add(argument); } )* )? )
     { return arguments; }
 }
 


### PR DESCRIPTION
@bratseth: please review

This is an attempt to fix the regression in pull request #7805.
