### PR TITLE
Add git info for last submitted package to app response

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -391,6 +391,11 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
                                                  "/instance/" + application.id().instance().value() + "/job/",
                                                  request.getUri()).toString());
 
+        application.deploymentJobs().statusOf(JobType.component)
+                   .flatMap(status -> status.lastSuccess())
+                   .map(run -> run.application().source())
+                   .ifPresent(source -> sourceRevisionToSlime(source, object.setObject("source")));
+
         // Currently deploying change
         if (application.change().isPresent()) {
             toSlime(object.setObject("deploying"), application.change());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -396,6 +396,9 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
                    .map(run -> run.application().source())
                    .ifPresent(source -> sourceRevisionToSlime(source, object.setObject("source")));
 
+        application.deploymentJobs().projectId()
+                   .ifPresent(id -> object.setLong("projectId", id));
+
         // Currently deploying change
         if (application.change().isPresent()) {
             toSlime(object.setObject("deploying"), application.change());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -97,6 +97,7 @@ import static org.junit.Assert.assertTrue;
  * @author bratseth
  * @author mpolden
  * @author bjorncs
+ * @author jonmv
  */
 public class ApplicationApiTest extends ControllerContainerTest {
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
@@ -2,6 +2,11 @@
   "application": "application1",
   "instance": "default",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/default/job/",
+  "source": {
+    "gitRepository": "repository1",
+    "gitBranch": "master",
+    "gitCommit": "commit1"
+  },
   "deployedInternally": false,
   "deploymentJobs": [
     {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-without-change-multiple-deployments.json
@@ -7,6 +7,7 @@
     "gitBranch": "master",
     "gitCommit": "commit1"
   },
+  "projectId": 1,
   "deployedInternally": false,
   "deploymentJobs": [
     {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
@@ -7,6 +7,7 @@
     "gitBranch": "master",
     "gitCommit": "commit1"
   },
+  "projectId": 123,
   "deploying": {
     "revision": {
       "hash": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
@@ -2,6 +2,11 @@
   "application": "application1",
   "instance": "default",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/default/job/",
+  "source": {
+    "gitRepository": "repository1",
+    "gitBranch": "master",
+    "gitCommit": "commit1"
+  },
   "deploying": {
     "revision": {
       "hash": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
@@ -7,6 +7,7 @@
     "gitBranch": "master",
     "gitCommit": "commit1"
   },
+  "projectId": 123,
   "deploying": {
     "revision": {
       "hash": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
@@ -2,6 +2,11 @@
   "application": "application1",
   "instance": "default",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/default/job/",
+  "source": {
+    "gitRepository": "repository1",
+    "gitBranch": "master",
+    "gitCommit": "commit1"
+  },
   "deploying": {
     "revision": {
       "hash": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2.json
@@ -2,6 +2,11 @@
   "application": "application2",
   "instance": "default",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant2/application/application2/instance/default/job/",
+  "source": {
+    "gitRepository": "repository1",
+    "gitBranch": "master",
+    "gitCommit": "commit1"
+  },
   "deploying": {
     "version": "(ignore)"
   },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2.json
@@ -7,6 +7,7 @@
     "gitBranch": "master",
     "gitCommit": "commit1"
   },
+  "projectId": 456,
   "deploying": {
     "version": "(ignore)"
   },


### PR DESCRIPTION
@bratseth or @ldalves please review. 

This will allow cleanup of code in the dashboard which uses deployments to find information which belongs with the application itself, and consequently to display this information when there are no deployments of the application. 