### PR TITLE
Fixes to adaptive timeout handling

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -425,7 +425,7 @@ public class IndexedSearchCluster extends SearchCluster
         builder.searchableCopies(rootDispatch.getSearchableCopies());
         if (searchCoverage != null) {
             if (searchCoverage.getMinimum() != null)
-                builder.minSearchCoverage(searchCoverage.getMinimum());
+                builder.minSearchCoverage(searchCoverage.getMinimum() * 100.0);
             if (searchCoverage.getMinWaitAfterCoverageFactor() != null)
                 builder.minWaitAfterCoverageFactor(searchCoverage.getMinWaitAfterCoverageFactor());
             if (searchCoverage.getMaxWaitAfterCoverageFactor() != null)

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -134,7 +134,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         if (requests == responses || minimumCoverage >= 100.0) {
             return query.getTimeLeft();
         }
-        int minimumResponses = (int) (requests * minimumCoverage / 100.0);
+        int minimumResponses = (int) Math.ceil(requests * minimumCoverage / 100.0);
 
         if (responses < minimumResponses) {
             return query.getTimeLeft();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchInvoker.java
@@ -56,7 +56,9 @@ public abstract class SearchInvoker extends CloseableInvoker {
 
     protected Optional<Coverage> getErrorCoverage() {
         if(node.isPresent()) {
-            return Optional.of(new Coverage(0, node.get().getActiveDocuments(), 0));
+            Coverage error = new Coverage(0, node.get().getActiveDocuments(), 0);
+            error.setNodesTried(1);
+            return Optional.of(error);
         } else {
             return Optional.empty();
         }

--- a/container-search/src/main/java/com/yahoo/search/result/Coverage.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Coverage.java
@@ -47,6 +47,16 @@ public class Coverage extends com.yahoo.container.handler.Coverage {
     public Coverage setSoonActive(long soonActive) { this.soonActive = soonActive; return this; }
 
     /**
+     * Will set number of documents present
+     *
+     * @param active Number of documents active
+     * @return self for chaining
+
+     */
+    @Beta
+    public Coverage setActive(long active) { this.active = active; return this; }
+
+    /**
      * Will set the reasons for degraded coverage as reported by vespa backend.
      *
      * @param degradedReason Reason for degradation


### PR DESCRIPTION
Fixes a few inconsistencies between adaptive timeouts in the java dispatcher and fdispatch. With these changes it's also evident that the next step will be to refactor `InterleavedSearchInvoker` so that the coverage calculations can be done there in a cleaner manner and the additions to `com.yahoo.search.result.Coverage` can be removed.