### PR TITLE
JDK 11 updates.

### DIFF
--- a/abi-check-plugin/pom.xml
+++ b/abi-check-plugin/pom.xml
@@ -14,14 +14,10 @@
   <packaging>maven-plugin</packaging>
   <name>${project.artifactId}</name>
   <description>Maven Plugin for ensuring ABI stability.</description>
-  <prerequisites>
-    <maven>2.2.1</maven>
-  </prerequisites>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -36,7 +32,6 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>7.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -79,6 +74,25 @@
         <artifactId>clover-maven-plugin</artifactId>
         <version>4.3.1</version>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <version>[3.5, )</version>
+                            </requireMavenVersion>
+                        </rules>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/AnnotationCollector.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/AnnotationCollector.java
@@ -12,7 +12,7 @@ public class AnnotationCollector extends ClassVisitor {
   private final Set<String> annotations = new HashSet<>();
 
   public AnnotationCollector() {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
   }
 
   @Override

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
@@ -26,7 +26,7 @@ public class PublicSignatureCollector extends ClassVisitor {
   private Set<String> currentFields;
 
   public PublicSignatureCollector() {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
   }
 
   private static boolean testBit(long access, long mask) {


### PR DESCRIPTION
The two first items are necessary to make unit tests pass on the 7 branch.

- Use Opcodes.ASM7
- Inherit maven-plugin-api version from parent (currently 3.6.0)
- Use enforcer-plugin instead of Maven 2 prerequisites
- Require maven 3.5 as for the rest of Vespa
- Inherit asm version from parent to stay updated

FYI: @aressem, @bjorncs, @geirst