### PR TITLE
Bratseth/increase default barrier limit

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -10,7 +10,8 @@ numRpcThreads int default=0
 # ZooKeeper
 zookeeperserver[].hostname string
 zookeeperserver[].port int default=2181
-zookeeper.barrierTimeout long default=120 # in seconds
+# ZK write timeout in seconds, must be long enough to write application packages to other nodes
+zookeeper.barrierTimeout long default=360
 zookeeperLocalhostAffinity bool default=true
 
 # Directories

--- a/container-core/src/main/resources/configdefinitions/qr.def
+++ b/container-core/src/main/resources/configdefinitions/qr.def
@@ -28,5 +28,5 @@ coveragereports bool default=false restart
 ## this string will be unique for every QRS in a Vespa application.
 discriminator string default="qrserver.0" restart
 
-## Force restart of container on deploy?
+## Force restart of container on deploy, and defer any changes until restart
 restartOnDeploy bool default=false restart


### PR DESCRIPTION
@hmusum increase zk write timeout from 2 to 6 minutes as some applications run into this limit in the field

Caution: I do not know of any reasons to not increase it, but you might.