### PR TITLE
Result merging moved to InterleavedSearchInvoker

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4InvokerFactory.java
@@ -109,7 +109,7 @@ public class FS4InvokerFactory {
         if (invokers.size() == 1) {
             return Optional.of(invokers.get(0));
         } else {
-            return Optional.of(new InterleavedSearchInvoker(invokers, searchCluster));
+            return Optional.of(new InterleavedSearchInvoker(invokers, searcher, searchCluster));
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
@@ -14,15 +14,12 @@ import com.yahoo.search.dispatch.ResponseMonitor;
 import com.yahoo.search.dispatch.SearchInvoker;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.searchchain.Execution;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.util.Arrays.asList;
 
 /**
  * {@link SearchInvoker} implementation for FS4 nodes and fdispatch
@@ -52,7 +49,7 @@ public class FS4SearchInvoker extends SearchInvoker implements ResponseMonitor<F
         if (isLoggingFine())
             getLogger().finest("sending query packet");
 
-        if(queryPacket == null) {
+        if (queryPacket == null) {
             // query changed for subchannel
             queryPacket = searcher.createQueryPacket(searcher.getServerId(), query);
         }
@@ -73,8 +70,8 @@ public class FS4SearchInvoker extends SearchInvoker implements ResponseMonitor<F
     }
 
     @Override
-    protected List<Result> getSearchResults(CacheKey cacheKey) throws IOException {
-        if(pendingSearchError != null) {
+    protected Result getSearchResult(CacheKey cacheKey, Execution execution) throws IOException {
+        if (pendingSearchError != null) {
             return errorResult(pendingSearchError);
         }
         BasicPacket[] basicPackets;
@@ -125,13 +122,13 @@ public class FS4SearchInvoker extends SearchInvoker implements ResponseMonitor<F
                 cacheControl.cache(cacheKey, query, new DocsumPacketKey[0], packets, distributionKey());
             }
         }
-        return asList(result);
+        return result;
     }
 
-    private List<Result> errorResult(ErrorMessage errorMessage) {
+    private Result errorResult(ErrorMessage errorMessage) {
         Result error = new Result(query, errorMessage);
         getErrorCoverage().ifPresent(error::setCoverage);
-        return Arrays.asList(error);
+        return error;
     }
 
     @Override
@@ -158,4 +155,5 @@ public class FS4SearchInvoker extends SearchInvoker implements ResponseMonitor<F
     public void responseAvailable(FS4Channel from) {
         responseAvailable();
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -149,7 +149,7 @@ public class FastSearcher extends VespaBackEndSearcher {
     public Result doSearch2(Query query, QueryPacket queryPacket, CacheKey cacheKey, Execution execution) {
         if (dispatcher.searchCluster().groupSize() == 1)
             forceSinglePassGrouping(query);
-        try(SearchInvoker invoker = getSearchInvoker(query, execution)) {
+        try(SearchInvoker invoker = getSearchInvoker(query)) {
             Result result = invoker.search(query, queryPacket, cacheKey, execution);
 
             if (query.properties().getBoolean(Ranking.RANKFEATURES, false)) {
@@ -209,7 +209,7 @@ public class FastSearcher extends VespaBackEndSearcher {
      * depends on query properties with the default being an invoker that interfaces with a dispatcher
      * on the same host.
      */
-    private SearchInvoker getSearchInvoker(Query query, Execution execution) {
+    private SearchInvoker getSearchInvoker(Query query) {
         Optional<SearchInvoker> invoker = dispatcher.getSearchInvoker(query, fs4InvokerFactory);
         if (invoker.isPresent()) {
             return invoker.get();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
@@ -7,10 +7,9 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.searchchain.Execution;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -45,12 +44,12 @@ public class SearchErrorInvoker extends SearchInvoker {
     }
 
     @Override
-    protected List<Result> getSearchResults(CacheKey cacheKey) throws IOException {
+    protected Result getSearchResult(CacheKey cacheKey, Execution execution) throws IOException {
         Result res = new Result(query, message);
         if (coverage != null) {
             res.setCoverage(coverage);
         }
-        return Arrays.asList(res);
+        return res;
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/result/Coverage.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Coverage.java
@@ -47,16 +47,6 @@ public class Coverage extends com.yahoo.container.handler.Coverage {
     public Coverage setSoonActive(long soonActive) { this.soonActive = soonActive; return this; }
 
     /**
-     * Will set number of documents present
-     *
-     * @param active Number of documents active
-     * @return self for chaining
-
-     */
-    @Beta
-    public Coverage setActive(long active) { this.active = active; return this; }
-
-    /**
      * Will set the reasons for degraded coverage as reported by vespa backend.
      *
      * @param degradedReason Reason for degradation
@@ -65,17 +55,4 @@ public class Coverage extends com.yahoo.container.handler.Coverage {
     public Coverage setDegradedReason(int degradedReason) { this.degradedReason = degradedReason; return this; }
 
     public Coverage setNodesTried(int nodesTried) { super.setNodesTried(nodesTried); return this; }
-
-    public void mergeWithPartition(Coverage other) {
-        if (other == null) {
-            return;
-        }
-        int newResultSets = Integer.max(this.resultSets, other.resultSets);
-        int newFullResultSets = Integer.min(this.fullResultSets, other.fullResultSets);
-
-        merge(other);
-
-        this.resultSets = newResultSets;
-        this.fullResultSets = newFullResultSets;
-    }
 }


### PR DESCRIPTION
Result merging is now in `InterleavedSearchInvoker` which gets rid of the `List<Result>` return types and removes a few gotchas (and some code that was added to `Coverage` for coverage merging).

This adds one more back-reference from invocation to `VespaBackendSearcher`, but for now that's less ugly than also having a callback method passed around for document summary fetching (used in trimming merged result sets). Cleaning up references to `VespaBackendSearcher` is dependent on either removing cache handling or fusing it into the FS4 invokers, either of which is a separate refactoring and possibly better done once there's an RPC version in the works.