### PR TITLE
Cache ClusterList and BucketSpacesConfig upon component construction

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/BucketSpaceEnumerator.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/BucketSpaceEnumerator.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 /**
  * Class that based on BucketspacesConfig builds a mapping from document type to which bucket space it belongs to.
  */
-class BucketSpaceEnumerator {
+public class BucketSpaceEnumerator {
 
     private final Map<String, String> doctypeToSpace;
 

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandlerImpl.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandlerImpl.java
@@ -101,10 +101,6 @@ public class OperationHandlerImpl implements OperationHandler {
                 .get(docType));
     }
 
-    public OperationHandlerImpl(DocumentAccess documentAccess, MetricReceiver metricReceiver) {
-        this(documentAccess, defaultClusterEnumerator(), defaultBucketResolver(), metricReceiver);
-    }
-
     public OperationHandlerImpl(DocumentAccess documentAccess, ClusterEnumerator clusterEnumerator,
                                 BucketSpaceResolver bucketSpaceResolver, MetricReceiver metricReceiver) {
         this.documentAccess = documentAccess;


### PR DESCRIPTION
@bjorncs @freva please review
@baldersheim FYI

Avoids re-fetching per request. Since we depend on `ClusterListConfig` and
`DocumentmanagerConfig`, the component should be recreated if any relevant
cluster or document sets in the application changes.

Note: this is a stop-gap solution, we should add a global config containing mappings from
_all_ clusters, as we can then just inject it in the constructor.