### PR TITLE
Inject RestApi ClusterListConfig instead of fetching it every time

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandlerImpl.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandlerImpl.java
@@ -101,8 +101,8 @@ public class OperationHandlerImpl implements OperationHandler {
                 .get(docType));
     }
 
-    public OperationHandlerImpl(DocumentAccess documentAccess, MetricReceiver metricReceiver) {
-        this(documentAccess, defaultClusterEnumerator(), defaultBucketResolver(), metricReceiver);
+    public OperationHandlerImpl(DocumentAccess documentAccess, ClusterEnumerator clusterEnumerator, MetricReceiver metricReceiver) {
+        this(documentAccess, clusterEnumerator, defaultBucketResolver(), metricReceiver);
     }
 
     public OperationHandlerImpl(DocumentAccess documentAccess, ClusterEnumerator clusterEnumerator,


### PR DESCRIPTION
@freva please review. This is a subset of the changes in #7867
@bjorncs @baldersheim FYI

PS none of this stuff is in packages tagged `@PublicApi` so changing constructors around shouldn't break anything (AFAIK!)