### PR TITLE
Remove corp zone from controller tests

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/JobType.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/JobType.java
@@ -16,6 +16,7 @@ public enum JobType {
     component              ("component"                   , null                                                       , null                                                          ),
     systemTest             ("system-test"                 , ZoneId.from("test"   , "us-east-1")      , ZoneId.from("test"   , "cd-us-central-1")  ),
     stagingTest            ("staging-test"                , ZoneId.from("staging", "us-east-3")      , ZoneId.from("staging", "cd-us-central-1")  ),
+    // TODO: Remove after corp zone disappears
     productionCorpUsEast1  ("production-corp-us-east-1"   , ZoneId.from("prod"   , "corp-us-east-1") , null                                                          ),
     productionUsEast3      ("production-us-east-3"        , ZoneId.from("prod"   , "us-east-3")      , null                                                          ),
     productionUsWest1      ("production-us-west-1"        , ZoneId.from("prod"   , "us-west-1")      , null                                                          ),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepository.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepository.java
@@ -104,6 +104,7 @@ public class RotationRepository {
         return allRotations.get(rotation);
     }
 
+    // TODO: Remove after corp zones disappear
     private static boolean isCorp(DeploymentSpec.DeclaredZone zone) {
         return zone.region().isPresent() && zone.region().get().value().contains("corp");
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -40,7 +40,6 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Inject
     public ZoneRegistryMock() {
-        zones.add(ZoneId.from("prod", "corp-us-east-1"));
         zones.add(ZoneId.from("prod", "us-east-3"));
         zones.add(ZoneId.from("prod", "us-west-1"));
         zones.add(ZoneId.from("prod", "us-central-1"));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentIssueReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentIssueReporterTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.component;
-import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.productionCorpUsEast1;
+import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.productionUsWest1;
 import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.stagingTest;
 import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.systemTest;
 import static com.yahoo.vespa.hosted.controller.maintenance.DeploymentIssueReporter.maxFailureAge;
@@ -39,11 +39,11 @@ public class DeploymentIssueReporterTest {
 
     private final static ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
             .environment(Environment.prod)
-            .region("corp-us-east-1")
+            .region("us-west-1")
             .build();
     private final static ApplicationPackage canaryPackage = new ApplicationPackageBuilder()
             .environment(Environment.prod)
-            .region("corp-us-east-1")
+            .region("us-west-1")
             .upgradePolicy("canary")
             .build();
 
@@ -95,7 +95,7 @@ public class DeploymentIssueReporterTest {
         tester.jobCompletion(component).application(app3).uploadArtifact(applicationPackage).submit();
         tester.deployAndNotify(app3, applicationPackage, true, systemTest);
         tester.deployAndNotify(app3, applicationPackage, true, stagingTest);
-        tester.deployAndNotify(app3, applicationPackage, false, productionCorpUsEast1);
+        tester.deployAndNotify(app3, applicationPackage, false, productionUsWest1);
 
         reporter.maintain();
         reporter.maintain();
@@ -130,7 +130,7 @@ public class DeploymentIssueReporterTest {
 
 
         // app3 fixes their problems, but the ticket for app3 is left open; see the resolved ticket is not escalated when another escalation period has passed.
-        tester.deployAndNotify(app3, applicationPackage, true, productionCorpUsEast1);
+        tester.deployAndNotify(app3, applicationPackage, true, productionUsWest1);
         tester.clock().advance(maxInactivity.plus(Duration.ofDays(1)));
 
         reporter.maintain();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -102,7 +102,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
     private static final ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
             .environment(Environment.prod)
             .globalServiceId("foo")
-            .region("corp-us-east-1")
+            .region("us-central-1")
             .region("us-east-3")
             .region("us-west-1")
             .blockChange(false, true, "mon-fri", "0-8", "UTC")
@@ -249,11 +249,11 @@ public class ApplicationApiTest extends ControllerContainerTest {
                         .submit();
 
         // ... prod zone
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/", POST)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/", POST)
                                       .data(createApplicationDeployData(Optional.empty(), false))
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
-        controllerTester.jobCompletion(JobType.productionCorpUsEast1)
+        controllerTester.jobCompletion(JobType.productionUsCentral1)
                         .application(id)
                         .projectId(screwdriverProjectId)
                         .unsuccessful()
@@ -306,7 +306,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                       .userIdentity(USER_ID),
                               new File("application.json"));
         // GET an application deployment
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default", GET)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default", GET)
                                       .userIdentity(USER_ID),
                               new File("deployment.json"));
 
@@ -333,7 +333,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               new File("application1-recursive.json"));
 
         // GET logs
-        tester.assertResponse(request("/application/v4/tenant/tenant2/application//application1/environment/prod/region/corp-us-east-1/instance/default/logs?from=1233&to=3214", GET).userIdentity(USER_ID), new File("logs.json"));
+        tester.assertResponse(request("/application/v4/tenant/tenant2/application//application1/environment/prod/region/us-central-1/instance/default/logs?from=1233&to=3214", GET).userIdentity(USER_ID), new File("logs.json"));
 
         // DELETE (cancel) ongoing change
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/deploying", DELETE)
@@ -362,26 +362,26 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               "{\"message\":\"Triggered production-us-west-1 for tenant1.application1\"}");
 
         // POST a 'restart application' command
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/restart", POST)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/restart", POST)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
-                              "Requested restart of tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default");
+                              "Requested restart of tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default");
 
         // POST a 'restart application' command with a host filter (other filters not supported yet)
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/restart?hostname=host1", POST)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/restart?hostname=host1", POST)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               "{\"error-code\":\"INTERNAL_SERVER_ERROR\",\"message\":\"No node with the hostname host1 is known.\"}", 500);
 
         // GET suspended
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/suspended", GET)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/suspended", GET)
                                       .userIdentity(USER_ID),
                               new File("suspended.json"));
 
         // GET services
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/service", GET)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/service", GET)
                                       .userIdentity(USER_ID),
                               new File("services.json"));
         // GET service
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/service/storagenode-awe3slno6mmq2fye191y324jl/state/v1/", GET)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/service/storagenode-awe3slno6mmq2fye191y324jl/state/v1/", GET)
                                       .userIdentity(USER_ID),
                               new File("service.json"));
 
@@ -395,15 +395,15 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               "Deactivated tenant/tenant1/application/application1/environment/dev/region/us-west-1/instance/default");
 
         // DELETE (deactivate) a deployment - prod
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default", DELETE)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default", DELETE)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
-                              "Deactivated tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default");
+                              "Deactivated tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default");
 
 
         // DELETE (deactivate) a deployment is idempotent
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default", DELETE)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default", DELETE)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
-                              "Deactivated tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default");
+                              "Deactivated tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default");
 
         // POST an application package and a test jar, submitting a new application for internal pipeline deployment.
         // First attempt does not have an Athenz service definition in deployment spec, and fails.
@@ -584,7 +584,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
         // POST (deploy) an application to a prod zone - allowed when project ID is not specified
         HttpEntity entity = createApplicationDeployData(applicationPackage, true);
-        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/deploy", POST)
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/deploy", POST)
                                       .data(entity)
                                       .screwdriverIdentity(SCREWDRIVER_ID),
                               new File("deploy-result.json"));
@@ -1026,7 +1026,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
         Application app = controllerTester.createApplication();
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
-                .region("corp-us-east-1")
+                .region("us-central-1")
                 .build();
 
         Version vespaVersion = new Version("6.1"); // system version from mock config server client
@@ -1080,7 +1080,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
         Application app = controllerTester.createApplication();
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
-                .region("corp-us-east-1")
+                .region("us-central-1")
                 .build();
 
         // Report job failing with out of capacity

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application.json
@@ -66,7 +66,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -80,7 +80,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -94,7 +94,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       }
     },
@@ -112,7 +112,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -126,7 +126,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -140,12 +140,12 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       }
     },
     {
-      "type": "production-corp-us-east-1",
+      "type": "production-us-central-1",
       "success": false,
       "lastTriggered": {
         "id": -1,
@@ -231,12 +231,12 @@
     },
     {
       "environment": "prod",
-      "region": "corp-us-east-1",
+      "region": "us-central-1",
       "instance": "default",
       "bcpStatus": {
         "rotationStatus": "UNKNOWN"
       },
-      "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default"
+      "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default"
     }
   ],
   "metrics": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-recursive.json
@@ -66,7 +66,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -80,7 +80,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -94,7 +94,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       }
     },
@@ -112,7 +112,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastCompleted": {
@@ -126,7 +126,7 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       },
       "lastSuccess": {
@@ -140,12 +140,12 @@
             "gitCommit": "commit1"
           }
         },
-        "reason": "Testing deployment for production-corp-us-east-1 (platform 6.1, application 1.0.42-commit1)",
+        "reason": "Testing deployment for production-us-central-1 (platform 6.1, application 1.0.42-commit1)",
         "at": "(ignore)"
       }
     },
     {
-      "type": "production-corp-us-east-1",
+      "type": "production-us-central-1",
       "success": false,
       "lastTriggered": {
         "id": -1,
@@ -224,7 +224,7 @@
   "rotationId": "rotation-id-1",
   "instances": [
     @include(dev-us-west-1.json),
-    @include(prod-corp-us-east-1.json)
+    @include(prod-us-central-1.json)
   ],
   "metrics": {
     "queryServiceQuality": 0.5,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -6,9 +6,9 @@
     "http://global-endpoint.vespa.yahooapis.com:4080",
     "http://alias-endpoint.vespa.yahooapis.com:4080"
   ],
-  "nodes": "http://localhost:8080/zone/v2/prod/corp-us-east-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
-  "elkUrl": "http://log.prod.corp-us-east-1.test/#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'HV-tenant:%22tenant1%22%20AND%20HV-application:%22application1%22%20AND%20HV-region:%22corp-us-east-1%22%20AND%20HV-instance:%22default%22%20AND%20HV-environment:%22prod%22')),sort:!('@timestamp',desc))",
-  "yamasUrl": "http://monitoring-system.test/?environment=prod&region=corp-us-east-1&application=tenant1.application1",
+  "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
+  "elkUrl": "http://log.prod.us-central-1.test/#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'HV-tenant:%22tenant1%22%20AND%20HV-application:%22application1%22%20AND%20HV-region:%22us-central-1%22%20AND%20HV-instance:%22default%22%20AND%20HV-environment:%22prod%22')),sort:!('@timestamp',desc))",
+  "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-central-1&application=tenant1.application1",
   "version": "(ignore)",
   "revision": "(ignore)",
   "deployTimeEpochMs": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -1,6 +1,6 @@
 {
   "environment": "prod",
-  "region": "corp-us-east-1",
+  "region": "us-central-1",
   "instance": "default",
   "bcpStatus": {
     "rotationStatus": "UNKNOWN"
@@ -12,9 +12,9 @@
     "http://global-endpoint.vespa.yahooapis.com:4080",
     "http://alias-endpoint.vespa.yahooapis.com:4080"
   ],
-  "nodes": "http://localhost:8080/zone/v2/prod/corp-us-east-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
-  "elkUrl": "http://log.prod.corp-us-east-1.test/#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'HV-tenant:%22tenant1%22%20AND%20HV-application:%22application1%22%20AND%20HV-region:%22corp-us-east-1%22%20AND%20HV-instance:%22default%22%20AND%20HV-environment:%22prod%22')),sort:!('@timestamp',desc))",
-  "yamasUrl": "http://monitoring-system.test/?environment=prod&region=corp-us-east-1&application=tenant1.application1",
+  "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.default",
+  "elkUrl": "http://log.prod.us-central-1.test/#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'HV-tenant:%22tenant1%22%20AND%20HV-application:%22application1%22%20AND%20HV-region:%22us-central-1%22%20AND%20HV-instance:%22default%22%20AND%20HV-environment:%22prod%22')),sort:!('@timestamp',desc))",
+  "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-central-1&application=tenant1.application1",
   "version": "(ignore)",
   "revision": "(ignore)",
   "deployTimeEpochMs": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/services.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/services.json
@@ -3,10 +3,10 @@
     {
       "name": "cluster1",
       "type": "content",
-      "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/service/container-clustercontroller-6s8slgtps7ry8uh6lx21ejjiv/cluster/v2/cluster1",
+      "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/service/container-clustercontroller-6s8slgtps7ry8uh6lx21ejjiv/cluster/v2/cluster1",
       "services": [
         {
-          "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/environment/prod/region/corp-us-east-1/instance/default/service/storagenode-awe3slno6mmq2fye191y324jl/state/v1/",
+          "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-central-1/instance/default/service/storagenode-awe3slno6mmq2fye191y324jl/state/v1/",
           "serviceType": "storagenode",
           "serviceName": "storagenode",
           "configId": "cluster1/storage/0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,13 +39,13 @@ public class DeploymentApiTest extends ControllerContainerTest {
     }
 
     @Test
-    public void testDeploymentApi() throws IOException {
+    public void testDeploymentApi() {
         ContainerControllerTester tester = new ContainerControllerTester(container, responseFiles);
         Version version = Version.fromString("5.0");
         tester.containerTester().upgradeSystem(version);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
-                .region("corp-us-east-1")
+                .region("us-west-1")
                 .build();
 
         // 3 applications deploy on current system version
@@ -61,7 +60,7 @@ public class DeploymentApiTest extends ControllerContainerTest {
 
         // Deploy once so that job information is stored, then remove the deployment
         deployCompletely(applicationWithoutDeployment, applicationPackage, 3L, true);
-        tester.controller().applications().deactivate(applicationWithoutDeployment.id(), ZoneId.from("prod", "corp-us-east-1"));
+        tester.controller().applications().deactivate(applicationWithoutDeployment.id(), ZoneId.from("prod", "us-west-1"));
 
         // New version released
         version = Version.fromString("5.1");
@@ -121,8 +120,8 @@ public class DeploymentApiTest extends ControllerContainerTest {
               .submit();
         if (success) {
             tester.deploy(application, applicationPackage, ZoneId.from(Environment.prod,
-                                                                       RegionName.from("corp-us-east-1")));
-            tester.jobCompletion(JobType.productionCorpUsEast1)
+                                                                       RegionName.from("us-west-1")));
+            tester.jobCompletion(JobType.productionUsWest1)
                   .application(application)
                   .projectId(projectId)
                   .submit();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.rotation;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
@@ -145,6 +146,8 @@ public class RotationTest {
 
     @Test
     public void application_with_only_one_non_corp_region() {
+        tester.controllerTester().zoneRegistry().setZones(ZoneId.from("prod", "corp-us-east-1"),
+                                                          ZoneId.from("prod", "us-east-3"));
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .globalServiceId("foo")
                 .region("us-east-3")
@@ -159,6 +162,9 @@ public class RotationTest {
 
     @Test
     public void application_with_corp_region_and_two_non_corp_region() {
+        tester.controllerTester().zoneRegistry().setZones(ZoneId.from("prod", "corp-us-east-1"),
+                                                          ZoneId.from("prod", "us-east-3"),
+                                                          ZoneId.from("prod", "us-west-1"));
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .globalServiceId("foo")
                 .region("us-east-3")
@@ -177,7 +183,6 @@ public class RotationTest {
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .globalServiceId("foo")
                 .region("us-east-3")
-                .region("corp-us-east-1")
                 .region("us-west-1")
                 .build();
         Application application = tester.createApplication("app2", "tenant2", 22L,


### PR DESCRIPTION
No functional changes. Just makes it easier to remove
`JobType.productionCorpUsEast1` once the zone is completely gone.