### PR TITLE
Fix bug where allocation of too large buffers in data store caused of…

### DIFF
--- a/searchlib/src/vespa/searchlib/datastore/buffer_type.h
+++ b/searchlib/src/vespa/searchlib/datastore/buffer_type.h
@@ -51,7 +51,7 @@ public:
     virtual void initializeReservedElements(void *buffer, size_t reservedElements) = 0;
     virtual size_t elementSize() const = 0;
     virtual void cleanHold(void *buffer, uint64_t offset, uint64_t len, CleanContext cleanCtx) = 0;
-    uint32_t getClusterSize() const { return _clusterSize; }
+    size_t getClusterSize() const { return _clusterSize; }
     void flushLastUsed();
     virtual void onActive(uint32_t bufferId, size_t *usedElems, size_t &deadElems, void *buffer);
     void onHold(const size_t *usedElems);
@@ -70,7 +70,7 @@ public:
     void clampMaxClusters(uint32_t maxClusters);
 
     uint32_t getActiveBuffers() const { return _activeBuffers; }
-    uint32_t getMaxClusters() const { return _maxClusters; }
+    size_t getMaxClusters() const { return _maxClusters; }
     uint32_t getNumClustersForNewBuffer() const { return _numClustersForNewBuffer; }
 };
 

--- a/searchlib/src/vespa/searchlib/datastore/bufferstate.cpp
+++ b/searchlib/src/vespa/searchlib/datastore/bufferstate.cpp
@@ -80,6 +80,11 @@ calcAllocation(uint32_t bufferId,
     size_t allocClusters = typeHandler.calcClustersToAlloc(bufferId, elementsNeeded, resizing);
     size_t allocElements = allocClusters * typeHandler.getClusterSize();
     size_t allocBytes = roundUpToMatchAllocator(allocElements * typeHandler.elementSize());
+    size_t maxAllocBytes = typeHandler.getMaxClusters() * typeHandler.getClusterSize() * typeHandler.elementSize();
+    if (allocBytes > maxAllocBytes) {
+        // Ensure that allocated bytes does not exceed the maximum handled by this type.
+        allocBytes = maxAllocBytes;
+    }
     size_t adjustedAllocElements = (allocBytes / typeHandler.elementSize());
     return AllocResult(adjustedAllocElements, allocBytes);
 }


### PR DESCRIPTION
…fset in EntryRefT to be out of bounds.

This happened in cases where wanted number of bytes was not a power of 2 and less than huge page size.
After rounding up to nearest power of 2 (to match the underlying memory allocator) the allocated buffer became too large for the offset in EntryRefT to handle.

@baldersheim and @toregge please review