### PR TITLE
Remove redundant log

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerApiImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerApiImpl.java
@@ -127,13 +127,15 @@ public class ConfigServerApiImpl implements ConfigServerApi {
                 if (!e.isRetryable()) throw e;
                 lastException = e;
             } catch (Exception e) {
+                lastException = e;
+                if (configServers.size() == 1) break;
+
                 // Failure to communicate with a config server is not abnormal during upgrades
                 if (e.getMessage().contains("(Connection refused)")) {
                     NODE_ADMIN_LOGGER.info("Connection refused to " + configServer + " (upgrading?), will try next");
                 } else {
                     NODE_ADMIN_LOGGER.warning("Failed to communicate with " + configServer + ", will try next: " + e.getMessage());
                 }
-                lastException = e;
             }
         }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -265,9 +265,6 @@ public class DockerOperationsImpl implements DockerOperations {
         return docker.getAllContainersManagedBy(MANAGER_NAME);
     }
 
-    /**
-     * Returns map of directories to mount and whether they should be writable by everyone
-     */
     private static void addMounts(NodeAgentContext context, Docker.CreateContainerCommand command) {
         final Path varLibSia = Paths.get("/var/lib/sia");
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/IOExceptionUtil.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/IOExceptionUtil.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.node.admin.task.util.file;
 
 import com.yahoo.yolean.Exceptions;
 
-import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.NoSuchFileException;
 import java.util.Optional;

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/UnixPath.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/UnixPath.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 
 import static com.yahoo.vespa.hosted.node.admin.task.util.file.IOExceptionUtil.ifExists;
 import static com.yahoo.yolean.Exceptions.uncheck;
-import static com.yahoo.yolean.Exceptions.uncheckAndIgnore;
 
 /**
  * Thin wrapper around java.nio.file.Path, especially nice for UNIX-specific features.

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileDeleterTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileDeleterTest.java
@@ -18,7 +18,7 @@ public class FileDeleterTest {
     private final TaskContext context = mock(TaskContext.class);
 
     @Test
-    public void deleteExisting() throws IOException {
+    public void deleteExisting() {
         assertFalse(deleter.converge(context));
         path.createParents().writeUtf8File("bar");
         assertTrue(deleter.converge(context));


### PR DESCRIPTION
When we do health check on config server, we only check against local one and that well fail for a while when we first start it. Logging that it "will try next" or logging anything is redundant since this exception will be rethrown anyway.