### PR TITLE
Use feature flag to control how to do bootstrapping

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -70,4 +70,3 @@ sleepTimeWhenRedeployingFails long default=30
 buildMinimalSetOfConfigModels bool default=true
 useDedicatedNodeForLogserver bool default=true
 throwIfBootstrappingTenantRepoFails bool default=true
-bootstrapInSeparateThread bool default=true

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static com.yahoo.vespa.config.server.ConfigServerBootstrap.RedeployingApplicationsFails.*;
 
 /**
  * Main component that bootstraps and starts config server threads.
@@ -41,10 +44,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class ConfigServerBootstrap extends AbstractComponent implements Runnable {
 
-    private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(ConfigServerBootstrap.class.getName());
-    static final String bootstrapFeatureFlag = "config-server-bootstrap-in-separate-thread";
+    private static final Logger log = Logger.getLogger(ConfigServerBootstrap.class.getName());
+    private static final String bootstrapFeatureFlag = "config-server-bootstrap-in-separate-thread";
 
-    enum Mode {BOOTSTRAP_IN_CONSTRUCTOR, BOOTSTRAP_IN_SEPARATE_THREAD, INITIALIZE_ONLY} // INITIALIZE_ONLY is for testing only
+    // INITIALIZE_ONLY is for testing only
+    enum Mode {BOOTSTRAP_IN_CONSTRUCTOR, BOOTSTRAP_IN_SEPARATE_THREAD, INITIALIZE_ONLY}
     enum RedeployingApplicationsFails {EXIT_JVM, CONTINUE}
 
     private final ApplicationRepository applicationRepository;
@@ -59,20 +63,27 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
     private final RedeployingApplicationsFails exitIfRedeployingApplicationsFails;
     private final ExecutorService rpcServerExecutor;
 
-    @SuppressWarnings("WeakerAccess")
+    @SuppressWarnings("unused")
     @Inject
     public ConfigServerBootstrap(ApplicationRepository applicationRepository, RpcServer server,
                                  VersionState versionState, StateMonitor stateMonitor, VipStatus vipStatus,
                                  FlagSource flagSource) {
         this(applicationRepository, server, versionState, stateMonitor, vipStatus,
-             new FeatureFlag(bootstrapFeatureFlag, true, flagSource).value() ? Mode.BOOTSTRAP_IN_SEPARATE_THREAD : Mode.BOOTSTRAP_IN_CONSTRUCTOR,
-             RedeployingApplicationsFails.EXIT_JVM);
+             new FeatureFlag(bootstrapFeatureFlag, true, flagSource).value()
+                     ? Mode.BOOTSTRAP_IN_SEPARATE_THREAD
+                     : Mode.BOOTSTRAP_IN_CONSTRUCTOR,
+             EXIT_JVM);
     }
 
     // For testing only
     ConfigServerBootstrap(ApplicationRepository applicationRepository, RpcServer server, VersionState versionState,
-                          StateMonitor stateMonitor, VipStatus vipStatus, Mode mode,
-                          RedeployingApplicationsFails exitIfRedeployingApplicationsFails) {
+                          StateMonitor stateMonitor, VipStatus vipStatus, Mode mode) {
+        this(applicationRepository, server, versionState, stateMonitor, vipStatus, mode, CONTINUE);
+    }
+
+    private ConfigServerBootstrap(ApplicationRepository applicationRepository, RpcServer server,
+                                  VersionState versionState, StateMonitor stateMonitor, VipStatus vipStatus,
+                                  Mode mode, RedeployingApplicationsFails exitIfRedeployingApplicationsFails) {
         this.applicationRepository = applicationRepository;
         this.server = server;
         this.versionState = versionState;
@@ -192,7 +203,7 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
     }
 
     private void redeployingApplicationsFailed() {
-        if (exitIfRedeployingApplicationsFails == RedeployingApplicationsFails.EXIT_JVM) System.exit(1);
+        if (exitIfRedeployingApplicationsFails == EXIT_JVM) System.exit(1);
     }
 
     private boolean redeployAllApplications() throws InterruptedException {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -22,6 +22,8 @@ import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.version.VersionState;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.FlagId;
+import com.yahoo.vespa.flags.FlagSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -38,9 +40,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
+import static com.yahoo.vespa.config.server.ConfigServerBootstrap.bootstrapFeatureFlag;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Ulf Lilleengen
@@ -143,8 +148,11 @@ public class ConfigServerBootstrapTest {
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
         VipStatus vipStatus = new VipStatus();
+        FlagSource flagSource = mock(FlagSource.class);
+        when(flagSource.getString(new FlagId(bootstrapFeatureFlag))).thenReturn(Optional.of("true"));
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
-                                                                    createStateMonitor(), vipStatus);
+                                                                    createStateMonitor(), vipStatus,
+                                                                    flagSource);
 
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
         waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -22,8 +22,6 @@ import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.version.VersionState;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
-import com.yahoo.vespa.flags.FlagId;
-import com.yahoo.vespa.flags.FlagSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -40,12 +38,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-import static com.yahoo.vespa.config.server.ConfigServerBootstrap.bootstrapFeatureFlag;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Ulf Lilleengen
@@ -73,8 +68,7 @@ public class ConfigServerBootstrapTest {
         provisioner.allocations().values().iterator().next().remove(0);
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer,
                                                                     versionState, createStateMonitor(), vipStatus,
-                                                                    ConfigServerBootstrap.Mode.INITIALIZE_ONLY,
-                                                                    ConfigServerBootstrap.RedeployingApplicationsFails.CONTINUE);
+                                                                    ConfigServerBootstrap.Mode.INITIALIZE_ONLY);
         assertFalse(vipStatus.isInRotation());
         bootstrap.start();
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
@@ -107,8 +101,7 @@ public class ConfigServerBootstrapTest {
         VipStatus vipStatus = new VipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
                                                                     createStateMonitor(), vipStatus,
-                                                                    ConfigServerBootstrap.Mode.INITIALIZE_ONLY,
-                                                                    ConfigServerBootstrap.RedeployingApplicationsFails.CONTINUE);
+                                                                    ConfigServerBootstrap.Mode.INITIALIZE_ONLY);
         assertFalse(vipStatus.isInRotation());
         // Call method directly, to be sure that it is finished redeploying all applications and we can check status
         bootstrap.start();
@@ -148,11 +141,9 @@ public class ConfigServerBootstrapTest {
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
         VipStatus vipStatus = new VipStatus();
-        FlagSource flagSource = mock(FlagSource.class);
-        when(flagSource.getString(new FlagId(bootstrapFeatureFlag))).thenReturn(Optional.of("true"));
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
                                                                     createStateMonitor(), vipStatus,
-                                                                    flagSource);
+                                                                    ConfigServerBootstrap.Mode.BOOTSTRAP_IN_SEPARATE_THREAD);
 
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
         waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");


### PR DESCRIPTION
Makes it easier to actually try this out, since it can be set at any time and work the next time the config server is upgraded/restarted