### PR TITLE
Always activate or remove infrastructure application

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.component.Version;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.NodeType;
@@ -11,19 +12,22 @@ import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.service.duper.DuperModel;
 import com.yahoo.vespa.service.monitor.DuperModelInfraApi;
 import com.yahoo.vespa.service.monitor.InfraApplicationApi;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
- * This maintainer makes sure that infrastructure nodes are allocated with correct wanted
- * version. Source for the wanted version comes from the target version set using
- * /nodes/v2/upgrade/ endpoint.
+ * This maintainer makes sure that 1. infrastructure nodes are allocated with correct wanted
+ * version and 2. keeping {@link DuperModel} up to date. Source for the wanted version comes
+ * from the target version set using /nodes/v2/upgrade/ endpoint.
  *
  * @author freva
  */
@@ -34,6 +38,7 @@ public class InfrastructureProvisioner extends Maintainer {
     private final Provisioner provisioner;
     private final InfrastructureVersions infrastructureVersions;
     private final DuperModelInfraApi duperModel;
+    private final Map<ApplicationId, Version> lastActivations = new HashMap<>();
 
     public InfrastructureProvisioner(Provisioner provisioner, NodeRepository nodeRepository,
                                      InfrastructureVersions infrastructureVersions, Duration interval, JobControl jobControl,
@@ -52,8 +57,8 @@ public class InfrastructureProvisioner extends Maintainer {
 
                 Optional<Version> targetVersion = infrastructureVersions.getTargetVersionFor(nodeType);
                 if (!targetVersion.isPresent()) {
-                    logger.log(LogLevel.DEBUG, "Skipping provision of " + nodeType + ": No target version set");
-                    duperModel.infraApplicationRemoved(application.getApplicationId());
+                    logger.log(LogLevel.DEBUG, "No target version set for " + nodeType + ", removing application");
+                    removeApplication(application.getApplicationId());
                     continue;
                 }
 
@@ -65,16 +70,8 @@ public class InfrastructureProvisioner extends Maintainer {
                                 .orElse(null))
                         .collect(Collectors.toList());
                 if (wantedVersions.isEmpty()) {
-                    // TODO: Unprovision active nodes from application?
-                    logger.log(LogLevel.DEBUG, "Skipping provision of " + nodeType + ": No nodes to provision");
-                    duperModel.infraApplicationRemoved(application.getApplicationId());
-                    continue;
-                }
-
-                if (wantedVersions.stream().allMatch(targetVersion.get()::equals) &&
-                        duperModel.infraApplicationIsActive(application.getApplicationId())) {
-                    logger.log(LogLevel.DEBUG, "Skipping provision of " + nodeType +
-                            ": Already provisioned to target version " + targetVersion);
+                    logger.log(LogLevel.DEBUG, "No nodes to provision for " + nodeType + ", removing application");
+                    removeApplication(application.getApplicationId());
                     continue;
                 }
 
@@ -99,11 +96,18 @@ public class InfrastructureProvisioner extends Maintainer {
                 } else {
                     detail = " with " + hostSpecs.size() + " hosts";
                 }
-                logger.log(LogLevel.INFO, "Infrastructure application " + application.getApplicationId() + " activated" + detail);
+                logger.log(LogLevel.DEBUG, "Infrastructure application " + application.getApplicationId() + " activated" + detail);
             } catch (RuntimeException e) {
                 logger.log(LogLevel.INFO, "Failed to activate " + application.getApplicationId(), e);
                 // loop around to activate the next application
             }
         }
+    }
+
+    private void removeApplication(ApplicationId applicationId) {
+        NestedTransaction nestedTransaction = new NestedTransaction();
+        provisioner.remove(nestedTransaction, applicationId);
+        nestedTransaction.commit();
+        duperModel.infraApplicationRemoved(applicationId);
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisionerTest.java
@@ -123,19 +123,18 @@ public class InfrastructureProvisionerTest {
 
         when(provisioner.prepare(any(), any(), any(), anyInt(), any())).thenReturn(Arrays.asList(
                 new HostSpec(node1.value(), Collections.emptyList()),
-                new HostSpec(node2.value(), Collections.emptyList()),
                 new HostSpec(node3.value(), Collections.emptyList())));
 
         infrastructureProvisioner.maintain();
 
         verify(provisioner).prepare(eq(application.getApplicationId()), any(), any(), anyInt(), any());
         verify(provisioner).activate(any(), eq(application.getApplicationId()), any());
-        verify(duperModelInfraApi).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node1, node2, node3));
+        verify(duperModelInfraApi).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node3, node1));
     }
 
 
     @Test
-    public void activates_the_first_time_after_jvm_start() {
+    public void always_activates_for_dupermodel() {
         when(infrastructureVersions.getTargetVersionFor(eq(nodeType))).thenReturn(Optional.of(target));
 
         addNode(1, Node.State.active, Optional.of(target));
@@ -146,9 +145,15 @@ public class InfrastructureProvisionerTest {
 
         infrastructureProvisioner.maintain();
 
-        verify(provisioner).prepare(eq(application.getApplicationId()), any(), any(), anyInt(), any());
-        verify(provisioner).activate(any(), eq(application.getApplicationId()), any());
-        verify(duperModelInfraApi).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node1));
+        verify(provisioner, never()).prepare(any(), any(), any(), anyInt(), any());
+        verify(provisioner, never()).activate(any(), any(), any());
+        verify(duperModelInfraApi, times(1)).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node1));
+
+        infrastructureProvisioner.maintain();
+
+        verify(provisioner, never()).prepare(any(), any(), any(), anyInt(), any());
+        verify(provisioner, never()).activate(any(), any(), any());
+        verify(duperModelInfraApi, times(2)).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node1));
     }
 
     @Test
@@ -168,7 +173,7 @@ public class InfrastructureProvisionerTest {
 
         verify(provisioner).prepare(eq(application.getApplicationId()), any(), any(), anyInt(), any());
         verify(provisioner).activate(any(), eq(application.getApplicationId()), any());
-        verify(duperModelInfraApi).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node2, node3));
+        verify(duperModelInfraApi).infraApplicationActivated(application.getApplicationId(), Arrays.asList(node3, node2));
     }
 
     @Test


### PR DESCRIPTION
If an infrastructure node is added to the node repository (as ready, active, or similar), when the first of 3 config servers runs InfrastructureProvisioner's maintain(), it will correctly activate the application and add the nodes to the DuperModel. The next run of maintain() for the same config server will see all nodes as having the correct wanted version and therefore short-circuit activating again.

But the later config servers will see all nodes as having the correct wanted version the first maintain(), and therefore will never activate (which is fine) and never add the nodes to the DuperModel (not fine). 

The effect is that the Orchestrator returns 404 Host not found if host admin happens to hit one of the two config servers.

This PR makes InfrastructureProvisioner
- either activate the application and add the application to DuperModel, or
- remove the application and remove it from DuperModel

This requires the activate and the remove operations of the NodeRepositoryProvisioner and DuperModel to be idempotent. I'm not entirely sure about NRProvisioner, but DuperModel(Manager) is idempotent.

This introduces potentially some unnecessary work in NRP and DM. Alternatively, the IP could make a cache key of what it did last, such that if nothing has changed it could skip to the next application. I chose not to do this yet as the cache key is non-trivial requiring a new class and more (the set of nodes, for each node their state, the wanted version).