### PR TITLE
[VESPA-13861] Add wantToRetire to node history

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -134,6 +134,18 @@ public final class Node {
     public History history() { return history; }
 
     /**
+     * Returns a copy of this node with wantToRetire set to the given value and updated history.
+     * If given wantToRetire is equal to the current, the method is no-op.
+     */
+    public Node withWantToRetire(boolean wantToRetire, Instant at) {
+        if (wantToRetire == status.wantToRetire()) return this;
+        return with(status.withWantToRetire(wantToRetire))
+                // Also update history when we un-wantToRetire so the OperatorChangeApplicationMaintainer picks it
+                // up quickly
+                .with(history.with(new History.Event(History.Event.Type.wantToRetire, Agent.operator, at)));
+    }
+
+    /**
      * Returns a copy of this node which is retired.
      * If the node was already retired it is returned as-is.
      */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -129,6 +129,8 @@ public class History {
         public enum Type { 
             // State move events
             provisioned(false), readied, reserved, activated, deactivated, deallocated, parked,
+            // The node was scheduled for retirement
+            wantToRetire,
             // The active node was retired
             retired,
             // The active node went down according to the service monitor

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -268,6 +268,7 @@ public class NodeSerializer {
             case "readied" : return History.Event.Type.readied;
             case "reserved" : return History.Event.Type.reserved;
             case "activated" : return History.Event.Type.activated;
+            case "wantToRetire": return History.Event.Type.wantToRetire;
             case "retired" : return History.Event.Type.retired;
             case "deactivated" : return History.Event.Type.deactivated;
             case "parked" : return History.Event.Type.parked;
@@ -285,6 +286,7 @@ public class NodeSerializer {
             case readied : return "readied";
             case reserved : return "reserved";
             case activated : return "activated";
+            case wantToRetire: return "wantToRetire";
             case retired : return "retired";
             case deactivated : return "deactivated";
             case parked : return "parked";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -129,7 +129,7 @@ public class NodePatcher {
             case "additionalIpAddresses" :
                 return node.withIpAddressPool(asStringSet(value));
             case WANT_TO_RETIRE :
-                return node.with(node.status().withWantToRetire(asBoolean(value)));
+                return node.withWantToRetire(asBoolean(value), nodeRepository.clock().instant());
             case WANT_TO_DEPROVISION :
                 return node.with(node.status().withWantToDeprovision(asBoolean(value)));
             case "hardwareDivergence" :

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -71,6 +71,11 @@
       "event": "rebooted",
       "at": 123,
       "agent": "system"
+    },
+    {
+      "event": "wantToRetire",
+      "at": 123,
+      "agent": "operator"
     }
   ],
   "ipAddresses": [


### PR DESCRIPTION
Adds `wantToRetire` to node history so that it can be picked up by `OperatorChangeApplicationMaintainer` for faster retiring.