### PR TITLE
Typed flag classes

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/Application.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/Application.java
@@ -23,9 +23,9 @@ import com.yahoo.vespa.config.server.rpc.ConfigResponseFactory;
 import com.yahoo.vespa.config.server.rpc.UncompressedConfigResponseFactory;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.util.ConfigUtils;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.FileFlagSource;
-import com.yahoo.vespa.flags.Flag;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
 
@@ -49,7 +49,7 @@ public class Application implements ModelResult {
     private final ServerCache cache;
     private final MetricUpdater metricUpdater;
     private final ApplicationId app;
-    private final Flag<Boolean> useConfigServerCache;
+    private final BooleanFlag useConfigServerCache;
 
     public Application(Model model, ServerCache cache, long appGeneration, boolean internalRedeploy,
                        Version vespaVersion, MetricUpdater metricUpdater, ApplicationId app) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/flags/DefinedFlags.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/flags/DefinedFlags.java
@@ -20,12 +20,12 @@ import java.util.List;
  */
 public class DefinedFlags extends HttpResponse {
     private static ObjectMapper mapper = new ObjectMapper();
-    private static final Comparator<FlagDefinition<?>> sortByFlagId =
+    private static final Comparator<FlagDefinition> sortByFlagId =
             (left, right) -> left.getUnboundFlag().id().compareTo(right.getUnboundFlag().id());
 
-    private final List<FlagDefinition<?>> flags;
+    private final List<FlagDefinition> flags;
 
-    public DefinedFlags(List<FlagDefinition<?>> flags) {
+    public DefinedFlags(List<FlagDefinition> flags) {
         super(Response.Status.OK);
         this.flags = flags;
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/BooleanFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/BooleanFlag.java
@@ -1,0 +1,18 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class BooleanFlag extends FlagImpl<Boolean, BooleanFlag> {
+    public BooleanFlag(FlagId id, boolean defaultValue, FetchVector vector, FlagSerializer<Boolean> serializer, FlagSource source) {
+        super(id, defaultValue, vector, serializer, source, BooleanFlag::new);
+    }
+
+    public boolean value() {
+        return boxedValue();
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flag.java
@@ -1,44 +1,23 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
-import javax.annotation.concurrent.Immutable;
-
 /**
+ * Interface for flag.
+ *
+ * @param <T> The type of the flag value (boxed for primitives)
+ * @param <F> The concrete subclass type of the flag
  * @author hakonhall
  */
-@Immutable
-public class Flag<T> {
-    private final FlagId id;
-    private final T defaultValue;
-    private final FlagSource source;
-    private final Deserializer<T> deserializer;
-    private final FetchVector fetchVector;
+public interface Flag<T, F> {
+    /** The flag ID. */
+    FlagId id();
 
-    public Flag(String flagId, T defaultValue, FlagSource source, Deserializer<T> deserializer) {
-        this(new FlagId(flagId), defaultValue, source, deserializer);
-    }
+    /** Returns the flag serializer. */
+    FlagSerializer<T> serializer();
 
-    public Flag(FlagId id, T defaultValue, FlagSource source, Deserializer<T> deserializer) {
-        this(id, defaultValue, deserializer, new FetchVector(), source);
-    }
+    /** Returns an immutable clone of the current object, except with the dimension set accordingly. */
+    F with(FetchVector.Dimension dimension, String dimensionValue);
 
-    public Flag(FlagId id, T defaultValue, Deserializer<T> deserializer, FetchVector fetchVector, FlagSource source) {
-        this.id = id;
-        this.defaultValue = defaultValue;
-        this.source = source;
-        this.deserializer = deserializer;
-        this.fetchVector = fetchVector;
-    }
-
-    public FlagId id() {
-        return id;
-    }
-
-    public Flag<T> with(FetchVector.Dimension dimension, String value) {
-        return new Flag<>(id, defaultValue, deserializer, fetchVector.with(dimension, value), source);
-    }
-
-    public T value() {
-        return source.fetch(id, fetchVector).map(deserializer::deserialize).orElse(defaultValue);
-    }
+    /** Returns the value, boxed if the flag wraps a primitive type. */
+    T boxedValue();
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/FlagDefinition.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FlagDefinition.java
@@ -1,7 +1,8 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
 import javax.annotation.concurrent.Immutable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -9,21 +10,21 @@ import java.util.List;
  * @author hakonhall
  */
 @Immutable
-public class FlagDefinition<T> {
-    private final UnboundFlag<T> unboundFlag;
+public class FlagDefinition {
+    private final UnboundFlag<?, ?, ?> unboundFlag;
     private final String description;
     private final String modificationEffect;
     private final List<FetchVector.Dimension> dimensions;
 
-    public FlagDefinition(UnboundFlag<T> unboundFlag, String description, String modificationEffect,
-                          List<FetchVector.Dimension> dimensions) {
+    public FlagDefinition(UnboundFlag<?, ?, ?> unboundFlag, String description, String modificationEffect,
+                          FetchVector.Dimension... dimensions) {
         this.unboundFlag = unboundFlag;
         this.description = description;
         this.modificationEffect = modificationEffect;
-        this.dimensions = Collections.unmodifiableList(dimensions);
+        this.dimensions = Collections.unmodifiableList(Arrays.asList(dimensions));
     }
 
-    public UnboundFlag<T> getUnboundFlag() {
+    public UnboundFlag<?, ?, ?> getUnboundFlag() {
         return unboundFlag;
     }
 

--- a/flags/src/main/java/com/yahoo/vespa/flags/FlagImpl.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FlagImpl.java
@@ -1,0 +1,47 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+/**
+ * @author hakonhall
+ */
+public abstract class FlagImpl<T, F extends FlagImpl<T, F>> implements Flag<T, F> {
+    private final FlagId id;
+    private final T defaultValue;
+    private final FlagSerializer<T> serializer;
+    private final FetchVector fetchVector;
+    private final UnboundFlagImpl.FlagFactory<T, F> factory;
+    private final FlagSource source;
+
+    protected FlagImpl(FlagId id,
+                       T defaultValue,
+                       FetchVector fetchVector, FlagSerializer<T> serializer,
+                       FlagSource source,
+                       UnboundFlagImpl.FlagFactory<T, F> factory) {
+        this.id = id;
+        this.defaultValue = defaultValue;
+        this.serializer = serializer;
+        this.fetchVector = fetchVector;
+        this.factory = factory;
+        this.source = source;
+    }
+
+    @Override
+    public FlagId id() {
+        return id;
+    }
+
+    @Override
+    public F with(FetchVector.Dimension dimension, String dimensionValue) {
+        return factory.create(id, defaultValue, fetchVector.with(dimension, dimensionValue), serializer, source);
+    }
+
+    @Override
+    public T boxedValue() {
+        return source.fetch(id, fetchVector).map(serializer::deserialize).orElse(defaultValue);
+    }
+
+    @Override
+    public FlagSerializer<T> serializer() {
+        return serializer;
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/IntFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/IntFlag.java
@@ -1,0 +1,18 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class IntFlag extends FlagImpl<Integer, IntFlag> {
+    public IntFlag(FlagId id, int defaultValue, FetchVector vector, FlagSerializer<Integer> serializer, FlagSource source) {
+        super(id, defaultValue, vector, serializer, source, IntFlag::new);
+    }
+
+    public int value() {
+        return boxedValue();
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/JacksonFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/JacksonFlag.java
@@ -1,0 +1,18 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class JacksonFlag<T> extends FlagImpl<T, JacksonFlag<T>> {
+    public JacksonFlag(FlagId id, T defaultValue, FetchVector vector, FlagSerializer<T> serializer, FlagSource source) {
+        super(id, defaultValue, vector, serializer, source, JacksonFlag::new);
+    }
+
+    public T value() {
+        return boxedValue();
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/LongFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/LongFlag.java
@@ -1,0 +1,18 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class LongFlag extends FlagImpl<Long, LongFlag> {
+    public LongFlag(FlagId id, Long defaultValue, FetchVector vector, FlagSerializer<Long> serializer, FlagSource source) {
+        super(id, defaultValue, vector, serializer, source, LongFlag::new);
+    }
+
+    public long value() {
+        return boxedValue();
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/OrderedFlagSource.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/OrderedFlagSource.java
@@ -15,7 +15,6 @@ public class OrderedFlagSource implements FlagSource {
     private final List<FlagSource> sources;
 
     /**
-     *
      * @param sources Flag sources in descending priority order.
      */
     public OrderedFlagSource(FlagSource... sources) {

--- a/flags/src/main/java/com/yahoo/vespa/flags/StringFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/StringFlag.java
@@ -1,0 +1,18 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class StringFlag extends FlagImpl<String, StringFlag> {
+    public StringFlag(FlagId id, String defaultValue, FetchVector vector, FlagSerializer<String> serializer, FlagSource source) {
+        super(id, defaultValue, vector, serializer, source, StringFlag::new);
+    }
+
+    public String value() {
+        return boxedValue();
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundBooleanFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundBooleanFlag.java
@@ -1,0 +1,27 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class UnboundBooleanFlag extends UnboundFlagImpl<Boolean, BooleanFlag, UnboundBooleanFlag> {
+    public UnboundBooleanFlag(FlagId id) {
+        this(id, false);
+    }
+
+    public UnboundBooleanFlag(FlagId id, boolean defaultValue) {
+        this(id, defaultValue, new FetchVector());
+    }
+
+    public UnboundBooleanFlag(FlagId id, boolean defaultValue, FetchVector defaultFetchVector) {
+        super(id, defaultValue, defaultFetchVector,
+                new SimpleFlagSerializer<>(BooleanNode::valueOf, JsonNode::isBoolean, JsonNode::asBoolean),
+                UnboundBooleanFlag::new, BooleanFlag::new);
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundFlag.java
@@ -1,38 +1,27 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author hakonhall
  */
-@Immutable
-public class UnboundFlag<T> {
-    private final FlagId id;
-    private final T defaultValue;
-    private final Deserializer<T> deserializer;
-    private final FetchVector fetchVector;
 
-    public UnboundFlag(String flagId, T defaultValue, Deserializer<T> deserializer) {
-        this(new FlagId(flagId), defaultValue, deserializer, new FetchVector());
-    }
+/**
+ * Interface of an unbound flag.
+ *
+ * @param <T> Type of boxed value, e.g. Integer
+ * @param <F> Type of flag, e.g. IntFlag
+ * @param <U> Type of unbound flag, e.g. UnboundIntFlag
+ */
+public interface UnboundFlag<T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>> {
+    /** The flag ID. */
+    FlagId id();
 
-    public UnboundFlag(FlagId id, T defaultValue, Deserializer<T> deserializer, FetchVector fetchVector) {
-        this.id = id;
-        this.defaultValue = defaultValue;
-        this.deserializer = deserializer;
-        this.fetchVector = fetchVector;
-    }
+    /** Returns the flag serializer. */
+    FlagSerializer<T> serializer();
 
-    public FlagId id() {
-        return id;
-    }
+    /** Returns a clone of the unbound flag, but with the dimension set accordingly. */
+    U with(FetchVector.Dimension dimension, String dimensionValue);
 
-    public UnboundFlag<T> with(FetchVector.Dimension dimension, String value) {
-        return new UnboundFlag<>(id, defaultValue, deserializer, fetchVector.with(dimension, value));
-    }
-
-    public Flag<T> bindTo(FlagSource source) {
-        return new Flag<>(id, defaultValue, deserializer, fetchVector, source);
-    }
+    /** Binds to a flag source, returning a (bound) flag. */
+    F bindTo(FlagSource source);
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundFlagImpl.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundFlagImpl.java
@@ -1,0 +1,58 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+/**
+ * @author hakonhall
+ */
+public abstract class UnboundFlagImpl<T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>>
+        implements UnboundFlag<T, F, U> {
+
+    private final FlagId id;
+    private final T defaultValue;
+    private final FlagSerializer<T> serializer;
+    private final FetchVector defaultFetchVector;
+    private final UnboundFlagFactory<T, F, U> unboundFlagFactory;
+    private final FlagFactory<T, F> flagFactory;
+
+    public interface UnboundFlagFactory<T1, F1 extends Flag<T1, F1>, U1 extends UnboundFlag<T1, F1, U1>> {
+        U1 create(FlagId id, T1 defaultValue, FetchVector fetchVector);
+    }
+
+    public interface FlagFactory<T2, F2 extends Flag<T2, F2>> {
+        F2 create(FlagId id, T2 defaultValue, FetchVector fetchVector, FlagSerializer<T2> serializer, FlagSource source);
+    }
+
+    protected UnboundFlagImpl(FlagId id,
+                              T defaultValue,
+                              FetchVector defaultFetchVector,
+                              FlagSerializer<T> serializer,
+                              UnboundFlagFactory<T, F, U> unboundFlagFactory,
+                              FlagFactory<T, F> flagFactory) {
+        this.id = id;
+        this.defaultValue = defaultValue;
+        this.serializer = serializer;
+        this.defaultFetchVector = defaultFetchVector;
+        this.unboundFlagFactory = unboundFlagFactory;
+        this.flagFactory = flagFactory;
+    }
+
+    @Override
+    public FlagId id() {
+        return id;
+    }
+
+    @Override
+    public U with(FetchVector.Dimension dimension, String dimensionValue) {
+        return unboundFlagFactory.create(id, defaultValue, defaultFetchVector.with(dimension, dimensionValue));
+    }
+
+    @Override
+    public F bindTo(FlagSource source) {
+        return flagFactory.create(id, defaultValue, defaultFetchVector, serializer, source);
+    }
+
+    @Override
+    public FlagSerializer<T> serializer() {
+        return serializer;
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundIntFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundIntFlag.java
@@ -1,0 +1,23 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class UnboundIntFlag extends UnboundFlagImpl<Integer, IntFlag, UnboundIntFlag> {
+    public UnboundIntFlag(FlagId id, int defaultValue) {
+        this(id, defaultValue, new FetchVector());
+    }
+
+    public UnboundIntFlag(FlagId id, int defaultValue, FetchVector defaultFetchVector) {
+        super(id, defaultValue, defaultFetchVector,
+                new SimpleFlagSerializer<>(IntNode::new, JsonNode::isIntegralNumber, JsonNode::asInt),
+                UnboundIntFlag::new, IntFlag::new);
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundJacksonFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundJacksonFlag.java
@@ -1,0 +1,21 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class UnboundJacksonFlag<T> extends UnboundFlagImpl<T, JacksonFlag<T>, UnboundJacksonFlag<T>> {
+    public UnboundJacksonFlag(FlagId id, T defaultValue, Class<T> jacksonClass) {
+        this(id, defaultValue, new FetchVector(), jacksonClass);
+    }
+
+    public UnboundJacksonFlag(FlagId id, T defaultValue, FetchVector defaultFetchVector, Class<T> jacksonClass) {
+        super(id, defaultValue, defaultFetchVector,
+                new JacksonSerializer<>(jacksonClass),
+                (id2, defaultValue2, vector2) -> new UnboundJacksonFlag<>(id2, defaultValue2, vector2, jacksonClass),
+                JacksonFlag::new);
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundLongFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundLongFlag.java
@@ -1,0 +1,23 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class UnboundLongFlag extends UnboundFlagImpl<Long, LongFlag, UnboundLongFlag> {
+    public UnboundLongFlag(FlagId id, long defaultValue) {
+        this(id, defaultValue, new FetchVector());
+    }
+
+    public UnboundLongFlag(FlagId id, Long defaultValue, FetchVector defaultFetchVector) {
+        super(id, defaultValue, defaultFetchVector,
+                new SimpleFlagSerializer<>(LongNode::new, JsonNode::isIntegralNumber, JsonNode::asLong),
+                UnboundLongFlag::new, LongFlag::new);
+    }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundStringFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundStringFlag.java
@@ -1,0 +1,23 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * @author hakonhall
+ */
+@Immutable
+public class UnboundStringFlag extends UnboundFlagImpl<String, StringFlag, UnboundStringFlag> {
+    public UnboundStringFlag(FlagId id, String defaultValue) {
+        this(id, defaultValue, new FetchVector());
+    }
+
+    public UnboundStringFlag(FlagId id, String defaultValue, FetchVector defaultFetchVector) {
+        super(id, defaultValue, defaultFetchVector,
+                new SimpleFlagSerializer<>(TextNode::new, JsonNode::isTextual, JsonNode::asText),
+                UnboundStringFlag::new, StringFlag::new);
+    }
+}

--- a/flags/src/test/java/com/yahoo/vespa/flags/FileFlagSourceTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/FileFlagSourceTest.java
@@ -24,44 +24,44 @@ public class FileFlagSourceTest {
 
     @Test
     public void testFeatureLikeFlags() throws IOException {
-        Flag<Boolean> featureFlag = new Flag<>(id, false, source, Flags.BOOLEAN_SERIALIZER);
-        Flag<Boolean> byDefaultTrue = new Flag<>(id, true, source, Flags.BOOLEAN_SERIALIZER);
+        BooleanFlag booleanFlag = new UnboundBooleanFlag(id).bindTo(source);
+        BooleanFlag byDefaultTrue = new UnboundBooleanFlag(id, true).bindTo(source);
 
-        assertFalse(featureFlag.value());
+        assertFalse(booleanFlag.value());
         assertTrue(byDefaultTrue.value());
 
         writeFlag(id.toString(), "true\n");
 
-        assertTrue(featureFlag.value());
+        assertTrue(booleanFlag.value());
         assertTrue(byDefaultTrue.value());
 
         writeFlag(id.toString(), "false\n");
 
-        assertFalse(featureFlag.value());
+        assertFalse(booleanFlag.value());
         assertFalse(byDefaultTrue.value());
     }
 
     @Test
     public void testIntegerLikeFlags() throws IOException {
-        Flag<Integer> intFlag = new Flag<>(id, -1, source, Flags.INT_SERIALIZER);
-        Flag<Long> longFlag = new Flag<>(id, -2L, source, Flags.LONG_SERIALIZER);
+        IntFlag intFlag = new UnboundIntFlag(id, -1).bindTo(source);
+        LongFlag longFlag = new UnboundLongFlag(id, -2L).bindTo(source);
 
         assertFalse(fetch().isPresent());
         assertFalse(fetch().isPresent());
-        assertEquals(-1, (int) intFlag.value());
-        assertEquals(-2L, (long) longFlag.value());
+        assertEquals(-1, intFlag.value());
+        assertEquals(-2L, longFlag.value());
 
         writeFlag(id.toString(), "1\n");
 
         assertTrue(fetch().isPresent());
         assertTrue(fetch().isPresent());
-        assertEquals(1, (int) intFlag.value());
-        assertEquals(1L, (long) longFlag.value());
+        assertEquals(1, intFlag.value());
+        assertEquals(1L, longFlag.value());
     }
 
     @Test
     public void testStringFlag() throws IOException {
-        Flag<String> stringFlag = new Flag<>(id, "default", source, Flags.STRING_SERIALIZER);
+        StringFlag stringFlag = new UnboundStringFlag(id, "default").bindTo(source);
         assertFalse(fetch().isPresent());
         assertEquals("default", stringFlag.value());
 
@@ -71,11 +71,11 @@ public class FileFlagSourceTest {
 
     @Test
     public void parseFailure() throws IOException {
-        Flag<Boolean> featureFlag = new Flag<>(id, false, source, Flags.BOOLEAN_SERIALIZER);
-        writeFlag(featureFlag.id().toString(), "garbage");
+        BooleanFlag booleanFlag = new UnboundBooleanFlag(id).bindTo(source);
+        writeFlag(booleanFlag.id().toString(), "garbage");
 
         try {
-            featureFlag.value();
+            booleanFlag.value();
         } catch (UncheckedIOException e) {
             assertThat(e.getMessage(), containsString("garbage"));
         }

--- a/flags/src/test/java/com/yahoo/vespa/flags/FlagsTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/FlagsTest.java
@@ -31,7 +31,7 @@ public class FlagsTest {
     public void testBoolean() {
         final boolean defaultValue = false;
         FlagSource source = mock(FlagSource.class);
-        Flag<Boolean> booleanFlag = Flags.defineBoolean("id", defaultValue, "description",
+        BooleanFlag booleanFlag = Flags.defineFeatureFlag("id", defaultValue, "description",
                 "modification effect", FetchVector.Dimension.ZONE_ID, FetchVector.Dimension.HOSTNAME)
                 .with(FetchVector.Dimension.ZONE_ID, "a-zone")
                 .bindTo(source);
@@ -65,19 +65,19 @@ public class FlagsTest {
 
     @Test
     public void testString() {
-        testGeneric(Flags.defineString("string-id", "default value", "description",
+        testGeneric(Flags.defineStringFlag("string-id", "default value", "description",
                 "modification effect", FetchVector.Dimension.ZONE_ID, FetchVector.Dimension.HOSTNAME),
                 "default value", "other value");
     }
 
     @Test
     public void testInt() {
-        testGeneric(Flags.defineInt("int-id", 2, "desc", "mod"), 2, 3);
+        testGeneric(Flags.defineIntFlag("int-id", 2, "desc", "mod"), 2, 3);
     }
 
     @Test
     public void testLong() {
-        testGeneric(Flags.defineLong("long-id", 1L, "desc", "mod"), 1L, 2L);
+        testGeneric(Flags.defineLongFlag("long-id", 1L, "desc", "mod"), 1L, 2L);
     }
 
     @Test
@@ -87,24 +87,23 @@ public class FlagsTest {
         instance.integer = -2;
         instance.string = "foo";
 
-        testGeneric(Flags.defineJackson("jackson-id", ExampleJacksonClass.class, defaultInstance,
+        testGeneric(Flags.defineJacksonFlag("jackson-id", defaultInstance, ExampleJacksonClass.class,
                 "description", "modification effect", FetchVector.Dimension.HOSTNAME),
                 defaultInstance, instance);
     }
 
-    private <T> void testGeneric(UnboundFlag<T> unboundFlag, T defaultValue, T value) {
+    private <T> void testGeneric(UnboundFlag<?, ?, ?> unboundFlag, T defaultValue, T value) {
         FlagSource source = mock(FlagSource.class);
-        Flag<T> flag = unboundFlag.bindTo(source);
+        Flag<?, ?> flag = unboundFlag.bindTo(source);
 
         when(source.fetch(any(), any())).thenReturn(Optional.empty());
-        assertThat(flag.value(), equalTo(defaultValue));
+        assertThat(flag.boxedValue(), equalTo(defaultValue));
 
         when(source.fetch(any(), any())).thenReturn(Optional.of(JsonNodeRawFlag.fromJacksonClass(value)));
-        assertThat(flag.value(), equalTo(value));
+        assertThat(flag.boxedValue(), equalTo(value));
 
         assertTrue(Flags.getFlag(unboundFlag.id()).isPresent());
     }
-
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private static class ExampleJacksonClass {

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
@@ -8,7 +8,7 @@ import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceType;
-import com.yahoo.vespa.flags.Flag;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.service.duper.DuperModelManager;
@@ -50,7 +50,7 @@ public class HealthMonitorManager implements MonitorManager {
     private final ConcurrentHashMap<ApplicationId, ApplicationHealthMonitor> healthMonitors = new ConcurrentHashMap<>();
     private final DuperModelManager duperModel;
     private final ApplicationHealthMonitorFactory applicationHealthMonitorFactory;
-    private final Flag<Boolean> monitorInfra;
+    private final BooleanFlag monitorInfra;
 
     @Inject
     public HealthMonitorManager(DuperModelManager duperModel, FlagSource flagSource) {
@@ -60,13 +60,13 @@ public class HealthMonitorManager implements MonitorManager {
     }
 
     private HealthMonitorManager(DuperModelManager duperModel,
-                                 Flag<Boolean> monitorInfra,
+                                 BooleanFlag monitorInfra,
                                  StateV1HealthModel healthModel) {
         this(duperModel, monitorInfra, id -> new ApplicationHealthMonitor(id, healthModel));
     }
 
     HealthMonitorManager(DuperModelManager duperModel,
-                         Flag<Boolean> monitorInfra,
+                         BooleanFlag monitorInfra,
                          ApplicationHealthMonitorFactory applicationHealthMonitorFactory) {
         this.duperModel = duperModel;
         this.monitorInfra = monitorInfra;

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/HealthMonitorManagerTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/HealthMonitorManagerTest.java
@@ -7,7 +7,7 @@ import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceType;
-import com.yahoo.vespa.flags.Flag;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.service.duper.ConfigServerApplication;
 import com.yahoo.vespa.service.duper.ControllerHostApplication;
 import com.yahoo.vespa.service.duper.DuperModelManager;
@@ -33,8 +33,7 @@ import static org.mockito.Mockito.when;
 public class HealthMonitorManagerTest {
     private final ConfigServerApplication configServerApplication = new ConfigServerApplication();
     private final DuperModelManager duperModel = mock(DuperModelManager.class);
-    @SuppressWarnings("unchecked")
-    private final Flag<Boolean> monitorInfra = (Flag<Boolean>) mock(Flag.class);
+    private final BooleanFlag monitorInfra = mock(BooleanFlag.class);
     private final ApplicationHealthMonitor monitor = mock(ApplicationHealthMonitor.class);
     private final ApplicationHealthMonitorFactory monitorFactory = mock(ApplicationHealthMonitorFactory.class);
     private final HealthMonitorManager manager = new HealthMonitorManager(duperModel, monitorInfra, monitorFactory);


### PR DESCRIPTION
This reintroduces the non-generic flag classes:
 - a value() returns the primitive type for flags wrapping a primitive type
 - easier to use in testing
 - Serializer is moved to internals of typed class

Defines the flag backed by boolean BooleanFlag instead of FeatureFlag since not
all boolean flags are necessarily guarding a feature.