### PR TITLE
Re-enable IPv6 check

### DIFF
--- a/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/verification/spec/SpecVerifier.java
+++ b/node-maintainer/src/main/java/com/yahoo/vespa/hosted/node/verification/spec/SpecVerifier.java
@@ -65,7 +65,7 @@ public class SpecVerifier extends Main.VerifierCommand {
     }
 
     private SpecVerificationReport verifySpec(NodeSpec nodeSpec, CommandExecutor commandExecutor) {
-        VerifierSettings verifierSettings = new VerifierSettings(false);
+        VerifierSettings verifierSettings = new VerifierSettings(true);
         HardwareInfo actualHardware = HardwareInfoRetriever.retrieve(commandExecutor, verifierSettings);
         return makeVerificationReport(actualHardware, nodeSpec, skipLookup, skipReverseLookup);
     }


### PR DESCRIPTION
@andreer, if wanted I can let the NodeFailer ignore IPv6 check failures.