### PR TITLE
Make unit tests work when java dispatching is used by default

### DIFF
--- a/container-search/src/main/java/com/yahoo/fs4/mplex/FS4Channel.java
+++ b/container-search/src/main/java/com/yahoo/fs4/mplex/FS4Channel.java
@@ -199,9 +199,7 @@ public class FS4Channel {
         throws InterruptedException, InvalidChannelException
     {
         ensureValidQ().put(packet);
-        if(monitor != null) {
-            monitor.responseAvailable(this);
-        }
+        notifyMonitor();
     }
 
     /**
@@ -248,5 +246,11 @@ public class FS4Channel {
 
     public void setResponseMonitor(ResponseMonitor<FS4Channel> monitor) {
         this.monitor = monitor;
+    }
+
+    protected void notifyMonitor() {
+        if(monitor != null) {
+            monitor.responseAvailable(this);
+        }
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -36,6 +36,7 @@ import java.util.Set;
  * @author ollvir
  */
 public class Dispatcher extends AbstractComponent {
+    private static final boolean INTERNAL_BY_DEFAULT = false;
     private static final int MAX_GROUP_SELECTION_ATTEMPTS = 3;
 
     /** If enabled, this internal dispatcher will be preferred over fdispatch whenever possible */
@@ -76,7 +77,7 @@ public class Dispatcher extends AbstractComponent {
         if (rpcInvoker.isPresent()) {
             return rpcInvoker;
         }
-        if (result.getQuery().properties().getBoolean(dispatchInternal, false)) {
+        if (result.getQuery().properties().getBoolean(dispatchInternal, INTERNAL_BY_DEFAULT)) {
             Optional<FillInvoker> fs4Invoker = fs4InvokerFactory.getFillInvoker(result);
             if (fs4Invoker.isPresent()) {
                 return fs4Invoker;
@@ -86,7 +87,7 @@ public class Dispatcher extends AbstractComponent {
     }
 
     public Optional<SearchInvoker> getSearchInvoker(Query query, FS4InvokerFactory fs4InvokerFactory) {
-        if (multilevelDispatch || ! query.properties().getBoolean(dispatchInternal, false)) {
+        if (multilevelDispatch || ! query.properties().getBoolean(dispatchInternal, INTERNAL_BY_DEFAULT)) {
             return Optional.empty();
         }
 

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/DirectSearchTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/DirectSearchTestCase.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Tests that FastSearcher will bypass dispatch when the conditions are right
- * 
+ *
  * @author bratseth
  */
 public class DirectSearchTestCase {
@@ -26,7 +26,7 @@ public class DirectSearchTestCase {
     @Test
     public void testDirectSearchDisabled() {
         FastSearcherTester tester = new FastSearcherTester(1, FastSearcherTester.selfHostname + ":9999:0");
-        tester.search("?query=test&dispatch.direct=false");
+        tester.search("?query=test&dispatch.direct=false&dispatch.internal=false");
         assertEquals(0, tester.requestCount(FastSearcherTester.selfHostname, 9999));
     }
 
@@ -40,7 +40,7 @@ public class DirectSearchTestCase {
     @Test
     public void testNoDirectSearchWhenMoreSearchNodesThanContainers() {
         FastSearcherTester tester = new FastSearcherTester(1, FastSearcherTester.selfHostname + ":9999:0", "otherhost:9999:1");
-        tester.search("?query=test&dispatch.direct=true");
+        tester.search("?query=test&dispatch.direct=true&dispatch.internal=false");
         assertEquals(0, tester.requestCount(FastSearcherTester.selfHostname, 9999));
     }
 
@@ -65,7 +65,7 @@ public class DirectSearchTestCase {
     @Test
     public void testNoDirectSearchWhenMultipleNodesPerGroup() {
         FastSearcherTester tester = new FastSearcherTester(2, FastSearcherTester.selfHostname + ":9999:0", "otherhost:9999:0");
-        tester.search("?query=test&dispatch.direct=true");
+        tester.search("?query=test&dispatch.direct=true&dispatch.internal=false");
         assertEquals(0, tester.requestCount(FastSearcherTester.selfHostname, 9999));
     }
 
@@ -123,7 +123,7 @@ public class DirectSearchTestCase {
                      4, tester.requestCount(FastSearcherTester.selfHostname, 9999));
         tester.waitForInRotationIs(false);
     }
-    
+
     @Test
     public void testCoverageWithSingleGroup() {
         FastSearcherTester tester = new FastSearcherTester(1, FastSearcherTester.selfHostname + ":9999:0");

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockBackend.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockBackend.java
@@ -19,7 +19,7 @@ public class MockBackend extends Backend {
     public MockBackend() {
         this("", 0L, true);
     }
-    
+
     public MockBackend(String hostname, long activeDocumentsInBackend, boolean working) {
         super();
         this.hostname = hostname;
@@ -46,4 +46,8 @@ public class MockBackend extends Backend {
 
     public void shutdown() {}
 
+    @Override
+    public boolean probeConnection() {
+        return working;
+    }
 }

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockFSChannel.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/fs4mock/MockFSChannel.java
@@ -27,7 +27,7 @@ public class MockFSChannel extends FS4Channel {
 
     /** The number of active documents this should report in ping reponses */
     private final long activeDocuments;
-    
+
     public MockFSChannel(Backend backend) {
         this(0, backend);
     }
@@ -39,7 +39,7 @@ public class MockFSChannel extends FS4Channel {
 
     private BasicPacket lastReceived = null;
 
-    private QueryPacket lastQueryPacket = null;
+    private static QueryPacket lastQueryPacket = null;
 
     /** Initial value of docstamp */
     private static int docstamp = 1088490666;
@@ -59,6 +59,7 @@ public class MockFSChannel extends FS4Channel {
             lastQueryPacket = (QueryPacket) packet;
 
         lastReceived = packet;
+        notifyMonitor();
         return true;
     }
 
@@ -106,7 +107,7 @@ public class MockFSChannel extends FS4Channel {
                                          1855, 234, 1));
             }
             packets.add(result);
-        } 
+        }
         else if (lastReceived instanceof GetDocSumsPacket) {
             addDocsums(packets, lastQueryPacket);
         }
@@ -121,7 +122,7 @@ public class MockFSChannel extends FS4Channel {
     }
 
     /** Adds the number of docsums requested in queryPacket.getHits() */
-    private void addDocsums(List packets, QueryPacket queryPacket) {
+    private void addDocsums(List<BasicPacket> packets, QueryPacket queryPacket) {
         int numHits = queryPacket.getHits();
 
         if (lastReceived instanceof GetDocSumsPacket) {


### PR DESCRIPTION
DirectSearchTestCase will eventually either be useless or need refactoring, but for now these changes make the unit tests pass when the java dispatcher is enabled at compile time.