### PR TITLE
Export FlagData wire format

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -6,13 +6,13 @@ import com.yahoo.vespa.defaults.Defaults;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeMap;
 
 /**
  * @author hakonhall
  */
 public class Flags {
-    private static volatile ConcurrentHashMap<FlagId, FlagDefinition> flags = new ConcurrentHashMap<>();
+    private static volatile TreeMap<FlagId, FlagDefinition> flags = new TreeMap<>();
 
     public static final UnboundBooleanFlag HEALTHMONITOR_MONITOR_INFRA = defineFeatureFlag(
             "healthmonitor-monitorinfra", true,
@@ -156,22 +156,39 @@ public class Flags {
      * <p>Returns a Replacer instance to be used with e.g. a try-with-resources block. Within the block,
      * the flags starts out as cleared. Flags can be defined, etc. When leaving the block, the flags from
      * before the block is reinserted.
-     * */
+     *
+     * <p>NOT thread-safe. Tests using this cannot run in parallel.
+     */
     public static Replacer clearFlagsForTesting() {
         return new Replacer();
     }
 
     public static class Replacer implements AutoCloseable {
-        private final ConcurrentHashMap<FlagId, FlagDefinition> savedFlags;
+        private static volatile boolean flagsCleared = false;
+
+        private final TreeMap<FlagId, FlagDefinition> savedFlags;
 
         private Replacer() {
+            verifyAndSetFlagsCleared(true);
             this.savedFlags = Flags.flags;
-            Flags.flags = new ConcurrentHashMap<>();
+            Flags.flags = new TreeMap<>();
         }
 
         @Override
         public void close() {
+            verifyAndSetFlagsCleared(false);
             Flags.flags = savedFlags;
+        }
+
+        /**
+         * Used to implement a simple verification that Replacer is not used by multiple threads.
+         * For instance two different tests running in parallel cannot both use Replacer.
+         */
+        private static void verifyAndSetFlagsCleared(boolean newValue) {
+            if (flagsCleared == newValue) {
+                throw new IllegalStateException("clearFlagsForTesting called while already cleared - running tests in parallell!?");
+            }
+            flagsCleared = newValue;
         }
     }
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/FlagData.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/FlagData.java
@@ -74,7 +74,8 @@ public class FlagData {
         return toWire().serializeToJsonNode();
     }
 
-    private WireFlagData toWire() {
+    /** Can be used with Jackson. */
+    public WireFlagData toWire() {
         WireFlagData wireFlagData = new WireFlagData();
 
         wireFlagData.id = id.toString();
@@ -100,7 +101,8 @@ public class FlagData {
         return fromWire(WireFlagData.deserialize(string));
     }
 
-    private static FlagData fromWire(WireFlagData wireFlagData) {
+    /** Can be used with Jackson. */
+    public static FlagData fromWire(WireFlagData wireFlagData) {
         if (wireFlagData.id == null) {
             throw new IllegalArgumentException("Flag ID missing");
         }

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/wire/package-info.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/wire/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.vespa.flags.json.wire;
+
+import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
The FlagData wire format (WireFlagData and friends) is useful with e.g. Jersey
JAX-RS client when Jackson is used as a serializer. Therefore, export it.

Also, add a bit more sanity-checking on using Flags.Replacer during tests.