### PR TITLE
Fix global rotation override

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
@@ -51,6 +51,7 @@ public interface ConfigServer {
      * @param status The new status with metadata
      * @throws IOException If trouble contacting the server
      */
+    // TODO: Remove checked exception from signature
     void setGlobalRotationStatus(DeploymentId deployment, String endpoint, EndpointStatus status) throws IOException;
 
     /**
@@ -61,6 +62,7 @@ public interface ConfigServer {
      * @return The endpoint status with metadata
      * @throws IOException If trouble contacting the server
      */
+    // TODO: Remove checked exception from signature
     EndpointStatus getGlobalRotationStatus(DeploymentId deployment, String endpoint) throws IOException;
 
     /** The node repository on this config server */

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingEndpoint.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingEndpoint.java
@@ -9,25 +9,33 @@ public class RoutingEndpoint {
     private final boolean isGlobal;
     private final String endpoint;
     private final String hostname;
+    private final String upstreamName;
 
-    public RoutingEndpoint(String endpoint, String hostname, boolean isGlobal) {
+    public RoutingEndpoint(String endpoint, String hostname, boolean isGlobal, String upstreamName) {
         this.endpoint = endpoint;
         this.hostname = hostname;
         this.isGlobal = isGlobal;
+        this.upstreamName = upstreamName;
     }
 
-    /** @return True if the endpoint is global */
+    /** Whether this is a global endpoint */
     public boolean isGlobal() {
         return isGlobal;
     }
 
-    /* @return The URI for the endpoint */
-    public String getEndpoint() {
+    /** URL for this endpoint */
+    public String endpoint() {
         return endpoint;
     }
 
-    /** @return The hostname for this endpoint */
-    public String getHostname() {
+    /** First hostname for an upstream behind this endpoint */
+    public String hostname() {
         return hostname;
     }
+
+    /** The upstream name of this endpoint */
+    public String upstreamName() {
+        return upstreamName;
+    }
+
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalDeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalDeploymentTester.java
@@ -107,7 +107,12 @@ public class InternalDeploymentTester {
                                                                                          zone.region().value(),
                                                                                          zone.environment().value()),
                                                                            "host1",
-                                                                           false)));
+                                                                           false,
+                                                                           String.format("cluster1.%s.%s.%s.%s",
+                                                                                         id.application().value(),
+                                                                                         id.tenant().value(),
+                                                                                         zone.region().value(),
+                                                                                         zone.environment().value()))));
     }
 
     /**

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunnerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunnerTest.java
@@ -17,7 +17,6 @@ import com.yahoo.vespa.hosted.controller.api.integration.LogEntry;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.RunId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.TesterCloud;
-import com.yahoo.vespa.hosted.controller.api.integration.organization.Mail;
 import com.yahoo.vespa.hosted.controller.api.integration.stubs.MockMailer;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneId;
 import org.junit.Before;
@@ -32,7 +31,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import static com.yahoo.vespa.hosted.controller.api.integration.LogEntry.Type.debug;
@@ -236,7 +234,7 @@ public class InternalStepRunnerTest {
         RunId id = tester.startSystemTestTests();
         tester.runner().run();
         assertEquals(unfinished, tester.jobs().run(id).get().steps().get(Step.endTests));
-        assertEquals(URI.create(tester.routing().endpoints(new DeploymentId(testerId.id(), JobType.systemTest.zone(tester.tester().controller().system()))).get(0).getEndpoint()),
+        assertEquals(URI.create(tester.routing().endpoints(new DeploymentId(testerId.id(), JobType.systemTest.zone(tester.tester().controller().system()))).get(0).endpoint()),
                      tester.cloud().testerUrl());
         Inspector configObject = SlimeUtils.jsonToSlime(tester.cloud().config()).get();
         assertEquals(appId.serializedForm(), configObject.field("application").asString());
@@ -245,7 +243,7 @@ public class InternalStepRunnerTest {
         assertEquals(1, configObject.field("endpoints").children());
         assertEquals(1, configObject.field("endpoints").field(JobType.systemTest.zone(tester.tester().controller().system()).value()).entries());
         configObject.field("endpoints").field(JobType.systemTest.zone(tester.tester().controller().system()).value()).traverse((ArrayTraverser) (__, endpoint) ->
-                assertEquals(tester.routing().endpoints(new DeploymentId(appId, JobType.systemTest.zone(tester.tester().controller().system()))).get(0).getEndpoint(), endpoint.asString()));
+                assertEquals(tester.routing().endpoints(new DeploymentId(appId, JobType.systemTest.zone(tester.tester().controller().system()))).get(0).endpoint(), endpoint.asString()));
 
         long lastId = tester.jobs().details(id).get().lastId().getAsLong();
         tester.cloud().add(new LogEntry(0, 123, info, "Ready!"));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/RoutingGeneratorMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/RoutingGeneratorMock.java
@@ -19,27 +19,28 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class RoutingGeneratorMock implements RoutingGenerator {
 
-    private final Map<DeploymentId, List<RoutingEndpoint>> allEndpoints = new ConcurrentHashMap<>();
+    private final Map<DeploymentId, List<RoutingEndpoint>> routingTable = new ConcurrentHashMap<>();
+
     private static final List<RoutingEndpoint> defaultEndpoints =
-            Arrays.asList(new RoutingEndpoint("http://old-endpoint.vespa.yahooapis.com:4080", "host1", false),
-                          new RoutingEndpoint("http://qrs-endpoint.vespa.yahooapis.com:4080", "host1", false),
-                          new RoutingEndpoint("http://feeding-endpoint.vespa.yahooapis.com:4080", "host2", false),
-                          new RoutingEndpoint("http://global-endpoint.vespa.yahooapis.com:4080", "host1", true),
-                          new RoutingEndpoint("http://alias-endpoint.vespa.yahooapis.com:4080", "host1", true));
+            Arrays.asList(new RoutingEndpoint("http://old-endpoint.vespa.yahooapis.com:4080", "host1", false, "upstream3"),
+                          new RoutingEndpoint("http://qrs-endpoint.vespa.yahooapis.com:4080", "host1", false, "upstream1"),
+                          new RoutingEndpoint("http://feeding-endpoint.vespa.yahooapis.com:4080", "host2", false, "upstream2"),
+                          new RoutingEndpoint("http://global-endpoint.vespa.yahooapis.com:4080", "host1", true, "upstream1"),
+                          new RoutingEndpoint("http://alias-endpoint.vespa.yahooapis.com:4080", "host1", true, "upstream1"));
 
     @Override
     public List<RoutingEndpoint> endpoints(DeploymentId deployment) {
-        return allEndpoints.isEmpty()
+        return routingTable.isEmpty()
                 ? defaultEndpoints
-                : allEndpoints.getOrDefault(deployment, Collections.emptyList());
+                : routingTable.getOrDefault(deployment, Collections.emptyList());
     }
 
     public void putEndpoints(DeploymentId deployment, List<RoutingEndpoint> endpoints) {
-        allEndpoints.put(deployment, endpoints);
+        routingTable.put(deployment, endpoints);
     }
 
     public void removeEndpoints(DeploymentId deployment) {
-        allEndpoints.remove(deployment);
+        routingTable.remove(deployment);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -556,6 +556,25 @@ public class ApplicationApiTest extends ControllerContainerTest {
                         .submit();
         setZoneInRotation("rotation-fqdn-1", ZoneId.from("prod", "us-west-1"));
 
+        // Invalid application fails
+        tester.assertResponse(request("/application/v4/tenant/tenant2/application/application2/environment/prod/region/us-west-1/instance/default/global-rotation", GET)
+                                      .userIdentity(USER_ID),
+                              "{\"error-code\":\"BAD_REQUEST\",\"message\":\"tenant2.application2 not found\"}",
+                              400);
+
+        // Invalid deployment fails
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-east-3/instance/default/global-rotation", GET)
+                                      .userIdentity(USER_ID),
+                              "{\"error-code\":\"NOT_FOUND\",\"message\":\"application 'tenant1.application1' has no deployment in zone prod.us-east-3 in default\"}",
+                              404);
+
+        // Change status of non-existing deployment fails
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-east-3/instance/default/global-rotation/override", PUT)
+                                      .userIdentity(USER_ID)
+                                      .data("{\"reason\":\"unit-test\"}"),
+                              "{\"error-code\":\"NOT_FOUND\",\"message\":\"application 'tenant1.application1' has no deployment in zone prod.us-east-3 in default\"}",
+                              404);
+
         // GET global rotation status
         setZoneInRotation("rotation-fqdn-1", ZoneId.from("prod", "us-west-1"));
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-west-1/instance/default/global-rotation", GET)
@@ -570,13 +589,13 @@ public class ApplicationApiTest extends ControllerContainerTest {
         // SET global rotation override status
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-west-1/instance/default/global-rotation/override", PUT)
                                       .userIdentity(USER_ID)
-                                      .data("{\"reason\":\"because i can\"}"),
+                                      .data("{\"reason\":\"unit-test\"}"),
                               new File("global-rotation-put.json"));
 
         // DELETE global rotation override status
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-west-1/instance/default/global-rotation/override", DELETE)
                                       .userIdentity(USER_ID)
-                                      .data("{\"reason\":\"because i can\"}"),
+                                      .data("{\"reason\":\"unit-test\"}"),
                               new File("global-rotation-delete.json"));
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-delete.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-delete.json
@@ -1,1 +1,1 @@
-{"message":"Rotations [qrs-endpoint] successfully set to in service"}
+{"message":"Successfully set tenant1.application1 in prod.us-west-1 in service"}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-get.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-get.json
@@ -1,1 +1,1 @@
-{"globalrotationoverride":["qrs-endpoint",{"status":"in","reason":"","agent":"","timestamp":1497618757}]}
+{"globalrotationoverride":["upstream1",{"status":"in","reason":"","agent":"","timestamp":1497618757}]}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-put.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-put.json
@@ -1,1 +1,1 @@
-{"message":"Rotations [qrs-endpoint] successfully set to out of service"}
+{"message":"Successfully set tenant1.application1 in prod.us-west-1 out of service"}


### PR DESCRIPTION
Removes guesswork and sends the correct identifier (upstream name) to the API on the config server.