### PR TITLE
Revert "Compact lid space on source selector."

### DIFF
--- a/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
@@ -140,14 +140,12 @@ struct MyIndexWriter : public test::MockIndexWriter
     MyLidVector _removes;
     int _heartBeatCount;
     uint32_t _commitCount;
-    uint32_t _wantedLidLimit;
     MyTracer &_tracer;
     MyIndexWriter(MyTracer &tracer)
         : test::MockIndexWriter(IIndexManager::SP(new test::MockIndexManager())),
           _removes(),
           _heartBeatCount(0),
           _commitCount(0),
-          _wantedLidLimit(0),
           _tracer(tracer)
     {}
     virtual void put(SerialNum serialNum, const document::Document &doc,
@@ -166,9 +164,6 @@ struct MyIndexWriter : public test::MockIndexWriter
         _tracer.traceCommit(indexAdapterTypeName, serialNum);
     }
     virtual void heartBeat(SerialNum) override { ++_heartBeatCount; }
-    void compactLidSpace(SerialNum, uint32_t lidLimit) override {
-        _wantedLidLimit = lidLimit;
-    }
 };
 
 struct MyGidToLidChangeHandler : public MockGidToLidChangeHandler
@@ -1149,7 +1144,7 @@ TEST_F("require that compactLidSpace() propagates to document meta store and doc
     f.compactLidSpaceAndWait(2);
     // performIndexForceCommit in index thread, then completion callback
     // in master thread.
-    EXPECT_TRUE(assertThreadObserver(7, 5, 3, f.writeServiceObserver()));
+    EXPECT_TRUE(assertThreadObserver(7, 4, 3, f.writeServiceObserver()));
     EXPECT_EQUAL(2u, f.metaStoreObserver()._compactLidSpaceLidLimit);
     EXPECT_EQUAL(2u, f.getDocumentStore()._compactLidSpaceLidLimit);
     EXPECT_EQUAL(1u, f.metaStoreObserver()._holdUnblockShrinkLidSpaceCnt);
@@ -1167,7 +1162,7 @@ TEST_F("require that compactLidSpace() doesn't propagate to "
     op.setSerialNum(0);
     f.runInMaster([&] () { f.fv.handleCompactLidSpace(op); });
     // Delayed holdUnblockShrinkLidSpace() in index thread, then master thread
-    EXPECT_TRUE(assertThreadObserver(6, 4, 3, f.writeServiceObserver()));
+    EXPECT_TRUE(assertThreadObserver(6, 3, 3, f.writeServiceObserver()));
     EXPECT_EQUAL(0u, f.metaStoreObserver()._compactLidSpaceLidLimit);
     EXPECT_EQUAL(0u, f.getDocumentStore()._compactLidSpaceLidLimit);
     EXPECT_EQUAL(0u, f.metaStoreObserver()._holdUnblockShrinkLidSpaceCnt);
@@ -1181,13 +1176,6 @@ TEST_F("require that compactLidSpace() propagates to attributeadapter",
     EXPECT_EQUAL(2u, f.maw._wantedLidLimit);
 }
 
-TEST_F("require that compactLidSpace() propagates to index writer",
-       SearchableFeedViewFixture)
-{
-    f.populateBeforeCompactLidSpace();
-    f.compactLidSpaceAndWait(2);
-    EXPECT_EQUAL(2u, f.miw._wantedLidLimit);
-}
 
 TEST_F("require that commit is called if visibility delay is 0",
        SearchableFeedViewFixture)

--- a/searchcore/src/tests/proton/index/index_writer/index_writer_test.cpp
+++ b/searchcore/src/tests/proton/index/index_writer/index_writer_test.cpp
@@ -33,11 +33,8 @@ struct MyIndexManager : public test::MockIndexManager
     SerialNum current;
     SerialNum flushed;
     SerialNum commitSerial;
-    uint32_t  wantedLidLimit;
-    SerialNum compactSerial;
     MyIndexManager() : puts(), removes(), current(0), flushed(0),
-                       commitSerial(0),
-                       wantedLidLimit(0), compactSerial(0)
+                       commitSerial(0)
     {
     }
     std::string getPut(uint32_t lid) {
@@ -64,10 +61,6 @@ struct MyIndexManager : public test::MockIndexManager
     }
     virtual SerialNum getFlushedSerialNum() const override {
         return flushed;
-    }
-    void compactLidSpace(uint32_t lidLimit, SerialNum serialNum) override {
-        wantedLidLimit = lidLimit;
-        compactSerial = serialNum;
     }
 };
 
@@ -102,7 +95,7 @@ struct Fixture
     }
 };
 
-TEST_F("require that index writer ignores old operations", Fixture)
+TEST_F("require that index adapter ignores old operations", Fixture)
 {
     f.mim.flushed = 10;
     f.put(8, 1);
@@ -115,21 +108,6 @@ TEST_F("require that commit is forwarded to index manager", Fixture)
 {
     f.iw.commit(10, std::shared_ptr<IDestructorCallback>());
     EXPECT_EQUAL(10u, f.mim.commitSerial);
-}
-
-TEST_F("require that compactLidSpace is forwarded to index manager", Fixture)
-{
-    f.iw.compactLidSpace(4, 2);
-    EXPECT_EQUAL(2u, f.mim.wantedLidLimit);
-    EXPECT_EQUAL(4u, f.mim.compactSerial);
-}
-
-TEST_F("require that old compactLidSpace is not forwarded to index manager", Fixture)
-{
-    f.mim.flushed = 10;
-    f.iw.compactLidSpace(4, 2);
-    EXPECT_EQUAL(0u, f.mim.wantedLidLimit);
-    EXPECT_EQUAL(0u, f.mim.compactSerial);
 }
 
 TEST_MAIN()

--- a/searchcore/src/tests/proton/index/indexmanager_test.cpp
+++ b/searchcore/src/tests/proton/index/indexmanager_test.cpp
@@ -145,14 +145,6 @@ struct Fixture {
                           });
         _writeService.indexFieldWriter().sync();
     }
-    void removeDocument(uint32_t docId) {
-        SerialNum serialNum = ++_serial_num;
-        removeDocument(docId, serialNum);
-    }
-    void compactLidSpace(uint32_t lidLimit) {
-        SerialNum serialNum = ++_serial_num;
-        runAsIndex([&]() { _index_manager->compactLidSpace(lidLimit, serialNum); });
-    }
     void assertStats(uint32_t expNumDiskIndexes,
                      uint32_t expNumMemoryIndexes,
                      SerialNum expLastiskIndexSerialNum,
@@ -721,18 +713,6 @@ TEST_F("require that indexes manager stats can be generated", Fixture)
     TEST_DO(f.assertStats(1, 1, 1, 1));
     f.addDocument(2);
     TEST_DO(f.assertStats(1, 1, 1, 2));
-}
-
-TEST_F("require that compactLidSpace works", Fixture)
-{
-    Schema empty_schema;
-    f.addDocument(1);
-    f.addDocument(2);
-    f.removeDocument(2);
-    auto fsc = f._index_manager->getMaintainer().getSourceCollection();
-    EXPECT_EQUAL(3u, fsc->getSourceSelector().getDocIdLimit());
-    f.compactLidSpace(2);
-    EXPECT_EQUAL(2u, fsc->getSourceSelector().getDocIdLimit());
 }
 
 }  // namespace

--- a/searchcore/src/vespa/searchcore/proton/index/i_index_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/index/i_index_writer.h
@@ -27,7 +27,6 @@ public:
     virtual void remove(search::SerialNum serialNum, const search::DocumentIdT lid) = 0;
     virtual void commit(search::SerialNum serialNum, OnWriteDoneType onWriteDone) = 0;
     virtual void heartBeat(search::SerialNum serialNum) = 0;
-    virtual void compactLidSpace(search::SerialNum serialNum, const search::DocumentIdT lid) = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/index/index_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/index/index_writer.cpp
@@ -67,13 +67,4 @@ IndexWriter::heartBeat(search::SerialNum serialNum)
     _mgr->heartBeat(serialNum);
 }
 
-void
-IndexWriter::compactLidSpace(search::SerialNum serialNum, const search::DocumentIdT lid)
-{
-    if (serialNum <= _mgr->getFlushedSerialNum()) {
-        return;
-    }
-    _mgr->compactLidSpace(lid, serialNum);
-}
-
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/index/index_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/index/index_writer.h
@@ -31,7 +31,6 @@ public:
 
     virtual void
     heartBeat(search::SerialNum serialNum) override;
-    void compactLidSpace(search::SerialNum serialNum, const search::DocumentIdT lid) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/index/indexmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/index/indexmanager.cpp
@@ -89,11 +89,5 @@ IndexManager::IndexManager(const vespalib::string &baseDir,
 
 IndexManager::~IndexManager() = default;
 
-void
-IndexManager::compactLidSpace(uint32_t lidLimit, SerialNum serialNum)
-{
-    _maintainer.compactLidSpace(lidLimit, serialNum);
-}
-
 } // namespace proton
 

--- a/searchcore/src/vespa/searchcore/proton/index/indexmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/index/indexmanager.h
@@ -98,7 +98,6 @@ public:
     void heartBeat(SerialNum serialNum) override {
         _maintainer.heartBeat(serialNum);
     }
-    void compactLidSpace(uint32_t lidLimit, SerialNum serialNum) override;
 
     SerialNum getCurrentSerialNum() const override {
         return _maintainer.getCurrentSerialNum();

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
@@ -6,7 +6,6 @@
 #include "removedonecontext.h"
 #include <vespa/searchcore/proton/common/feedtoken.h>
 #include <vespa/searchcore/proton/documentmetastore/ilidreusedelayer.h>
-#include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
 #include <vespa/searchlib/common/isequencedtaskexecutor.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/vespalib/util/closuretask.h>
@@ -202,17 +201,6 @@ SearchableFeedView::performIndexForceCommit(SerialNum serialNum, OnForceCommitDo
 {
     assert(_writeService.index().isCurrentThread());
     _indexWriter->commit(serialNum, onCommitDone);
-}
-
-void
-SearchableFeedView::handleCompactLidSpace(const CompactLidSpaceOperation &op)
-{
-    Parent::handleCompactLidSpace(op);
-    _writeService.index().execute(
-            makeLambdaTask([this, &op]() {
-                               _indexWriter->compactLidSpace(op.getSerialNum(), op.getLidLimit());
-                           }));
-    _writeService.index().sync();
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.h
@@ -76,7 +76,6 @@ public:
 
     ~SearchableFeedView() override;
     const IIndexWriter::SP &getIndexWriter() const { return _indexWriter; }
-    void handleCompactLidSpace(const CompactLidSpaceOperation &op) override;
     void sync() override;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/test/mock_index_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_index_manager.h
@@ -28,7 +28,6 @@ struct MockIndexManager : public searchcorespi::IIndexManager
     }
     virtual void setSchema(const Schema &, SerialNum) override {}
     virtual void heartBeat(SerialNum) override {}
-    void compactLidSpace(uint32_t, SerialNum) override {}
     virtual void setMaxFlushed(uint32_t) override { }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/test/mock_index_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_index_writer.h
@@ -20,7 +20,6 @@ struct MockIndexWriter : public IIndexWriter
     virtual void remove(search::SerialNum, const search::DocumentIdT) override {}
     virtual void commit(search::SerialNum, OnWriteDoneType) override {}
     virtual void heartBeat(search::SerialNum) override {}
-    void compactLidSpace(search::SerialNum, const search::DocumentIdT) override {}
 };
 
 } // namespace test

--- a/searchcorespi/src/tests/plugin/plugin.cpp
+++ b/searchcorespi/src/tests/plugin/plugin.cpp
@@ -20,7 +20,6 @@ public:
     virtual void removeDocument(uint32_t, SerialNum) override { }
     virtual void commit(SerialNum, OnWriteDoneType) override { }
     virtual void heartBeat(SerialNum ) override {}
-    void compactLidSpace(uint32_t, SerialNum) override {}
     virtual SerialNum getCurrentSerialNum() const override { return 0; }
     virtual SerialNum getFlushedSerialNum() const override { return 0; }
     virtual IndexSearchable::SP getSearchable() const override {

--- a/searchcorespi/src/vespa/searchcorespi/index/iindexmanager.h
+++ b/searchcorespi/src/vespa/searchcorespi/index/iindexmanager.h
@@ -108,14 +108,6 @@ public:
     virtual void heartBeat(SerialNum serialNum) = 0;
 
     /**
-     * This method is called when lid space is compacted.
-     *
-     * @param lidLimit  The new lid limit.
-     * @param serialNum The serial number of the lid space compaction operation.
-     */
-    virtual void compactLidSpace(uint32_t lidLimit, SerialNum serialNum) = 0;
-
-    /**
      * Returns the current serial number of the index.
      * This should also reflect any heart beats.
      *

--- a/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.cpp
@@ -1173,16 +1173,6 @@ IndexMaintainer::heartBeat(SerialNum serialNum)
     _current_serial_num = serialNum;
 }
 
-void
-IndexMaintainer::compactLidSpace(uint32_t lidLimit, SerialNum serialNum)
-{
-    assert(_ctx.getThreadingService().index().isCurrentThread());
-    LOG(info, "compactLidSpace(%u, %lu)", lidLimit, serialNum);
-    LockGuard lock(_index_update_lock);
-    _current_serial_num = serialNum;
-    _selector->compactLidSpace(lidLimit);
-}
-
 IFlushTarget::List
 IndexMaintainer::getFlushTargets(void)
 {

--- a/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.h
+++ b/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.h
@@ -357,7 +357,6 @@ public:
     void removeDocument(uint32_t lid, SerialNum serialNum) override;
     void commit(SerialNum serialNum, OnWriteDoneType onWriteDone) override;
     void heartBeat(search::SerialNum serialNum) override;
-    void compactLidSpace(uint32_t lidLimit, SerialNum serialNum) override;
 
     SerialNum getCurrentSerialNum() const override {
         return _current_serial_num;

--- a/searchlib/src/tests/attribute/sourceselector/sourceselector_test.cpp
+++ b/searchlib/src/tests/attribute/sourceselector/sourceselector_test.cpp
@@ -41,7 +41,7 @@ private:
     void requireThatSelectorCanCloneAndSubtract();
     void requireThatSelectorCanCloneAndSubtract();
     template <typename SelectorType>
-    void requireThatSelectorCanSaveAndLoad(bool compactLidSpace);
+    void requireThatSelectorCanSaveAndLoad();
     void requireThatSelectorCanSaveAndLoad();
     template <typename SelectorType>
     void requireThatCompleteSourceRangeIsHandled();
@@ -49,7 +49,6 @@ private:
     template <typename SelectorType>
     void requireThatSourcesAreCountedCorrectly();
     void requireThatSourcesAreCountedCorrectly();
-    void requireThatDocIdLimitIsCorrect();
 };
 
 int
@@ -65,7 +64,6 @@ Test::Main()
     TEST_DO(requireThatSelectorCanSaveAndLoad());
     TEST_DO(requireThatCompleteSourceRangeIsHandled());
     TEST_DO(requireThatSourcesAreCountedCorrectly());
-    TEST_DO(requireThatDocIdLimitIsCorrect());
 
     TEST_DONE();
 }
@@ -142,15 +140,12 @@ Test::requireThatSelectorCanCloneAndSubtract()
 
 template <typename SelectorType>
 void
-Test::requireThatSelectorCanSaveAndLoad(bool compactLidSpace)
+Test::requireThatSelectorCanSaveAndLoad()
 {
     SelectorType selector(default_source, base_file_name2);
     setSources(selector);
     selector.setBaseId(base_id);
     selector.setSource(maxDocId + 1, default_source);
-    if (compactLidSpace) {
-        selector.compactLidSpace(maxDocId - 4);
-    }
 
     FastOS_FileInterface::EmptyAndRemoveDirectory(index_dir.c_str());
     FastOS_FileInterface::MakeDirIfNotPresentOrExit(index_dir.c_str());
@@ -160,13 +155,9 @@ Test::requireThatSelectorCanSaveAndLoad(bool compactLidSpace)
     save_info->save(TuneFileAttributes(), DummyFileHeaderContext());
     typename SelectorType::UP
         selector2(SelectorType::load(base_file_name));
-    testSourceSelector(docs, arraysize(docs) - compactLidSpace, default_source, *selector2);
+    testSourceSelector(docs, arraysize(docs), default_source, *selector2);
     EXPECT_EQUAL(base_id, selector2->getBaseId());
-    if (compactLidSpace) {
-        EXPECT_EQUAL(maxDocId - 4, selector2->getDocIdLimit());
-    } else {
-        EXPECT_EQUAL(maxDocId + 2, selector2->getDocIdLimit());
-    }
+    EXPECT_EQUAL(maxDocId + 2, selector2->getDocIdLimit());
 
     FastOS_FileInterface::EmptyAndRemoveDirectory(index_dir.c_str());
 }
@@ -174,8 +165,7 @@ Test::requireThatSelectorCanSaveAndLoad(bool compactLidSpace)
 void
 Test::requireThatSelectorCanSaveAndLoad()
 {
-    requireThatSelectorCanSaveAndLoad<FixedSourceSelector>(false);
-    requireThatSelectorCanSaveAndLoad<FixedSourceSelector>(true);
+    requireThatSelectorCanSaveAndLoad<FixedSourceSelector>();
 }
 
 template <typename SelectorType>
@@ -219,21 +209,6 @@ void
 Test::requireThatSourcesAreCountedCorrectly()
 {
     requireThatSourcesAreCountedCorrectly<FixedSourceSelector>();
-}
-
-void
-Test::requireThatDocIdLimitIsCorrect()
-{
-    FixedSourceSelector selector(default_source, base_file_name);
-    EXPECT_EQUAL(0u, selector.getDocIdLimit());
-    selector.setSource(8, 10);
-    EXPECT_EQUAL(9u, selector.getDocIdLimit());
-    selector.compactLidSpace(4);
-    EXPECT_EQUAL(4u, selector.getDocIdLimit());
-    selector.setSource(6, 10);
-    EXPECT_EQUAL(7u, selector.getDocIdLimit());
-    auto selector2 = selector.cloneAndSubtract(base_file_name2, 3);
-    EXPECT_EQUAL(7u, selector2->getDocIdLimit());
 }
 
 }  // namespace

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -256,6 +256,12 @@ protected:
     EnumModifier getEnumModifier();
     ValueModifier getValueModifier() { return ValueModifier(*this); }
 
+    void updateUncommittedDocIdLimit(DocId doc) {
+        if (_uncommittedDocIdLimit <= doc)  {
+            _uncommittedDocIdLimit = doc + 1;
+        }
+    }
+
     void updateCommittedDocIdLimit() {
         if (_uncommittedDocIdLimit != 0) {
             if (_uncommittedDocIdLimit > _committedDocIdLimit) {
@@ -406,11 +412,6 @@ public:
     uint32_t & getCommittedDocIdLimitRef() { return _committedDocIdLimit; }
     void setCommittedDocIdLimit(uint32_t committedDocIdLimit) {
         _committedDocIdLimit = committedDocIdLimit;
-    }
-    void updateUncommittedDocIdLimit(DocId doc) {
-        if (_uncommittedDocIdLimit <= doc)  {
-            _uncommittedDocIdLimit = doc + 1;
-        }
     }
 
     const Status & getStatus() const { return _status; }

--- a/searchlib/src/vespa/searchlib/attribute/fixedsourceselector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/fixedsourceselector.cpp
@@ -45,7 +45,6 @@ FixedSourceSelector::cloneAndSubtract(const vespalib::string & attrBaseFileName,
     }
     selector->_source.commit();
     selector->setBaseId(getBaseId() + diff);
-    selector->_source.setCommittedDocIdLimit(_source.getCommittedDocIdLimit());
     return selector;
 }
 
@@ -86,14 +85,7 @@ FixedSourceSelector::setSource(uint32_t docId, queryeval::Source source)
      **/
     reserve(docId+1);
     _source.update(docId, source);
-    _source.updateUncommittedDocIdLimit(docId + 1);
     _source.commit();
-}
-
-void
-FixedSourceSelector::compactLidSpace(uint32_t lidLimit)
-{
-    _source.compactLidSpace(lidLimit + 1);
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/fixedsourceselector.h
+++ b/searchlib/src/vespa/searchlib/attribute/fixedsourceselector.h
@@ -38,9 +38,8 @@ public:
     // Inherit doc from ISourceSelector
     void setSource(uint32_t docId, queryeval::Source source) final override;
     uint32_t getDocIdLimit() const final override {
-        return _source.getCommittedDocIdLimit() - 1;
+        return _source.getNumDocs() - 1;
     }
-    void compactLidSpace(uint32_t lidLimit) override;
     std::unique_ptr<IIterator> createIterator() const final override {
         return std::make_unique<Iterator>(*this);
     }

--- a/searchlib/src/vespa/searchlib/queryeval/isourceselector.h
+++ b/searchlib/src/vespa/searchlib/queryeval/isourceselector.h
@@ -73,13 +73,6 @@ public:
     virtual uint32_t getDocIdLimit() const = 0;
 
     /**
-     * Sets the lid limit in this selector.
-     *
-     * @param lidLimit the new lid limit (one above highest valid doc id).
-     */
-    virtual void compactLidSpace(uint32_t lidLimit) = 0;
-
-    /**
      * Create a new iterator over the data held by this source
      * selector.
      *


### PR DESCRIPTION
Reverts vespa-engine/vespa#8017

Seems to have broken LidSpaceCompactionPerfTest