### PR TITLE
Revert "Enable java dispatcher as default for build pipeline test"

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * @author ollvir
  */
 public class Dispatcher extends AbstractComponent {
-    private static final boolean INTERNAL_BY_DEFAULT = true;
+    private static final boolean INTERNAL_BY_DEFAULT = false;
     private static final int MAX_GROUP_SELECTION_ATTEMPTS = 3;
 
     /** If enabled, this internal dispatcher will be preferred over fdispatch whenever possible */


### PR DESCRIPTION
Reverts vespa-engine/vespa#8048

Revert once we have a system and performance test on Vespa >= 6.328.23