### PR TITLE
Since there is no dependency between the monitorer and the monitored,…

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/monitoring/Metrics.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/monitoring/Metrics.java
@@ -48,8 +48,8 @@ public class Metrics extends TimerTask implements MetricUpdaterFactory {
 
         log.log(LogLevel.DEBUG, "Metric update interval is " + healthMonitorConfig.snapshot_interval() + " seconds");
         long intervalMs = (long) (healthMonitorConfig.snapshot_interval() * 1000);
-        timer.scheduleAtFixedRate(this, 5000, intervalMs);
-        zkMetricUpdater = new ZKMetricUpdater(zkServerConfig, 4500, intervalMs);
+        timer.scheduleAtFixedRate(this, 20000, intervalMs);
+        zkMetricUpdater = new ZKMetricUpdater(zkServerConfig, 19500, intervalMs);
     }
 
     public static Metrics createTestMetrics() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/monitoring/ZKMetricUpdater.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/monitoring/ZKMetricUpdater.java
@@ -43,10 +43,10 @@ public class ZKMetricUpdater extends TimerTask {
     private final Timer timer = new Timer();
     private final int zkPort;
 
-    public ZKMetricUpdater(ZookeeperServerConfig zkServerConfig, long delay, long interval) {
+    public ZKMetricUpdater(ZookeeperServerConfig zkServerConfig, long delayMS, long intervalMS) {
         this.zkPort = zkServerConfig.clientPort();
-        if (interval > 0) {
-            timer.scheduleAtFixedRate(this, delay, interval);
+        if (intervalMS > 0) {
+            timer.scheduleAtFixedRate(this, delayMS, intervalMS);
         }
     }
 


### PR DESCRIPTION
… let us give it some more time to avoid

noise in the log and system tests.
@ollivir 