### PR TITLE
DuperModel config server app from InfrastructureProvisioner not ConfigserverConfig

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -23,7 +23,7 @@ public class Flags {
             HOSTNAME);
 
     public static final UnboundBooleanFlag DUPERMODEL_CONTAINS_INFRA = defineFeatureFlag(
-            "dupermodel-contains-infra", true,
+            "dupermodel-contains-infra", false,
             "Whether the DuperModel in config server/controller includes active infrastructure applications " +
                     "(except from controller/config apps).",
             "Requires restart of config server/controller to take effect.",


### PR DESCRIPTION
The new value "false" has already rolled out via file flags to controllers,
which had to be done intra-rollout since the name changed.

The config server rollout should be seemless as the name and set of config
servers are identical (post BM -> DH cfg migration).