### PR TITLE
Avoid periodic removal

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
@@ -108,9 +108,12 @@ public class InfrastructureProvisioner extends Maintainer {
     }
 
     private void removeApplication(ApplicationId applicationId) {
-        NestedTransaction nestedTransaction = new NestedTransaction();
-        provisioner.remove(nestedTransaction, applicationId);
-        nestedTransaction.commit();
-        duperModel.infraApplicationRemoved(applicationId);
+        // Use the DuperModel as source-of-truth on whether it has also been activated (to avoid periodic removals)
+        if (duperModel.infraApplicationIsActive(applicationId)) {
+            NestedTransaction nestedTransaction = new NestedTransaction();
+            provisioner.remove(nestedTransaction, applicationId);
+            nestedTransaction.commit();
+            duperModel.infraApplicationRemoved(applicationId);
+        }
     }
 }


### PR DESCRIPTION
The controller log contains errors about refusing to handle the config server
application since the controller application is active.

The message is misleading: Only the controller application will be activated,
while the config server application will be tried removed, and the message
comes as part of this removal.

This PR adds a check that actual removal from duper model and provisioner will
only be done if it is active in the duper model.

There are edge cases that the application may be active in the provisioner
while not in duper model, but it's fixed on a restart.