### PR TITLE
improve path/query handling

### DIFF
--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
@@ -118,20 +118,8 @@ StatusWebServer::WebServer::get(vespalib::Portal::GetRequest request)
 void
 StatusWebServer::WebServer::handle_get(vespalib::Portal::GetRequest request)
 {
-    const vespalib::string &tmpurl = request.get_uri();
-    Fast_URL urlCodec;
-    int bufLength = tmpurl.length() * 2 + 10;
-    char * encodedUrl = new char[bufLength];
-    strcpy(encodedUrl, tmpurl.c_str());
-    char decodedUrl[bufLength];
-    urlCodec.DecodeQueryString(encodedUrl);
-    urlCodec.decode(encodedUrl, decodedUrl, bufLength);
-    delete [] encodedUrl;
-
-    vespalib::string url = decodedUrl;
-
-    LOG(debug, "Status got get request '%s'", url.c_str());
-    framework::HttpUrlPath urlpath(url.c_str(), request.get_host());
+    LOG(debug, "Status got get request '%s'", request.get_uri().c_str());
+    framework::HttpUrlPath urlpath(request.get_path(), request.export_params(), request.get_host());
     _status.handlePage(urlpath, std::move(request));
 }
 

--- a/storageframework/src/vespa/storageframework/generic/status/httpurlpath.cpp
+++ b/storageframework/src/vespa/storageframework/generic/status/httpurlpath.cpp
@@ -6,35 +6,42 @@
 namespace storage::framework {
 
 HttpUrlPath::HttpUrlPath(const vespalib::string& urlpath)
-    : _urlPath(urlpath),
-      _path(),
+    : _path(),
       _attributes(),
       _serverSpec()
 {
-    init();
+    init(urlpath);
 }
 
 HttpUrlPath::HttpUrlPath(const vespalib::string& urlpath,
                          const vespalib::string& serverSpec)
-    : _urlPath(urlpath),
-      _path(),
+    : _path(),
       _attributes(),
       _serverSpec(serverSpec)
 {
-    init();
+    init(urlpath);
+}
+
+HttpUrlPath::HttpUrlPath(vespalib::string path,
+                         std::map<vespalib::string, vespalib::string> attributes,
+                         vespalib::string serverSpec)
+    : _path(std::move(path)),
+      _attributes(std::move(attributes)),
+      _serverSpec(std::move(serverSpec))
+{
 }
 
 HttpUrlPath::~HttpUrlPath() {}
 
 void
-HttpUrlPath::init()
+HttpUrlPath::init(const vespalib::string &urlpath)
 {
-    vespalib::string::size_type pos = _urlPath.find('?');
+    vespalib::string::size_type pos = urlpath.find('?');
     if (pos == vespalib::string::npos) {
-        _path = _urlPath;
+        _path = urlpath;
     } else {
-        _path = _urlPath.substr(0, pos);
-        vespalib::string sub(_urlPath.substr(pos+1));
+        _path = urlpath.substr(0, pos);
+        vespalib::string sub(urlpath.substr(pos+1));
         vespalib::StringTokenizer tokenizer(sub, "&", "");
         for (uint32_t i=0, n=tokenizer.size(); i<n; ++i) {
             const vespalib::string& s(tokenizer[i]);
@@ -54,7 +61,7 @@ HttpUrlPath::hasAttribute(const vespalib::string& id) const
     return (_attributes.find(id) != _attributes.end());
 }
 
-const vespalib::string&
+vespalib::string
 HttpUrlPath::getAttribute(const vespalib::string& id,
                           const vespalib::string& defaultValue) const
 {
@@ -66,7 +73,21 @@ HttpUrlPath::getAttribute(const vespalib::string& id,
 void
 HttpUrlPath::print(std::ostream& out, bool, const std::string&) const
 {
-    out << _urlPath;
+    out << _path;
+    if (!_attributes.empty()) {
+        out << "?";
+        size_t cnt = 0;
+        for (const auto attr: _attributes) {
+            if (cnt++ > 0) {
+                out << "&";
+            }
+            out << attr.first;
+            if (!attr.second.empty()) {
+                out << "=";
+                out << attr.second;
+            }
+        }
+    }
 }
 
 }

--- a/storageframework/src/vespa/storageframework/generic/status/httpurlpath.h
+++ b/storageframework/src/vespa/storageframework/generic/status/httpurlpath.h
@@ -14,16 +14,18 @@
 namespace storage::framework {
 
 class HttpUrlPath : public vespalib::Printable {
-    vespalib::string _urlPath;
     vespalib::string _path;
     std::map<vespalib::string, vespalib::string> _attributes;
     vespalib::string _serverSpec; // "host:port"
 
-    void init();
+    void init(const vespalib::string &urlpath);
 
 public:
     HttpUrlPath(const vespalib::string& urlpath);
     HttpUrlPath(const vespalib::string& urlpath, const vespalib::string& serverSpec);
+    HttpUrlPath(vespalib::string path,
+                std::map<vespalib::string, vespalib::string> attributes,
+                vespalib::string serverSpec);
     ~HttpUrlPath();
 
     const vespalib::string& getPath() const { return _path; }
@@ -31,8 +33,8 @@ public:
             { return _attributes; }
 
     bool hasAttribute(const vespalib::string& id) const;
-    const vespalib::string& getAttribute(const vespalib::string& id,
-                                         const vespalib::string& defaultValue = "") const;
+    vespalib::string getAttribute(const vespalib::string& id,
+                                  const vespalib::string& defaultValue = "") const;
 
     const vespalib::string& getServerSpec() const {
         return _serverSpec;


### PR DESCRIPTION
- return attributes by value to avoid referencing deconstructed objects.
- use path/query form portal request to avoid dequoting issues
- log raw uri instead of dequoted non-parsed uri

@vekterli please review