### PR TITLE
Reset container CPU cap fixes

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
@@ -48,7 +48,7 @@ public class ContainerResources {
     }
 
     public int cpuQuota() {
-        return (int) cpus * CPU_PERIOD;
+        return (int) (cpus * CPU_PERIOD);
     }
 
     public int cpuPeriod() {

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
@@ -47,8 +47,10 @@ public class ContainerResources {
         return cpus;
     }
 
+    // Although docker allows to update cpu quota to 0, this is not a legal value, must be set -1 for unlimited
+    // See: https://github.com/docker/for-linux/issues/558
     public int cpuQuota() {
-        return (int) (cpus * CPU_PERIOD);
+        return cpus > 0 ? (int) (cpus * CPU_PERIOD) : -1;
     }
 
     public int cpuPeriod() {

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -246,8 +246,8 @@ public class DockerImpl implements Docker {
                     // --cpus requires API 1.25+ on create and 1.29+ on update
                     // NanoCPUs is supported in docker-java as of 3.1.0 on create and not at all on update
                     // TODO: Simplify this to .withNanoCPUs(resources.cpu()) when docker-java supports it
-                    .withCpuPeriod(resources.cpuQuota() > 0 ? resources.cpuPeriod() : null)
-                    .withCpuQuota(resources.cpuQuota() > 0 ? resources.cpuQuota() : null);
+                    .withCpuPeriod(resources.cpuPeriod())
+                    .withCpuQuota(resources.cpuQuota());
 
             updateContainerCmd.exec();
         } catch (NotFoundException e) {

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -288,7 +288,12 @@ public class DockerImpl implements Docker {
     }
 
     private static ContainerResources containerResourcesFromHostConfig(HostConfig hostConfig) {
-        final double cpus = hostConfig.getCpuPeriod() > 0 ?
+        // Docker keeps an internal state of what the period and quota are: in cgroups, the quota is always set
+        // (default is 100000), but docker will report it as 0 unless explicitly set by the user.
+        // This may lead to a state where the quota is set, but period is 0 (accord to docker), which will
+        // mess up the calculation below. This can only happen if someone sets it manually, since this class
+        // will always set both quota and period.
+        final double cpus = hostConfig.getCpuQuota() > 0 ?
                 (double) hostConfig.getCpuQuota() / hostConfig.getCpuPeriod() : 0;
         return new ContainerResources(cpus, hostConfig.getCpuShares(), hostConfig.getMemory());
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -53,7 +53,8 @@ public class Flags {
 
     public static final UnboundDoubleFlag CONTAINER_CPU_CAP = defineDoubleFlag(
             "container-cpu-cap", 0,
-            "Hard limit on how many CPUs a container may use",
+            "Hard limit on how many CPUs a container may use. This value is multiplied by CPU allocated to node, so " +
+            "to cap CPU at 200%, set this to 2, etc.",
             "Takes effect on next node agent tick. Change is orchestrated, but does NOT require container restart",
             HOSTNAME, APPLICATION_ID);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -362,7 +362,7 @@ public class NodeAgentImpl implements NodeAgent {
                 .map(NodeSpec.Owner::asApplicationId)
                 .map(appId -> containerCpuCap.with(FetchVector.Dimension.APPLICATION_ID, appId.serializedForm()))
                 .orElse(containerCpuCap)
-                .value();
+                .value() * context.node().getMinCpuCores();
 
         ContainerResources wantedContainerResources = ContainerResources.from(
                 cpuCap, context.node().getMinCpuCores(), context.node().getMinMainMemoryAvailableGb());

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -278,7 +278,7 @@ public class NodeAgentImplTest {
         flagSource.withDoubleFlag(Flags.CONTAINER_CPU_CAP.id(), 2.3);
 
         nodeAgent.converge(thirdContext);
-        inOrder.verify(dockerOperations).updateContainer(eq(thirdContext), eq(ContainerResources.from(2.3, 4, 16)));
+        inOrder.verify(dockerOperations).updateContainer(eq(thirdContext), eq(ContainerResources.from(9.2, 4, 16)));
         inOrder.verify(orchestrator).resume(any(String.class));
     }
 


### PR DESCRIPTION
I created a ticket to docker (https://github.com/docker/for-linux/issues/558) and did some more experimentation. Summary:
* Docker accepts 0 for `CpuPeriod` and `CpuQuota` even though those values are not valid for cgroup config. Either daemon ignores those values, or tries to write to cgroups files, but fails.
* The cgroup files default for quota (unlimited) is `-1`. This is possible to set through docker and works as expected. Only issue is that the return from docker API can be somewhat inconsitent:
    - If `CpuPeriod` and/or `CpuQuota` has never been set, docker will report both as `0`.
    - If `CpuQuota` is set, it will report that value, but `CpuPeriod` will still report `0`! Even though the value in the cgroups file is always 100000.
    - If `CpuQuota` is set to `-1` (the default/unlimited), docker will also report `-1`, even though it is equivalent to the `0` value it reported initially.

This PR adds special handling around that, and changes the meaning of feature flag to be multiple of the allocated CPUs, rather than actual CPUs. Otherwise it is not useful to use feature flag on application level: There may nodes of different flavors within an application, setting 1 CPU limit for them all is not very useful.