### PR TITLE
Do not take refs to temporaries that immediately go out of scope

### DIFF
--- a/vdslib/src/vespa/vdslib/state/clusterstate.cpp
+++ b/vdslib/src/vespa/vdslib/state/clusterstate.cpp
@@ -74,7 +74,7 @@ ClusterState::ClusterState(const vespalib::string& serialized)
         if (index == vespalib::string::npos) {
             throw IllegalArgumentException("Token " + *it + " does not contain ':': " + serialized, VESPA_STRLOC);
         }
-        vespalib::stringref key = it->substr(0, index);
+        vespalib::string key = it->substr(0, index);
         vespalib::stringref value = it->substr(index + 1);
         if (key.size() > 0 && key[0] == '.') {
             if (lastAbsolutePath == "") {


### PR DESCRIPTION
@baldersheim please review

The `key = lastAbsolutePath + key` code path is not well defined when `key` is of ref type, as the ref will end up pointing to a temporary constructed string.