### PR TITLE
use-local-node support and fix to coverage estimation

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -422,6 +422,7 @@ public class IndexedSearchCluster extends SearchCluster
         }
         builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());
         builder.useMultilevelDispatch(useMultilevelDispatchSetup());
+        builder.useLocalNode(tuning.dispatch.useLocalNode);
         builder.searchableCopies(rootDispatch.getSearchableCopies());
         if (searchCoverage != null) {
             if (searchCoverage.getMinimum() != null)

--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -1,4 +1,4 @@
-# Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 # Configuration of dispatch from container nodes to search clusters
 
 namespace=vespa.config.search
@@ -18,6 +18,9 @@ distributionPolicy enum { ROUNDROBIN, ADAPTIVE } default=ROUNDROBIN
 
 # Is multi-level dispatch configured for this cluster
 useMultilevelDispatch bool default=false
+
+# Dispatch only to local nodes
+useLocalNode bool default=false
 
 # Number of document copies
 searchableCopies long default=1

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -135,7 +135,9 @@ public class Dispatcher extends AbstractComponent {
             return invokerFactory.supply(query, -1, Arrays.asList(node), true);
         }
 
-        int max = Integer.min(searchCluster.orderedGroups().size(), MAX_GROUP_SELECTION_ATTEMPTS);
+        int covered = searchCluster.groupsWithSufficientCoverage();
+        int groups = searchCluster.orderedGroups().size();
+        int max = Integer.min(Integer.min(covered + 1, groups), MAX_GROUP_SELECTION_ATTEMPTS);
         Set<Integer> rejected = null;
         for (int i = 0; i < max; i++) {
             Optional<Group> groupInCluster = loadBalancer.takeGroup(rejected);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/LoadBalancer.java
@@ -35,7 +35,7 @@ public class LoadBalancer {
         for (Group group : searchCluster.orderedGroups()) {
             scoreboard.add(new GroupStatus(group));
         }
-        if (roundRobin) {
+        if (roundRobin || scoreboard.size() == 1) {
             this.scheduler = new RoundRobinScheduler(scoreboard);
         } else {
             this.scheduler = new AdaptiveScheduler(new Random(), scoreboard);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -44,6 +44,16 @@ public class Group {
         hasSufficientCoverage.lazySet(sufficientCoverage);
     }
 
+    public int workingNodes() {
+        int nodesUp = 0;
+        for (Node node : nodes) {
+            if (node.isWorking()) {
+                nodesUp++;
+            }
+        }
+        return nodesUp;
+    }
+
     void aggregateActiveDocuments() {
         long activeDocumentsInGroup = 0;
         for (Node node : nodes) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
@@ -75,6 +75,11 @@ public class MockSearchCluster extends SearchCluster {
     }
 
     @Override
+    public int groupsWithSufficientCoverage() {
+        return numGroups;
+    }
+
+    @Override
     public Optional<Group> group(int n) {
         if (n < numGroups) {
             return Optional.of(groups.get(n));


### PR DESCRIPTION
The implementation here disregards all other nodes in case `tuning/dispatch/use-local-node` is used, which are then also not pinged. That change will take effect regardless of whether the java dispatcher is used or not.

Testing this feature revealed a deficiency in the implementation of `isPartialGroupCoverageSufficient` which is also fixed. Specifically, a group with no coverage at all was considered to have full coverage in some code paths.