### PR TITLE
Disable memory swap

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
@@ -162,6 +162,7 @@ class CreateContainerCommandImpl implements Docker.CreateContainerCommand {
         containerResources.ifPresent(cr -> hostConfig
                 .withCpuShares(cr.cpuShares())
                 .withMemory(cr.memoryBytes())
+                .withMemorySwap(cr.memoryBytes())
                 .withCpuPeriod(cr.cpuQuota() > 0 ? cr.cpuPeriod() : null)
                 .withCpuQuota(cr.cpuQuota() > 0 ? cr.cpuQuota() : null));
 

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/DockerImpl.java
@@ -238,6 +238,7 @@ public class DockerImpl implements Docker {
             UpdateContainerCmd updateContainerCmd = dockerClient.updateContainerCmd(containerName.asString())
                     .withCpuShares(resources.cpuShares())
                     .withMemory(resources.memoryBytes())
+                    .withMemorySwap(resources.memoryBytes())
 
                     // Command line argument `--cpus c` is sent over to docker daemon as "NanoCPUs", which is the
                     // value of `c * 1e9`. This however, is just a shorthand for `--cpu-period p` and `--cpu-quota q`


### PR DESCRIPTION
This sets `MemorySwap` (memory + swap) to the same as `Memory`, which means the container is not allowed to use any swap. See https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details

By default, `MemorySwap` is set to 2x `Memory`. If we resize a container by more than 2x, the command will fail as we will be attempting to set `Memory` > `MemorySwap`.

We can either disable swap entirely, or we could continue updating `MemorySwap` to 2x (or some other constant) `Memory`.