### PR TITLE
Set source to default source from committed docid limit to new guard

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/fixedsourceselector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/fixedsourceselector.cpp
@@ -70,9 +70,9 @@ void FixedSourceSelector::reserve(uint32_t numDocs)
     if (newMaxDocIdPlussOne > maxDoc) {
         uint32_t newDocId(0);
         for (_source.addDoc(newDocId); newDocId < numDocs; _source.addDoc(newDocId));
-        for (uint32_t i = maxDoc; i < newMaxDocIdPlussOne; ++i) {
-            _source.set(i, getDefaultSource());
-        }
+    }
+    for (uint32_t i = _source.getCommittedDocIdLimit(); i < newMaxDocIdPlussOne; ++i) {
+        _source.set(i, getDefaultSource());
     }
 }
 


### PR DESCRIPTION
when reserving space for source mapping.  This reinitializes data
that was set to "undefined" value (-128) in the backing int8_t single
value attribute when compacting lid space.

@baldersheim: please review
