### PR TITLE
Restart container on memory change

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
@@ -65,14 +65,23 @@ public class ContainerResources {
         return memoryBytes;
     }
 
+
+    /** Returns true iff the memory component(s) of between <code>this</code> and <code>other</code> are equal */
+    public boolean equalsMemory(ContainerResources other) {
+        return memoryBytes == other.memoryBytes;
+    }
+
+    /** Returns true iff the CPU component(s) of between <code>this</code> and <code>other</code> are equal */
+    public boolean equalsCpu(ContainerResources other) {
+        return Math.abs(other.cpus - cpus) < 0.0001 && cpuShares == other.cpuShares;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ContainerResources that = (ContainerResources) o;
-        return Math.abs(that.cpus - cpus) < 0.0001 &&
-                cpuShares == that.cpuShares &&
-                memoryBytes == that.memoryBytes;
+        return equalsMemory(that) && equalsCpu(that);
     }
 
     @Override
@@ -80,10 +89,20 @@ public class ContainerResources {
         return Objects.hash(cpus, cpuShares, memoryBytes);
     }
 
+
+    /** Returns only the memory component(s) of {@link #toString()} */
+    public String toStringMemory() {
+        return (memoryBytes > 0 ? memoryBytes + "B" : "unlimited") + " memory";
+    }
+
+    /** Returns only the CPU component(s) of {@link #toString()} */
+    public String toStringCpu() {
+        return (cpus > 0 ? cpus : "unlimited") +" CPUs, " +
+                (cpuShares > 0 ? cpuShares : "unlimited") + " CPU Shares";
+    }
+
     @Override
     public String toString() {
-        return (cpus > 0 ? cpus : "unlimited") +" CPUs, " +
-                (cpuShares > 0 ? cpuShares : "unlimited") + " CPU Shares, " +
-                (memoryBytes > 0 ? memoryBytes + "B" : "unlimited") + " memory";
+        return toStringCpu() + ", " + toStringMemory();
     }
 }

--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/CreateContainerCommandImpl.java
@@ -162,6 +162,7 @@ class CreateContainerCommandImpl implements Docker.CreateContainerCommand {
         containerResources.ifPresent(cr -> hostConfig
                 .withCpuShares(cr.cpuShares())
                 .withMemory(cr.memoryBytes())
+                // MemorySwap is the total amount of memory and swap, if MemorySwap == Memory, then container has no access swap
                 .withMemorySwap(cr.memoryBytes())
                 .withCpuPeriod(cr.cpuQuota() > 0 ? cr.cpuPeriod() : null)
                 .withCpuQuota(cr.cpuQuota() > 0 ? cr.cpuQuota() : null));


### PR DESCRIPTION
Hopefully this is the last PR that has to do with docker container resources...

Yesterday, I suddenly remembered that we set an environment variable for how much memory the container can use, this is read by proton on startup. Live memory change will therefore be unnoticed by proton, so we should just restart the entire container. Once proton can correctly detect the available memory from cgroups, we can remove the env. variable and just restart Vespa rather than the entire container.