### PR TITLE
Set -XX:ActiveProcessorCount option if set in config

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -90,6 +90,12 @@ configure_memory() {
     fi
 }
 
+configure_cpu() {
+    if ((jvm_availableProcessors > 0)); then
+        cpu_options="-XX:ActiveProcessorCount=${jvm_availableProcessors}"
+    fi
+}
+
 configure_numactl() {
     log_message debug "starting ${VESPA_SERVICE_NAME} for ${VESPA_CONFIG_ID}"
     if numactl --interleave all true &> /dev/null; then
@@ -177,11 +183,14 @@ configure_gcopts
 configure_env_vars
 configure_classpath
 configure_numactl
+configure_cpu
 configure_preload
 
 exec $numactlcmd $envcmd java \
         -Dconfig.id="${VESPA_CONFIG_ID}" \
         -XX:+PreserveFramePointer \
+        ${VESPA_CONTAINER_JVMARGS} \
+        ${cpu_options} \
         ${memory_options} \
         ${jvm_gcopts} \
         -XX:MaxJavaStackTraceDepth=1000000 \

--- a/container-search/src/main/resources/configdefinitions/qr-start.def
+++ b/container-search/src/main/resources/configdefinitions/qr-start.def
@@ -27,6 +27,10 @@ jvm.directMemorySizeCache int default=0 restart
 ## value above. Setting outside [1, 99] disables this setting.
 jvm.heapSizeAsPercentageOfPhysicalMemory int default=0 restart
 
+## Number of processors available, can be used to set -XX:ActiveProcessorCount if set to non-zero.
+## In that case will be the number returned by the JVM when calling Runtime.getRuntime().availableProcessors()
+jvm.availableProcessors int default=0 restart
+
 ## Extra environment variables
 qrs.env string default="YELL_MA_EURO=INXIGHT" restart
 


### PR DESCRIPTION
Use VESPA_CONTAINER_JVMARGS if set

@aressem FYI, needed to get correct processor count in Java 11 JVM. Another PR will be made to set VESPA_CONTAINER_JVMARGS for Docker containers