### PR TITLE
Default to system version when deploying to dev MERGEOK

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -58,7 +58,6 @@ import com.yahoo.vespa.hosted.controller.rotation.RotationLock;
 import com.yahoo.vespa.hosted.controller.rotation.RotationRepository;
 import com.yahoo.vespa.hosted.controller.tenant.AthenzTenant;
 import com.yahoo.vespa.hosted.controller.tenant.Tenant;
-import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 import com.yahoo.vespa.hosted.rotation.config.RotationsConfig;
 import com.yahoo.yolean.Exceptions;
 
@@ -68,10 +67,8 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -280,9 +277,7 @@ public class ApplicationController {
             ApplicationVersion applicationVersion;
             ApplicationPackage applicationPackage;
             if (canDeployDirectly) {
-                platformVersion = options.vespaVersion.map(Version::new).orElse(curator.readTargetMajorVersion()
-                                                                                       .flatMap(this::lastCompatibleVersion)
-                                                                                       .orElse(controller.systemVersion()));
+                platformVersion = options.vespaVersion.map(Version::new).orElse(controller.systemVersion());
                 applicationVersion = applicationVersionFromDeployer.orElse(ApplicationVersion.unknown);
                 applicationPackage = applicationPackageFromDeployer.orElseThrow(
                         () -> new IllegalArgumentException("Application package must be given when deploying to " + zone));
@@ -730,14 +725,6 @@ public class ApplicationController {
                                   }
                               }
                           });
-    }
-
-    /** Returns the latest known version within the given major. */
-    private Optional<Version> lastCompatibleVersion(int targetMajorVersion) {
-        return controller.versionStatus().versions().stream()
-                         .map(VespaVersion::versionNumber)
-                         .filter(version -> version.getMajor() == targetMajorVersion)
-                         .max(naturalOrder());
     }
 
     private boolean isUserDeployment(Optional<AthenzIdentity> identity) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -446,8 +446,6 @@ public class ControllerTest {
     @Test
     public void testDeployDirectly() {
         DeploymentTester tester = new DeploymentTester();
-        Version six = Version.fromString("6.1");
-        tester.upgradeSystem(six);
         tester.controllerTester().zoneRegistry().setSystemName(SystemName.cd);
         tester.controllerTester().zoneRegistry().setZones(ZoneId.from("prod", "cd-us-central-1"));
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
@@ -470,12 +468,6 @@ public class ControllerTest {
 
         assertTrue("No job status added",
                    tester.applications().require(app.id()).deploymentJobs().jobStatus().isEmpty());
-
-        Version seven = Version.fromString("7.2");
-        tester.upgrader().setTargetMajorVersion(Optional.of(6));
-        tester.upgradeSystem(seven);
-        tester.controller().applications().deploy(app.id(), zone, Optional.of(applicationPackage), options);
-        assertEquals(six, tester.application(app.id()).deployments().get(zone).version());
     }
 
     @Test


### PR DESCRIPTION
@hmusum @bratseth I think it was wrong to do this, and think we should revert this part now. We can keep the auto-upgrades of existing deployments in `dev` for a little while. 

This is part of #8163.

Wrong because: when building locally, default compile version is latest released parent, which is 7. Default deploy version (without this revert) is 6. Bad combo, and by default. Not good.

To build against 6, you'll need to do something extra anyway, and so doing something extra to deploy against 6 is not much of a deal.