### PR TITLE
Allow a client connection to be considered established in test [recheck merge]

### DIFF
--- a/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
+++ b/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
@@ -632,7 +632,8 @@ TEST_F("Failure statistics are incremented on authorization failures", CertFixtu
     EXPECT_EQUAL(0u, client_stats.invalid_peer_credentials);
     EXPECT_EQUAL(1u, server_stats.failed_tls_handshakes);
     EXPECT_EQUAL(0u, server_stats.tls_connections);
-    EXPECT_EQUAL(0u, client_stats.tls_connections);
+    // Client TLS connection count may be 0 (<= v1.2) or 1 (v1.3), since v1.3
+    // completes its handshake earlier.
 }
 
 TEST_F("Success statistics are incremented on OK authorization", CertFixture) {


### PR DESCRIPTION
@havardpe please review. The previous assumption broke testing under OpenSSL 1.1.1+ since it uses TLSv1.3
@toregge FYI

TLSv1.3 completes in fewer roundtrips and may therefore seemingly not
observe that a server has rejected it as part of the handshake itself.