### PR TITLE
Deployment spec majorVersion take precedence over Application value MERGEOK

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -153,9 +153,8 @@ public class Application {
     }
 
     /**
-     * Overrides the preferred major version for this application.
-     * This overrides the major version set in the deployment spec (if any) and the major version the system
-     * wants to use.
+     * Overrides the system major version for this application. This override takes effect if the deployment
+     * spec does not specify a major version.
      */
     public Optional<Integer> majorVersion() { return majorVersion; }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
@@ -166,7 +166,7 @@ public class ApplicationList {
      * @param defaultMajorVersion the default major version to assume for applications not specifying one
      */
     public ApplicationList allowMajorVersion(int targetMajorVersion, int defaultMajorVersion) {
-        return listOf(list.stream().filter(a -> a.majorVersion().orElse(a.deploymentSpec().majorVersion().orElse(defaultMajorVersion))
+        return listOf(list.stream().filter(a -> a.deploymentSpec().majorVersion().orElse(a.majorVersion().orElse(defaultMajorVersion))
                                            >= targetMajorVersion));
     }
 


### PR DESCRIPTION
Overriding the major version set in the deployment spec does not work
because config servers will filter out major versions based on the
deployment spec, and it is not useful because we should respect
applications explicit choices when specified.

@jonmv please review