### PR TITLE
Return HTTP 400 status code on bad request parameters

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
@@ -203,7 +203,7 @@ public class RestApi extends LoggingRequestHandler {
         try {
             create = parseBoolean(CREATE_PARAMETER_NAME, request);
         } catch (IllegalArgumentException e) {
-            return Response.createErrorResponse(403, "Non valid value for 'create' parameter, must be empty, true, or " +
+            return Response.createErrorResponse(400, "Non valid value for 'create' parameter, must be empty, true, or " +
                     "false: " + request.getProperty(CREATE_PARAMETER_NAME), RestUri.apiErrorCodes.INVALID_CREATE_VALUE);
         }
         String condition = request.getProperty(CONDITION_PARAMETER_NAME);
@@ -282,7 +282,7 @@ public class RestApi extends LoggingRequestHandler {
     }
 
     private static HttpResponse createInvalidParameterResponse(String parameter, String explanation) {
-        return Response.createErrorResponse(403, String.format("Invalid '%s' value. %s", parameter, explanation), RestUri.apiErrorCodes.UNSPECIFIED);
+        return Response.createErrorResponse(400, String.format("Invalid '%s' value. %s", parameter, explanation), RestUri.apiErrorCodes.UNSPECIFIED);
     }
 
     static class BadRequestParameterException extends IllegalArgumentException {

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/OperationHandlerImplTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/OperationHandlerImplTest.java
@@ -85,6 +85,7 @@ public class OperationHandlerImplTest {
         try {
             OperationHandlerImpl.resolveClusterDef(Optional.of("wrong"), clusterDef);
         } catch(RestApiException e) {
+            assertThat(e.getResponse().getStatus(), is(400));
             String errorMsg = renderRestApiExceptionAsString(e);
             assertThat(errorMsg, is("{\"errors\":[{\"description\":" +
                     "\"MISSING_CLUSTER Your vespa cluster contains the content clusters foo2 (configId2), foo (configId)," +


### PR DESCRIPTION
@freva please review. Actual code change is literally just 2 integer values, the rest is just added and improved testing.

Add explicit checking of HTTP response status codes to many REST API unit tests.