### PR TITLE
Cache flags DB 

### DIFF
--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/FlagsDbImpl.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/FlagsDbImpl.java
@@ -31,7 +31,7 @@ public class FlagsDbImpl implements FlagsDb {
         this.curator = curator;
         curator.create(ROOT_PATH);
         ExecutorService executorService = Executors.newFixedThreadPool(1);
-        this.cache = curator.createDirectoryCache(ROOT_PATH.toString(), true, false, executorService);
+        this.cache = curator.createDirectoryCache(ROOT_PATH.getAbsolute(), true, false, executorService);
     }
 
     @Override

--- a/configserver-flags/src/test/java/com/yahoo/vespa/configserver/flags/db/FlagsDbImplTest.java
+++ b/configserver-flags/src/test/java/com/yahoo/vespa/configserver/flags/db/FlagsDbImplTest.java
@@ -43,7 +43,8 @@ public class FlagsDbImplTest {
                 dataCopy.get().serializeToJson());
 
         FlagId flagId2 = new FlagId("id2");
-        db.setValue(flagId2, data);
+        FlagData data2 = new FlagData(flagId2, new FetchVector().with(FetchVector.Dimension.ZONE_ID, "zone-a"), rule1);
+        db.setValue(flagId2, data2);
         Map<FlagId, FlagData> flags = db.getAllFlags();
         assertThat(flags.size(), equalTo(2));
         assertThat(flags.get(flagId), notNullValue());

--- a/zkfacade/abi-spec.json
+++ b/zkfacade/abi-spec.json
@@ -36,6 +36,7 @@
       "public abstract void start()",
       "public abstract void addListener(org.apache.curator.framework.recipes.cache.PathChildrenCacheListener)",
       "public abstract java.util.List getCurrentData()",
+      "public abstract org.apache.curator.framework.recipes.cache.ChildData getCurrentData(com.yahoo.path.Path)",
       "public abstract void close()"
     ],
     "fields": []

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -358,6 +358,9 @@ public class Curator implements AutoCloseable {
 
         List<ChildData> getCurrentData();
 
+        /** Returns the ChildData, or null if it does not exist. */
+        ChildData getCurrentData(Path absolutePath);
+
         void close();
 
     }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/PathChildrenCacheWrapper.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/PathChildrenCacheWrapper.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.curator;
 
+import com.yahoo.path.Path;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -41,6 +42,11 @@ class PathChildrenCacheWrapper implements Curator.DirectoryCache {
     @Override
     public List<ChildData> getCurrentData() {
         return wrapped.getCurrentData();
+    }
+
+    @Override
+    public ChildData getCurrentData(Path absolutePath) {
+        return wrapped.getCurrentData(absolutePath.getAbsolute());
     }
 
     @Override

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCurator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCurator.java
@@ -572,6 +572,15 @@ public class MockCurator extends Curator {
             return childData;
         }
 
+        @Override
+        public ChildData getCurrentData(Path fullPath) {
+            if (!fullPath.getParentPath().equals(path)) {
+                throw new IllegalArgumentException("Path '" + fullPath + "' is not a child path of '" + path + "'");
+            }
+
+            return getData(fullPath).map(bytes -> new ChildData(fullPath.getAbsolute(), null, bytes)).orElse(null);
+        }
+
         private void collectData(Node parent, Path parentPath, List<ChildData> data) {
             for (Node child : parent.children().values()) {
                 Path childPath = parentPath.append(child.name());


### PR DESCRIPTION
Up until now every lookup of a flag on ZooKeeperFlagSource would hit ZooKeeper.
Flags are ideal for caching: Changes seldom, little data, clients should handle
short-lived inconsistencies at the time it is changed (flag-flips must be reversible).

This PR will make the backing FlagsDbImpl cache the /flags/v1 ZK directory and
completes the optimization of ConfigServerFlagSource. See also #8244.