### PR TITLE
Report values from initial snapshot (MERGEOK)

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/metric/JrtMetrics.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/metric/JrtMetrics.java
@@ -15,7 +15,7 @@ class JrtMetrics {
 
     private final TransportMetrics transportMetrics = TransportMetrics.getInstance();
     private final Metric metric;
-    private Snapshot previousSnapshot = transportMetrics.snapshot();
+    private Snapshot previousSnapshot = Snapshot.EMPTY;
 
     JrtMetrics(Metric metric) {
         this.metric = metric;

--- a/jrt/src/com/yahoo/jrt/TransportMetrics.java
+++ b/jrt/src/com/yahoo/jrt/TransportMetrics.java
@@ -87,6 +87,8 @@ public class TransportMetrics {
     }
 
     public static class Snapshot {
+        public static final Snapshot EMPTY = new Snapshot(0, 0, 0, 0, 0, 0);
+
         private final long tlsCertificateVerificationFailures;
         private final long peerAuthorizationFailures;
         private final long serverTlsConnectionsEstablished;


### PR DESCRIPTION
Initialize `JrtMetrics` with empty snapshot so that the values of the
first real snapshot are reported.

FYI @havardpe 