### PR TITLE
Start sessions maintainer as early as possible

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/Maintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/Maintainer.java
@@ -33,12 +33,17 @@ public abstract class Maintainer extends AbstractComponent implements Runnable {
     protected final Curator curator;
 
     Maintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval) {
+        this(applicationRepository, curator, interval, interval);
+    }
+
+    Maintainer(ApplicationRepository applicationRepository, Curator curator, Duration initialDelay, Duration interval) {
         this.applicationRepository = applicationRepository;
         this.curator = curator;
         this.maintenanceInterval = interval;
         service = new ScheduledThreadPoolExecutor(1, new DaemonThreadFactory(name()));
-        service.scheduleAtFixedRate(this, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+        service.scheduleAtFixedRate(this, initialDelay.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
     }
+
 
     @Override
     @SuppressWarnings({"try", "unused"})

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -17,7 +17,9 @@ public class SessionsMaintainer extends Maintainer {
     private final boolean hostedVespa;
 
     SessionsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval) {
-        super(applicationRepository, curator, interval);
+        // Start this maintainer immediately. It frees disk space, so if disk goes full and config server
+        // restarts this makes sure that cleanup will happen as early as possible
+        super(applicationRepository, curator, Duration.ZERO, interval);
         this.hostedVespa = applicationRepository.configserverConfig().hostedVespa();
     }
 


### PR DESCRIPTION
We have seen a couple of times that disk goes full and that a config
server will not recover, since disk is full and it needs disk space
for redeploying applications when starting