### PR TITLE
Revert "Docsum and bolding: don't return empty strings for empty fields"

### DIFF
--- a/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
@@ -436,10 +436,8 @@ DynamicTeaserDFW::insertField(uint32_t docid, GeneralResult *gres, GetDocsumsSta
                               vespalib::slime::Inserter &target)
 {
     vespalib::string teaser = makeDynamicTeaser(docid, gres, state);
-    if (teaser.length() > 0) {
-        vespalib::Memory value(teaser.c_str(), teaser.size());
-        target.insertString(value);
-    }
+    vespalib::Memory value(teaser.c_str(), teaser.size());
+    target.insertString(value);
 }
 
 }


### PR DESCRIPTION
This reverts commit bf8e19e7456dd95ac1f3297bdb09ccf078105c64.

