### PR TITLE
Skip fields with null values when parsing document puts

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/readers/ArrayReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/ArrayReader.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.json.readers;
 
+import com.fasterxml.jackson.core.JsonToken;
+import com.google.common.base.Preconditions;
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.CollectionFieldValue;
 import com.yahoo.document.datatypes.FieldValue;
@@ -14,6 +16,7 @@ import static com.yahoo.document.json.readers.SingleValueReader.readSingleValue;
 public class ArrayReader {
     public static void fillArrayUpdate(TokenBuffer buffer, int initNesting, DataType valueType, List<FieldValue> arrayContents) {
         while (buffer.nesting() >= initNesting) {
+            Preconditions.checkArgument(buffer.currentToken() != JsonToken.VALUE_NULL, "Illegal null value for array entry");
             arrayContents.add(readSingleValue(buffer, valueType));
             buffer.next();
         }
@@ -25,6 +28,7 @@ public class ArrayReader {
         expectArrayStart(buffer.currentToken());
         buffer.next();
         while (buffer.nesting() >= initNesting) {
+            Preconditions.checkArgument(buffer.currentToken() != JsonToken.VALUE_NULL, "Illegal null value for array entry");
             parent.add(readSingleValue(buffer, valueType));
             buffer.next();
         }

--- a/document/src/main/java/com/yahoo/document/json/readers/StructReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/StructReader.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.json.readers;
 
+import com.fasterxml.jackson.core.JsonToken;
 import com.yahoo.document.Field;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.StructuredFieldValue;
@@ -18,8 +19,11 @@ public class StructReader {
         while (buffer.nesting() >= initNesting) {
             Field f = getField(buffer, parent);
             try {
-                FieldValue v = readSingleValue(buffer, f.getDataType());
-                parent.setFieldValue(f, v);
+                // skip fields set to null
+                if (buffer.currentToken() != JsonToken.VALUE_NULL) {
+                    FieldValue v = readSingleValue(buffer, f.getDataType());
+                    parent.setFieldValue(f, v);
+                }
                 buffer.next();
             } catch (IllegalArgumentException e) {
                 throw new JsonReaderException(f, e);


### PR DESCRIPTION
Also throws an exception for null values in arrays.

@geirst Please review.