### PR TITLE
Health rest API

### DIFF
--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ServiceStatusInfo.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ServiceStatusInfo.java
@@ -17,21 +17,29 @@ public class ServiceStatusInfo {
     private final Optional<Instant> since;
     private final Optional<Instant> lastChecked;
     private final Optional<String> error;
+    private final Optional<String> endpoint;
 
     public ServiceStatusInfo(ServiceStatus status) {
-        this(status, Optional.empty(), Optional.empty(), Optional.empty());
+        this(status, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    public ServiceStatusInfo(ServiceStatus status, Instant since, Instant lastChecked, Optional<String> error) {
-        this(status, Optional.of(since), Optional.of(lastChecked), error);
+    public ServiceStatusInfo(ServiceStatus status, Instant since, Instant lastChecked, Optional<String> error,
+                             Optional<String> endpoint) {
+        this(status, Optional.of(since), Optional.of(lastChecked), error, endpoint);
     }
 
     public ServiceStatusInfo(ServiceStatus status, Optional<Instant> since, Optional<Instant> lastChecked,
-                             Optional<String> error) {
+                             Optional<String> error, Optional<String> endpoint) {
         this.status = status;
         this.since = since;
         this.lastChecked = lastChecked;
         this.error = error;
+        this.endpoint = endpoint;
+    }
+
+    @JsonProperty("endpoint")
+    public String endpointOrNull() {
+        return endpoint.orElse(null);
     }
 
     @JsonProperty("serviceStatus")

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/ApplicationReferenceList.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/ApplicationReferenceList.java
@@ -1,0 +1,21 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.restapi.wire;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A list of references to applications.
+ *
+ * @author hakonhall
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApplicationReferenceList {
+    @JsonProperty("applications")
+    public List<UrlReference> applicationList = Collections.emptyList();
+}

--- a/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/UrlReference.java
+++ b/orchestrator-restapi/src/main/java/com/yahoo/vespa/orchestrator/restapi/wire/UrlReference.java
@@ -1,0 +1,18 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.restapi.wire;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A reference to a REST resource.
+ *
+ * @author hakonhall
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UrlReference {
+    @JsonProperty("url")
+    public String url;
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/ApplicationServices.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/ApplicationServices.java
@@ -1,0 +1,16 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.resources;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * @author hakonhall
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public class ApplicationServices {
+    @JsonProperty("services")
+    public List<ServiceResource> services;
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HealthResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HealthResource.java
@@ -1,0 +1,84 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.resources;
+
+import com.google.inject.Inject;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.container.jaxrs.annotation.Component;
+import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
+import com.yahoo.vespa.orchestrator.restapi.wire.ApplicationReferenceList;
+import com.yahoo.vespa.orchestrator.restapi.wire.UrlReference;
+import com.yahoo.vespa.service.manager.HealthMonitorApi;
+import com.yahoo.vespa.service.monitor.ServiceId;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author hakonhall
+ */
+@Path("/v1/health")
+public class HealthResource {
+    private final UriInfo uriInfo;
+    private final HealthMonitorApi healthMonitorApi;
+
+    @Inject
+    public HealthResource(@Context UriInfo uriInfo, @Component HealthMonitorApi healthMonitorApi) {
+        this.uriInfo = uriInfo;
+        this.healthMonitorApi = healthMonitorApi;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApplicationReferenceList getAllInstances() {
+        List<ApplicationId> applications = new ArrayList<>(healthMonitorApi.getMonitoredApplicationIds());
+        applications.sort(Comparator.comparing(ApplicationId::serializedForm));
+
+        ApplicationReferenceList list = new ApplicationReferenceList();
+        list.applicationList = applications.stream().map(applicationId -> {
+            UrlReference reference = new UrlReference();
+            reference.url = uriInfo.getBaseUriBuilder()
+                    .path(HealthResource.class)
+                    .path(applicationId.serializedForm())
+                    .build()
+                    .toString();
+            return reference;
+        }).collect(Collectors.toList());
+
+        return list;
+    }
+
+    @GET
+    @Path("/{applicationId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApplicationServices getInstance(@PathParam("applicationId") String applicationIdString) {
+        ApplicationId applicationId = ApplicationId.fromSerializedForm(applicationIdString);
+
+        Map<ServiceId, ServiceStatusInfo> services = healthMonitorApi.getServices(applicationId);
+
+        List<ServiceResource> serviceResources = services.entrySet().stream().map(entry -> {
+            ServiceResource serviceResource = new ServiceResource();
+            serviceResource.clusterId = entry.getKey().getClusterId();
+            serviceResource.serviceType = entry.getKey().getServiceType();
+            serviceResource.configId = entry.getKey().getConfigId();
+            serviceResource.serviceStatusInfo = entry.getValue();
+            return serviceResource;
+        })
+                .sorted(Comparator.comparing(resource -> resource.serviceType.s()))
+                .collect(Collectors.toList());
+
+        ApplicationServices applicationServices = new ApplicationServices();
+        applicationServices.services = serviceResources;
+        return applicationServices;
+    }
+
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/ServiceResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/ServiceResource.java
@@ -1,0 +1,25 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.resources;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.vespa.applicationmodel.ClusterId;
+import com.yahoo.vespa.applicationmodel.ConfigId;
+import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
+import com.yahoo.vespa.applicationmodel.ServiceType;
+
+/**
+ * @author hakonhall
+ */
+public class ServiceResource {
+    @JsonProperty("clusterId")
+    public ClusterId clusterId;
+
+    @JsonProperty("serviceType")
+    public ServiceType serviceType;
+
+    @JsonProperty("configId")
+    public ConfigId configId;
+
+    @JsonProperty("status")
+    public ServiceStatusInfo serviceStatusInfo;
+}

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/ApplicationHealthMonitor.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/ApplicationHealthMonitor.java
@@ -8,13 +8,14 @@ import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.applicationmodel.ServiceType;
-import com.yahoo.vespa.service.model.ServiceId;
+import com.yahoo.vespa.service.monitor.ServiceId;
 import com.yahoo.vespa.service.monitor.ServiceStatusProvider;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Responsible for monitoring a whole application using /state/v1/health.
@@ -24,6 +25,10 @@ import java.util.Set;
 class ApplicationHealthMonitor implements ServiceStatusProvider, AutoCloseable {
     private final ApplicationId applicationId;
     private final StateV1HealthModel healthModel;
+
+    // Guards against concurrent access to monitors field w/objects in 1. monitor() (called from e.g. DuperModel),
+    // 2. getStatus() called from caching layer and Orchestrator above, and 3. REST calls to getAllServiceStatuses().
+    private final Object guard = new Object();
     private final Map<ServiceId, HealthMonitor> monitors = new HashMap<>();
 
     ApplicationHealthMonitor(ApplicationId applicationId, StateV1HealthModel healthModel) {
@@ -38,13 +43,15 @@ class ApplicationHealthMonitor implements ServiceStatusProvider, AutoCloseable {
 
         Map<ServiceId, HealthEndpoint> endpoints = healthModel.extractHealthEndpoints(applicationInfo);
 
-        // Remove obsolete monitors
-        Set<ServiceId> removed = new HashSet<>(monitors.keySet());
-        removed.removeAll(endpoints.keySet());
-        removed.stream().map(monitors::remove).forEach(HealthMonitor::close);
+        synchronized (guard) {
+            // Remove obsolete monitors
+            Set<ServiceId> removed = new HashSet<>(monitors.keySet());
+            removed.removeAll(endpoints.keySet());
+            removed.stream().map(monitors::remove).forEach(HealthMonitor::close);
 
-        // Add new monitors.
-        endpoints.forEach((serviceId, endpoint) -> monitors.computeIfAbsent(serviceId, ignoredId -> endpoint.startMonitoring()));
+            // Add new monitors.
+            endpoints.forEach((serviceId, endpoint) -> monitors.computeIfAbsent(serviceId, ignoredId -> endpoint.startMonitoring()));
+        }
     }
 
     @Override
@@ -53,12 +60,23 @@ class ApplicationHealthMonitor implements ServiceStatusProvider, AutoCloseable {
                                        ServiceType serviceType,
                                        ConfigId configId) {
         ServiceId serviceId = new ServiceId(applicationId, clusterId, serviceType, configId);
-        HealthMonitor monitor = monitors.get(serviceId);
-        if (monitor == null) {
-            return new ServiceStatusInfo(ServiceStatus.NOT_CHECKED);
-        }
 
-        return monitor.getStatus();
+        synchronized (guard) {
+            HealthMonitor monitor = monitors.get(serviceId);
+            if (monitor == null) {
+                return new ServiceStatusInfo(ServiceStatus.NOT_CHECKED);
+            }
+
+            return monitor.getStatus();
+        }
+    }
+
+    public Map<ServiceId, ServiceStatusInfo> getAllServiceStatuses() {
+        synchronized (guard) {
+            return monitors.entrySet().stream().collect(Collectors.toMap(
+                    entry -> entry.getKey(),
+                    entry -> entry.getValue().getStatus()));
+        }
     }
 
     @Override

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthEndpoint.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthEndpoint.java
@@ -1,7 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.service.health;
 
-import com.yahoo.vespa.service.model.ServiceId;
+import com.yahoo.vespa.service.monitor.ServiceId;
 
 /**
  * An endpoint 1-1 with a service and that can be health monitored.

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
@@ -14,9 +14,14 @@ import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.service.duper.DuperModelManager;
 import com.yahoo.vespa.service.duper.ZoneApplication;
 import com.yahoo.vespa.service.executor.RunletExecutorImpl;
+import com.yahoo.vespa.service.manager.HealthMonitorApi;
 import com.yahoo.vespa.service.manager.MonitorManager;
+import com.yahoo.vespa.service.monitor.ServiceId;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -24,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author hakon
  */
-public class HealthMonitorManager implements MonitorManager {
+public class HealthMonitorManager implements MonitorManager, HealthMonitorApi {
     // Weight the following against each other:
     //  - The number of threads N working on health checking
     //  - The health request timeout T
@@ -138,5 +143,20 @@ public class HealthMonitorManager implements MonitorManager {
         }
 
         return false;
+    }
+
+    @Override
+    public List<ApplicationId> getMonitoredApplicationIds() {
+        return Collections.list(healthMonitors.keys());
+    }
+
+    @Override
+    public Map<ServiceId, ServiceStatusInfo> getServices(ApplicationId applicationId) {
+        ApplicationHealthMonitor applicationHealthMonitor = healthMonitors.get(applicationId);
+        if (applicationHealthMonitor == null) {
+            return Collections.emptyMap();
+        }
+
+        return applicationHealthMonitor.getAllServiceStatuses();
     }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/StateV1HealthEndpoint.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/StateV1HealthEndpoint.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.service.health;
 
 import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.service.executor.RunletExecutor;
-import com.yahoo.vespa.service.model.ServiceId;
+import com.yahoo.vespa.service.monitor.ServiceId;
 
 import java.net.URL;
 import java.time.Duration;

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/StateV1HealthUpdater.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/StateV1HealthUpdater.java
@@ -13,15 +13,17 @@ import java.util.Optional;
  * @author hakonhall
  */
 class StateV1HealthUpdater implements HealthUpdater {
+    private final String endpoint;
     private final StateV1HealthClient healthClient;
 
     private volatile ServiceStatusInfo serviceStatusInfo = new ServiceStatusInfo(ServiceStatus.NOT_CHECKED);
 
     StateV1HealthUpdater(URL url, Duration requestTimeout, Duration connectionKeepAlive) {
-        this(new StateV1HealthClient(url, requestTimeout, connectionKeepAlive));
+        this(url.toString(), new StateV1HealthClient(url, requestTimeout, connectionKeepAlive));
     }
 
-    StateV1HealthUpdater(StateV1HealthClient healthClient) {
+    StateV1HealthUpdater(String endpoint, StateV1HealthClient healthClient) {
+        this.endpoint = endpoint;
         this.healthClient = healthClient;
     }
 
@@ -46,7 +48,8 @@ class StateV1HealthUpdater implements HealthUpdater {
         Optional<Instant> newSince = newServiceStatus == serviceStatusInfo.serviceStatus() ?
                 serviceStatusInfo.since() : Optional.of(now);
 
-        serviceStatusInfo = new ServiceStatusInfo(newServiceStatus, newSince, Optional.of(now), healthInfo.getErrorDescription());
+        serviceStatusInfo = new ServiceStatusInfo(newServiceStatus, newSince, Optional.of(now),
+                healthInfo.getErrorDescription(), Optional.of(endpoint));
     }
 
     @Override

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/manager/HealthMonitorApi.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/manager/HealthMonitorApi.java
@@ -1,0 +1,21 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.manager;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
+import com.yahoo.vespa.service.health.HealthMonitorManager;
+import com.yahoo.vespa.service.monitor.ServiceId;
+import com.yahoo.vespa.service.monitor.ServiceStatusProvider;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The API of {@link HealthMonitorManager} which is exported to other bundles (typically for REST).
+ *
+ * @author hakonhall
+ */
+public interface HealthMonitorApi extends ServiceStatusProvider {
+    List<ApplicationId> getMonitoredApplicationIds();
+    Map<ServiceId, ServiceStatusInfo> getServices(ApplicationId applicationId);
+}

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/model/ApplicationInstanceGenerator.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/model/ApplicationInstanceGenerator.java
@@ -18,6 +18,7 @@ import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.applicationmodel.TenantId;
 import com.yahoo.vespa.service.duper.ConfigServerApplication;
+import com.yahoo.vespa.service.monitor.ServiceId;
 import com.yahoo.vespa.service.monitor.ServiceStatusProvider;
 
 import java.util.HashMap;

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/ServiceId.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/ServiceId.java
@@ -1,5 +1,5 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.service.model;
+package com.yahoo.vespa.service.monitor;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.applicationmodel.ClusterId;

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/ApplicationHealthMonitorTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/ApplicationHealthMonitorTest.java
@@ -6,7 +6,7 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.service.duper.ConfigServerApplication;
-import com.yahoo.vespa.service.model.ServiceId;
+import com.yahoo.vespa.service.monitor.ServiceId;
 import com.yahoo.vespa.service.monitor.ConfigserverUtil;
 import org.junit.Test;
 

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthModelTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthModelTest.java
@@ -13,7 +13,7 @@ import com.yahoo.vespa.service.duper.TestZoneApplication;
 import com.yahoo.vespa.service.duper.ZoneApplication;
 import com.yahoo.vespa.service.executor.Cancellable;
 import com.yahoo.vespa.service.executor.RunletExecutor;
-import com.yahoo.vespa.service.model.ServiceId;
+import com.yahoo.vespa.service.monitor.ServiceId;
 import org.junit.Test;
 
 import java.time.Duration;

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthMonitorTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthMonitorTest.java
@@ -17,7 +17,7 @@ public class StateV1HealthMonitorTest {
     public void downThenUpThenDown() throws Exception {
         StateV1HealthClient client = mock(StateV1HealthClient.class);
 
-        StateV1HealthUpdater updater = new StateV1HealthUpdater(client);
+        StateV1HealthUpdater updater = new StateV1HealthUpdater("https://foo/state/v1/health", client);
         RunletExecutor executor = new RunletExecutorImpl(2);
         try (StateV1HealthMonitor monitor = new StateV1HealthMonitor(updater, executor, Duration.ofMillis(10))) {
             assertEquals(ServiceStatus.NOT_CHECKED, monitor.getStatus().serviceStatus());

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthUpdaterTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthUpdaterTest.java
@@ -165,6 +165,6 @@ public class StateV1HealthUpdaterTest {
     private StateV1HealthUpdater makeUpdater(CloseableHttpClient client, Function<HttpEntity, String> getContentFunction) {
         ApacheHttpClient apacheHttpClient = new ApacheHttpClient(url, client);
         StateV1HealthClient healthClient = new StateV1HealthClient(apacheHttpClient, getContentFunction);
-        return new StateV1HealthUpdater(healthClient);
+        return new StateV1HealthUpdater(url.toString(), healthClient);
     }
 }


### PR DESCRIPTION
Makes a new REST API /orchestrator/v1/health/<ApplicationId> that shows the
list of services that are monitored for health. This information is currently a
bit difficult to infer from
/orchestrator/v1/instances/<ApplicationInstanceReference> since it is the
combined view of health and Slobrok. There are already APIs for Slobrok.

Example content:
```
$ curl -s localhost:19071/orchestrator/v1/health/hosted-vespa:zone-config-serve\
rs:default|jq .
  {
    "services": [
      {
        "clusterId": "zone-config-servers",
        "serviceType": "configserver",
        "configId": "zone-config-servers/cfg6",
        "status": {
          "serviceStatus": "UP",
          "lastChecked": 1548939111.708718,
          "since": 1548939051.686223,
          "endpoint": "http://cfg4.prod.cd-us-central-1.vespahosted.ne1.yahoo.com:19071/state/v1/health"
        }
      },
      ...
    ]
  }
```
This view is slightly different from the application model view, just because
that's exactly how the health monitoring is structured (individual monitors
against endpoints).

The "endpoint" information will also be added to /instances if the status comes
from health and not Slobrok.