### PR TITLE
Populate all access log fields in log() 

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServlet.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServlet.java
@@ -106,7 +106,6 @@ class JDiscHttpServlet extends HttpServlet {
 
     private void dispatchHttpRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
         AccessLogEntry accessLogEntry = new AccessLogEntry();
-        AccessLogRequestLog.populateAccessLogEntryFromHttpServletRequest(request, accessLogEntry);
         request.setAttribute(ATTRIBUTE_NAME_ACCESS_LOG_ENTRY, accessLogEntry);
         try {
             switch (request.getDispatcherType()) {


### PR DESCRIPTION
Populate all fields in log() as populateAccessLogEntryFromHttpServletRequest was not guaranteed to be called (e.g. when request headers/uri has invalid encoding).