### PR TITLE
Identify node(s) in error messages

### DIFF
--- a/messagebus/src/main/java/com/yahoo/messagebus/routing/RoutingNode.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/routing/RoutingNode.java
@@ -183,7 +183,7 @@ public class RoutingNode implements ReplyHandler {
     }
 
     /**
-     * This method markss this node as ready for merge. If it has a parent routing node, its pending member is
+     * This method marks this node as ready for merge. If it has a parent routing node, its pending member is
      * decremented. If this causes the parent's pending count to reach zero, its {@link #notifyMerge()} method is
      * invoked. A special flag is used to make sure that failed resending avoids notifying parents of previously
      * resolved branches of the tree.

--- a/messagebus/src/vespa/messagebus/network/rpcnetwork.h
+++ b/messagebus/src/vespa/messagebus/network/rpcnetwork.h
@@ -105,6 +105,8 @@ private:
      */
     void send(SendContext &ctx);
 
+    static vespalib::string buildRecipientListString(const SendContext& ctx);
+
 protected:
     /**
      * Returns the version of this network. This gets called when the

--- a/messagebus/src/vespa/messagebus/network/rpctarget.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpctarget.cpp
@@ -74,12 +74,12 @@ RPCTarget::RequestDone(FRT_RPCRequest *req)
         if (req->CheckReturnTypes("s")) {
             FRT_Values &val = *req->GetReturn();
             try {
-                _version.reset(new vespalib::Version(val[0]._string._str));
+                _version = std::make_unique<vespalib::Version>(val[0]._string._str);
             } catch (vespalib::IllegalArgumentException &e) {
                 (void)e;
             }
         } else if (req->GetErrorCode() == FRTE_RPC_NO_SUCH_METHOD) {
-            _version.reset(new vespalib::Version("4.1"));
+            // Talking to a non-messagebus RPC endpoint. _version remains nullptr.
         }
         _versionHandlers.swap(handlers);
         _state = PROCESSING_HANDLERS;

--- a/messagebus/src/vespa/messagebus/network/rpctarget.h
+++ b/messagebus/src/vespa/messagebus/network/rpctarget.h
@@ -31,7 +31,7 @@ public:
 
         /**
          * This method is invoked once the version of the corresponding {@link
-         * RPCTarget} becomes available. If a problem occured while retrieving
+         * RPCTarget} becomes available. If a problem occurred while retrieving
          * the version, this method is invoked with a null argument.
          *
          * @param ver The version of corresponding target, or null.

--- a/messagebus/src/vespa/messagebus/routing/routingnode.h
+++ b/messagebus/src/vespa/messagebus/routing/routingnode.h
@@ -74,7 +74,7 @@ private:
 
     /**
      * This method merges the content of all its children, and invokes itself on
-     * the parent node. If not all children are ready for merg, this method does
+     * the parent node. If not all children are ready for merge, this method does
      * nothing. The rationale for this is that the last child to receive a reply
      * will propagate the merge upwards. Once this method reaches the root node,
      * the reply is either scheduled for resending or passed to the owning reply
@@ -421,7 +421,7 @@ public:
      *
      * @return True if an address is set.
      */
-    bool hasServiceAddress() { return _serviceAddress.get() != nullptr; }
+    bool hasServiceAddress() const { return _serviceAddress.get() != nullptr; }
 
     /**
      * Returns the service address of this node. This is attached by the network

--- a/storage/src/tests/storageserver/bouncertest.cpp
+++ b/storage/src/tests/storageserver/bouncertest.cpp
@@ -213,9 +213,11 @@ BouncerTest::assertMessageBouncedWithAbort()
 {
     CPPUNIT_ASSERT_EQUAL(size_t(1), _upper->getNumReplies());
     CPPUNIT_ASSERT_EQUAL(size_t(0), _upper->getNumCommands());
-    CPPUNIT_ASSERT_EQUAL(api::ReturnCode::ABORTED,
-            static_cast<api::RemoveReply&>(*_upper->getReply(0)).
-            getResult().getResult());
+    auto& reply = dynamic_cast<api::StorageReply&>(*_upper->getReply(0));
+    CPPUNIT_ASSERT_EQUAL(api::ReturnCode(api::ReturnCode::ABORTED,
+                         "We don't allow command of type MessageType(12, Remove) "
+                         "when node is in state Down (on storage.2)"),
+                         reply.getResult());
     CPPUNIT_ASSERT_EQUAL(size_t(0), _lower->getNumCommands());
 }
 

--- a/storage/src/vespa/storage/storageserver/bouncer.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer.cpp
@@ -102,6 +102,10 @@ Bouncer::validateConfig(
     }
 }
 
+void Bouncer::append_node_identity(std::ostream& target_stream) const {
+    target_stream << " (on " << _component.getNodeType() << '.' << _component.getIndex() << ")";
+}
+
 void
 Bouncer::abortCommandForUnavailableNode(api::StorageMessage& msg,
                                         const lib::State& state)
@@ -111,7 +115,8 @@ Bouncer::abortCommandForUnavailableNode(api::StorageMessage& msg,
             static_cast<api::StorageCommand&>(msg).makeReply().release());
     std::ostringstream ost;
     ost << "We don't allow command of type " << msg.getType()
-        << " when node is in state " << state.toString(true) << ".";
+        << " when node is in state " << state.toString(true);
+    append_node_identity(ost);
     reply->setResult(api::ReturnCode(api::ReturnCode::ABORTED, ost.str()));
     sendUp(reply);
 }
@@ -123,7 +128,8 @@ Bouncer::rejectCommandWithTooHighClockSkew(api::StorageMessage& msg,
     auto& as_cmd = dynamic_cast<api::StorageCommand&>(msg);
     std::ostringstream ost;
     ost << "Message " << msg.getType() << " is more than "
-        << maxClockSkewInSeconds << " seconds in the future.";
+        << maxClockSkewInSeconds << " seconds in the future";
+    append_node_identity(ost);
     LOGBP(warning, "Rejecting operation from distributor %u: %s",
           as_cmd.getSourceIndex(), ost.str().c_str());
     _metrics->clock_skew_aborts.inc();
@@ -140,7 +146,8 @@ Bouncer::abortCommandDueToClusterDown(api::StorageMessage& msg)
             static_cast<api::StorageCommand&>(msg).makeReply().release());
     std::ostringstream ost;
     ost << "We don't allow external load while cluster is in state "
-        << _clusterState->toString(true) << ".";
+        << _clusterState->toString(true);
+    append_node_identity(ost);
     reply->setResult(api::ReturnCode(api::ReturnCode::ABORTED, ost.str()));
     sendUp(reply);
 }

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -89,6 +89,7 @@ private:
     void handleNewState() override;
     const lib::NodeState &getDerivedNodeState(document::BucketSpace bucketSpace) const;
 
+    void append_node_identity(std::ostream& target_stream) const;
 };
 
 } // storage


### PR DESCRIPTION
@baldersheim please review

This augments several oft-spotted error messages with identifies of the responder (as well as targets when applicable). Intention is to make it more obvious where the problem lies when error messages are propagated through many layers of indirection.

Also removes deprecated C++ implementation fallback to 4.1 protocol version if
remote RPC endpoint does not understand `mbus.getVersion` call. Will now
fail as expected with a handshake error instead.