### PR TITLE
remove non-working (?) options

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -292,14 +292,6 @@ public class VdsVisit {
                 .build());
 
         options.addOption(Option.builder()
-                .longOpt("maxhits")
-                .hasArg(true)
-                .argName("num")
-                .desc("Abort visiting when we have received this many \"first pass\" documents. Only appropriate for visiting involving id.order. This is only an approximate number, all pending work will be completed and those documents will also be returned.")
-                .type(Number.class)
-                .build());
-
-        options.addOption(Option.builder()
                 .longOpt("maxtotalhits")
                 .hasArg(true)
                 .argName("num")
@@ -320,13 +312,6 @@ public class VdsVisit {
                 .argName("name")
                 .desc("Priority used for each visitor. Defaults to NORMAL_3. " +
                         "Use with care to avoid starving lower prioritized traffic in the cluster")
-                .build());
-
-        options.addOption(Option.builder()
-                .longOpt("ordering")
-                .hasArg(true)
-                .argName("order")
-                .desc("Order to visit documents in. Only makes sense in conjunction with a document selection involving id.order. Legal values are \"ascending\" and \"descending\"")
                 .build());
 
         options.addOption(Option.builder()

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
@@ -123,11 +123,9 @@ public class VdsVisitTestCase {
                 "--libraryparam", "asdf", "rargh",
                 "--libraryparam", "pinkie", "pie",
                 "--processtime", "555",
-                "--maxhits", "1001",
                 "--maxtotalhits", "2002",
                 "--tracelevel", "8",
                 "--priority", "NORMAL_1",
-                "--ordering", "ascending",
                 "--skipbucketsonfatalerrors",
                 "--abortonclusterdown",
                 "--visitremoves",
@@ -161,11 +159,9 @@ public class VdsVisitTestCase {
         assertTrue(Arrays.equals("rargh".getBytes(), params.getLibraryParameters().get("asdf")));
         //assertTrue(Arrays.equals("pie".getBytes(), params.getLibraryParameters().get("pinkie")));
         assertEquals(555, allParams.getProcessTime());
-        assertEquals(1001, params.getMaxFirstPassHits());
         assertEquals(2002, params.getMaxTotalHits());
         assertEquals(8, params.getTraceLevel());
         assertEquals(DocumentProtocol.Priority.NORMAL_1, params.getPriority());
-        assertEquals(OrderingSpecification.ASCENDING, params.getVisitorOrdering());
         assertTrue(allParams.getAbortOnClusterDown());
         assertTrue(params.visitRemoves());
 
@@ -192,13 +188,6 @@ public class VdsVisitTestCase {
                         "Visitor priority NORMAL_1" + nl +
                         "Skip visiting super buckets with fatal errors." + nl,
                 outputStream.toString("utf-8"));
-
-        args = new String[] {
-                "--ordering", "descending"
-        };
-        allParams = parser.parse(args);
-        params = allParams.getVisitorParameters();
-        assertEquals(OrderingSpecification.DESCENDING, params.getVisitorOrdering());
     }
 
     private static String[] emptyArgList() { return new String[]{}; }
@@ -222,20 +211,6 @@ public class VdsVisitTestCase {
             fail("no exception thrown");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Unknown priority name"));
-        }
-    }
-
-    @Test
-    public void testBadOrderingValue() throws Exception {
-        String[] args = new String[] {
-                "--ordering", "yonder"
-        };
-        VdsVisit.ArgumentParser parser = createMockArgumentParser();
-        try {
-            parser.parse(args);
-            fail("no exception thrown");
-        } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("Unknown ordering"));
         }
     }
 


### PR DESCRIPTION
I'm not sure if the options should be removed (this PR) or if we should change the description to DEPRECATED/DO-NOT-USE - or something else.

If this is functionality that does not work, maybe easier to removed the options for less noise - what do you say, @vekterli ?