### PR TITLE
Let GroupPreparer provision hosts if needed

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -12,7 +12,6 @@ import java.util.TreeMap;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.APPLICATION_ID;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.NODE_TYPE;
-import static com.yahoo.vespa.flags.FetchVector.Dimension.ZONE_ID;
 
 /**
  * @author hakonhall
@@ -95,6 +94,13 @@ public class Flags {
             "Should adaptive dispatch be used over round robin",
             "Takes effect at redeployment",
             APPLICATION_ID);
+
+    public static final UnboundBooleanFlag ENABLE_DYNAMIC_PROVISIONING = defineFeatureFlag(
+            "enable-dynamic-provisioning", false,
+            "Provision a new docker host when we otherwise can't allocate a docker node",
+            "Takes effect on next deployment",
+            APPLICATION_ID);
+
 
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, String description,

--- a/node-repository/pom.xml
+++ b/node-repository/pom.xml
@@ -89,6 +89,12 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>flags</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- compile -->
         <dependency>

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -110,7 +110,7 @@ public class NodeList implements Iterable<Node> {
     /** Returns the immutable list of nodes in this */
     public List<Node> asList() { return nodes; }
 
-    private NodeList filter(Predicate<Node> predicate) {
+    public NodeList filter(Predicate<Node> predicate) {
         return nodes.stream().filter(predicate).collect(collectingAndThen(Collectors.toList(), NodeList::wrap));
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -69,7 +69,7 @@ public class GroupPreparer {
                 prioritizer.addApplicationNodes();
                 prioritizer.addSurplusNodes(surplusActiveNodes);
                 prioritizer.addReadyNodes();
-                prioritizer.addNewDockerNodes(allocationLock);
+                prioritizer.addNewDockerNodes(allocationLock, dynamicProvisioningEnabled);
 
                 // Allocate from the prioritized list
                 NodeAllocation allocation = new NodeAllocation(nodeList, application, cluster, requestedNodes,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
@@ -20,10 +20,9 @@ public interface HostProvisioner {
      * @param numHosts number of hosts to provision
      * @param nodeFlavor Vespa flavor of the node that will run on this host. The resulting provisioned host
      *                   will be of a flavor that is at least as big or bigger than this.
-     * @return list of nodes that should be added to the node-repo, the list will contain exactly 2 elements:
-     * the provisioned host, and a docker container on that host with flavor {@code nodeFlavor}
+     * @return list of {@link ProvisionedHost} describing the provisioned hosts and nodes on them.
      */
-    List<Node> provisionHosts(int numHosts, Flavor nodeFlavor);
+    List<ProvisionedHost> provisionHosts(int numHosts, Flavor nodeFlavor);
 
     /**
      * Continue provisioning of given list of Nodes.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.lang.MutableInteger;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
@@ -25,10 +26,11 @@ class Preparer {
     private final GroupPreparer groupPreparer;
     private final int spareCount;
 
-    public Preparer(NodeRepository nodeRepository, int spareCount) {
+    public Preparer(NodeRepository nodeRepository, int spareCount, Optional<HostProvisioner> hostProvisioner,
+                    BooleanFlag dynamicProvisioningEnabled) {
         this.nodeRepository = nodeRepository;
         this.spareCount = spareCount;
-        this.groupPreparer = new GroupPreparer(nodeRepository);
+        this.groupPreparer = new GroupPreparer(nodeRepository, hostProvisioner, dynamicProvisioningEnabled);
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
@@ -1,0 +1,69 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.provisioning;
+
+import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.hosted.provision.Node;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Describes a single newly provisioned host by {@link HostProvisioner}.
+ *
+ * @author freva
+ */
+public class ProvisionedHost {
+    private final String id;
+    private final String hostHostname;
+    private final Flavor hostFlavor;
+    private final String nodeHostname;
+    private final Flavor nodeFlavor;
+
+    public ProvisionedHost(String id, String hostHostname, Flavor hostFlavor, String nodeHostname, Flavor nodeFlavor) {
+        this.id = Objects.requireNonNull(id, "Host id must be set");
+        this.hostHostname = Objects.requireNonNull(hostHostname, "Host hostname must be set");
+        this.hostFlavor = Objects.requireNonNull(hostFlavor, "Host flavor must be set");
+        this.nodeHostname = Objects.requireNonNull(nodeHostname, "Node hostname must be set");
+        this.nodeFlavor = Objects.requireNonNull(nodeFlavor, "Node flavor must be set");
+    }
+
+    /** Generate {@link Node} instance representing the provisioned physical host */
+    Node generateHost() {
+        return Node.create(id, Set.of(), Set.of(), hostHostname, Optional.empty(), hostFlavor, NodeType.host);
+    }
+
+    /** Generate {@link Node} instance representing the node running on this physical host */
+    Node generateNode() {
+        return Node.createDockerNode(Set.of(), Set.of(), nodeHostname, hostHostname, nodeFlavor, NodeType.tenant);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProvisionedHost that = (ProvisionedHost) o;
+        return id.equals(that.id) &&
+                hostHostname.equals(that.hostHostname) &&
+                hostFlavor.equals(that.hostFlavor) &&
+                nodeHostname.equals(that.nodeHostname) &&
+                nodeFlavor.equals(that.nodeFlavor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, hostHostname, hostFlavor, nodeHostname, nodeFlavor);
+    }
+
+    @Override
+    public String toString() {
+        return "ProvisionedHost{" +
+                "id='" + id + '\'' +
+                ", hostHostname='" + hostHostname + '\'' +
+                ", hostFlavor=" + hostFlavor +
+                ", nodeHostname='" + nodeHostname + '\'' +
+                ", nodeFlavor=" + nodeFlavor +
+                '}';
+    }
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -17,6 +17,7 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.flag.FlagId;
@@ -59,7 +60,8 @@ public class MockNodeRepository extends NodeRepository {
     }
 
     private void populate() {
-        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(this, flavors, Zone.defaultZone(), new MockProvisionServiceProvider());
+        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(this, flavors, Zone.defaultZone(),
+                new MockProvisionServiceProvider(), new InMemoryFlagSource());
         List<Node> nodes = new ArrayList<>();
 
         // Regular nodes

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
@@ -21,6 +21,7 @@ import com.yahoo.test.ManualClock;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
@@ -250,7 +251,7 @@ public class FailedExpirerTest {
                                                      new MockNameResolver().mockAnyLookup(),
                                                      new DockerImage("docker-image"),
                                                      true);
-            this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, Zone.defaultZone(), new MockProvisionServiceProvider());
+            this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, Zone.defaultZone(), new MockProvisionServiceProvider(), new InMemoryFlagSource());
             this.expirer = new FailedExpirer(nodeRepository, zone, clock, Duration.ofMinutes(30),
                                              new JobControl(nodeRepository.database()));
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -23,6 +23,7 @@ import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.monitoring.MetricsReporterTest;
@@ -85,7 +86,7 @@ public class NodeFailTester {
         curator = new MockCurator();
         nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, new MockNameResolver().mockAnyLookup(),
                 new DockerImage("docker-registry.domain.tld:8080/dist/vespa"), true);
-        provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider());
+        provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
         hostLivenessTracker = new TestHostLivenessTracker(clock);
         orchestrator = new OrchestratorMock();
         this.configserverConfig = configserverConfig;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTester.java
@@ -15,6 +15,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.maintenance.retire.RetirementPolicy;
@@ -75,7 +76,7 @@ public class NodeRetirerTester {
         nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, new MockNameResolver().mockAnyLookup(),
                                             new DockerImage("docker-registry.domain.tld:8080/dist/vespa"), true);
         jobControl = new JobControl(nodeRepository.database());
-        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider());
+        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
         deployer = new MockDeployer(provisioner, clock, apps);
         flavors = nodeFlavors.getFlavors().stream().sorted(Comparator.comparing(Flavor::name)).collect(Collectors.toList());
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainerTest.java
@@ -20,6 +20,7 @@ import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -124,7 +125,7 @@ public class OperatorChangeApplicationMaintainerTest {
         Fixture(Zone zone, NodeRepository nodeRepository, NodeFlavors flavors, Curator curator) {
             this.nodeRepository = nodeRepository;
             this.curator = curator;
-            this.provisioner = new NodeRepositoryProvisioner(nodeRepository, flavors, zone, new MockProvisionServiceProvider());
+            this.provisioner = new NodeRepositoryProvisioner(nodeRepository, flavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
         }
 
         void activate() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -21,6 +21,7 @@ import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -249,7 +250,7 @@ public class PeriodicApplicationMaintainerTest {
         Fixture(Zone zone, NodeRepository nodeRepository, NodeFlavors flavors, Curator curator) {
             this.nodeRepository = nodeRepository;
             this.curator = curator;
-            this.provisioner =  new NodeRepositoryProvisioner(nodeRepository, flavors, zone, new MockProvisionServiceProvider());
+            this.provisioner =  new NodeRepositoryProvisioner(nodeRepository, flavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
 
             Map<ApplicationId, MockDeployer.ApplicationContext> apps = new HashMap<>();
             apps.put(app1, new MockDeployer.ApplicationContext(app1, clusterApp1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
@@ -12,6 +12,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
@@ -46,7 +47,7 @@ public class ReservationExpirerTest {
                                                            new MockNameResolver().mockAnyLookup(),
                                                            new DockerImage("docker-registry.domain.tld:8080/dist/vespa"),
                                                            true);
-        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, flavors, Zone.defaultZone(), new MockProvisionServiceProvider());
+        NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, flavors, Zone.defaultZone(), new MockProvisionServiceProvider(), new InMemoryFlagSource());
 
         List<Node> nodes = new ArrayList<>(2);
         nodes.add(nodeRepository.createNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Optional.empty(), flavors.getFlavorOrThrow("default"), NodeType.tenant));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -21,6 +21,7 @@ import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
@@ -61,7 +62,7 @@ public class RetiredExpirerTest {
     private final NodeRepository nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
             new MockNameResolver().mockAnyLookup(),
             new DockerImage("docker-registry.domain.tld:8080/dist/vespa"), true);
-    private final NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider());
+    private final NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
     private final Orchestrator orchestrator = mock(Orchestrator.class);
 
     private static final Duration RETIRED_EXPIRATION = Duration.ofHours(12);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
 /**
  * @author mortent
  */
-public class DynamicDockerProvisioningTest {
+public class DynamicDockerAllocationTest {
 
     /**
      * Test relocation of nodes from spare hosts.

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
@@ -1,0 +1,136 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.provisioning;
+
+import com.google.common.collect.ImmutableSet;
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Capacity;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.HostSpec;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author freva
+ */
+public class DynamicDockerProvisionTest {
+
+    private final MockNameResolver nameResolver = new MockNameResolver().mockAnyLookup();
+    private final HostProvisioner hostProvisioner = mock(HostProvisioner.class);
+    private final InMemoryFlagSource flagSource = new InMemoryFlagSource()
+            .withBooleanFlag(Flags.ENABLE_DYNAMIC_PROVISIONING.id(), true);
+    private final ProvisioningTester tester = new ProvisioningTester.Builder()
+            .hostProvisioner(hostProvisioner).flagSource(flagSource).nameResolver(nameResolver).build();
+
+    @Test
+    public void dynamically_provision_with_empty_node_repo() {
+        assertEquals(0, tester.nodeRepository().list().size());
+
+        ApplicationId application1 = tester.makeApplicationId();
+        Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("dockerSmall");
+
+        mockHostProvisioner(hostProvisioner, tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("small"));
+        List<HostSpec> hostSpec = tester.prepare(application1, clusterSpec("myContent.t1.a1"), 4, 1, flavor.canonicalName());
+        verify(hostProvisioner).provisionHosts(4, flavor);
+
+        // Total of 8 nodes should now be in node-repo, 4 hosts in state provisioned, and 4 reserved nodes
+        assertEquals(8, tester.nodeRepository().list().size());
+        assertEquals(4, tester.nodeRepository().getNodes(NodeType.host, Node.State.provisioned).size());
+        assertEquals(4, tester.nodeRepository().getNodes(NodeType.tenant, Node.State.reserved).size());
+        assertEquals(List.of("host-1-1", "host-2-1", "host-3-1", "host-4-1"),
+                hostSpec.stream().map(HostSpec::hostname).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void does_not_allocate_to_available_empty_hosts() {
+        tester.makeReadyNodes(3, "small", NodeType.host, 10);
+        deployZoneApp(tester);
+
+        ApplicationId application = tester.makeApplicationId();
+        Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("dockerSmall");
+
+        mockHostProvisioner(hostProvisioner, tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("small"));
+        tester.prepare(application, clusterSpec("myContent.t2.a2"), 2, 1, flavor.canonicalName());
+        verify(hostProvisioner).provisionHosts(2, flavor);
+    }
+
+    @Test
+    public void allocates_to_hosts_already_hosting_nodes_by_this_tenant() {
+        ApplicationId application = tester.makeApplicationId();
+        Flavor flavor = tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("dockerSmall");
+
+        mockHostProvisioner(hostProvisioner, tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("large"));
+        tester.prepare(application, clusterSpec("myContent.t2.a2"), 2, 1, flavor.canonicalName());
+        verify(hostProvisioner).provisionHosts(2, flavor);
+
+        // Ready the provisioned hosts, add an IP addreses to pool and activate them
+        for (int i = 1; i < 3; i++) {
+            String hostname = "host-" + i;
+            Node host = tester.nodeRepository().getNode(hostname).orElseThrow()
+                    .withIpAddressPool(Set.of("::" + i + ":2")).withIpAddresses(Set.of("::" + i + ":0"));
+            tester.nodeRepository().setReady(List.of(host), Agent.system, getClass().getSimpleName());
+            nameResolver.addRecord(hostname + "-2", "::" + i + ":2");
+        }
+        deployZoneApp(tester);
+
+        mockHostProvisioner(hostProvisioner, tester.nodeRepository().getAvailableFlavors().getFlavorOrThrow("small"));
+        tester.prepare(application, clusterSpec("another-id"), 2, 1, flavor.canonicalName());
+        // Verify there was only 1 call to provision hosts (during the first prepare)
+        verify(hostProvisioner).provisionHosts(anyInt(), any());
+
+        // Node-repo should now consist of 2 active hosts with 2 reserved nodes on each
+        assertEquals(6, tester.nodeRepository().list().size());
+        assertEquals(2, tester.nodeRepository().getNodes(NodeType.host, Node.State.active).size());
+        assertEquals(4, tester.nodeRepository().getNodes(NodeType.tenant, Node.State.reserved).size());
+    }
+
+
+    private static void deployZoneApp(ProvisioningTester tester) {
+        ApplicationId applicationId = tester.makeApplicationId();
+        List<HostSpec> list = tester.prepare(applicationId,
+                ClusterSpec.request(ClusterSpec.Type.container,
+                        ClusterSpec.Id.from("node-admin"),
+                        Version.fromString("6.42"),
+                        false, Collections.emptySet()),
+                Capacity.fromRequiredNodeType(NodeType.host),
+                1);
+        tester.activate(applicationId, ImmutableSet.copyOf(list));
+    }
+
+
+    private static ClusterSpec clusterSpec(String clusterId) {
+        return ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from(clusterId), Version.fromString("6.42"), false, Collections.emptySet());
+    }
+
+    private static void mockHostProvisioner(HostProvisioner hostProvisioner, Flavor hostFlavor) {
+        final int[] numProvisioned = { 0 };
+        doAnswer(invocation -> {
+            int numHosts = (int) invocation.getArguments()[0];
+            Flavor nodeFlavor = (Flavor) invocation.getArguments()[1];
+            System.out.println(numHosts + " " + nodeFlavor);
+            return IntStream.range(0, numHosts)
+                    .map(i -> ++numProvisioned[0])
+                    .mapToObj(i -> new ProvisionedHost("id-" + i, "host-" + i, hostFlavor, "host-" + i + "-1", nodeFlavor))
+                    .collect(Collectors.toList());
+        }).when(hostProvisioner).provisionHosts(anyInt(), any());
+    }
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
@@ -126,7 +126,6 @@ public class DynamicDockerProvisionTest {
         doAnswer(invocation -> {
             int numHosts = (int) invocation.getArguments()[0];
             Flavor nodeFlavor = (Flavor) invocation.getArguments()[1];
-            System.out.println(numHosts + " " + nodeFlavor);
             return IntStream.range(0, numHosts)
                     .map(i -> ++numProvisioned[0])
                     .mapToObj(i -> new ProvisionedHost("id-" + i, "host-" + i, hostFlavor, "host-" + i + "-1", nodeFlavor))

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -452,7 +452,7 @@ public class ProvisioningTester {
                     Optional.ofNullable(zone).orElseGet(Zone::defaultZone),
                     Optional.ofNullable(nameResolver).orElseGet(() -> new MockNameResolver().mockAnyLookup()),
                     orchestrator,
-                    Optional.ofNullable(hostProvisioner).orElseGet(() -> null),
+                    Optional.ofNullable(hostProvisioner).orElse(null),
                     Optional.ofNullable(loadBalancerService).orElseGet(LoadBalancerServiceMock::new),
                     Optional.ofNullable(flagSource).orElseGet(InMemoryFlagSource::new));
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -452,7 +452,7 @@ public class ProvisioningTester {
                     Optional.ofNullable(zone).orElseGet(Zone::defaultZone),
                     Optional.ofNullable(nameResolver).orElseGet(() -> new MockNameResolver().mockAnyLookup()),
                     orchestrator,
-                    Optional.ofNullable(hostProvisioner).orElse(null),
+                    hostProvisioner,
                     Optional.ofNullable(loadBalancerService).orElseGet(LoadBalancerServiceMock::new),
                     Optional.ofNullable(flagSource).orElseGet(InMemoryFlagSource::new));
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -22,6 +22,8 @@ import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -79,7 +81,7 @@ public class ProvisioningTester {
     public ProvisioningTester(
             Curator curator, NodeFlavors nodeFlavors, Zone zone, NameResolver nameResolver,
             Orchestrator orchestrator, HostProvisioner hostProvisioner,
-            LoadBalancerServiceMock loadBalancerService) {
+            LoadBalancerServiceMock loadBalancerService, FlagSource flagSource) {
         this.curator = curator;
         this.nodeFlavors = nodeFlavors;
         this.clock = new ManualClock();
@@ -87,7 +89,7 @@ public class ProvisioningTester {
                 new DockerImage("docker-registry.domain.tld:8080/dist/vespa"), true);
         this.orchestrator = orchestrator;
         ProvisionServiceProvider provisionServiceProvider = new MockProvisionServiceProvider(loadBalancerService, hostProvisioner);
-        this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, provisionServiceProvider);
+        this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, provisionServiceProvider, flagSource);
         this.capacityPolicies = new CapacityPolicies(zone, nodeFlavors);
         this.provisionLogger = new NullProvisionLogger();
         this.loadBalancerService = loadBalancerService;
@@ -390,6 +392,7 @@ public class ProvisioningTester {
         private Orchestrator orchestrator;
         private HostProvisioner hostProvisioner;
         private LoadBalancerServiceMock loadBalancerService;
+        private FlagSource flagSource;
 
         public Builder curator(Curator curator) {
             this.curator = curator;
@@ -426,6 +429,11 @@ public class ProvisioningTester {
             return this;
         }
 
+        public Builder flagSource(FlagSource flagSource) {
+            this.flagSource = flagSource;
+            return this;
+        }
+
         public ProvisioningTester build() {
             Orchestrator orchestrator = Optional.ofNullable(this.orchestrator)
                     .orElseGet(() -> {
@@ -445,7 +453,8 @@ public class ProvisioningTester {
                     Optional.ofNullable(nameResolver).orElseGet(() -> new MockNameResolver().mockAnyLookup()),
                     orchestrator,
                     Optional.ofNullable(hostProvisioner).orElseGet(() -> null),
-                    Optional.ofNullable(loadBalancerService).orElseGet(LoadBalancerServiceMock::new));
+                    Optional.ofNullable(loadBalancerService).orElseGet(LoadBalancerServiceMock::new),
+                    Optional.ofNullable(flagSource).orElseGet(InMemoryFlagSource::new));
         }
     }
 


### PR DESCRIPTION
Ideally, `NodePrioritizer` would add enough fake nodes with lowest priority, then, the number of nodes picked by `NodeAllocation` would be provisioned. But this created a bunch of new problems, the fake nodes generated in `NodePrioritizer` would have fake hostnames, those would need to be changed and there is no easy way to create a new `Node` with a different hostname (for good reason, since that is the zk ID...). As result, I added logic `NodeAllocation` to determine how many more nodes are needed before throwing `OutOfCapacityException`.

Another issue; While this does allow for regular allocation of nodes to hosts that already have a node by the same tenant, it requires that that host already has `additionalIpAddresses` set. Which means that we probably wont be able to use this optimization often. It is difficult to make this kind of optimization when each `prepare()` only deals with a single cluster & group.