### PR TITLE
Use a synchronized tenant map

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -67,7 +67,7 @@ public class TenantRepository implements ConnectionStateListener, PathChildrenCa
     private static final Duration checkForRemovedApplicationsInterval = Duration.ofMinutes(1);
     private static final Logger log = Logger.getLogger(TenantRepository.class.getName());
 
-    private final Map<TenantName, Tenant> tenants = new LinkedHashMap<>();
+    private final Map<TenantName, Tenant> tenants = Collections.synchronizedMap(new LinkedHashMap<>());
     private final GlobalComponentRegistry globalComponentRegistry;
     private final List<TenantListener> tenantListeners = Collections.synchronizedList(new ArrayList<>());
     private final Curator curator;


### PR DESCRIPTION
When creating tenants there are multiple threads populating this map,
this may lead to an inconsistent state unless using a regular map.