### PR TITLE
Revert "Remove traces of global grow."

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
@@ -156,6 +156,7 @@ public class Tuning extends AbstractConfigProducer implements PartitionsConfig.P
             @Override
             public void getConfig(ProtonConfig.Builder builder) {
                 if (initialDocumentCount!=null) {
+                    builder.grow.initial(initialDocumentCount);
                     for (ProtonConfig.Documentdb.Builder db : builder.documentdb) {
                         db.allocation.initialnumdocs(initialDocumentCount);
                     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilderTest.java
@@ -138,6 +138,8 @@ public class DomSearchTuningBuilderTest extends DomBuilderTest {
                 "</resizing>"));
         assertEquals(128, t.searchNode.resizing.initialDocumentCount.intValue());
         assertEquals(13, t.searchNode.resizing.amortizeCount.intValue());
+        String cfg = getProtonCfg(t);
+        assertThat(cfg, containsString("grow.initial 128"));
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/NodeFlavorTuningTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/NodeFlavorTuningTest.java
@@ -45,6 +45,7 @@ public class NodeFlavorTuningTest {
     @Test
     public void require_that_initial_numdocs_is_dependent_of_mode() {
         ProtonConfig cfg = getProtonMemoryConfig(Arrays.asList(new Pair<>("a", "INDEX"), new Pair<>("b", "STREAMING"), new Pair<>("c", "STORE_ONLY")), 24);
+        assertEquals(1024, cfg.grow().initial());
         assertEquals(3, cfg.documentdb().size());
         assertEquals(1024, cfg.documentdb(0).allocation().initialnumdocs());
         assertEquals("a", cfg.documentdb(0).inputdoctypename());

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/DocumentDatabaseTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/DocumentDatabaseTestCase.java
@@ -178,6 +178,7 @@ public class DocumentDatabaseTestCase {
         VespaModel model = createModel(nameAndModes, xmlTuning);
         ContentSearchCluster contentSearchCluster = model.getContentClusters().get("test").getSearch();
         ProtonConfig proton = getProtonCfg(contentSearchCluster);
+        assertEquals(global, proton.grow().initial());
         assertEquals(local.size(), proton.documentdb().size());
         for (int i = 0; i < local.size(); i++) {
             assertEquals(local.get(i).longValue(), proton.documentdb(i).allocation().initialnumdocs());

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -185,6 +185,27 @@ distribution.redundancy long default=1
 ## Searchable copies of the documents.
 distribution.searchablecopies long default=1
 
+## Minimum initial size for any per document tables.
+## Deprecated -> Use documentdb.allocation.xxx
+grow.initial long default=1024 restart
+
+## Grow factor in percent for any per document tables.
+## Deprecated -> Use documentdb.allocation.xxx
+grow.factor int default=20 restart
+
+## Constant added when growing any per document tables.
+## Deprecated -> Use documentdb.allocation.xxx
+grow.add int default=1 restart
+
+## The number of documents to amortize memory spike cost over
+## Deprecated -> Use documentdb.allocation.xxx
+grow.numdocs int default=10000 restart
+
+## The grow factor used when allocating buffers in the array store
+## used in multi-value attribute vectors to store underlying values.
+## Deprecated -> Use documentdb.allocation.xxx
+grow.multivalueallocfactor double default=0.2 restart
+
 ## Control cache size in bytes.
 ## Postive numbers are absolute in bytes.
 ## Negative numbers are a percentage of memory.


### PR DESCRIPTION
Reverts vespa-engine/vespa#8266

Not 100% sure, but I believe that this broke:
https://factory-web.vespa.corp.yahoo.com/versions/1/builds/40792/products/1/tests/212637/testruns/28732703
