### PR TITLE
Expose data metrics per bucket space on content node

### DIFF
--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -79,10 +79,10 @@ private:
      * The unified version of the last cluster state.
      */
     std::string _lastUnifiedClusterState;
-    std::shared_ptr<BucketManagerMetrics> _metrics;
     bool _doneInitialized;
     size_t _requestsCurrentlyProcessing;
     ServiceLayerComponent _component;
+    std::shared_ptr<BucketManagerMetrics> _metrics;
     framework::Thread::UP _thread;
 
     BucketManager(const BucketManager&);

--- a/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.cpp
@@ -28,7 +28,7 @@ DataStoredMetrics::DataStoredMetrics(const std::string& name, metrics::MetricSet
 DataStoredMetrics::~DataStoredMetrics() = default;
 
 BucketSpaceMetrics::BucketSpaceMetrics(const vespalib::string& space_name, metrics::MetricSet* owner)
-        : metrics::MetricSet("bucket_space", {{"name", space_name}}, "", owner),
+        : metrics::MetricSet("bucket_space", {{"bucketSpace", space_name}}, "", owner),
           buckets_total("buckets_total", {}, "Total number buckets present in the bucket space (ready + not ready)", this),
           docs("docs", {}, "Documents stored in the bucket space", this),
           bytes("bytes", {}, "Bytes stored across all documents in the bucket space", this),

--- a/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.h
@@ -2,12 +2,15 @@
 
 #pragma once
 
+#include <vespa/document/bucket/bucketspace.h>
 #include <vespa/metrics/metrics.h>
+
+#include <unordered_map>
+#include <memory>
 
 namespace storage {
 
-struct DataStoredMetrics : public metrics::MetricSet
-{
+struct DataStoredMetrics : metrics::MetricSet {
     typedef std::shared_ptr<DataStoredMetrics> SP;
 
     metrics::LongValueMetric buckets;
@@ -17,20 +20,35 @@ struct DataStoredMetrics : public metrics::MetricSet
     metrics::LongValueMetric ready;
 
     DataStoredMetrics(const std::string& name, metrics::MetricSet* owner);
-    ~DataStoredMetrics();
+    ~DataStoredMetrics() override;
 };
 
-class BucketManagerMetrics : public metrics::MetricSet
-{
+struct BucketSpaceMetrics : metrics::MetricSet {
+    // Superficially very similar to DataStoredMetrics, but metric naming and dimensions differ
+    metrics::LongValueMetric buckets_total;
+    metrics::LongValueMetric docs;
+    metrics::LongValueMetric bytes;
+    metrics::LongValueMetric active_buckets;
+    metrics::LongValueMetric ready_buckets;
+
+    BucketSpaceMetrics(const vespalib::string& space_name, metrics::MetricSet* owner);
+    ~BucketSpaceMetrics() override;
+};
+
+class ContentBucketSpaceRepo;
+
+class BucketManagerMetrics : public metrics::MetricSet {
 public:
-    std::vector<std::shared_ptr<DataStoredMetrics> > disks;
+    std::vector<std::shared_ptr<DataStoredMetrics>> disks;
+    using BucketSpaceMap = std::unordered_map<document::BucketSpace, std::unique_ptr<BucketSpaceMetrics>, document::BucketSpace::hash>;
+    BucketSpaceMap bucket_spaces;
     metrics::SumMetric<metrics::MetricSet> total;
     metrics::LongValueMetric simpleBucketInfoRequestSize;
     metrics::LongAverageMetric fullBucketInfoRequestSize;
     metrics::LongAverageMetric fullBucketInfoLatency;
 
-    BucketManagerMetrics();
-    ~BucketManagerMetrics();
+    explicit BucketManagerMetrics(const ContentBucketSpaceRepo& repo);
+    ~BucketManagerMetrics() override;
     void setDisks(uint16_t numDisks);
 };
 


### PR DESCRIPTION
@geirst please review. Right now I'm just using a metric dimension key of "name" for the bucket space metrics, but might want to choose something else if these metrics are to be exported via the proxy.
@hakonhall FYI, this is intended to be used as input to the orchestrator logic when deciding if a retired node can be removed
@yngveaasheim FYI

Example dump of metrics with this change:
```
vds.datastored.alldisks.buckets average=33 last=33 min=33 max=33 count=2 total=66
vds.datastored.alldisks.docs average=34 last=34 min=34 max=34 count=2 total=68
vds.datastored.alldisks.bytes average=1984 last=1984 min=1984 max=1984 count=2 total=3968
vds.datastored.alldisks.activebuckets average=13 last=13 min=13 max=13 count=2 total=26
vds.datastored.alldisks.readybuckets average=18 last=18 min=18 max=18 count=2 total=36
vds.datastored.bucket_space{name:global}.buckets_total average=9 last=9 min=9 max=9 count=2 total=18
vds.datastored.bucket_space{name:global}.docs average=8 last=8 min=8 max=8 count=2 total=16
vds.datastored.bucket_space{name:global}.bytes average=432 last=432 min=432 max=432 count=2 total=864
vds.datastored.bucket_space{name:global}.active_buckets average=4 last=4 min=4 max=4 count=2 total=8
vds.datastored.bucket_space{name:global}.ready_buckets average=9 last=9 min=9 max=9 count=2 total=18
vds.datastored.bucket_space{name:default}.buckets_total average=24 last=24 min=24 max=24 count=2 total=48
vds.datastored.bucket_space{name:default}.docs average=26 last=26 min=26 max=26 count=2 total=52
vds.datastored.bucket_space{name:default}.bytes average=1552 last=1552 min=1552 max=1552 count=2 total=3104
vds.datastored.bucket_space{name:default}.active_buckets average=9 last=9 min=9 max=9 count=2 total=18
vds.datastored.bucket_space{name:default}.ready_buckets average=9 last=9 min=9 max=9 count=2 total=18
```
As can be observed above, legacy metrics that cover all bucket spaces remain unchanged.