### PR TITLE
Derive correct distribution partition spec for grouped clusters

### DIFF
--- a/storage/src/vespa/storage/common/global_bucket_space_distribution_converter.cpp
+++ b/storage/src/vespa/storage/common/global_bucket_space_distribution_converter.cpp
@@ -44,15 +44,19 @@ const Group& find_non_root_group_by_index(const vespalib::string& index, const G
 }
 
 vespalib::string sub_groups_to_partition_spec(const Group& parent) {
-    vespalib::asciistream partitions;
-    // In case of a flat cluster config, this ends up with a partition spec of '*',
-    // which is fine. It basically means "put all replicas in this group", which
-    // happens to be exactly what we want.
-    for (auto& child : parent.sub_groups) {
-        partitions << child.second->nested_leaf_count << '|';
+    if (parent.sub_groups.empty()) {
+        return "*";
     }
-    partitions << '*';
-    return partitions.str();
+    vespalib::asciistream spec;
+    // We simplify the generated partition spec by only emitting wildcard entries.
+    // These will have replicas evenly divided amongst them.
+    for (size_t i = 0; i < parent.sub_groups.size(); ++i) {
+        if (i != 0) {
+            spec << '|';
+        }
+        spec << '*';
+    }
+    return spec.str();
 }
 
 bool is_leaf_group(const DistributionConfigBuilder::Group& g) noexcept {

--- a/vdslib/src/tests/state/grouptest.cpp
+++ b/vdslib/src/tests/state/grouptest.cpp
@@ -181,6 +181,12 @@ void
 GroupTest::testStarConversion()
 {
     {
+        MAKEGROUP(g, "group", 0, "*");
+        std::vector<double> distribution = g.getDistribution(3);
+        CPPUNIT_ASSERT_EQUAL((size_t) 1, distribution.size());
+        CPPUNIT_ASSERT_EQUAL((double) 3, distribution[0]);
+    }
+    {
         MAKEGROUP(g, "group", 0, "1|*|*");
         std::vector<double> distribution = g.getDistribution(5);
         CPPUNIT_ASSERT_EQUAL((size_t) 3, distribution.size());
@@ -243,6 +249,14 @@ GroupTest::testStarConversion()
         CPPUNIT_ASSERT_EQUAL((double) 2, distribution[0]);
         CPPUNIT_ASSERT_EQUAL((double) 2, distribution[1]);
         CPPUNIT_ASSERT_EQUAL((double) 1, distribution[2]);
+    }
+    {
+        MAKEGROUP(g, "group", 0, "*|*|*");
+        std::vector<double> distribution = g.getDistribution(12); // Shall be evenly divided
+        CPPUNIT_ASSERT_EQUAL((size_t) 3, distribution.size());
+        CPPUNIT_ASSERT_EQUAL((double) 4, distribution[0]);
+        CPPUNIT_ASSERT_EQUAL((double) 4, distribution[1]);
+        CPPUNIT_ASSERT_EQUAL((double) 4, distribution[2]);
     }
     {
         MAKEGROUP(g, "group", 0, "*|*|*|*");


### PR DESCRIPTION
@geirst please review

Simplify code by emitting wildcards for all groups instead of using
explicit leaf counts. Distribution code will distribute replicas
evenly across all wildcarded groups.

This fixes #8475