### PR TITLE
Revert "Revert "Switch to java dispatch for system/perf tests"" (i.e. activate java dispatcher for test)

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -84,7 +84,7 @@ public class Flags {
             NODE_TYPE, APPLICATION_ID, HOSTNAME);
 
     public static final UnboundBooleanFlag USE_FDISPATCH_BY_DEFAULT = defineFeatureFlag(
-            "use-fdispatch-by-default", true,
+            "use-fdispatch-by-default", false,
             "Should fdispatch be used as the default instead of the java dispatcher",
             "Takes effect at redeployment",
             APPLICATION_ID);


### PR DESCRIPTION
Reverts vespa-engine/vespa#8368

Also known as: reapply java dispatch for testing