### PR TITLE
Force node clones to get a copy of all fields

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -65,14 +65,10 @@ public final class Node {
                 .build();
     }
 
-    /**
-     * Creates a node with all fields specified, necessary for serialization code.
-     *
-     * Others should use the {@code create} methods to create nodes, or the Builder to modify nodes.
-     */
-    public Node(String id, Set<String> ipAddresses, Set<String> ipAddressPool, String hostname, Optional<String> parentHostname,
-                Flavor flavor, Status status, State state, Optional<Allocation> allocation, History history, NodeType type,
-                Reports reports, Optional<String> modelId) {
+    /** Creates an immutable node. Clients should create nodes through the create methods or the Builder. */
+    private Node(String id, Set<String> ipAddresses, Set<String> ipAddressPool, String hostname, Optional<String> parentHostname,
+                 Flavor flavor, Status status, State state, Optional<Allocation> allocation, History history, NodeType type,
+                 Reports reports, Optional<String> modelId) {
         Objects.requireNonNull(id, "A node must have an ID");
         requireNonEmptyString(hostname, "A node must have a hostname");
         requireNonEmptyString(parentHostname, "A parent host name must be a proper value");
@@ -103,8 +99,8 @@ public final class Node {
         this.modelId = modelId;
     }
 
-    /** Helper for creating and mutating node objects. */
-    private static class Builder {
+    /** Builds a node object. */
+    public static class Builder {
         private final String hostname;
 
         // Required but mutable fields
@@ -132,13 +128,29 @@ public final class Node {
         }
 
         private Builder(Node node) {
-            this(node.id, node.ipAddresses, node.hostname, node.flavor, node.type);
-            withIpAddressPool(node.ipAddressPool.asSet());
-            node.parentHostname.ifPresent(this::withParentHostname);
-            withStatus(node.status);
-            withState(node.state);
-            withHistory(node.history);
-            node.allocation.ifPresent(this::withAllocation);
+            this(node.id, node.ipAddresses, node.ipAddressPool.asSet(), node.hostname, node.parentHostname,
+                    node.flavor, node.status, node.state, node.allocation, node.history, node.type, node.reports,
+                    node.modelId);
+        }
+
+        /** Create a Builder with ALL fields set, useful for e.g. serialization code. */
+        public Builder(String id, Set<String> ipAddresses, Set<String> ipAddressPool, String hostname,
+                       Optional<String> parentHostname, Flavor flavor, Status status, State state,
+                       Optional<Allocation> allocation, History history, NodeType type, Reports reports,
+                       Optional<String> modelId) {
+            this.id = id;
+            this.ipAddresses = ipAddresses;
+            this.hostname = hostname;
+            this.flavor = flavor;
+            this.type = type;
+            this.ipAddressPool = ipAddressPool;
+            this.parentHostname = parentHostname;
+            this.status = status;
+            this.state = state;
+            this.history = history;
+            this.allocation = allocation;
+            this.reports = reports;
+            this.modelId = modelId;
         }
 
         public Builder withId(String id) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -206,13 +206,13 @@ public class CuratorDatabaseClient {
 
         CuratorTransaction curatorTransaction = curatorDatabase.newCuratorTransactionIn(transaction);
         for (Node node : nodes) {
-            Node newNode = new Node(node.id(), node.ipAddresses(), node.ipAddressPool().asSet(), node.hostname(),
+            Node newNode = new Node.Builder(node.id(), node.ipAddresses(), node.ipAddressPool().asSet(), node.hostname(),
                                     node.parentHostname(), node.flavor(),
                                     newNodeStatus(node, toState),
                                     toState,
                                     toState.isAllocated() ? node.allocation() : Optional.empty(),
                                     node.history().recordStateTransition(node.state(), toState, agent, clock.instant()),
-                                    node.type(), node.reports(), node.modelId());
+                                    node.type(), node.reports(), node.modelId()).build();
             curatorTransaction.add(CuratorOperations.delete(toPath(node).getAbsolute()))
                               .add(CuratorOperations.create(toPath(toState, newNode.hostname()).getAbsolute(), nodeSerializer.toJson(newNode)));
             writtenNodes.add(newNode);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -161,7 +161,7 @@ public class NodeSerializer {
     }
 
     private Node nodeFromSlime(Node.State state, Inspector object) {
-        return new Node(object.field(idKey).asString(),
+        return new Node.Builder(object.field(idKey).asString(),
                         ipAddressesFromSlime(object, ipAddressesKey),
                         ipAddressesFromSlime(object, ipAddressPoolKey),
                         object.field(hostnameKey).asString(),
@@ -173,7 +173,7 @@ public class NodeSerializer {
                         historyFromSlime(object.field(historyKey)),
                         nodeTypeFromString(object.field(nodeTypeKey).asString()),
                         Reports.fromSlime(object.field(reportsKey)),
-                        modelIdFromSlime(object));
+                        modelIdFromSlime(object)).build();
     }
 
     private Status statusFromSlime(Inspector object) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainerTest.java
@@ -143,8 +143,9 @@ public class HostProvisionMaintainerTest {
                             Generation.initial(),
                             false));
             Set<String> ips = state == Node.State.active ? Set.of("::1") : Set.of();
-            return new Node("fake-id-" + hostname, ips, Set.of(), hostname,
-                    parentHostname, flavor, Status.initial(), state, allocation, History.empty(), nodeType, new Reports(), Optional.empty());
+            return new Node.Builder("fake-id-" + hostname, ips, Set.of(), hostname,
+                    parentHostname, flavor, Status.initial(), state, allocation, History.empty(), nodeType,
+                    new Reports(), Optional.empty()).build();
         }
 
         NodeRepository nodeRepository() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AllocationSimulator.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AllocationSimulator.java
@@ -80,10 +80,10 @@ public class AllocationSimulator {
     }
 
     private Node node(String hostname, Flavor flavor, Optional<String> parent, Optional<String> tenant) {
-        return new Node("fake", Collections.singleton("127.0.0.1"),
+        return new Node.Builder("fake", Collections.singleton("127.0.0.1"),
                 parent.isPresent() ? Collections.emptySet() : getAdditionalIP(), hostname, parent, flavor, Status.initial(),
                 parent.isPresent() ? Node.State.ready : Node.State.active, allocation(tenant), History.empty(),
-                parent.isPresent() ? NodeType.tenant : NodeType.host, new Reports(), Optional.empty());
+                parent.isPresent() ? NodeType.tenant : NodeType.host, new Reports(), Optional.empty()).build();
     }
 
     private Set<String> getAdditionalIP() {


### PR DESCRIPTION
I observed the node reports were removed after some time.

I have traced this to

    https://github.com/vespa-engine/vespa/blob/master/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java#L134

When Node wants to create a clone of itself with a modification, e.g. with
wantToRetire, it calls that Builder constructor. The problem is that
this.reports is not copied to the Builder's reports field, and so the new node
has lost the report.

A new field 'modelId' has been added to the node after 'reports', and it too
is not copied to the builder.

This is clearly too fragile.

This PR makes a public Builder() constructor taking in ALL fields of the Node
constructor, and forces all code outside to use that Builder constructor by
making the Node constructor private. This is just a refactoring.

However the Builder(Node) constructor calls the new Builder constructor, thus
forcing forwarding of all fields. This solves the problem.