### PR TITLE
Track group coverage changes in ping iterations

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -19,6 +19,7 @@ public class Group {
     private final ImmutableList<Node> nodes;
 
     private final AtomicBoolean hasSufficientCoverage = new AtomicBoolean(true);
+    private final AtomicBoolean hasFullCoverage = new AtomicBoolean(true);
     private final AtomicLong activeDocuments = new AtomicLong(0);
 
     public Group(int id, List<Node> nodes) {
@@ -81,5 +82,10 @@ public class Group {
         if (other == this) return true;
         if (!(other instanceof Group)) return false;
         return ((Group) other).id == this.id;
+    }
+
+    public boolean isFullCoverageStatusChanged(boolean hasFullCoverageNow) {
+        boolean previousState = hasFullCoverage.getAndSet(hasFullCoverageNow);
+        return previousState != hasFullCoverageNow;
     }
 }


### PR DESCRIPTION
The previous logging didn't track when the coverage is good again, and in a situation where the coverage is down and the searcher gets searches could become very spammy. (Also: should once again fix a system test when the java dispatcher is used)