### PR TITLE
Revert "Use VIP status file for config server (and controller) in hosted"

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -6,6 +6,10 @@
       <initialStatus>initializing</initialStatus>
     </config>
 
+    <config name="container.core.vip-status">
+      <initiallyInRotation>false</initiallyInRotation>
+    </config>
+
     <accesslog type="vespa" fileNamePattern="logs/vespa/configserver/access.log.%Y%m%d%H%M%S" compressOnRotation="true" symlinkName="access.log" />
     <preprocess:include file='access-logging.xml' required='false' />
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -11,9 +11,6 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.Zone;
-import com.yahoo.container.QrSearchersConfig;
-import com.yahoo.container.core.VipStatusConfig;
-import com.yahoo.container.handler.ClustersStatus;
 import com.yahoo.container.handler.VipStatus;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.container.jdisc.state.StateMonitor;
@@ -41,10 +38,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-import static com.yahoo.vespa.config.server.ConfigServerBootstrap.Mode.BOOTSTRAP_IN_SEPARATE_THREAD;
-import static com.yahoo.vespa.config.server.ConfigServerBootstrap.Mode.INITIALIZE_ONLY;
-import static com.yahoo.vespa.config.server.ConfigServerBootstrap.VipStatusMode.VIP_STATUS_FILE;
-import static com.yahoo.vespa.config.server.ConfigServerBootstrap.VipStatusMode.VIP_STATUS_PROGRAMMATICALLY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -70,12 +63,12 @@ public class ConfigServerBootstrapTest {
         assertTrue(versionState.isUpgraded());
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
+        VipStatus vipStatus = new VipStatus();
         // Take a host away so that there are too few for the application, to verify we can still bootstrap
         provisioner.allocations().values().iterator().next().remove(0);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_PROGRAMMATICALLY);
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer,
-                                                                    versionState, createStateMonitor(),
-                                                                    vipStatus, INITIALIZE_ONLY, VIP_STATUS_PROGRAMMATICALLY);
+                                                                    versionState, createStateMonitor(), vipStatus,
+                                                                    ConfigServerBootstrap.Mode.INITIALIZE_ONLY);
         assertFalse(vipStatus.isInRotation());
         bootstrap.start();
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
@@ -86,33 +79,6 @@ public class ConfigServerBootstrapTest {
         assertEquals(StateMonitor.Status.down, bootstrap.status());
         assertFalse(rpcServer.isRunning());
         assertFalse(vipStatus.isInRotation());
-    }
-
-    // Just tests setup, the actual response of accessing /status.html depends on the status
-    // file existing or not, which cannot be tested here
-    @Test
-    public void testBootstrapWithVipStatusFile() throws Exception {
-        ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
-        InMemoryProvisioner provisioner = new InMemoryProvisioner(true, "host0", "host1", "host3");
-        DeployTester tester = new DeployTester(configserverConfig, provisioner);
-        tester.deployApp("src/test/apps/hosted/");
-
-        File versionFile = temporaryFolder.newFile();
-        VersionState versionState = new VersionState(versionFile);
-        assertTrue(versionState.isUpgraded());
-
-        RpcServer rpcServer = createRpcServer(configserverConfig);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_FILE);
-        ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer,
-                                                                    versionState, createStateMonitor(),
-                                                                    vipStatus, INITIALIZE_ONLY, VIP_STATUS_FILE);
-        assertTrue(vipStatus.isInRotation()); // default is in rotation when using status file
-
-        bootstrap.start();
-        waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
-        waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");
-        waitUntil(vipStatus::isInRotation, "failed waiting for server to be in rotation");
-        bootstrap.deconstruct();
     }
 
     @Test
@@ -132,10 +98,10 @@ public class ConfigServerBootstrapTest {
                                            .resolve("sessions/2/services.xml"));
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_PROGRAMMATICALLY);
+        VipStatus vipStatus = new VipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
-                                                                    createStateMonitor(),
-                                                                    vipStatus, INITIALIZE_ONLY, VIP_STATUS_PROGRAMMATICALLY);
+                                                                    createStateMonitor(), vipStatus,
+                                                                    ConfigServerBootstrap.Mode.INITIALIZE_ONLY);
         assertFalse(vipStatus.isInRotation());
         // Call method directly, to be sure that it is finished redeploying all applications and we can check status
         bootstrap.start();
@@ -174,13 +140,15 @@ public class ConfigServerBootstrapTest {
         curator.set(Path.fromString("/config/v2/tenants/" + applicationId.tenant().value() + "/sessions/2/version"), Utf8.toBytes("1.2.2"));
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_PROGRAMMATICALLY);
+        VipStatus vipStatus = new VipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
                                                                     createStateMonitor(), vipStatus,
-                                                                    BOOTSTRAP_IN_SEPARATE_THREAD, VIP_STATUS_PROGRAMMATICALLY);
+                                                                    ConfigServerBootstrap.Mode.BOOTSTRAP_IN_SEPARATE_THREAD);
+
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
         waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");
         waitUntil(vipStatus::isInRotation, "failed waiting for server to be in rotation");
+        bootstrap.deconstruct();
     }
 
     private void waitUntil(BooleanSupplier booleanSupplier, String messageIfWaitingFails) throws InterruptedException {
@@ -229,15 +197,6 @@ public class ConfigServerBootstrapTest {
         return new Host(hostname, Collections.emptyList(), Optional.empty(), Optional.of(com.yahoo.component.Version.fromString(version)));
     }
 
-    private VipStatus createVipStatus(ConfigServerBootstrap.VipStatusMode vipStatusMode) throws IOException {
-        return new VipStatus(new QrSearchersConfig.Builder().build(),
-                             new VipStatusConfig.Builder()
-                                     .initiallyInRotation(vipStatusMode == VIP_STATUS_FILE)
-                                     .statusfile(temporaryFolder.newFile().getAbsolutePath())
-                                     .accessdisk(vipStatusMode == VIP_STATUS_FILE)
-                                     .build(),
-                             new ClustersStatus());
-    }
 
     public static class MockRpc extends com.yahoo.vespa.config.server.rpc.MockRpc {
 

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerApplication.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerApplication.java
@@ -15,19 +15,14 @@ import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
 import com.yahoo.config.model.ConfigModelRepo;
-import com.yahoo.config.model.api.ConfigServerSpec;
-import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.model.application.provider.StaticConfigDefinitionRepo;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
-import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.RegionName;
-import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.di.config.SubscriberFactory;
@@ -48,14 +43,12 @@ import org.w3c.dom.Element;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.yahoo.collections.CollectionUtil.first;
@@ -88,7 +81,6 @@ public class StandaloneContainerApplication implements Application {
     private final Application configuredApplication;
     private final Container container;
 
-    @SuppressWarnings("WeakerAccess")
     @Inject
     public StandaloneContainerApplication(Injector injector) {
         this.injector = injector;
@@ -220,9 +212,9 @@ public class StandaloneContainerApplication implements Application {
         }
     }
 
-    private static ContainerModelBuilder newContainerModelBuilder(Networking networkingOption, CloudConfigInstallVariables cloudConfigInstallVariables) {
+    private static ContainerModelBuilder newContainerModelBuilder(Networking networkingOption) {
         return isConfigServer() ?
-                new ConfigServerContainerModelBuilder(cloudConfigInstallVariables) :
+                new ConfigServerContainerModelBuilder(new CloudConfigInstallVariables()) :
                 new ContainerModelBuilder(true, networkingOption);
     }
 
@@ -246,16 +238,14 @@ public class StandaloneContainerApplication implements Application {
                 .includeSourceFiles(true).preprocessedDir(preprocessedApplicationDir).build();
         ApplicationPackage applicationPackage = rawApplicationPackage.preprocess(getZone(), logger);
         validateApplication(applicationPackage);
-        CloudConfigInstallVariables cloudConfigInstallVariables = new CloudConfigInstallVariables();
-        DeployState deployState = createDeployState(applicationPackage, fileRegistry, logger, cloudConfigInstallVariables);
+        DeployState deployState = createDeployState(applicationPackage, fileRegistry, logger);
 
         VespaModel root = VespaModel.createIncomplete(deployState);
         ApplicationConfigProducerRoot vespaRoot = new ApplicationConfigProducerRoot(root, "vespa", deployState.getDocumentModel(),
                 deployState.getVespaVersion(), deployState.getProperties().applicationId());
 
         Element spec = containerRootElement(applicationPackage);
-        ContainerModel containerModel = newContainerModelBuilder(networkingOption, cloudConfigInstallVariables)
-                .build(deployState, root, configModelRepo, vespaRoot, spec);
+        ContainerModel containerModel = newContainerModelBuilder(networkingOption).build(deployState, root, configModelRepo, vespaRoot, spec);
         containerModel.getCluster().prepare(deployState);
         initializeContainerModel(containerModel, configModelRepo);
         Container container = first(containerModel.getCluster().getContainers());
@@ -284,14 +274,19 @@ public class StandaloneContainerApplication implements Application {
         return new Zone(system, environment, region);
     }
 
-    private static DeployState createDeployState(ApplicationPackage applicationPackage, FileRegistry fileRegistry,
-                                                 DeployLogger logger, CloudConfigInstallVariables cloudConfigInstallVariables) {
+    private static DeployState createDeployState(ApplicationPackage applicationPackage, FileRegistry fileRegistry, DeployLogger logger) {
         DeployState.Builder builder = new DeployState.Builder()
                 .applicationPackage(applicationPackage)
                 .fileRegistry(fileRegistry)
                 .deployLogger(logger)
-                .configDefinitionRepo(configDefinitionRepo)
-                .properties(new StandaloneContainerModelContextProperties(cloudConfigInstallVariables));
+                .configDefinitionRepo(configDefinitionRepo);
+
+        /* Temporarily disable until we know how status.html is updated for config servers/controllers
+        if (isConfigServer())
+            builder.properties(new DeployProperties.Builder()
+                                       .hostedVespa(new CloudConfigInstallVariables().hostedVespa().orElse(Boolean.FALSE))
+                                       .build());
+        */
 
         return builder.build();
     }
@@ -343,84 +338,6 @@ public class StandaloneContainerApplication implements Application {
             return fromEnv;
         }
         return Optional.ofNullable(System.getProperty(name)); // for unit testing
-    }
-
-    private static class StandaloneContainerModelContextProperties implements ModelContext.Properties {
-        private final CloudConfigInstallVariables cloudConfigInstallVariables;
-
-        StandaloneContainerModelContextProperties(CloudConfigInstallVariables cloudConfigInstallVariables) {
-            this.cloudConfigInstallVariables = cloudConfigInstallVariables;
-        }
-
-        @Override
-        public boolean multitenant() {
-            return cloudConfigInstallVariables.multiTenant().orElse(Boolean.FALSE);
-        }
-
-        @Override
-        public ApplicationId applicationId() {
-            return ApplicationId.defaultId();
-        }
-
-        @Override
-        public List<ConfigServerSpec> configServerSpecs() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public HostName loadBalancerName() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public URI ztsUrl() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public String athenzDnsSuffix() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean hostedVespa() {
-            return cloudConfigInstallVariables.hostedVespa().orElse(Boolean.FALSE);
-        }
-
-        @Override
-        public Zone zone() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Set<Rotation> rotations() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isBootstrap() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isFirstTimeDeployment() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean useDedicatedNodeForLogserver() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean useFdispatchByDefault() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean useAdaptiveDispatch() {
-            throw new UnsupportedOperationException();
-        }
     }
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#8480

Seems to break some tests which apparently end up calling some of the methods in StandaloneContainerModelContextProperties which throws UnsupportedOperationException, but no stack trace so hard to tell what it is.