### PR TITLE
Revert "Do not depend or build node-maintainer RPM"

### DIFF
--- a/node-admin/vespa-node-admin.spec
+++ b/node-admin/vespa-node-admin.spec
@@ -18,6 +18,7 @@ URL:            http://vespa.ai
 Requires: bash
 Requires: vespa-base = %{version}
 Requires: vespa-standalone-container = %{version}
+Requires: vespa-node-maintainer = %{version}
 Requires: vespa-log-utils = %{version}
 
 Conflicts: vespa

--- a/node-maintainer/vespa-node-maintainer.spec
+++ b/node-maintainer/vespa-node-maintainer.spec
@@ -1,0 +1,36 @@
+# Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+# Force special prefix for Vespa
+%define _prefix /opt/vespa
+
+# Hack to speed up jar packing for now. This does not affect the rpm size.
+%define __jar_repack %{nil}
+
+Name:           vespa-node-maintainer
+Version:        %version
+Release:        1%{?dist}
+BuildArch:      noarch
+Summary:        Vespa Node Maintainer
+Group:          Applications/Databases
+License:        Commercial
+URL:            http://vespa.ai
+
+Requires: bash
+Requires: vespa-base = %{version}
+
+Conflicts: vespa
+
+%description
+The Node Maintainer does various maintenance tasks on a node.
+
+
+%install
+mkdir -p %buildroot%_prefix/lib/jars
+cp node-maintainer/target/node-maintainer-jar-with-dependencies.jar %buildroot%_prefix/lib/jars
+
+%clean
+rm -rf %buildroot
+
+%files
+%defattr(-,vespa,vespa,-)
+%_prefix/*


### PR DESCRIPTION
Reverts vespa-engine/vespa#8521

RPM installation fails with:
`Feb 16 21:59:21 controllerhost-cd-3.vespahosted.corp.bf1.yahoo.com host-sentinel: Error: Package: vespa-node-maintainer-7.13.67-1.el7.noarch (vespa_rpms)
Feb 16 21:59:21 controllerhost-cd-3.vespahosted.corp.bf1.yahoo.com host-sentinel: Requires: vespa-base = 7.13.67
Feb 16 21:59:21 controllerhost-cd-3.vespahosted.corp.bf1.yahoo.com host-sentinel: Removing: vespa-base-7.13.54-1.el7.noarch (@vespa_rpms)
Feb 16 21:59:21 controllerhost-cd-3.vespahosted.corp.bf1.yahoo.com host-sentinel: vespa-base = 7.13.54-1.el7
Feb 16 21:59:21 controllerhost-cd-3.vespahosted.corp.bf1.yahoo.com host-sentinel: Updated By: vespa-base-7.13.72-1.el7.noarch (vespa_rpms)
Feb 16 21:59:21 controllerhost-cd-3.vespahosted.corp.bf1.yahoo.com host-sentinel: vespa-base = 7.13.72-1.el7`