### PR TITLE
Minor HostProvisioner fixes 

### DIFF
--- a/config-provisioning/abi-spec.json
+++ b/config-provisioning/abi-spec.json
@@ -695,6 +695,7 @@
       "public void <init>(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public void <init>(com.yahoo.config.provision.SystemName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public void <init>(com.yahoo.config.provision.CloudName, com.yahoo.config.provision.SystemName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
+      "public void <init>(com.yahoo.config.provision.CloudName, com.yahoo.config.provision.SystemName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName, com.yahoo.config.provision.NodeFlavors)",
       "public com.yahoo.config.provision.CloudName cloud()",
       "public com.yahoo.config.provision.SystemName system()",
       "public com.yahoo.config.provision.Environment environment()",

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Zone.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Zone.java
@@ -41,12 +41,21 @@ public class Zone {
 
     /** Create from system, environment and region. Use for testing. */
     public Zone(SystemName systemName, Environment environment, RegionName region) {
-        this(CloudName.defaultName(), systemName, environment, region, new FlavorDefaults("default"), null);
+        this(CloudName.defaultName(), systemName, environment, region);
     }
 
     /** Create from cloud, system, environment and region. Use for testing. */
     public Zone(CloudName cloudName, SystemName systemName, Environment environment, RegionName region) {
-        this(cloudName, systemName, environment, region, new FlavorDefaults("default"), null);
+        this(cloudName, systemName, environment, region, null);
+    }
+
+    /** Create from cloud, system, environment, region and node flavors. Use for testing. */
+    public Zone(CloudName cloudName,
+                SystemName systemName,
+                Environment environment,
+                RegionName region,
+                NodeFlavors nodeFlavors) {
+        this(cloudName, systemName, environment, region, new FlavorDefaults("default"), nodeFlavors);
     }
 
     private Zone(CloudName cloudName,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainer.java
@@ -3,6 +3,9 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.transaction.Mutex;
+import com.yahoo.vespa.flags.BooleanFlag;
+import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -28,15 +31,19 @@ public class HostProvisionMaintainer extends Maintainer {
     private static final Logger log = Logger.getLogger(HostProvisionMaintainer.class.getName());
 
     private final HostProvisioner hostProvisioner;
+    private final BooleanFlag dynamicProvisioningEnabled;
 
-    public HostProvisionMaintainer(
-            NodeRepository nodeRepository, Duration interval, JobControl jobControl, HostProvisioner hostProvisioner) {
+    public HostProvisionMaintainer(NodeRepository nodeRepository, Duration interval, JobControl jobControl,
+                                   HostProvisioner hostProvisioner, FlagSource flagSource) {
         super(nodeRepository, interval, jobControl);
         this.hostProvisioner = hostProvisioner;
+        this.dynamicProvisioningEnabled = Flags.ENABLE_DYNAMIC_PROVISIONING.bindTo(flagSource);
     }
 
     @Override
     protected void maintain() {
+        if (! dynamicProvisioningEnabled.value()) return;
+
         try (Mutex lock = nodeRepository().lockAllocation()) {
             NodeList nodes = nodeRepository().list();
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainer.java
@@ -7,8 +7,9 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
-import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
 import com.yahoo.vespa.hosted.provision.provisioning.FatalProvisioningException;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+import com.yahoo.yolean.Exceptions;
 
 import java.time.Duration;
 import java.util.List;
@@ -43,6 +44,8 @@ public class HostProvisionMaintainer extends Maintainer {
                 try {
                     List<Node> updatedNodes = hostProvisioner.provision(host, children);
                     nodeRepository().write(updatedNodes);
+                } catch (IllegalArgumentException | IllegalStateException e) {
+                    log.log(Level.INFO, "Failed to provision " + host.hostname() + ": " + Exceptions.toMessageString(e));
                 } catch (FatalProvisioningException e) {
                     log.log(Level.SEVERE, "Failed to provision " + host.hostname() + ", failing out the host recursively", e);
                     // Fail out as operator to force a quick redeployment

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
@@ -30,13 +30,33 @@ public class ProvisionedHost {
     }
 
     /** Generate {@link Node} instance representing the provisioned physical host */
-    Node generateHost() {
+    public Node generateHost() {
         return Node.create(id, Set.of(), Set.of(), hostHostname, Optional.empty(), hostFlavor, NodeType.host);
     }
 
     /** Generate {@link Node} instance representing the node running on this physical host */
-    Node generateNode() {
+    public Node generateNode() {
         return Node.createDockerNode(Set.of(), Set.of(), nodeHostname, Optional.of(hostHostname), nodeFlavor, NodeType.tenant);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getHostHostname() {
+        return hostHostname;
+    }
+
+    public Flavor getHostFlavor() {
+        return hostFlavor;
+    }
+
+    public String getNodeHostname() {
+        return nodeHostname;
+    }
+
+    public Flavor getNodeFlavor() {
+        return nodeFlavor;
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ContainerConfig.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ContainerConfig.java
@@ -26,6 +26,7 @@ public class ContainerConfig {
                "  <component id='com.yahoo.vespa.hosted.provision.testutils.MockNodeRepository'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.provision.testutils.MockProvisionServiceProvider'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.provision.maintenance.NodeRepositoryMaintenance'/>\n" +
+               "  <component id='com.yahoo.vespa.flags.InMemoryFlagSource'/>\n" +
                "  <component id='com.yahoo.config.provision.Zone'/>\n" +
                "  <handler id='com.yahoo.vespa.hosted.provision.restapi.v2.NodesApiHandler'>\n" +
                "    <binding>http://*/nodes/v2/*</binding>\n" +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostDeprovisionMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostDeprovisionMaintainerTest.java
@@ -2,6 +2,9 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
@@ -32,8 +35,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class HostDeprovisionMaintainerTest {
     private final HostProvisionerTester tester = new HostProvisionerTester();
     private final HostProvisioner hostProvisioner = mock(HostProvisioner.class);
+    private final FlagSource flagSource = new InMemoryFlagSource().withBooleanFlag(Flags.ENABLE_DYNAMIC_PROVISIONING.id(), true);
     private final HostDeprovisionMaintainer maintainer = new HostDeprovisionMaintainer(
-            tester.nodeRepository(), Duration.ofDays(1), tester.jobControl(), hostProvisioner);
+            tester.nodeRepository(), Duration.ofDays(1), tester.jobControl(), hostProvisioner, flagSource);
 
     @Test
     public void removes_nodes_if_successful() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainerTest.java
@@ -10,6 +10,9 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -18,9 +21,9 @@ import com.yahoo.vespa.hosted.provision.node.Generation;
 import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.node.Reports;
 import com.yahoo.vespa.hosted.provision.node.Status;
+import com.yahoo.vespa.hosted.provision.provisioning.FatalProvisioningException;
 import com.yahoo.vespa.hosted.provision.provisioning.FlavorConfigBuilder;
 import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
-import com.yahoo.vespa.hosted.provision.provisioning.FatalProvisioningException;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
 import org.junit.Test;
 
@@ -52,8 +55,9 @@ public class HostProvisionMaintainerTest {
 
     private final HostProvisionerTester tester = new HostProvisionerTester();
     private final HostProvisioner hostProvisioner = mock(HostProvisioner.class);
+    private final FlagSource flagSource = new InMemoryFlagSource().withBooleanFlag(Flags.ENABLE_DYNAMIC_PROVISIONING.id(), true);
     private final HostProvisionMaintainer maintainer = new HostProvisionMaintainer(
-            tester.nodeRepository(), Duration.ofDays(1), tester.jobControl(), hostProvisioner);
+            tester.nodeRepository(), Duration.ofDays(1), tester.jobControl(), hostProvisioner, flagSource);
 
     @Test
     public void delegates_to_host_provisioner_and_writes_back_result() {


### PR DESCRIPTION
Originally, I was planning to control the Maintainers using the `JobControl` and `/nodes/v2/maintenance/` API, but since these maintainers are currently not started (Because `HostProvisioner` `Optional` is still empty), there is no way to disable them now, so I wired in the same feature flag I use in `GroupPreparer`.