### PR TITLE
Enable deferred handshake work in OpenSSL codec implementation

### DIFF
--- a/vespalib/src/vespa/vespalib/net/tls/crypto_codec_adapter.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/crypto_codec_adapter.cpp
@@ -72,12 +72,16 @@ CryptoCodecAdapter::handshake()
     for (;;) {
         auto in = _input.obtain();
         auto out = _output.reserve(_codec->min_encode_buffer_size());
-        auto hs_res = _codec->handshake(in.data, in.size, out.data, out.size);
+        ::vespalib::net::tls::HandshakeResult hs_res;
+        while ((hs_res = _codec->handshake(in.data, in.size, out.data, out.size)).needs_work()) {
+            _codec->do_handshake_work();
+        }
         _input.evict(hs_res.bytes_consumed);
         _output.commit(hs_res.bytes_produced);
         switch (hs_res.state) {
         case ::vespalib::net::tls::HandshakeResult::State::Failed: return HandshakeResult::FAIL;
         case ::vespalib::net::tls::HandshakeResult::State::Done: return hs_try_flush();
+        case ::vespalib::net::tls::HandshakeResult::State::NeedsWork: abort(); // Impossible
         case ::vespalib::net::tls::HandshakeResult::State::NeedsMorePeerData:
             auto flush_res = hs_try_flush();
             if (flush_res != HandshakeResult::DONE) {


### PR DESCRIPTION
@havardpe please review
@bjorncs FYI

Separates handshaking into lightweight `handshake()` and potentially
CPU-heavy `do_handshake_work()` functions. Intended to enable asynchronous
processing of handshake work in separate threads further down the line.