### PR TITLE
Stop running storage unit tests in parallel

### DIFF
--- a/storage/src/tests/CMakeLists.txt
+++ b/storage/src/tests/CMakeLists.txt
@@ -31,9 +31,7 @@ vespa_add_executable(storage_testrunner_app TEST
     storage_teststatus
 )
 
-# TODO: Test with a larger chunk size to parallelize test suite runs 
 vespa_add_test(
     NAME storage_testrunner_app
-    COMMAND python ${PROJECT_SOURCE_DIR}/cppunit-parallelize.py --chunks 8 $<TARGET_FILE:storage_testrunner_app>
-    DEPENDS storage_testrunner_app
+    COMMAND storage_testrunner_app
 )


### PR DESCRIPTION
The tests can interfere with each other, cf. PersistenceTestUtils::setupDisks().