### PR TITLE
Add workarounds for legacy global distribution hash handling

### DIFF
--- a/storage/src/tests/common/global_bucket_space_distribution_converter_test.cpp
+++ b/storage/src/tests/common/global_bucket_space_distribution_converter_test.cpp
@@ -17,6 +17,7 @@ struct GlobalBucketSpaceDistributionConverterTest : public CppUnit::TestFixture 
     CPPUNIT_TEST(config_retired_state_is_propagated);
     CPPUNIT_TEST(group_capacities_are_propagated);
     CPPUNIT_TEST(global_distribution_has_same_owner_distributors_as_default);
+    CPPUNIT_TEST(can_generate_config_with_legacy_partition_spec);
     CPPUNIT_TEST_SUITE_END();
 
     void can_transform_flat_cluster_config();
@@ -27,6 +28,7 @@ struct GlobalBucketSpaceDistributionConverterTest : public CppUnit::TestFixture 
     void config_retired_state_is_propagated();
     void group_capacities_are_propagated();
     void global_distribution_has_same_owner_distributors_as_default();
+    void can_generate_config_with_legacy_partition_spec();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(GlobalBucketSpaceDistributionConverterTest);
@@ -35,9 +37,9 @@ using DistributionConfig = vespa::config::content::StorDistributionConfig;
 
 namespace {
 
-vespalib::string default_to_global_config(const vespalib::string& default_config) {
+vespalib::string default_to_global_config(const vespalib::string& default_config, bool legacy_mode = false) {
     auto default_cfg = GlobalBucketSpaceDistributionConverter::string_to_config(default_config);
-    auto as_global = GlobalBucketSpaceDistributionConverter::convert_to_global(*default_cfg);
+    auto as_global = GlobalBucketSpaceDistributionConverter::convert_to_global(*default_cfg, legacy_mode);
     return GlobalBucketSpaceDistributionConverter::config_to_string(*as_global);
 }
 
@@ -375,6 +377,66 @@ group[2].nodes[1].index 2
         const auto global_index = global_distr.getIdealDistributorNode(state, bucket, "ui");
         CPPUNIT_ASSERT_EQUAL(default_index, global_index);
     }
+}
+
+// By "legacy" read "broken", but we need to be able to generate it to support rolling upgrades properly.
+// TODO remove on Vespa 8 - this is a workaround for https://github.com/vespa-engine/vespa/issues/8475
+void GlobalBucketSpaceDistributionConverterTest::can_generate_config_with_legacy_partition_spec() {
+    vespalib::string default_config(
+R"(redundancy 2
+group[3]
+group[0].name "invalid"
+group[0].index "invalid"
+group[0].partitions 1|*
+group[0].nodes[0]
+group[1].name rack0
+group[1].index 0
+group[1].nodes[3]
+group[1].nodes[0].index 0
+group[1].nodes[1].index 1
+group[1].nodes[2].index 2
+group[2].name rack1
+group[2].index 1
+group[2].nodes[3]
+group[2].nodes[0].index 3
+group[2].nodes[1].index 4
+group[2].nodes[2].index 5
+)");
+
+    vespalib::string expected_global_config(
+R"(redundancy 6
+initial_redundancy 0
+ensure_primary_persisted true
+ready_copies 6
+active_per_leaf_group true
+distributor_auto_ownership_transfer_on_whole_group_down true
+group[0].index "invalid"
+group[0].name "invalid"
+group[0].capacity 1
+group[0].partitions "3|3|*"
+group[1].index "0"
+group[1].name "rack0"
+group[1].capacity 1
+group[1].partitions ""
+group[1].nodes[0].index 0
+group[1].nodes[0].retired false
+group[1].nodes[1].index 1
+group[1].nodes[1].retired false
+group[1].nodes[2].index 2
+group[1].nodes[2].retired false
+group[2].index "1"
+group[2].name "rack1"
+group[2].capacity 1
+group[2].partitions ""
+group[2].nodes[0].index 3
+group[2].nodes[0].retired false
+group[2].nodes[1].index 4
+group[2].nodes[1].retired false
+group[2].nodes[2].index 5
+group[2].nodes[2].retired false
+disk_distribution MODULO_BID
+)");
+    CPPUNIT_ASSERT_EQUAL(expected_global_config, default_to_global_config(default_config, true));
 }
 
 }

--- a/storage/src/vespa/storage/common/global_bucket_space_distribution_converter.h
+++ b/storage/src/vespa/storage/common/global_bucket_space_distribution_converter.h
@@ -10,8 +10,9 @@ namespace storage {
 
 struct GlobalBucketSpaceDistributionConverter {
     using DistributionConfig = vespa::config::content::StorDistributionConfig;
-    static std::shared_ptr<DistributionConfig> convert_to_global(const DistributionConfig&);
-    static std::shared_ptr<lib::Distribution>  convert_to_global(const lib::Distribution&);
+    // TODO remove legacy_mode flags on Vespa 8 - this is a workaround for https://github.com/vespa-engine/vespa/issues/8475
+    static std::shared_ptr<DistributionConfig> convert_to_global(const DistributionConfig&, bool legacy_mode = false);
+    static std::shared_ptr<lib::Distribution>  convert_to_global(const lib::Distribution&, bool legacy_mode = false);
 
     // Helper functions which may be of use outside this class
     static std::unique_ptr<DistributionConfig> string_to_config(const vespalib::string&);

--- a/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.cpp
+++ b/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.cpp
@@ -35,7 +35,8 @@ PendingBucketSpaceDbTransition::PendingBucketSpaceDbTransition(const PendingClus
       _pendingClusterState(pendingClusterState),
       _distributorBucketSpace(distributorBucketSpace),
       _distributorIndex(_clusterInfo->getDistributorIndex()),
-      _bucketOwnershipTransfer(distributionChanged)
+      _bucketOwnershipTransfer(distributionChanged),
+      _rejectedRequests()
 {
     if (distributorChanged()) {
         _bucketOwnershipTransfer = true;

--- a/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.h
+++ b/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.h
@@ -4,6 +4,7 @@
 #include "pending_bucket_space_db_transition_entry.h"
 #include "outdated_nodes.h"
 #include <vespa/storage/bucketdb/bucketdatabase.h>
+#include <unordered_map>
 
 namespace storage::api { class RequestBucketInfoReply; }
 namespace storage::lib { class ClusterState; class State; }
@@ -48,6 +49,7 @@ private:
     DistributorBucketSpace                   &_distributorBucketSpace;
     uint16_t                                  _distributorIndex;
     bool                                      _bucketOwnershipTransfer;
+    std::unordered_map<uint16_t, size_t>      _rejectedRequests;
 
     // BucketDataBase::MutableEntryProcessor API
     bool process(BucketDatabase::Entry& e) override;
@@ -111,6 +113,14 @@ public:
     // Methods used by unit tests.
     const EntryList& results() const { return _entries; }
     void addNodeInfo(const document::BucketId& id, const BucketCopy& copy);
+
+    void incrementRequestRejections(uint16_t node) {
+        _rejectedRequests[node]++;
+    }
+    size_t rejectedRequests(uint16_t node) const {
+        auto iter = _rejectedRequests.find(node);
+        return ((iter != _rejectedRequests.end()) ? iter->second : 0);
+    }
 };
 
 }


### PR DESCRIPTION
@geirst please review

This addresses a regression introduced as part of #8479, which in
turn was intended to serve as a fix for issue #8475. This regression
would stall cluster state convergence when a subset of nodes contained
the fix and another subset did not.

With the workarounds present, nodes gracefully handle the case where
different distribution hashes are expected for the global bucket space.

`BucketManager` will now fall back to comparing the new incoming hash
to that of the legacy derived distribution config if it mismatches.

`PendingClusterState` will try to send a subset of bucket info requests
with legacy hash format for the global bucket space iff there has been
at least 1 rejected request.

All these workarounds will be removed on Vespa 8.