### PR TITLE
Fail client ops gracefully when distributor is marked down

### DIFF
--- a/storage/src/tests/common/teststorageapp.cpp
+++ b/storage/src/tests/common/teststorageapp.cpp
@@ -248,8 +248,7 @@ TestDistributorApp::configure(vespalib::stringref id)
 
 TestDistributorApp::TestDistributorApp(vespalib::stringref configId)
     : TestStorageApp(
-            StorageComponentRegisterImpl::UP(
-                new DistributorComponentRegisterImpl),
+            std::make_unique<DistributorComponentRegisterImpl>(),
             lib::NodeType::DISTRIBUTOR, getIndexFromConfig(configId), configId),
       _compReg(dynamic_cast<DistributorComponentRegisterImpl&>(
                     TestStorageApp::getComponentRegister())),
@@ -263,7 +262,7 @@ TestDistributorApp::TestDistributorApp(vespalib::stringref configId)
 TestDistributorApp::TestDistributorApp(NodeIndex index,
                                        vespalib::stringref configId)
     : TestStorageApp(
-            StorageComponentRegisterImpl::UP(new StorageComponentRegisterImpl),
+            std::make_unique<DistributorComponentRegisterImpl>(),
             lib::NodeType::DISTRIBUTOR, index, configId),
       _compReg(dynamic_cast<DistributorComponentRegisterImpl&>(
                     TestStorageApp::getComponentRegister())),

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -70,6 +70,8 @@ private:
 
     bool clusterIsUp() const;
 
+    bool isDistributor() const;
+
     bool isExternalLoad(const api::MessageType&) const noexcept;
 
     bool isExternalWriteOperation(const api::MessageType&) const noexcept;

--- a/storage/src/vespa/storage/storageserver/bouncer_metrics.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer_metrics.cpp
@@ -7,7 +7,9 @@ namespace storage {
 BouncerMetrics::BouncerMetrics()
     : MetricSet("bouncer", {}, "Metrics for Bouncer component", nullptr),
       clock_skew_aborts("clock_skew_aborts", {}, "Number of client operations that were aborted due to "
-                        "clock skew between sender and receiver exceeding acceptable range", this)
+                        "clock skew between sender and receiver exceeding acceptable range", this),
+      unavailable_node_aborts("unavailable_node_aborts", {}, "Number of operations that were aborted due "
+                              "to the node (or target bucket space) being unavailable", this)
 {
 }
 

--- a/storage/src/vespa/storage/storageserver/bouncer_metrics.h
+++ b/storage/src/vespa/storage/storageserver/bouncer_metrics.h
@@ -8,6 +8,7 @@ namespace storage {
 
 struct BouncerMetrics : metrics::MetricSet {
     metrics::LongCountMetric clock_skew_aborts;
+    metrics::LongCountMetric unavailable_node_aborts;
 
     BouncerMetrics();
     ~BouncerMetrics() override;


### PR DESCRIPTION
@geirst please review

Previously, clients would only receive `ABORTED` when the distributor was
marked down by orchestration. This would simply cause the client to resend
until either the `StoragePolicy` would discard the cluster state entirely
and retry against a working distributor, or the operations would time out.

Now they will receive a `WrongDistributionReply` that shall immediately update
the `StoragePolicy` to avoid sending to the distributor that has been
marked down.

Also add a separate metric for number of operations aborted by `Bouncer`.

This fixes #8448.