### PR TITLE
Remove initiallyInRotation=false option: Not used

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -40,7 +40,7 @@ import static com.yahoo.vespa.config.server.ConfigServerBootstrap.RedeployingApp
  * applications. If that is done successfully the RPC server will start and the health status code will change from
  * 'initializing' to 'up'. If VIP status mode is VIP_STATUS_PROGRAMMATICALLY the config server
  * will be put into rotation (start serving status.html with 200 OK), if the mode is VIP_STATUS_FILE a VIP status
- * file is created or removed ny some external pgrogram based on the health status code.
+ * file is created or removed ny some external program based on the health status code.
  *
  * @author Ulf Lilleengen
  * @author hmusum
@@ -176,12 +176,10 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
     }
 
     private void up() {
-        stateMonitor.status(StateMonitor.Status.up);
         vipStatus.setInRotation(true);
     }
 
     private void down() {
-        stateMonitor.status(StateMonitor.Status.down);
         vipStatus.setInRotation(false);
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -72,7 +72,7 @@ public class ConfigServerBootstrapTest {
         RpcServer rpcServer = createRpcServer(configserverConfig);
         // Take a host away so that there are too few for the application, to verify we can still bootstrap
         provisioner.allocations().values().iterator().next().remove(0);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_PROGRAMMATICALLY);
+        VipStatus vipStatus = createVipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer,
                                                                     versionState, createStateMonitor(),
                                                                     vipStatus, INITIALIZE_ONLY, VIP_STATUS_PROGRAMMATICALLY);
@@ -102,7 +102,7 @@ public class ConfigServerBootstrapTest {
         assertTrue(versionState.isUpgraded());
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_FILE);
+        VipStatus vipStatus = createVipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer,
                                                                     versionState, createStateMonitor(),
                                                                     vipStatus, INITIALIZE_ONLY, VIP_STATUS_FILE);
@@ -132,7 +132,7 @@ public class ConfigServerBootstrapTest {
                                            .resolve("sessions/2/services.xml"));
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_PROGRAMMATICALLY);
+        VipStatus vipStatus = createVipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
                                                                     createStateMonitor(),
                                                                     vipStatus, INITIALIZE_ONLY, VIP_STATUS_PROGRAMMATICALLY);
@@ -174,7 +174,7 @@ public class ConfigServerBootstrapTest {
         curator.set(Path.fromString("/config/v2/tenants/" + applicationId.tenant().value() + "/sessions/2/version"), Utf8.toBytes("1.2.2"));
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
-        VipStatus vipStatus = createVipStatus(VIP_STATUS_PROGRAMMATICALLY);
+        VipStatus vipStatus = createVipStatus();
         ConfigServerBootstrap bootstrap = new ConfigServerBootstrap(tester.applicationRepository(), rpcServer, versionState,
                                                                     createStateMonitor(), vipStatus,
                                                                     BOOTSTRAP_IN_SEPARATE_THREAD, VIP_STATUS_PROGRAMMATICALLY);
@@ -229,13 +229,8 @@ public class ConfigServerBootstrapTest {
         return new Host(hostname, Collections.emptyList(), Optional.empty(), Optional.of(com.yahoo.component.Version.fromString(version)));
     }
 
-    private VipStatus createVipStatus(ConfigServerBootstrap.VipStatusMode vipStatusMode) throws IOException {
+    private VipStatus createVipStatus() {
         return new VipStatus(new QrSearchersConfig.Builder().build(),
-                             new VipStatusConfig.Builder()
-                                     .initiallyInRotation(vipStatusMode == VIP_STATUS_FILE)
-                                     .statusfile(temporaryFolder.newFile().getAbsolutePath())
-                                     .accessdisk(vipStatusMode == VIP_STATUS_FILE)
-                                     .build(),
                              new ClustersStatus());
     }
 

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -241,6 +241,7 @@
       "public void <init>()",
       "public void <init>(com.yahoo.container.QrSearchersConfig)",
       "public void <init>(com.yahoo.container.handler.ClustersStatus)",
+      "public void <init>(com.yahoo.container.QrSearchersConfig, com.yahoo.container.handler.ClustersStatus)",
       "public void <init>(com.yahoo.container.QrSearchersConfig, com.yahoo.container.core.VipStatusConfig, com.yahoo.container.handler.ClustersStatus)",
       "public void setInRotation(java.lang.Boolean)",
       "public void addToRotation(java.lang.String)",

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -242,6 +242,7 @@
       "public void <init>(com.yahoo.container.QrSearchersConfig)",
       "public void <init>(com.yahoo.container.handler.ClustersStatus)",
       "public void <init>(com.yahoo.container.QrSearchersConfig, com.yahoo.container.handler.ClustersStatus)",
+      "public void <init>(com.yahoo.container.QrSearchersConfig, com.yahoo.container.handler.ClustersStatus, com.yahoo.container.jdisc.state.StateMonitor)",
       "public void <init>(com.yahoo.container.QrSearchersConfig, com.yahoo.container.core.VipStatusConfig, com.yahoo.container.handler.ClustersStatus)",
       "public void setInRotation(java.lang.Boolean)",
       "public void addToRotation(java.lang.String)",

--- a/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
@@ -26,9 +26,6 @@ public class ClustersStatus extends AbstractComponent {
     /** Are there any (in-service influencing) clusters in this container? */
     private boolean containerHasClusters;
 
-    /** If we have no clusters, what should we answer? */
-    private boolean receiveTrafficByDefault;
-
     private final Object mutex = new Object();
 
     /** The status of clusters, when known. Note that clusters may exist for which there is no knowledge yet. */
@@ -42,10 +39,9 @@ public class ClustersStatus extends AbstractComponent {
         }
     }
 
+    /** @deprecated this is ignored */
+    @Deprecated // TODO: remove on Vespa 8
     public void setReceiveTrafficByDefault(boolean receiveTrafficByDefault) {
-        synchronized (mutex) {
-            this.receiveTrafficByDefault = receiveTrafficByDefault;
-        }
     }
 
     void setUp(String clusterIdentifier) {
@@ -80,7 +76,7 @@ public class ClustersStatus extends AbstractComponent {
                 return clusterStatus.values().stream().anyMatch(status -> status==true);
             }
             else {
-                return receiveTrafficByDefault;
+                return true;
             }
         }
     }

--- a/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
@@ -15,6 +15,8 @@ import java.util.Map;
  * will survive reconfiguration events and inform other components even immediately after a reconfiguration
  * (where the true statue of clusters may not yet be available).
  *
+ * This is multithread safe.
+ *
  * @author bratseth
  */
 public class ClustersStatus extends AbstractComponent {

--- a/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
@@ -9,7 +9,9 @@ import java.util.Map;
 
 /**
  * A component which tracks the up/down status of any clusters which should influence
- * the up down status of this container itself, as well as the separate fact that such clusters are present.
+ * the up down status of this container itself, as well as the separate fact (from config)
+ * that such clusters are present. This is a separate fact because we might know we have clusters configured
+ * but we don't have positive information that they are up yet, and in this case we should be down.
  *
  * This is a separate component which has <b>no dependencies</b> such that the status tracked in this
  * will survive reconfiguration events and inform other components even immediately after a reconfiguration

--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -7,7 +7,8 @@ import com.yahoo.container.core.VipStatusConfig;
 import com.yahoo.container.jdisc.state.StateMonitor;
 
 /**
- * API for programmatically removing the container from VIP rotation.
+ * A component which keeps track of whether or not this container instance should receive traffic
+ * and respond that it is in good health.
  *
  * This is multithread safe.
  *

--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -59,7 +59,7 @@ public class VipStatus {
 
     /** @deprecated don't pass VipStatusConfig */
     @Deprecated // TODO: Remove on Vespa 8
-    public VipStatus(QrSearchersConfig dispatchers, VipStatusConfig vipStatusConfig, ClustersStatus clustersStatus) {
+    public VipStatus(QrSearchersConfig dispatchers, VipStatusConfig ignored, ClustersStatus clustersStatus) {
         this(dispatchers, clustersStatus);
     }
 

--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -24,7 +24,7 @@ public class VipStatus {
     }
 
     public VipStatus(QrSearchersConfig dispatchers) {
-        this(dispatchers, new VipStatusConfig(new VipStatusConfig.Builder()), new ClustersStatus());
+        this(dispatchers, new ClustersStatus());
     }
 
     public VipStatus(ClustersStatus clustersStatus) {
@@ -32,10 +32,15 @@ public class VipStatus {
     }
 
     @Inject
-    public VipStatus(QrSearchersConfig dispatchers, VipStatusConfig vipStatusConfig, ClustersStatus clustersStatus) {
+    public VipStatus(QrSearchersConfig dispatchers, ClustersStatus clustersStatus) {
         this.clustersStatus = clustersStatus;
-        clustersStatus.setReceiveTrafficByDefault(vipStatusConfig.initiallyInRotation());
         clustersStatus.setContainerHasClusters(! dispatchers.searchcluster().isEmpty());
+    }
+
+    /** @deprecated don't pass VipStatusConfig */
+    @Deprecated // TODO: Remove on Vespa 8
+    public VipStatus(QrSearchersConfig dispatchers, VipStatusConfig vipStatusConfig, ClustersStatus clustersStatus) {
+        this(dispatchers, clustersStatus);
     }
 
     /**

--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatusHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatusHandler.java
@@ -185,23 +185,7 @@ public final class VipStatusHandler extends ThreadedHttpRequestHandler {
     public HttpResponse handle(HttpRequest request) {
         if (metric != null)
             metric.add(NUM_REQUESTS_METRIC, 1, null);
-        if (vipStatus != null)
-            updateAndLogRotationState();
         return new StatusResponse();
-    }
-
-    private void updateAndLogRotationState() {
-        boolean currentlyInRotation = vipStatus.isInRotation();
-        boolean previousRotationAnswer = previouslyInRotation;
-        previouslyInRotation = currentlyInRotation;
-
-        if (previousRotationAnswer != currentlyInRotation) {
-            if (currentlyInRotation) {
-                log.log(LogLevel.INFO, "Putting container back into rotation by serving status.html again.");
-            } else {
-                log.log(LogLevel.WARNING, "Removing container from rotation by no longer serving status.html.");
-            }
-        }
     }
 
 }

--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatusHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatusHandler.java
@@ -57,7 +57,7 @@ public final class VipStatusHandler extends ThreadedHttpRequestHandler {
         private StatusResponse() {
             super(com.yahoo.jdisc.http.HttpResponse.Status.OK); // status may be overwritten below
             if (vipStatus != null && ! vipStatus.isInRotation()) {
-                searchContainerOutOfService();
+                setOutOfServiceStatus();
             } else if (accessDisk) {
                 preSlurpFile();
             } else {
@@ -140,7 +140,7 @@ public final class VipStatusHandler extends ThreadedHttpRequestHandler {
         /**
          * Behaves like a VIP status response file has been deleted.
          */
-        private void searchContainerOutOfService() {
+        private void setOutOfServiceStatus() {
             contentType = "text/plain";
             data = Utf8.toBytes(NO_SEARCH_BACKENDS);
             setStatus(com.yahoo.jdisc.http.HttpResponse.Status.NOT_FOUND);
@@ -191,8 +191,8 @@ public final class VipStatusHandler extends ThreadedHttpRequestHandler {
     }
 
     private void updateAndLogRotationState() {
-        final boolean currentlyInRotation = vipStatus.isInRotation();
-        final boolean previousRotationAnswer = previouslyInRotation;
+        boolean currentlyInRotation = vipStatus.isInRotation();
+        boolean previousRotationAnswer = previouslyInRotation;
         previouslyInRotation = currentlyInRotation;
 
         if (previousRotationAnswer != currentlyInRotation) {

--- a/container-core/src/main/java/com/yahoo/container/jdisc/state/StateMonitor.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/state/StateMonitor.java
@@ -6,6 +6,7 @@ import com.yahoo.component.AbstractComponent;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.jdisc.Timer;
 import com.yahoo.jdisc.application.MetricConsumer;
+import com.yahoo.jdisc.core.SystemTimer;
 import com.yahoo.log.LogLevel;
 
 import java.util.Map;
@@ -36,6 +37,11 @@ public class StateMonitor extends AbstractComponent {
     private volatile MetricSnapshot snapshot;
     private volatile Status status;
     private final TreeSet<String> valueNames = new TreeSet<>();
+
+    /** For testing */
+    public StateMonitor() {
+        this(new HealthMonitorConfig.Builder().build(), new SystemTimer());
+    }
 
     @Inject
     public StateMonitor(HealthMonitorConfig config, Timer timer) {

--- a/container-core/src/main/resources/configdefinitions/vip-status.def
+++ b/container-core/src/main/resources/configdefinitions/vip-status.def
@@ -8,5 +8,5 @@ accessdisk bool default=false
 ## If the path is relative vespa home is prepended
 statusfile string default="share/qrsdocs/status.html"
 
-## The default rotation state when there are no configured clusters to decide rotation state
+## Not used TODO: Remove on Vespa 8
 initiallyInRotation bool default=true

--- a/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.container.handler;
 
 import static org.junit.Assert.*;
 
+import com.yahoo.container.QrSearchersConfig;
 import org.junit.Test;
 
 /**
@@ -14,13 +15,17 @@ public class VipStatusTestCase {
 
     @Test
     public void testVipStatusWorksWithClusters() {
-        ClustersStatus clustersStatus = new ClustersStatus();
-        clustersStatus.setContainerHasClusters(true);
-        VipStatus v = new VipStatus(clustersStatus);
+        var b = new QrSearchersConfig.Builder();
+        var searchClusterB = new QrSearchersConfig.Searchcluster.Builder();
+        searchClusterB.name("cluster1");
+        searchClusterB.name("cluster2");
+        searchClusterB.name("cluster3");
+        b.searchcluster(searchClusterB);
+        VipStatus v = new VipStatus(b.build());
 
-        String cluster1 = new String("a");
-        String cluster2 = new String("b");
-        String cluster3 = new String("c");
+        String cluster1 = "cluster1";
+        String cluster2 = "cluster2";
+        String cluster3 = "cluster3";
 
         // initial state
         assertFalse(v.isInRotation());

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
@@ -2,6 +2,7 @@
 package com.yahoo.prelude.fastsearch.test;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.handler.ClustersStatus;
 import com.yahoo.container.handler.VipStatus;
 import com.yahoo.net.HostName;
@@ -45,11 +46,16 @@ class FastSearcherTester {
     }
 
     public FastSearcherTester(int containerClusterSize, List<Node> searchNodes) {
-        ClustersStatus clustersStatus = new ClustersStatus();
-        clustersStatus.setContainerHasClusters(true);
-        vipStatus = new VipStatus(clustersStatus);
+        String clusterId = "a";
+
+        var b = new QrSearchersConfig.Builder();
+        var searchClusterB = new QrSearchersConfig.Searchcluster.Builder();
+        searchClusterB.name(clusterId);
+        b.searchcluster(searchClusterB);
+        vipStatus = new VipStatus(b.build());
+
         mockFS4ResourcePool = new MockFS4ResourcePool();
-        mockDispatcher = new MockDispatcher("a", searchNodes, mockFS4ResourcePool, containerClusterSize, vipStatus);
+        mockDispatcher = new MockDispatcher(clusterId, searchNodes, mockFS4ResourcePool, containerClusterSize, vipStatus);
         fastSearcher = new FastSearcher(new MockBackend(selfHostname, 0L, true),
                                         mockFS4ResourcePool,
                                         mockDispatcher,


### PR DESCRIPTION
@gjoranv please review

I suggest reviewing each commit in order. The purpose of this is to tie the state/v1/health response of the container to the vip status: Whenever the container decides that it is not fit to receive traffic it should also respond that it's in bad health.