### PR TITLE
Use connect instead of connectSync

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/UrlDownloader.java
+++ b/config/src/main/java/com/yahoo/vespa/config/UrlDownloader.java
@@ -43,10 +43,15 @@ public class UrlDownloader {
         int timeRemaining = 5000;
         try {
             while (timeRemaining > 0) {
-                target = supervisor.connectSync(spec);
-                if (target.isValid()) {
+                target = supervisor.connect(spec);
+                // ping to check if connection is working
+                Request request = new Request("frt.rpc.ping");
+                target.invokeSync(request, 5.0);
+                if (! request.isError()) {
                     log.log(LogLevel.DEBUG, "Successfully connected to '" + spec + "', this = " + System.identityHashCode(this));
                     return;
+                } else {
+                    target.close();
                 }
                 Thread.sleep(500);
                 timeRemaining -= 500;

--- a/config/src/main/java/com/yahoo/vespa/config/benchmark/LoadTester.java
+++ b/config/src/main/java/com/yahoo/vespa/config/benchmark/LoadTester.java
@@ -234,6 +234,7 @@ public class LoadTester {
                             System.out.println("# Connection lost, reconnecting...");
                             reconnCycle = true;
                         }
+                        target.close();
                         target = connect(spec);
                     } else {
                         System.err.println(request.errorMessage());
@@ -270,7 +271,7 @@ public class LoadTester {
         }
 
         private Target connect(Spec spec) {
-            return supervisor.connectSync(spec);
+            return supervisor.connect(spec);
         }
     }
 }

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
@@ -52,14 +52,18 @@ class FileAcquirerImpl implements FileAcquirer {
         private void connect(Timer timer) throws InterruptedException {
             while (timer.isTimeLeft()) {
                 pause();
-                target = supervisor.connectSync(spec);
-                if (target.isValid()) {
+                target = supervisor.connect(spec);
+                // ping to check if connection is working
+                Request request = new Request("frt.rpc.ping");
+                target.invokeSync(request, 5.0);
+                if (request.isError()) {
+                    logWarning();
+                    target.close();
+                } else {
                     log.log(LogLevel.DEBUG, "Successfully connected to '" + spec + "', this = " + System.identityHashCode(this));
                     pauseTime = 0;
                     logCount = 0;
                     return;
-                } else {
-                    logWarning();
                 }
             }
         }


### PR DESCRIPTION
When using TLS the handshake may not be finished when connectSync returns,
which might lead to unpredicatable and confusing behavior, use connect and
ping to check for RPC connection being up instead.