### PR TITLE
Add some leniency to latestLogThreshold

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
@@ -4,11 +4,11 @@ package com.yahoo.container.handler;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.time.Duration;
 import java.util.Base64;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.attribute.BasicFileAttributes;
 
 public class LogReader {
 
@@ -17,7 +17,7 @@ public class LogReader {
 
     protected JSONObject readLogs(String logDirectory, long earliestLogThreshold, long latestLogThreshold) throws IOException, JSONException {
         this.earliestLogThreshold = earliestLogThreshold;
-        this.latestLogThreshold = latestLogThreshold;
+        this.latestLogThreshold = latestLogThreshold + Duration.ofMinutes(5).toMillis(); // Add some time to allow retrieving logs currently being modified
         JSONObject json = new JSONObject();
         File root = new File(logDirectory);
         traverse_folder(root, json, "");
@@ -27,7 +27,7 @@ public class LogReader {
     private void traverse_folder(File root, JSONObject json, String filename) throws IOException, JSONException {
         File[] files = root.listFiles();
         for(File child : files) {
-            long logTime = Files.readAttributes(child.toPath(), BasicFileAttributes.class).creationTime().toMillis();
+            long logTime = Files.getLastModifiedTime(child.toPath()).toMillis();
             if(child.isFile() && earliestLogThreshold < logTime && logTime < latestLogThreshold) {
                 json.put(filename + child.getName(), Base64.getEncoder().encodeToString(Files.readAllBytes(child.toPath())));
             }

--- a/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.time.Instant;
 
 import static org.junit.Assert.*;
 
@@ -22,7 +23,7 @@ public class LogReaderTest {
     public void testThatFilesAreWrittenCorrectlyToOutputStream() throws Exception{
         String logDirectory = "src/test/resources/logfolder/";
         LogReader logReader = new LogReader();
-        JSONObject json = logReader.readLogs(logDirectory, 21, Long.MAX_VALUE);
+        JSONObject json = logReader.readLogs(logDirectory, 21, Instant.now().toEpochMilli());
         String expected = "{\"subfolder-log2.log\":\"VGhpcyBpcyBhbm90aGVyIGxvZyBmaWxl\",\"log1.log\":\"VGhpcyBpcyBvbmUgbG9nIGZpbGU=\"}";
         String actual = json.toString();
         assertEquals(expected, actual);


### PR DESCRIPTION
Apparently Linux doesn't keep file creation time as an attribute, so creationTime() actually returns lastModifiedTime()