### PR TITLE
Deploy zone-app faster

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
@@ -12,15 +12,12 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * @author bratseth
@@ -75,17 +72,8 @@ public abstract class ApplicationMaintainer extends Maintainer {
 
     protected Deployer deployer() { return deployer; }
 
-    protected Set<ApplicationId> applicationsNeedingMaintenance() {
-        return nodesNeedingMaintenance().stream()
-                                        .map(node -> node.allocation().get().owner())
-                                        .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * Returns the nodes whose applications should be maintained by this now. 
-     * This should be some subset of the allocated nodes. 
-     */
-    protected abstract List<Node> nodesNeedingMaintenance();
+    /** Returns the applications that should be maintained by this now. */
+    protected abstract Set<ApplicationId> applicationsNeedingMaintenance();
 
     /** Redeploy this application. A lock will be taken for the duration of the deployment activation */
     protected final void deployWithLock(ApplicationId application) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainer.java
@@ -75,7 +75,6 @@ public class PeriodicApplicationMaintainer extends ApplicationMaintainer {
         return clock.instant().isBefore(start.plus(minTimeBetweenRedeployments));
     }
 
-    @Override
     protected List<Node> nodesNeedingMaintenance() {
         return nodeRepository().getNodes(Node.State.active);
     }


### PR DESCRIPTION
Currently, zone-app is only re-deployed by the `PeriodicApplicationMaintainer` (and the controller during upgrades) which is rather rare. This PR introduces a small hack to consider unallocated nodes of type `host` with a recent change by `operator`.

When a new host is provisioned, it is added in the `provisioned` state. Then `host-admin` will move it to `ready` which will be registered as `operator` change (which is confusing, but all changes through the REST API are registered as by `operator`), which is a good time to redeploy the zone-app to take in the new hosts.

The long term goal is still to move tenant hosts out of zone-app and let this be handled by the much more frequent `InfrastructureProvisioner` maintainer.