### PR TITLE
Don't do request parsing on jrt transport thread

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
@@ -141,6 +141,7 @@ class GetConfigProcessor implements Runnable {
     }
     @Override
     public void run() {
+        rpcServer.hostLivenessTracker().receivedRequestFrom(request.getClientHostName());
         Pair<GetConfigContext, Long> delayed = getConfig(request);
 
         if (delayed != null) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
@@ -152,9 +152,7 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
             log.log(LogLevel.SPAM, getConfigMethodName);
         }
         req.detach();
-        JRTServerConfigRequestV3 request = JRTServerConfigRequestV3.createFromRequest(req);
-        addToRequestQueue(request);
-        hostLivenessTracker.receivedRequestFrom(request.getClientHostName());
+        addToRequestQueue(JRTServerConfigRequestV3.createFromRequest(req));
     }
 
     /**
@@ -560,4 +558,7 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
         req.returnValues().add(new Int32Value(0));
     }
 
+    HostLivenessTracker hostLivenessTracker() {
+        return hostLivenessTracker;
+    }
 }


### PR DESCRIPTION
Parsing the slime request body should not be performed on the jrt
transport thread as this will reduce max throughput.

Increases QPS with 40% on config loadtest with TLS enabled.

FYI @vekterli @havardpe 