### PR TITLE
rewrite port allocation

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
@@ -42,7 +42,7 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
     private int id = 0;
 
     /** The actual base port for this Service. */
-    private int basePort;
+    private int basePort = 0;
 
     /** The ports allocated to this Service. */
     private List<Integer> ports = new ArrayList<>();
@@ -483,8 +483,7 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
      *  currently uses the first port as container http port.
      */
     public void reservePortPrepended(int port, String suffix) {
-        hostResource.reservePort(this, port, suffix);
-        ports.add(0, port);
+        ports.add(0, hostResource.requireNetworkPort(port, this, suffix));
     }
 
     public void setHostResource(HostResource hostResource) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
@@ -483,7 +483,7 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
      *  currently uses the first port as container http port.
      */
     public void reservePortPrepended(int port, String suffix) {
-        ports.add(0, hostResource.requireNetworkPort(port, this, suffix));
+        ports.add(0, hostResource.ports().requireNetworkPort(port, this, suffix));
     }
 
     public void setHostResource(HostResource hostResource) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
@@ -42,13 +42,24 @@ public class HostPorts {
 
     private Optional<NetworkPorts> networkPortsList = Optional.empty();
 
+    /**
+     * Get the allocated network ports.
+     * Should be called after allocation is complete and flushPortReservations has been called
+     **/
     public Optional<NetworkPorts> networkPorts() { return networkPortsList; }
 
+    /**
+     * Add port allocation from previous deployments.
+     * Call this before starting port allocations, to re-use existing ports where possible
+     **/
     public void addNetworkPorts(NetworkPorts ports) {
         this.networkPortsList = Optional.of(ports);
         this.portFinder = new PortFinder(ports.allocations());
     }
 
+    /**
+     * Setup logging in order to send warnings back to the user.
+     **/
     public void useLogger(DeployLogger logger) {
         this.deployLogger = logger;
     }
@@ -81,6 +92,7 @@ public class HostPorts {
         return 0;
     }
 
+    /** Allocate a specific port number for a service */
     public int requireNetworkPort(int port, NetworkPortRequestor service, String suffix) {
         reservePort(service, port, suffix);
         String servType = service.getServiceType();
@@ -89,6 +101,7 @@ public class HostPorts {
         return port;
     }
 
+    /** Allocate a preferred port number for a service, fall back to using any dynamic port */
     public int wantNetworkPort(int port, NetworkPortRequestor service, String suffix) {
         if (portDB.containsKey(port)) {
             int fallback = nextAvailableNetworkPort();
@@ -102,10 +115,12 @@ public class HostPorts {
         return requireNetworkPort(port, service, suffix);
     }
 
+    /** Convenience method to allocate a preferred or required port number for a service */
     public int wantNetworkPort(int port, NetworkPortRequestor service, String suffix, boolean forceRequired) {
         return forceRequired ? requireNetworkPort(port, service, suffix) : wantNetworkPort(port, service, suffix);
     }
 
+    /** Allocate a dynamic port number for a service */
     public int allocateNetworkPort(NetworkPortRequestor service, String suffix) {
         String servType = service.getServiceType();
         String configId = service.getConfigId();
@@ -116,6 +131,7 @@ public class HostPorts {
         return port;
     }
 
+    /** Allocate all ports for a service */
     List<Integer> allocatePorts(NetworkPortRequestor service, int wantedPort) {
         List<Integer> ports = new ArrayList<>();
         final int count = service.getPortCount();

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
@@ -1,0 +1,205 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.model;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.provision.NetworkPorts;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+
+/**
+ * Allocator for network ports on a host
+ * @author arnej
+ */
+public class HostPorts {
+
+    public HostPorts(String hostname) {
+        this.hostname = hostname;
+    }
+
+    final String hostname;
+    public final static int BASE_PORT = 19100;
+    final static int MAX_PORTS = 799;
+
+    private DeployLogger deployLogger = new DeployLogger() {
+        public void log(Level level, String message) {
+            System.err.println("deploy log["+level+"]: "+message);
+        }
+    };
+
+    private final Map<Integer, NetworkPortRequestor> portDB = new LinkedHashMap<>();
+
+    private int allocatedPorts = 0;
+
+    private PortFinder portFinder = new PortFinder(Collections.emptyList());
+
+    private Optional<NetworkPorts> networkPortsList = Optional.empty();
+
+    public Optional<NetworkPorts> networkPorts() { return networkPortsList; }
+
+    public void addNetworkPorts(NetworkPorts ports) {
+        this.networkPortsList = Optional.of(ports);
+        this.portFinder = new PortFinder(ports.allocations());
+    }
+
+    public void useLogger(DeployLogger logger) {
+        this.deployLogger = logger;
+    }
+
+    /**
+     * Returns the baseport of the first available port range of length numPorts,
+     * or 0 if there is no range of that length available.
+     *
+     * @param numPorts  The length of the desired port range.
+     * @return  The baseport of the first available range, or 0 if no range is available.
+     */
+    public int nextAvailableBaseport(int numPorts) {
+        int range = 0;
+        int port = BASE_PORT;
+        for (; port < BASE_PORT + MAX_PORTS && (range < numPorts); port++) {
+            if (portDB.containsKey(port)) {
+                range = 0;
+                continue;
+            }
+            range++;
+        }
+        return range == numPorts ? port - range : 0;
+    }
+
+    private int nextAvailableNetworkPort() {
+        int port = BASE_PORT;
+        for (; port < BASE_PORT + MAX_PORTS; port++) {
+            if (!portDB.containsKey(port)) return port;
+        }
+        return 0;
+    }
+
+    public int requireNetworkPort(int port, NetworkPortRequestor service, String suffix) {
+        reservePort(service, port, suffix);
+        String servType = service.getServiceType();
+        String configId = service.getConfigId();
+        portFinder.use(new NetworkPorts.Allocation(port, servType, configId, suffix));
+        return port;
+    }
+
+    public int wantNetworkPort(int port, NetworkPortRequestor service, String suffix) {
+        if (portDB.containsKey(port)) {
+            int fallback = nextAvailableNetworkPort();
+            NetworkPortRequestor s = portDB.get(port);
+            deployLogger.log(Level.WARNING,
+                service.getServiceName() +" cannot reserve port " + port + " on " +
+                hostname + ": Already reserved for " + s.getServiceName() +
+                ". Using default port range from " + fallback);
+            return allocateNetworkPort(service, suffix);
+        }
+        return requireNetworkPort(port, service, suffix);
+    }
+
+    public int wantNetworkPort(int port, NetworkPortRequestor service, String suffix, boolean forceRequired) {
+        return forceRequired ? requireNetworkPort(port, service, suffix) : wantNetworkPort(port, service, suffix);
+    }
+
+    public int allocateNetworkPort(NetworkPortRequestor service, String suffix) {
+        String servType = service.getServiceType();
+        String configId = service.getConfigId();
+        int fallback = nextAvailableNetworkPort();
+        int port = portFinder.findPort(new NetworkPorts.Allocation(fallback, servType, configId, suffix));
+        reservePort(service, port, suffix);
+        portFinder.use(new NetworkPorts.Allocation(port, servType, configId, suffix));
+        return port;
+    }
+
+    List<Integer> allocatePorts(NetworkPortRequestor service, int wantedPort) {
+        List<Integer> ports = new ArrayList<>();
+        final int count = service.getPortCount();
+        if (count < 1)
+            return ports;
+
+        String[] suffixes = service.getPortSuffixes();
+        if (suffixes.length != count) {
+            throw new IllegalArgumentException("service "+service+" had "+suffixes.length+" port suffixes, but port count "+count+", mismatch");
+        }
+
+        if (wantedPort > 0) {
+            boolean force = service.requiresWantedPort();
+            if (service.requiresConsecutivePorts()) {
+                for (int i = 0; i < count; i++) {
+                    ports.add(wantNetworkPort(wantedPort+i, service, suffixes[i], force));
+                }
+            } else {
+                ports.add(wantNetworkPort(wantedPort, service, suffixes[0], force));
+                for (int i = 1; i < count; i++) {
+                    ports.add(allocateNetworkPort(service, suffixes[i]));
+                }
+            }
+        } else {
+            for (int i = 0; i < count; i++) {
+                ports.add(allocateNetworkPort(service, suffixes[i]));
+            }
+        }
+        return ports;
+    }
+
+    public void flushPortReservations() {
+        this.networkPortsList = Optional.of(new NetworkPorts(portFinder.allocations()));
+    }
+
+    /**
+     * Reserves the desired port for the given service, or throws as exception if the port
+     * is not available.
+     *
+     * @param service the service that wishes to reserve the port.
+     * @param port the port to be reserved.
+     */
+    void reservePort(NetworkPortRequestor service, int port, String suffix) {
+        if (portDB.containsKey(port)) {
+            portAlreadyReserved(service, port);
+        }
+        if (inVespasPortRange(port)) {
+            allocatedPorts++;
+            if (allocatedPorts > MAX_PORTS) {
+                noMoreAvailablePorts();
+            }
+        }
+        portDB.put(port, service);
+    }
+
+    private boolean inVespasPortRange(int port) {
+        return port >= BASE_PORT &&
+                port < BASE_PORT + MAX_PORTS;
+    }
+
+    private void portAlreadyReserved(NetworkPortRequestor service, int port) {
+        NetworkPortRequestor otherService = portDB.get(port);
+        int nextAvailablePort = nextAvailableBaseport(service.getPortCount());
+        if (nextAvailablePort == 0) {
+            noMoreAvailablePorts();
+        }
+        String msg = (service.getClass().equals(otherService.getClass()) && service.requiresWantedPort())
+                ? "You must set port explicitly for all instances of this service type, except the first one. "
+                : "";
+        throw new RuntimeException(service.getServiceName() + " cannot reserve port " + port +
+                    " on " + hostname + ": Already reserved for " + otherService.getServiceName() +
+                    ". " + msg + "Next available port is: " + nextAvailablePort + " ports used: " + portDB);
+    }
+
+    private void noMoreAvailablePorts() {
+        throw new RuntimeException
+            ("Too many ports are reserved in Vespa's port range (" +
+                    BASE_PORT  + ".." + (BASE_PORT+MAX_PORTS) + ") on " + hostname +
+                    ". Move one or more services to another host, or outside this port range.");
+    }
+
+    @Override
+    public String toString() {
+        return "HostPorts{"+hostname+"}";
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostResource.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostResource.java
@@ -28,31 +28,15 @@ import java.util.stream.Collectors;
  *
  * @author Ulf Lilleengen
  */
-public class HostResource implements Comparable<HostResource> {
+public class HostResource
+    extends HostPorts
+    implements Comparable<HostResource>
+{
 
-    public final static int BASE_PORT = 19100;
-    final static int MAX_PORTS = 799;
     private final Host host;
 
     /** Map from "sentinel name" to service */
     private final Map<String, Service> services = new LinkedHashMap<>();
-
-    private final Map<Integer, NetworkPortRequestor> portDB = new LinkedHashMap<>();
-
-    private int allocatedPorts = 0;
-
-    static class PortReservation {
-        int gotPort;
-        NetworkPortRequestor service;
-        String suffix;
-        PortReservation(int port, NetworkPortRequestor svc, String suf) {
-            this.gotPort = port;
-            this.service = svc;
-            this.suffix = suf;
-        }
-    }
-
-    private List<PortReservation> portReservations = new ArrayList<>();
 
     private Set<ClusterMembership> clusterMemberships = new LinkedHashSet<>();
 
@@ -61,12 +45,6 @@ public class HostResource implements Comparable<HostResource> {
 
     /** The current Vespa version running on this node, or empty if not known */
     private final Optional<Version> version;
-
-    private Optional<NetworkPorts> networkPortsList = Optional.empty();
-
-    public Optional<NetworkPorts> networkPorts() { return networkPortsList; }
-
-    public void addNetworkPorts(NetworkPorts ports) { this.networkPortsList = Optional.of(ports); }
 
     /**
      * Create a new {@link HostResource} bound to a specific {@link com.yahoo.vespa.model.Host}.
@@ -78,6 +56,7 @@ public class HostResource implements Comparable<HostResource> {
     }
 
     public HostResource(Host host, Optional<Version> version) {
+        super(host.getHostname());
         this.host = host;
         this.version = version;
     }
@@ -92,26 +71,6 @@ public class HostResource implements Comparable<HostResource> {
     public Optional<Version> version() { return version; }
 
     /**
-     * Returns the baseport of the first available port range of length numPorts,
-     * or 0 if there is no range of that length available.
-     *
-     * @param numPorts  The length of the desired port range.
-     * @return  The baseport of the first available range, or 0 if no range is available.
-     */
-    public int nextAvailableBaseport(int numPorts) {
-        int range = 0;
-        int port = BASE_PORT;
-        for (; port < BASE_PORT + MAX_PORTS && (range < numPorts); port++) {
-            if (portDB.containsKey(port)) {
-                range = 0;
-                continue;
-            }
-            range++;
-        }
-        return range == numPorts ? port - range : 0;
-    }
-
-    /**
      * Adds service and allocates resources for it.
      *
      * @param service The Service to allocate resources for
@@ -119,118 +78,14 @@ public class HostResource implements Comparable<HostResource> {
      * @return  The allocated ports for the Service.
      */
     List<Integer> allocateService(DeployLogger deployLogger, AbstractService service, int wantedPort) {
-        List<Integer> ports = allocatePorts(deployLogger, service, wantedPort);
+        useLogger(deployLogger);
+        List<Integer> ports = allocatePorts(service, wantedPort);
         assert (getService(service.getServiceName()) == null) :
                 ("There is already a service with name '" + service.getServiceName() + "' registered on " + this +
                 ". Most likely a programming error - all service classes must have unique names, even in different packages!");
 
         services.put(service.getServiceName(), service);
         return ports;
-    }
-
-    private List<Integer> allocatePorts(DeployLogger deployLogger, NetworkPortRequestor service, int wantedPort) {
-        List<Integer> ports = new ArrayList<>();
-        if (service.getPortCount() < 1)
-            return ports;
-
-        int serviceBasePort = BASE_PORT + allocatedPorts;
-        if (wantedPort > 0) {
-            if (service.requiresWantedPort() || canUseWantedPort(deployLogger, service, wantedPort, serviceBasePort))
-                serviceBasePort = wantedPort;
-        }
-        String[] suffixes = service.getPortSuffixes();
-        if (suffixes.length != service.getPortCount()) {
-            throw new IllegalArgumentException("service "+service+" had "+suffixes.length+" port suffixes, but port count "+service.getPortCount()+", mismatch");
-        }
-
-        reservePort(service, serviceBasePort, suffixes[0]);
-        ports.add(serviceBasePort);
-
-        int remainingPortsStart =  service.requiresConsecutivePorts() ?
-                serviceBasePort + 1:
-                BASE_PORT + allocatedPorts;
-        for (int i = 0; i < service.getPortCount() - 1; i++) {
-            int port = remainingPortsStart + i;
-            reservePort(service, port, suffixes[i+1]);
-            ports.add(port);
-        }
-        if (suffixes.length != service.getPortCount()) {
-            throw new IllegalArgumentException("service "+service+" had "+suffixes.length+" port suffixes, but port count "+service.getPortCount()+", mismatch");
-        }
-        return ports;
-    }
-
-    public void flushPortReservations() {
-        List<NetworkPorts.Allocation> list = new ArrayList<>();
-        for (PortReservation pr : portReservations) {
-            String servType = pr.service.getServiceType();
-            String configId = pr.service.getConfigId();
-            list.add(new NetworkPorts.Allocation(pr.gotPort, servType, configId, pr.suffix));
-        }
-        this.networkPortsList = Optional.of(new NetworkPorts(list));
-    }
-
-    private boolean canUseWantedPort(DeployLogger deployLogger, NetworkPortRequestor service, int wantedPort, int serviceBasePort) {
-        for (int i = 0; i < service.getPortCount(); i++) {
-            int port = wantedPort + i;
-            if (portDB.containsKey(port)) {
-                NetworkPortRequestor s = portDB.get(port);
-                deployLogger.log(Level.WARNING, service.getServiceName() +" cannot reserve port " + port + " on " +
-                        this + ": Already reserved for " + s.getServiceName() +
-                        ". Using default port range from " + serviceBasePort);
-                return false;
-            }
-            if (!service.requiresConsecutivePorts()) break;
-        }
-        return true;
-    }
-
-    /**
-     * Reserves the desired port for the given service, or throws as exception if the port
-     * is not available.
-     *
-     * @param service the service that wishes to reserve the port.
-     * @param port the port to be reserved.
-     */
-    void reservePort(NetworkPortRequestor service, int port, String suffix) {
-        if (portDB.containsKey(port)) {
-            portAlreadyReserved(service, port);
-        } else {
-            if (inVespasPortRange(port)) {
-                allocatedPorts++;
-                if (allocatedPorts > MAX_PORTS) {
-                    noMoreAvailablePorts();
-                }
-            }
-            portDB.put(port, service);
-            portReservations.add(new PortReservation(port, service, suffix));
-        }
-    }
-
-    private boolean inVespasPortRange(int port) {
-        return port >= BASE_PORT &&
-                port < BASE_PORT + MAX_PORTS;
-    }
-
-    private void portAlreadyReserved(NetworkPortRequestor service, int port) {
-        NetworkPortRequestor otherService = portDB.get(port);
-        int nextAvailablePort = nextAvailableBaseport(service.getPortCount());
-        if (nextAvailablePort == 0) {
-            noMoreAvailablePorts();
-        }
-        String msg = (service.getClass().equals(otherService.getClass()) && service.requiresWantedPort())
-                ? "You must set port explicitly for all instances of this service type, except the first one. "
-                : "";
-        throw new RuntimeException(service.getServiceName() + " cannot reserve port " + port +
-                    " on " + this + ": Already reserved for " + otherService.getServiceName() +
-                    ". " + msg + "Next available port is: " + nextAvailablePort + " ports used: " + portDB);
-    }
-
-    private void noMoreAvailablePorts() {
-        throw new RuntimeException
-            ("Too many ports are reserved in Vespa's port range (" +
-                    BASE_PORT  + ".." + (BASE_PORT+MAX_PORTS) + ") on " + this +
-                    ". Move one or more services to another host, or outside this port range.");
     }
 
     /**

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostResource.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostResource.java
@@ -28,10 +28,11 @@ import java.util.stream.Collectors;
  *
  * @author Ulf Lilleengen
  */
-public class HostResource
-    extends HostPorts
-    implements Comparable<HostResource>
+public class HostResource implements Comparable<HostResource>
 {
+    private final HostPorts hostPorts;
+
+    public HostPorts ports() { return hostPorts; }
 
     private final Host host;
 
@@ -56,7 +57,7 @@ public class HostResource
     }
 
     public HostResource(Host host, Optional<Version> version) {
-        super(host.getHostname());
+        this.hostPorts = new HostPorts(host.getHostname());
         this.host = host;
         this.version = version;
     }
@@ -78,8 +79,8 @@ public class HostResource
      * @return  The allocated ports for the Service.
      */
     List<Integer> allocateService(DeployLogger deployLogger, AbstractService service, int wantedPort) {
-        useLogger(deployLogger);
-        List<Integer> ports = allocatePorts(service, wantedPort);
+        ports().useLogger(deployLogger);
+        List<Integer> ports = hostPorts.allocatePorts(service, wantedPort);
         assert (getService(service.getServiceName()) == null) :
                 ("There is already a service with name '" + service.getServiceName() + "' registered on " + this +
                 ". Most likely a programming error - all service classes must have unique names, even in different packages!");

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
@@ -131,7 +131,7 @@ public class HostSystem extends AbstractConfigProducer<Host> {
                                                      hostSpec.version());
         hostResource.setFlavor(hostSpec.flavor());
         hostSpec.membership().ifPresent(hostResource::addClusterMembership);
-        hostSpec.networkPorts().ifPresent(hostResource::addNetworkPorts);
+        hostSpec.networkPorts().ifPresent(np -> hostResource.ports().addNetworkPorts(np));
         hostname2host.put(host.getHostname(), hostResource);
         log.log(DEBUG, () -> "Added new host resource for " + host.getHostname() + " with flavor " + hostResource.getFlavor());
         return hostResource;
@@ -146,7 +146,7 @@ public class HostSystem extends AbstractConfigProducer<Host> {
 
     public void dumpPortAllocations() {
         for (HostResource hr : getHosts()) {
-            hr.flushPortReservations();
+            hr.ports().flushPortReservations();
 /*
             System.out.println("port allocations for: "+hr.getHostname());
             NetworkPorts ports = hr.networkPorts().get();
@@ -193,7 +193,7 @@ public class HostSystem extends AbstractConfigProducer<Host> {
     Set<HostSpec> getHostSpecs() {
         return getHosts().stream()
                 .map(host -> new HostSpec(host.getHostname(), Collections.emptyList(),
-                                          host.getFlavor(), host.primaryClusterMembership(), host.version(), host.networkPorts()))
+                                          host.getFlavor(), host.primaryClusterMembership(), host.version(), host.ports().networkPorts()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
@@ -1,0 +1,57 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.model;
+
+import static com.yahoo.config.provision.NetworkPorts.Allocation;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class PortFinder {
+
+    private final Map<String, Allocation> byKeys = new HashMap<>();
+    private final Map<Integer, Allocation> byPorts = new TreeMap<>();
+
+    /** force add the given allocation, removing any conflicting ones */
+    public void use(Allocation allocation) {
+        String key = allocation.key();
+        if (byKeys.containsKey(key)) {
+            if (byKeys.get(key).port == allocation.port) {
+                return; // already OK
+            }
+            Allocation toRemove = byKeys.remove(key);
+            byPorts.remove(toRemove.port);
+        }
+        if (byPorts.containsKey(allocation.port)) {
+            Allocation toRemove = byPorts.remove(allocation.port);
+            byKeys.remove(toRemove.key());
+        }
+        byPorts.put(allocation.port, allocation);
+        byKeys.put(key, allocation);
+    }
+
+    public int findPort(Allocation request) {
+        String key = request.key();
+        if (byKeys.containsKey(key)) {
+            return byKeys.get(key).port;
+        }
+        int port = request.port;
+        while (byPorts.containsKey(port)) {
+            ++port;
+        }
+        return port;
+    }
+
+    public PortFinder(Collection<Allocation> allocations) {
+        for (Allocation a : allocations) {
+            use(a);
+        }
+    }
+
+    public Collection<Allocation> allocations() {
+        return byPorts.values();
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
@@ -9,7 +9,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
 public class PortFinder {
+
+    private static final Logger log = Logger.getLogger(PortFinder.class.getName());
 
     private final Map<String, Allocation> byKeys = new HashMap<>();
     private final Map<Integer, Allocation> byPorts = new TreeMap<>();
@@ -35,7 +40,9 @@ public class PortFinder {
     public int findPort(Allocation request) {
         String key = request.key();
         if (byKeys.containsKey(key)) {
-            return byKeys.get(key).port;
+            int port = byKeys.get(key).port;
+            log.log(Level.INFO, "Re-using port "+port+" for allocation "+request);
+            return port;
         }
         int port = request.port;
         while (byPorts.containsKey(port)) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Slobrok.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Slobrok.java
@@ -15,7 +15,7 @@ public class Slobrok extends AbstractService implements StateserverConfig.Produc
 
     @Override
     public void getConfig(StateserverConfig.Builder builder) {
-        builder.httpport(getStatePort());
+        builder.httpport(getHealthPort());
     }
 
     /**
@@ -46,7 +46,7 @@ public class Slobrok extends AbstractService implements StateserverConfig.Produc
     }
 
     public String getStartupCommand() {
-        return "exec $ROOT/sbin/vespa-slobrok -p " + getPort() + " -c " + getConfigId();
+        return "exec $ROOT/sbin/vespa-slobrok -p " + getRpcPort() + " -c " + getConfigId();
     }
 
     /**
@@ -62,16 +62,17 @@ public class Slobrok extends AbstractService implements StateserverConfig.Produc
     }
 
     /**
-     * @return The port on which this slobrok should respond, as a String.
+     * @return The port on which this slobrok should respond
      */
-    private String getPort() {
-        return String.valueOf(getRelativePort(0));
+    private int getRpcPort() {
+        return getRelativePort(0);
     }
 
     /**
      * @return The port on which the state server should respond
      */
-    public int getStatePort() {
+    @Override
+    public int getHealthPort() {
         return getRelativePort(1);
     }
 
@@ -79,7 +80,7 @@ public class Slobrok extends AbstractService implements StateserverConfig.Produc
      * @return The connection spec to this Slobrok
      */
     public String getConnectionSpec() {
-        return "tcp/" + getHostName() + ":" + getPort();
+        return "tcp/" + getHostName() + ":" + getRpcPort();
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -272,7 +272,7 @@ public class Container extends AbstractService implements
      * @return the actual search port
      * TODO: Remove. Use {@link #getPortsMeta()} and check tags in conjunction with {@link #getRelativePort(int)}.
      */
-    public int getSearchPort(){
+    public int getSearchPort() {
         if (getHttp() != null)
             throw new AssertionError("getSearchPort must not be used when http section is present.");
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -326,7 +326,7 @@ public class Content extends ConfigModel {
                     Container docprocService = new Container(indexingCluster, containerName, index,
                                                              modelContext.getDeployState().isHosted());
                     index++;
-                    docprocService.setBasePort(host.nextAvailableBaseport(docprocService.getPortCount()));
+                    docprocService.setBasePort(host.ports().nextAvailableBaseport(docprocService.getPortCount()));
                     docprocService.setHostResource(host);
                     docprocService.initService(modelContext.getDeployLogger());
                     nodes.add(docprocService);

--- a/config-model/src/main/java/com/yahoo/vespa/model/package-info.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/package-info.java
@@ -142,8 +142,8 @@ com.yahoo.config.model.producer.AbstractConfigProducer
 
     <p>Each {@link com.yahoo.vespa.model.Host Host} has an available
     dynamic port range running from {@link
-    com.yahoo.vespa.model.HostResource#BASE_PORT BASE_PORT} (currently 19100)
-    with {@link com.yahoo.vespa.model.HostResource#MAX_PORTS MAX_PORTS}
+    com.yahoo.vespa.model.HostPorts#BASE_PORT BASE_PORT} (currently 19100)
+    with {@link com.yahoo.vespa.model.HostPorts#MAX_PORTS MAX_PORTS}
     (currently 799) ports upwards. When an instance of a subclass of
     {@link com.yahoo.vespa.model.AbstractService  AbstractService} is
     assigned to a host, it is given the lowest available base port in

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/Dispatch.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/Dispatch.java
@@ -89,7 +89,7 @@ public class Dispatch extends AbstractService implements SearchInterface,
         return "exec sbin/vespa-dispatch -c $VESPA_CONFIG_ID";
     }
 
-    public int getFrtPort()  { return getRelativePort(0); }
+    private int getFrtPort()  { return getRelativePort(0); }
     public int getDispatchPort()   { return getRelativePort(1); }
     @Override
     public int getHealthPort() { return getRelativePort(2); }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
@@ -202,7 +202,7 @@ public class SearchNode extends AbstractService implements
         return getRelativePort(FS4_PORT);
     }
 
-    public int getHttpPort() {
+    private int getHttpPort() {
         return getRelativePort(HEALTH_PORT);
     }
 
@@ -300,7 +300,13 @@ public class SearchNode extends AbstractService implements
 
     @Override
     public Optional<String> getPreShutdownCommand() {
-        return Optional.ofNullable(flushOnShutdown ? getDefaults().underVespaHome("bin/vespa-proton-cmd ") + getRpcPort() + " prepareRestart" : null);
+        if (flushOnShutdown) {
+            int port = getRpcPort();
+            String cmd = getDefaults().underVespaHome("bin/vespa-proton-cmd ") + port + " prepareRestart";
+            return Optional.of(cmd);
+        } else {
+            return Optional.empty();
+        }
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/TransactionLogServer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/TransactionLogServer.java
@@ -48,7 +48,7 @@ public class TransactionLogServer extends AbstractService  {
      *
      * @return The port.
      */
-    public int getTlsPort() {
+    int getTlsPort() {
         return getRelativePort(0);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/HostPortsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/HostPortsTest.java
@@ -26,15 +26,15 @@ public class HostPortsTest {
     @Test
     public void next_available_baseport_is_BASE_PORT_when_no_ports_have_been_reserved() {
         HostPorts host = new HostPorts("myhostname");
-        assertThat(host.nextAvailableBaseport(1), is(HostResource.BASE_PORT));
+        assertThat(host.nextAvailableBaseport(1), is(HostPorts.BASE_PORT));
     }
 
     @Test
     public void next_available_baseport_is_BASE_PORT_plus_one_when_one_port_has_been_reserved() {
         HostPorts host = new HostPorts("myhostname");
         MockRoot root = new MockRoot();
-        host.reservePort(new TestService(root, 1), HostResource.BASE_PORT, "foo");
-        assertThat(host.nextAvailableBaseport(1), is(HostResource.BASE_PORT + 1));
+        host.reservePort(new TestService(root, 1), HostPorts.BASE_PORT, "foo");
+        assertThat(host.nextAvailableBaseport(1), is(HostPorts.BASE_PORT + 1));
     }
 
     @Test
@@ -42,13 +42,13 @@ public class HostPortsTest {
         HostPorts host = new HostPorts("myhostname");
         MockRoot root = new MockRoot();
 
-        for (int p = HostResource.BASE_PORT; p < HostResource.BASE_PORT + HostResource.MAX_PORTS; p += 2) {
+        for (int p = HostPorts.BASE_PORT; p < HostPorts.BASE_PORT + HostPorts.MAX_PORTS; p += 2) {
             host.reservePort(new TestService(root, 1), p, "foo");
         }
         assertThat(host.nextAvailableBaseport(2), is(0));
 
         try {
-            host.reservePort(new TestService(root, 2), HostResource.BASE_PORT, "bar");
+            host.reservePort(new TestService(root, 2), HostPorts.BASE_PORT, "bar");
         } catch (RuntimeException e) {
             assertThat(e.getMessage(), containsString("Too many ports are reserved"));
         }
@@ -58,7 +58,7 @@ public class HostPortsTest {
     public void port_above_vespas_port_range_can_be_reserved() {
         HostPorts host = new HostPorts("myhostname");
         MockRoot root = new MockRoot();
-        host.allocatePorts(new TestService(root, 1), HostResource.BASE_PORT + HostResource.MAX_PORTS + 1);
+        host.allocatePorts(new TestService(root, 1), HostPorts.BASE_PORT + HostPorts.MAX_PORTS + 1);
     }
 
     @Test(expected = RuntimeException.class)
@@ -68,8 +68,8 @@ public class HostPortsTest {
         TestService service1 = new TestService(root, 1);
         TestService service2 = new TestService(root, 1);
 
-        host.allocatePorts(service1, HostResource.BASE_PORT);
-        host.allocatePorts(service2, HostResource.BASE_PORT);
+        host.allocatePorts(service1, HostPorts.BASE_PORT);
+        host.allocatePorts(service2, HostPorts.BASE_PORT);
     }
 
     @Test(expected = RuntimeException.class)
@@ -79,8 +79,8 @@ public class HostPortsTest {
         TestService service2 = new TestService(root, 2);
         TestService service1 = new TestService(root, 1);
 
-        host.allocatePorts(service2, HostResource.BASE_PORT);
-        host.allocatePorts(service1, HostResource.BASE_PORT + 1);
+        host.allocatePorts(service2, HostPorts.BASE_PORT);
+        host.allocatePorts(service1, HostPorts.BASE_PORT + 1);
     }
 
     NetworkPorts emulOldPorts() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/HostPortsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/HostPortsTest.java
@@ -1,0 +1,153 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model;
+
+import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.test.MockRoot;
+import com.yahoo.config.provision.NetworkPorts;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author arnej
+ */
+public class HostPortsTest {
+
+    @Test
+    public void next_available_baseport_is_BASE_PORT_when_no_ports_have_been_reserved() {
+        HostPorts host = new HostPorts("myhostname");
+        assertThat(host.nextAvailableBaseport(1), is(HostResource.BASE_PORT));
+    }
+
+    @Test
+    public void next_available_baseport_is_BASE_PORT_plus_one_when_one_port_has_been_reserved() {
+        HostPorts host = new HostPorts("myhostname");
+        MockRoot root = new MockRoot();
+        host.reservePort(new TestService(root, 1), HostResource.BASE_PORT, "foo");
+        assertThat(host.nextAvailableBaseport(1), is(HostResource.BASE_PORT + 1));
+    }
+
+    @Test
+    public void no_available_baseport_when_service_requires_more_consecutive_ports_than_available() {
+        HostPorts host = new HostPorts("myhostname");
+        MockRoot root = new MockRoot();
+
+        for (int p = HostResource.BASE_PORT; p < HostResource.BASE_PORT + HostResource.MAX_PORTS; p += 2) {
+            host.reservePort(new TestService(root, 1), p, "foo");
+        }
+        assertThat(host.nextAvailableBaseport(2), is(0));
+
+        try {
+            host.reservePort(new TestService(root, 2), HostResource.BASE_PORT, "bar");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), containsString("Too many ports are reserved"));
+        }
+    }
+
+    @Test
+    public void port_above_vespas_port_range_can_be_reserved() {
+        HostPorts host = new HostPorts("myhostname");
+        MockRoot root = new MockRoot();
+        host.allocatePorts(new TestService(root, 1), HostResource.BASE_PORT + HostResource.MAX_PORTS + 1);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void allocating_same_port_throws_exception() {
+        HostPorts host = new HostPorts("myhostname");
+        MockRoot root = new MockRoot();
+        TestService service1 = new TestService(root, 1);
+        TestService service2 = new TestService(root, 1);
+
+        host.allocatePorts(service1, HostResource.BASE_PORT);
+        host.allocatePorts(service2, HostResource.BASE_PORT);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void allocating_overlapping_ports_throws_exception() {
+        HostPorts host = new HostPorts("myhostname");
+        MockRoot root = new MockRoot();
+        TestService service2 = new TestService(root, 2);
+        TestService service1 = new TestService(root, 1);
+
+        host.allocatePorts(service2, HostResource.BASE_PORT);
+        host.allocatePorts(service1, HostResource.BASE_PORT + 1);
+    }
+
+    NetworkPorts emulOldPorts() {
+        List<NetworkPorts.Allocation> list = new ArrayList<>();
+        list.add(new NetworkPorts.Allocation(8080, "qrs", "foo", "http"));
+        list.add(new NetworkPorts.Allocation(19101, "slobrok", "slobrok.0", "http"));
+        return new NetworkPorts(list);
+    }
+
+    @Test
+    public void use_old_port_when_available() {
+        HostPorts host = new HostPorts("myhostname");
+        host.addNetworkPorts(emulOldPorts());
+
+        MockRoot root = new MockRoot();
+        Service service = new MockSlobrok(root, 0);
+        assertThat(service.getConfigId(), is("slobrok.0"));
+
+        // check that matching service get port from saved allocations
+        List<Integer> ports = host.allocatePorts(service, 0);
+        assertThat(ports.size(), is(1));
+        assertThat(ports.get(0), is(19101));
+
+        // check that new service get next free port
+        ports = host.allocatePorts(new MockSlobrok(root, 1), 0);
+        assertThat(ports.get(0), is(19100));
+
+        // check that new service get next free port, skipping the allocated one
+        ports = host.allocatePorts(new MockSlobrok(root, 2), 0);
+        assertThat(ports.get(0), is(19102));
+    }
+
+    private static class MockSlobrok extends AbstractService {
+        MockSlobrok(AbstractConfigProducer parent, int number) {
+            super(parent, "slobrok."+number);
+        }
+        @Override public int getPortCount() { return 1; }
+        @Override public String[] getPortSuffixes() { return new String[]{"http"}; }
+        @Override public String getServiceType() { return "slobrok"; }
+    }
+
+    private static int counter = 0;
+    int getCounter() { return ++counter; }
+
+    private class TestService extends AbstractService {
+        private final int portCount;
+
+        TestService(AbstractConfigProducer parent, int portCount) {
+            super(parent, "testService" + getCounter());
+            this.portCount = portCount;
+        }
+
+        @Override
+        public boolean requiresWantedPort() {
+            return true;
+        }
+
+        @Override
+        public int getPortCount() { return portCount; }
+
+        @Override
+        public String[] getPortSuffixes() {
+            String[] suffixes = new String[portCount];
+            for (int i = 0; i < portCount; i++) {
+                suffixes[i] = "generic." + i;
+            }
+            return suffixes;
+        }
+    }
+}

--- a/config-model/src/test/java/com/yahoo/vespa/model/HostResourceTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/HostResourceTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model;
 
 import com.yahoo.component.Version;
+import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
@@ -27,41 +28,9 @@ import static org.junit.Assert.assertTrue;
 public class HostResourceTest {
 
     @Test
-    public void next_available_baseport_is_BASE_PORT_when_no_ports_have_been_reserved() {
-        MockRoot root = new MockRoot();
-        HostResource host = mockHostResource(root);
-        assertThat(host.nextAvailableBaseport(1), is(HostResource.BASE_PORT));
-    }
-
-    @Test
-    public void next_available_baseport_is_BASE_PORT_plus_one_when_one_port_has_been_reserved() {
-        MockRoot root = new MockRoot();
-        HostResource host = mockHostResource(root);
-        host.reservePort(new TestService(1), HostResource.BASE_PORT, "foo");
-        assertThat(host.nextAvailableBaseport(1), is(HostResource.BASE_PORT + 1));
-    }
-
-    @Test
-    public void no_available_baseport_when_service_requires_more_consecutive_ports_than_available() {
-        MockRoot root = new MockRoot();
-        HostResource host = mockHostResource(root);
-
-        for (int p = HostResource.BASE_PORT; p < HostResource.BASE_PORT + HostResource.MAX_PORTS; p += 2) {
-            host.reservePort(new TestService(1), p, "foo");
-        }
-        assertThat(host.nextAvailableBaseport(2), is(0));
-
-        try {
-            host.reservePort(new TestService(2), HostResource.BASE_PORT, "bar");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("Too many ports are reserved"));
-        }
-    }
-
-    @Test
     public void require_exception_when_no_matching_hostalias() {
-        TestService service = new TestService(1);
         MockRoot root = new MockRoot();
+        TestService service = new TestService(root, 1);
 
         try {
             service.initService(root.deployLogger());
@@ -69,36 +38,6 @@ public class HostResourceTest {
             assertThat(e.getMessage(), endsWith("No host found for service 'hostresourcetest$testservice0'. " +
                     "The hostalias is probably missing from hosts.xml."));
         }
-    }
-
-    @Test
-    public void port_above_vespas_port_range_can_be_reserved() {
-        MockRoot root = new MockRoot();
-        HostResource host = mockHostResource(root);
-
-        host.allocateService(root.deployLogger(), new TestService(1), HostResource.BASE_PORT + HostResource.MAX_PORTS + 1);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void allocating_same_port_throws_exception() {
-        MockRoot root = new MockRoot();
-        HostResource host = mockHostResource(root);
-        TestService service1 = new TestService(1);
-        TestService service2 = new TestService(1);
-
-        host.allocateService(root.deployLogger(), service1, HostResource.BASE_PORT);
-        host.allocateService(root.deployLogger(), service2, HostResource.BASE_PORT);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void allocating_overlapping_ports_throws_exception() {
-        MockRoot root = new MockRoot();
-        HostResource host = mockHostResource(root);
-        TestService service2 = new TestService(2);
-        TestService service1 = new TestService(1);
-
-        host.allocateService(root.deployLogger(), service2, HostResource.BASE_PORT);
-        host.allocateService(root.deployLogger(), service1, HostResource.BASE_PORT + 1);
     }
 
     @Test
@@ -166,11 +105,14 @@ public class HostResourceTest {
         return host;
     }
 
+    private static int counter = 0;
+    int getCounter() { return ++counter; }
+
     private class TestService extends AbstractService {
         private final int portCount;
 
-        TestService(int portCount) {
-            super("testService");
+        TestService(AbstractConfigProducer parent, int portCount) {
+            super(parent, "testService" + getCounter());
             this.portCount = portCount;
         }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -279,7 +279,8 @@ public class ContainerClusterTest {
 
     private static ContainerCluster newContainerCluster() {
         DeployState deployState = DeployState.createTestState();
-        ContainerCluster cluster = new ContainerCluster(null, "subId", "name", deployState);
+        MockRoot root = new MockRoot("foo", deployState);
+        ContainerCluster cluster = new ContainerCluster(root, "subId", "name", deployState);
         addContainer(deployState.getDeployLogger(), cluster, "c1", "host-c1");
         addContainer(deployState.getDeployLogger(), cluster, "c2", "host-c2");
         return cluster;

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
@@ -11,7 +11,7 @@ import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.jdisc.ContainerMbusConfig;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.search.config.QrStartConfig;
-import com.yahoo.vespa.model.HostResource;
+import com.yahoo.vespa.model.HostPorts;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModel;
@@ -120,7 +120,7 @@ public class DocprocBuilderTest extends DomBuilderTest {
     @Test
     public void testContainerMbusConfig() {
         assertThat(containerMbusConfig.enabled(), is(true));
-        assertTrue(containerMbusConfig.port() >= HostResource.BASE_PORT);
+        assertTrue(containerMbusConfig.port() >= HostPorts.BASE_PORT);
         assertThat(containerMbusConfig.maxpendingcount(), is(300));
         assertThat(containerMbusConfig.maxpendingsize(), is(100));
     }


### PR DESCRIPTION
* refactor port allocation into its own class
* add and use PortFinder to reuse saved allocations
* remove superfluous PortReservation class
* this should (hopefully) not change the actual port allocations,
  even when saved allocations are not present.

@bratseth please review
@hmusum @gjoranv FYI