### PR TITLE
Limit fields that can be mutated by a LoadBalancerService

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -18,6 +18,7 @@ import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.hosted.provision.flag.Flags;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerList;
+import com.yahoo.vespa.hosted.provision.lb.LoadBalancerInstance;
 import com.yahoo.vespa.hosted.provision.maintenance.PeriodicApplicationMaintainer;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.NodeAcl;
@@ -199,7 +200,8 @@ public class NodeRepository extends AbstractComponent {
         node.allocation().ifPresent(allocation -> {
             trustedNodes.addAll(candidates.owner(allocation.owner()).asList());
             loadBalancers.owner(allocation.owner()).asList().stream()
-                         .map(LoadBalancer::networks)
+                         .map(LoadBalancer::instance)
+                         .map(LoadBalancerInstance::networks)
                          .forEach(trustedNetworks::addAll);
         });
         trustedPorts.add(22);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
@@ -2,13 +2,10 @@
 package com.yahoo.vespa.hosted.provision.lb;
 
 import com.google.common.collect.ImmutableSortedSet;
-import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.RotationName;
 import com.yahoo.vespa.hosted.provision.maintenance.LoadBalancerExpirer;
 
-import java.util.Collections;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -19,26 +16,13 @@ import java.util.Set;
 public class LoadBalancer {
 
     private final LoadBalancerId id;
-    private final HostName hostname;
-    private final Optional<DnsZone> dnsZone;
-    private final Set<Integer> ports;
-    private final Set<String> networks;
-    private final Set<Real> reals;
+    private final LoadBalancerInstance instance;
     private final Set<RotationName> rotations;
     private final boolean inactive;
 
-    public LoadBalancer(LoadBalancerId id, HostName hostname, Optional<DnsZone> dnsZone, Set<Integer> ports, Set<String> networks, Set<Real> reals, boolean inactive) {
-        this(id, hostname, dnsZone, ports, networks, reals, Collections.emptySet(), inactive);
-    }
-
-    public LoadBalancer(LoadBalancerId id, HostName hostname, Optional<DnsZone> dnsZone, Set<Integer> ports,
-                        Set<String> networks, Set<Real> reals, Set<RotationName> rotations, boolean inactive) {
+    public LoadBalancer(LoadBalancerId id, LoadBalancerInstance instance, Set<RotationName> rotations, boolean inactive) {
         this.id = Objects.requireNonNull(id, "id must be non-null");
-        this.hostname = Objects.requireNonNull(hostname, "hostname must be non-null");
-        this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
-        this.ports = ImmutableSortedSet.copyOf(requirePorts(ports));
-        this.networks = ImmutableSortedSet.copyOf(Objects.requireNonNull(networks, "networks must be non-null"));
-        this.reals = ImmutableSortedSet.copyOf(Objects.requireNonNull(reals, "targets must be non-null"));
+        this.instance = Objects.requireNonNull(instance, "instance must be non-null");
         this.rotations = ImmutableSortedSet.copyOf(Objects.requireNonNull(rotations, "rotations must be non-null"));
         this.inactive = inactive;
     }
@@ -48,39 +32,19 @@ public class LoadBalancer {
         return id;
     }
 
-    /** Fully-qualified domain name of this load balancer. This hostname can be used for query and feed */
-    public HostName hostname() {
-        return hostname;
-    }
-
-    /** ID of the DNS zone associated with this */
-    public Optional<DnsZone> dnsZone() {
-        return dnsZone;
-    }
-
-    /** Listening port(s) of this load balancer */
-    public Set<Integer> ports() {
-        return ports;
-    }
-
-    /** Networks (CIDR blocks) of this load balancer */
-    public Set<String> networks() {
-        return networks;
-    }
-
-    /** Real servers behind this load balancer */
-    public Set<Real> reals() {
-        return reals;
-    }
-
     /** The rotations of which this is a member */
     public Set<RotationName> rotations() {
         return rotations;
     }
 
+    /** The instance associated with this */
+    public LoadBalancerInstance instance() {
+        return instance;
+    }
+
     /**
-     * Returns whether this load balancer is inactive. Inactive load balancers cannot be re-activated, and are
-     * eventually removed by {@link LoadBalancerExpirer}.
+     * Returns whether this load balancer is inactive. Inactive load balancers are eventually removed by
+     * {@link LoadBalancerExpirer}. Inactive load balancers may be reactivated if a deleted cluster is redeployed.
      */
     public boolean inactive() {
         return inactive;
@@ -88,23 +52,7 @@ public class LoadBalancer {
 
     /** Return a copy of this that is set inactive */
     public LoadBalancer deactivate() {
-        return new LoadBalancer(id, hostname, dnsZone, ports, networks, reals, true);
-    }
-
-    /** Returns a copy of this with rotation membership set to given rotations */
-    public LoadBalancer with(Set<RotationName> rotations) {
-        return new LoadBalancer(id, hostname, dnsZone, ports, networks, reals, rotations, inactive);
-    }
-
-    private static Set<Integer> requirePorts(Set<Integer> ports) {
-        Objects.requireNonNull(ports, "ports must be non-null");
-        if (ports.isEmpty()) {
-            throw new IllegalArgumentException("ports must be non-empty");
-        }
-        if (!ports.stream().allMatch(port -> port >= 1 && port <= 65535)) {
-            throw new IllegalArgumentException("all ports must be >= 1 and <= 65535");
-        }
-        return ports;
+        return new LoadBalancer(id, instance, rotations, true);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
@@ -1,0 +1,70 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.lb;
+
+import com.google.common.collect.ImmutableSortedSet;
+import com.yahoo.config.provision.HostName;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Represents a load balancer instance. This contains the fields that are owned by a {@link LoadBalancerService} and is
+ * immutable.
+ *
+ * @author mpolden
+ */
+public class LoadBalancerInstance {
+
+    private final HostName hostname;
+    private final Optional<DnsZone> dnsZone;
+    private final Set<Integer> ports;
+    private final Set<String> networks;
+    private final Set<Real> reals;
+
+    public LoadBalancerInstance(HostName hostname, Optional<DnsZone> dnsZone, Set<Integer> ports, Set<String> networks,
+                                Set<Real> reals) {
+        this.hostname = Objects.requireNonNull(hostname, "hostname must be non-null");
+        this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
+        this.ports = ImmutableSortedSet.copyOf(requirePorts(ports));
+        this.networks = ImmutableSortedSet.copyOf(Objects.requireNonNull(networks, "networks must be non-null"));
+        this.reals = ImmutableSortedSet.copyOf(Objects.requireNonNull(reals, "targets must be non-null"));
+    }
+
+    /** Fully-qualified domain name of this load balancer. This hostname can be used for query and feed */
+    public HostName hostname() {
+        return hostname;
+    }
+
+    /** ID of the DNS zone associated with this */
+    public Optional<DnsZone> dnsZone() {
+        return dnsZone;
+    }
+
+    /** Listening port(s) of this load balancer */
+    public Set<Integer> ports() {
+        return ports;
+    }
+
+    /** Networks (CIDR blocks) of this load balancer */
+    public Set<String> networks() {
+        return networks;
+    }
+
+    /** Real servers behind this load balancer */
+    public Set<Real> reals() {
+        return reals;
+    }
+
+    private static Set<Integer> requirePorts(Set<Integer> ports) {
+        Objects.requireNonNull(ports, "ports must be non-null");
+        if (ports.isEmpty()) {
+            throw new IllegalArgumentException("ports must be non-empty");
+        }
+        if (!ports.stream().allMatch(port -> port >= 1 && port <= 65535)) {
+            throw new IllegalArgumentException("all ports must be >= 1 and <= 65535");
+        }
+        return ports;
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerList.java
@@ -1,18 +1,16 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.lb;
 
-import com.google.common.collect.ImmutableList;
 import com.yahoo.config.provision.ApplicationId;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.collectingAndThen;
+import java.util.stream.Stream;
 
 /**
- * A filterable load balancer list
+ * A filterable load balancer list.
  *
  * @author mpolden
  */
@@ -21,25 +19,25 @@ public class LoadBalancerList {
     private final List<LoadBalancer> loadBalancers;
 
     public LoadBalancerList(Collection<LoadBalancer> loadBalancers) {
-        this.loadBalancers = ImmutableList.copyOf(Objects.requireNonNull(loadBalancers, "loadBalancers must be non-null"));
+        this.loadBalancers = List.copyOf(Objects.requireNonNull(loadBalancers, "loadBalancers must be non-null"));
     }
 
     /** Returns the subset of load balancers owned by given application */
     public LoadBalancerList owner(ApplicationId application) {
-        return loadBalancers.stream()
-                            .filter(lb -> lb.id().application().equals(application))
-                            .collect(collectingAndThen(Collectors.toList(), LoadBalancerList::new));
+        return of(loadBalancers.stream().filter(lb -> lb.id().application().equals(application)));
     }
 
     /** Returns the subset of load balancers that are inactive */
     public LoadBalancerList inactive() {
-        return loadBalancers.stream()
-                            .filter(LoadBalancer::inactive)
-                            .collect(collectingAndThen(Collectors.toList(), LoadBalancerList::new));
+        return of(loadBalancers.stream().filter(LoadBalancer::inactive));
     }
 
     public List<LoadBalancer> asList() {
         return loadBalancers;
+    }
+
+    private static LoadBalancerList of(Stream<LoadBalancer> stream) {
+        return new LoadBalancerList(stream.collect(Collectors.toUnmodifiableList()));
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerService.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerService.java
@@ -4,8 +4,6 @@ package com.yahoo.vespa.hosted.provision.lb;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -16,16 +14,7 @@ import java.util.Set;
 public interface LoadBalancerService {
 
     /** Create a load balancer for given application cluster. Implementations are expected to be idempotent */
-    // TODO: Remove once removed from all implementations
-    default LoadBalancer create(ApplicationId application, ClusterSpec.Id cluster, List<Real> reals) {
-        return create(application, cluster, new HashSet<>(reals));
-    }
-
-    /** Create a load balancer for given application cluster. Implementations are expected to be idempotent */
-    // TODO: Remove default implementation once implemented everywhere
-    default LoadBalancer create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals) {
-        throw new UnsupportedOperationException();
-    }
+    LoadBalancer create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals);
 
     /** Permanently remove load balancer with given ID */
     void remove(LoadBalancerId loadBalancer);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerService.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerService.java
@@ -14,10 +14,10 @@ import java.util.Set;
 public interface LoadBalancerService {
 
     /** Create a load balancer for given application cluster. Implementations are expected to be idempotent */
-    LoadBalancer create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals);
+    LoadBalancerInstance create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals);
 
-    /** Permanently remove load balancer with given ID */
-    void remove(LoadBalancerId loadBalancer);
+    /** Permanently remove load balancer for given application cluster */
+    void remove(ApplicationId application, ClusterSpec.Id cluster);
 
     /** Returns the protocol supported by this load balancer service */
     Protocol protocol();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
@@ -17,10 +17,10 @@ import java.util.Set;
  */
 public class LoadBalancerServiceMock implements LoadBalancerService {
 
-    private final Map<LoadBalancerId, LoadBalancer> loadBalancers = new HashMap<>();
+    private final Map<LoadBalancerId, LoadBalancerInstance> instances = new HashMap<>();
 
-    public Map<LoadBalancerId, LoadBalancer> loadBalancers() {
-        return Collections.unmodifiableMap(loadBalancers);
+    public Map<LoadBalancerId, LoadBalancerInstance> instances() {
+        return Collections.unmodifiableMap(instances);
     }
 
     @Override
@@ -37,14 +37,13 @@ public class LoadBalancerServiceMock implements LoadBalancerService {
                 Collections.singleton(4443),
                 ImmutableSet.of("10.2.3.0/24", "10.4.5.0/24"),
                 reals);
-        LoadBalancer loadBalancer = new LoadBalancer(id, instance, Set.of(), false);
-        loadBalancers.put(loadBalancer.id(), loadBalancer);
+        instances.put(id, instance);
         return instance;
     }
 
     @Override
     public void remove(ApplicationId application, ClusterSpec.Id cluster) {
-        loadBalancers.remove(new LoadBalancerId(application, cluster));
+        instances.remove(new LoadBalancerId(application, cluster));
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
@@ -29,22 +29,22 @@ public class LoadBalancerServiceMock implements LoadBalancerService {
     }
 
     @Override
-    public LoadBalancer create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals) {
-        LoadBalancer loadBalancer = new LoadBalancer(
-                new LoadBalancerId(application, cluster),
+    public LoadBalancerInstance create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals) {
+        LoadBalancerId id = new LoadBalancerId(application, cluster);
+        LoadBalancerInstance instance = new LoadBalancerInstance(
                 HostName.from("lb-" + application.toShortString() + "-" + cluster.value()),
                 Optional.of(new DnsZone("zone-id-1")),
                 Collections.singleton(4443),
                 ImmutableSet.of("10.2.3.0/24", "10.4.5.0/24"),
-                reals,
-                false);
+                reals);
+        LoadBalancer loadBalancer = new LoadBalancer(id, instance, Set.of(), false);
         loadBalancers.put(loadBalancer.id(), loadBalancer);
-        return loadBalancer;
+        return instance;
     }
 
     @Override
-    public void remove(LoadBalancerId loadBalancer) {
-        loadBalancers.remove(loadBalancer);
+    public void remove(ApplicationId application, ClusterSpec.Id cluster) {
+        loadBalancers.remove(new LoadBalancerId(application, cluster));
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * Periodically remove inactive load balancers permanently.
  *
  * When an application is removed, any associated load balancers are only deactivated. This maintainer ensures that
- * such resources are eventually freed.
+ * underlying load balancer instances are eventually freed.
  *
  * @author mpolden
  */
@@ -50,7 +50,7 @@ public class LoadBalancerExpirer extends Maintainer {
                     continue;
                 }
                 try {
-                    service.remove(loadBalancer.id());
+                    service.remove(loadBalancer.id().application(), loadBalancer.id().cluster());
                     db.removeLoadBalancer(loadBalancer.id());
                 } catch (Exception e) {
                     failed.add(loadBalancer.id());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -11,6 +11,7 @@ import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerId;
+import com.yahoo.vespa.hosted.provision.lb.LoadBalancerInstance;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerService;
 import com.yahoo.vespa.hosted.provision.lb.Real;
 import com.yahoo.vespa.hosted.provision.node.IP;
@@ -51,8 +52,11 @@ public class LoadBalancerProvisioner {
             try (Mutex loadBalancersLock = db.lockLoadBalancers()) {
                 Map<LoadBalancerId, LoadBalancer> loadBalancers = new LinkedHashMap<>();
                 for (Map.Entry<ClusterSpec, List<Node>> kv : activeContainers(application).entrySet()) {
-                    LoadBalancer loadBalancer = create(application, kv.getKey().id(), kv.getValue())
-                            .with(kv.getKey().rotations());
+                    LoadBalancerId id = new LoadBalancerId(application, kv.getKey().id());
+                    LoadBalancerInstance instance = create(application, kv.getKey().id(), kv.getValue());
+                    // Load balancer is always re-activated here to avoid reallocation if an application/cluster is
+                    // deleted and then redeployed.
+                    LoadBalancer loadBalancer = new LoadBalancer(id, instance, kv.getKey().rotations(), false);
                     loadBalancers.put(loadBalancer.id(), loadBalancer);
                     db.writeLoadBalancer(loadBalancer);
                 }
@@ -76,7 +80,7 @@ public class LoadBalancerProvisioner {
         }
     }
 
-    private LoadBalancer create(ApplicationId application, ClusterSpec.Id cluster, List<Node> nodes) {
+    private LoadBalancerInstance create(ApplicationId application, ClusterSpec.Id cluster, List<Node> nodes) {
         Map<HostName, Set<String>> hostnameToIpAdresses = nodes.stream()
                                                                .collect(Collectors.toMap(node -> HostName.from(node.hostname()),
                                                                                          this::reachableIpAddresses));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -16,7 +16,6 @@ import com.yahoo.vespa.hosted.provision.lb.Real;
 import com.yahoo.vespa.hosted.provision.node.IP;
 import com.yahoo.vespa.hosted.provision.persistence.CuratorDatabaseClient;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -81,7 +80,7 @@ public class LoadBalancerProvisioner {
         Map<HostName, Set<String>> hostnameToIpAdresses = nodes.stream()
                                                                .collect(Collectors.toMap(node -> HostName.from(node.hostname()),
                                                                                          this::reachableIpAddresses));
-        List<Real> reals = new ArrayList<>();
+        Set<Real> reals = new LinkedHashSet<>();
         hostnameToIpAdresses.forEach((hostname, ipAddresses) -> {
             ipAddresses.forEach(ipAddress -> reals.add(new Real(hostname, ipAddress)));
         });

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -95,6 +95,7 @@ public class LoadBalancerProvisioner {
     private Map<ClusterSpec, List<Node>> activeContainers(ApplicationId application) {
         return new NodeList(nodeRepository.getNodes(Node.State.active))
                 .owner(application)
+                .filter(node -> node.state().isAllocated())
                 .type(ClusterSpec.Type.container)
                 .asList()
                 .stream()

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/LoadBalancersResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/LoadBalancersResponse.java
@@ -59,17 +59,17 @@ public class LoadBalancersResponse extends HttpResponse {
             lbObject.setString("tenant", lb.id().application().tenant().value());
             lbObject.setString("instance", lb.id().application().instance().value());
             lbObject.setString("cluster", lb.id().cluster().value());
-            lbObject.setString("hostname", lb.hostname().value());
-            lb.dnsZone().ifPresent(dnsZone -> lbObject.setString("dnsZone", dnsZone.id()));
+            lbObject.setString("hostname", lb.instance().hostname().value());
+            lb.instance().dnsZone().ifPresent(dnsZone -> lbObject.setString("dnsZone", dnsZone.id()));
 
             Cursor networkArray = lbObject.setArray("networks");
-            lb.networks().forEach(networkArray::addString);
+            lb.instance().networks().forEach(networkArray::addString);
 
             Cursor portArray = lbObject.setArray("ports");
-            lb.ports().forEach(portArray::addLong);
+            lb.instance().ports().forEach(portArray::addLong);
 
             Cursor realArray = lbObject.setArray("reals");
-            lb.reals().forEach(real -> {
+            lb.instance().reals().forEach(real -> {
                 Cursor realObject = realArray.addObject();
                 realObject.setString("hostname", real.hostname().value());
                 realObject.setString("ipAddress", real.ipAddress());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirerTest.java
@@ -56,16 +56,16 @@ public class LoadBalancerExpirerTest {
 
         // Expirer defers removal while nodes are still allocated to application
         expirer.maintain();
-        assertEquals(2, tester.loadBalancerService().loadBalancers().size());
+        assertEquals(2, tester.loadBalancerService().instances().size());
 
         // Expirer removes load balancers once nodes are deallocated
         dirtyNodesOf(app1);
         expirer.maintain();
-        assertFalse("Inactive load balancer removed", tester.loadBalancerService().loadBalancers().containsKey(lb1));
+        assertFalse("Inactive load balancer removed", tester.loadBalancerService().instances().containsKey(lb1));
 
         // Active load balancer is left alone
         assertFalse(loadBalancers.get().get(lb2).inactive());
-        assertTrue("Active load balancer is not removed", tester.loadBalancerService().loadBalancers().containsKey(lb2));
+        assertTrue("Active load balancer is not removed", tester.loadBalancerService().instances().containsKey(lb2));
     }
 
     private void dirtyNodesOf(ApplicationId application) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.RotationName;
 import com.yahoo.vespa.hosted.provision.lb.DnsZone;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerId;
+import com.yahoo.vespa.hosted.provision.lb.LoadBalancerInstance;
 import com.yahoo.vespa.hosted.provision.lb.Real;
 import org.junit.Test;
 
@@ -27,29 +28,30 @@ public class LoadBalancerSerializerTest {
                                                                                            "application1",
                                                                                            "default"),
                                                                         ClusterSpec.Id.from("qrs")),
-                                                     HostName.from("lb-host"),
-                                                     Optional.of(new DnsZone("zone-id-1")),
-                                                     ImmutableSet.of(4080, 4443),
-                                                     ImmutableSet.of("10.2.3.4/24"),
-                                                     ImmutableSet.of(new Real(HostName.from("real-1"),
-                                                                              "127.0.0.1",
-                                                                              4080),
-                                                                     new Real(HostName.from("real-2"),
-                                                                              "127.0.0.2",
-                                                                              4080)),
+                                                     new LoadBalancerInstance(
+                                                             HostName.from("lb-host"),
+                                                             Optional.of(new DnsZone("zone-id-1")),
+                                                             ImmutableSet.of(4080, 4443),
+                                                             ImmutableSet.of("10.2.3.4/24"),
+                                                             ImmutableSet.of(new Real(HostName.from("real-1"),
+                                                                                      "127.0.0.1",
+                                                                                      4080),
+                                                                             new Real(HostName.from("real-2"),
+                                                                                      "127.0.0.2",
+                                                                                      4080))),
                                                      ImmutableSet.of(RotationName.from("eu-cluster"),
                                                                      RotationName.from("us-cluster")),
                                                      false);
 
         LoadBalancer serialized = LoadBalancerSerializer.fromJson(LoadBalancerSerializer.toJson(loadBalancer));
         assertEquals(loadBalancer.id(), serialized.id());
-        assertEquals(loadBalancer.hostname(), serialized.hostname());
-        assertEquals(loadBalancer.dnsZone(), serialized.dnsZone());
-        assertEquals(loadBalancer.ports(), serialized.ports());
-        assertEquals(loadBalancer.networks(), serialized.networks());
+        assertEquals(loadBalancer.instance().hostname(), serialized.instance().hostname());
+        assertEquals(loadBalancer.instance().dnsZone(), serialized.instance().dnsZone());
+        assertEquals(loadBalancer.instance().ports(), serialized.instance().ports());
+        assertEquals(loadBalancer.instance().networks(), serialized.instance().networks());
         assertEquals(loadBalancer.rotations(), serialized.rotations());
         assertEquals(loadBalancer.inactive(), serialized.inactive());
-        assertEquals(loadBalancer.reals(), serialized.reals());
+        assertEquals(loadBalancer.instance().reals(), serialized.instance().reals());
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -115,6 +116,17 @@ public class LoadBalancerProvisionerTest {
 
         assertEquals(2, loadBalancers.get().size());
         assertTrue("Deactivated load balancers", loadBalancers.get().stream().allMatch(LoadBalancer::inactive));
+
+        // Application is redeployed with one cluster and load balancer is re-activated
+        tester.activate(app1, prepare(app1,
+                                      clusterRequest(ClusterSpec.Type.container, containerCluster1),
+                                      clusterRequest(ClusterSpec.Type.content, contentCluster)));
+        assertFalse("Re-activated load balancer for " + containerCluster1,
+                    loadBalancers.get().stream()
+                                 .filter(lb -> lb.id().cluster().equals(containerCluster1))
+                                 .findFirst()
+                                 .orElseThrow()
+                                 .inactive());
     }
 
     private ClusterSpec clusterRequest(ClusterSpec.Type type, ClusterSpec.Id id) {


### PR DESCRIPTION
Prevents accidental mutation of fields that are not owned by the load balancer service,
such as rotations and inactive status.

Changes the API used by internal code so I'll coordinate the merging myself.