### PR TITLE
Stop reload task when there are no external references to the managers

### DIFF
--- a/security-utils/src/test/java/com/yahoo/security/tls/ReloadingTlsContextTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/tls/ReloadingTlsContextTest.java
@@ -1,0 +1,70 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.security.tls;
+
+import com.yahoo.security.KeyUtils;
+import com.yahoo.security.X509CertificateBuilder;
+import com.yahoo.security.X509CertificateUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.net.ssl.SSLEngine;
+import javax.security.auth.x500.X500Principal;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+
+import static com.yahoo.security.KeyAlgorithm.EC;
+import static com.yahoo.security.SignatureAlgorithm.SHA256_WITH_ECDSA;
+import static java.time.Instant.EPOCH;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author bjorncs
+ */
+public class ReloadingTlsContextTest {
+
+    @Rule
+    public TemporaryFolder tempDirectory = new TemporaryFolder();
+
+    @Test
+    public void can_create_sslcontext_from_credentials() throws IOException, InterruptedException {
+        KeyPair keyPair = KeyUtils.generateKeypair(EC);
+        Path privateKeyFile = tempDirectory.newFile().toPath();
+        Files.writeString(privateKeyFile, KeyUtils.toPem(keyPair.getPrivate()));
+
+        X509Certificate certificate = X509CertificateBuilder
+                .fromKeypair(keyPair, new X500Principal("CN=dummy"), EPOCH, EPOCH.plus(1, DAYS), SHA256_WITH_ECDSA, BigInteger.ONE)
+                .build();
+        Path certificateChainFile = tempDirectory.newFile().toPath();
+        String certificatePem = X509CertificateUtils.toPem(certificate);
+        Files.writeString(certificateChainFile, certificatePem);
+
+        Path caCertificatesFile = tempDirectory.newFile().toPath();
+        Files.writeString(caCertificatesFile, certificatePem);
+
+        TransportSecurityOptions options = new TransportSecurityOptions.Builder()
+                .withCertificates(certificateChainFile, privateKeyFile)
+                .withCaCertificates(caCertificatesFile)
+                .build();
+
+        Path optionsFile = tempDirectory.newFile().toPath();
+        options.toJsonFile(optionsFile);
+
+        try (TlsContext tlsContext = new ReloadingTlsContext(optionsFile, AuthorizationMode.ENFORCE)) {
+            SSLEngine sslEngine = tlsContext.createSslEngine();
+            assertThat(sslEngine).isNotNull();
+            String[] enabledCiphers = sslEngine.getEnabledCipherSuites();
+            assertThat(enabledCiphers).isNotEmpty();
+            assertThat(enabledCiphers).isSubsetOf(DefaultTlsContext.ALLOWED_CIPHER_SUITES.toArray(new String[0]));
+
+            String[] enabledProtocols = sslEngine.getEnabledProtocols();
+            assertThat(enabledProtocols).contains("TLSv1.2");
+        }
+    }
+
+}


### PR DESCRIPTION
The reload task will shut down the executor service when the GC has
determined that there are no other references to the key/trust manager.