### PR TITLE
Gjoranv/use container service type

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/container/ContainerServiceType.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/container/ContainerServiceType.java
@@ -12,10 +12,10 @@ public enum ContainerServiceType {
     LOGSERVER_CONTAINER("logserver-container"),
     METRICS_PROXY_CONTAINER("metrics-proxy-container");
 
-    public final String name;
+    public final String serviceName;
 
-    ContainerServiceType(String name) {
-        this.name = name;
+    ContainerServiceType(String serviceName) {
+        this.serviceName = serviceName;
     }
 
 }

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/container/ContainerServiceType.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/container/ContainerServiceType.java
@@ -1,5 +1,5 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.model.container;
+package com.yahoo.config.model.api.container;
 
 /**
  * @author gjoranv

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/container/package-info.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/container/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.config.model.api.container;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/config-model-api/src/test/java/com/yahoo/config/model/api/container/ContainerServiceTypeTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/model/api/container/ContainerServiceTypeTest.java
@@ -1,0 +1,31 @@
+package com.yahoo.config.model.api.container;
+
+import org.junit.Test;
+
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author gjoranv
+ */
+public class ContainerServiceTypeTest {
+
+    @Test
+    public void new_values_are_not_added_without_updating_tests() {
+        assertEquals(5, ContainerServiceType.values().length);
+    }
+
+    @Test
+    public void service_names_do_not_change() {
+        assertEquals("container", CONTAINER.serviceName);
+        assertEquals("qrserver", QRSERVER.serviceName);
+        assertEquals("container-clustercontroller", CLUSTERCONTROLLER_CONTAINER.serviceName);
+        assertEquals("logserver-container", LOGSERVER_CONTAINER.serviceName);
+        assertEquals("metrics-proxy-container", METRICS_PROXY_CONTAINER.serviceName);
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.admin;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
-import com.yahoo.vespa.model.container.ContainerServiceType;
+import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.vespa.model.container.component.Handler;
 
 /**

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -13,7 +13,7 @@ import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
 import com.yahoo.vespa.model.container.Container;
-import com.yahoo.vespa.model.container.ContainerServiceType;
+import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -2,8 +2,8 @@
 package com.yahoo.vespa.model.container;
 
 import com.yahoo.component.ComponentId;
-import com.yahoo.component.ComponentSpecification;
 import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.ComponentsConfig;
 import com.yahoo.container.QrConfig;
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -198,7 +198,7 @@ public abstract class Container extends AbstractService implements
         if (myServiceType == null) {
             myServiceType = myServiceType();
         }
-        return myServiceType.name;
+        return myServiceType.serviceName;
     }
 
     /** Subclasses must implement this for a custom service name. */

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerImpl.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerImpl.java
@@ -1,5 +1,6 @@
 package com.yahoo.vespa.model.container;
 
+import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 
 /**

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
@@ -18,6 +18,7 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
 import static com.yahoo.test.Matchers.hasItemWithMethod;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -99,7 +100,7 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
     public void cluster_with_only_search_gets_qrserver_as_service_name() throws Exception {
         createClusterWithOnlyDefaultChains();
         ContainerCluster cluster = (ContainerCluster)root.getChildren().get("default");
-        assertThat(cluster.getContainers().get(0).getServiceName(), is("qrserver"));
+        assertThat(cluster.getContainers().get(0).getServiceName(), is(QRSERVER.serviceName));
     }
 
     @Test

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -12,6 +12,7 @@ import com.yahoo.config.application.api.ApplicationMetaData;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.ServiceInfo;
+import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.HostFilter;
@@ -74,6 +75,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static java.nio.file.Files.readAttributes;
 
 /**
@@ -335,7 +337,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         // TODO: It would be nice to have a simple check to verify pathSuffix doesn't contain /../ components.
         String relativePath = "clustercontroller-status/" + pathSuffix;
 
-        return httpProxy.get(getApplication(applicationId), hostName, "container-clustercontroller", relativePath);
+        return httpProxy.get(getApplication(applicationId), hostName,
+                             CLUSTERCONTROLLER_CONTAINER.serviceName, relativePath);
     }
 
     public Long getApplicationGeneration(ApplicationId applicationId) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
@@ -31,6 +31,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
+
 /**
  * Checks for convergence of config generation for a given application.
  *
@@ -44,8 +47,8 @@ public class ConfigConvergenceChecker extends AbstractComponent {
     private static final String statePath = "/state/v1/";
     private static final String configSubPath = "config";
     private final static Set<String> serviceTypesToCheck = new HashSet<>(Arrays.asList(
-            "container",
-            "qrserver",
+            CONTAINER.serviceName,
+            QRSERVER.serviceName,
             "searchnode",
             "storagenode",
             "distributor"

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/model/LbServicesProducer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/model/LbServicesProducer.java
@@ -19,6 +19,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
+
 /**
  * Produces lb-services cfg
  *
@@ -68,8 +71,8 @@ public class LbServicesProducer implements LbServicesConfig.Producer {
         boolean activeRotation = false;
         for (HostInfo hostInfo : app.getModel().getHosts()) {
             Optional<ServiceInfo> container = hostInfo.getServices().stream().filter(
-                    serviceInfo -> serviceInfo.getServiceType().equals("container") ||
-                                   serviceInfo.getServiceType().equals("qrserver")).
+                    serviceInfo -> serviceInfo.getServiceType().equals(CONTAINER.serviceName) ||
+                                   serviceInfo.getServiceType().equals(QRSERVER.serviceName)).
                     findAny();
             if (container.isPresent()) {
                 activeRotation |= Boolean.valueOf(container.get().getProperty("activeRotation").orElse("false"));

--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/ServiceModel.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/ServiceModel.java
@@ -21,14 +21,14 @@ import com.yahoo.vespa.serviceview.bindings.ServiceView;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
+
 /**
  * A transposed view for cloud.config.model.
  *
  * @author Steinar Knutsen
  */
 public final class ServiceModel {
-
-    private static final String CLUSTERCONTROLLER_TYPENAME = "container-clustercontroller";
 
     private static final String CONTENT_CLUSTER_TYPENAME = "content";
 
@@ -169,7 +169,7 @@ public final class ServiceModel {
 
     private Service getFirstClusterController() {
         // This is used assuming all cluster controllers know of all fleet controllers in an application
-        return getFirstServiceInstanceByType(CLUSTERCONTROLLER_TYPENAME);
+        return getFirstServiceInstanceByType(CLUSTERCONTROLLER_CONTAINER.serviceName);
     }
 
     private StringBuilder getLinkBuilder(String uriBase) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/SuperModelControllerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/SuperModelControllerTest.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -146,7 +147,7 @@ public class SuperModelControllerTest {
         assertThat(hosts.hostname(), is(host));
         for (Map.Entry<String, Applications.Hosts.Services> e : app.hosts(host).services().entrySet()) {
             System.out.println(e.getKey());
-            if ("qrserver".equals(e.getKey())) {
+            if (QRSERVER.serviceName.equals(e.getKey())) {
                 Applications.Hosts.Services s = e.getValue();
                 System.out.println(s);
                 assertThat(s.type(), is("qrserver"));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/HttpProxyTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/HttpProxyTest.java
@@ -12,6 +12,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.URL;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -39,8 +40,8 @@ public class HttpProxyTest {
         HttpResponse response = new StaticResponse(200, "application/json", "body");
         when(fetcher.get(actualParams.capture(), actualUrl.capture())).thenReturn(response);
 
-        HttpResponse actualResponse = proxy.get(
-                applicationMock, hostname, "container-clustercontroller", "clustercontroller-status/v1/clusterName");
+        HttpResponse actualResponse = proxy.get(applicationMock, hostname, CLUSTERCONTROLLER_CONTAINER.serviceName,
+                                                "clustercontroller-status/v1/clusterName");
 
         assertEquals(1, actualParams.getAllValues().size());
         assertEquals(2000, actualParams.getValue().readTimeoutMs);
@@ -58,7 +59,7 @@ public class HttpProxyTest {
     public void testFetchException() {
         when(fetcher.get(any(), any())).thenThrow(new RequestTimeoutException("timed out"));
 
-        HttpResponse actualResponse = proxy.get(
-                applicationMock, hostname, "container-clustercontroller", "clustercontroller-status/v1/clusterName");
+        HttpResponse actualResponse = proxy.get(applicationMock, hostname, CLUSTERCONTROLLER_CONTAINER.serviceName,
+                                                "clustercontroller-status/v1/clusterName");
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/MockModel.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/MockModel.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
+
 /**
  * Model with two services, one that does not have a state port
  *
@@ -47,7 +49,7 @@ public class MockModel implements Model {
         ServiceInfo container = createServiceInfo(
                 hostname,
                 "foo", // name
-                "container-clustercontroller", // type
+                CLUSTERCONTROLLER_CONTAINER.serviceName,
                 ClusterSpec.Type.container,
                 statePort,
                 "state http external query");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -40,6 +40,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -167,7 +168,7 @@ public class ApplicationHandlerTest {
                                                                                 new ConfigserverConfig(new ConfigserverConfig.Builder()),
                                                                                 new OrchestratorMock());
         ApplicationHandler mockHandler = createApplicationHandler(applicationRepository);
-        when(mockHttpProxy.get(any(), eq(host), eq("container-clustercontroller"), eq("clustercontroller-status/v1/clusterName1")))
+        when(mockHttpProxy.get(any(), eq(host), eq(CLUSTERCONTROLLER_CONTAINER.serviceName),eq("clustercontroller-status/v1/clusterName1")))
                 .thenReturn(new StaticResponse(200, "text/html", "<html>...</html>"));
 
         HttpResponse response = mockHandler.handle(HttpRequest.createTestRequest(url, com.yahoo.jdisc.http.HttpRequest.Method.GET));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/model/LbServicesProducerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/model/LbServicesProducerTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -62,7 +63,7 @@ public class LbServicesProducerTest {
     public void testConfigAliases() throws IOException, SAXException {
         Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder());
         LbServicesConfig conf = getLbServicesConfig(Zone.defaultZone(), testModel);
-        final LbServicesConfig.Tenants.Applications.Hosts.Services services = conf.tenants("foo").applications("foo:prod:default:default").hosts("foo.foo.yahoo.com").services("qrserver");
+        final LbServicesConfig.Tenants.Applications.Hosts.Services services = conf.tenants("foo").applications("foo:prod:default:default").hosts("foo.foo.yahoo.com").services(QRSERVER.serviceName);
         assertThat(services.servicealiases().size(), is(1));
         assertThat(services.endpointaliases().size(), is(2));
 
@@ -106,7 +107,7 @@ public class LbServicesProducerTest {
         Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder().rotations(rotations));
         RegionName regionName = RegionName.from("us-east-1");
         LbServicesConfig conf = getLbServicesConfig(new Zone(Environment.prod, regionName), testModel);
-        final LbServicesConfig.Tenants.Applications.Hosts.Services services = conf.tenants("foo").applications("foo:prod:" + regionName.value() + ":default").hosts("foo.foo.yahoo.com").services("qrserver");
+        final LbServicesConfig.Tenants.Applications.Hosts.Services services = conf.tenants("foo").applications("foo:prod:" + regionName.value() + ":default").hosts("foo.foo.yahoo.com").services(QRSERVER.serviceName);
         assertThat(services.servicealiases().size(), is(1));
         assertThat(services.endpointaliases().size(), is(4));
 

--- a/configserver/src/test/java/com/yahoo/vespa/serviceview/ServiceModelTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/serviceview/ServiceModelTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -54,7 +55,7 @@ public class ServiceModelTest {
             service1.clustername = "examplecluster";
             service1.clustertype = "somethingservers";
             service1.index = 2L;
-            service1.type = "container-clustercontroller";
+            service1.type = CLUSTERCONTROLLER_CONTAINER.serviceName;
             service1.name = "clustercontroller";
             service1.configid = "clustercontroller/lbl.0";
             ServicePort port = new ServicePort();


### PR DESCRIPTION
Moved to config-model-api to allow using it without depending on config-model. Perhaps there's a more logical home for it?

FYI: @bratseth 