### PR TITLE
Revert "Change default to 'tls_client_mixed_server'"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -72,7 +72,7 @@ public class Flags {
             HOSTNAME, APPLICATION_ID);
 
     public static final UnboundStringFlag TLS_INSECURE_MIXED_MODE = defineStringFlag(
-            "tls-insecure-mixed-mode", "tls_client_mixed_server",
+            "tls-insecure-mixed-mode", "plaintext_client_mixed_server",
             "TLS insecure mixed mode. Allowed values: ['plaintext_client_mixed_server', 'tls_client_mixed_server', 'tls_client_tls_server']",
             "Takes effect on restart of Docker container",
             NODE_TYPE, APPLICATION_ID, HOSTNAME);


### PR DESCRIPTION
Reverts vespa-engine/vespa#8661

Broke hosted