### PR TITLE
simplify dynamic container setup

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
@@ -130,7 +130,7 @@ public class HostPorts {
         String servType = service.getServiceType();
         String configId = service.getConfigId();
         int fallback = nextAvailableNetworkPort();
-        int port = portFinder.findPort(new NetworkPorts.Allocation(fallback, servType, configId, suffix));
+        int port = portFinder.findPort(new NetworkPorts.Allocation(fallback, servType, configId, suffix), hostname);
         reservePort(service, port, suffix);
         portFinder.use(new NetworkPorts.Allocation(port, servType, configId, suffix));
         return port;

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
@@ -67,11 +67,12 @@ public class HostPorts {
     /**
      * Returns the baseport of the first available port range of length numPorts,
      * or 0 if there is no range of that length available.
+     * TODO: remove this API
      *
      * @param numPorts  The length of the desired port range.
      * @return  The baseport of the first available range, or 0 if no range is available.
      */
-    public int nextAvailableBaseport(int numPorts) {
+    int nextAvailableBaseport(int numPorts) {
         int range = 0;
         int port = BASE_PORT;
         for (; port < BASE_PORT + MAX_PORTS && (range < numPorts); port++) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostPorts.java
@@ -76,7 +76,7 @@ public class HostPorts {
         int range = 0;
         int port = BASE_PORT;
         for (; port < BASE_PORT + MAX_PORTS && (range < numPorts); port++) {
-            if (portDB.containsKey(port)) {
+            if (!isFree(port)) {
                 range = 0;
                 continue;
             }
@@ -88,9 +88,13 @@ public class HostPorts {
     private int nextAvailableNetworkPort() {
         int port = BASE_PORT;
         for (; port < BASE_PORT + MAX_PORTS; port++) {
-            if (!portDB.containsKey(port)) return port;
+            if (isFree(port)) return port;
         }
         return 0;
+    }
+
+    private boolean isFree(int port) {
+        return portFinder.isFree(port) && !portDB.containsKey(port);
     }
 
     /** Allocate a specific port number for a service */

--- a/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
@@ -37,11 +37,13 @@ public class PortFinder {
         byKeys.put(key, allocation);
     }
 
-    public int findPort(Allocation request) {
+    public int findPort(Allocation request, String host) {
         String key = request.key();
         if (byKeys.containsKey(key)) {
             int port = byKeys.get(key).port;
-            log.log(Level.INFO, "Re-using port "+port+" for allocation "+request);
+            if (port != request.port) {
+                log.log(Level.INFO, "Re-using port "+port+" for allocation "+request+" on "+host);
+            }
             return port;
         }
         int port = request.port;

--- a/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/PortFinder.java
@@ -51,6 +51,10 @@ public class PortFinder {
         return port;
     }
 
+    public boolean isFree(int port) {
+        return !byPorts.containsKey(port);
+    }
+
     public PortFinder(Collection<Allocation> allocations) {
         for (Allocation a : allocations) {
             use(a);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -55,6 +55,7 @@ public abstract class Container extends AbstractService implements
     protected final AbstractConfigProducer parent;
     private final String name;
     private final boolean isHostedVespa;
+    private boolean requireSpecificPorts = true;
 
     private String clusterName = null;
     private Optional<String> hostResponseHeaderKey = Optional.empty();
@@ -210,7 +211,12 @@ public abstract class Container extends AbstractService implements
 
     @Override
     public int getWantedPort() {
-        return getHttp() == null ? BASEPORT: 0;
+        return requiresWantedPort() ? BASEPORT: 0;
+    }
+
+    /** instance can use any port number for its default HTTP server */
+    public void useDynamicPorts() {
+        requireSpecificPorts = false;
     }
 
     /**
@@ -218,7 +224,7 @@ public abstract class Container extends AbstractService implements
      */
     @Override
     public boolean requiresWantedPort() {
-        return getHttp() == null;
+        return requireSpecificPorts && (getHttp() == null);
     }
 
     public boolean requiresConsecutivePorts() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -327,7 +327,7 @@ public class Content extends ConfigModel {
                     Container docprocService = new ContainerImpl(indexingCluster, containerName, index,
                                                                  modelContext.getDeployState().isHosted());
                     index++;
-                    docprocService.setBasePort(host.ports().nextAvailableBaseport(docprocService.getPortCount()));
+                    docprocService.useDynamicPorts();
                     docprocService.setHostResource(host);
                     docprocService.initService(modelContext.getDeployLogger());
                     nodes.add(docprocService);


### PR DESCRIPTION
* instead of explicitly finding the next available dynamic port,
  and then forcing the dynamic container to use that one, just
  make that container instance relax its requirements.  This
  should end up allocating the same port as before in the normal
  case, but works better when reusing previous port allocations.

@bratseth please review
@gjoranv @hmusum FYI