### PR TITLE
JDK 11: Replace LogRecord.setMillis with setInstant.

### DIFF
--- a/controller-server/pom.xml
+++ b/controller-server/pom.xml
@@ -177,15 +177,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <arg>-Xlint:-serial</arg>
-                        <arg>-Xlint:-deprecation</arg>
-                        <arg>-Xlint:-try</arg>
-                        <arg>-Werror</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -260,6 +260,7 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
         return true;
     }
 
+    @SuppressWarnings("deprecation")
     private static CloseableHttpClient createHttpClient(RequestConfig config,
                                                         ServiceIdentityProvider sslContextProvider,
                                                         ZoneRegistry zoneRegistry,
@@ -277,6 +278,7 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
                 .build();
     }
 
+    @SuppressWarnings("deprecation")
     private static class AthenzIdentityVerifierAdapter implements X509HostnameVerifier {
 
         private final AthenzIdentityVerifier verifier;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -144,7 +144,7 @@ public final class ControllerTester {
         // Make root logger use time from manual clock
         configureDefaultLogHandler(handler -> handler.setFilter(
                 record -> {
-                    record.setMillis(clock.millis());
+                    record.setInstant(clock.instant());
                     return true;
                 }));
     }

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/core/OsgiLogHandlerTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/core/OsgiLogHandlerTestCase.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.log.LogService;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.ResourceBundle;
@@ -70,15 +71,13 @@ public class OsgiLogHandlerTestCase {
     }
 
     @Test
-    // TODO: Remove deprecation annotation and replace calls to LogRecord.setMillis() when we no longer have to support Java 8
-    @SuppressWarnings("deprecation")
     public void requireThatJdk14PropertiesAreAvailableThroughServiceReference() {
         MyLogService logService = new MyLogService();
 
         Logger log = newLogger(logService);
         LogRecord record = new LogRecord(Level.INFO, "message");
         record.setLoggerName("loggerName");
-        record.setMillis(69);
+        record.setInstant(Instant.ofEpochMilli(69));
         Object[] parameters = new Object[0];
         record.setParameters(parameters);
         ResourceBundle resouceBundle = new MyResourceBundle();

--- a/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.log;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.Level;
@@ -20,8 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
  *
  * @author Bjorn Borud
  */
-// TODO: Remove annotation and replace setMillis with setInstant when we don't support Java 8 anymore.
-@SuppressWarnings("deprecation")
 public class LogSetupTestCase {
     // For testing zookeeper log records
     protected static LogRecord zookeeperLogRecord;
@@ -44,11 +43,11 @@ public class LogSetupTestCase {
 
         zookeeperLogRecord = new LogRecord(Level.WARNING, "zookeeper log record");
         zookeeperLogRecord.setLoggerName("org.apache.zookeeper.server.NIOServerCnxn");
-        zookeeperLogRecord.setMillis(1107011348029L);
+        zookeeperLogRecord.setInstant(Instant.ofEpochMilli(1107011348029L));
 
         curatorLogRecord = new LogRecord(Level.WARNING, "curator log record");
         curatorLogRecord.setLoggerName("org.apache.curator.utils.DefaultTracerDriver");
-        curatorLogRecord.setMillis(1107011348029L);
+        curatorLogRecord.setInstant(Instant.ofEpochMilli(1107011348029L));
 
         hostname = Util.getHostName();
         pid = Util.getPID();
@@ -62,15 +61,15 @@ public class LogSetupTestCase {
 
         zookeeperLogRecordError = new LogRecord(Level.SEVERE, "zookeeper error");
         zookeeperLogRecordError.setLoggerName("org.apache.zookeeper.server.NIOServerCnxn");
-        zookeeperLogRecordError.setMillis(1107011348029L);
+        zookeeperLogRecordError.setInstant(Instant.ofEpochMilli(1107011348029L));
 
         curatorLogRecordError = new LogRecord(Level.SEVERE, "curator log record");
         curatorLogRecordError.setLoggerName("org.apache.curator.utils.DefaultTracerDriver");
-        curatorLogRecordError.setMillis(1107011348029L);
+        curatorLogRecordError.setInstant(Instant.ofEpochMilli(1107011348029L));
 
         notzookeeperLogRecord = new LogRecord(Level.WARNING, "not zookeeper log record");
         notzookeeperLogRecord.setLoggerName("org.apache.foo.Bar");
-        notzookeeperLogRecord.setMillis(1107011348029L);
+        notzookeeperLogRecord.setInstant(Instant.ofEpochMilli(1107011348029L));
     }
 
     @Test

--- a/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
@@ -1,21 +1,22 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.Ignore;
-
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author  Bjorn Borud
  */
-// TODO: Remove annotation and replace setMillis with setInstant when we don't support Java 8 anymore.
-@SuppressWarnings("deprecation")
 public class VespaFormatterTestCase {
 
     private String hostname;
@@ -36,7 +37,7 @@ public class VespaFormatterTestCase {
         pid = Util.getPID();
 
         testRecord1 = new LogRecord(Level.INFO, "this is a test");
-        testRecord1.setMillis(1098709021843L);
+        testRecord1.setInstant(Instant.ofEpochMilli(1098709021843L));
         testRecord1.setThreadID(123);
 
         expected1 = "1098709021.843\t"
@@ -59,7 +60,7 @@ public class VespaFormatterTestCase {
 
 
         testRecord2 = new LogRecord(Level.INFO, "this is a test");
-        testRecord2.setMillis(1098709021843L);
+        testRecord2.setInstant(Instant.ofEpochMilli(1098709021843L));
         testRecord2.setThreadID(123);
         testRecord2.setLoggerName("org.foo");
 
@@ -100,12 +101,12 @@ public class VespaFormatterTestCase {
     /**
      * test that {0} etc is replaced properly
      */
-        @Test
+    @Test
     public void testTextFormatting () {
         VespaFormatter formatter = new VespaFormatter(serviceName, app);
 
         LogRecord testRecord = new LogRecord(Level.INFO, "this {1} is {0} test");
-        testRecord.setMillis(1098709021843L);
+        testRecord.setInstant(Instant.ofEpochMilli(1098709021843L));
         testRecord.setThreadID(123);
         testRecord.setLoggerName("org.foo");
         Object[] params = { "a small", "message" };

--- a/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.*;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -14,14 +15,13 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import static java.time.Instant.ofEpochMilli;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 /**
  * @author  Bjorn Borud
  */
-// TODO: Remove annotation and replace setMillis with setInstant when we don't support Java 8 anymore.
-@SuppressWarnings("deprecation")
 public class VespaLogHandlerTestCase {
     protected static String hostname;
     protected static String pid;
@@ -43,7 +43,7 @@ public class VespaLogHandlerTestCase {
         pid = Util.getPID();
 
         record1 = new LogRecord(Level.INFO, "This is a test");
-        record1.setMillis(1100011348029L);
+        record1.setInstant(ofEpochMilli(1100011348029L));
         record1String = "1100011348.029\t"
             + hostname
             + "\t"
@@ -53,7 +53,7 @@ public class VespaLogHandlerTestCase {
             + "\tmy-test-config-id\tTST\tinfo\tThis is a test";
 
         record2 = new LogRecord(Level.FINE, "This is a test too");
-        record2.setMillis(1100021348029L);
+        record2.setInstant(ofEpochMilli(1100021348029L));
         record2.setLoggerName("com.yahoo.log.test");
         record2String = "1100021348.029\t"
             + hostname
@@ -63,7 +63,7 @@ public class VespaLogHandlerTestCase {
 
         record3 = new LogRecord(Level.WARNING, "another test");
         record3.setLoggerName("com.yahoo.log.test");
-        record3.setMillis(1107011348029L);
+        record3.setInstant(ofEpochMilli(1107011348029L));
         record3String = "1107011348.029\t"
             + hostname
             + "\t"
@@ -73,7 +73,7 @@ public class VespaLogHandlerTestCase {
 
         record4 = new LogRecord(Level.WARNING, "unicode \u00E6\u00F8\u00E5 test \u7881 unicode");
         record4.setLoggerName("com.yahoo.log.test");
-        record4.setMillis(1107011348029L);
+        record4.setInstant(ofEpochMilli(1107011348029L));
         record4String = "1107011348.029\t"
             + hostname
             + "\t"


### PR DESCRIPTION
- Suppress deprecation warnings locally instead of globally
  in controller-server.

Thanks to IDEA structural search/replace!