### PR TITLE
Revert "Use latest maven-dependency-plugin."

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -121,7 +121,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>2.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Reverts vespa-engine/vespa#8672

Fails on factory, but not locally.
```
[INFO] integration_test ................................... FAILURE [  1.629 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.026 s
[INFO] Finished at: 2019-03-04T13:59:16Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.1:copy-dependencies (copy-dependencies) on project integration_test: Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187. -> [Help 1]
```