### PR TITLE
Lesters/add relevance tracking 2

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -219,6 +219,13 @@ public class VespaMetricSet {
         metrics.add(new Metric("requestsOverQuota.rate"));
         metrics.add(new Metric("requestsOverQuota.count"));
 
+        metrics.add(new Metric("relevance.at_1.average"));
+        metrics.add(new Metric("relevance.at_1.count"));
+        metrics.add(new Metric("relevance.at_3.average"));
+        metrics.add(new Metric("relevance.at_3.count"));
+        metrics.add(new Metric("relevance.at_10.average"));
+        metrics.add(new Metric("relevance.at_10.count"));
+
         // Errors from qrserver
         metrics.add(new Metric("error.timeout.rate"));
         metrics.add(new Metric("error.backends_oos.rate"));


### PR DESCRIPTION
@yngveaasheim Please review. The previous implementation called computeIfAbsent on a CopyOnWriteHashMap, which had a risk of throwing a ConcurrentModificationException if the item was updated (in a different thread) while computing the value.