### PR TITLE
Revert "Decouple test framework version now we're on 7"

### DIFF
--- a/tenant-base/pom.xml
+++ b/tenant-base/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <vespaversion>${project.version}</vespaversion>
-        <test_framework_version>${project.version}</test_framework_version>
+        <test_framework_version>${vespaversion}</test_framework_version>
         <target_jdk_version>11</target_jdk_version>
         <compiler_plugin_version>3.8.0</compiler_plugin_version>
         <surefire_version>2.22.0</surefire_version> <!-- NOTE bjorncs 15.06.2017: Version 2.20 has OoM issues -->


### PR DESCRIPTION
Reverts vespa-engine/vespa#8680

All integration tests now fail with:
`Could not resolve dependencies for project com.yahoo.vespa.hosted:athens-test:container-plugin:1.0: Could not find artifact com.yahoo.vespa.tenant:systemtest-framework:jar:1.0 in artifactory-maven-remote-repos (https://edge.artifactory.yahoo.com:4443/artifactory/maven-remote-repos) -> [Help 1]`