### PR TITLE
Fix parsing of array query properties in JSON payload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 # Contributing to Vespa
 Contributions to [Vespa](http://github.com/vespa-engine/vespa),
+[Vespa system tests](http://github.com/vespa-engine/system-test),
 [Vespa samples](https://github.com/vespa-engine/sample-apps)
 and the [Vespa documentation](http://github.com/vespa-engine/documentation) are welcome.
 This documents tells you what you need to know to contribute.

--- a/container-search/src/main/java/com/yahoo/fs4/QueryPacket.java
+++ b/container-search/src/main/java/com/yahoo/fs4/QueryPacket.java
@@ -237,7 +237,7 @@ public class QueryPacket extends Packet {
          * such a way the comparing SORTDATA for two different hits
          * will reproduce the order in which the data were returned when
          * using sortspec.  For now we simply drop these. If they
-         * become necessar, QueryResultPacket must be
+         * become necessary, QueryResultPacket must be
          * updated to be able to read the sort data.
          */
         flags |= QFLAG_DROP_SORTDATA;

--- a/container-search/src/main/java/com/yahoo/prelude/query/Highlight.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Highlight.java
@@ -8,7 +8,7 @@ import static com.yahoo.language.LinguisticsCase.toLowerCase;
 /**
  * Class encapsulating information on extra highlight-terms for a query
  *
- * @author <a href="mailto:mathiasm@yahoo-inc.com">Mathias Lidal</a>
+ * @author Mathias Lidal
  */
 public class Highlight implements Cloneable {
 

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -786,7 +786,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         } catch (IllegalArgumentException e) {
             return "Invalid query: " + Exceptions.toMessageString(e);
         } catch (RuntimeException e) {
-            return "Unepected error parsing or serializing query: " + Exceptions.toMessageString(e);
+            return "Unexpected error parsing or serializing query: " + Exceptions.toMessageString(e);
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -424,7 +424,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
 
     /** Calls properties.set on all entries in requestMap */
     private void setPropertiesFromRequestMap(Map<String, String> requestMap, Properties properties) {
-        for (Map.Entry<String, String> entry : requestMap.entrySet()) {
+        for (var entry : requestMap.entrySet()) {
             try {
                 properties.set(entry.getKey(), entry.getValue(), requestMap);
             }
@@ -771,7 +771,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
 
     /**
      * Serialize this query as YQL+. This method will never throw exceptions,
-     * but instead return a human readable error message if a problem occured
+     * but instead return a human readable error message if a problem occurred while
      * serializing the query. Hits and offset information will be included if
      * different from default, while linguistics metadata are not added.
      *
@@ -783,9 +783,10 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
             return yqlRepresentation(true);
         } catch (NullItemException e) {
             return "Query currently a placeholder, NullItem encountered.";
+        } catch (IllegalArgumentException e) {
+            return "Invalid query: " + Exceptions.toMessageString(e);
         } catch (RuntimeException e) {
-            return "Failed serializing query as YQL+, please file a ticket including the query causing this: "
-                    + Exceptions.toMessageString(e);
+            return "Unepected error parsing or serializing query: " + Exceptions.toMessageString(e);
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/handler/test/JSONSearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/test/JSONSearchHandlerTestCase.java
@@ -304,11 +304,11 @@ public class JSONSearchHandlerTestCase {
 
         JSONObject select = new JSONObject();
 
-            JSONObject where = new JSONObject();
-            where.put("where", "where");
+        JSONObject where = new JSONObject();
+        where.put("where", "where");
 
-            JSONObject grouping = new JSONObject();
-            grouping.put("grouping", "grouping");
+        JSONObject grouping = new JSONObject();
+        grouping.put("grouping", "grouping");
 
         select.put("where", where);
         select.put("grouping", grouping);
@@ -342,6 +342,54 @@ public class JSONSearchHandlerTestCase {
         String result = driver.sendRequest(uri + "searchChain=echoingQuery", com.yahoo.jdisc.http.HttpRequest.Method.POST, root.toString(), JSON_CONTENT_TYPE).readAll();
         assertEquals("{\"root\":{\"id\":\"toplevel\",\"relevance\":1.0,\"fields\":{\"totalCount\":0},\"children\":[{\"id\":\"Query\",\"relevance\":1.0,\"fields\":{\"query\":\"select * from sources * where default contains \\\"bad\\\";\"}}]}}",
                      result);
+    }
+
+    @Test
+    public void testJsonWithWhereAndGroupingUnderSelect() {
+        String query = "{\n" +
+                       "  \"select\": {\n" +
+                       "    \"where\": {\n" +
+                       "      \"contains\": [\n" +
+                       "        \"field\",\n" +
+                       "        \"term\"\n" +
+                       "      ]\n" +
+                       "    },\n" +
+                       "    \"grouping\":[\n" +
+                       "      {\n" +
+                       "        \"all\": {\n" +
+                       "          \"output\": \"count()\"\n" +
+                       "        }\n" +
+                       "      }\n" +
+                       "    ]\n" +
+                       "  }\n" +
+                       "}\n";
+        String result = driver.sendRequest(uri + "searchChain=echoingQuery", com.yahoo.jdisc.http.HttpRequest.Method.POST, query, JSON_CONTENT_TYPE).readAll();
+
+        String expected = "{\"root\":{\"id\":\"toplevel\",\"relevance\":1.0,\"fields\":{\"totalCount\":0},\"children\":[{\"id\":\"Query\",\"relevance\":1.0,\"fields\":{\"query\":\"select * from sources * where field contains \\\"term\\\" | all(output(count()));\"}}]}}";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testJsonWithWhereAndGroupingSeparate() {
+        String query = "{\n" +
+                       "  \"select.where\": {\n" +
+                       "    \"contains\": [\n" +
+                       "      \"field\",\n" +
+                       "      \"term\"\n" +
+                       "    ]\n" +
+                       "  },\n" +
+                       "  \"select.grouping\":[\n" +
+                       "    {\n" +
+                       "      \"all\": {\n" +
+                       "        \"output\": \"count()\"\n" +
+                       "      }\n" +
+                       "    }\n" +
+                       "  ]\n" +
+                       "}\n";
+        String result = driver.sendRequest(uri + "searchChain=echoingQuery", com.yahoo.jdisc.http.HttpRequest.Method.POST, query, JSON_CONTENT_TYPE).readAll();
+
+        String expected = "{\"root\":{\"id\":\"toplevel\",\"relevance\":1.0,\"fields\":{\"totalCount\":0},\"children\":[{\"id\":\"Query\",\"relevance\":1.0,\"fields\":{\"query\":\"select * from sources * where field contains \\\"term\\\" | all(output(count()));\"}}]}}";
+        assertEquals(expected, result);
     }
 
     @Test

--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -2712,6 +2712,7 @@
     "methods": [
       "public static boolean isTextCharacter(int)",
       "public static java.util.OptionalInt validateTextString(java.lang.String)",
+      "public static boolean isDisplayable(int)",
       "public static java.lang.String stripInvalidCharacters(java.lang.String)"
     ],
     "fields": []

--- a/vespajlib/src/main/java/com/yahoo/slime/SlimeInserter.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/SlimeInserter.java
@@ -4,8 +4,9 @@ package com.yahoo.slime;
 /**
  * Helper class for inserting values into a Slime object.
  * For justification read Inserter documentation.
- **/
+ */
 public final class SlimeInserter implements Inserter {
+
     private Slime target;
 
     public SlimeInserter(Slime target) {
@@ -26,4 +27,5 @@ public final class SlimeInserter implements Inserter {
     public final Cursor insertDATA(byte[] value)   { return target.setData(value); }
     public final Cursor insertARRAY()              { return target.setArray(); }
     public final Cursor insertOBJECT()             { return target.setObject(); }
+
 }

--- a/vespajlib/src/main/java/com/yahoo/text/Text.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Text.java
@@ -109,6 +109,33 @@ public final class Text {
         return OptionalInt.empty();
     }
 
+    /** Returns whether the given code point is displayable. */
+    public static boolean isDisplayable(int codePoint) {
+        switch (Character.getType(codePoint)) {
+            case Character.CONNECTOR_PUNCTUATION :
+            case Character.DASH_PUNCTUATION :
+            case Character.START_PUNCTUATION :
+            case Character.END_PUNCTUATION :
+            case Character.INITIAL_QUOTE_PUNCTUATION :
+            case Character.FINAL_QUOTE_PUNCTUATION:
+            case Character.OTHER_PUNCTUATION :
+            case Character.LETTER_NUMBER :
+            case Character.OTHER_LETTER :
+            case Character.LOWERCASE_LETTER :
+            case Character.TITLECASE_LETTER :
+            case Character.MODIFIER_LETTER :
+            case Character.UPPERCASE_LETTER :
+            case Character.DECIMAL_DIGIT_NUMBER :
+            case Character.OTHER_NUMBER :
+            case Character.CURRENCY_SYMBOL :
+            case Character.OTHER_SYMBOL :
+            case Character.MATH_SYMBOL :
+                return true;
+            default :
+                return false;
+        }
+    }
+
     private static StringBuilder lazy(StringBuilder sb, String s, int i) {
         if (sb == null) {
             sb = new StringBuilder(s.substring(0, i));

--- a/vespajlib/src/test/java/com/yahoo/text/TextTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/text/TextTestCase.java
@@ -7,6 +7,7 @@ import java.util.OptionalInt;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TextTestCase {
 
@@ -45,6 +46,19 @@ public class TextTestCase {
     public void testThatHighSurrogateRequireLowSurrogate() {
         assertEquals(OptionalInt.of(0xD800), Text.validateTextString(new StringBuilder().appendCodePoint(0xD800).toString()));
         assertEquals(OptionalInt.of(0xD800), Text.validateTextString(new StringBuilder().appendCodePoint(0xD800).append(0x0000).toString()));
+    }
+
+    @Test
+    public void testIsDisplayable() {
+        assertTrue(Text.isDisplayable('A'));
+        assertTrue(Text.isDisplayable('a'));
+        assertTrue(Text.isDisplayable('5'));
+        assertTrue(Text.isDisplayable(','));
+        assertTrue(Text.isDisplayable('\"'));
+        assertTrue(Text.isDisplayable('}'));
+        assertTrue(Text.isDisplayable('-'));
+        assertFalse(Text.isDisplayable(' '));
+        assertFalse(Text.isDisplayable(0));
     }
 
 }


### PR DESCRIPTION
These were translated to request properties by calling
asString on the payload, which returns an empty value for arrays.
toString returns the correct value.

This also improves error messages for Slime JSON parsing
of queries, and in general.

@arnej27959 og @henrhoi please review