### PR TITLE
Don't use custom (old) version of ph-javacc-maven-plugin

### DIFF
--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -96,7 +96,6 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-javacc-maven-plugin</artifactId>
-        <version>4.0.3</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
I must have forgotten this one when I switched from the original maven-javacc-plugin