### PR TITLE
Stabilize LogReaderTest

### DIFF
--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -211,6 +211,12 @@
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>testutil</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
@@ -1,14 +1,18 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.handler;
 
+import com.yahoo.vespa.test.file.TestFileSystem;
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Scanner;
 import java.util.regex.Pattern;
@@ -18,7 +22,20 @@ import static org.junit.Assert.assertEquals;
 
 public class LogReaderTest {
 
-    private final Path logDirectory = Paths.get("src/test/resources/logfolder/");
+    private final FileSystem fileSystem = TestFileSystem.create();
+    private final Path logDirectory = fileSystem.getPath("/opt/vespa/logs");
+
+    @Before
+    public void setup() throws IOException {
+        Files.createDirectories(logDirectory.resolve("subfolder"));
+
+        Files.setLastModifiedTime(
+                Files.write(logDirectory.resolve("log1.log"), "This is one log file\n".getBytes()),
+                FileTime.from(Instant.ofEpochMilli(123)));
+        Files.setLastModifiedTime(
+                Files.write(logDirectory.resolve("subfolder/log2.log"), "This is another log file\n".getBytes()),
+                FileTime.from(Instant.ofEpochMilli(234)));
+    }
 
     @Test
     public void testThatFilesAreWrittenCorrectlyToOutputStream() throws Exception{

--- a/container-core/src/test/resources/logfolder/log1.log
+++ b/container-core/src/test/resources/logfolder/log1.log
@@ -1,1 +1,0 @@
-This is one log file

--- a/container-core/src/test/resources/logfolder/subfolder/log2.log
+++ b/container-core/src/test/resources/logfolder/subfolder/log2.log
@@ -1,1 +1,0 @@
-This is another log file


### PR DESCRIPTION
Since streaming depends on the last modified time of the files, the test occasionally breaks for me when I switch between branches and git may overwrite the files in some other order :man_shrugging: 

This will create a filesystem in memory and write the test files with a given last modified ensuring consistent order.