### PR TITLE
Reimplement how to find all configs produced by a ConfigProducer.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
@@ -474,7 +474,7 @@ public final class VespaModel extends AbstractConfigProducerRoot implements Seri
     }
 
     private static Set<ConfigKey<?>> configsProduced(ConfigProducer cp) {
-        Set<ConfigKey<?>> ret = ReflectionUtil.configsProducedByInterface(cp.getClass(), cp.getConfigId());
+        Set<ConfigKey<?>> ret = ReflectionUtil.getAllConfigsProduced(cp.getClass(), cp.getConfigId());
         UserConfigRepo userConfigs = cp.getUserConfigs();
         for (ConfigDefinitionKey userKey : userConfigs.configsProduced()) {
             ret.add(new ConfigKey<>(userKey.getName(), cp.getConfigId(), userKey.getNamespace()));

--- a/config-model/src/test/java/com/yahoo/vespa/model/utils/internal/ReflectionUtilTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/utils/internal/ReflectionUtilTest.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.utils.internal;
 
+import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.test.ArraytypesConfig;
 import com.yahoo.config.ChangesRequiringRestart;
 import com.yahoo.config.ConfigInstance;
@@ -10,6 +11,7 @@ import org.junit.Test;
 
 import java.util.Set;
 
+import static com.yahoo.vespa.model.utils.internal.ReflectionUtil.getAllConfigsProduced;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -19,26 +21,37 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Ulf Lilleengen
  * @author bjorncs
+ * @author gjoranv
  * @since 5.1
  */
 public class ReflectionUtilTest {
 
-    private static interface ComplexInterface extends SimpletypesConfig.Producer, ArraytypesConfig.Producer {
+    private static class SimpleProducer extends AbstractConfigProducer implements SimpletypesConfig.Producer {
+        SimpleProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
+
+        @Override
+        public void getConfig(SimpletypesConfig.Builder builder) { }
     }
 
-    private static class SimpleProducer implements SimpletypesConfig.Producer {
+    private interface ProducerInterface extends SimpletypesConfig.Producer, ArraytypesConfig.Producer { }
+
+    private static class InterfaceImplementingProducer extends AbstractConfigProducer implements ProducerInterface {
+        InterfaceImplementingProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
+
         @Override
-        public void getConfig(SimpletypesConfig.Builder builder) {
-        }
+        public void getConfig(ArraytypesConfig.Builder builder) { }
+        @Override
+        public void getConfig(SimpletypesConfig.Builder builder) { }
     }
 
-    private static class ComplexProducer implements ComplexInterface {
+    private static abstract class MyAbstractProducer extends AbstractConfigProducer implements SimpletypesConfig.Producer {
+        MyAbstractProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
         @Override
-        public void getConfig(ArraytypesConfig.Builder builder) {
-        }
-        @Override
-        public void getConfig(SimpletypesConfig.Builder builder) {
-        }
+        public void getConfig(SimpletypesConfig.Builder builder) { }
+    }
+
+    private static class ConcreteProducer extends MyAbstractProducer {
+        ConcreteProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
     }
 
     private static class RestartConfig extends ConfigInstance {
@@ -56,16 +69,23 @@ public class ReflectionUtilTest {
     private static class NonRestartConfig extends ConfigInstance {}
 
     @Test
-    public void requireThatConfigsProducedByInterfaceTakesParentIntoAccount() {
-        Set<ConfigKey<?>> configs = ReflectionUtil.configsProducedByInterface(ComplexProducer.class, "foo");
+    public void getAllConfigsProduced_includes_configs_produced_by_super_class() {
+        Set<ConfigKey<?>> configs = getAllConfigsProduced(ConcreteProducer.class, "foo");
+        assertThat(configs.size(), is(1));
+        assertTrue(configs.contains(new ConfigKey<>(SimpletypesConfig.CONFIG_DEF_NAME, "foo", SimpletypesConfig.CONFIG_DEF_NAMESPACE)));
+    }
+
+    @Test
+    public void getAllConfigsProduced_includes_configs_produced_by_implemented_interface() {
+        Set<ConfigKey<?>> configs = getAllConfigsProduced(InterfaceImplementingProducer.class, "foo");
         assertThat(configs.size(), is(2));
         assertTrue(configs.contains(new ConfigKey<>(SimpletypesConfig.CONFIG_DEF_NAME, "foo", SimpletypesConfig.CONFIG_DEF_NAMESPACE)));
         assertTrue(configs.contains(new ConfigKey<>(ArraytypesConfig.CONFIG_DEF_NAME, "foo", ArraytypesConfig.CONFIG_DEF_NAMESPACE)));
     }
 
     @Test
-    public void requireThatConfigsProducedByInterfaceAreFound() {
-        Set<ConfigKey<?>> configs = ReflectionUtil.configsProducedByInterface(SimpleProducer.class, "foo");
+    public void getAllConfigsProduced_includes_configs_directly_implemented_by_producer() {
+        Set<ConfigKey<?>> configs = getAllConfigsProduced(SimpleProducer.class, "foo");
         assertThat(configs.size(), is(1));
         assertTrue(configs.contains(new ConfigKey<>(SimpletypesConfig.CONFIG_DEF_NAME, "foo", SimpletypesConfig.CONFIG_DEF_NAMESPACE)));
     }


### PR DESCRIPTION
- Search also super classes, not only implemented interfaces.
  This is necessary to get the correct set of configs for Container
  implementations and future ContainerCluster implementations.