### PR TITLE
Emit warning when using deprecated 'filedistribution' element.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
@@ -54,6 +54,10 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
 
         ModelElement adminElement = new ModelElement(adminE);
         addLogForwarders(adminElement.getChild("logforwarding"), admin);
+
+        if (adminElement.getChild("filedistribution") != null) {
+            deployState.getDeployLogger().log(LogLevel.WARNING, "'filedistribution' element is deprecated and ignored");
+        }
     }
 
     private List<Configserver> parseConfigservers(DeployState deployState, Admin admin, Element adminE) {


### PR DESCRIPTION
Element is only legal for v2 of 'admin', so need to warn only here