### PR TITLE
Set generation in empty sentinel config response

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
@@ -167,7 +167,7 @@ class GetConfigProcessor implements Runnable {
         log.log(LogLevel.INFO, "Returning empty sentinel config for request from " + request.getClientHostName());
         ConfigPayload emptyPayload = ConfigPayload.empty();
         String configMd5 = ConfigUtils.getMd5(emptyPayload);
-        ConfigResponse config = SlimeConfigResponse.fromConfigPayload(emptyPayload, null, 0, false, configMd5);
+        ConfigResponse config = SlimeConfigResponse.fromConfigPayload(emptyPayload, null, request.getRequestGeneration() + 1, false, configMd5);
         request.addOkResponse(request.payloadFromResponse(config), config.getGeneration(), false, config.getConfigMd5());
         respond(request);
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/RpcServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/RpcServerTest.java
@@ -96,6 +96,8 @@ public class RpcServerTest {
             new ConfigPayloadApplier<>(builder).applyPayload(payload);
             SentinelConfig config = new SentinelConfig(builder);
             assertEquals(0, config.service().size());
+            // Test generation explicitly since it is not set set the usual way
+            assertTrue(clientReq.getNewGeneration() > clientReq.getRequestGeneration());
         }
     }
 


### PR DESCRIPTION
Neccessary after https://github.com/vespa-engine/vespa/pull/8131, a system test for empty sentinel config response is being worked on as well