### PR TITLE
Harden zip handling

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ZipStreamReader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ZipStreamReader.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.application;
 
 import com.google.common.collect.ImmutableList;
@@ -6,7 +6,9 @@ import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -14,50 +16,59 @@ import java.util.zip.ZipInputStream;
  * @author bratseth
  */
 public class ZipStreamReader {
-    
-    private final ImmutableList<ZipEntryWithContent> entries;
 
-    public ZipStreamReader(InputStream input) {
+    private final ImmutableList<ZipEntryWithContent> entries;
+    private final int maxEntrySizeInBytes;
+
+    public ZipStreamReader(InputStream input, Predicate<String> entryNameMatcher, int maxEntrySizeInBytes) {
+        this.maxEntrySizeInBytes = maxEntrySizeInBytes;
         try (ZipInputStream zipInput = new ZipInputStream(input)) {
             ImmutableList.Builder<ZipEntryWithContent> builder = new ImmutableList.Builder<>();
             ZipEntry zipEntry;
-            while (null != (zipEntry = zipInput.getNextEntry()))
+            while (null != (zipEntry = zipInput.getNextEntry())) {
+                if (!entryNameMatcher.test(zipEntry.getName())) continue;
                 builder.add(new ZipEntryWithContent(zipEntry, readContent(zipInput)));
+            }
             entries = builder.build();
-        }
-        catch (IOException e) {
-            throw new IllegalArgumentException("IO error reading zip content", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException("IO error reading zip content", e);
         }
     }
-    
+
     private byte[] readContent(ZipInputStream zipInput) {
         try (ByteArrayOutputStream bis = new ByteArrayOutputStream()) {
             byte[] buffer = new byte[2048];
             int read;
-            while ( -1 != (read = zipInput.read(buffer)))
+            int size = 0;
+            while ( -1 != (read = zipInput.read(buffer))) {
+                size += read;
+                if (size > maxEntrySizeInBytes) {
+                    throw new IllegalArgumentException("Entry in zip content exceeded size limit of " +
+                                                       maxEntrySizeInBytes + " bytes");
+                }
                 bis.write(buffer, 0, read);
+            }
             return bis.toByteArray();
-        }
-        catch (IOException e) {
-            throw new IllegalArgumentException("Failed reading from zipped content", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed reading from zipped content", e);
         }
     }
-    
+
     public List<ZipEntryWithContent> entries() { return entries; }
     
     public static class ZipEntryWithContent {
-        
+
         private final ZipEntry zipEntry;
         private final byte[] content;
-        
+
         public ZipEntryWithContent(ZipEntry zipEntry, byte[] content) {
             this.zipEntry = zipEntry;
             this.content = content;
         }
-        
+
         public ZipEntry zipEntry() { return zipEntry; }
         public byte[] content() { return content; }
-        
+
     }
-    
+
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ZipStreamReader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ZipStreamReader.java
@@ -41,7 +41,7 @@ public class ZipStreamReader {
         try (ByteArrayOutputStream bis = new ByteArrayOutputStream()) {
             byte[] buffer = new byte[2048];
             int read;
-            int size = 0;
+            long size = 0;
             while ( -1 != (read = zipInput.read(buffer))) {
                 size += read;
                 if (size > maxEntrySizeInBytes) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -524,6 +524,17 @@ public class ControllerTest {
         tester.controller().applications().deactivate(app.id(), ZoneId.from(Environment.prod, RegionName.from("us-west-1")));
     }
 
+    @Test
+    public void testDeployApplicationPackageWithApplicationDir() {
+        DeploymentTester tester = new DeploymentTester();
+        Application application = tester.createApplication("app1", "tenant1", 1, 1L);
+        ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
+                .environment(Environment.prod)
+                .region("us-west-1")
+                .build(true);
+        tester.deployCompletely(application, applicationPackage);
+    }
+
     private void runUpgrade(DeploymentTester tester, ApplicationId application, ApplicationVersion version) {
         Version next = Version.fromString("6.2");
         tester.upgradeSystem(next);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/ZipStreamReaderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/ZipStreamReaderTest.java
@@ -1,0 +1,53 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.application;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author mpolden
+ */
+public class ZipStreamReaderTest {
+
+    @Test
+    public void test_size_limit() {
+        Map<String, String> entries = Map.of("foo.xml", "foobar");
+        try {
+            new ZipStreamReader(new ByteArrayInputStream(zip(entries)), "foo.xml"::equals, 1);
+            fail("Expected exception");
+        } catch (IllegalArgumentException ignored) {}
+
+        entries = Map.of("foo.xml", "foobar",
+                         "foo.zip", "0".repeat(100) // File not extracted and thus not subject to size limit
+        );
+        ZipStreamReader reader = new ZipStreamReader(new ByteArrayInputStream(zip(entries)), "foo.xml"::equals,10);
+        byte[] extracted = reader.entries().get(0).content();
+        assertEquals("foobar", new String(extracted, StandardCharsets.UTF_8));
+    }
+
+    private static byte[] zip(Map<String, String> entries) {
+        ByteArrayOutputStream zip = new ByteArrayOutputStream();
+        try (ZipOutputStream out = new ZipOutputStream(zip)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                out.putNextEntry(new ZipEntry(entry.getKey()));
+                out.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return zip.toByteArray();
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
@@ -172,18 +172,26 @@ public class ApplicationPackageBuilder {
     }
 
     public ApplicationPackage build() {
+        return build(false);
+    }
+
+    public ApplicationPackage build(boolean useApplicationDir) {
+        String dir = "";
+        if (useApplicationDir) {
+            dir = "application/";
+        }
         ByteArrayOutputStream zip = new ByteArrayOutputStream();
         try (ZipOutputStream out = new ZipOutputStream(zip)) {
-            out.putNextEntry(new ZipEntry("deployment.xml"));
+            out.putNextEntry(new ZipEntry(dir + "deployment.xml"));
             out.write(deploymentSpec());
             out.closeEntry();
-            out.putNextEntry(new ZipEntry("validation-overrides.xml"));
+            out.putNextEntry(new ZipEntry(dir + "validation-overrides.xml"));
             out.write(validationOverrides());
             out.closeEntry();
-            out.putNextEntry(new ZipEntry("search-definitions/test.sd"));
+            out.putNextEntry(new ZipEntry(dir + "search-definitions/test.sd"));
             out.write(searchDefinition());
             out.closeEntry();
-            out.putNextEntry(new ZipEntry("build-meta.json"));
+            out.putNextEntry(new ZipEntry(dir + "build-meta.json"));
             out.write(buildMeta());
             out.closeEntry();
         } catch (IOException e) {


### PR DESCRIPTION
This adds some basic constraints for zip file extraction that should deal with
the most common security issues, e.g. resource starvation and path traversals.

I verified that all deployed application packages work with this change.

This also has the added benefit of not extracting/copying files the controller
doesn't care about (e.g. large bundles), which reduces the amount of garbage
generated on each deploy.