### PR TITLE
Log query params in audit log

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLogger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLogger.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.time.Clock;
@@ -67,7 +68,7 @@ public class AuditLogger {
         }
 
         Instant now = clock.instant();
-        AuditLog.Entry entry = new AuditLog.Entry(now, principal.getName(), method.get(), request.getUri().getPath(),
+        AuditLog.Entry entry = new AuditLog.Entry(now, principal.getName(), method.get(), pathAndQueryOf(request.getUri()),
                                                   Optional.of(new String(data, StandardCharsets.UTF_8)));
         try (Lock lock = db.lockAuditLog()) {
             AuditLog auditLog = db.readAuditLog()
@@ -88,6 +89,15 @@ public class AuditLogger {
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }
+    }
+
+    private static String pathAndQueryOf(URI url) {
+        String pathAndQuery = url.getPath();
+        String query = url.getQuery();
+        if (query != null) {
+            pathAndQuery += "?" + query;
+        }
+        return pathAndQuery;
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLoggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLoggerTest.java
@@ -36,7 +36,7 @@ public class AuditLoggerTest {
         }
 
         { // PATCH request is logged in audit log
-            URI url = URI.create("http://localhost:8080/os/v1/");
+            URI url = URI.create("http://localhost:8080/os/v1/?foo=bar");
             String data = "{\"cloud\":\"cloud9\",\"version\":\"42.0\"}";
             HttpRequest request = testRequest(Method.PATCH, url, data);
             tester.controller().auditLogger().log(request);
@@ -44,7 +44,7 @@ public class AuditLoggerTest {
             assertEquals(instant(), log.get().entries().get(0).at());
             assertEquals("user", log.get().entries().get(0).principal());
             assertEquals(Entry.Method.PATCH, log.get().entries().get(0).method());
-            assertEquals("/os/v1/", log.get().entries().get(0).resource());
+            assertEquals("/os/v1/?foo=bar", log.get().entries().get(0).resource());
             assertEquals(data, log.get().entries().get(0).data().get());
         }
 
@@ -55,6 +55,7 @@ public class AuditLoggerTest {
             tester.controller().auditLogger().log(request);
             assertEquals(2, log.get().entries().size());
             assertEquals(instant(), log.get().entries().get(0).at());
+            assertEquals("/os/v1/", log.get().entries().get(0).resource());
         }
 
         { // 14 days pass and another PATCH request is logged. Older entries are removed due to expiry


### PR DESCRIPTION
Noticed that some of our APIs use mutable methods in combination with query
parameters.