### PR TITLE
Send response also when config generation is 0

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ClientUpdater.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ClientUpdater.java
@@ -49,7 +49,8 @@ class ClientUpdater {
         for (DelayedResponse response : responseDelayQueue.toArray(new DelayedResponse[0])) {
             JRTServerConfigRequest request = response.getRequest();
             if (request.getConfigKey().equals(config.getKey())
-                    && (config.getGeneration() >= request.getRequestGeneration())) {
+                    // Generation 0 is special, used when returning empty sentinel config
+                    && (config.getGeneration() >= request.getRequestGeneration() || config.getGeneration() == 0)) {
                 if (delayedResponses.remove(response)) {
                     found = true;
                     log.log(LogLevel.DEBUG, () -> "Call returnOkResponse for " + config.getKey() + "," + config.getGeneration());

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ProxyServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ProxyServerTest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.proxy;
 
-import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.vespa.config.*;
 import com.yahoo.vespa.config.protocol.JRTServerConfigRequest;
 import com.yahoo.vespa.config.protocol.Payload;
@@ -220,9 +219,13 @@ public class ProxyServerTest {
     }
 
     private static RawConfig createConfigWithNextConfigGeneration(RawConfig config, int errorCode, Payload payload) {
+        return createConfigWithNextConfigGeneration(config, errorCode, payload, config.getGeneration() + 1);
+    }
+
+    static RawConfig createConfigWithNextConfigGeneration(RawConfig config, int errorCode, Payload payload, long configGeneration) {
         return new RawConfig(config.getKey(), config.getDefMd5(),
                              payload, config.getConfigMd5(),
-                             config.getGeneration() + 1, false,
+                             configGeneration, false,
                              errorCode, config.getDefContent(), Optional.empty());
     }
 


### PR DESCRIPTION
Needed for returning empty sentinel config, since we cannot use a new generation
numbed. 0 is used as a special generation number that should allow response
to be given to client even if it is not higher than the current generation.