### PR TITLE
Revert "Remove bad format string macro hack."

### DIFF
--- a/vespalib/src/vespa/vespalib/util/stringfmt.h
+++ b/vespalib/src/vespa/vespalib/util/stringfmt.h
@@ -3,7 +3,12 @@
 
 #include <vespa/vespalib/stllike/string.h>
 #include <cstdarg>
-#include <cinttypes>
+
+#ifndef PRId64
+  #define PRId64 "ld"
+  #define PRIu64 "lu"
+  #define PRIx64 "lx"
+#endif
 
 namespace vespalib {
 

--- a/vespalog/src/vespa/log/log.h
+++ b/vespalog/src/vespa/log/log.h
@@ -7,7 +7,6 @@
 #include <new>         // for placement new
 #include <cstdlib>     // for malloc
 #include <cstring>     // for memset
-#include <cinttypes>
 
 /**
  * If this macro is defined, the regular LOG calls will go through the
@@ -288,3 +287,9 @@ extern void log_abort(const char *message,
 #else
 #define LOG_ASSERT(expr)
 #endif // #ifndef NDEBUG
+
+#ifndef PRId64
+    #define PRId64 "ld"
+    #define PRIu64 "lu"
+    #define PRIx64 "lx"
+#endif


### PR DESCRIPTION
Reverts vespa-engine/vespa#8780

Broke the build