### PR TITLE
Add support for an optional prefix to path matching

### DIFF
--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -872,6 +872,7 @@
     ],
     "methods": [
       "public void <init>(java.lang.String)",
+      "public void <init>(java.lang.String, java.lang.String)",
       "public boolean matches(java.lang.String)",
       "public java.lang.String get(java.lang.String)",
       "public java.lang.String getRest()",

--- a/container-core/src/main/java/com/yahoo/restapi/Path.java
+++ b/container-core/src/main/java/com/yahoo/restapi/Path.java
@@ -99,7 +99,7 @@ public class Path {
      */
     public boolean matches(String pathSpec) {
         if (matches_inner(pathSpec)) return true;
-        if (optionalPrefix.isEmpty() || optionalPrefix.length() > pathSpec.length()) return false;
+        if (optionalPrefix.isEmpty()) return false;
         return  matches_inner(optionalPrefix + pathSpec);
     }
 

--- a/container-core/src/test/java/com/yahoo/restapi/PathTest.java
+++ b/container-core/src/test/java/com/yahoo/restapi/PathTest.java
@@ -11,7 +11,20 @@ import static org.junit.Assert.assertEquals;
  * @author bratseth
  */
 public class PathTest {
-    
+
+    @Test
+    public void testWithPrefix() {
+        // Test that a path with a prefix matches spec
+        Path path = new Path("/ball/a/1/bar/fuz", "/ball");
+        assertTrue(path.matches("/a/{foo}/bar/{b}"));
+        assertEquals("1", path.get("foo"));
+        assertEquals("fuz", path.get("b"));
+
+        // One negative test where the prefix should not count
+        assertFalse(path.matches("/ball/a/{foo}/zoo/{b}"));
+    }
+
+
     @Test
     public void testPath() {
         assertFalse(new Path("").matches("/a/{foo}/bar/{b}"));

--- a/container-core/src/test/java/com/yahoo/restapi/PathTest.java
+++ b/container-core/src/test/java/com/yahoo/restapi/PathTest.java
@@ -14,13 +14,13 @@ public class PathTest {
 
     @Test
     public void testWithPrefix() {
-        // Test that a path with a prefix matches spec
+        // Test that a path with a prefix matches spec without the prefix
         Path path = new Path("/ball/a/1/bar/fuz", "/ball");
         assertTrue(path.matches("/a/{foo}/bar/{b}"));
         assertEquals("1", path.get("foo"));
         assertEquals("fuz", path.get("b"));
 
-        // One negative test where the prefix should not count
+        // Also test that prefix does not cause false matches
         assertFalse(path.matches("/ball/a/{foo}/zoo/{b}"));
     }
 


### PR DESCRIPTION
We want to serve frontend resources and api backend calls from the same domain name. The idea is that we'll bind api calls for the frontend domain to the /api prefix and then use the same handlers as for the '/' prefix on the api domain. The support for one optional prefix is to be able to reuse the handler code with minimal change. 