### PR TITLE
Remove vespa-cppunit as a run-time dependency of vespa

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -147,7 +147,6 @@ Requires: llvm-libs >= 8.0.0
 %endif
 Requires: java-11-openjdk
 Requires: openssl
-Requires: vespa-cppunit >= 1.12.1-6
 Requires(pre): shadow-utils
 
 # Ugly workaround because vespamalloc/src/vespamalloc/malloc/mmap.cpp uses the private


### PR DESCRIPTION
There is no similar yinst package installed in a tenant node, nor does it have
any of the libcppunit*.so files installed.

This will allow us to avoid copr rpm repo dependency of vespa RPM.