### PR TITLE
Remove proxy ACL for port 443

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -240,9 +240,8 @@ public class NodeRepository extends AbstractComponent {
             case proxy:
                 // Proxy nodes trust:
                 // - config servers
-                // - all connections from the world on 443 (for dashboard app), 4080 (insecure tb removed), and 4443
+                // - all connections from the world on 4080 (insecure tb removed), and 4443
                 trustedNodes.addAll(candidates.nodeType(NodeType.config).asList());
-                trustedPorts.add(443);
                 trustedPorts.add(4080);
                 trustedPorts.add(4443);
                 break;


### PR DESCRIPTION
I assume this can be removed since dashboard has moved to controller.