### PR TITLE
protobuf-java dependency cleanup

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -383,11 +383,6 @@
                 <artifactId>xml-apis</artifactId>
                 <version>1.4.01</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
 
             <!--  NOTE: The dependencies below are not provided from the jdisc container runtime, but had to be moved
                         here from 'parent' because factorylib reads the text in parent/pom.xml and this pom file to
@@ -459,7 +454,6 @@
         <jaxb.version>2.3.0</jaxb.version>
         <jetty.version>9.4.15.v20190215</jetty.version>
         <slf4j.version>1.7.5</slf4j.version>
-        <protobuf.version>3.7.0</protobuf.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->
         <!-- MUST be updated each time jersey2 is upgraded! -->

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -89,11 +89,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>docproc</artifactId>
       <version>${project.version}</version>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -710,6 +710,11 @@
                 <version>${jna.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.tensorflow</groupId>
                 <artifactId>proto</artifactId>
                 <version>${tensorflow.version}</version>
@@ -758,6 +763,7 @@
         <test.hide>true</test.hide>
         <doclint>all</doclint>
         <surefire.version>2.21.0</surefire.version>
+        <protobuf.version>3.7.0</protobuf.version>
     </properties>
 
 </project>


### PR DESCRIPTION
- Versioning moved from container-dependency-versions to parent
- compile scope moved from container-search-and-docproc to container-search