### PR TITLE
Use VIP in AWS

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -81,7 +81,7 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
         // Make a local copy of the list as we want to manipulate it in case of ping problems.
         List<URI> allServers = zoneRegistry.getConfigServerVipUri(zoneId)
                 // TODO: Use config server VIP for all zones that have one
-                .filter(zone -> zoneId.region().value().startsWith("aws-") || zoneId.region().value().startsWith("cd-aws-"))
+                .filter(zone -> zoneId.region().value().startsWith("aws-") || zoneId.region().value().contains("-aws-"))
 
                 .map(Collections::singletonList)
                 .orElseGet(() -> new ArrayList<>(zoneRegistry.getConfigServerUris(zoneId)));


### PR DESCRIPTION
Will make `/zone/v2` use VIP when talking to config servers in AWS, in a zone that shall not be named :zipper_mouth_face: 