### PR TITLE
Retrieve document summaries over jrt/protobuf 

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackEndSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackEndSearcher.java
@@ -52,7 +52,6 @@ import java.util.logging.Logger;
  *
  * @author  baldersheim
  */
-@SuppressWarnings("deprecation")
 public abstract class VespaBackEndSearcher extends PingableSearcher {
 
     static final CompoundName PACKET_COMPRESSION_LIMIT = new CompoundName("packetcompressionlimit");

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -48,7 +48,7 @@ public class Dispatcher extends AbstractComponent {
     private static final CompoundName dispatchInternal = new CompoundName("dispatch.internal");
 
     /** If enabled, search queries will use protobuf rpc */
-    private static final CompoundName dispatchProtobuf = new CompoundName("dispatch.protobuf");
+    public static final CompoundName dispatchProtobuf = new CompoundName("dispatch.protobuf");
 
     /** A model of the search cluster this dispatches to */
     private final SearchCluster searchCluster;

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -1,7 +1,8 @@
 package com.yahoo.search.dispatch.rpc;
 
 import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
-import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol.SearchRequest.Builder;
+import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol.StringProperty;
+import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol.TensorProperty;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.yahoo.document.GlobalId;
@@ -15,11 +16,10 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.grouping.vespa.GroupingExecutor;
 import com.yahoo.search.query.Model;
+import com.yahoo.search.query.QueryTree;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.Sorting;
 import com.yahoo.search.query.Sorting.Order;
-import com.yahoo.search.query.ranking.RankFeatures;
-import com.yahoo.search.query.ranking.RankProperties;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.Relevance;
 import com.yahoo.searchlib.aggregation.Grouping;
@@ -28,31 +28,24 @@ import com.yahoo.vespa.objects.BufferSerializer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class ProtobufSerialization {
     private static final int INITIAL_SERIALIZATION_BUFFER_SIZE = 10 * 1024;
 
-    public static byte[] serializeQuery(Query query, String serverId, boolean includeQueryData) {
-        return convertFromQuery(query, serverId, includeQueryData).toByteArray();
+    public static byte[] serializeSearchRequest(Query query, String serverId) {
+        return convertFromQuery(query, serverId).toByteArray();
     }
 
-    public static byte[] serializeResult(Result searchResult) {
-        return convertFromResult(searchResult).toByteArray();
-    }
-
-    public static Result deserializeToResult(byte[] payload, Query query, VespaBackEndSearcher searcher)
-            throws InvalidProtocolBufferException {
-        var protobuf = SearchProtocol.SearchReply.parseFrom(payload);
-        var result = convertToResult(query, protobuf, searcher.getDocumentDatabase(query));
-        return result;
-    }
-
-    private static SearchProtocol.SearchRequest convertFromQuery(Query query, String serverId, boolean includeQueryData) {
+    private static SearchProtocol.SearchRequest convertFromQuery(Query query, String serverId) {
         var builder = SearchProtocol.SearchRequest.newBuilder().setHits(query.getHits()).setOffset(query.getOffset())
                 .setTimeout((int) query.getTimeLeft());
 
-        mergeToRequestFromRanking(query.getRanking(), builder, includeQueryData);
-        mergeToRequestFromModel(query.getModel(), builder);
+        var documentDb = query.getModel().getDocumentDb();
+        if (documentDb != null) {
+            builder.setDocumentType(documentDb);
+        }
+        builder.setQueryTreeBlob(serializeQueryTree(query.getModel().getQueryTree()));
 
         if (query.getGroupingSessionCache() || query.getRanking().getQueryCache()) {
             // TODO verify that the session key is included whenever rank properties would have been
@@ -71,71 +64,101 @@ public class ProtobufSerialization {
             gbuf.getBuf().flip();
             builder.setGroupingBlob(ByteString.copyFrom(gbuf.getBuf().getByteBuffer()));
         }
-
         if (query.getGroupingSessionCache()) {
             builder.setCacheGrouping(true);
         }
 
+        mergeToSearchRequestFromRanking(query.getRanking(), builder);
+
         return builder.build();
     }
 
-    private static void mergeToRequestFromModel(Model model, SearchProtocol.SearchRequest.Builder builder) {
-        if (model.getDocumentDb() != null) {
-            builder.setDocumentType(model.getDocumentDb());
+    private static void mergeToSearchRequestFromRanking(Ranking ranking, SearchProtocol.SearchRequest.Builder builder) {
+        builder.setRankProfile(ranking.getProfile());
+
+        if (ranking.getQueryCache()) {
+            builder.setCacheQuery(true);
         }
-        int bufferSize = INITIAL_SERIALIZATION_BUFFER_SIZE;
-        boolean success = false;
-        while (!success) {
-            try {
-                ByteBuffer treeBuffer = ByteBuffer.allocate(bufferSize);
-                model.getQueryTree().encode(treeBuffer);
-                treeBuffer.flip();
-                builder.setQueryTreeBlob(ByteString.copyFrom(treeBuffer));
-                success = true;
-            } catch (java.nio.BufferOverflowException e) {
-                bufferSize *= 2;
-            }
+        if (ranking.getSorting() != null) {
+            mergeToSearchRequestFromSorting(ranking.getSorting(), builder);
         }
+        if (ranking.getLocation() != null) {
+            builder.setGeoLocation(ranking.getLocation().toString());
+        }
+
+        var featureMap = ranking.getFeatures().asMap();
+        MapConverter.convertMapStrings(featureMap, builder::addFeatureOverrides);
+        MapConverter.convertMapTensors(featureMap, builder::addTensorFeatureOverrides);
+        mergeRankProperties(ranking, builder::addRankProperties, builder::addTensorRankProperties);
     }
 
-    private static void mergeToRequestFromSorting(Sorting sorting, SearchProtocol.SearchRequest.Builder builder, boolean includeQueryData) {
+    private static void mergeToSearchRequestFromSorting(Sorting sorting, SearchProtocol.SearchRequest.Builder builder) {
         for (var field : sorting.fieldOrders()) {
-            var sortField = SearchProtocol.SortField.newBuilder().setField(field.getSorter().getName())
+            var sortField = SearchProtocol.SortField.newBuilder()
+                    .setField(field.getSorter().getName())
                     .setAscending(field.getSortOrder() == Order.ASCENDING).build();
             builder.addSorting(sortField);
         }
     }
 
-    private static void mergeToRequestFromRanking(Ranking ranking, SearchProtocol.SearchRequest.Builder builder, boolean includeQueryData) {
-        builder.setRankProfile(ranking.getProfile());
+    public static SearchProtocol.DocsumRequest.Builder createDocsumRequestBuilder(Query query, String serverId, String summaryClass,
+            boolean includeQueryData) {
+        var builder = SearchProtocol.DocsumRequest.newBuilder()
+                .setTimeout((int) query.getTimeLeft())
+                .setDumpFeatures(query.properties().getBoolean(Ranking.RANKFEATURES, false));
+
+        if (summaryClass != null) {
+            builder.setSummaryClass(summaryClass);
+        }
+
+        var documentDb = query.getModel().getDocumentDb();
+        if (documentDb != null) {
+            builder.setDocumentType(documentDb);
+        }
+
+        var ranking = query.getRanking();
         if (ranking.getQueryCache()) {
             builder.setCacheQuery(true);
+            builder.setSessionKey(query.getSessionId(serverId).toString());
         }
-        if (ranking.getSorting() != null) {
-            mergeToRequestFromSorting(ranking.getSorting(), builder, includeQueryData);
+        builder.setRankProfile(query.getRanking().getProfile());
+
+        if (includeQueryData) {
+            mergeQueryDataToDocsumRequest(query, builder);
         }
-        if (ranking.getLocation() != null) {
-            builder.setGeoLocation(ranking.getLocation().toString());
-        }
-        mergeToRequestFromRankFeatures(ranking.getFeatures(), builder, includeQueryData);
-        mergeToRequestFromRankProperties(ranking.getProperties(), builder, includeQueryData);
+
+        return builder;
     }
 
-    private static void mergeToRequestFromRankFeatures(RankFeatures features, SearchProtocol.SearchRequest.Builder builder, boolean includeQueryData) {
-        if (includeQueryData) {
-            MapConverter.convertMapStrings(features.asMap(), builder::addFeatureOverrides);
-            MapConverter.convertMapTensors(features.asMap(), builder::addTensorFeatureOverrides);
+    public static byte[] serializeDocsumRequest(SearchProtocol.DocsumRequest.Builder builder, List<FastHit> documents) {
+        builder.clearGlobalIds();
+        for (var hit : documents) {
+            builder.addGlobalIds(ByteString.copyFrom(hit.getGlobalId().getRawId()));
         }
+        return builder.build().toByteArray();
     }
 
-    private static void mergeToRequestFromRankProperties(RankProperties properties, Builder builder, boolean includeQueryData) {
-        if (includeQueryData) {
-            MapConverter.convertMultiMap(properties.asMap(), propB -> {
-                if (!GetDocSumsPacket.sessionIdKey.equals(propB.getName())) {
-                    builder.addRankProperties(propB);
-                }
-            }, builder::addTensorRankProperties);
-        }
+    private static void mergeQueryDataToDocsumRequest(Query query, SearchProtocol.DocsumRequest.Builder builder) {
+        var ranking = query.getRanking();
+        var featureMap = ranking.getFeatures().asMap();
+
+        builder.setQueryTreeBlob(serializeQueryTree(query.getModel().getQueryTree()));
+        builder.setGeoLocation(ranking.getLocation().toString());
+        MapConverter.convertMapStrings(featureMap, builder::addFeatureOverrides);
+        MapConverter.convertMapTensors(featureMap, builder::addTensorFeatureOverrides);
+        MapConverter.convertStringMultiMap(query.getPresentation().getHighlight().getHighlightTerms(), builder::addHighlightTerms);
+        mergeRankProperties(ranking, builder::addRankProperties, builder::addTensorRankProperties);
+    }
+
+    public static byte[] serializeResult(Result searchResult) {
+        return convertFromResult(searchResult).toByteArray();
+    }
+
+    public static Result deserializeToSearchResult(byte[] payload, Query query, VespaBackEndSearcher searcher)
+            throws InvalidProtocolBufferException {
+        var protobuf = SearchProtocol.SearchReply.parseFrom(payload);
+        var result = convertToResult(query, protobuf, searcher.getDocumentDatabase(query));
+        return result;
     }
 
     private static Result convertToResult(Query query, SearchProtocol.SearchReply protobuf, DocumentDatabase documentDatabase) {
@@ -211,4 +234,26 @@ public class ProtobufSerialization {
         return builder.build();
     }
 
+    private static ByteString serializeQueryTree(QueryTree queryTree) {
+        int bufferSize = INITIAL_SERIALIZATION_BUFFER_SIZE;
+        while (true) {
+            try {
+                ByteBuffer treeBuffer = ByteBuffer.allocate(bufferSize);
+                queryTree.encode(treeBuffer);
+                treeBuffer.flip();
+                return ByteString.copyFrom(treeBuffer);
+            } catch (java.nio.BufferOverflowException e) {
+                bufferSize *= 2;
+            }
+        }
+    }
+
+    private static void mergeRankProperties(Ranking ranking, Consumer<StringProperty.Builder> stringProperties,
+            Consumer<TensorProperty.Builder> tensorProperties) {
+        MapConverter.convertMultiMap(ranking.getProperties().asMap(), propB -> {
+            if (!GetDocSumsPacket.sessionIdKey.equals(propB.getName())) {
+                stringProperties.accept(propB);
+            }
+        }, tensorProperties);
+    }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
@@ -1,0 +1,227 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.rpc;
+
+import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.yahoo.collections.ListMap;
+import com.yahoo.collections.Pair;
+import com.yahoo.compress.CompressionType;
+import com.yahoo.compress.Compressor;
+import com.yahoo.container.protect.Error;
+import com.yahoo.data.access.Inspector;
+import com.yahoo.data.access.slime.SlimeAdapter;
+import com.yahoo.prelude.fastsearch.DocumentDatabase;
+import com.yahoo.prelude.fastsearch.FastHit;
+import com.yahoo.prelude.fastsearch.TimeoutException;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.dispatch.FillInvoker;
+import com.yahoo.search.dispatch.rpc.Client.ProtobufResponse;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.result.Hit;
+import com.yahoo.slime.ArrayTraverser;
+import com.yahoo.slime.BinaryFormat;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link FillInvoker} implementation using Protobuf over JRT
+ *
+ * @author bratseth
+ * @author ollivir
+ */
+public class RpcProtobufFillInvoker extends FillInvoker {
+    private final String RPC_METHOD = "vespa.searchprotocol.getDocsums";
+
+    private static final Logger log = Logger.getLogger(RpcProtobufFillInvoker.class.getName());
+
+    private final DocumentDatabase documentDb;
+    private final RpcResourcePool resourcePool;
+    private final boolean summaryNeedsQuery;
+    private final String serverId;
+
+    private BlockingQueue<Pair<Client.ResponseOrError<ProtobufResponse>, List<FastHit>>> responses;
+
+    /** Whether we have already logged/notified about an error - to avoid spamming */
+    private boolean hasReportedError = false;
+
+    /** The number of responses we should receive (and process) before this is complete */
+    private int outstandingResponses;
+
+    RpcProtobufFillInvoker(RpcResourcePool resourcePool, DocumentDatabase documentDb, String serverId, boolean summaryNeedsQuery) {
+        this.documentDb = documentDb;
+        this.resourcePool = resourcePool;
+        this.serverId = serverId;
+        this.summaryNeedsQuery = summaryNeedsQuery;
+    }
+
+    @Override
+    protected void sendFillRequest(Result result, String summaryClass) {
+        ListMap<Integer, FastHit> hitsByNode = hitsByNode(result);
+
+        CompressionType compression = CompressionType
+                .valueOf(result.getQuery().properties().getString(RpcResourcePool.dispatchCompression, "LZ4").toUpperCase());
+
+        result.getQuery().trace(false, 5, "Sending ", hitsByNode.size(), " summary fetch requests with jrt/protobuf");
+
+        outstandingResponses = hitsByNode.size();
+        responses = new LinkedBlockingQueue<>(outstandingResponses);
+
+        var builder = ProtobufSerialization.createDocsumRequestBuilder(result.getQuery(), serverId, summaryClass, summaryNeedsQuery);
+        for (Map.Entry<Integer, List<FastHit>> nodeHits : hitsByNode.entrySet()) {
+            var payload = ProtobufSerialization.serializeDocsumRequest(builder, nodeHits.getValue());
+            sendDocsumsRequest(nodeHits.getKey(), nodeHits.getValue(), payload, compression, result);
+        }
+    }
+
+    @Override
+    protected void getFillResults(Result result, String summaryClass) {
+        try {
+            processResponses(result, summaryClass);
+            result.hits().setSorted(false);
+            result.analyzeHits();
+        } catch (TimeoutException e) {
+            result.hits().addError(ErrorMessage.createTimeout("Summary data is incomplete: " + e.getMessage()));
+        }
+    }
+
+    @Override
+    protected void release() {
+        // nothing to release
+    }
+
+    /** Called by a thread belonging to the client when a valid response becomes available */
+    public void receive(Client.ResponseOrError<ProtobufResponse> response, List<FastHit> hitsContext) {
+        responses.add(new Pair<>(response, hitsContext));
+    }
+
+    /** Return a map of hits by their search node (partition) id */
+    private static ListMap<Integer, FastHit> hitsByNode(Result result) {
+        ListMap<Integer, FastHit> hitsByNode = new ListMap<>();
+        for (Iterator<Hit> i = result.hits().unorderedDeepIterator(); i.hasNext();) {
+            Hit h = i.next();
+            if (!(h instanceof FastHit))
+                continue;
+            FastHit hit = (FastHit) h;
+
+            hitsByNode.put(hit.getDistributionKey(), hit);
+        }
+        return hitsByNode;
+    }
+
+    /** Send a docsums request to a node. Responses will be added to the given receiver. */
+    private void sendDocsumsRequest(int nodeId, List<FastHit> hits, byte[] payload, CompressionType compression, Result result) {
+        Client.NodeConnection node = resourcePool.nodeConnections().get(nodeId);
+        if (node == null) {
+            String error = "Could not fill hits from unknown node " + nodeId;
+            receive(Client.ResponseOrError.fromError(error), hits);
+            result.hits().addError(ErrorMessage.createEmptyDocsums(error));
+            log.warning("Got hits with partid " + nodeId + ", which is not included in the current dispatch config");
+            return;
+        }
+
+        Query query = result.getQuery();
+        double timeoutSeconds = ((double) query.getTimeLeft() - 3.0) / 1000.0;
+        Compressor.Compression compressionResult = resourcePool.compressor().compress(compression, payload);
+        resourcePool.client().request(RPC_METHOD, node, compressionResult.type(), payload.length, compressionResult.data(),
+                roe -> receive(roe, hits), timeoutSeconds);
+    }
+
+    private void processResponses(Result result, String summaryClass) throws TimeoutException {
+        try {
+            int skippedHits = 0;
+            while (outstandingResponses > 0) {
+                long timeLeftMs = result.getQuery().getTimeLeft();
+                if (timeLeftMs <= 0) {
+                    throwTimeout();
+                }
+                var responseAndHits = responses.poll(timeLeftMs, TimeUnit.MILLISECONDS);
+                if (responseAndHits == null) {
+                    throwTimeout();
+                }
+                var response = responseAndHits.getFirst();
+                var hitsContext = responseAndHits.getSecond();
+                skippedHits += processResponse(result, response, hitsContext, summaryClass);
+                outstandingResponses--;
+            }
+            if (skippedHits != 0) {
+                result.hits().addError(ErrorMessage
+                        .createEmptyDocsums("Missing hit summary data for summary " + summaryClass + " for " + skippedHits + " hits"));
+            }
+        } catch (InterruptedException e) {
+            // TODO: Add error
+        }
+    }
+
+    private int processResponse(Result result, Client.ResponseOrError<ProtobufResponse> responseOrError, List<FastHit> hitsContext,
+            String summaryClass) {
+        if (responseOrError.error().isPresent()) {
+            if (hasReportedError) {
+                return 0;
+            }
+            String error = responseOrError.error().get();
+            result.hits().addError(ErrorMessage.createBackendCommunicationError(error));
+            log.log(Level.WARNING, "Error fetching summary data: " + error);
+            hasReportedError = true;
+        } else {
+            Client.ProtobufResponse response = responseOrError.response().get();
+            CompressionType compression = CompressionType.valueOf(response.compression());
+            byte[] responseBytes = resourcePool.compressor().decompress(response.compressedPayload(), compression,
+                    response.uncompressedSize());
+            return fill(result, hitsContext, summaryClass, responseBytes);
+        }
+        return 0;
+    }
+
+    private void addErrors(Result result, com.yahoo.slime.Inspector errors) {
+        errors.traverse((ArrayTraverser) (index, value) -> {
+            int errorCode = ("timeout".equalsIgnoreCase(value.field("type").asString())) ? Error.TIMEOUT.code : Error.UNSPECIFIED.code;
+            result.hits().addError(new ErrorMessage(errorCode, value.field("message").asString(), value.field("details").asString()));
+        });
+    }
+
+    private int fill(Result result, List<FastHit> hits, String summaryClass, byte[] payload) {
+        try {
+            var protobuf = SearchProtocol.DocsumReply.parseFrom(payload);
+            var root = BinaryFormat.decode(protobuf.getSlimeSummaries().toByteArray()).get();
+            var errors = root.field("errors");
+            boolean hasErrors = errors.valid() && (errors.entries() > 0);
+            if (hasErrors) {
+                addErrors(result, errors);
+            }
+
+            Inspector summaries = new SlimeAdapter(root.field("docsums"));
+            if (!summaries.valid()) {
+                return 0; // No summaries; Perhaps we requested a non-existing summary class
+            }
+            int skippedHits = 0;
+            for (int i = 0; i < hits.size(); i++) {
+                Inspector summary = summaries.entry(i).field("docsum");
+                if (summary.fieldCount() != 0) {
+                    hits.get(i).setField(Hit.SDDOCNAME_FIELD, documentDb.getName());
+                    hits.get(i).addSummary(documentDb.getDocsumDefinitionSet().getDocsum(summaryClass), summary);
+                    hits.get(i).setFilled(summaryClass);
+                } else {
+                    skippedHits++;
+                }
+            }
+            return skippedHits;
+        } catch (InvalidProtocolBufferException ex) {
+            log.log(Level.WARNING, "Invalid response to docsum request", ex);
+            result.hits().addError(ErrorMessage.createInternalServerError("Invalid response to docsum request from backend"));
+            return 0;
+        }
+    }
+
+    private void throwTimeout() throws TimeoutException {
+        throw new TimeoutException("Timed out waiting for summary data. " + outstandingResponses + " responses outstanding.");
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
  * @author ollivir
  */
 public class RpcProtobufFillInvoker extends FillInvoker {
-    private final String RPC_METHOD = "vespa.searchprotocol.getDocsums";
+    private static final String RPC_METHOD = "vespa.searchprotocol.getDocsums";
 
     private static final Logger log = Logger.getLogger(RpcProtobufFillInvoker.class.getName());
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -9,7 +9,7 @@ import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.SearchInvoker;
-import com.yahoo.search.dispatch.rpc.Client.SearchResponse;
+import com.yahoo.search.dispatch.rpc.Client.ProtobufResponse;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
@@ -25,11 +25,13 @@ import java.util.concurrent.TimeUnit;
  *
  * @author ollivir
  */
-public class RpcSearchInvoker extends SearchInvoker {
+public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseReceiver {
+    private final String RPC_METHOD = "vespa.searchprotocol.search";
+
     private final VespaBackEndSearcher searcher;
     private final Node node;
     private final RpcResourcePool resourcePool;
-    private final BlockingQueue<Client.SearchResponseOrError> responses;
+    private final BlockingQueue<Client.ResponseOrError<ProtobufResponse>> responses;
 
     private Query query;
 
@@ -50,15 +52,16 @@ public class RpcSearchInvoker extends SearchInvoker {
 
         Client.NodeConnection nodeConnection = resourcePool.nodeConnections().get(node.key());
         if (nodeConnection == null) {
-            responses.add(Client.SearchResponseOrError.fromError("Could send search to unknown node " + node.key()));
+            responses.add(Client.ResponseOrError.fromError("Could not send search to unknown node " + node.key()));
             responseAvailable();
             return;
         }
+        query.trace(false, 5, "Sending search request with jrt/protobuf to node with dist key ", node.key());
 
-        var payload = ProtobufSerialization.serializeQuery(query, searcher.getServerId(), true);
+        var payload = ProtobufSerialization.serializeSearchRequest(query, searcher.getServerId());
         double timeoutSeconds = ((double) query.getTimeLeft() - 3.0) / 1000.0;
         Compressor.Compression compressionResult = resourcePool.compressor().compress(compression, payload);
-        resourcePool.client().search(nodeConnection, compressionResult.type(), payload.length, compressionResult.data(), this,
+        resourcePool.client().request(RPC_METHOD, nodeConnection, compressionResult.type(), payload.length, compressionResult.data(), this,
                 timeoutSeconds);
     }
 
@@ -68,7 +71,7 @@ public class RpcSearchInvoker extends SearchInvoker {
         if (timeLeftMs <= 0) {
             return errorResult(query, ErrorMessage.createTimeout("Timeout while waiting for " + getName()));
         }
-        Client.SearchResponseOrError response = null;
+        Client.ResponseOrError<ProtobufResponse> response = null;
         try {
             response = responses.poll(timeLeftMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
@@ -84,11 +87,11 @@ public class RpcSearchInvoker extends SearchInvoker {
             return errorResult(query, ErrorMessage.createInternalServerError("Neither error nor result available"));
         }
 
-        SearchResponse searchResponse = response.response().get();
-        CompressionType compression = CompressionType.valueOf(searchResponse.compression());
-        byte[] payload = resourcePool.compressor().decompress(searchResponse.compressedPayload(), compression,
-                searchResponse.uncompressedSize());
-        var result = ProtobufSerialization.deserializeToResult(payload, query, searcher);
+        ProtobufResponse protobufResponse = response.response().get();
+        CompressionType compression = CompressionType.valueOf(protobufResponse.compression());
+        byte[] payload = resourcePool.compressor().decompress(protobufResponse.compressedPayload(), compression,
+                protobufResponse.uncompressedSize());
+        var result = ProtobufSerialization.deserializeToSearchResult(payload, query, searcher);
         result.hits().unorderedIterator().forEachRemaining(hit -> {
             if(hit instanceof FastHit) {
                 FastHit fhit = (FastHit) hit;
@@ -106,7 +109,7 @@ public class RpcSearchInvoker extends SearchInvoker {
         // nothing to release
     }
 
-    public void receive(Client.SearchResponseOrError response) {
+    public void receive(Client.ResponseOrError<ProtobufResponse> response) {
         responses.add(response);
         responseAvailable();
     }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * @author ollivir
  */
 public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseReceiver {
-    private final String RPC_METHOD = "vespa.searchprotocol.search";
+    private static final String RPC_METHOD = "vespa.searchprotocol.search";
 
     private final VespaBackEndSearcher searcher;
     private final Node node;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
@@ -54,8 +54,8 @@ public class RpcSearchInvokerTest {
             AtomicInteger lengthHolder) {
         return new Client() {
             @Override
-            public void search(NodeConnection node, CompressionType compression, int uncompressedLength, byte[] compressedPayload,
-                    RpcSearchInvoker responseReceiver, double timeoutSeconds) {
+            public void request(String rpcMethod, NodeConnection node, CompressionType compression, int uncompressedLength,
+                    byte[] compressedPayload, ResponseReceiver responseReceiver, double timeoutSeconds) {
                 compressionTypeHolder.set(compression);
                 payloadHolder.set(compressedPayload);
                 lengthHolder.set(uncompressedLength);


### PR DESCRIPTION
Implements the retrieval using the method with protobuf messages. The older docsum retriever over JRT+Slime is not removed in this change set. When it is removed, `RpcProtobufFillInvoker` can drop protobuf from its name.