### PR TITLE
Don't create and close streams in loop

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
@@ -57,13 +57,10 @@ class LogReader {
     void writeLogs(OutputStream outputStream, Instant earliestLogThreshold, Instant latestLogThreshold) {
         try {
             for (Path file : getMatchingFiles(earliestLogThreshold, latestLogThreshold)) {
-                if (file.toString().endsWith(".gz")) {
-                    Files.copy(file, outputStream);
-                } else {
-                    OutputStream zip = new GZIPOutputStream(outputStream);
-                    Files.copy(file, zip);
-                    zip.close();
+                if (!file.toString().endsWith(".gz") && !(outputStream instanceof GZIPOutputStream)) {
+                    outputStream = new GZIPOutputStream(outputStream);
                 }
+                Files.copy(file, outputStream);
             }
             outputStream.close();
         } catch (IOException e) {

--- a/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
@@ -69,14 +69,6 @@ public class LogReaderTest {
     @Test
     public void testZippedStreaming() throws IOException {
 
-        // Add some more files
-        Files.setLastModifiedTime(
-                Files.write(logDirectory.resolve("log3.gz"), compress("Three\n")),
-                FileTime.from(Instant.ofEpochMilli(324)));
-        Files.setLastModifiedTime(
-                Files.write(logDirectory.resolve("log4"), "Four\n".getBytes()),
-                FileTime.from(Instant.ofEpochMilli(432)));
-
         ByteArrayOutputStream zippedBaos = new ByteArrayOutputStream();
         LogReader logReader = new LogReader(logDirectory, Pattern.compile(".*"));
         logReader.writeLogs(zippedBaos, Instant.ofEpochMilli(21), Instant.now());
@@ -85,7 +77,7 @@ public class LogReaderTest {
         Scanner s = new Scanner(unzippedIs).useDelimiter("\\A");
         String actual = s.hasNext() ? s.next() : "";
 
-        String expected = "This is one log file\nThis is another log file\nThree\nFour\n";
+        String expected = "This is one log file\nThis is another log file\n";
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
So we're back to depending on zipped files appearing before unzipped files...

The problem is closing the `GZIPOutputStream` also closed the response `outputStream`. The test didn't catch this, since `ByteArrayOutputStream.close()` is a no-op >_<

@hmusum fyi