### PR TITLE
Change Role API to produce roles with correct Context (NVM implementa…

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/AthenzRoleResolver.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/AthenzRoleResolver.java
@@ -88,12 +88,11 @@ public class AthenzRoleResolver implements RoleMembership.Resolver {
 
         AthenzIdentity identity = ((AthenzPrincipal) principal).getIdentity();
 
-        RoleMembership.Builder memberships = RoleMembership.in(system);
         if (isHostedOperator(identity)) {
-            memberships.add(Role.hostedOperator);
+            return Role.hostedOperator.limitedTo(system);
         }
         if (tenant.isPresent() && isTenantAdmin(identity, tenant.get())) {
-            memberships.add(Role.athenzTenantAdmin).limitedTo(tenant.get().name());
+            return Role.athenzTenantAdmin.limitedTo(tenant.get().name(), system);
         }
         AthenzDomain principalDomain = identity.getDomain();
         if (principalDomain.equals(SCREWDRIVER_DOMAIN)) {
@@ -102,16 +101,15 @@ public class AthenzRoleResolver implements RoleMembership.Resolver {
                 if (tenant.get() instanceof AthenzTenant) {
                     AthenzDomain tenantDomain = ((AthenzTenant) tenant.get()).domain();
                     if (hasDeployerAccess(identity, tenantDomain, application.get())) {
-                        memberships.add(Role.tenantPipeline).limitedTo(tenant.get().name(), application.get());
+                        return Role.tenantPipeline.limitedTo(application.get(), tenant.get().name(), system);
                     }
                 }
                 else {
-                    memberships.add(Role.tenantPipeline).limitedTo(tenant.get().name(), application.get());
+                    return Role.tenantPipeline.limitedTo(application.get(), tenant.get().name(), system);
                 }
             }
         }
-        memberships.add(Role.everyone);
-        return memberships.build();
+        return Role.everyone.limitedTo(system);
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilter.java
@@ -10,11 +10,11 @@ import com.yahoo.jdisc.http.filter.security.cors.CorsRequestFilterBase;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.role.Action;
+import com.yahoo.vespa.hosted.controller.role.Role;
 import com.yahoo.vespa.hosted.controller.role.RoleMembership;
 import com.yahoo.yolean.chain.After;
 import com.yahoo.yolean.chain.Provides;
 
-import javax.ws.rs.WebApplicationException;
 import java.security.Principal;
 import java.util.Optional;
 import java.util.Set;
@@ -59,7 +59,7 @@ public class ControllerAuthorizationFilter extends CorsRequestFilterBase {
             Action action = Action.from(HttpRequest.Method.valueOf(request.getMethod()));
 
             // Avoid expensive lookups when request is always legal.
-            if (RoleMembership.everyoneIn(controller.system()).allows(action, request.getRequestURI()))
+            if (Role.everyone.limitedTo(controller.system()).allows(action, request.getRequestURI()))
                 return Optional.empty();
 
             RoleMembership roles = this.roleResolver.membership(principal, Optional.of(request.getRequestURI()));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/user/UserApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/user/UserApiHandler.java
@@ -85,4 +85,6 @@ public class UserApiHandler extends LoggingRequestHandler {
         return response;
     }
 
+
+
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/Role.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/Role.java
@@ -1,7 +1,12 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.role;
 
+import com.yahoo.config.provision.ApplicationName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.TenantName;
+
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -14,71 +19,73 @@ import java.util.Set;
  * @author mpolden
  * @author jonmv
  */
-public enum Role {
+public class Role implements RoleInSystem, RoleInSystemWithTenant, RoleInSystemWithTenantAndApplication {
 
     /** Deus ex machina. */
-    hostedOperator(Policy.operator),
+    public static final RoleInSystem hostedOperator = new Role(Policy.operator);
 
     /** Build service which may submit new applications for continuous deployment. */
-    buildService(Policy.submission,
-                 Policy.applicationRead),
+    public static final RoleInSystemWithTenantAndApplication buildService = new Role(Policy.submission,
+                                                                                     Policy.applicationRead);
 
     /** Base role which every user is part of. */
-    everyone(Policy.classifiedRead,
-             Policy.publicRead,
-             Policy.userCreate,
-             Policy.tenantCreate),
+    public static final RoleInSystem everyone = new Role(Policy.classifiedRead,
+                                                         Policy.publicRead,
+                                                         Policy.userCreate,
+                                                         Policy.tenantCreate);
 
     /** Application reader which can see all information about an application, its tenant and deployments. */
-    applicationReader(everyone,
-                      Policy.tenantRead,
-                      Policy.applicationRead,
-                      Policy.deploymentRead),
+    public static final RoleInSystemWithTenantAndApplication applicationReader = new Role(everyone,
+                                                                                          Policy.tenantRead,
+                                                                                          Policy.applicationRead,
+                                                                                          Policy.deploymentRead);
 
     /** Application developer with access to deploy to development zones. */
-    applicationDeveloper(applicationReader,
-                         Policy.developmentDeployment),
+    public static final RoleInSystemWithTenantAndApplication applicationDeveloper = new Role(applicationReader,
+                                                                                             Policy.developmentDeployment);
 
     /** Application operator with access to normal, operational tasks of an application. */
-    applicationOperator(applicationDeveloper,
-                        Policy.applicationOperations),
+    public static final RoleInSystemWithTenantAndApplication applicationOperator = new Role(applicationDeveloper,
+                                                                                            Policy.applicationOperations);
 
     /** Application administrator with full access to an already existing application, including emergency operations. */
-    applicationAdmin(applicationOperator,
-                     Policy.applicationUpdate,
-                     Policy.productionDeployment,
-                     Policy.submission),
+    public static final RoleInSystemWithTenantAndApplication applicationAdmin = new Role(applicationOperator,
+                                                                                         Policy.applicationUpdate,
+                                                                                         Policy.productionDeployment,
+                                                                                         Policy.submission);
 
     /** Tenant admin with full access to all tenant resources, including the ability to create new applications. */
-    tenantAdmin(applicationAdmin,
-                Policy.applicationCreate,
-                Policy.applicationDelete,
-                Policy.manager,
-                Policy.tenantWrite),
+    public static final RoleInSystemWithTenant tenantAdmin = new Role(applicationAdmin,
+                                                                      Policy.applicationCreate,
+                                                                      Policy.applicationDelete,
+                                                                      Policy.manager,
+                                                                      Policy.tenantWrite);
 
     /** Build and continuous delivery service. */ // TODO replace with buildService, when everyone is on new pipeline.
-    tenantPipeline(Policy.submission,
-                   Policy.deploymentPipeline,
-                   Policy.productionDeployment),
+    public static final RoleInSystemWithTenantAndApplication tenantPipeline = new Role(everyone,
+                                                                                       Policy.submission,
+                                                                                       Policy.deploymentPipeline,
+                                                                                       Policy.productionDeployment);
 
     /** Tenant administrator with full access to all child resources. */
-    athenzTenantAdmin(Policy.tenantWrite,
-                      Policy.tenantRead,
-                      Policy.applicationCreate,
-                      Policy.applicationUpdate,
-                      Policy.applicationDelete,
-                      Policy.applicationOperations,
-                      Policy.developmentDeployment); // TODO remove, as it is covered by applicationAdmin.
+    public static final RoleInSystemWithTenant athenzTenantAdmin = new Role(everyone,
+                                                                            Policy.tenantWrite,
+                                                                            Policy.tenantRead,
+                                                                            Policy.applicationCreate,
+                                                                            Policy.applicationUpdate,
+                                                                            Policy.applicationDelete,
+                                                                            Policy.applicationOperations,
+                                                                            Policy.developmentDeployment);
 
     private final Set<Policy> policies;
 
-    Role(Policy... policies) {
+    private Role(Policy... policies) {
         this.policies = EnumSet.copyOf(Set.of(policies));
     }
 
-    Role(Role inherited, Policy... policies) {
+    private Role(Object inherited, Policy... policies) {
         this.policies = EnumSet.copyOf(Set.of(policies));
-        this.policies.addAll(inherited.policies);
+        this.policies.addAll(((Role) inherited).policies);
     }
 
     /**
@@ -87,6 +94,30 @@ public enum Role {
      */
     public boolean allows(Action action, String path, Context context) {
         return policies.stream().anyMatch(policy -> policy.evaluate(action, path, context));
+    }
+
+    @Override
+    public RoleMembership limitedTo(SystemName system) {
+        return new RoleWithContext(this, Context.unlimitedIn(system));
+    }
+
+    @Override
+    public RoleMembership limitedTo(TenantName tenant, SystemName system) {
+        return new RoleWithContext(this, Context.limitedTo(tenant, system));
+    }
+
+    @Override
+    public RoleMembership limitedTo(ApplicationName application, TenantName tenant, SystemName system) {
+        return new RoleWithContext(this, Context.limitedTo(tenant, application, system));
+    }
+
+
+    public static class RoleWithContext extends RoleMembership { // TODO fix.
+
+        private RoleWithContext(Role role, Context context) {
+            super(Map.of(role, Set.of(context)));
+        }
+
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleInSystem.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleInSystem.java
@@ -1,0 +1,8 @@
+package com.yahoo.vespa.hosted.controller.role;
+
+import com.yahoo.config.provision.SystemName;
+
+/** A role which requires only the context of a system. */
+public interface RoleInSystem {
+    RoleMembership limitedTo(SystemName system);
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleInSystemWithTenant.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleInSystemWithTenant.java
@@ -1,0 +1,9 @@
+package com.yahoo.vespa.hosted.controller.role;
+
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.TenantName;
+
+/** A role which requires the context of a system and a tenant. */
+public interface RoleInSystemWithTenant {
+    RoleMembership limitedTo(TenantName tenant, SystemName system);
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleInSystemWithTenantAndApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleInSystemWithTenantAndApplication.java
@@ -1,0 +1,10 @@
+package com.yahoo.vespa.hosted.controller.role;
+
+import com.yahoo.config.provision.ApplicationName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.TenantName;
+
+/** A role which requires the context of a system, a tenant, and an application. */
+public interface RoleInSystemWithTenantAndApplication {
+    RoleMembership limitedTo(ApplicationName application, TenantName tenant, SystemName system);
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleMembership.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/role/RoleMembership.java
@@ -1,6 +1,7 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.role;
 
+import com.google.common.collect.ImmutableMap;
 import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
@@ -14,6 +15,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A list of roles and their associated contexts. This defines the role membership of a tenant, and in which contexts
@@ -22,23 +24,27 @@ import java.util.stream.Collectors;
  * @author mpolden
  * @author jonmv
  */
-public class RoleMembership {
+public class RoleMembership { // TODO replace with Set<RoleWithContext>
 
     private final Map<Role, Set<Context>> roles;
 
-    private RoleMembership(Map<Role, Set<Context>> roles) {
+    RoleMembership(Map<Role, Set<Context>> roles) {
         this.roles = roles.entrySet().stream()
                           .collect(Collectors.toUnmodifiableMap(entry -> entry.getKey(),
                                                                 entry -> Set.copyOf(entry.getValue())));
     }
 
-    public static RoleMembership everyoneIn(SystemName system) {
-        return in(system).add(Role.everyone).build();
+    public RoleMembership and(RoleMembership other) {
+        return new RoleMembership(Stream.concat(this.roles.entrySet().stream(),
+                                                other.roles.entrySet().stream())
+                                        .collect(Collectors.toMap(Map.Entry::getKey,
+                                                                  Map.Entry::getValue,
+                                                                  (set1, set2) -> Stream.concat(set1.stream(), set2.stream()).collect(Collectors.toUnmodifiableSet()))));
     }
 
-    public static Builder in(SystemName system) { return new BuilderWithRole(system); }
-
-    /** Returns whether any role in this allows action to take place in path */
+    /**
+     * Returns whether any role in this allows action to take place in path
+     */
     public boolean allows(Action action, String path) {
         return roles.entrySet().stream().anyMatch(kv -> {
             Role role = kv.getKey();
@@ -47,9 +53,11 @@ public class RoleMembership {
         });
     }
 
-    /** Returns the set of contexts for which the given role is valid. */
-    public Set<Context> contextsFor(Role role) {
-        return roles.getOrDefault(role, Collections.emptySet());
+    /**
+     * Returns the set of contexts for which the given role is valid.
+     */
+    public Set<Context> contextsFor(Object role) { // TODO fix.
+        return roles.getOrDefault((Role) role, Collections.emptySet());
     }
 
     @Override
@@ -62,60 +70,8 @@ public class RoleMembership {
      * membership to a {@link RoleMembership}.
      */
     public interface Resolver {
+
         RoleMembership membership(Principal user, Optional<String> path); // TODO get rid of path.
-    }
-
-    public interface Builder {
-
-        BuilderWithRole add(Role role);
-
-        RoleMembership build();
-
-    }
-
-    public static class BuilderWithRole implements Builder {
-
-        private final SystemName system;
-        private final Map<Role, Set<Context>> roles;
-
-        private Role current;
-
-        private BuilderWithRole(SystemName system) {
-            this.system = Objects.requireNonNull(system);
-            this.roles = new HashMap<>();
-        }
-
-        @Override
-        public BuilderWithRole add(Role role) {
-            consumeCurrent(Context.unlimitedIn(system));
-            current = role;
-            return this;
-        }
-
-        public Builder limitedTo(TenantName tenant) {
-            consumeCurrent(Context.limitedTo(tenant, system));
-            return this;
-        }
-
-        public Builder limitedTo(TenantName tenant, ApplicationName application) {
-            consumeCurrent(Context.limitedTo(tenant, application, system));
-            return this;
-        }
-
-        @Override
-        public RoleMembership build() {
-            consumeCurrent(Context.unlimitedIn(system));
-            return new RoleMembership(roles);
-        }
-
-        private void consumeCurrent(Context context) {
-            if (current != null) {
-                roles.putIfAbsent(current, new HashSet<>());
-                roles.get(current).add(context);
-            }
-            current = null;
-        }
-
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/AthenzRoleResolverTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/AthenzRoleResolverTest.java
@@ -70,11 +70,13 @@ public class AthenzRoleResolverTest {
     @Test
     public void testTranslations() {
 
-        // Everyone is member of the everyone role.
-        assertEquals(Set.of(Context.unlimitedIn(tester.controller().system())),
+        // Only unprivileged users are members of the everyone role.
+        assertEquals(emptySet(),
                      resolver.membership(HOSTED_OPERATOR, APPLICATION_CONTEXT_PATH).contextsFor(Role.everyone));
-        assertEquals(Set.of(Context.unlimitedIn(tester.controller().system())),
+        assertEquals(emptySet(),
                      resolver.membership(TENANT_ADMIN, TENANT_CONTEXT_PATH).contextsFor(Role.everyone));
+        assertEquals(Set.of(Context.unlimitedIn(tester.controller().system())),
+                     resolver.membership(TENANT_ADMIN, TENANT2_CONTEXT_PATH).contextsFor(Role.everyone));
         assertEquals(Set.of(Context.unlimitedIn(tester.controller().system())),
                      resolver.membership(TENANT_PIPELINE, NO_CONTEXT_PATH).contextsFor(Role.everyone));
         assertEquals(Set.of(Context.unlimitedIn(tester.controller().system())),
@@ -90,8 +92,8 @@ public class AthenzRoleResolverTest {
         assertEquals(emptySet(),
                      resolver.membership(USER, TENANT_CONTEXT_PATH).contextsFor(Role.hostedOperator));
 
-        // Operators and tenant admins are tenant admins of their tenants.
-        assertEquals(Set.of(Context.limitedTo(TENANT, tester.controller().system())),
+        // Only tenant admins are tenant admins of their tenants.
+        assertEquals(emptySet(),
                      resolver.membership(HOSTED_OPERATOR, APPLICATION_CONTEXT_PATH).contextsFor(Role.athenzTenantAdmin));
         assertEquals(emptySet(), // TODO this is wrong, but we can't do better until we ask ZMS for roles.
                      resolver.membership(TENANT_ADMIN, NO_CONTEXT_PATH).contextsFor(Role.athenzTenantAdmin));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/ControllerAuthorizationFilterTest.java
@@ -38,9 +38,7 @@ public class ControllerAuthorizationFilterTest {
     @Test
     public void operator() {
         ControllerTester tester = new ControllerTester();
-        RoleMembership.Resolver operatorResolver = (user, path) -> RoleMembership.in(tester.controller().system())
-                                                                                 .add(Role.hostedOperator)
-                                                                                 .build();
+        RoleMembership.Resolver operatorResolver = (user, path) -> Role.hostedOperator.limitedTo(tester.controller().system());
         ControllerAuthorizationFilter filter = createFilter(tester, operatorResolver);
         assertIsAllowed(invokeFilter(filter, createRequest(Method.POST, "/zone/v2/path", identity)));
         assertIsAllowed(invokeFilter(filter, createRequest(Method.PUT, "/application/v4/user", identity)));
@@ -50,7 +48,7 @@ public class ControllerAuthorizationFilterTest {
     @Test
     public void unprivileged() {
         ControllerTester tester = new ControllerTester();
-        RoleMembership.Resolver emptyResolver = (user, path) -> RoleMembership.in(tester.controller().system()).build();
+        RoleMembership.Resolver emptyResolver = (user, path) -> Role.everyone.limitedTo(tester.controller().system());
         ControllerAuthorizationFilter filter = createFilter(tester, emptyResolver);
         assertIsForbidden(invokeFilter(filter, createRequest(Method.POST, "/zone/v2/path", identity)));
         assertIsAllowed(invokeFilter(filter, createRequest(Method.PUT, "/application/v4/user", identity)));
@@ -61,7 +59,7 @@ public class ControllerAuthorizationFilterTest {
     public void unprivilegedInPublic() {
         ControllerTester tester = new ControllerTester();
         tester.zoneRegistry().setSystemName(SystemName.Public);
-        RoleMembership.Resolver emptyResolver = (user, path) -> RoleMembership.in(tester.controller().system()).build();
+        RoleMembership.Resolver emptyResolver = (user, path) -> Role.everyone.limitedTo(tester.controller().system());
         ControllerAuthorizationFilter filter = createFilter(tester, emptyResolver);
         assertIsForbidden(invokeFilter(filter, createRequest(Method.POST, "/zone/v2/path", identity)));
         assertIsForbidden(invokeFilter(filter, createRequest(Method.PUT, "/application/v4/user", identity)));


### PR DESCRIPTION
…tion for now)

@mpolden and @tokle please consider this. 

Never mind the implementation details for now — there are some `TODO`s to resolve before this could be merged.

Do mind the way a `Role` gets its `Context`, however. This way, you need to do stupid things to improperly limit a `Role`, like you could otherwise do with 
```java
return RoleMembership.in(system).add(Role.athenzTenantAdmin).build();
```
which is a role that _should_ have a `TenantName` context. 