### PR TITLE
Balder/allow multiple value types

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -1295,6 +1295,7 @@
     ],
     "methods": [
       "public final com.yahoo.tensor.TensorType$ValueType valueType()",
+      "public final com.yahoo.tensor.TensorType valueType(com.yahoo.tensor.TensorType$ValueType)",
       "public static com.yahoo.tensor.TensorType fromSpec(java.lang.String)",
       "public int rank()",
       "public java.util.List dimensions()",

--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -1162,8 +1162,11 @@
     ],
     "methods": [
       "public void <init>()",
+      "public void <init>(com.yahoo.tensor.TensorType$ValueType)",
       "public varargs void <init>(com.yahoo.tensor.TensorType[])",
+      "public varargs void <init>(com.yahoo.tensor.TensorType$ValueType, com.yahoo.tensor.TensorType[])",
       "public void <init>(java.lang.Iterable)",
+      "public void <init>(com.yahoo.tensor.TensorType$ValueType, java.lang.Iterable)",
       "public int rank()",
       "public com.yahoo.tensor.TensorType$Builder set(com.yahoo.tensor.TensorType$Dimension)",
       "public com.yahoo.tensor.TensorType$Builder indexed(java.lang.String, long)",

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
@@ -27,16 +27,17 @@ public class TensorType {
     public enum ValueType { DOUBLE, FLOAT};
 
     /** The empty tensor type - which is the same as a double */
-    public static final TensorType empty = new TensorType(Collections.emptyList());
+    public static final TensorType empty = new TensorType(ValueType.DOUBLE, Collections.emptyList());
 
-    private final ValueType valueType = ValueType.DOUBLE;
+    private final ValueType valueType;
 
     public final ValueType valueType() { return valueType; }
 
     /** Sorted list of the dimensions of this */
     private final ImmutableList<Dimension> dimensions;
 
-    private TensorType(Collection<Dimension> dimensions) {
+    private TensorType(ValueType valueType, Collection<Dimension> dimensions) {
+        this.valueType = valueType;
         List<Dimension> dimensionList = new ArrayList<>(dimensions);
         Collections.sort(dimensionList);
         this.dimensions = ImmutableList.copyOf(dimensionList);
@@ -379,8 +380,15 @@ public class TensorType {
 
         private final Map<String, Dimension> dimensions = new LinkedHashMap<>();
 
-        /** Creates an empty builder */
+        private final ValueType valueType;
+
+        /** Creates an empty builder with cells of type double*/
         public Builder() {
+            this(ValueType.DOUBLE);
+        }
+
+        public Builder(ValueType valueType) {
+            this.valueType = valueType;
         }
 
         /**
@@ -391,6 +399,10 @@ public class TensorType {
          * If it is indexed in one and mapped in the other it will become mapped.
          */
         public Builder(TensorType ... types) {
+            this(ValueType.DOUBLE, types);
+        }
+        public Builder(ValueType valueType, TensorType ... types) {
+            this.valueType = valueType;
             for (TensorType type : types)
                 addDimensionsOf(type);
         }
@@ -399,6 +411,10 @@ public class TensorType {
          * Creates a builder from the given dimensions.
          */
         public Builder(Iterable<Dimension> dimensions) {
+            this(ValueType.DOUBLE, dimensions);
+        }
+        public Builder(ValueType valueType, Iterable<Dimension> dimensions) {
+            this.valueType = valueType;
             for (TensorType.Dimension dimension : dimensions) {
                 dimension(dimension);
             }
@@ -497,7 +513,7 @@ public class TensorType {
         }
 
         public TensorType build() {
-            return new TensorType(dimensions.values());
+            return new TensorType(valueType, dimensions.values());
         }
 
     }

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
@@ -29,9 +29,15 @@ public class TensorType {
     /** The empty tensor type - which is the same as a double */
     public static final TensorType empty = new TensorType(ValueType.DOUBLE, Collections.emptyList());
 
-    private final ValueType valueType;
+    private ValueType valueType;
 
     public final ValueType valueType() { return valueType; }
+
+    //TODO Remove once value type is wired in were it should.
+    public final TensorType valueType(ValueType valueType) {
+        this.valueType = valueType;
+        return this;
+    }
 
     /** Sorted list of the dimensions of this */
     private final ImmutableList<Dimension> dimensions;

--- a/vespajlib/src/test/java/com/yahoo/tensor/serialization/DenseBinaryFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/serialization/DenseBinaryFormatTestCase.java
@@ -41,7 +41,7 @@ public class DenseBinaryFormatTestCase {
     }
 
     @Test
-    public void requireThatSerializationFormatDoNotChange() {
+    public void requireThatDefaultSerializationFormatDoNotChange() {
         byte[] encodedTensor = new byte[]{2, // binary format type
                                           2, // dimension count
                                           2, (byte) 'x', (byte) 'y', 2, // dimension xy with size
@@ -53,11 +53,31 @@ public class DenseBinaryFormatTestCase {
                      Arrays.toString(TypedBinaryFormat.encode(Tensor.from("tensor(xy[],z[]):{{xy:0,z:0}:2.0,{xy:1,z:0}:3.0}"))));
     }
 
-    private void assertSerialization(String tensorString) {
-        assertSerialization(Tensor.from(tensorString));
+    @Test
+    public void requireThatFloatSerializationFormatDoNotChange() {
+        byte[] encodedTensor = new byte[]{4, // binary format type
+                1, // float type
+                2, // dimension count
+                2, (byte) 'x', (byte) 'y', 2, // dimension xy with size
+                1, (byte) 'z', 1, // dimension z with size
+                64, 0, 0, 0, // value 1
+                64, 64, 0, 0,  // value 2
+        };
+        Tensor tensor = Tensor.from("tensor(xy[],z[]):{{xy:0,z:0}:2.0,{xy:1,z:0}:3.0}");
+        tensor.type().valueType(TensorType.ValueType.FLOAT);
+        assertEquals(Arrays.toString(encodedTensor),
+                Arrays.toString(TypedBinaryFormat.encode(tensor)));
     }
 
-    private void assertSerialization(Tensor tensor) {
+    private void assertSerialization(String tensorString) {
+        assertSerialization(TensorType.ValueType.DOUBLE, Tensor.from(tensorString));
+    }
+    private void assertSerialization(TensorType.ValueType valueType, String tensorString) {
+        assertSerialization(valueType, Tensor.from(tensorString));
+    }
+
+    private void assertSerialization(TensorType.ValueType valueType, Tensor tensor) {
+        tensor.type().valueType(valueType);
         assertSerialization(tensor, tensor.type());
     }
 


### PR DESCRIPTION
@bratseth Now it is complete. Serialization will now take valueType into account.
@lesters FYI

@bratseth I will leave the tensor interface for you so that we can allow different backing than array of double, and avoid conversion via double.