### PR TITLE
Use sort data with java dispatcher

### DIFF
--- a/container-search/src/main/java/com/yahoo/fs4/DocumentInfo.java
+++ b/container-search/src/main/java/com/yahoo/fs4/DocumentInfo.java
@@ -17,14 +17,20 @@ public class DocumentInfo implements Cloneable {
     private final double metric;
     private final int partId;
     private final int distributionKey;
+    private final byte[] sortData;
 
     DocumentInfo(ByteBuffer buffer, QueryResultPacket owner) {
+        this(buffer, owner, null);
+    }
+
+    DocumentInfo(ByteBuffer buffer, QueryResultPacket owner, byte[] sortData) {
         byte[] rawGid = new byte[GlobalId.LENGTH];
         buffer.get(rawGid);
         globalId = new GlobalId(rawGid);
         metric = decodeMetric(buffer);
         partId = owner.getMldFeature() ? buffer.getInt() : 0;
         distributionKey = owner.getMldFeature() ? buffer.getInt() : 0;
+        this.sortData = sortData;
     }
 
     public DocumentInfo(GlobalId globalId, int metric, int partId, int distributionKey) {
@@ -32,6 +38,7 @@ public class DocumentInfo implements Cloneable {
         this.metric = metric;
         this.partId = partId;
         this.distributionKey = distributionKey;
+        this.sortData = null;
     }
 
     private double decodeMetric(ByteBuffer buffer) {
@@ -48,6 +55,10 @@ public class DocumentInfo implements Cloneable {
 
     /** Unique key for the node this document resides on */
     public int getDistributionKey() { return distributionKey; }
+
+    public byte[] getSortData() {
+        return sortData;
+    }
 
     public String toString() {
         return "document info [globalId=" + globalId + ", metric=" + metric + "]";

--- a/container-search/src/main/java/com/yahoo/fs4/QueryPacket.java
+++ b/container-search/src/main/java/com/yahoo/fs4/QueryPacket.java
@@ -5,6 +5,7 @@ import com.yahoo.compress.IntegerCompressor;
 import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.search.Query;
+import com.yahoo.search.dispatch.Dispatcher;
 import com.yahoo.search.grouping.vespa.GroupingExecutor;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.searchlib.aggregation.Grouping;
@@ -176,18 +177,7 @@ public class QueryPacket extends Packet {
     private int getFlagInt() {
         int flags = getQueryFlags(query);
         queryPacketData.setQueryFlags(flags);
-
-        /*
-         * QFLAG_DROP_SORTDATA
-         * SORTDATA is a mangling of data from the attribute vectors
-         * which were used in the search which is byte comparable in
-         * such a way the comparing SORTDATA for two different hits
-         * will reproduce the order in which the data were returned when
-         * using sortspec.  For now we simply drop these. If they
-         * become necessary, QueryResultPacket must be
-         * updated to be able to read the sort data.
-         */
-        flags |= QFLAG_DROP_SORTDATA;
+        flags |= query.properties().getBoolean(Dispatcher.dispatchInternal, false) ? 0 : QFLAG_DROP_SORTDATA;
         return flags;
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
@@ -47,10 +47,8 @@ public class FS4SearchInvoker extends SearchInvoker implements ResponseMonitor<F
     protected void sendSearchRequest(Query query) throws IOException {
         log.finest("sending query packet");
 
-        var queryPacket = searcher.createQueryPacket(searcher.getServerId(), query);
-
         this.query = query;
-        this.queryPacket = queryPacket;
+        this.queryPacket = searcher.createQueryPacket(searcher.getServerId(), query);
 
         try {
             boolean couldSend = channel.sendPacket(queryPacket);

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FS4SearchInvoker.java
@@ -44,13 +44,10 @@ public class FS4SearchInvoker extends SearchInvoker implements ResponseMonitor<F
     }
 
     @Override
-    protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+    protected void sendSearchRequest(Query query) throws IOException {
         log.finest("sending query packet");
 
-        if (queryPacket == null) {
-            // query changed for subchannel
-            queryPacket = searcher.createQueryPacket(searcher.getServerId(), query);
-        }
+        var queryPacket = searcher.createQueryPacket(searcher.getServerId(), query);
 
         this.query = query;
         this.queryPacket = queryPacket;

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -142,11 +142,11 @@ public class FastSearcher extends VespaBackEndSearcher {
     }
 
     @Override
-    public Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+    public Result doSearch2(Query query, Execution execution) {
         if (dispatcher.searchCluster().groupSize() == 1)
             forceSinglePassGrouping(query);
         try(SearchInvoker invoker = getSearchInvoker(query)) {
-            Result result = invoker.search(query, queryPacket, execution);
+            Result result = invoker.search(query, execution);
 
             if (query.properties().getBoolean(Ranking.RANKFEATURES, false)) {
                 // There is currently no correct choice for which

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/SortDataHitSorter.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/SortDataHitSorter.java
@@ -1,0 +1,64 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.fastsearch;
+
+import com.yahoo.search.query.Sorting;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.result.HitGroup;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class SortDataHitSorter {
+    public static void sort(HitGroup hitGroup, List<Hit> hits) {
+        var sorting = hitGroup.getQuery().getRanking().getSorting();
+        var fallbackOrderer = hitGroup.getOrderer();
+        if (sorting == null || fallbackOrderer == null) {
+            return;
+        }
+        var fallbackComparator = fallbackOrderer.getComparator();
+        Collections.sort(hits, getComparator(sorting, fallbackComparator));
+    }
+
+    public static boolean isSortable(Hit hit, HitGroup hitGroup) {
+        if (hitGroup.getQuery() == null) {
+            return false;
+        }
+        if (hit instanceof FastHit) {
+            var fhit = (FastHit) hit;
+            return fhit.hasSortData(hitGroup.getQuery().getRanking().getSorting());
+        } else {
+            return false;
+        }
+    }
+
+    public static Comparator<Hit> getComparator(Sorting sorting, Comparator<Hit> fallback) {
+        if (fallback == null) {
+            return (left, right) -> compareTwo(left, right, sorting);
+        } else {
+            return (left, right) -> compareWithFallback(left, right, sorting, fallback);
+        }
+    }
+
+    private static int compareTwo(Hit left, Hit right, Sorting sorting) {
+        if (left == null || right == null || !(left instanceof FastHit) || !(right instanceof FastHit)) {
+            return 0;
+        }
+        FastHit fl = (FastHit) left;
+        FastHit fr = (FastHit) right;
+        return FastHit.compareSortData(fl, fr, sorting);
+    }
+
+    private static int compareWithFallback(Hit left, Hit right, Sorting sorting, Comparator<Hit> fallback) {
+        if (left == null || right == null || !(left instanceof FastHit) || !(right instanceof FastHit)) {
+            return fallback.compare(left, right);
+        }
+        FastHit fl = (FastHit) left;
+        FastHit fr = (FastHit) right;
+        if (fl.hasSortData(sorting) && fr.hasSortData(sorting)) {
+            return FastHit.compareSortData(fl, fr, sorting);
+        } else {
+            return fallback.compare(left, right);
+        }
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -45,7 +45,7 @@ public class Dispatcher extends AbstractComponent {
     private static final int MAX_GROUP_SELECTION_ATTEMPTS = 3;
 
     /** If enabled, this internal dispatcher will be preferred over fdispatch whenever possible */
-    private static final CompoundName dispatchInternal = new CompoundName("dispatch.internal");
+    public static final CompoundName dispatchInternal = new CompoundName("dispatch.internal");
 
     /** If enabled, search queries will use protobuf rpc */
     public static final CompoundName dispatchProtobuf = new CompoundName("dispatch.protobuf");
@@ -135,6 +135,8 @@ public class Dispatcher extends AbstractComponent {
             query.setOffset(0);
         }
         emitDispatchMetric(invoker);
+        query.properties().set(dispatchInternal, true);
+
         return invoker;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
@@ -93,7 +93,7 @@ public abstract class InvokerFactory {
         if (invokers.size() == 1 && failed == null) {
             return Optional.of(invokers.get(0));
         } else {
-            return Optional.of(new InterleavedSearchInvoker(invokers, searcher, searchCluster, failed));
+            return Optional.of(new InterleavedSearchInvoker(invokers, searchCluster, failed));
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchErrorInvoker.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.result.Coverage;
@@ -35,7 +34,7 @@ public class SearchErrorInvoker extends SearchInvoker {
     }
 
     @Override
-    protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+    protected void sendSearchRequest(Query query) throws IOException {
         this.query = query;
         if(monitor != null) {
             monitor.responseAvailable(this);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchInvoker.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.searchcluster.Node;
@@ -31,14 +30,14 @@ public abstract class SearchInvoker extends CloseableInvoker {
      * nodes, the provided {@link Execution} may be used to retrieve document summaries required
      * for correct result windowing.
      */
-    public Result search(Query query, QueryPacket queryPacket, Execution execution) throws IOException {
-        sendSearchRequest(query, queryPacket);
+    public Result search(Query query, Execution execution) throws IOException {
+        sendSearchRequest(query);
         Result result = getSearchResult(execution);
         setFinalStatus(result.hits().getError() == null);
         return result;
     }
 
-    protected abstract void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException;
+    protected abstract void sendSearchRequest(Query query) throws IOException;
 
     protected abstract Result getSearchResult(Execution execution) throws IOException;
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -181,13 +181,14 @@ public class ProtobufSerialization {
             result.hits().add(hit);
         }
 
+        var sorting = query.getRanking().getSorting();
         for (var replyHit : protobuf.getHitsList()) {
             FastHit hit = new FastHit();
             hit.setQuery(query);
 
             hit.setRelevance(new Relevance(replyHit.getRelevance()));
             hit.setGlobalId(new GlobalId(replyHit.getGlobalId().toByteArray()));
-
+            hit.setSortData(replyHit.getSortData().toByteArray(), sorting);
             hit.setFillable();
             hit.setCached(false);
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -3,7 +3,6 @@ package com.yahoo.search.dispatch.rpc;
 
 import com.yahoo.compress.CompressionType;
 import com.yahoo.compress.Compressor;
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.search.Query;
@@ -44,7 +43,7 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
     }
 
     @Override
-    protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+    protected void sendSearchRequest(Query query) throws IOException {
         this.query = query;
 
         CompressionType compression = CompressionType

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -1,19 +1,12 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.yahoo.document.DocumentId;
 import com.yahoo.document.idstring.IdString;
 import com.yahoo.document.select.parser.ParseException;
 import com.yahoo.document.select.parser.TokenMgrException;
 import com.yahoo.fs4.DocsumPacket;
 import com.yahoo.fs4.Packet;
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.log.LogLevel;
 import com.yahoo.messagebus.routing.Route;
 import com.yahoo.prelude.Ping;
@@ -22,9 +15,9 @@ import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.fastsearch.GroupingListHit;
 import com.yahoo.prelude.fastsearch.TimeoutException;
 import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
+import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
-import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.result.Relevance;
@@ -33,6 +26,12 @@ import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
 import com.yahoo.vdslib.VisitorStatistics;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * The searcher which forwards queries to storage nodes using visiting.
@@ -92,7 +91,7 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
     }
 
     @Override
-    public Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+    public Result doSearch2(Query query, Execution execution) {
         // TODO refactor this method into smaller methods, it's hard to see the actual code
         lazyTrace(query, 7, "Routing to storage cluster ", getStorageClusterRouteSpec());
 

--- a/container-search/src/test/java/com/yahoo/fs4/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/fs4/test/QueryTestCase.java
@@ -310,5 +310,4 @@ public class QueryTestCase {
     }
 
     public static final byte ignored = -128;
-
 }

--- a/container-search/src/test/java/com/yahoo/fs4/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/fs4/test/QueryTestCase.java
@@ -310,4 +310,5 @@ public class QueryTestCase {
     }
 
     public static final byte ignored = -128;
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
@@ -201,7 +201,7 @@ public class ClusterSearcherTestCase {
         }
 
         @Override
-        protected com.yahoo.search.Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+        protected com.yahoo.search.Result doSearch2(Query query, Execution execution) {
             return null; // search() is overriden, this should never be called
         }
 

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/FS4SearchInvokerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/FS4SearchInvokerTestCase.java
@@ -3,7 +3,6 @@
 package com.yahoo.prelude.fastsearch;
 
 import com.yahoo.fs4.BasicPacket;
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.fs4.mplex.FS4Channel;
 import com.yahoo.fs4.mplex.InvalidChannelException;
 import com.yahoo.search.Query;
@@ -31,10 +30,10 @@ public class FS4SearchInvokerTestCase {
         var searcher = mockSearcher();
         var cluster = new MockSearchCluster("?", 1, 1);
         var fs4invoker = new FS4SearchInvoker(searcher, query, mockFailingChannel(), Optional.empty());
-        var interleave = new InterleavedSearchInvoker(Collections.singleton(fs4invoker), searcher, cluster, null);
+        var interleave = new InterleavedSearchInvoker(Collections.singleton(fs4invoker), cluster, null);
 
         long start = System.currentTimeMillis();
-        interleave.search(query, QueryPacket.create(null, null), null);
+        interleave.search(query, null);
         long elapsed = System.currentTimeMillis() - start;
 
         assertThat("Connection error should fail fast", elapsed, Matchers.lessThan(500L));
@@ -43,7 +42,7 @@ public class FS4SearchInvokerTestCase {
     private static VespaBackEndSearcher mockSearcher() {
         return new VespaBackEndSearcher() {
             @Override
-            protected Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+            protected Result doSearch2(Query query, Execution execution) {
                 return null;
             }
 

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/PartialFillTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/PartialFillTestCase.java
@@ -3,7 +3,6 @@ package com.yahoo.prelude.fastsearch.test;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.component.chain.Chain;
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.language.simple.SimpleLinguistics;
 import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
@@ -32,7 +31,7 @@ public class PartialFillTestCase {
 
     public static class FS4 extends VespaBackEndSearcher {
         public List<Result> history = new ArrayList<>();
-        protected Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+        protected Result doSearch2(Query query, Execution execution) {
             return new Result(query);
         }
         protected void doPartialFill(Result result, String summaryClass) {
@@ -41,7 +40,7 @@ public class PartialFillTestCase {
     }
 
     public static class BadFS4 extends VespaBackEndSearcher {
-        protected Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+        protected Result doSearch2(Query query, Execution execution) {
             return new Result(query);
         }
         protected void doPartialFill(Result result, String summaryClass) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -49,7 +49,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(4900, 100, 1));
         expectedEvents.add(new Event(4800, 100, 2));
 
-        invoker.search(query, null, null);
+        invoker.search(query, null);
 
         assertTrue("All test scenario events processed", expectedEvents.isEmpty());
     }
@@ -63,7 +63,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(4700, 300, 1));
         expectedEvents.add(null);
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         assertTrue("All test scenario events processed", expectedEvents.isEmpty());
         assertNull("Result is not marked as an error", result.hits().getErrorHit());
@@ -82,7 +82,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(2400, 100, 2));
         expectedEvents.add(new Event(0, 0, null));
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         assertTrue("All test scenario events processed", expectedEvents.isEmpty());
         assertNull("Result is not marked as an error", result.hits().getErrorHit());
@@ -101,7 +101,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(null, 100, 0));
         expectedEvents.add(new Event(null, 200, 1));
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         Coverage cov = result.getCoverage(true);
         assertThat(cov.getDocs(), is(100000L));
@@ -122,7 +122,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(null, 100, 0));
         expectedEvents.add(new Event(null, 200, 1));
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         Coverage cov = result.getCoverage(true);
         assertThat(cov.getDocs(), is(23420L));
@@ -144,7 +144,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(null, 100, 0));
         expectedEvents.add(new Event(null, 200, 1));
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         Coverage cov = result.getCoverage(true);
         assertThat(cov.getDocs(), is(9900L));
@@ -166,7 +166,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(null, 100, 0));
         expectedEvents.add(null);
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         Coverage cov = result.getCoverage(true);
         assertThat(cov.getDocs(), is(50155L));
@@ -191,7 +191,7 @@ public class InterleavedSearchInvokerTest {
         expectedEvents.add(new Event(null,   1, 1));
         expectedEvents.add(new Event(null, 100, 0));
 
-        Result result = invoker.search(query, null, null);
+        Result result = invoker.search(query, null);
 
         Coverage cov = result.getCoverage(true);
         assertThat(cov.getDocs(), is(50155L));
@@ -209,7 +209,7 @@ public class InterleavedSearchInvokerTest {
             invokers.add(new MockInvoker(i));
         }
 
-        return new InterleavedSearchInvoker(invokers, null, searchCluster, null) {
+        return new InterleavedSearchInvoker(invokers, searchCluster, null) {
             @Override
             protected long currentTime() {
                 return clock.millis();

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockInvoker.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockInvoker.java
@@ -1,7 +1,6 @@
 // Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.searchcluster.Node;
@@ -25,7 +24,7 @@ class MockInvoker extends SearchInvoker {
     }
 
     @Override
-    protected void sendSearchRequest(Query query, QueryPacket queryPacket) throws IOException {
+    protected void sendSearchRequest(Query query) throws IOException {
         this.query = query;
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
@@ -5,7 +5,6 @@ package com.yahoo.search.dispatch.rpc;
 import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.compress.CompressionType;
-import com.yahoo.fs4.QueryPacket;
 import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.search.Query;
@@ -40,7 +39,7 @@ public class RpcSearchInvokerTest {
         var invoker = new RpcSearchInvoker(mockSearcher(), new Node(7, "seven", 77, 1), mockPool);
 
         Query q = new Query("search/?query=test&hits=10&offset=3");
-        invoker.sendSearchRequest(q, null);
+        invoker.sendSearchRequest(q);
 
         var bytes = mockPool.compressor().decompress(payloadHolder.get(), compressionTypeHolder.get(), lengthHolder.get());
         var request = SearchProtocol.SearchRequest.newBuilder().mergeFrom(bytes).build();
@@ -78,7 +77,7 @@ public class RpcSearchInvokerTest {
     private VespaBackEndSearcher mockSearcher() {
         return new VespaBackEndSearcher() {
             @Override
-            protected Result doSearch2(Query query, QueryPacket queryPacket, Execution execution) {
+            protected Result doSearch2(Query query, Execution execution) {
                 fail("Unexpected call");
                 return null;
             }

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcherTestCase.java
@@ -136,9 +136,8 @@ public class VdsStreamingSearcherTestCase {
     }
 
     private static Result executeQuery(VdsStreamingSearcher searcher, Query query) {
-        QueryPacket queryPacket = QueryPacket.create("container.0", query);
         Execution execution = new Execution(new Execution.Context(null, null, null, null, null));
-        return searcher.doSearch2(query, queryPacket, execution);
+        return searcher.doSearch2(query, execution);
     }
 
     private static Query[] generateTestQueries(String queryString) {


### PR DESCRIPTION
- `QueryPacket` removed from search interfaces since it's no longer used for caching and can be generated later (when the use/non-use of sort data is known)
- Request and process sort data from content nodes when using the java dispatcher
- Prefer sort data in `HitGroup` for sorting
- Sort data is tied to a specific `Sorting` in `FastHit` to avoid comparing apples to oranges
