### PR TITLE
Handle 'https' scheme in uri pattern matching as 'http'

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/application/UriPattern.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/application/UriPattern.java
@@ -65,7 +65,7 @@ public class UriPattern implements Comparable<UriPattern> {
         if (!matcher.find()) {
             throw new IllegalArgumentException(uri);
         }
-        scheme = GlobPattern.compile(resolvePatternComponent(matcher.group(1)));
+        scheme = GlobPattern.compile(normalizeScheme(resolvePatternComponent(matcher.group(1))));
         host = GlobPattern.compile(resolvePatternComponent(matcher.group(2)));
         port = resolvePortPattern(matcher.group(4));
         path = GlobPattern.compile(resolvePatternComponent(matcher.group(7)));
@@ -91,7 +91,7 @@ public class UriPattern implements Comparable<UriPattern> {
             return null;
         }
         // Match scheme before host because it has a higher chance of differing (e.g. http versus https)
-        GlobPattern.Match schemeMatch = scheme.match(resolveUriComponent(uri.getScheme()));
+        GlobPattern.Match schemeMatch = scheme.match(normalizeScheme(resolveUriComponent(uri.getScheme())));
         if (schemeMatch == null) {
             return null;
         }
@@ -170,6 +170,11 @@ public class UriPattern implements Comparable<UriPattern> {
             case "https": return 443;
             default: return -1;
         }
+    }
+
+    private static String normalizeScheme(String scheme) {
+        if (scheme.equals("https")) return "http"; // handle 'https' in bindings and uris as 'http'
+        return scheme;
     }
 
     /**

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/application/UriPatternTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/application/UriPatternTestCase.java
@@ -295,6 +295,15 @@ public class UriPatternTestCase {
         assertMatch(httpsPattern, "https://host/path", NO_GROUPS);
     }
 
+    @Test
+    public void requireThatHttpsSchemeIsHandledAsHttp() {
+        UriPattern httpPattern = new UriPattern("http://host:80/path");
+        assertMatch(httpPattern, "https://host:80/path", NO_GROUPS);
+
+        UriPattern httpsPattern = new UriPattern("https://host:443/path");
+        assertMatch(httpsPattern, "http://host:443/path", NO_GROUPS);
+    }
+
     private static void assertIllegalPattern(String uri) {
         try {
             new UriPattern(uri);


### PR DESCRIPTION
FYI @gjoranv 

Identical to #8991. The failing tests were not caused by this change.