### PR TITLE
Revert "Check logserver container for config convergence"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
-import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
 
 /**
@@ -44,12 +43,12 @@ import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER
 public class ConfigConvergenceChecker extends AbstractComponent {
 
     private static final ApplicationId routingApplicationId = ApplicationId.from("hosted-vespa", "routing", "default");
+    private static final String nodeAdminName = "node-admin";
     private static final String statePath = "/state/v1/";
     private static final String configSubPath = "config";
     private final static Set<String> serviceTypesToCheck = new HashSet<>(Arrays.asList(
             CONTAINER.serviceName,
             QRSERVER.serviceName,
-            LOGSERVER_CONTAINER.serviceName,
             "searchnode",
             "storagenode",
             "distributor"


### PR DESCRIPTION
Reverts vespa-engine/vespa#8986

Need to wait until applications are on a version where the logserver-container works