### PR TITLE
Apache httpclient must be included in compile scope

### DIFF
--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -19,12 +19,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional> <!-- Only needed for classes in com.yahoo.security.tls.https -->
-    </dependency>
 
     <!-- compile scope -->
     <dependency>
@@ -35,6 +29,16 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
The apache http libraries are not osgi bundles. Including them as
provided scope does not work as the required import-package statements
are not added to the jar manifest.