### PR TITLE
Optimizations for search protocol over jrt/protobuf

### DIFF
--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -40,6 +40,9 @@ minWaitAfterCoverageFactor double default=0
 # Maximum wait time for full coverage after minimum coverage is achieved, factored based on time left at minimum coverage
 maxWaitAfterCoverageFactor double default=1
 
+# Number of JRT connection supervisors
+numJrtSupervisors int default=8
+
 # The unique key of a search node
 node[].key int
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/Client.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/Client.java
@@ -2,8 +2,6 @@
 package com.yahoo.search.dispatch.rpc;
 
 import com.yahoo.compress.CompressionType;
-import com.yahoo.compress.Compressor;
-import com.yahoo.prelude.Pong;
 import com.yahoo.prelude.fastsearch.FastHit;
 
 import java.util.List;
@@ -15,14 +13,6 @@ import java.util.Optional;
  * @author bratseth
  */
 interface Client {
-
-    void getDocsums(List<FastHit> hits, NodeConnection node, CompressionType compression,
-                    int uncompressedLength, byte[] compressedSlime, RpcFillInvoker.GetDocsumsResponseReceiver responseReceiver,
-                    double timeoutSeconds);
-
-    void request(String rpcMethod, NodeConnection node, CompressionType compression, int uncompressedLength,
-            byte[] compressedPayload, ResponseReceiver responseReceiver, double timeoutSeconds);
-
     /** Creates a connection to a particular node in this */
     NodeConnection createConnection(String hostname, int port);
 
@@ -91,6 +81,11 @@ interface Client {
     }
 
     interface NodeConnection {
+        void getDocsums(List<FastHit> hits, CompressionType compression, int uncompressedLength, byte[] compressedSlime,
+                RpcFillInvoker.GetDocsumsResponseReceiver responseReceiver, double timeoutSeconds);
+
+        void request(String rpcMethod, CompressionType compression, int uncompressedLength, byte[] compressedPayload,
+                ResponseReceiver responseReceiver, double timeoutSeconds);
 
         /** Closes this connection */
         void close();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcPing.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcPing.java
@@ -52,12 +52,12 @@ public class RpcPing implements Callable<Pong> {
     }
 
     private void sendPing(LinkedBlockingQueue<ResponseOrError<ProtobufResponse>> queue) {
-        var connection = resourcePool.nodeConnections().get(node.key());
+        var connection = resourcePool.getConnection(node.key());
         var ping = SearchProtocol.MonitorRequest.newBuilder().build().toByteArray();
         double timeoutSeconds = ((double) clusterMonitor.getConfiguration().getRequestTimeout()) / 1000.0;
         Compressor.Compression compressionResult = resourcePool.compressor().compress(PING_COMPRESSION, ping);
-        resourcePool.client().request(RPC_METHOD, connection, compressionResult.type(), ping.length, compressionResult.data(),
-                rsp -> queue.add(rsp), timeoutSeconds);
+        connection.request(RPC_METHOD, compressionResult.type(), ping.length, compressionResult.data(), rsp -> queue.add(rsp),
+                timeoutSeconds);
     }
 
     private Pong decodeReply(ProtobufResponse response) throws InvalidProtocolBufferException {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -46,10 +46,7 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
     protected void sendSearchRequest(Query query) throws IOException {
         this.query = query;
 
-        CompressionType compression = CompressionType
-                .valueOf(query.properties().getString(RpcResourcePool.dispatchCompression, "LZ4").toUpperCase());
-
-        Client.NodeConnection nodeConnection = resourcePool.nodeConnections().get(node.key());
+        Client.NodeConnection nodeConnection = resourcePool.getConnection(node.key());
         if (nodeConnection == null) {
             responses.add(Client.ResponseOrError.fromError("Could not send search to unknown node " + node.key()));
             responseAvailable();
@@ -59,9 +56,8 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
 
         var payload = ProtobufSerialization.serializeSearchRequest(query, searcher.getServerId());
         double timeoutSeconds = ((double) query.getTimeLeft() - 3.0) / 1000.0;
-        Compressor.Compression compressionResult = resourcePool.compressor().compress(compression, payload);
-        resourcePool.client().request(RPC_METHOD, nodeConnection, compressionResult.type(), payload.length, compressionResult.data(), this,
-                timeoutSeconds);
+        Compressor.Compression compressionResult = resourcePool.compress(query, payload);
+        nodeConnection.request(RPC_METHOD, compressionResult.type(), payload.length, compressionResult.data(), this, timeoutSeconds);
     }
 
     @Override

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
@@ -154,7 +154,8 @@ public class FastSearcherTestCase {
             doFill(fastSearcher, result);
             ErrorMessage error = result.hits().getError();
             assertEquals("Since we don't actually run summary backends we get this error when the Dispatcher is used",
-                         "Error response from rpc node connection to host1:0: Connection error", error.getDetailedMessage());
+                         "Error response from rpc node connection to hostX:0: Connection error",
+                         error.getDetailedMessage().replaceAll("host[12]", "hostX"));
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/FillTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/FillTestCase.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-
 /**
  * Tests using a dispatcher to fill a result
  *
@@ -38,7 +37,7 @@ public class FillTestCase {
         nodes.put(0, client.createConnection("host0", 123));
         nodes.put(1, client.createConnection("host1", 123));
         nodes.put(2, client.createConnection("host2", 123));
-        RpcResourcePool rpcResourcePool = new RpcResourcePool(client, nodes);
+        RpcResourcePool rpcResourcePool = new RpcResourcePool(nodes);
         RpcInvokerFactory factory = new RpcInvokerFactory(rpcResourcePool, null, true);
 
         Query query = new Query();
@@ -75,7 +74,7 @@ public class FillTestCase {
         nodes.put(0, client.createConnection("host0", 123));
         nodes.put(1, client.createConnection("host1", 123));
         nodes.put(2, client.createConnection("host2", 123));
-        RpcResourcePool rpcResourcePool = new RpcResourcePool(client, nodes);
+        RpcResourcePool rpcResourcePool = new RpcResourcePool(nodes);
         RpcInvokerFactory factory = new RpcInvokerFactory(rpcResourcePool, null, true);
 
         Query query = new Query();
@@ -90,7 +89,7 @@ public class FillTestCase {
         client.setDocsumReponse("host2", 1, "summaryClass1", map("field1", "s.2.1", "field2", 1));
         client.setDocsumReponse("host1", 2, "summaryClass1", new HashMap<>());
         client.setDocsumReponse("host2", 3, "summaryClass1", map("field1", "s.2.3", "field2", 3));
-        client.setDocsumReponse("host0", 4, "summaryClass1",new HashMap<>());
+        client.setDocsumReponse("host0", 4, "summaryClass1", new HashMap<>());
 
         factory.createFillInvoker(db()).fill(result, "summaryClass1");
 
@@ -115,7 +114,7 @@ public class FillTestCase {
 
         Map<Integer, Client.NodeConnection> nodes = new HashMap<>();
         nodes.put(0, client.createConnection("host0", 123));
-        RpcResourcePool rpcResourcePool = new RpcResourcePool(client, nodes);
+        RpcResourcePool rpcResourcePool = new RpcResourcePool(nodes);
         RpcInvokerFactory factory = new RpcInvokerFactory(rpcResourcePool, null, true);
 
         Query query = new Query();
@@ -133,14 +132,13 @@ public class FillTestCase {
 
         Map<Integer, Client.NodeConnection> nodes = new HashMap<>();
         nodes.put(0, client.createConnection("host0", 123));
-        RpcResourcePool rpcResourcePool = new RpcResourcePool(client, nodes);
+        RpcResourcePool rpcResourcePool = new RpcResourcePool(nodes);
         RpcInvokerFactory factory = new RpcInvokerFactory(rpcResourcePool, null, true);
 
         Query query = new Query();
         Result result = new Result(query);
         result.hits().add(createHit(0, 0));
         result.hits().add(createHit(1, 1));
-
 
         factory.createFillInvoker(db()).fill(result, "summaryClass1");
 
@@ -151,8 +149,7 @@ public class FillTestCase {
         List<DocsumField> fields = new ArrayList<>();
         fields.add(DocsumField.create("field1", "string"));
         fields.add(DocsumField.create("field2", "int64"));
-        DocsumDefinitionSet docsums = new DocsumDefinitionSet(Collections.singleton(new DocsumDefinition("summaryClass1",
-                                                                                                         fields)));
+        DocsumDefinitionSet docsums = new DocsumDefinitionSet(Collections.singleton(new DocsumDefinition("summaryClass1", fields)));
         return new DocumentDatabase("default", docsums, Collections.emptySet());
     }
 


### PR DESCRIPTION
Two changes (and code shuffling to make them easier):
1. Parallel JRT Supervisors -- the default 8 is copied from the equivalent in FS4ResourcePool/FS4Config
1. Use faster compression level for LZ4
