### PR TITLE
Limit number of persistence threads that can process merges in parallel

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.cpp
@@ -6,14 +6,14 @@ namespace storage {
 
 FileStorHandler::FileStorHandler(MessageSender& sender, FileStorMetrics& metrics,
                                  const spi::PartitionStateList& partitions, ServiceLayerComponentRegister& compReg)
-        : _impl(new FileStorHandlerImpl(1, sender, metrics, partitions, compReg))
+        : _impl(new FileStorHandlerImpl(1, 1, sender, metrics, partitions, compReg))
 {
 }
 
 
-FileStorHandler::FileStorHandler(uint32_t numStripes, MessageSender& sender, FileStorMetrics& metrics,
+FileStorHandler::FileStorHandler(uint32_t numThreads, uint32_t numStripes, MessageSender& sender, FileStorMetrics& metrics,
                                  const spi::PartitionStateList& partitions, ServiceLayerComponentRegister& compReg)
-    : _impl(new FileStorHandlerImpl(numStripes, sender, metrics, partitions, compReg))
+    : _impl(new FileStorHandlerImpl(numThreads, numStripes, sender, metrics, partitions, compReg))
 {
 }
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -71,7 +71,7 @@ public:
         CLOSED
     };
 
-    FileStorHandler(uint32_t numStripes, MessageSender&, FileStorMetrics&,
+    FileStorHandler(uint32_t numThreads, uint32_t numStripes, MessageSender&, FileStorMetrics&,
                     const spi::PartitionStateList&, ServiceLayerComponentRegister&);
     FileStorHandler(MessageSender&, FileStorMetrics&,
                     const spi::PartitionStateList&, ServiceLayerComponentRegister&);

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -115,6 +115,9 @@ public:
         void release(const document::Bucket & bucket, api::LockingRequirements reqOfReleasedLock,
                      api::StorageMessage::Id lockMsgId);
 
+        // Subsumes isLocked
+        bool operationIsInhibited(const vespalib::MonitorGuard&, const document::Bucket&,
+                                  const api::StorageMessage&) const noexcept;
         bool isLocked(const vespalib::MonitorGuard &, const document::Bucket&,
                       api::LockingRequirements lockReq) const noexcept;
 
@@ -230,7 +233,7 @@ public:
         api::LockingRequirements _lockReq;
     };
 
-    FileStorHandlerImpl(uint32_t numStripes, MessageSender&, FileStorMetrics&,
+    FileStorHandlerImpl(uint32_t numThreads, uint32_t numStripes, MessageSender&, FileStorMetrics&,
                         const spi::PartitionStateList&, ServiceLayerComponentRegister&);
 
     ~FileStorHandlerImpl();
@@ -293,6 +296,8 @@ private:
 
     uint32_t _getNextMessageTimeout;
 
+    uint32_t _activeMergesSoftLimit;
+    mutable std::atomic<uint32_t> _activeMerges;
     vespalib::Monitor _pauseMonitor;
     std::atomic<bool> _paused;
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -108,7 +108,7 @@ FileStorManager::configure(std::unique_ptr<vespa::config::content::StorFilestorC
         size_t numStripes = std::min(2ul, numThreads);
         _metrics->initDiskMetrics(_disks.size(), _component.getLoadTypes()->getMetricLoadTypes(), numStripes, numThreads);
 
-        _filestorHandler.reset(new FileStorHandler(numStripes, *this, *_metrics, _partitions, _compReg));
+        _filestorHandler.reset(new FileStorHandler(numThreads, numStripes, *this, *_metrics, _partitions, _compReg));
         for (uint32_t i=0; i<_component.getDiskCount(); ++i) {
             if (_partitions[i].isUp()) {
                 LOG(spam, "Setting up disk %u", i);


### PR DESCRIPTION
@baldersheim please review

Avoids starving other operations when there is a lot of merge activity taking place.
For now, 1/2 of the total persistence thread pool may process merges.