### PR TITLE
Remove controller-api from configserver-app

### DIFF
--- a/controller-api/CMakeLists.txt
+++ b/controller-api/CMakeLists.txt
@@ -1,1 +1,0 @@
-install_configserver_component(controller-api)


### PR DESCRIPTION
Note: As it were, controller-api was not mentioned in the root-level
CMakeLists.txt, and were therefore not installed.