### PR TITLE
Enable rpc protocol

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -149,6 +149,7 @@ public class Admin extends AbstractConfigProducer implements Serializable {
         else {
             builder.
                 logserver(new LogdConfig.Logserver.Builder().
+                        userpc(true).
                         use(logServerContainerCluster.isPresent() || !isHostedVespa).
                         host(logserver.getHostName()).
                         rpcport(logserver.getRelativePort(0)).


### PR DESCRIPTION
The config definition cannot be changed as it will impact older Vespa
versions (for configservers with multiple config models).

FYI @geirst @toregge 