### PR TITLE
Add missing DNS record types

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/Record.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/Record.java
@@ -50,7 +50,10 @@ public class Record implements Comparable<Record> {
         PTR,
         SOA,
         SRV,
-        TXT
+        TXT,
+        SPF,
+        NAPTR,
+        CAA,
     }
 
     @Override


### PR DESCRIPTION
Noticed that we don't handle certain record types, which causes DnsMaintainer to
occassionally fail.