### PR TITLE
Make QueryTree.and public.

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5066,6 +5066,7 @@
       "public void addItem(com.yahoo.prelude.query.Item)",
       "public void addItem(int, com.yahoo.prelude.query.Item)",
       "public boolean isEmpty()",
+      "public com.yahoo.prelude.query.Item and(com.yahoo.prelude.query.Item)",
       "public static java.util.List getPositiveTerms(com.yahoo.prelude.query.Item)",
       "public bridge synthetic com.yahoo.prelude.query.CompositeItem clone()",
       "public bridge synthetic com.yahoo.prelude.query.Item clone()",

--- a/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
@@ -108,9 +108,12 @@ public class QueryTree extends CompositeItem {
 
     // -------------- Facade
 
-    /** Modifies this query to become the current query AND the given item */
-    // TODO: Make sure this is complete, unit test and make it public
-    private void and(Item item) {
+    /**
+     * Modifies this query to become the current query AND the given item.
+     *
+     * @return the resulting root item in this
+     */
+    public Item and(Item item) {
         if (isEmpty()) {
             setRoot(item);
         }
@@ -126,12 +129,16 @@ public class QueryTree extends CompositeItem {
             notItem.addPositiveItem(getRoot());
             setRoot(notItem);
         }
+        else if (getRoot() instanceof AndItem) {
+            ((AndItem) getRoot()).addItem(item);
+        }
         else {
             AndItem andItem = new AndItem();
             andItem.addItem(getRoot());
             andItem.addItem(item);
             setRoot(andItem);
         }
+        return getRoot();
     }
 
     /** Returns a flattened list of all positive query terms under the given item */

--- a/container-search/src/main/java/com/yahoo/search/querytransform/BooleanSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/BooleanSearcher.java
@@ -20,7 +20,8 @@ import static com.yahoo.yolean.Exceptions.toMessageString;
 
 /**
  * Searcher that builds a PredicateItem from the &amp;boolean properties and inserts it into a query.
- * @author <a href="mailto:magnarn@yahoo-inc.com">Magnar Nedland</a>
+ *
+ * @author Magnar Nedland
  */
 @After({ STEMMING, ACCENT_REMOVAL })
 @Provides(BooleanSearcher.PREDICATE)
@@ -74,7 +75,7 @@ public class BooleanSearcher extends Searcher {
         item.setIndexName(fieldName);
         new PredicateValueAttributeParser(item).parse(attributes);
         new PredicateRangeAttributeParser(item).parse(rangeAttributes);
-        QueryTreeUtil.andQueryItemWithRoot(query, item);
+        query.getModel().getQueryTree().and(item);
     }
 
     static public class PredicateValueAttributeParser extends BooleanAttributeParser {

--- a/container-search/src/main/java/com/yahoo/search/querytransform/QueryTreeUtil.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/QueryTreeUtil.java
@@ -3,6 +3,7 @@ package com.yahoo.search.querytransform;
 
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.QueryCanonicalizer;
 import com.yahoo.search.Query;
 import com.yahoo.search.query.QueryTree;
 
@@ -10,27 +11,27 @@ import com.yahoo.search.query.QueryTree;
  * Utility class for manipulating a QueryTree.
  *
  * @author geirst
+ * @deprecated use QueryTree.and instead // TODO: Remove on Vespa 8
  */
+@Deprecated
 public class QueryTreeUtil {
 
-    static public void andQueryItemWithRoot(Query query, Item item) {
-        andQueryItemWithRoot(query.getModel().getQueryTree(), item);
+    /**
+     * Adds the given item to this query
+     *
+     * @return the new root of the query tree
+     */
+    static public Item andQueryItemWithRoot(Query query, Item item) {
+        return andQueryItemWithRoot(query.getModel().getQueryTree(), item);
     }
 
-    static public void andQueryItemWithRoot(QueryTree tree, Item item) {
-        if (tree.isEmpty()) {
-            tree.setRoot(item);
-        } else {
-            Item oldRoot = tree.getRoot();
-            if (oldRoot.getClass() == AndItem.class) {
-                ((AndItem) oldRoot).addItem(item);
-            } else {
-                AndItem newRoot = new AndItem();
-                newRoot.addItem(oldRoot);
-                newRoot.addItem(item);
-                tree.setRoot(newRoot);
-            }
-        }
+    /**
+     * Adds the given item to this query
+     *
+     * @return the new root of the query tree
+     */
+    static public Item andQueryItemWithRoot(QueryTree tree, Item item) {
+        return tree.and(item);
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WandSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WandSearcher.java
@@ -15,7 +15,6 @@ import com.yahoo.text.MapParser;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static com.yahoo.container.protect.Error.UNSPECIFIED;
 import com.yahoo.yolean.Exceptions;
 
 /**
@@ -147,7 +146,7 @@ public class WandSearcher extends Searcher {
             InputResolver inputs = new InputResolver(query, execution);
             if ( ! inputs.hasValidData()) return execution.search(query);
 
-            QueryTreeUtil.andQueryItemWithRoot(query, createWandQueryItem(inputs));
+            query.getModel().getQueryTree().and(createWandQueryItem(inputs));
             query.trace("WandSearcher: Added WAND operator", true, 4);
             return execution.search(query);
         }

--- a/container-search/src/test/java/com/yahoo/search/query/QueryTreeTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/QueryTreeTest.java
@@ -1,0 +1,26 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.query;
+
+import com.yahoo.prelude.query.NotItem;
+import com.yahoo.prelude.query.WordItem;
+import org.junit.Assert;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author bratseth
+ */
+public class QueryTreeTest {
+
+    @Test
+    public void testAddQueryItemWithRoot() {
+        Assert.assertEquals("AND a b",
+                            new QueryTree(new WordItem("a")).and(new WordItem("b")).toString());
+
+        NotItem not = new NotItem();
+        not.addNegativeItem(new WordItem("b"));
+        assertEquals("+a -b",
+                     new QueryTree(new WordItem("a")).and(not).toString());
+     }
+
+}

--- a/container-search/src/test/java/com/yahoo/search/querytransform/TestUtils.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/TestUtils.java
@@ -6,7 +6,9 @@ import com.yahoo.prelude.query.Item;
 import com.yahoo.search.Result;
 
 public class TestUtils {
+
     public static Item getQueryTreeRoot(Result result) {
         return result.getQuery().getModel().getQueryTree().getRoot();
     }
+
 }

--- a/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/fieldmatch/FieldMatchMetrics.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/fieldmatch/FieldMatchMetrics.java
@@ -19,9 +19,9 @@ public final class FieldMatchMetrics implements Cloneable {
     private FieldMatchMetricsComputer source;
 
     /** The trace accumulated during execution - empty if no tracing */
-    private final Trace trace=new Trace();
+    private final Trace trace = new Trace();
 
-    private boolean complete=false;
+    private boolean complete;
 
     // Metrics
     private int outOfOrder;
@@ -352,7 +352,7 @@ public final class FieldMatchMetrics implements Cloneable {
      * </p>
      *
      *
-     * <p>Weight and significance are not taken into account because this is mean to capture tha quality of the
+     * <p>Weight and significance are not taken into account because this is meant to capture tha quality of the
      * match in this field, while those measures relate this match to matches in other fields. This number
      * can be multiplied with those values when combining with other field match scores.</p>
      */

--- a/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/fieldmatch/FieldMatchMetricsComputer.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/fieldmatch/FieldMatchMetricsComputer.java
@@ -136,7 +136,7 @@ public final class FieldMatchMetricsComputer {
 
         // Explore segmentations
         while (segmentStartPoint!=null) {
-            metrics =segmentStartPoint.getMetrics().clone();
+            metrics = segmentStartPoint.getMetrics().clone();
             if (collectTrace)
                 metrics.trace().add("\nLooking for segment from " + segmentStartPoint + "..." + "\n");
             boolean found=findAlternativeSegmentFrom(segmentStartPoint);
@@ -148,7 +148,7 @@ public final class FieldMatchMetricsComputer {
             segmentStartPoint=findOpenSegment(segmentStartPoint.getI());
         }
 
-        metrics=findLastStartPoint().getMetrics(); // these metrics are the final set
+        metrics = findLastStartPoint().getMetrics(); // these metrics are the final set
         setOccurrenceCounts(metrics);
         metrics.onComplete();
         metrics.setComplete(true);


### PR DESCRIPTION
- Make QueryTree.and public as it handles more cases than most alternatives
- Implement QueryTreeUtils methodas by calling QueryTree.and
- Deprecate QueryTreeUtils