### PR TITLE
Revert "Fix scripts to use correct binary name"

### DIFF
--- a/zkfacade/src/main/sh/zkcat
+++ b/zkfacade/src/main/sh/zkcat
@@ -70,4 +70,4 @@ findhost
 
 # END environment bootstrap section
 
-$VESPA_HOME/bin/vespa-zkctl get $@
+$VESPA_HOME/bin/zkctl get $@

--- a/zkfacade/src/main/sh/zkctl
+++ b/zkfacade/src/main/sh/zkctl
@@ -71,4 +71,4 @@ findhost
 # END environment bootstrap section
 
 # Get rid of the interactive zkcli prompt by running it in a subshell
-(echo "$@" | $VESPA_HOME/bin/vespa-zkcli)
+(echo "$@" | $VESPA_HOME/bin/zkcli)

--- a/zkfacade/src/main/sh/zkls
+++ b/zkfacade/src/main/sh/zkls
@@ -70,4 +70,4 @@ findhost
 
 # END environment bootstrap section
 
-$VESPA_HOME/bin/vespa-zkctl ls $@
+$VESPA_HOME/bin/zkctl ls $@


### PR DESCRIPTION
Reverts vespa-engine/vespa#9089

Different binaries in RPM and in yinst package, need to fix that first