### PR TITLE
Upgrade Jetty to 9.4.16

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ConfigserverSslContextFactoryProvider.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/ConfigserverSslContextFactoryProvider.java
@@ -109,7 +109,7 @@ public class ConfigserverSslContextFactoryProvider extends AbstractComponent imp
                                                                  AthenzService configserverIdentity,
                                                                  ZtsClient ztsClient,
                                                                  AthenzProviderServiceConfig.Zones zoneConfig) {
-        SslContextFactory factory = new SslContextFactory();
+        SslContextFactory.Server factory = new SslContextFactory.Server();
 
         factory.setWantClientAuth(true);
 

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -452,7 +452,7 @@
         <guava.version>20.0</guava.version>
         <guice.version>3.0</guice.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.15.v20190215</jetty.version>
+        <jetty.version>9.4.16.v20190411</jetty.version>
         <slf4j.version>1.7.5</slf4j.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/tls/ControllerSslContextFactoryProvider.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/tls/ControllerSslContextFactoryProvider.java
@@ -56,7 +56,7 @@ public class ControllerSslContextFactoryProvider extends AbstractComponent imple
 
     /** Create a SslContextFactory backed by an in-memory key and trust store */
     private SslContextFactory createSslContextFactory(int port) {
-        SslContextFactory factory = new SslContextFactory();
+        SslContextFactory.Server factory = new SslContextFactory.Server();
         if (port != 443) {
             factory.setWantClientAuth(true);
         }

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/ConfiguredSslContextFactoryProvider.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/ConfiguredSslContextFactoryProvider.java
@@ -37,7 +37,7 @@ public class ConfiguredSslContextFactoryProvider implements SslContextFactoryPro
     public SslContextFactory getInstance(String containerId, int port) {
         ConnectorConfig.Ssl sslConfig = connectorConfig.ssl();
         if (!sslConfig.enabled()) throw new IllegalStateException();
-        SslContextFactory factory = new JDiscSslContextFactory();
+        SslContextFactory.Server factory = new JDiscSslContextFactory();
 
         switch (sslConfig.clientAuth()) {
             case NEED_AUTH:

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/JDiscSslContextFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/JDiscSslContextFactory.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  *
  * @author bjorncs
  */
-class JDiscSslContextFactory extends SslContextFactory {
+class JDiscSslContextFactory extends SslContextFactory.Server {
 
     private String trustStorePassword;
 

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/TlsContextManagedSslContextFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/ssl/impl/TlsContextManagedSslContextFactory.java
@@ -13,7 +13,7 @@ import java.net.InetSocketAddress;
  *
  * @author bjorncs
  */
-class TlsContextManagedSslContextFactory extends SslContextFactory {
+class TlsContextManagedSslContextFactory extends SslContextFactory.Server {
 
     private final TlsContext tlsContext;
 


### PR DESCRIPTION
Use Server subclass as default constructor of SslContextFactory and some
methods are marked as deprecated.