### PR TITLE
Upgrade confighost before config

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -1,16 +1,14 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.application;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.ServiceConvergence;
-import com.yahoo.config.provision.zone.ZoneId;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,7 +22,7 @@ public enum SystemApplication {
 
     configServerHost(ApplicationId.from("hosted-vespa", "configserver-host", "default"), NodeType.confighost),
     proxyHost(ApplicationId.from("hosted-vespa", "proxy-host", "default"), NodeType.proxyhost),
-    configServer(ApplicationId.from("hosted-vespa", "zone-config-servers", "default"), NodeType.config),
+    configServer(ApplicationId.from("hosted-vespa", "zone-config-servers", "default"), NodeType.config, configServerHost),
     zone(ApplicationId.from("hosted-vespa", "routing", "default"), ImmutableSet.of(NodeType.proxy, NodeType.host),
          configServerHost, proxyHost, configServer);
 
@@ -33,7 +31,7 @@ public enum SystemApplication {
     private final List<SystemApplication> dependencies;
 
     SystemApplication(ApplicationId id, NodeType nodeType, SystemApplication... dependencies) {
-        this(id, Collections.singleton(nodeType), dependencies);
+        this(id, Set.of(nodeType), dependencies);
     }
 
     SystemApplication(ApplicationId id, Set<NodeType> nodeTypes, SystemApplication... dependencies) {
@@ -42,7 +40,7 @@ public enum SystemApplication {
         }
         this.id = id;
         this.nodeTypes = ImmutableSet.copyOf(nodeTypes);
-        this.dependencies = ImmutableList.copyOf(dependencies);
+        this.dependencies = List.of(dependencies);
     }
 
     public ApplicationId id() {
@@ -79,7 +77,7 @@ public enum SystemApplication {
 
     /** All known system applications */
     public static List<SystemApplication> all() {
-        return ImmutableList.copyOf(values());
+        return List.of(values());
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -1,15 +1,15 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
-import com.google.common.collect.ImmutableSet;
 import com.yahoo.component.Version;
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -23,7 +23,7 @@ public class SystemUpgrader extends InfrastructureUpgrader {
 
     private static final Logger log = Logger.getLogger(SystemUpgrader.class.getName());
 
-    private static final Set<Node.State> upgradableNodeStates = ImmutableSet.of(Node.State.active, Node.State.reserved);
+    private static final Set<Node.State> upgradableNodeStates = EnumSet.of(Node.State.active, Node.State.reserved);
 
     public SystemUpgrader(Controller controller, Duration interval, JobControl jobControl) {
         super(controller, interval, jobControl, controller.zoneRegistry().upgradePolicy(), null);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
@@ -2,9 +2,9 @@
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
-import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.config.provision.zone.UpgradePolicy;
 import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryMock;
@@ -195,10 +195,11 @@ public class SystemUpgraderTest {
 
         // System upgrades in zone 1:
         systemUpgrader.maintain();
-        List<SystemApplication> allExceptZone = List.of(SystemApplication.configServerHost,
-                                                              SystemApplication.proxyHost,
-                                                              SystemApplication.configServer);
-        completeUpgrade(allExceptZone, version2, zone1);
+        List<SystemApplication> allExceptZoneAndConfig = List.of(SystemApplication.configServerHost,
+                                                                 SystemApplication.proxyHost);
+        completeUpgrade(allExceptZoneAndConfig, version2, zone1);
+        systemUpgrader.maintain();
+        completeUpgrade(SystemApplication.configServer, version2, zone1);
         systemUpgrader.maintain();
         completeUpgrade(SystemApplication.zone, version2, zone1);
         convergeServices(SystemApplication.zone, zone1);
@@ -206,7 +207,9 @@ public class SystemUpgraderTest {
 
         // zone 2 and 3:
         systemUpgrader.maintain();
-        completeUpgrade(allExceptZone, version2, zone2, zone3);
+        completeUpgrade(allExceptZoneAndConfig, version2, zone2, zone3);
+        systemUpgrader.maintain();
+        completeUpgrade(SystemApplication.configServer, version2, zone2, zone3);
         systemUpgrader.maintain();
         completeUpgrade(SystemApplication.zone, version2, zone2, zone3);
         convergeServices(SystemApplication.zone, zone2, zone3);
@@ -214,7 +217,9 @@ public class SystemUpgraderTest {
 
         // zone 4:
         systemUpgrader.maintain();
-        completeUpgrade(allExceptZone, version2, zone4);
+        completeUpgrade(allExceptZoneAndConfig, version2, zone4);
+        systemUpgrader.maintain();
+        completeUpgrade(SystemApplication.configServer, version2, zone4);
         systemUpgrader.maintain();
         completeUpgrade(SystemApplication.zone, version2, zone4);
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -1,16 +1,14 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi.os;
 
-
-import com.google.common.collect.ImmutableList;
 import com.yahoo.application.container.handler.Request;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.UpgradePolicy;
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.athenz.api.AthenzIdentity;
 import com.yahoo.vespa.athenz.api.AthenzUser;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
-import com.yahoo.config.provision.zone.UpgradePolicy;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerMock;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryMock;
@@ -55,7 +53,7 @@ public class OsApiTest extends ControllerContainerTest {
                           .setZones(zone1, zone2, zone3)
                           .setOsUpgradePolicy(cloud1, UpgradePolicy.create().upgrade(zone1).upgrade(zone2))
                           .setOsUpgradePolicy(cloud2, UpgradePolicy.create().upgrade(zone3));
-        osUpgraders = ImmutableList.of(
+        osUpgraders = List.of(
                 new OsUpgrader(tester.controller(), Duration.ofDays(1),
                                new JobControl(tester.controller().curator()),
                                cloud1),


### PR DESCRIPTION
Host-admin will now write all config server config when creating the container (previously config files were included in the image), this means that the host must be upgraded before we start the container.