### PR TITLE
Fix suboptimal test bootstrapping

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -13,7 +13,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * This represents a system-level application in hosted Vespa. E.g. the zone-application.
+ * This represents a system-level application in hosted Vespa. All infrastructure nodes in a hosted Vespa zones are
+ * allocated to a system application.
  *
  * @author mpolden
  */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.application;
 
-import com.google.common.collect.ImmutableSet;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -23,7 +22,7 @@ public enum SystemApplication {
     configServerHost(ApplicationId.from("hosted-vespa", "configserver-host", "default"), NodeType.confighost),
     proxyHost(ApplicationId.from("hosted-vespa", "proxy-host", "default"), NodeType.proxyhost),
     configServer(ApplicationId.from("hosted-vespa", "zone-config-servers", "default"), NodeType.config, configServerHost),
-    zone(ApplicationId.from("hosted-vespa", "routing", "default"), ImmutableSet.of(NodeType.proxy, NodeType.host),
+    zone(ApplicationId.from("hosted-vespa", "routing", "default"), Set.of(NodeType.proxy, NodeType.host),
          configServerHost, proxyHost, configServer);
 
     private final ApplicationId id;
@@ -39,7 +38,7 @@ public enum SystemApplication {
             throw new IllegalArgumentException("Node types must be non-empty");
         }
         this.id = id;
-        this.nodeTypes = ImmutableSet.copyOf(nodeTypes);
+        this.nodeTypes = Set.copyOf(nodeTypes);
         this.dependencies = List.of(dependencies);
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -102,11 +102,17 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
     public void addNodes(List<ZoneId> zones, List<SystemApplication> applications, Optional<NodeType> type) {
         for (ZoneId zone : zones) {
             for (SystemApplication application : applications) {
+                NodeType nodeType = type.orElseGet(() -> {
+                    // Zone application has two node types. Use proxy
+                    if (application == SystemApplication.zone) return NodeType.proxy;
+                    if (application.nodeTypes().size() != 1) throw new IllegalArgumentException(application + " has several node types. Unable to detect type automatically");
+                    return application.nodeTypes().iterator().next();
+                });
                 List<Node> nodes = IntStream.rangeClosed(1, 3)
                                             .mapToObj(i -> new Node(
                                                     HostName.from("node-" + i + "-" + application.id().application()
                                                                                                  .value()),
-                                                    Node.State.active, type.orElseGet(() -> application.nodeTypes().iterator().next()),
+                                                    Node.State.active, nodeType,
                                                     Optional.of(application.id()),
                                                     initialVersion,
                                                     initialVersion


### PR DESCRIPTION
Problem was that the mock tries to guess the node type of zone application by
picking the first element of a `Set` iterator, which is stable for
`ImmutableSet`, but not for `Set`.