### PR TITLE
Temporarily set explicit version of maven-dependency-analyzer

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -122,6 +122,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.1</version>
+                    <dependencies>
+                      <!-- TODO: Remove when upgrading to 3.1.2 -->
+                      <dependency>
+                        <groupId>org.apache.maven.shared</groupId>
+                        <artifactId>maven-dependency-analyzer</artifactId>
+                        <version>1.11.1</version>
+                      </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- to allow running 'mvn dependency:analyze' with JDK 11.