### PR TITLE
Revert "Separate user and system exceptions"

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
@@ -52,7 +52,7 @@ public class JsonFeedReader implements FeedReader {
         } else if (documentOperation instanceof DocumentPut) {
             return new DocumentFeedOperation(((DocumentPut) documentOperation).getDocument(), documentOperation.getCondition());
         } else {
-            throw new IllegalArgumentException("Got unknown class from JSON reader: " + documentOperation.getClass().getName());
+            throw new IllegalStateException("Got unknown class from JSON reader: " + documentOperation.getClass().getName());
         }
     }
 

--- a/document/src/main/java/com/yahoo/document/json/JsonReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonReader.java
@@ -49,7 +49,7 @@ public class JsonReader {
             parser = parserFactory.createParser(input);
         } catch (IOException e) {
             state = END_OF_FEED;
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -61,13 +61,13 @@ public class JsonReader {
      */
     public DocumentOperation readSingleDocument(DocumentParser.SupportedOperation operationType, String docIdString) {
         DocumentId docId = new DocumentId(docIdString);
-        DocumentParseInfo documentParseInfo;
+        final DocumentParseInfo documentParseInfo;
         try {
             DocumentParser documentParser = new DocumentParser(parser);
             documentParseInfo = documentParser.parse(Optional.of(docId)).get();
         } catch (IOException e) {
             state = END_OF_FEED;
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException(e);
         }
         documentParseInfo.operationType = operationType;
         VespaJsonDocumentReader vespaJsonDocumentReader = new VespaJsonDocumentReader();
@@ -96,9 +96,9 @@ public class JsonReader {
         } catch (IOException r) {
             // Jackson is not able to recover from structural parse errors
             state = END_OF_FEED;
-            throw new IllegalArgumentException(r);
+            throw new RuntimeException(r);
         }
-        if ( ! documentParseInfo.isPresent()) {
+        if (! documentParseInfo.isPresent()) {
             state = END_OF_FEED;
             return null;
         }
@@ -117,8 +117,9 @@ public class JsonReader {
 
     private static DocumentType getDocumentTypeFromString(String docTypeString, DocumentTypeManager typeManager) {
         final DocumentType docType = typeManager.getDocumentType(docTypeString);
-        if (docType == null)
+        if (docType == null) {
             throw new IllegalArgumentException(String.format("Document type %s does not exist", docTypeString));
+        }
         return docType;
     }
 
@@ -128,7 +129,7 @@ public class JsonReader {
         } catch (IOException e) {
             // Jackson is not able to recover from structural parse errors
             state = END_OF_FEED;
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/document/src/main/java/com/yahoo/document/json/SingleDocumentParser.java
+++ b/document/src/main/java/com/yahoo/document/json/SingleDocumentParser.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
  * @author dybis
  */
 public class SingleDocumentParser {
-
     private static final JsonFactory jsonFactory = new JsonFactory().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
     private DocumentTypeManager docMan;
 
@@ -37,12 +36,12 @@ public class SingleDocumentParser {
     }
 
     private FeedOperation parse(InputStream inputStream, String docId, DocumentParser.SupportedOperation supportedOperation)  {
-        JsonReader reader = new JsonReader(docMan, inputStream, jsonFactory);
-        DocumentOperation documentOperation = reader.readSingleDocument(supportedOperation, docId);
+        final JsonReader reader = new JsonReader(docMan, inputStream, jsonFactory);
+        final DocumentOperation documentOperation = reader.readSingleDocument(supportedOperation, docId);
         try {
             inputStream.close();
         } catch (IOException e) {
-            throw new IllegalStateException(e);
+            throw new RuntimeException(e);
         }
         if (supportedOperation == DocumentParser.SupportedOperation.PUT) {
             return new DocumentFeedOperation(((DocumentPut) documentOperation).getDocument(), documentOperation.getCondition());
@@ -50,5 +49,4 @@ public class SingleDocumentParser {
             return new DocumentUpdateFeedOperation((DocumentUpdate) documentOperation, documentOperation.getCondition());
         }
     }
-
 }

--- a/document/src/main/java/com/yahoo/document/json/readers/JsonParserHelpers.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/JsonParserHelpers.java
@@ -6,59 +6,27 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.google.common.base.Preconditions;
 
 public class JsonParserHelpers {
-
     public static void expectArrayStart(JsonToken token) {
-        try {
-            Preconditions.checkState(token == JsonToken.START_ARRAY, "Expected start of array, got %s", token);
-        }
-        catch (IllegalStateException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Preconditions.checkState(token == JsonToken.START_ARRAY, "Expected start of array, got %s", token);
     }
 
     public static void expectArrayEnd(JsonToken token) {
-        try {
-            Preconditions.checkState(token == JsonToken.END_ARRAY, "Expected start of array, got %s", token);
-        }
-        catch (IllegalStateException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Preconditions.checkState(token == JsonToken.END_ARRAY, "Expected start of array, got %s", token);
     }
 
     public static void expectObjectStart(JsonToken token) {
-        try {
-            Preconditions.checkState(token == JsonToken.START_OBJECT, "Expected start of JSON object, got %s", token);
-        }
-        catch (IllegalStateException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Preconditions.checkState(token == JsonToken.START_OBJECT, "Expected start of JSON object, got %s", token);
     }
 
     public static void expectObjectEnd(JsonToken token) {
-        try {
-            Preconditions.checkState(token == JsonToken.END_OBJECT, "Expected end of JSON object, got %s", token);
-        }
-        catch (IllegalStateException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Preconditions.checkState(token == JsonToken.END_OBJECT, "Expected end of JSON object, got %s", token);
     }
 
     public static void expectCompositeEnd(JsonToken token) {
-        try {
-            Preconditions.checkState(token.isStructEnd(), "Expected end of composite, got %s", token);
-        }
-        catch (IllegalStateException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Preconditions.checkState(token.isStructEnd(), "Expected end of composite, got %s", token);
     }
 
     public static void expectScalarValue(JsonToken token) {
-        try {
-            Preconditions.checkState(token.isScalarValue(), "Expected to be scalar value, got %s", token);
-        }
-        catch (IllegalStateException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Preconditions.checkState(token.isScalarValue(), "Expected to be scalar value, got %s", token);
     }
-
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#9204

Broke system test tests/search/httpgateway/documentv1.rb::realtimefeed, which expects status code 400 when feeding with unknown field, but now gets status code 500.
