### PR TITLE
Queue name service requests

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/AliasTarget.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/AliasTarget.java
@@ -38,6 +38,11 @@ public class AliasTarget {
         return zone;
     }
 
+    /** Returns the fields in this encoded as record data */
+    public RecordData asData() {
+        return RecordData.from(name.value() + "/" + dnsZone + "/" + zone.value());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -54,6 +59,15 @@ public class AliasTarget {
     @Override
     public String toString() {
         return String.format("rotation target %s [zone: %s] in %s", name, dnsZone, zone);
+    }
+
+    public static AliasTarget from(RecordData data) {
+        var parts = data.asString().split("/");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Expected data to be on format [hostname]/[DNS zone]/[zone], but got " +
+                                               data.asString());
+        }
+        return new AliasTarget(HostName.from(parts[0]), parts[1], ZoneId.from(parts[2]));
     }
 
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/MemoryNameService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/MemoryNameService.java
@@ -33,8 +33,7 @@ public class MemoryNameService implements NameService {
     public List<Record> createAlias(RecordName name, Set<AliasTarget> targets) {
         var records = targets.stream()
                              .sorted((a, b) -> Comparator.comparing(AliasTarget::name).compare(a, b))
-                             .map(target -> new Record(Record.Type.ALIAS, name,
-                                                       RecordData.fqdn(target.name().value())))
+                             .map(target -> new Record(Record.Type.ALIAS, name, target.asData()))
                              .collect(Collectors.toList());
         // Satisfy idempotency contract of interface
         removeRecords(findRecords(Record.Type.ALIAS, name));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/CreateRecord.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/CreateRecord.java
@@ -1,0 +1,68 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.dns;
+
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Create or update a record.
+ *
+ * @author mpolden
+ */
+public class CreateRecord implements NameServiceRequest {
+
+    private final Record record;
+
+    /** DO NOT USE. Public for serialization purposes */
+    public CreateRecord(Record record) {
+        this.record = Objects.requireNonNull(record, "record must be non-null");
+        if (record.type() != Record.Type.CNAME) {
+            throw new IllegalArgumentException("Record of type " + record.type() + " is not supported: " + record);
+        }
+    }
+
+    public Record record() {
+        return record;
+    }
+
+    @Override
+    public void dispatchTo(NameService nameService) {
+        List<Record> records = nameService.findRecords(record.type(), record.name());
+        records.forEach(r -> {
+            // Ensure that existing record has correct data
+            if (!r.data().equals(record.data())) {
+                nameService.updateRecord(r, record.data());
+            }
+        });
+        if (records.isEmpty()) {
+            nameService.createCname(record.name(), record.data());
+        }
+    }
+
+    @Override
+    public List<Record> affectedRecords() {
+        return List.of(record);
+    }
+
+    @Override
+    public String toString() {
+        return "create record " + record;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateRecord that = (CreateRecord) o;
+        return record.equals(that.record);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(record);
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/CreateRecords.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/CreateRecords.java
@@ -1,0 +1,86 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.dns;
+
+import com.yahoo.vespa.hosted.controller.api.integration.dns.AliasTarget;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Create or update multiple records of the same type and name.
+ *
+ * @author mpolden
+ */
+public class CreateRecords implements NameServiceRequest {
+
+    private final RecordName name;
+    private final Record.Type type;
+    private final List<Record> records;
+
+    /** DO NOT USE. Public for serialization purposes */
+    public CreateRecords(List<Record> records) {
+        this.name = requireOneOf(Record::name, records);
+        this.type = requireOneOf(Record::type, records);
+        this.records = List.copyOf(Objects.requireNonNull(records, "records must be non-null"));
+        if (type != Record.Type.ALIAS && type != Record.Type.TXT) {
+            throw new IllegalArgumentException("Records of type " + type + "are not supported: " + records);
+        }
+    }
+
+    public List<Record> records() {
+        return records;
+    }
+
+    @Override
+    public void dispatchTo(NameService nameService) {
+        switch (type) {
+            case ALIAS:
+                var targets = records.stream().map(Record::data).map(AliasTarget::from).collect(Collectors.toSet());
+                nameService.createAlias(name, targets);
+                break;
+            case TXT:
+                var dataFields = records.stream().map(Record::data).collect(Collectors.toList());
+                nameService.createTxtRecords(name, dataFields);
+                break;
+        }
+    }
+
+    @Override
+    public List<Record> affectedRecords() {
+        return records();
+    }
+
+    @Override
+    public String toString() {
+        return "create records " + records();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateRecords that = (CreateRecords) o;
+        return records.equals(that.records);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(records);
+    }
+
+    /** Find exactly one distinct value of field in given list */
+    private static <T, V> T requireOneOf(Function<V, T> field, List<V> list) {
+        Set<T> values = list.stream().map(field).collect(Collectors.toSet());
+        if (values.size() != 1) {
+            throw new IllegalArgumentException("Expected one distinct value, but found " + values + " in " + list);
+        }
+        return values.iterator().next();
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueue.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueue.java
@@ -1,0 +1,107 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.dns;
+
+import com.yahoo.log.LogLevel;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.logging.Logger;
+
+/**
+ * A queue of outstanding {@link NameServiceRequest}s. Requests in this have not yet been dispatched to a
+ * {@link NameService} and are thus not visible in DNS.
+ *
+ * This is immutable.
+ *
+ * @author mpolden
+ */
+public class NameServiceQueue {
+
+    public static final NameServiceQueue EMPTY = new NameServiceQueue(List.of());
+
+    private static final Logger log = Logger.getLogger(NameServiceQueue.class.getName());
+
+    private final LinkedBlockingDeque<NameServiceRequest> requests;
+
+    /** DO NOT USE. Public for serialization purposes */
+    public NameServiceQueue(Collection<NameServiceRequest> requests) {
+        this.requests = new LinkedBlockingDeque<>();
+        this.requests.addAll(Objects.requireNonNull(requests, "requests must be non-null"));
+    }
+
+    /** Returns a view of requests in this queue */
+    public Collection<NameServiceRequest> requests() {
+        return Collections.unmodifiableCollection(requests);
+    }
+
+    /** Returns a copy of this containing only the n most recent requests */
+    public NameServiceQueue last(int n) {
+        requireNonNegative(n);
+        if (requests.size() <= n) return this;
+        List<NameServiceRequest> requests = new ArrayList<>(this.requests);
+        return new NameServiceQueue(requests.subList(requests.size() - n, requests.size()));
+    }
+
+    /** Returns a copy of this with given request queued according to priority */
+    public NameServiceQueue with(NameServiceRequest request, Priority priority) {
+        var queue = new NameServiceQueue(this.requests);
+        if (priority == Priority.high) {
+            queue.requests.addFirst(request);
+        } else {
+            queue.requests.add(request);
+        }
+        return queue;
+    }
+
+    public NameServiceQueue with(NameServiceRequest request) {
+        return with(request, Priority.normal);
+    }
+
+    /**
+     * Dispatch n requests from the head of this to given name service.
+     *
+     * @return A copy of this, without the successfully dispatched requests.
+     */
+    public NameServiceQueue dispatchTo(NameService nameService, int n) {
+        requireNonNegative(n);
+        if (requests.isEmpty()) return this;
+
+        var queue = new NameServiceQueue(requests);
+        for (var i = 0; i < n && !queue.requests.isEmpty(); i++) {
+            var request = queue.requests.peek();
+            try {
+                request.dispatchTo(nameService);
+                queue.requests.poll();
+            } catch (Exception e) {
+                log.log(LogLevel.WARNING, "Failed to execute " + request + ": " + e.getMessage() +
+                                          ", request will be retried");
+            }
+        }
+
+        return queue;
+    }
+
+    @Override
+    public String toString() {
+        return requests.toString();
+    }
+
+    private static void requireNonNegative(int n) {
+        if (n < 0) throw new IllegalArgumentException("n must be >= 0, got " + n);
+    }
+
+    /** Priority of a request added to this */
+    public enum Priority {
+        /** Default priority. Request will be delivered in FIFO order */
+        normal,
+
+        /**Request is queued before others. Useful for code that needs to act on effects of a request */
+        high
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceRequest.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceRequest.java
@@ -1,0 +1,22 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.dns;
+
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+
+import java.util.List;
+
+/**
+ * Interface for requests to a {@link NameService}.
+ *
+ * @author mpolden
+ */
+public interface NameServiceRequest {
+
+    /** Send this to given name service */
+    void dispatchTo(NameService nameService);
+
+    /** Returns the records affected by executing this */
+    List<Record> affectedRecords();
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/RemoveRecords.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/RemoveRecords.java
@@ -1,0 +1,90 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.dns;
+
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Permanently removes all matching records by type and name or data.
+ *
+ * @author mpolden
+ */
+public class RemoveRecords implements NameServiceRequest {
+
+    private final Record.Type type;
+    private final Optional<RecordName> name;
+    private final Optional<RecordData> data;
+
+    public RemoveRecords(Record.Type type, RecordName name) {
+        this(type, Optional.of(name), Optional.empty());
+    }
+
+    public RemoveRecords(Record.Type type, RecordData data) {
+        this(type, Optional.empty(), Optional.of(data));
+    }
+
+    /** DO NOT USE. Public for serialization purposes */
+    public RemoveRecords(Record.Type type, Optional<RecordName> name, Optional<RecordData> data) {
+        this.type = Objects.requireNonNull(type, "type must be non-null");
+        this.name = Objects.requireNonNull(name, "name must be non-null");
+        this.data = Objects.requireNonNull(data, "data must be non-null");
+        if (name.isPresent() == data.isPresent()) {
+            throw new IllegalArgumentException("exactly one of name or data must be non-empty");
+        }
+    }
+
+    public Record.Type type() {
+        return type;
+    }
+
+    public Optional<RecordName> name() {
+        return name;
+    }
+
+    public Optional<RecordData> data() {
+        return data;
+    }
+
+    @Override
+    public void dispatchTo(NameService nameService) {
+        List<Record> records = new ArrayList<>();
+        name.ifPresent(n -> records.addAll(nameService.findRecords(type, n)));
+        data.ifPresent(d -> records.addAll(nameService.findRecords(type, d)));
+        nameService.removeRecords(records);
+    }
+
+    @Override
+    public List<Record> affectedRecords() {
+        return List.of();
+    }
+
+    @Override
+    public String toString() {
+        return "remove records of type " + type + " by " +
+               name.map(n -> "name " + n).orElse("") +
+               data.map(d -> "data " + d).orElse("");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RemoveRecords that = (RemoveRecords) o;
+        return type == that.type &&
+               name.equals(that.name) &&
+               data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name, data);
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -55,6 +55,7 @@ public class ControllerMaintenance extends AbstractComponent {
     private final CostReportMaintainer costReportMaintainer;
     private final RoutingPolicyMaintainer routingPolicyMaintainer;
     private final ResourceMeterMaintainer resourceMeterMaintainer;
+    private final NameServiceDispatcher nameServiceDispatcher;
 
     @SuppressWarnings("unused") // instantiated by Dependency Injection
     public ControllerMaintenance(MaintainerConfig maintainerConfig, ApiAuthorityConfig apiAuthorityConfig, Controller controller, CuratorDb curator,
@@ -78,15 +79,16 @@ public class ControllerMaintenance extends AbstractComponent {
         clusterUtilizationMaintainer = new ClusterUtilizationMaintainer(controller, Duration.ofHours(2), jobControl);
         deploymentMetricsMaintainer = new DeploymentMetricsMaintainer(controller, Duration.ofMinutes(5), jobControl);
         applicationOwnershipConfirmer = new ApplicationOwnershipConfirmer(controller, Duration.ofHours(12), jobControl, ownershipIssues);
-        dnsMaintainer = new DnsMaintainer(controller, Duration.ofMinutes(5), jobControl, nameService);
+        dnsMaintainer = new DnsMaintainer(controller, Duration.ofMinutes(5), jobControl);
         systemUpgrader = new SystemUpgrader(controller, Duration.ofMinutes(1), jobControl);
         jobRunner = new JobRunner(controller, Duration.ofMinutes(2), jobControl);
         osUpgraders = osUpgraders(controller, jobControl);
         osVersionStatusUpdater = new OsVersionStatusUpdater(controller, maintenanceInterval, jobControl);
         contactInformationMaintainer = new ContactInformationMaintainer(controller, Duration.ofHours(12), jobControl, contactRetriever);
         costReportMaintainer = new CostReportMaintainer(controller, Duration.ofHours(2), reportConsumer, jobControl, nodeRepositoryClient, Clock.systemUTC(), selfHostedCostConfig);
-        routingPolicyMaintainer = new RoutingPolicyMaintainer(controller, Duration.ofMinutes(5), jobControl, nameService, curator);
+        routingPolicyMaintainer = new RoutingPolicyMaintainer(controller, Duration.ofMinutes(5), jobControl, curator);
         resourceMeterMaintainer = new ResourceMeterMaintainer(controller, Duration.ofMinutes(60), jobControl, nodeRepositoryClient, Clock.systemUTC(), metric, resourceSnapshotConsumer);
+        nameServiceDispatcher = new NameServiceDispatcher(controller, Duration.ofSeconds(5), jobControl, nameService);
     }
 
     public Upgrader upgrader() { return upgrader; }
@@ -116,6 +118,7 @@ public class ControllerMaintenance extends AbstractComponent {
         costReportMaintainer.deconstruct();
         routingPolicyMaintainer.deconstruct();
         resourceMeterMaintainer.deconstruct();
+        nameServiceDispatcher.deconstruct();
     }
 
     /** Create one OS upgrader per cloud found in the zone registry of controller */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -88,7 +88,7 @@ public class ControllerMaintenance extends AbstractComponent {
         costReportMaintainer = new CostReportMaintainer(controller, Duration.ofHours(2), reportConsumer, jobControl, nodeRepositoryClient, Clock.systemUTC(), selfHostedCostConfig);
         routingPolicyMaintainer = new RoutingPolicyMaintainer(controller, Duration.ofMinutes(5), jobControl, curator);
         resourceMeterMaintainer = new ResourceMeterMaintainer(controller, Duration.ofMinutes(60), jobControl, nodeRepositoryClient, Clock.systemUTC(), metric, resourceSnapshotConsumer);
-        nameServiceDispatcher = new NameServiceDispatcher(controller, Duration.ofSeconds(5), jobControl, nameService);
+        nameServiceDispatcher = new NameServiceDispatcher(controller, Duration.ofSeconds(2), jobControl, nameService);
     }
 
     public Upgrader upgrader() { return upgrader; }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainer.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.vespa.hosted.controller.Controller;
-import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
 import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue.Priority;
@@ -12,12 +11,7 @@ import com.yahoo.vespa.hosted.controller.rotation.RotationLock;
 import com.yahoo.vespa.hosted.controller.rotation.RotationRepository;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Performs DNS maintenance tasks such as removing DNS aliases for unassigned rotations.
@@ -25,8 +19,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author mpolden
  */
 public class DnsMaintainer extends Maintainer {
-
-    private final AtomicInteger rotationIndex = new AtomicInteger(0);
 
     public DnsMaintainer(Controller controller, Duration interval, JobControl jobControl) {
         super(controller, interval, jobControl);
@@ -40,7 +32,7 @@ public class DnsMaintainer extends Maintainer {
     protected void maintain() {
         try (RotationLock lock = rotationRepository().lock()) {
             Map<RotationId, Rotation> unassignedRotations = rotationRepository().availableRotations(lock);
-            rotationToCheckOf(unassignedRotations.values()).ifPresent(this::removeCname);
+            unassignedRotations.values().forEach(this::removeCname);
         }
     }
 
@@ -48,22 +40,6 @@ public class DnsMaintainer extends Maintainer {
     private void removeCname(Rotation rotation) {
         // When looking up CNAME by data, the data must be a FQDN
         controller().nameServiceForwarder().removeRecords(Record.Type.CNAME, RecordData.fqdn(rotation.name()), Priority.normal);
-    }
-
-    /**
-     * Returns the rotation that should be checked in this run. We check only one rotation per run to avoid running into
-     * rate limits that may be imposed by the {@link NameService} implementation.
-     */
-    private Optional<Rotation> rotationToCheckOf(Collection<Rotation> rotations) {
-        if (rotations.isEmpty()) return Optional.empty();
-        List<Rotation> rotationList = new ArrayList<>(rotations);
-        int index = rotationIndex.getAndUpdate((i) -> {
-            if (i < rotationList.size() - 1) {
-                return ++i;
-            }
-            return 0;
-        });
-        return Optional.of(rotationList.get(index));
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainer.java
@@ -5,7 +5,7 @@ import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
-import com.yahoo.vespa.hosted.controller.application.Endpoint;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue.Priority;
 import com.yahoo.vespa.hosted.controller.rotation.Rotation;
 import com.yahoo.vespa.hosted.controller.rotation.RotationId;
 import com.yahoo.vespa.hosted.controller.rotation.RotationLock;
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Performs DNS maintenance tasks such as removing DNS aliases for unassigned rotations.
@@ -28,15 +26,10 @@ import java.util.stream.Collectors;
  */
 public class DnsMaintainer extends Maintainer {
 
-    private static final Logger log = Logger.getLogger(DnsMaintainer.class.getName());
-
-    private final NameService nameService;
     private final AtomicInteger rotationIndex = new AtomicInteger(0);
 
-    public DnsMaintainer(Controller controller, Duration interval, JobControl jobControl,
-                         NameService nameService) {
+    public DnsMaintainer(Controller controller, Duration interval, JobControl jobControl) {
         super(controller, interval, jobControl);
-        this.nameService = nameService;
     }
 
     private RotationRepository rotationRepository() {
@@ -54,15 +47,7 @@ public class DnsMaintainer extends Maintainer {
     /** Remove CNAME(s) for unassigned rotation */
     private void removeCname(Rotation rotation) {
         // When looking up CNAME by data, the data must be a FQDN
-        List<Record> records = nameService.findRecords(Record.Type.CNAME, RecordData.fqdn(rotation.name())).stream()
-                                          .filter(DnsMaintainer::canUpdate)
-                                          .collect(Collectors.toList());
-        if (records.isEmpty()) {
-            return;
-        }
-        log.info(String.format("Removing DNS records %s because they point to the unassigned " +
-                               "rotation %s (%s)", records, rotation.id().asString(), rotation.name()));
-        nameService.removeRecords(records);
+        controller().nameServiceForwarder().removeRecords(Record.Type.CNAME, RecordData.fqdn(rotation.name()), Priority.normal);
     }
 
     /**
@@ -79,13 +64,6 @@ public class DnsMaintainer extends Maintainer {
             return 0;
         });
         return Optional.of(rotationList.get(index));
-    }
-
-    /** Returns whether we can update the given record */
-    private static boolean canUpdate(Record record) {
-        String recordName = record.name().asString();
-        return recordName.endsWith(Endpoint.YAHOO_DNS_SUFFIX) ||
-               recordName.endsWith(Endpoint.OATH_DNS_SUFFIX);
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporter.java
@@ -43,6 +43,7 @@ public class MetricsReporter extends Maintainer {
     public static final String DEPLOYMENT_BUILD_AGE_SECONDS = "deployment.buildAgeSeconds";
     public static final String DEPLOYMENT_WARNINGS = "deployment.warnings";
     public static final String REMAINING_ROTATIONS = "remaining_rotations";
+    public static final String NAME_SERVICE_REQUESTS_QUEUED = "dns.queuedRequests";
 
     private final Metric metric;
     private final Chef chefClient;
@@ -68,6 +69,7 @@ public class MetricsReporter extends Maintainer {
         reportChefMetrics();
         reportDeploymentMetrics();
         reportRemainingRotations();
+        reportQueuedNameServiceRequests();
     }
 
     private void reportRemainingRotations() {
@@ -145,6 +147,11 @@ public class MetricsReporter extends Maintainer {
                        .ifPresent(buildTime -> metric.set(DEPLOYMENT_BUILD_AGE_SECONDS,
                                                           controller().clock().instant().getEpochSecond() - buildTime.getEpochSecond(),
                                                           metric.createContext(dimensions(application.id()))));
+    }
+
+    private void reportQueuedNameServiceRequests() {
+        metric.set(NAME_SERVICE_REQUESTS_QUEUED, controller().curator().readNameServiceQueue().requests().size(),
+                   metric.createContext(Map.of()));
     }
     
     private static double deploymentFailRatio(ApplicationList applicationList) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/NameServiceDispatcher.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/NameServiceDispatcher.java
@@ -1,0 +1,48 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.maintenance;
+
+import com.yahoo.vespa.curator.Lock;
+import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue;
+import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
+
+import java.time.Duration;
+
+/**
+ * This consumes requests from the {@link NameServiceQueue} by submitting them to a {@link NameService}. Successfully
+ * consumed requests are removed from the queue.
+ *
+ * @author mpolden
+ */
+public class NameServiceDispatcher extends Maintainer {
+
+    private static final int defaultRequestCount = 1;
+
+    private final CuratorDb db;
+    private final NameService nameService;
+    private final int requestCount;
+
+    public NameServiceDispatcher(Controller controller, Duration interval, JobControl jobControl,
+                                 NameService nameService) {
+        this(controller, interval, jobControl, nameService, defaultRequestCount);
+    }
+
+    public NameServiceDispatcher(Controller controller, Duration interval, JobControl jobControl,
+                                 NameService nameService, int requestCount) {
+        super(controller, interval, jobControl);
+        this.db = controller.curator();
+        this.nameService = nameService;
+        this.requestCount = requestCount;
+    }
+
+    @Override
+    protected void maintain() {
+        try (Lock lock = db.lockNameServiceQueue()) {
+            NameServiceQueue queue = db.readNameServiceQueue();
+            NameServiceQueue remaining = queue.dispatchTo(nameService, requestCount);
+            db.writeNameServiceQueue(remaining);
+        }
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/AuditLogSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/AuditLogSerializer.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.hosted.controller.auditlog.AuditLog;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -51,7 +50,7 @@ public class AuditLogSerializer {
                     entryObject.field(principalField).asString(),
                     methodFrom(entryObject.field(methodField)),
                     entryObject.field(resourceField).asString(),
-                    optionalField(entryObject.field(dataField), Function.identity())
+                    Serializers.optionalField(entryObject.field(dataField), Function.identity())
             ));
         });
         return new AuditLog(entries);
@@ -73,10 +72,6 @@ public class AuditLogSerializer {
             case "DELETE": return AuditLog.Entry.Method.DELETE;
             default: throw new IllegalArgumentException("Unknown serialized value '" + field.asString() + "'");
         }
-    }
-
-    private static <T> Optional<T> optionalField(Inspector field, Function<String, T> fieldMapper) {
-        return Optional.of(field).filter(Inspector::valid).map(Inspector::asString).map(fieldMapper);
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/NameServiceQueueSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/NameServiceQueueSerializer.java
@@ -1,0 +1,126 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.persistence;
+
+
+import com.yahoo.slime.ArrayTraverser;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Inspector;
+import com.yahoo.slime.Slime;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
+import com.yahoo.vespa.hosted.controller.dns.CreateRecord;
+import com.yahoo.vespa.hosted.controller.dns.CreateRecords;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceRequest;
+import com.yahoo.vespa.hosted.controller.dns.RemoveRecords;
+
+import java.util.ArrayList;
+
+/**
+ * Serializer for {@link com.yahoo.vespa.hosted.controller.dns.NameServiceQueue}.
+ *
+ * @author mpolden
+ */
+public class NameServiceQueueSerializer {
+
+    private static final String requestsField = "requests";
+    private static final String requestType = "requestType";
+    private static final String recordsField = "records";
+    private static final String typeField = "type";
+    private static final String nameField = "name";
+    private static final String dataField = "data";
+
+    public Slime toSlime(NameServiceQueue queue) {
+        var slime = new Slime();
+        var root = slime.setObject();
+        var array = root.setArray(requestsField);
+
+        for (var request : queue.requests()) {
+            var object = array.addObject();
+
+            if (request instanceof CreateRecords) toSlime(object, (CreateRecords) request);
+            else if (request instanceof CreateRecord) toSlime(object, (CreateRecord) request);
+            else if (request instanceof RemoveRecords) toSlime(object, (RemoveRecords) request);
+            else throw new IllegalArgumentException("No serialization defined for request of type " +
+                                                    request.getClass().getName());
+        }
+
+        return slime;
+    }
+
+    public NameServiceQueue fromSlime(Slime slime) {
+        var items = new ArrayList<NameServiceRequest>();
+        var root = slime.get();
+        root.field(requestsField).traverse((ArrayTraverser) (i, object) -> {
+            var request = Request.valueOf(object.field(requestType).asString());
+            switch (request) {
+                case createRecords:
+                    items.add(createRecordsFromSlime(object));
+                    break;
+                case createRecord:
+                    items.add(createRecordFromSlime(object));
+                    break;
+                case removeRecords:
+                    items.add(removeRecordsFromSlime(object));
+                    break;
+                default: throw new IllegalArgumentException("No serialization defined for request " + request);
+            }
+        });
+        return new NameServiceQueue(items);
+    }
+
+    private void toSlime(Cursor object, CreateRecord createRecord) {
+        object.setString(requestType, Request.createRecord.name());
+        toSlime(object, createRecord.record());
+    }
+
+    private void toSlime(Cursor object, CreateRecords createRecords) {
+        object.setString(requestType, Request.createRecords.name());
+        var recordArray = object.setArray(recordsField);
+        createRecords.records().forEach(record -> toSlime(recordArray.addObject(), record));
+    }
+
+    private void toSlime(Cursor object, RemoveRecords removeRecords) {
+        object.setString(requestType, Request.removeRecords.name());
+        object.setString(typeField, removeRecords.type().name());
+        removeRecords.name().ifPresent(name -> object.setString(nameField, name.asString()));
+        removeRecords.data().ifPresent(data -> object.setString(dataField, data.asString()));
+    }
+
+    private void toSlime(Cursor object, Record record) {
+        object.setString(typeField, record.type().name());
+        object.setString(nameField, record.name().asString());
+        object.setString(dataField, record.data().asString());
+    }
+
+    private CreateRecords createRecordsFromSlime(Inspector object) {
+        var records = new ArrayList<Record>();
+        object.field(recordsField).traverse((ArrayTraverser) (i, recordObject) -> records.add(recordFromSlime(recordObject)));
+        return new CreateRecords(records);
+    }
+
+    private CreateRecord createRecordFromSlime(Inspector object) {
+        return new CreateRecord(recordFromSlime(object));
+    }
+
+    private RemoveRecords removeRecordsFromSlime(Inspector object) {
+        var type = Record.Type.valueOf(object.field(typeField).asString());
+        var name = Serializers.optionalField(object.field(nameField), RecordName::from);
+        var data = Serializers.optionalField(object.field(dataField), RecordData::from);
+        return new RemoveRecords(type, name, data);
+    }
+
+    private Record recordFromSlime(Inspector object) {
+        return new Record(Record.Type.valueOf(object.field(typeField).asString()),
+                          RecordName.from(object.field(nameField).asString()),
+                          RecordData.from(object.field(dataField).asString()));
+    }
+
+    private enum Request {
+        createRecord,
+        createRecords,
+        removeRecords,
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializer.java
@@ -5,16 +5,15 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.RotationName;
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.RoutingPolicy;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -62,7 +61,7 @@ public class RoutingPolicySerializer {
                                            clusterId(inspect.field(clusterField)),
                                            ZoneId.from(inspect.field(zoneField).asString()),
                                            HostName.from(inspect.field(canonicalNameField).asString()),
-                                           optionalField(inspect.field(dnsZoneField), Function.identity()),
+                                           Serializers.optionalField(inspect.field(dnsZoneField), Function.identity()),
                                            rotations));
         });
         return Collections.unmodifiableSet(policies);
@@ -70,11 +69,8 @@ public class RoutingPolicySerializer {
 
     // TODO: Remove and inline after Vespa 7.43
     private static ClusterSpec.Id clusterId(Inspector field) {
-        return optionalField(field, ClusterSpec.Id::from).orElseGet(() -> new ClusterSpec.Id("default"));
+        return Serializers.optionalField(field, ClusterSpec.Id::from).orElseGet(() -> new ClusterSpec.Id("default"));
     }
 
-    private static <T> Optional<T> optionalField(Inspector field, Function<String, T> fieldMapper) {
-        return Optional.of(field).filter(Inspector::valid).map(Inspector::asString).map(fieldMapper);
-    }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/Serializers.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/Serializers.java
@@ -1,0 +1,22 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.persistence;
+
+import com.yahoo.slime.Inspector;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Reusable serialization logic.
+ *
+ * @author mpolden
+ */
+public class Serializers {
+
+    private Serializers() {}
+
+    public static <T> Optional<T> optionalField(Inspector field, Function<String, T> fieldMapper) {
+        return Optional.of(field).filter(Inspector::valid).map(Inspector::asString).map(fieldMapper);
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -63,10 +63,11 @@ import static org.junit.Assert.fail;
  */
 public class ControllerTest {
 
+    private final DeploymentTester tester = new DeploymentTester();
+
     @Test
     public void testDeployment() {
         // Setup system
-        DeploymentTester tester = new DeploymentTester();
         ApplicationController applications = tester.controller().applications();
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
@@ -205,7 +206,6 @@ public class ControllerTest {
 
     @Test
     public void testDeploymentApplicationVersion() {
-        DeploymentTester tester = new DeploymentTester();
         Application app = tester.createApplication("app1", "tenant1", 1, 11L);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
@@ -227,7 +227,7 @@ public class ControllerTest {
     @Test
     public void testGlobalRotations() {
         // Setup
-        ControllerTester tester = new ControllerTester();
+        ControllerTester tester = this.tester.controllerTester();
         ZoneId zone = ZoneId.from(Environment.defaultEnvironment(), RegionName.defaultName());
         ApplicationId app = ApplicationId.from("tenant", "app1", "default");
         DeploymentId deployment = new DeploymentId(app, zone);
@@ -274,7 +274,6 @@ public class ControllerTest {
 
     @Test
     public void testDnsAliasRegistration() {
-        DeploymentTester tester = new DeploymentTester();
         Application application = tester.createApplication("app1", "tenant1", 1, 1L);
 
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
@@ -295,6 +294,7 @@ public class ControllerTest {
                                 "app1--tenant1.global.vespa.yahooapis.com"),
                          tester.configServer().rotationCnames().get(new DeploymentId(application.id(), deployment.zone())));
         }
+        tester.updateDns();
         assertEquals(3, tester.controllerTester().nameService().records().size());
 
         Optional<Record> record = tester.controllerTester().findCname("app1--tenant1.global.vespa.yahooapis.com");
@@ -315,7 +315,6 @@ public class ControllerTest {
 
     @Test
     public void testRedirectLegacyDnsNames() { // TODO: Remove together with Flags.REDIRECT_LEGACY_DNS_NAMES
-        DeploymentTester tester = new DeploymentTester();
         Application application = tester.createApplication("app1", "tenant1", 1, 1L);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
@@ -347,8 +346,6 @@ public class ControllerTest {
 
     @Test
     public void testUpdatesExistingDnsAlias() {
-        DeploymentTester tester = new DeploymentTester();
-
         // Application 1 is deployed and deleted
         {
             Application app1 = tester.createApplication("app1", "tenant1", 1, 1L);
@@ -461,7 +458,6 @@ public class ControllerTest {
 
     @Test
     public void testIntegrationTestDeployment() {
-        DeploymentTester tester = new DeploymentTester();
         Version six = Version.fromString("6.1");
         tester.upgradeSystem(six);
         tester.controllerTester().zoneRegistry().setSystemName(SystemName.cd);
@@ -496,7 +492,6 @@ public class ControllerTest {
 
     @Test
     public void testDevDeployment() {
-        DeploymentTester tester = new DeploymentTester();
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.dev)
                 .majorVersion(6)
@@ -518,7 +513,6 @@ public class ControllerTest {
 
     @Test
     public void testSuspension() {
-        DeploymentTester tester = new DeploymentTester();
         Application app = tester.createApplication("app1", "tenant1", 1, 11L);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                                                         .environment(Environment.prod)
@@ -543,7 +537,6 @@ public class ControllerTest {
     // second time will not fail
     @Test
     public void testDeletingApplicationThatHasAlreadyBeenDeleted() {
-        DeploymentTester tester = new DeploymentTester();
         Application app = tester.createApplication("app2", "tenant1", 1, 12L);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
@@ -559,7 +552,6 @@ public class ControllerTest {
 
     @Test
     public void testDeployApplicationPackageWithApplicationDir() {
-        DeploymentTester tester = new DeploymentTester();
         Application application = tester.createApplication("app1", "tenant1", 1, 1L);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
@@ -570,7 +562,6 @@ public class ControllerTest {
 
     @Test
     public void testDeployApplicationWithWarnings() {
-        DeploymentTester tester = new DeploymentTester();
         Application application = tester.createApplication("app1", "tenant1", 1, 1L);
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -74,7 +74,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public final class ControllerTester {
 
-    public static final int availableRotations = 10;
+    private static final int availableRotations = 10;
 
     private final AthenzDbMock athenzDb;
     private final ManualClock clock;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -340,7 +340,6 @@ public final class ControllerTester {
                                                zoneRegistryMock,
                                                configServer,
                                                metricsService,
-                                               nameService,
                                                routingGenerator,
                                                new ChefMock(),
                                                clock,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
@@ -53,13 +53,19 @@ public class DeploymentTester {
     private final OutstandingChangeDeployer outstandingChangeDeployer;
     private final ReadyJobsTrigger readyJobTrigger;
     private final NameServiceDispatcher nameServiceDispatcher;
+    private final boolean updateDnsAutomatically;
 
     public DeploymentTester() {
         this(new ControllerTester());
     }
 
     public DeploymentTester(ControllerTester tester) {
+        this(tester, true);
+    }
+
+    public DeploymentTester(ControllerTester tester, boolean updateDnsAutomatically) {
         this.tester = tester;
+        this.updateDnsAutomatically = updateDnsAutomatically;
         tester.curator().writeUpgradesPerMinute(100);
 
         JobControl jobControl = new JobControl(tester.curator());
@@ -218,7 +224,9 @@ public class DeploymentTester {
         } else {
             assertFalse(applications().require(application.id()).change().hasTargets());
         }
-        updateDns();
+        if (updateDnsAutomatically) {
+            updateDns();
+        }
     }
 
     public void completeUpgrade(Application application, Version version, String upgradePolicy) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueueTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueueTest.java
@@ -1,0 +1,86 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.dns;
+
+import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.AliasTarget;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.MemoryNameService;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue.Priority;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author mpolden
+ */
+public class NameServiceQueueTest {
+
+    @Test
+    public void test_queue() {
+        var nameService = new MemoryNameService();
+        var r1 = new Record(Record.Type.CNAME, RecordName.from("cname.vespa.oath.cloud"), RecordData.from("example.com"));
+        var r2 = new Record(Record.Type.TXT, RecordName.from("txt.example.com"), RecordData.from("text"));
+        var r3 = List.of(new Record(Record.Type.ALIAS, RecordName.from("alias.example.com"), RecordData.from("alias1/dns-zone-01/prod.us-north-1")),
+                         new Record(Record.Type.ALIAS, RecordName.from("alias.example.com"), RecordData.from("alias2/dns-zone-02/prod.us-north-2")));
+        var req1 = new CreateRecord(r1);
+        var req2 = new CreateRecords(List.of(r2));
+        var req3 = new CreateRecords(List.of(new Record(Record.Type.ALIAS, RecordName.from("alias.example.com"),
+                                                        new AliasTarget(HostName.from("alias1"),
+                                                                        "dns-zone-01",
+                                                                        ZoneId.from("prod", "us-north-1")).asData()),
+                                             new Record(Record.Type.ALIAS, RecordName.from("alias.example.com"),
+                                                        new AliasTarget(HostName.from("alias2"),
+                                                                        "dns-zone-02",
+                                                                        ZoneId.from("prod", "us-north-2")).asData()))
+        );
+        var req4 = new RemoveRecords(r3.get(0).type(), r3.get(0).name());
+        var req5 = new RemoveRecords(r2.type(), r2.data());
+        var req6 = new RemoveRecords(Record.Type.CNAME, r1.data());
+
+        // Add requests with different priorities and dispatch first one
+        var queue = NameServiceQueue.EMPTY.with(req2).with(req1, Priority.high);
+        assertEquals(2, queue.requests().size());
+        queue = queue.dispatchTo(nameService, 1);
+        assertEquals(r1, nameService.findRecords(r1.type(), r1.name()).get(0));
+        assertEquals(1, queue.requests().size());
+        assertEquals(req2, queue.requests().iterator().next());
+
+        // Dispatch remaining requests
+        queue = queue.dispatchTo(nameService, 10);
+        assertTrue(queue.requests().isEmpty());
+        assertEquals(r2, nameService.findRecords(r2.type(), r2.name()).get(0));
+
+        // Dispatch from empty queue
+        assertSame(queue, queue.dispatchTo(nameService, 10));
+
+        // Dispatch create alias
+        queue = queue.with(req3).dispatchTo(nameService, 1);
+        assertEquals(r3, nameService.findRecords(Record.Type.ALIAS, r3.get(0).name()));
+
+        // Dispatch removals
+        queue = queue.with(req4).with(req5).dispatchTo(nameService, 2);
+        assertTrue("Removed " + r2, nameService.findRecords(r2.type(), r2.name()).isEmpty());
+        assertTrue("Removed " + r3, nameService.findRecords(Record.Type.ALIAS, r3.get(0).name()).isEmpty());
+
+        // Dispatch removals by data
+        queue = queue.with(req6).dispatchTo(nameService, 1);
+        assertTrue(queue.requests().isEmpty());
+        assertTrue("Removed " + r1, nameService.findRecords(Record.Type.CNAME, r1.name()).isEmpty());
+
+        // Keep n most recent requests
+        queue = queue.with(req1).with(req2).with(req3).with(req4).with(req6)
+                     .last(2);
+        assertEquals(List.of(req4, req6), List.copyOf(queue.requests()));
+        assertSame(queue, queue.last(2));
+        assertSame(queue, queue.last(10));
+        assertTrue(queue.last(0).requests().isEmpty());
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainerTest.java
@@ -4,12 +4,12 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.Endpoint;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
@@ -43,8 +43,7 @@ public class DnsMaintainerTest {
     public void before() {
         tester = new DeploymentTester();
         maintainer = new DnsMaintainer(tester.controller(), Duration.ofHours(12),
-                                       new JobControl(new MockCuratorDb()),
-                                       tester.controllerTester().nameService());
+                                       new JobControl(new MockCuratorDb()));
     }
 
     @Test
@@ -105,6 +104,7 @@ public class DnsMaintainerTest {
         for (int i = 0; i < ControllerTester.availableRotations; i++) {
             maintainer.maintain();
         }
+        tester.updateDns();
         assertFalse("DNS record removed", findCname.apply("app1--tenant1.global.vespa.yahooapis.com").isPresent());
         assertFalse("DNS record removed", findCname.apply("app1--tenant1.global.vespa.oath.cloud").isPresent());
         assertFalse("DNS record removed", findCname.apply("app1.tenant1.global.vespa.yahooapis.com").isPresent());
@@ -124,6 +124,7 @@ public class DnsMaintainerTest {
         // One record is removed per run
         for (int i = 1; i <= staleTotal*2; i++) {
             maintainer.run();
+            tester.updateDns();
             assertEquals(Math.max(staleTotal - i, 0), records().size());
         }
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DnsMaintainerTest.java
@@ -6,17 +6,12 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.Application;
-import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
-import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
-import com.yahoo.vespa.hosted.controller.application.Endpoint;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
-import com.yahoo.vespa.hosted.controller.rotation.Rotation;
-import com.yahoo.vespa.hosted.controller.rotation.RotationId;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -101,41 +96,15 @@ public class DnsMaintainerTest {
         tester.controllerTester().deleteApplication(application.id());
 
         // DnsMaintainer removes records
-        for (int i = 0; i < ControllerTester.availableRotations; i++) {
-            maintainer.maintain();
-        }
+        maintainer.maintain();
         tester.updateDns();
         assertFalse("DNS record removed", findCname.apply("app1--tenant1.global.vespa.yahooapis.com").isPresent());
         assertFalse("DNS record removed", findCname.apply("app1--tenant1.global.vespa.oath.cloud").isPresent());
         assertFalse("DNS record removed", findCname.apply("app1.tenant1.global.vespa.yahooapis.com").isPresent());
     }
 
-    @Test
-    public void rate_limit_record_removal() {
-        // Create stale records
-        int staleTotal = ControllerTester.availableRotations;
-        for (int i = 1; i <= staleTotal; i++) {
-            Rotation r = rotation(i);
-            tester.controllerTester().nameService().createCname(RecordName.from("stale-record-" + i + "." +
-                                                                                Endpoint.OATH_DNS_SUFFIX),
-                                                                RecordData.from(r.name() + "."));
-        }
-
-        // One record is removed per run
-        for (int i = 1; i <= staleTotal*2; i++) {
-            maintainer.run();
-            tester.updateDns();
-            assertEquals(Math.max(staleTotal - i, 0), records().size());
-        }
-    }
-
     private Set<Record> records() {
         return tester.controllerTester().nameService().records();
-    }
-
-    private static Rotation rotation(int n) {
-        String id = String.format("%02d", n);
-        return new Rotation(new RotationId("rotation-id-" + id), "rotation-fqdn-" + id);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicyMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicyMaintainerTest.java
@@ -67,10 +67,10 @@ public class RoutingPolicyMaintainerTest {
         Supplier<List<Record>> records2 = () -> tester.controllerTester().nameService().findRecords(Record.Type.ALIAS, RecordName.from("r1.app1.tenant1.global.vespa.oath.cloud"));
         assertEquals(2, records1.get().size());
         assertEquals(records1.get().size(), records2.get().size());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-central-1.", records1.get().get(0).data().asString());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-west-1.", records1.get().get(1).data().asString());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-central-1.", records2.get().get(0).data().asString());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-west-1.", records2.get().get(1).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-central-1/dns-zone-1/prod.us-central-1", records1.get().get(0).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-west-1/dns-zone-1/prod.us-west-1", records1.get().get(1).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-central-1/dns-zone-1/prod.us-central-1", records2.get().get(0).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-west-1/dns-zone-1/prod.us-west-1", records2.get().get(1).data().asString());
         assertEquals(2, tester.controller().applications().routingPolicies(app1.id()).iterator().next()
                               .rotationEndpointsIn(SystemName.main).asList().size());
 
@@ -88,9 +88,9 @@ public class RoutingPolicyMaintainerTest {
         provisionLoadBalancers(app1, 2, rotations);
         maintainer.maintain();
         assertEquals(numberOfDeployments, records1.get().size());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-central-1.", records1.get().get(0).data().asString());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-east-3.", records1.get().get(1).data().asString());
-        assertEquals("lb-0--tenant1:app1:default--prod.us-west-1.", records1.get().get(2).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-central-1/dns-zone-1/prod.us-central-1", records1.get().get(0).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-east-3/dns-zone-1/prod.us-east-3", records1.get().get(1).data().asString());
+        assertEquals("lb-0--tenant1:app1:default--prod.us-west-1/dns-zone-1/prod.us-west-1", records1.get().get(2).data().asString());
 
         // Another application is deployed
         Supplier<List<Record>> records3 = () -> tester.controllerTester().nameService().findRecords(Record.Type.ALIAS, RecordName.from("r0.app2.tenant1.global.vespa.oath.cloud"));
@@ -98,8 +98,8 @@ public class RoutingPolicyMaintainerTest {
         provisionLoadBalancers(app2, 1, Map.of(0, Set.of(RotationName.from("r0"))));
         maintainer.maintain();
         assertEquals(2, records3.get().size());
-        assertEquals("lb-0--tenant1:app2:default--prod.us-central-1.", records3.get().get(0).data().asString());
-        assertEquals("lb-0--tenant1:app2:default--prod.us-west-1.", records3.get().get(1).data().asString());
+        assertEquals("lb-0--tenant1:app2:default--prod.us-central-1/dns-zone-1/prod.us-central-1", records3.get().get(0).data().asString());
+        assertEquals("lb-0--tenant1:app2:default--prod.us-west-1/dns-zone-1/prod.us-west-1", records3.get().get(1).data().asString());
 
         // All rotations for app1 are removed
         provisionLoadBalancers(app1, clustersPerZone, Collections.emptyMap());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicyMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicyMaintainerTest.java
@@ -45,7 +45,6 @@ public class RoutingPolicyMaintainerTest {
 
     private final RoutingPolicyMaintainer maintainer = new RoutingPolicyMaintainer(tester.controller(), Duration.ofHours(12),
                                                                                    new JobControl(new MockCuratorDb()),
-                                                                                   tester.controllerTester().nameService(),
                                                                                    tester.controllerTester().curator());
     private final ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
             .environment(Environment.prod)
@@ -62,7 +61,7 @@ public class RoutingPolicyMaintainerTest {
         provisionLoadBalancers(app1, clustersPerZone, rotations);
 
         // Creates alias records for cluster0
-        maintainer.maintain();
+        maintain();
         Supplier<List<Record>> records1 = () -> tester.controllerTester().nameService().findRecords(Record.Type.ALIAS, RecordName.from("r0.app1.tenant1.global.vespa.oath.cloud"));
         Supplier<List<Record>> records2 = () -> tester.controllerTester().nameService().findRecords(Record.Type.ALIAS, RecordName.from("r1.app1.tenant1.global.vespa.oath.cloud"));
         assertEquals(2, records1.get().size());
@@ -86,7 +85,7 @@ public class RoutingPolicyMaintainerTest {
 
         // Cluster in new deployment is added to the rotation
         provisionLoadBalancers(app1, 2, rotations);
-        maintainer.maintain();
+        maintain();
         assertEquals(numberOfDeployments, records1.get().size());
         assertEquals("lb-0--tenant1:app1:default--prod.us-central-1/dns-zone-1/prod.us-central-1", records1.get().get(0).data().asString());
         assertEquals("lb-0--tenant1:app1:default--prod.us-east-3/dns-zone-1/prod.us-east-3", records1.get().get(1).data().asString());
@@ -96,14 +95,14 @@ public class RoutingPolicyMaintainerTest {
         Supplier<List<Record>> records3 = () -> tester.controllerTester().nameService().findRecords(Record.Type.ALIAS, RecordName.from("r0.app2.tenant1.global.vespa.oath.cloud"));
         tester.deployCompletely(app2, applicationPackage);
         provisionLoadBalancers(app2, 1, Map.of(0, Set.of(RotationName.from("r0"))));
-        maintainer.maintain();
+        maintain();
         assertEquals(2, records3.get().size());
         assertEquals("lb-0--tenant1:app2:default--prod.us-central-1/dns-zone-1/prod.us-central-1", records3.get().get(0).data().asString());
         assertEquals("lb-0--tenant1:app2:default--prod.us-west-1/dns-zone-1/prod.us-west-1", records3.get().get(1).data().asString());
 
         // All rotations for app1 are removed
         provisionLoadBalancers(app1, clustersPerZone, Collections.emptyMap());
-        maintainer.maintain();
+        maintain();
         assertEquals(List.of(), records1.get());
         Set<RoutingPolicy> policies = tester.controller().curator().readRoutingPolicies(app1.id());
         assertEquals(clustersPerZone * numberOfDeployments, policies.size());
@@ -120,7 +119,7 @@ public class RoutingPolicyMaintainerTest {
         provisionLoadBalancers(app1, clustersPerZone);
 
         // Creates records and policies for all clusters in all zones
-        maintainer.maintain();
+        maintain();
         Set<String> expectedRecords = Set.of(
                 "c0.app1.tenant1.us-west-1.vespa.oath.cloud",
                 "c1.app1.tenant1.us-west-1.vespa.oath.cloud",
@@ -131,13 +130,13 @@ public class RoutingPolicyMaintainerTest {
         assertEquals(4, policies(app1).size());
 
         // Next run does nothing
-        maintainer.maintain();
+        maintain();
         assertEquals(expectedRecords, recordNames());
         assertEquals(4, policies(app1).size());
 
         // Add 1 cluster in each zone
         provisionLoadBalancers(app1, clustersPerZone + 1);
-        maintainer.maintain();
+        maintain();
         expectedRecords = Set.of(
                 "c0.app1.tenant1.us-west-1.vespa.oath.cloud",
                 "c1.app1.tenant1.us-west-1.vespa.oath.cloud",
@@ -152,7 +151,7 @@ public class RoutingPolicyMaintainerTest {
         // Add another application
         tester.deployCompletely(app2, applicationPackage);
         provisionLoadBalancers(app2, clustersPerZone);
-        maintainer.maintain();
+        maintain();
         expectedRecords = Set.of(
                 "c0.app1.tenant1.us-west-1.vespa.oath.cloud",
                 "c1.app1.tenant1.us-west-1.vespa.oath.cloud",
@@ -170,7 +169,7 @@ public class RoutingPolicyMaintainerTest {
 
         // Remove cluster from app1
         provisionLoadBalancers(app1, clustersPerZone);
-        maintainer.maintain();
+        maintain();
         expectedRecords = Set.of(
                 "c0.app1.tenant1.us-west-1.vespa.oath.cloud",
                 "c1.app1.tenant1.us-west-1.vespa.oath.cloud",
@@ -189,7 +188,7 @@ public class RoutingPolicyMaintainerTest {
                   tester.controller().applications().deactivate(app2.id(), zone);
                   tester.configServer().removeLoadBalancers(app2.id(), zone);
               });
-        maintainer.maintain();
+        maintain();
         expectedRecords = Set.of(
                 "c0.app1.tenant1.us-west-1.vespa.oath.cloud",
                 "c1.app1.tenant1.us-west-1.vespa.oath.cloud",
@@ -197,6 +196,11 @@ public class RoutingPolicyMaintainerTest {
                 "c1.app1.tenant1.us-central-1.vespa.oath.cloud"
         );
         assertEquals(expectedRecords, recordNames());
+    }
+
+    private void maintain() {
+        maintainer.run();
+        tester.updateDns();
     }
 
     private Set<RoutingPolicy> policies(Application application) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/NameServiceQueueSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/NameServiceQueueSerializerTest.java
@@ -1,0 +1,52 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.persistence;
+
+import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.AliasTarget;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
+import com.yahoo.vespa.hosted.controller.dns.CreateRecord;
+import com.yahoo.vespa.hosted.controller.dns.CreateRecords;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue;
+import com.yahoo.vespa.hosted.controller.dns.RemoveRecords;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mpolden
+ */
+public class NameServiceQueueSerializerTest {
+
+    private final NameServiceQueueSerializer serializer = new NameServiceQueueSerializer();
+
+    @Test
+    public void test_serialization() {
+        var record1 = new Record(Record.Type.CNAME, RecordName.from("cname.example.com"), RecordData.from("example.com"));
+        var record2 = new Record(Record.Type.TXT, RecordName.from("txt.example.com"), RecordData.from("text"));
+        var requests = List.of(
+                new CreateRecord(record1),
+                new CreateRecords(List.of(record2)),
+                new CreateRecords(List.of(new Record(Record.Type.ALIAS, RecordName.from("alias.example.com"),
+                                                     new AliasTarget(HostName.from("alias1"),
+                                                                     "dns-zone-01",
+                                                                     ZoneId.from("prod", "us-north-1")).asData()),
+                                          new Record(Record.Type.ALIAS, RecordName.from("alias.example.com"),
+                                                     new AliasTarget(HostName.from("alias2"),
+                                                                     "dns-zone-02",
+                                                                     ZoneId.from("prod", "us-north-2")).asData()))
+                ),
+                new RemoveRecords(record1.type(), record1.name()),
+                new RemoveRecords(record2.type(), record2.data())
+        );
+
+        var queue = new NameServiceQueue(requests);
+        var serialized = serializer.fromSlime(serializer.toSlime(queue));
+        assertEquals(List.copyOf(queue.requests()), List.copyOf(serialized.requests()));
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/responses/maintenance.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/responses/maintenance.json
@@ -37,6 +37,9 @@
       "name": "MetricsReporter"
     },
     {
+      "name": "NameServiceDispatcher"
+    },
+    {
       "name": "OsVersionStatusUpdater"
     },
     {


### PR DESCRIPTION
This introduces a queue for name service requests in the controller. Code that
previously interacted directly with a `NameService` now uses
`NameServiceForwarder` instead, which persists requests in a `NameServiceQueue`.

The maintainer `NameServiceDispatcher` picks one request from the queue on each
run (currently every 5 seconds) and submits it to the name service.

Max request rate will be be 2 requests / 5 seconds. Some implementations may
dispatch an extra request on execution, typically to ensure idempotency.

Code that needs to observe the effect of their request (e.g. TXT updates), may
provide `NameServiceForwarder` with a higher priority that adds the request to
the head of the queue.