### PR TITLE
Elide bucket DB pruning scans when possible

### DIFF
--- a/storage/src/tests/distributor/CMakeLists.txt
+++ b/storage/src/tests/distributor/CMakeLists.txt
@@ -51,6 +51,7 @@ vespa_add_library(storage_gtestdistributor TEST
     bucketdbupdatertest.cpp
     # Fixture etc. dupes with non-gtest runner :
     distributortestutil.cpp
+    bucket_db_prune_elision_test.cpp
     messagesenderstub.cpp
     DEPENDS
     storage_distributor

--- a/storage/src/tests/distributor/bucket_db_prune_elision_test.cpp
+++ b/storage/src/tests/distributor/bucket_db_prune_elision_test.cpp
@@ -1,0 +1,119 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/storage/distributor/bucket_db_prune_elision.h>
+#include <vespa/vdslib/state/clusterstate.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace storage::distributor {
+
+namespace {
+
+lib::ClusterState state_of(const char* str) {
+    return lib::ClusterState(str);
+}
+
+}
+
+TEST(IdempotentStateTransitionTest, state_differing_only_in_version_allows_elision) {
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("version:1 bits:8 distributor:3 storage:3"),
+                                         state_of("version:2 bits:8 distributor:3 storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, differing_cluster_state_disallows_elision) {
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("cluster:d distributor:3 storage:3"),
+                                          state_of("distributor:3 storage:3")));
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                          state_of("cluster:d distributor:3 storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, differing_distribution_bit_count_disallows_elision) {
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("bits:8 distributor:3 storage:3"),
+                                          state_of("bits:9 distributor:3 storage:3")));
+    // No explicit "bits:" implies 16 bits
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("bits:8 distributor:3 storage:3"),
+                                          state_of("distributor:3 storage:3")));
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                          state_of("bits:8 distributor:3 storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, same_implicit_distribution_bit_count_allows_elision) {
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                         state_of("bits:16 distributor:3 storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, changed_distributor_node_count_disallows_elision) {
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                          state_of("distributor:4 storage:3")));
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:4 storage:3"),
+                                          state_of("distributor:3 storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, changed_distributor_node_state_disallows_elision) {
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 .0.s:d storage:3"),
+                                          state_of("distributor:3 storage:3")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                          state_of("distributor:3 .0.s:d storage:3")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 .0.s:d storage:3"),
+                                          state_of("distributor:3 .0.s:u storage:3")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 .0.s:d storage:3"),
+                                          state_of("distributor:3 .1.s:d storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, changed_storage_node_count_disallows_elision) {
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                          state_of("distributor:3 storage:4")));
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:4"),
+                                          state_of("distributor:3 storage:3")));
+}
+
+TEST(IdempotentStateTransitionTest, changed_storage_node_state_disallows_elision) {
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:d"),
+                                          state_of("distributor:3 storage:3")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                          state_of("distributor:3 storage:3 .0.s:d")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:d"),
+                                          state_of("distributor:3 storage:3 .0.s:u")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:d"),
+                                          state_of("distributor:3 storage:3 .1.s:d")));
+}
+
+TEST(IdempotentStateTransitionTest, may_elide_for_transition_between_different_effective_storage_down_states) {
+    // Maintenance -> Down edge shall already have pruned DB on Maintenance edge
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:m"),
+                                         state_of("distributor:3 storage:3 .0.s:d")));
+
+    // Down -> Maintenance edge shall already have pruned DB on Down edge
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:d"),
+                                         state_of("distributor:3 storage:3 .0.s:m")));
+}
+
+TEST(IdempotentStateTransitionTest, may_elide_for_transition_between_different_effective_storage_up_states) {
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:i"),
+                                         state_of("distributor:3 storage:3")));
+
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .1.s:r"),
+                                         state_of("distributor:3 storage:3")));
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                         state_of("distributor:3 storage:3 .2.s:r")));
+}
+
+// Changed startup timestamps imply that bucket info should be fetched from a node, but
+// does not imply that pruning is required.
+TEST(IdempotentStateTransitionTest, may_elide_changed_startup_timestamps) {
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3"),
+                                         state_of("distributor:3 storage:3 .0.t:123456")));
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.t:123456"),
+                                         state_of("distributor:3 storage:3")));
+    EXPECT_TRUE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.t:123456"),
+                                         state_of("distributor:3 storage:3 .0.t:654321")));
+}
+
+}

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(storage_distributor
     activecopy.cpp
     blockingoperationstarter.cpp
     bucketdbupdater.cpp
+    bucket_db_prune_elision.cpp
     bucketgctimecalculator.cpp
     bucketlistmerger.cpp
     clusterinformation.cpp

--- a/storage/src/vespa/storage/distributor/bucket_db_prune_elision.cpp
+++ b/storage/src/vespa/storage/distributor/bucket_db_prune_elision.cpp
@@ -1,0 +1,58 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "bucket_db_prune_elision.h"
+#include <vespa/vdslib/state/clusterstate.h>
+
+namespace storage::distributor {
+
+// Returns whether the set of nodes of type `node_type` across two cluster states
+// are idempotent from the perspective of bucket pruning. This is the case iff
+// the effective down/up state of each node is unchanged. I.e. if the only difference
+// between two states is that a storage node goes from state Down to Maintenance (or
+// vice versa), the buckets shall already have been pruned during processing of the
+// first edge, so the subsequent pruning may be elided.
+//
+// If a node's state is not one of `up_states`, it is considered to be in an effective
+// Down state, and vice versa.
+//
+// Precondition: a.getNodeCount(node_type) == b.getNodeCount(node_type)
+bool node_states_are_idempotent_for_pruning(const lib::NodeType& node_type,
+                                            const lib::ClusterState& a,
+                                            const lib::ClusterState& b,
+                                            const char* up_states)
+{
+    const uint16_t node_count = a.getNodeCount(node_type);
+    for (uint16_t i = 0; i < node_count; ++i) {
+        lib::Node node(node_type, i);
+        const auto& a_s = a.getNodeState(node);
+        const auto& b_s = b.getNodeState(node);
+        // Transitioning from one effective Down state to another can elide DB pruning,
+        // as the DB shall already have been pruned of all relevant buckets on the _first_
+        // effective Down edge.
+        // No pruning shall take place on a transition from one effective Up state to another
+        // effective Up state.
+        if (a_s.getState().oneOf(up_states) != b_s.getState().oneOf(up_states)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool db_pruning_may_be_elided(const lib::ClusterState& a, const lib::ClusterState& b, const char* up_states) {
+    if (a.getClusterState() != b.getClusterState()) {
+        return false;
+    }
+    if (a.getDistributionBitCount() != b.getDistributionBitCount()) {
+        return false;
+    }
+    if (a.getNodeCount(lib::NodeType::DISTRIBUTOR) != b.getNodeCount(lib::NodeType::DISTRIBUTOR)) {
+        return false;
+    }
+    if (a.getNodeCount(lib::NodeType::STORAGE) != b.getNodeCount(lib::NodeType::STORAGE)) {
+        return false;
+    }
+    return (node_states_are_idempotent_for_pruning(lib::NodeType::DISTRIBUTOR, a, b, up_states) &&
+            node_states_are_idempotent_for_pruning(lib::NodeType::STORAGE, a, b, up_states));
+}
+
+}

--- a/storage/src/vespa/storage/distributor/bucket_db_prune_elision.h
+++ b/storage/src/vespa/storage/distributor/bucket_db_prune_elision.h
@@ -1,0 +1,27 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace storage::lib {
+class ClusterState;
+}
+
+namespace storage::distributor {
+
+/*
+ * Returns whether the state transition from a -> b is idempotent in terms
+ * of buckets needing to be pruned from the distributor's bucket database.
+ *
+ * Examples of when this is the case:
+ *   - `a` and `b` differ only in state version number
+ *   - Storage node 1 is .s:d in `a`, and .s:m in `b`. Buckets have already
+ *     been pruned when `a` was processed.
+ *   - Node startup timestamps have been changed. This will trigger bucket
+ *     info re-fetches if the distributor observes a higher startup timestamp
+ *     than it currently was aware of, but does not need any pruning.
+ */
+bool db_pruning_may_be_elided(const lib::ClusterState& a,
+                              const lib::ClusterState& b,
+                              const char* up_states = "uri");
+
+}

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.h
@@ -163,7 +163,8 @@ private:
 
     void updateState(const lib::ClusterState& oldState, const lib::ClusterState& newState);
 
-    void removeSuperfluousBuckets(const lib::ClusterStateBundle& newState);
+    void removeSuperfluousBuckets(const lib::ClusterStateBundle& newState,
+                                  bool is_distribution_config_change);
 
     void replyToPreviousPendingClusterStateIfAny();
     void replyToActivationWithActualVersion(


### PR DESCRIPTION
@geirst please review.

Only do a (potentially expensive) pruning pass over the bucket DB
when the cluster state transition indicates that one or more nodes
are not in the same availability-state as the currently active state.

For instance, if a cluster state change is for a content node going
from Maintenance to Down, no pruning action is required since that
shall already have taken place during the processing of the initial
Down edge (and no buckets shall have been created for it in the meantime).

We do not currently attempt to elide distribution config changes, as
these happen much more rarely than cluster state changes.