### PR TITLE
Avoid dereferencing symlink

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -559,7 +559,7 @@ function(install_fat_java_artifact NAME)
 endfunction()
 
 function(install_absolute_symlink TARGET LINK)
-    install(CODE "execute_process(COMMAND ln -sf ${TARGET} \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${LINK})")
+    install(CODE "execute_process(COMMAND ln -snf ${TARGET} \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${LINK})")
 endfunction(install_absolute_symlink)
 
 function(install_symlink TARGET LINK)


### PR DESCRIPTION
The call

  install_symlink(conf/configserver-app/components lib/jars/config-models)

would on first invocation install the symlink at lib/jars/config-models to
point at .../components. This is what we want.

But if invoked again, it would note config-models is a directory, and therefore
prepare to install a symlink in that directory. The name of the symlink would
be taken from the target (components). And therefore
conf/configserver-app/components/components would point to
conf/configserver-app/components!

With -n, symlink targets are not dereferenced and therefore the second
invocation should be a no-op (with -f).