### PR TITLE
Remove stale routing policies

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicyMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicyMaintainerTest.java
@@ -196,6 +196,8 @@ public class RoutingPolicyMaintainerTest {
                 "c1.app1.tenant1.us-central-1.vespa.oath.cloud"
         );
         assertEquals(expectedRecords, recordNames());
+        assertTrue("Removes stale routing policies " + app2, tester.controller().applications().routingPolicies(app2.id()).isEmpty());
+        assertEquals("Keeps routing policies for " + app1, 4, tester.controller().applications().routingPolicies(app1.id()).size());
     }
 
     private void maintain() {


### PR DESCRIPTION
This ensures that routing policies for non-existent load balancers are deleted.
Systems with frequent re-creation of deployments (e.g. CD) causes many load
balancers to be provisioned and deprovisioned. Each provisioned load balancer
gets a new hostname, and thus a new routing policy.

Since routing policies for each and every load balancer was kept, we ended up
with a large number of remove records requests and thus a large
`NameServiceQueue`.