### PR TITLE
Handle getting new config after getting empty config

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/MemoryCache.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/MemoryCache.java
@@ -40,7 +40,8 @@ public class MemoryCache {
      * @param config config to put in cache
      */
     public void put(RawConfig config) {
-        if (config.isError()) return;
+        // Do not cache errors or empty configs (which have generation 0)
+        if (config.isError() || config.getGeneration() == 0) return;
 
         log.log(LogLevel.DEBUG, () -> "Putting '" + config + "' into memory cache");
         cache.put(new ConfigCacheKey(config.getKey(), config.getDefMd5()), config);

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/RpcConfigSourceClient.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/RpcConfigSourceClient.java
@@ -132,7 +132,7 @@ class RpcConfigSourceClient implements ConfigSourceClient {
                     ret = cachedConfig;
                 }
             }
-            if (!cachedConfig.isError()) {
+            if (!cachedConfig.isError() && cachedConfig.getGeneration() > 0) {
                 needToGetConfig = false;
             }
         }


### PR DESCRIPTION
Sentinel config is empty with generation 0 if an application does not
exist. When we get that, make sure not to cache the config and make
sure to ask for new new config even when we have one for generation 0,
to handle cases where we get empty sentinel config due to some config server
issue/bug when upgrading and where the effect is that empty sentinel config
is served.

This change should make the sentinel start services immediately after such
an issue has been fixed.

@jobergum @andreer @yngveaasheim FYI