### PR TITLE
Set content-type for service api response

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ServiceApiResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ServiceApiResponse.java
@@ -79,6 +79,11 @@ class ServiceApiResponse extends HttpResponse {
         new JsonFormat(true).encode(stream, slime);
     }
 
+    @Override
+    public String getContentType() {
+        return "application/json";
+    }
+
     @SuppressWarnings("unchecked")
     private void mapToSlime(Map<?,?> data, Cursor object) {
         for (Map.Entry<String, Object> entry : ((Map<String, Object>)data).entrySet())


### PR DESCRIPTION
Returned the default (`text/plain`). We have a client in console that automatically conververts response based on content type, which failed in this case.