### PR TITLE
Jvenstad/open source controller client with athenz

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/SignatureFilterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/SignatureFilterTest.java
@@ -14,6 +14,8 @@ import com.yahoo.vespa.hosted.controller.restapi.ApplicationRequestToDiscFilterR
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.util.Set;
@@ -70,7 +72,7 @@ public class SignatureFilterTest {
         assertNull(unsigned.getAttribute(SecurityContext.ATTRIBUTE_NAME));
 
         // Signed request gets no role when no key is stored for the application.
-        DiscFilterRequest signed = requestOf(signer.signed(request, Method.GET), emptyBody);
+        DiscFilterRequest signed = requestOf(signer.signed(request, Method.GET, InputStream::nullInputStream), emptyBody);
         filter.filter(signed);
         assertNull(signed.getAttribute(SecurityContext.ATTRIBUTE_NAME));
 
@@ -90,7 +92,7 @@ public class SignatureFilterTest {
 
         // Signed POST request also gets a build service role.
         byte[] hiBytes = new byte[]{0x48, 0x69};
-        signed = requestOf(signer.signed(request, Method.POST), hiBytes);
+        signed = requestOf(signer.signed(request, Method.POST, () -> new ByteArrayInputStream(hiBytes)), hiBytes);
         filter.filter(signed);
         securityContext = (SecurityContext) signed.getAttribute(SecurityContext.ATTRIBUTE_NAME);
         assertEquals("buildService@my-tenant.my-app", securityContext.principal().getName());

--- a/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
+++ b/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
@@ -162,7 +162,7 @@ public abstract class ControllerHttpClient {
 
         private SigningControllerHttpClient(URI endpoint, Path privateKeyFile, ApplicationId id) {
             super(endpoint, HttpClient.newBuilder());
-            this.signer = new RequestSigner(unchecked(() -> Files.readString(privateKeyFile)), id.serializedForm());
+            this.signer = new RequestSigner(unchecked(() -> Files.readString(privateKeyFile, UTF_8)), id.serializedForm());
         }
 
         @Override

--- a/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
+++ b/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
@@ -12,7 +12,6 @@ import com.yahoo.slime.Slime;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -52,7 +51,7 @@ public class ControllerHttpClient {
         HttpRequest request = signer.signed(HttpRequest.newBuilder(applicationPath(id.tenant(), id.application()).resolve("submit"))
                                                        .timeout(Duration.ofMinutes(30)),
                                             POST,
-                                            new MultiPartStreamer().addJson("submitOptions", metaToSlime(submission))
+                                            new MultiPartStreamer().addJson("submitOptions", metoToJson(submission))
                                                                    .addFile("applicationZip", submission.applicationZip())
                                                                    .addFile("applicationTestZip", submission.applicationTestZip()));
         try {
@@ -84,7 +83,7 @@ public class ControllerHttpClient {
     }
 
     /** Returns a JSON representation of the submission meta data. */
-    private static String metaToSlime(Submission submission) {
+    private static String metaToJson(Submission submission) {
         try {
             Slime slime = new Slime();
             Cursor rootObject = slime.setObject();

--- a/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
+++ b/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
@@ -55,9 +55,9 @@ public abstract class ControllerHttpClient {
         return new SigningControllerHttpClient(endpoint, privateKeyFile, id);
     }
 
-    /** Creates an HTTP client against the given endpoint, which uses the given private key and certificate of an Athenz identity. */
-    public static ControllerHttpClient withAthenzIdentity(URI endpoint, Path privateKeyFile, Path certificateFile) {
-        return new AthenzControllerHttpClient(endpoint, privateKeyFile, certificateFile);
+    /** Creates an HTTP client against the given endpoint, which uses the given private key and certificate identity. */
+    public static ControllerHttpClient withKeyAndCertificate(URI endpoint, Path privateKeyFile, Path certificateFile) {
+        return new MutualTlsControllerHttpClient(endpoint, privateKeyFile, certificateFile);
     }
 
     /** Sends submission to the remote controller and returns the version of the accepted package, or throws if this fails. */
@@ -173,10 +173,10 @@ public abstract class ControllerHttpClient {
     }
 
 
-    /** Client that uses a given Athenz identity to authenticate to the remote controller. */
-    private static class AthenzControllerHttpClient extends ControllerHttpClient {
+    /** Client that uses a given key / certificate identity to authenticate to the remote controller. */
+    private static class MutualTlsControllerHttpClient extends ControllerHttpClient {
 
-        private AthenzControllerHttpClient(URI endpoint, Path privateKeyFile, Path certificateFile) {
+        private MutualTlsControllerHttpClient(URI endpoint, Path privateKeyFile, Path certificateFile) {
             super(endpoint,
                   HttpClient.newBuilder().sslContext(new SslContextBuilder().withKeyStore(privateKeyFile, certificateFile).build()));
         }

--- a/hosted-api/src/main/java/ai/vespa/hosted/api/RequestSigner.java
+++ b/hosted-api/src/main/java/ai/vespa/hosted/api/RequestSigner.java
@@ -70,35 +70,4 @@ public class RequestSigner {
         }
     }
 
-    /**
-     * Completes, signs and returns the given request builder and data.
-     *
-     * This sets the Content-Type header from the given streamer, and returns
-     * {@code signed(request, method, streamer::data)}.
-     */
-    public HttpRequest signed(HttpRequest.Builder request, Method method, MultiPartStreamer streamer) {
-        request.setHeader("Content-Type", streamer.contentType());
-        return signed(request, method, streamer::data);
-    }
-
-    /**
-     * Completes, signs and returns the given request builder.<br>
-     * <br>
-     * This is simply a convenience for<br>
-     * {@code signed(request, method, () -> new ByteArrayInputStream(data))}.
-     */
-    public HttpRequest signed(HttpRequest.Builder request, Method method, byte[] data) {
-        return signed(request, method, () -> new ByteArrayInputStream(data));
-    }
-
-    /**
-     * Completes, signs and returns the given request builder.<br>
-     * <br>
-     * This sets the data of the request to be empty, and returns <br>
-     * {@code signed(request, method, InputStream::nullInputStream)}.
-     */
-    public HttpRequest signed(HttpRequest.Builder request, Method method) {
-        return signed(request, method, InputStream::nullInputStream);
-    }
-
 }

--- a/hosted-api/src/main/java/ai/vespa/hosted/api/Signatures.java
+++ b/hosted-api/src/main/java/ai/vespa/hosted/api/Signatures.java
@@ -19,7 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Signatures {
 
-    /** Returns the SHA-256 hash of the content in the implied input stream, consuming it in the process. */
+    /** Returns the SHA-256 hash of the content in the implied input stream. */
     public static byte[] sha256Digest(Callable<InputStream> in) {
         try (DigestInputStream digester = sha256Digester(in.call())) {
             byte[] buffer = new byte[1 << 10];

--- a/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/SubmitMojo.java
+++ b/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/SubmitMojo.java
@@ -50,6 +50,9 @@ public class SubmitMojo extends AbstractMojo {
     @Parameter(property = "privateKeyFile", required = true)
     private String privateKeyFile;
 
+    @Parameter(property = "certificateFile")
+    private String certificateFile;
+
     @Parameter(property = "authorEmail", required = true)
     private String authorEmail;
 
@@ -66,9 +69,9 @@ public class SubmitMojo extends AbstractMojo {
     public void execute() {
         setup();
         ApplicationId id = ApplicationId.from(tenant, application, instance);
-        ControllerHttpClient controller = ControllerHttpClient.withSignatureKey(URI.create(endpointUri),
-                                                                                Paths.get(privateKeyFile),
-                                                                                id);
+        ControllerHttpClient controller = certificateFile == null
+                ? ControllerHttpClient.withSignatureKey(URI.create(endpointUri), Paths.get(privateKeyFile), id)
+                : ControllerHttpClient.withAthenzIdentity(URI.create(endpointUri), Paths.get(privateKeyFile), Paths.get(certificateFile));
 
         Submission submission = new Submission(repository, branch, commit, authorEmail,
                                                Paths.get(applicationZip), Paths.get(applicationTestZip));

--- a/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/SubmitMojo.java
+++ b/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/SubmitMojo.java
@@ -9,14 +9,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Submits a Vespa application package and corresponding test jars to the hosted Vespa API.
@@ -71,7 +66,7 @@ public class SubmitMojo extends AbstractMojo {
         ApplicationId id = ApplicationId.from(tenant, application, instance);
         ControllerHttpClient controller = certificateFile == null
                 ? ControllerHttpClient.withSignatureKey(URI.create(endpointUri), Paths.get(privateKeyFile), id)
-                : ControllerHttpClient.withAthenzIdentity(URI.create(endpointUri), Paths.get(privateKeyFile), Paths.get(certificateFile));
+                : ControllerHttpClient.withKeyAndCertificate(URI.create(endpointUri), Paths.get(privateKeyFile), Paths.get(certificateFile));
 
         Submission submission = new Submission(repository, branch, commit, authorEmail,
                                                Paths.get(applicationZip), Paths.get(applicationTestZip));


### PR DESCRIPTION
@bjorncs please review.

This adds the Athenz authentication option to the submit plugin, by specifying an optional certificate; if only a private key path is specified, request signing is used.

