### PR TITLE
Use a templated helper method to get proper inlining by allowing the …

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/i_search_context.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/i_search_context.h
@@ -52,15 +52,17 @@ public:
 
     int32_t find(DocId docId, int32_t elementId, int32_t &weight) const { return onFind(docId, elementId, weight); }
     int32_t find(DocId docId, int32_t elementId) const { return onFind(docId, elementId); }
-    bool matches(DocId docId, int32_t &weight) const {
+    template<typename SC>
+    static bool matches(const SC & sc, DocId docId, int32_t &weight) {
         weight = 0;
         int32_t oneWeight(0);
-        int32_t firstId = find(docId, 0, oneWeight);
-        for (int32_t id(firstId); id >= 0; id = find(docId, id + 1, oneWeight)) {
+        int32_t firstId = sc.find(docId, 0, oneWeight);
+        for (int32_t id(firstId); id >= 0; id = sc.find(docId, id + 1, oneWeight)) {
             weight += oneWeight;
         }
         return firstId >= 0;
     }
+    bool matches(DocId docId, int32_t &weight) const { return matches(*this, docId, weight); }
     bool matches(DocId doc) const { return find(doc, 0) >= 0; }
 
 };

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -6,10 +6,9 @@
 #include "postinglisttraits.h"
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>
+#include <vespa/searchcommon/attribute/i_search_context.h>
 
 namespace search {
-
-namespace attribute { class ISearchContext; }
 
 namespace fef {
     class TermFieldMatchData;
@@ -92,11 +91,15 @@ private:
     std::unique_ptr<BitVector> get_hits(uint32_t begin_id) override;
 
 protected:
+    bool matches(uint32_t docId, int32_t &weight) const {
+        return attribute::ISearchContext::matches(_concreteSearchCtx, docId, weight);
+    }
+    bool matches(uint32_t doc) const { return _concreteSearchCtx.find(doc, 0) >= 0; }
     const SC &_concreteSearchCtx;
 
 public:
     AttributeIteratorT(const SC &concreteSearchCtx, fef::TermFieldMatchData *matchData);
-    bool seekFast(uint32_t docId) const { return _concreteSearchCtx.matches(docId); }
+    bool seekFast(uint32_t docId) const { return matches(docId); }
 };
 
 template <typename SC>
@@ -110,11 +113,12 @@ private:
     std::unique_ptr<BitVector> get_hits(uint32_t begin_id) override;
 
 protected:
+    bool matches(uint32_t doc) const { return _concreteSearchCtx.find(doc, 0) >= 0; }
     const SC &_concreteSearchCtx;
 
 public:
     FilterAttributeIteratorT(const SC &concreteSearchCtx, fef::TermFieldMatchData *matchData);
-    bool seekFast(uint32_t docId) const { return _concreteSearchCtx.matches(docId); }
+    bool seekFast(uint32_t docId) const { return matches(docId); }
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
@@ -60,7 +60,7 @@ public:
     /*
      * Specialization of SearchContext for weighted set type
      */
-    class SetSearchContext : public NumericAttribute::Range<T>, public AttributeVector::SearchContext
+    class SetSearchContext final : public NumericAttribute::Range<T>, public AttributeVector::SearchContext
     {
     private:
         const MultiValueNumericAttribute<B, M> & _toBeSearched;
@@ -113,11 +113,11 @@ public:
     private:
         const MultiValueNumericAttribute<B, M> & _toBeSearched;
 
-        int32_t onFind(DocId docId, int32_t elemId, int32_t & weight) const override {
+        int32_t onFind(DocId docId, int32_t elemId, int32_t & weight) const override final {
             return find(docId, elemId, weight);
         }
 
-        int32_t onFind(DocId docId, int32_t elemId) const override {
+        int32_t onFind(DocId docId, int32_t elemId) const override final {
             return find(docId, elemId);
         }
 

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
@@ -160,9 +160,9 @@ SingleValueNumericAttribute<B>::getSearch(QueryTermSimple::UP qTerm,
     (void) params;
     QueryTermSimple::RangeResult<T> res = qTerm->getRange<T>();
     if (res.isEqual()) {
-        return AttributeVector::SearchContext::UP(new SingleSearchContext< NumericAttribute::Equal<T> >(std::move(qTerm), *this));
+        return std::make_unique<SingleSearchContext<NumericAttribute::Equal<T>>>(std::move(qTerm), *this);
     } else {
-        return AttributeVector::SearchContext::UP(new SingleSearchContext< NumericAttribute::Range<T> >(std::move(qTerm), *this));
+        return std::make_unique<SingleSearchContext<NumericAttribute::Range<T>>>(std::move(qTerm), *this);
     }
 }
 
@@ -228,18 +228,16 @@ SingleValueNumericAttribute<B>::SingleSearchContext<M>::
 createFilterIterator(fef::TermFieldMatchData * matchData, bool strict)
 {
     if (!valid()) {
-        return queryeval::SearchIterator::UP(new queryeval::EmptySearch());
+        return std::make_unique<queryeval::EmptySearch>();
     }
     if (getIsFilter()) {
-        return queryeval::SearchIterator::UP
-                (strict
-                 ? new FilterAttributeIteratorStrict<SingleSearchContext<M> >(*this, matchData)
-                 : new FilterAttributeIteratorT<SingleSearchContext<M> >(*this, matchData));
+        return strict
+                 ? std::make_unique<FilterAttributeIteratorStrict<SingleSearchContext<M>>>(*this, matchData)
+                 : std::make_unique<FilterAttributeIteratorT<SingleSearchContext<M>>>(*this, matchData);
     }
-    return queryeval::SearchIterator::UP
-            (strict
-             ? new AttributeIteratorStrict<SingleSearchContext<M> >(*this, matchData)
-             : new AttributeIteratorT<SingleSearchContext<M> >(*this, matchData));
+    return strict
+             ? std::make_unique<AttributeIteratorStrict<SingleSearchContext<M>>>(*this, matchData)
+             : std::make_unique<AttributeIteratorT<SingleSearchContext<M>>>(*this, matchData);
 }
 }
 


### PR DESCRIPTION
…correct type

to be known at the right place.
This yields a 3.3x improvement for the parent child test with slowdown on gcc 7 => 8 transition. 