### PR TITLE
re-implement delayed restart

### DIFF
--- a/configd/src/apps/sentinel/config-handler.h
+++ b/configd/src/apps/sentinel/config-handler.h
@@ -29,6 +29,7 @@ private:
     ConfigSubscriber _subscriber;
     ConfigHandle<SentinelConfig>::UP _sentinelHandle;
     ServiceMap _services;
+    ServiceMap _orphans;
     std::list<OutputConnection *> _outputConnections;
     CommandQueue _cmdQ;
     std::unique_ptr<RpcServer> _rpcServer;
@@ -46,6 +47,7 @@ private:
     void handleCmd(const Cmd& cmd);
     void handleOutputs();
     void handleChildDeaths();
+    void handleRestarts();
 
     static int listen(int port);
     void configure_port(int port);

--- a/configd/src/apps/sentinel/service.h
+++ b/configd/src/apps/sentinel/service.h
@@ -20,13 +20,14 @@ private:
 
     pid_t _pid;
     enum ServiceState { READY, STARTING, RUNNING, TERMINATING, KILLING,
+                        RESTARTING, REMOVING,
                         FINISHED, TERMINATED, KILLED, FAILED } _rawState;
     const enum ServiceState& _state;
     int _exitStatus;
     SentinelConfig::Service *_config;
     bool _isAutomatic;
 
-    static const int MAX_RESTART_PENALTY = 1800;
+    static const unsigned int MAX_RESTART_PENALTY = 1800;
     unsigned int _restartPenalty;
     time_t _last_start;
 
@@ -55,11 +56,13 @@ public:
     int terminate() {
         return terminate(true, false);
     }
-    int start();
+    void start();
+    void remove();
     void youExited(int status); // Call this if waitpid says it exited
     const vespalib::string & name() const;
     const char *stateName() const { return stateName(_state); }
     bool isRunning() const;
+    bool wantsRestart() const;
     int exitStatus() const { return _exitStatus; }
     const SentinelConfig::Service& serviceConfig() const { return *_config; }
     void setAutomatic(bool autoStatus);


### PR DESCRIPTION
* instead of sleeping in the forked process, make "restarting" a
  new service state and check if the restart penalty has been
  applied periodically
* reset restart penalty on config generation changes, meaning
  application deployment triggers immediate startup of delayed
  services
* also, keep removed services after re-configuration in a separate
  "orphans" list, to get better tracking of their final shutdown

@havardpe please review and merge
@baldersheim @bratseth FYI