### PR TITLE
Avoid unknown warning options when using clang. 

### DIFF
--- a/logd/src/logd/CMakeLists.txt
+++ b/logd/src/logd/CMakeLists.txt
@@ -7,7 +7,9 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(logd_PROTOBUF_SRCS logd_PROTOBUF_HDRS ../../../logserver/src/protobuf/log_protocol.proto)
 
 # protoc-generated files emit compiler warnings that we normally treat as errors.
-set_source_files_properties(${logd_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-suggest-override")
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set_source_files_properties(${logd_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-suggest-override")
+endif()
 
 vespa_add_library(logd STATIC
     SOURCES

--- a/logd/src/logd/log_protocol_proto.h
+++ b/logd/src/logd/log_protocol_proto.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
 
 #include "log_protocol.pb.h"
 

--- a/searchlib/src/vespa/searchlib/engine/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/engine/CMakeLists.txt
@@ -4,8 +4,10 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(searchlib_engine_PROTOBUF_SRCS searchlib_engine_PROTOBUF_HDRS ../../../../src/protobuf/search_protocol.proto)
 
 # protoc-generated files emit compiler warnings that we normally treat as errors.
-set_source_files_properties(${searchlib_engine_PROTOBUF_SRCS}
-                            PROPERTIES COMPILE_FLAGS "-Wno-suggest-override")
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set_source_files_properties(${searchlib_engine_PROTOBUF_SRCS}
+    PROPERTIES COMPILE_FLAGS "-Wno-suggest-override")
+endif()
 
 vespa_add_library(searchlib_engine OBJECT
     SOURCES

--- a/searchlib/src/vespa/searchlib/engine/search_protocol_proto.h
+++ b/searchlib/src/vespa/searchlib/engine/search_protocol_proto.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
 
 #include "search_protocol.pb.h"
 

--- a/storageapi/src/vespa/storageapi/mbusprot/CMakeLists.txt
+++ b/storageapi/src/vespa/storageapi/mbusprot/CMakeLists.txt
@@ -9,7 +9,9 @@ PROTOBUF_GENERATE_CPP(storageapi_PROTOBUF_SRCS storageapi_PROTOBUF_HDRS
 
 # protoc-generated files emit compiler warnings that we normally treat as errors.
 # Instead of rolling our own compiler plugin we'll pragmatically disable the noise.
-set_source_files_properties(${storageapi_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-suggest-override -Wno-inline")
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set_source_files_properties(${storageapi_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-suggest-override -Wno-inline")
+endif()
 # protoc explicitly annotates methods with inline, which triggers -Werror=inline when
 # the header file grows over a certain size.
 set_source_files_properties(protocolserialization7.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")

--- a/storageapi/src/vespa/storageapi/mbusprot/protobuf_includes.h
+++ b/storageapi/src/vespa/storageapi/mbusprot/protobuf_includes.h
@@ -4,7 +4,9 @@
 
 // Disable warnings emitted by protoc generated files
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
 
 #include "feed.pb.h"
 #include "visiting.pb.h"


### PR DESCRIPTION
@vekterli : please review
