### PR TITLE
Disable some warning options on clang. 

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -22,7 +22,8 @@ set(C_WARN_OPTS "-Winline -Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wc
 # Warnings that are specific to C++ compilation
 # Note: this is not a union of C_WARN_OPTS, since CMAKE_CXX_FLAGS already includes CMAKE_C_FLAGS, which in turn includes C_WARN_OPTS transitively
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CXX_SPECIFIC_WARN_OPTS "-Wnon-virtual-dtor -Wformat-security")
+  set(CXX_SPECIFIC_WARN_OPTS "-Wnon-virtual-dtor -Wformat-security -Wno-overloaded-virtual")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-delete-null-pointer-checks")
 else()
   set(CXX_SPECIFIC_WARN_OPTS "-Wsuggest-override -Wnon-virtual-dtor -Wformat-security")
 endif()


### PR DESCRIPTION
Disable null pointer check deletion on clang.

@vekterli : please review
