### PR TITLE
Remove unused method

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -56,8 +56,6 @@ public interface ModelContext {
         boolean useFdispatchByDefault();
         boolean dispatchWithProtobuf();
         boolean useAdaptiveDispatch();
-        // TODO: Remove when 7.40 is the oldest model in use
-        default boolean useSeparateServiceTypeForLogserverContainer() { return true; }
         boolean enableMetricsProxyContainer();
     }
 


### PR DESCRIPTION
Method has never been used by 6.x models, so should be safe to delete