### PR TITLE
Push metrics to both old and new metrics proxy.

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -39,8 +39,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -678,7 +680,7 @@ public class NodeAgentImplTest {
                 .replaceAll("\\s", "")
                 .replaceAll("\\n", "");
 
-        String[] expectedCommand = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:19091",  "setExtraMetrics", expectedMetrics};
+        String[] expectedCommand = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:19094",  "setExtraMetrics", expectedMetrics};
         doAnswer(invocation -> {
             NodeAgentContext calledContainerName = (NodeAgentContext) invocation.getArguments()[0];
             long calledTimeout = (long) invocation.getArguments()[1];
@@ -687,6 +689,9 @@ public class NodeAgentImplTest {
             calledCommand[calledCommand.length - 1] = calledCommand[calledCommand.length - 1]
                     .replaceAll("\"timestamp\":\\d+", "\"timestamp\":0")
                     .replaceAll("([0-9]+\\.[0-9]{1,3})([0-9]*)", "$1"); // Only keep the first 3 decimals
+
+            // TODO: Remove when old metrics proxy is discontinued.
+            calledCommand[3] = calledCommand[3].replaceFirst("19091", "19094");
 
             assertEquals(context, calledContainerName);
             assertEquals(5L, calledTimeout);


### PR DESCRIPTION
- Use short timeout for new proxy, which is disabled in most
  environments for now.