### PR TITLE
Disable bucket DB pruning elision optimization for now

### DIFF
--- a/storage/src/tests/distributor/bucket_db_prune_elision_test.cpp
+++ b/storage/src/tests/distributor/bucket_db_prune_elision_test.cpp
@@ -83,6 +83,9 @@ TEST(IdempotentStateTransitionTest, changed_storage_node_state_disallows_elision
 
     EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:d"),
                                           state_of("distributor:3 storage:3 .1.s:d")));
+
+    EXPECT_FALSE(db_pruning_may_be_elided(state_of("distributor:3 storage:3 .0.s:r"),
+                                          state_of("distributor:3 storage:3 .0.s:d")));
 }
 
 TEST(IdempotentStateTransitionTest, may_elide_for_transition_between_different_effective_storage_down_states) {

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
@@ -121,7 +121,7 @@ BucketDBUpdater::recheckBucketInfo(uint32_t nodeIdx,
 void
 BucketDBUpdater::removeSuperfluousBuckets(
         const lib::ClusterStateBundle& newState,
-        bool is_distribution_config_change)
+        [[maybe_unused]] bool is_distribution_config_change)
 {
     const bool move_to_read_only_db = shouldDeferStateEnabling();
     const char* up_states = _distributorComponent.getDistributor().getStorageNodeUpStates();
@@ -129,16 +129,6 @@ BucketDBUpdater::removeSuperfluousBuckets(
         const auto& newDistribution(elem.second->getDistribution());
         const auto& oldClusterState(elem.second->getClusterState());
         const auto& new_cluster_state = newState.getDerivedClusterState(elem.first);
-
-        // Running a full DB sweep is expensive, so if the cluster state transition does
-        // not actually indicate that buckets should possibly be removed, we elide it entirely.
-        if (!is_distribution_config_change
-            && db_pruning_may_be_elided(oldClusterState, *new_cluster_state, up_states))
-        {
-            LOG(debug, "Eliding DB pruning for state transition '%s' -> '%s'",
-                oldClusterState.toString().c_str(), new_cluster_state->toString().c_str());
-            continue;
-        }
 
         auto& bucketDb(elem.second->getBucketDatabase());
         auto& readOnlyDb(_distributorComponent.getReadOnlyBucketSpaceRepo().get(elem.first).getBucketDatabase());


### PR DESCRIPTION
@geirst please review

There may be a currently unknown edge case where some valid edges do not
trigger pruning as they should, so disable optimization entirely until
we know for sure.