### PR TITLE
Avoid recomputing bucket keys during sorting step.

### DIFF
--- a/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition_entry.h
+++ b/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition_entry.h
@@ -9,15 +9,19 @@ namespace storage::distributor::dbtransition {
 struct Entry {
     Entry(const document::BucketId& bid,
           const BucketCopy& copy_)
-        : bucketId(bid),
+        : bucket_key(bid.toKey()),
           copy(copy_)
     {}
 
-    document::BucketId bucketId;
+    uint64_t bucket_key;
     BucketCopy copy;
 
-    bool operator<(const Entry& other) const {
-        return bucketId.toKey() < other.bucketId.toKey();
+    document::BucketId bucket_id() const noexcept {
+        return document::BucketId(document::BucketId::keyToBucketId(bucket_key));
+    }
+
+    bool operator<(const Entry& other) const noexcept {
+        return bucket_key < other.bucket_key;
     }
 };
 


### PR DESCRIPTION
@geirst please review
Buckets are sorted in increasing key order before being merged into
the database. Instead of repeatedly calling `toKey()` on entries, just
store the key verbatim.

Add a (by default disabled) benchmarking test for this case.
With the bucket key change, running this locally brings total merge time
for 917K buckets down from 2 seconds to 1.3 seconds.