### PR TITLE
Revert "Wait until shutdown is completed."

### DIFF
--- a/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
@@ -405,7 +405,7 @@ RPCNetwork::sync()
 void
 RPCNetwork::shutdown()
 {
-    _transport->ShutDown(true);
+    _transport->ShutDown(false);
     _threadPool->Close();
     _executor->shutdown();
     _executor->sync();


### PR DESCRIPTION
Reverts vespa-engine/vespa#9428

Unit tests hang (more info in vespa-engine/vespa#9428)