### PR TITLE
band-aid to avoid blocking forever in transport shutdown

### DIFF
--- a/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
@@ -217,10 +217,10 @@ RPCNetwork::getSendAdapter(const vespalib::Version &version)
 bool
 RPCNetwork::start()
 {
-    if (!_orb->Listen(_requestedPort)) {
+    if (!_transport->Start(_threadPool.get())) {
         return false;
     }
-    if (!_transport->Start(_threadPool.get())) {
+    if (!_orb->Listen(_requestedPort)) {
         return false;
     }
     return true;


### PR DESCRIPTION
make it more likely that messagebus transport thread(s) are started
when start is called.

@baldersheim please review