### PR TITLE
Use more elaborate configId for metricsproxy containers.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -46,7 +46,7 @@ public class MetricsProxyContainer extends Container implements
     private final boolean isHostedVespa;
 
     public MetricsProxyContainer(AbstractConfigProducer parent, int index, boolean isHostedVespa) {
-        super(parent, "" + index, index);
+        super(parent, "metricsproxy." + index, index);
         this.isHostedVespa = isHostedVespa;
         setProp("clustertype", "admin");
         setProp("index", String.valueOf(index));

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
@@ -31,7 +31,7 @@ class MetricsProxyModelTester {
     static final String CLUSTER_CONFIG_ID = "admin/metrics";
 
     // Used for all configs that are produced by the container, not the cluster.
-    static final String CONTAINER_CONFIG_ID = CLUSTER_CONFIG_ID + "/0";
+    static final String CONTAINER_CONFIG_ID = CLUSTER_CONFIG_ID + "/metricsproxy.0";
 
     static VespaModel getModel(String servicesXml) {
         var numberOfHosts = 1;


### PR DESCRIPTION
- admin/metrics/0 => admin/metrics/metricsproxy.0