### PR TITLE
Mock RPC connections instead of relying on 'real' connectivity errors (edited for merge stop)

### DIFF
--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTestCase.java
@@ -30,6 +30,7 @@ import com.yahoo.processing.execution.Execution.Trace;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
+import com.yahoo.search.dispatch.rpc.MockRpcResourcePoolBuilder;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.grouping.GroupingRequest;
 import com.yahoo.search.grouping.request.AllOperation;
@@ -66,7 +67,6 @@ import static org.junit.Assert.assertTrue;
  *
  * @author bratseth
  */
-@SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
 public class FastSearcherTestCase {
 
     private final static DocumentdbInfoConfig documentdbInfoConfig = new DocumentdbInfoConfig(new DocumentdbInfoConfig.Builder());
@@ -77,7 +77,7 @@ public class FastSearcherTestCase {
         Logger.getLogger(FastSearcher.class.getName()).setLevel(Level.ALL);
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool("container.0", 1),
-                                                     new MockDispatcher("a", Collections.emptyList()),
+                                                     MockDispatcher.create(Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      documentdbInfoConfig);
@@ -94,7 +94,7 @@ public class FastSearcherTestCase {
         Logger.getLogger(FastSearcher.class.getName()).setLevel(Level.ALL);
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool("container.0", 1),
-                                                     new MockDispatcher("a", Collections.emptyList()),
+                                                     MockDispatcher.create(Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      documentdbInfoConfig);
@@ -121,12 +121,14 @@ public class FastSearcherTestCase {
 
         List<Node> nodes = new ArrayList<>();
         nodes.add(new Node(0, "host1", 5000, 0));
-        nodes.add(new Node(2, "host2", 5000, 0));
+        nodes.add(new Node(1, "host2", 5000, 0));
 
-        MockFS4ResourcePool mockFs4ResourcePool = new MockFS4ResourcePool();
+        var mockFs4ResourcePool = new MockFS4ResourcePool();
+        var mockRpcResourcePool = new MockRpcResourcePoolBuilder().connection(0).connection(1).build();
+
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                 mockFs4ResourcePool,
-                new MockDispatcher("a", nodes, mockFs4ResourcePool, 1, new VipStatus()),
+                MockDispatcher.create(nodes, mockFs4ResourcePool, mockRpcResourcePool, 1, new VipStatus()),
                 new SummaryParameters(null),
                 new ClusterParams("testhittype"),
                 documentdbConfigWithOneDb);
@@ -145,8 +147,7 @@ public class FastSearcherTestCase {
             doFill(fastSearcher, result);
             ErrorMessage error = result.hits().getError();
             assertEquals("Since we don't actually run summary backends we get this error when the Dispatcher is used",
-                         "Error response from rpc node connection to hostX:0: Connection error",
-                          error.getDetailedMessage().replaceAll("host[12]", "hostX"));
+                    "getDocsums(..) attempted for node X", error.getDetailedMessage().replaceAll("\\d", "X"));
         }
 
         { // direct.summaries due to no summary features
@@ -155,8 +156,7 @@ public class FastSearcherTestCase {
             doFill(fastSearcher, result);
             ErrorMessage error = result.hits().getError();
             assertEquals("Since we don't actually run summary backends we get this error when the Dispatcher is used",
-                         "Error response from rpc node connection to hostX:0: Connection error",
-                         error.getDetailedMessage().replaceAll("host[12]", "hostX"));
+                    "getDocsums(..) attempted for node X", error.getDetailedMessage().replaceAll("\\d", "X"));
         }
     }
 
@@ -167,7 +167,7 @@ public class FastSearcherTestCase {
             new DocumentdbInfoConfig(new DocumentdbInfoConfig.Builder().documentdb(new DocumentdbInfoConfig.Documentdb.Builder().name("testDb")));
         FastSearcher fastSearcher = new FastSearcher(mockBackend,
                                                      new FS4ResourcePool("container.0", 1),
-                                                     new MockDispatcher("a", Collections.emptyList()),
+                                                     MockDispatcher.create(Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      documentdbConfigWithOneDb);
@@ -335,7 +335,7 @@ public class FastSearcherTestCase {
         Logger.getLogger(FastSearcher.class.getName()).setLevel(Level.ALL);
         return new FastSearcher(mockBackend,
                                 new FS4ResourcePool("container.0", 1),
-                                new MockDispatcher("a", Collections.emptyList()),
+                                MockDispatcher.create(Collections.emptyList()),
                                 new SummaryParameters(null),
                                 new ClusterParams("testhittype"),
                                 config);
@@ -345,7 +345,7 @@ public class FastSearcherTestCase {
     public void testSinglePassGroupingIsForcedWithSingleNodeGroups() {
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool("container.0", 1),
-                                                     new MockDispatcher(new Node(0, "host0", 123, 0)),
+                                                     MockDispatcher.create(Collections.singletonList(new Node(0, "host0", 123, 0))),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      documentdbInfoConfig);
@@ -366,9 +366,7 @@ public class FastSearcherTestCase {
 
     @Test
     public void testSinglePassGroupingIsNotForcedWithSingleNodeGroups() {
-        MockDispatcher dispatcher =
-                new MockDispatcher("a", ImmutableList.of(new Node(0, "host0", 123, 0),
-                                                    new Node(2, "host1", 123, 0)));
+        MockDispatcher dispatcher = MockDispatcher.create(ImmutableList.of(new Node(0, "host0", 123, 0), new Node(2, "host1", 123, 0)));
 
         FastSearcher fastSearcher = new FastSearcher(new MockBackend(),
                                                      new FS4ResourcePool("container.0", 1),
@@ -411,7 +409,7 @@ public class FastSearcherTestCase {
         Backend backend = listeners.getBackend(server.host.getHostString(),server.host.getPort());
         FastSearcher fastSearcher = new FastSearcher(backend,
                                                      new FS4ResourcePool("container.0", 1),
-                                                     new MockDispatcher("a", Collections.emptyList()),
+                                                     MockDispatcher.create(Collections.emptyList()),
                                                      new SummaryParameters(null),
                                                      new ClusterParams("testhittype"),
                                                      documentdbInfoConfig);

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/FastSearcherTester.java
@@ -13,6 +13,8 @@ import com.yahoo.prelude.fastsearch.test.fs4mock.MockBackend;
 import com.yahoo.prelude.fastsearch.test.fs4mock.MockFS4ResourcePool;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
+import com.yahoo.search.dispatch.rpc.MockRpcResourcePoolBuilder;
+import com.yahoo.search.dispatch.rpc.RpcResourcePool;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.searchchain.Execution;
 
@@ -31,6 +33,7 @@ class FastSearcherTester {
     public static final String selfHostname = HostName.getLocalhost();
 
     private final MockFS4ResourcePool mockFS4ResourcePool;
+    private final RpcResourcePool mockRpcResourcePool;
     private final FastSearcher fastSearcher;
     private final MockDispatcher mockDispatcher;
     private final VipStatus vipStatus;
@@ -53,7 +56,10 @@ class FastSearcherTester {
         vipStatus = new VipStatus(b.build());
 
         mockFS4ResourcePool = new MockFS4ResourcePool();
-        mockDispatcher = new MockDispatcher(clusterId, searchNodes, mockFS4ResourcePool, containerClusterSize, vipStatus);
+        var builder = new MockRpcResourcePoolBuilder();
+        searchNodes.forEach(node -> builder.connection(node.key()));
+        mockRpcResourcePool = builder.build();
+        mockDispatcher = MockDispatcher.create(searchNodes, mockFS4ResourcePool, mockRpcResourcePool, containerClusterSize, vipStatus);
         fastSearcher = new FastSearcher(new MockBackend(selfHostname, 0L, true),
                                         mockFS4ResourcePool,
                                         mockDispatcher,

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
@@ -2,28 +2,37 @@
 package com.yahoo.prelude.fastsearch.test;
 
 import com.yahoo.container.handler.VipStatus;
+import com.yahoo.prelude.fastsearch.FS4InvokerFactory;
 import com.yahoo.prelude.fastsearch.FS4ResourcePool;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.Dispatcher;
+import com.yahoo.search.dispatch.rpc.RpcInvokerFactory;
+import com.yahoo.search.dispatch.rpc.RpcResourcePool;
 import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 import com.yahoo.vespa.config.search.DispatchConfig;
 
-import java.util.Collections;
 import java.util.List;
 
 class MockDispatcher extends Dispatcher {
+    public static MockDispatcher create(List<Node> nodes) {
+        var fs4ResourcePool = new FS4ResourcePool("container.0", 1);
+        var rpcResourcePool = new RpcResourcePool(toDispatchConfig(nodes));
 
-    public MockDispatcher(Node node) {
-        this(node.hostname(), Collections.singletonList(node));
+        return create(nodes, fs4ResourcePool, rpcResourcePool, 1, new VipStatus());
     }
 
-    public MockDispatcher(String clusterId, List<Node> nodes) {
-        this(clusterId, nodes, new FS4ResourcePool("container.0", 1), 1, new VipStatus());
+    public static MockDispatcher create(List<Node> nodes, FS4ResourcePool fs4ResourcePool, RpcResourcePool rpcResourcePool,
+            int containerClusterSize, VipStatus vipStatus) {
+        var dispatchConfig = toDispatchConfig(nodes);
+        var searchCluster = new SearchCluster("a", dispatchConfig, containerClusterSize, vipStatus);
+        return new MockDispatcher(searchCluster, dispatchConfig, fs4ResourcePool, rpcResourcePool);
     }
 
-    public MockDispatcher(String clusterId, List<Node> nodes, FS4ResourcePool fs4ResourcePool,
-                          int containerClusterSize, VipStatus vipStatus) {
-        super(clusterId, toDispatchConfig(nodes), fs4ResourcePool, containerClusterSize, vipStatus, new MockMetric());
+    private MockDispatcher(SearchCluster searchCluster, DispatchConfig dispatchConfig, FS4ResourcePool fs4ResourcePool,
+            RpcResourcePool rpcResourcePool) {
+        super(searchCluster, dispatchConfig, new FS4InvokerFactory(fs4ResourcePool, searchCluster),
+                new RpcInvokerFactory(rpcResourcePool, searchCluster, dispatchConfig.dispatchWithProtobuf()), new MockMetric());
     }
 
     private static DispatchConfig toDispatchConfig(List<Node> nodes) {
@@ -43,4 +52,5 @@ class MockDispatcher extends Dispatcher {
 
     public void fill(Result result, String summaryClass) {
     }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/MockRpcResourcePoolBuilder.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/MockRpcResourcePoolBuilder.java
@@ -1,0 +1,54 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.rpc;
+
+import com.yahoo.compress.CompressionType;
+import com.yahoo.prelude.fastsearch.FastHit;
+import com.yahoo.search.dispatch.rpc.Client.NodeConnection;
+import com.yahoo.search.dispatch.rpc.Client.ResponseReceiver;
+import com.yahoo.search.dispatch.rpc.RpcFillInvoker.GetDocsumsResponseReceiver;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author ovirtanen
+ */
+public class MockRpcResourcePoolBuilder {
+
+    private Map<Integer, NodeConnection> nodeConnections = new HashMap<>();
+
+    public MockRpcResourcePoolBuilder connection(int distKey) {
+        nodeConnections.put(distKey, new MockNodeConnection(distKey));
+        return this;
+    }
+
+    public RpcResourcePool build() {
+        return new RpcResourcePool(nodeConnections);
+    }
+
+    private static class MockNodeConnection implements NodeConnection {
+        private final int key;
+
+        public MockNodeConnection(int key) {
+            this.key = key;
+        }
+
+        @Override
+        public void getDocsums(List<FastHit> hits, CompressionType compression, int uncompressedLength, byte[] compressedSlime,
+                GetDocsumsResponseReceiver responseReceiver, double timeoutSeconds) {
+            responseReceiver.receive(Client.ResponseOrError.fromError("getDocsums(..) attempted for node " + key));
+        }
+
+        @Override
+        public void request(String rpcMethod, CompressionType compression, int uncompressedLength, byte[] compressedPayload,
+                ResponseReceiver responseReceiver, double timeoutSeconds) {
+            responseReceiver.receive(Client.ResponseOrError.fromError("request('"+rpcMethod+"', ..) attempted for node " + key));
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+}


### PR DESCRIPTION
Should fix unstable test on SDv4
FYI @aressem 