### PR TITLE
Prevent replica resurrection in bucket db during pending state transition windows.

### DIFF
--- a/storage/src/tests/distributor/CMakeLists.txt
+++ b/storage/src/tests/distributor/CMakeLists.txt
@@ -24,7 +24,6 @@ vespa_add_library(storage_testdistributor TEST
     ownership_transfer_safe_time_point_calculator_test.cpp
     pendingmessagetrackertest.cpp
     persistence_metrics_set_test.cpp
-    putoperationtest.cpp
     removebucketoperationtest.cpp
     removelocationtest.cpp
     removeoperationtest.cpp
@@ -50,6 +49,7 @@ vespa_add_library(storage_gtestdistributor TEST
     bucketdatabasetest.cpp
     bucketdbupdatertest.cpp
     mapbucketdatabasetest.cpp
+    putoperationtest.cpp
     # Fixture etc. dupes with non-gtest runner :
     distributortestutil.cpp
     bucket_db_prune_elision_test.cpp

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.h
@@ -37,10 +37,13 @@ public:
                     DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
                     DistributorMessageSender& sender,
                     DistributorComponentRegister& compReg);
-    ~BucketDBUpdater();
+    ~BucketDBUpdater() override;
 
     void flush();
+    // If there is a pending state, returns ownership state of bucket in it.
+    // Otherwise always returns "is owned", i.e. it must also be checked in the current state.
     BucketOwnership checkOwnershipInPendingState(const document::Bucket&) const;
+    const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const;
     void recheckBucketInfo(uint32_t nodeIdx, const document::Bucket& bucket);
 
     bool onSetSystemState(const std::shared_ptr<api::SetSystemStateCommand>& cmd) override;

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -143,6 +143,11 @@ Distributor::checkOwnershipInPendingState(const document::Bucket &b) const
     return _bucketDBUpdater.checkOwnershipInPendingState(b);
 }
 
+const lib::ClusterState*
+Distributor::pendingClusterStateOrNull(const document::BucketSpace& space) const {
+    return _bucketDBUpdater.pendingClusterStateOrNull(space);
+}
+
 void
 Distributor::sendCommand(const std::shared_ptr<api::StorageCommand>& cmd)
 {

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -74,6 +74,8 @@ public:
 
     BucketOwnership checkOwnershipInPendingState(const document::Bucket &bucket) const override;
 
+    const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const override;
+
     /**
      * Enables a new cluster state. Called after the bucket db updater has
      * retrieved all bucket info related to the change.

--- a/storage/src/vespa/storage/distributor/distributorcomponent.h
+++ b/storage/src/vespa/storage/distributor/distributorcomponent.h
@@ -175,9 +175,10 @@ public:
     bool initializing() const;
 
 private:
-    std::vector<uint16_t> enumerateDownNodes(
+    void enumerateUnavailableNodes(
+            std::vector<uint16_t>& unavailableNodes,
             const lib::ClusterState& s,
-            const document::Bucket &bucket,
+            const document::Bucket& bucket,
             const std::vector<BucketCopy>& candidates) const;
     DistributorInterface& _distributor;
 

--- a/storage/src/vespa/storage/distributor/distributorinterface.h
+++ b/storage/src/vespa/storage/distributor/distributorinterface.h
@@ -24,6 +24,7 @@ public:
     virtual DistributorMetricSet& getMetrics() = 0;
     virtual void enableClusterStateBundle(const lib::ClusterStateBundle& state) = 0;
     virtual BucketOwnership checkOwnershipInPendingState(const document::Bucket &bucket) const = 0;
+    virtual const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const = 0;
     virtual void notifyDistributionChangeEnabled() = 0;
 
     /**


### PR DESCRIPTION
@geirst please review. Most of this is CppUnit -> GTest conversion, but I forgot to add that as a separate commit (whoops).

We previously only checked for node availability in the _active_ state
without looking at the pending state. This opened up for a race condition
where a reply for a previously DB-pruned node could bring a replica back
in the DB iff received during a pending state window.

Consider Maintenance as unavailable for this case, not just Down.

This also re-enables the cluster state transition optimization where we elide
pruning the DB when not necessary.