### PR TITLE
Gjoranv/admin rpc for metricsproxy

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -60,7 +60,7 @@ public class MetricsProxyContainer extends Container implements
     }
 
     int metricsRpcPortOffset() {
-        return numHttpServerPorts;
+        return numHttpServerPorts + numMessageBusPorts() + numRpcPorts();
     }
 
     @Override
@@ -92,7 +92,7 @@ public class MetricsProxyContainer extends Container implements
     @Override
     protected void tagServers() {
         super.tagServers();
-        portsMeta.on(numHttpServerPorts).tag("rpc").tag("metrics");
+        portsMeta.on(metricsRpcPortOffset()).tag("rpc").tag("metrics");
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -83,7 +83,7 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         applicationId = deployState.getProperties().applicationId();
 
         setMessageBusEnabled(false);
-        setRpcServerEnabled(false);  // TODO: set to true
+        setRpcServerEnabled(true);
         addDefaultHandlersExceptStatus();
 
         addPlatformBundle(METRICS_PROXY_BUNDLE_FILE);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -164,18 +164,19 @@ public abstract class Container extends AbstractService implements
     }
 
     protected void tagServers() {
+        int offset = 0;
         if (numHttpServerPorts > 0) {
-            portsMeta.on(0).tag("http").tag("query").tag("external").tag("state");
+            portsMeta.on(offset++).tag("http").tag("query").tag("external").tag("state");
         }
 
         for (int i = 1; i < numHttpServerPorts; i++)
-            portsMeta.on(i).tag("http").tag("external");
+            portsMeta.on(offset++).tag("http").tag("external");
 
         if (messageBusEnabled()) {
-            portsMeta.on(numHttpServerPorts).tag("rpc").tag("messaging");
+            portsMeta.on(offset++).tag("rpc").tag("messaging");
         }
         if (rpcServerEnabled()) {
-            portsMeta.on(numHttpServerPorts + 1).tag("rpc").tag("admin");
+            portsMeta.on(offset++).tag("rpc").tag("admin");
         }
     }
 
@@ -260,7 +261,7 @@ public abstract class Container extends AbstractService implements
             suffixes[off++] = "messaging";
         }
         if (rpcServerEnabled()) {
-            suffixes[off++] = "rpc";
+            suffixes[off++] = "rpc/admin";
         }
         while (off < n) {
             suffixes[off] = "unused/" + off;
@@ -285,14 +286,14 @@ public abstract class Container extends AbstractService implements
         return rpcServerEnabled() ? getRelativePort(numHttpServerPorts + numMessageBusPorts()) : 0;
     }
 
-    private int numRpcPorts() { return rpcServerEnabled() ? 1 : 0; }
+    protected int numRpcPorts() { return rpcServerEnabled() ? 1 : 0; }
 
 
     private int getMessagingPort() {
         return messageBusEnabled() ? getRelativePort(numHttpServerPorts) : 0;
     }
 
-    private int numMessageBusPorts() { return messageBusEnabled() ? 1 : 0; }
+    protected int numMessageBusPorts() { return messageBusEnabled() ? 1 : 0; }
 
     @Override
     public int getHealthPort()  {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -137,8 +137,10 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private ContainerDocumentApi containerDocumentApi;
     private SecretStore secretStore;
 
+    // TODO: move all message-bus related fields/methods to ApplicationContainerCluster. No need for mbus for other clusters.
     private MbusParams mbusParams;
     private boolean messageBusEnabled = true;
+
     private boolean rpcServerEnabled = true;
     private boolean httpServerEnabled = true;
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
@@ -60,19 +60,32 @@ public class MetricsProxyContainerTest {
     }
 
     @Test
-    public void rpc_server_is_running_on_expected_port() {
+    public void metrics_rpc_server_is_running_on_expected_port() {
         VespaModel model = getModel(servicesWithContent());
-
         MetricsProxyContainer container = (MetricsProxyContainer)model.id2producer().get(CONTAINER_CONFIG_ID);
 
-        int rpcPort = container.metricsRpcPortOffset();
-        assertTrue(container.getPortsMeta().getTagsAt(rpcPort).contains("rpc"));
-        assertTrue(container.getPortsMeta().getTagsAt(rpcPort).contains("metrics"));
+        int offset = container.metricsRpcPortOffset();
+        assertEquals(2, container.getPortsMeta().getTagsAt(offset).size());
+        assertTrue(container.getPortsMeta().getTagsAt(offset).contains("rpc"));
+        assertTrue(container.getPortsMeta().getTagsAt(offset).contains("metrics"));
 
-        assertEquals("rpc/metrics", container.getPortSuffixes()[rpcPort]);
+        assertEquals("rpc/metrics", container.getPortSuffixes()[offset]);
 
         RpcConnectorConfig config = getRpcConnectorConfig(model);
-        assertEquals(19094, config.port());
+        assertEquals(19095, config.port());
+    }
+
+    @Test
+    public void admin_rpc_server_is_running() {
+        VespaModel model = getModel(servicesWithContent());
+        MetricsProxyContainer container = (MetricsProxyContainer)model.id2producer().get(CONTAINER_CONFIG_ID);
+
+        int offset = container.metricsRpcPortOffset() - 1;
+        assertEquals(2, container.getPortsMeta().getTagsAt(offset).size());
+        assertTrue(container.getPortsMeta().getTagsAt(offset).contains("rpc"));
+        assertTrue(container.getPortsMeta().getTagsAt(offset).contains("admin"));
+
+        assertEquals("rpc/admin", container.getPortSuffixes()[offset]);
     }
 
     @Test


### PR DESCRIPTION
This is to allow service-monitor/orchestrator to check metricsproxy containers via slobrok.
FYI: @hakonhall, @freva 
