### PR TITLE
Add a memory fence for application deployment reads in step runner

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -456,7 +456,7 @@ public class InternalStepRunner implements StepRunner {
 
     private Optional<RunStatus> copyVespaLogs(RunId id, DualLogger logger) {
         ZoneId zone = id.type().zone(controller.system());
-        if (controller.applications().require(id.application()).deployments().containsKey(zone))
+        if (deployment(id.application(), id.type()).isPresent())
             try {
                 logger.log("Copying Vespa log from nodes of " + id.application() + " in " + zone + " ...");
                 List<LogEntry> entries = new ArrayList<>();
@@ -566,6 +566,7 @@ public class InternalStepRunner implements StepRunner {
 
     /** Returns the real application with the given id. */
     private Application application(ApplicationId id) {
+        controller.applications().lockOrThrow(id, __ -> { }); // Memory fence.
         return controller.applications().require(id);
     }
 


### PR DESCRIPTION
@hmusum please review and merge. 

The lack of this has caused some jobs to fail: deployment happens, then, a second later, a different thread wants to check convergence, but doesn't yet see the deployment, and fails the job.