### PR TITLE
Move RcuVector and relevant support classes to vespalib

### DIFF
--- a/searchcommon/src/vespa/searchcommon/common/growstrategy.h
+++ b/searchcommon/src/vespa/searchcommon/common/growstrategy.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/vespalib/util/growstrategy.h>
 #include <cstdint>
 
 namespace search {
@@ -37,6 +38,10 @@ public:
     float getMultiValueAllocGrowFactor() const { return _multiValueAllocGrowFactor; }
     void    setDocsInitialCapacity(uint32_t v) { _docsInitialCapacity = v; }
     void          setDocsGrowDelta(uint32_t v) { _docsGrowDelta = v; }
+
+    vespalib::GrowStrategy to_generic_strategy() const {
+        return vespalib::GrowStrategy(_docsInitialCapacity, _docsGrowFactor, _docsGrowDelta);
+    }
 
     bool operator==(const GrowStrategy & rhs) const {
         return _docsInitialCapacity == rhs._docsInitialCapacity &&

--- a/searchcore/src/tests/proton/documentdb/configurer/configurer_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/configurer/configurer_test.cpp
@@ -197,7 +197,7 @@ Fixture::initViewSet(ViewSet &views)
     auto attrMgr = make_shared<AttributeManager>(BASE_DIR, "test.subdb", TuneFileAttributes(), views._fileHeaderContext,
                                                  views._writeService.attributeFieldWriter(),views._hwInfo);
     auto summaryMgr = make_shared<SummaryManager>
-            (_summaryExecutor, search::LogDocumentStore::Config(), GrowStrategy(), BASE_DIR, views._docTypeName,
+            (_summaryExecutor, search::LogDocumentStore::Config(), search::GrowStrategy(), BASE_DIR, views._docTypeName,
              TuneFileSummary(), views._fileHeaderContext,views._noTlSyncer, search::IBucketizer::SP());
     auto sesMgr = make_shared<SessionManager>(100);
     auto metaStore = make_shared<DocumentMetaStoreContext>(make_shared<BucketDBOwner>());

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -128,8 +128,8 @@ struct MyStoreOnlyConfig
         : _cfg(DocTypeName(DOCTYPE_NAME),
               SUB_NAME,
               BASE_DIR,
-              GrowStrategy(),
-                   0, 0, SubDbType::READY)
+              search::GrowStrategy(),
+              0, 0, SubDbType::READY)
     {
     }
 };

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_vector_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_vector_explorer.cpp
@@ -12,7 +12,7 @@ using search::AddressSpace;
 using search::AddressSpaceUsage;
 using search::AttributeVector;
 using search::EnumStoreBase;
-using search::MemoryUsage;
+using vespalib::MemoryUsage;
 using search::attribute::MultiValueMappingBase;
 using search::attribute::IPostingListAttributeBase;
 using namespace vespalib::slime;

--- a/searchcore/src/vespa/searchcore/proton/docsummary/document_store_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/document_store_explorer.cpp
@@ -18,7 +18,7 @@ DocumentStoreExplorer::DocumentStoreExplorer(ISummaryManager::SP mgr)
 namespace {
 
 void
-setMemoryUsage(Cursor &object, const search::MemoryUsage &usage)
+setMemoryUsage(Cursor &object, const vespalib::MemoryUsage &usage)
 {
     Cursor &memory = object.setObject("memoryUsage");
     memory.setLong("allocatedBytes", usage.allocatedBytes());

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -11,13 +11,13 @@
 #include <vespa/searchlib/btree/btreeroot.hpp>
 #include <vespa/searchlib/btree/btreebuilder.hpp>
 #include <vespa/searchlib/common/i_gid_to_lid_mapper.h>
-#include <vespa/vespalib/util/exceptions.h>
 #include <vespa/searchcore/proton/bucketdb/bucketsessionbase.h>
 #include <vespa/searchcore/proton/bucketdb/joinbucketssession.h>
 #include <vespa/searchcore/proton/bucketdb/splitbucketsession.h>
 #include <vespa/searchlib/util/bufferwriter.h>
-#include <vespa/searchlib/common/rcuvector.hpp>
 #include <vespa/searchlib/query/queryterm.h>
+#include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/rcuvector.hpp>
 #include <vespa/fastos/file.h>
 #include "document_meta_store_versions.h"
 
@@ -32,7 +32,7 @@ using search::FileReader;
 using search::GrowStrategy;
 using search::IAttributeSaveTarget;
 using search::LidUsageStats;
-using search::MemoryUsage;
+using vespalib::MemoryUsage;
 using search::attribute::SearchContextParams;
 using search::btree::BTreeNoLeafData;
 using search::fef::TermFieldMatchData;
@@ -200,7 +200,7 @@ DocumentMetaStore::insert(DocId lid, const RawDocumentMetaData &metaData)
 void
 DocumentMetaStore::onUpdateStat()
 {
-    MemoryUsage usage = _metaDataStore.getMemoryUsage();
+    vespalib::MemoryUsage usage = _metaDataStore.getMemoryUsage();
     usage.incAllocatedBytesOnHold(getGenerationHolder().getHeldBytes());
     size_t bvSize = _lidAlloc.getUsedLidsSize();
     usage.incAllocatedBytes(bvSize);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -11,10 +11,10 @@
 #include "raw_document_meta_data.h"
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
 #include <vespa/searchcore/proton/common/subdbtype.h>
-#include <vespa/searchlib/common/rcuvector.h>
 #include <vespa/searchlib/attribute/singlesmallnumericattribute.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/docstore/ibucketizer.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 namespace proton::bucketdb {
     class SplitBucketSession;
@@ -54,7 +54,7 @@ public:
 
 private:
     // maps from lid -> meta data
-    typedef search::attribute::RcuVectorBase<RawDocumentMetaData> MetaDataStore;
+    typedef vespalib::RcuVectorBase<RawDocumentMetaData> MetaDataStore;
     typedef documentmetastore::LidGidKeyComparator KeyComp;
 
     // Lids are stored as keys in the tree, sorted by their gid

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoresaver.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoresaver.h
@@ -25,7 +25,7 @@ public:
         search::btree::BTreeNoLeafData,
         search::btree::NoAggregated,
         const KeyComp &>;
-    using MetaDataStore = search::attribute::RcuVectorBase<RawDocumentMetaData>;
+    using MetaDataStore = vespalib::RcuVectorBase<RawDocumentMetaData>;
 
 private:
     GidIterator _gidIterator; // iterator over frozen tree

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_gid_key_comparator.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_gid_key_comparator.h
@@ -5,8 +5,8 @@
 #include "gid_compare.h"
 #include "raw_document_meta_data.h"
 #include <vespa/document/base/globalid.h>
-#include <vespa/searchlib/common/rcuvector.h>
 #include <vespa/searchlib/common/idocumentmetastore.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 namespace proton {
 namespace documentmetastore {
@@ -22,7 +22,7 @@ public:
 
 private:
     typedef search::IDocumentMetaStore::DocId DocId;
-    typedef search::attribute::RcuVectorBase<RawDocumentMetaData> MetaDataStore;
+    typedef vespalib::RcuVectorBase<RawDocumentMetaData> MetaDataStore;
 
     const document::GlobalId &_gid;
     const MetaDataStore      &_metaDataStore;

--- a/searchcore/src/vespa/searchcore/proton/index/memoryindexwrapper.h
+++ b/searchcore/src/vespa/searchcore/proton/index/memoryindexwrapper.h
@@ -68,7 +68,7 @@ public:
     search::index::Schema::SP getPrunedSchema() const override {
         return _index.getPrunedSchema();
     }
-    search::MemoryUsage getMemoryUsage() const override {
+    vespalib::MemoryUsage getMemoryUsage() const override {
         return _index.getMemoryUsage();
     }
     void insertDocument(uint32_t lid, const document::Document &doc) override {

--- a/searchcore/src/vespa/searchcore/proton/metrics/memory_usage_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/memory_usage_metrics.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "memory_usage_metrics.h"
-#include <vespa/searchlib/util/memoryusage.h>
+#include <vespa/vespalib/util/memoryusage.h>
 
 namespace proton {
 
@@ -17,7 +17,7 @@ MemoryUsageMetrics::MemoryUsageMetrics(metrics::MetricSet *parent)
 MemoryUsageMetrics::~MemoryUsageMetrics() {}
 
 void
-MemoryUsageMetrics::update(const search::MemoryUsage &usage)
+MemoryUsageMetrics::update(const vespalib::MemoryUsage &usage)
 {
     _allocatedBytes.set(usage.allocatedBytes());
     _usedBytes.set(usage.usedBytes());

--- a/searchcore/src/vespa/searchcore/proton/metrics/memory_usage_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/memory_usage_metrics.h
@@ -4,7 +4,7 @@
 
 #include <vespa/metrics/metrics.h>
 
-namespace search { class MemoryUsage; }
+namespace vespalib { class MemoryUsage; }
 
 namespace proton {
 
@@ -22,7 +22,7 @@ private:
 public:
     MemoryUsageMetrics(metrics::MetricSet *parent);
     ~MemoryUsageMetrics();
-    void update(const search::MemoryUsage &usage);
+    void update(const vespalib::MemoryUsage &usage);
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb_metrics_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb_metrics_updater.cpp
@@ -16,15 +16,15 @@
 #include <vespa/searchcore/proton/metrics/executor_threading_service_stats.h>
 #include <vespa/searchlib/attribute/attributevector.h>
 #include <vespa/searchlib/docstore/cachestats.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/searchlib/util/searchable_stats.h>
+#include <vespa/vespalib/util/memoryusage.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.server.documentdb_metrics_updater");
 
 using search::LidUsageStats;
 using search::CacheStats;
-using search::MemoryUsage;
+using vespalib::MemoryUsage;
 
 namespace proton {
 
@@ -49,7 +49,7 @@ DocumentDBMetricsUpdater::~DocumentDBMetricsUpdater() = default;
 namespace {
 
 struct TotalStats {
-    search::MemoryUsage memoryUsage;
+    MemoryUsage memoryUsage;
     uint64_t diskUsage;
     TotalStats() : memoryUsage(), diskUsage() {}
 };

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_store.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_store.h
@@ -50,7 +50,7 @@ struct DummyDocumentStore : public search::IDocumentStore
     virtual search::DataStoreStorageStats getStorageStats() const override {
         return search::DataStoreStorageStats(0, 0, 0.0, 0, 0, 0);
     }
-    virtual search::MemoryUsage getMemoryUsage() const override { return search::MemoryUsage(); }
+    virtual vespalib::MemoryUsage getMemoryUsage() const override { return vespalib::MemoryUsage(); }
     virtual std::vector<search::DataStoreFileChunkStats> getFileChunkStats() const override {
         std::vector<search::DataStoreFileChunkStats> result;
         return result;

--- a/searchcorespi/src/vespa/searchcorespi/index/imemoryindex.h
+++ b/searchcorespi/src/vespa/searchcorespi/index/imemoryindex.h
@@ -5,7 +5,7 @@
 #include <vespa/searchcommon/common/schema.h>
 #include <vespa/searchcorespi/index/indexsearchable.h>
 #include <vespa/searchlib/common/serialnum.h>
-#include <vespa/searchlib/util/memoryusage.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/string.h>
 
 namespace search
@@ -35,7 +35,7 @@ struct IMemoryIndex : public searchcorespi::IndexSearchable {
     /**
      * Returns the memory usage of this memory index.
      */
-    virtual search::MemoryUsage getMemoryUsage() const = 0;
+    virtual vespalib::MemoryUsage getMemoryUsage() const = 0;
 
     /**
      * Returns the memory usage of an empty version of this memory index.

--- a/searchcorespi/src/vespa/searchcorespi/index/index_manager_explorer.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/index_manager_explorer.cpp
@@ -26,7 +26,7 @@ insertDiskIndex(Cursor &arrayCursor, const DiskIndexStats &diskIndex)
 }
 
 void
-insertMemoryUsage(Cursor &object, const search::MemoryUsage &usage)
+insertMemoryUsage(Cursor &object, const vespalib::MemoryUsage &usage)
 {
     Cursor &memory = object.setObject("memoryUsage");
     memory.setLong("allocatedBytes", usage.allocatedBytes());

--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -103,7 +103,6 @@ vespa_define_module(
     src/tests/common/foregroundtaskexecutor
     src/tests/common/location
     src/tests/common/packets
-    src/tests/common/rcuvector
     src/tests/common/resultset
     src/tests/common/sequencedtaskexecutor
     src/tests/common/summaryfeatures

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -1816,7 +1816,7 @@ AttributeTest::testGeneration(const AttributePtr & attr, bool exactStatus)
     EXPECT_EQUAL(1u, ia.getCurrentGeneration());
     uint64_t lastAllocated;
     uint64_t lastOnHold;
-    MemoryUsage changeVectorMemoryUsage(attr->getChangeVectorMemoryUsage());
+    vespalib::MemoryUsage changeVectorMemoryUsage(attr->getChangeVectorMemoryUsage());
     size_t changeVectorAllocated = changeVectorMemoryUsage.allocatedBytes();
     if (exactStatus) {
         EXPECT_EQUAL(2u + changeVectorAllocated, ia.getStatus().getAllocated());

--- a/searchlib/src/tests/attribute/enumstore/enumstore_test.cpp
+++ b/searchlib/src/tests/attribute/enumstore/enumstore_test.cpp
@@ -702,7 +702,7 @@ EnumStoreTest::testMemoryUsage()
     uint32_t entrySize = StringEnumStore::alignEntrySize(8 + 1 + 5); // enum(4) + refcount(4) + 1(\0) + strlen("enumx")
 
     // usage before inserting enums
-    MemoryUsage usage = ses.getMemoryUsage();
+    vespalib::MemoryUsage usage = ses.getMemoryUsage();
     EXPECT_EQUAL(ses.getNumUniques(), uint32_t(0));
     // Note: Sizes of underlying data store buffers are power of 2.
     EXPECT_EQUAL(vespalib::roundUp2inN(enumStoreAlign(200u) + RESERVED_BYTES), usage.allocatedBytes());
@@ -748,7 +748,7 @@ EnumStoreTest::testMemoryUsage()
     ses.performCompaction(400, old2New);
 
     // usage after compaction
-    MemoryUsage usage2 = ses.getMemoryUsage();
+    vespalib::MemoryUsage usage2 = ses.getMemoryUsage();
     EXPECT_EQUAL(ses.getNumUniques(), num / 2);
     EXPECT_EQUAL(usage.usedBytes() + (num / 2) * entrySize, usage2.usedBytes());
     EXPECT_EQUAL(usage.deadBytes(), usage2.deadBytes());
@@ -758,7 +758,7 @@ EnumStoreTest::testMemoryUsage()
     ses.trimHoldLists(sesGen + 1);
 
     // usage after hold list trimming
-    MemoryUsage usage3 = ses.getMemoryUsage();
+    vespalib::MemoryUsage usage3 = ses.getMemoryUsage();
     EXPECT_EQUAL((num / 2) * entrySize, usage3.usedBytes());
     EXPECT_EQUAL(0u, usage3.deadBytes());
     EXPECT_EQUAL(0u, usage3.allocatedBytesOnHold());

--- a/searchlib/src/tests/attribute/reference_attribute/reference_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/reference_attribute/reference_attribute_test.cpp
@@ -12,7 +12,7 @@ LOG_SETUP("reference_attribute_test");
 #include <vespa/searchlib/test/mock_gid_to_lid_mapping.h>
 #include <vespa/document/base/documentid.h>
 
-using search::MemoryUsage;
+using vespalib::MemoryUsage;
 using vespalib::ArrayRef;
 using generation_t = vespalib::GenerationHandler::generation_t;
 using search::attribute::Reference;

--- a/searchlib/src/tests/btree/btree_test.cpp
+++ b/searchlib/src/tests/btree/btree_test.cpp
@@ -172,7 +172,7 @@ private:
     bool assertLeafNode(const std::string & exp, const LeafNodeType & n);
     bool assertSeek(int skey, int ekey, const MyTree & tree);
     bool assertSeek(int skey, int ekey, MyTree::Iterator & itr);
-    bool assertMemoryUsage(const MemoryUsage & exp, const MemoryUsage & act);
+    bool assertMemoryUsage(const vespalib::MemoryUsage & exp, const vespalib::MemoryUsage & act);
 
     void
     buildSubTree(const std::vector<LeafPair> &sub,
@@ -251,7 +251,7 @@ Test::assertSeek(int skey, int ekey, MyTree::Iterator & itr)
 }
 
 bool
-Test::assertMemoryUsage(const MemoryUsage & exp, const MemoryUsage & act)
+Test::assertMemoryUsage(const vespalib::MemoryUsage & exp, const vespalib::MemoryUsage & act)
 {
     if (!EXPECT_EQUAL(exp.allocatedBytes(), act.allocatedBytes())) return false;
     if (!EXPECT_EQUAL(exp.usedBytes(), act.usedBytes())) return false;
@@ -1047,7 +1047,7 @@ Test::requireThatMemoryUsageIsCalculated()
     GenerationHandler gh;
     gh.incGeneration();
     NodeAllocator tm;
-    MemoryUsage mu;
+    vespalib::MemoryUsage mu;
     const uint32_t initialInternalNodes = 128u;
     const uint32_t initialLeafNodes = 128u;
     mu.incAllocatedBytes(adjustAllocatedBytes(initialInternalNodes, sizeof(INode)));
@@ -1079,7 +1079,7 @@ Test::requireThatMemoryUsageIsCalculated()
     tm.transferHoldLists(gh.getCurrentGeneration());
     gh.incGeneration();
     tm.trimHoldLists(gh.getFirstUsedGeneration());
-    mu = MemoryUsage();
+    mu = vespalib::MemoryUsage();
     mu.incAllocatedBytes(adjustAllocatedBytes(initialInternalNodes, sizeof(INode)));
     mu.incAllocatedBytes(adjustAllocatedBytes(initialLeafNodes, sizeof(LNode)));
     mu.incUsedBytes(sizeof(INode) * 2);

--- a/searchlib/src/tests/common/rcuvector/.gitignore
+++ b/searchlib/src/tests/common/rcuvector/.gitignore
@@ -1,4 +1,0 @@
-.depend
-Makefile
-rcuvector_test
-searchlib_rcuvector_test_app

--- a/searchlib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/searchlib/src/tests/datastore/array_store/array_store_test.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 using namespace search::datastore;
-using search::MemoryUsage;
+using vespalib::MemoryUsage;
 using vespalib::ArrayRef;
 using generation_t = vespalib::GenerationHandler::generation_t;
 using MemStats = search::datastore::test::MemStats;

--- a/searchlib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/searchlib/src/tests/datastore/datastore/datastore_test.cpp
@@ -133,7 +133,7 @@ public:
             ++i;
         }
     }
-    MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
+    vespalib::MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
 };
 
 using MyRef = MyStore::RefType;
@@ -461,7 +461,7 @@ TEST(DataStoreTest, require_that_memory_usage_is_calculated)
     s.incDead(r, 1);
     s.holdBuffer(r.bufferId());
     s.transferHoldLists(100);
-    MemoryUsage m = s.getMemoryUsage();
+    vespalib::MemoryUsage m = s.getMemoryUsage();
     EXPECT_EQ(MyRef::offsetSize() * sizeof(int), m.allocatedBytes());
     EXPECT_EQ(5 * sizeof(int), m.usedBytes());
     EXPECT_EQ(2 * sizeof(int), m.deadBytes());
@@ -476,7 +476,7 @@ TEST(DataStoreTest, require_that_we_can_disable_elemement_hold_list)
     MyRef r2 = s.addEntry(20);
     MyRef r3 = s.addEntry(30);
     (void) r3;
-    MemoryUsage m = s.getMemoryUsage();
+    vespalib::MemoryUsage m = s.getMemoryUsage();
     EXPECT_EQ(MyRef::offsetSize() * sizeof(int), m.allocatedBytes());
     EXPECT_EQ(4 * sizeof(int), m.usedBytes());
     EXPECT_EQ(1 * sizeof(int), m.deadBytes());

--- a/searchlib/src/tests/datastore/unique_store/unique_store_test.cpp
+++ b/searchlib/src/tests/datastore/unique_store/unique_store_test.cpp
@@ -9,7 +9,7 @@ LOG_SETUP("unique_store_test");
 #include <vector>
 
 using namespace search::datastore;
-using search::MemoryUsage;
+using vespalib::MemoryUsage;
 using vespalib::ArrayRef;
 using generation_t = vespalib::GenerationHandler::generation_t;
 using MemStats = search::datastore::test::MemStats;

--- a/searchlib/src/tests/docstore/document_store/document_store_test.cpp
+++ b/searchlib/src/tests/docstore/document_store/document_store_test.cpp
@@ -33,7 +33,7 @@ struct NullDataStore : IDataStore {
     DataStoreStorageStats getStorageStats() const override {
         return DataStoreStorageStats(0, 0, 0.0, 0, 0, 0);
     }
-    MemoryUsage getMemoryUsage() const override { return MemoryUsage(); }
+    vespalib::MemoryUsage getMemoryUsage() const override { return vespalib::MemoryUsage(); }
     std::vector<DataStoreFileChunkStats>
     getFileChunkStats() const override {
         std::vector<DataStoreFileChunkStats> result;

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -984,12 +984,12 @@ TEST_F("require that lid space can be compacted and shrunk", Fixture)
     EXPECT_FALSE(f.store.canShrinkLidSpace());
 
     f.compactLidSpace(2);
-    MemoryUsage before = f.store.getMemoryUsage();
+    vespalib::MemoryUsage before = f.store.getMemoryUsage();
     EXPECT_TRUE(f.store.canShrinkLidSpace());
     EXPECT_EQUAL(8u, f.store.getEstimatedShrinkLidSpaceGain()); // one lid info entry
     f.store.shrinkLidSpace();
 
-    MemoryUsage after = f.store.getMemoryUsage();
+    vespalib::MemoryUsage after = f.store.getMemoryUsage();
     EXPECT_LESS(after.usedBytes(), before.usedBytes());
     EXPECT_EQUAL(8u, before.usedBytes() - after.usedBytes());
 }

--- a/searchlib/src/tests/memoryindex/compact_words_store/compact_words_store_test.cpp
+++ b/searchlib/src/tests/memoryindex/compact_words_store/compact_words_store_test.cpp
@@ -11,6 +11,7 @@
 using namespace search;
 using namespace search::datastore;
 using namespace search::memoryindex;
+using vespalib::MemoryUsage;
 
 typedef CompactWordsStore::Builder Builder;
 typedef CompactWordsStore::Iterator Iterator;

--- a/searchlib/src/tests/predicate/simple_index_test.cpp
+++ b/searchlib/src/tests/predicate/simple_index_test.cpp
@@ -64,7 +64,7 @@ const auto config = SimpleIndexConfig(UPPER_DOCID_FREQ_THRESHOLD,
                                       LOWER_VECTOR_SIZE_THRESHOLD,
                                       VECTOR_PRUNE_FREQUENCY,
                                       FOREACH_VECTOR_THRESHOLD,
-                                      GrowStrategy());
+                                      vespalib::GrowStrategy());
 struct Fixture {
     GenerationHolder _generation_holder;
     SimpleDocIdLimitProvider _limit_provider;

--- a/searchlib/src/tests/util/searchable_stats/searchable_stats_test.cpp
+++ b/searchlib/src/tests/util/searchable_stats/searchable_stats_test.cpp
@@ -22,7 +22,7 @@ Test::Main()
         EXPECT_EQUAL(0u, stats.sizeOnDisk());
         {
             SearchableStats rhs;
-            EXPECT_EQUAL(&rhs.memoryUsage(MemoryUsage(100,0,0,0)), &rhs);
+            EXPECT_EQUAL(&rhs.memoryUsage(vespalib::MemoryUsage(100,0,0,0)), &rhs);
             EXPECT_EQUAL(&rhs.docsInMemory(10), &rhs);
             EXPECT_EQUAL(&rhs.sizeOnDisk(1000), &rhs);
             EXPECT_EQUAL(&stats.add(rhs), &stats);
@@ -30,7 +30,7 @@ Test::Main()
         EXPECT_EQUAL(100u, stats.memoryUsage().allocatedBytes());
         EXPECT_EQUAL(10u, stats.docsInMemory());
         EXPECT_EQUAL(1000u, stats.sizeOnDisk());
-        EXPECT_EQUAL(&stats.add(SearchableStats().memoryUsage(MemoryUsage(100,0,0,0)).docsInMemory(10).sizeOnDisk(1000)), &stats);
+        EXPECT_EQUAL(&stats.add(SearchableStats().memoryUsage(vespalib::MemoryUsage(100,0,0,0)).docsInMemory(10).sizeOnDisk(1000)), &stats);
         EXPECT_EQUAL(200u, stats.memoryUsage().allocatedBytes());
         EXPECT_EQUAL(20u, stats.docsInMemory());
         EXPECT_EQUAL(2000u, stats.sizeOnDisk());

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -818,10 +818,10 @@ AttributeVector::makeReadGuard(bool stableEnumGuard) const
     return std::make_unique<ReadGuard>(this, _genHandler.takeGuard(), stableEnumGuard ? &_enumLock : nullptr);
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 AttributeVector::getChangeVectorMemoryUsage() const
 {
-    return MemoryUsage(0, 0, 0, 0);
+    return vespalib::MemoryUsage(0, 0, 0, 0);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -16,10 +16,10 @@
 #include <vespa/searchlib/common/address_space.h>
 #include <vespa/searchlib/common/i_compactable_lid_space.h>
 #include <vespa/searchlib/common/identifiable.h>
-#include <vespa/searchlib/common/rcuvector.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/vespalib/objects/identifiable.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <vespa/fastos/time.h>
 #include <cmath>
 #include <mutex>
@@ -662,7 +662,7 @@ public:
 
     static bool isEnumerated(const vespalib::GenericHeader &header);
 
-    virtual MemoryUsage getChangeVectorMemoryUsage() const;
+    virtual vespalib::MemoryUsage getChangeVectorMemoryUsage() const;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -5,9 +5,9 @@
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/searchcommon/common/undefinedvalues.h>
 
-namespace search {
+namespace vespalib { class MemoryUsage; }
 
-class MemoryUsage;
+namespace search {
 
 struct ChangeBase {
     enum Type {
@@ -171,7 +171,7 @@ public:
     void clear();
     const_iterator begin() const { return const_iterator(_v, 0); }
     const_iterator end()   const { return const_iterator(_v, size()); }
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 private:
     void linkIn(uint32_t doc, size_t index, size_t last);
     Vector _v;

--- a/searchlib/src/vespa/searchlib/attribute/changevector.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.hpp
@@ -4,7 +4,7 @@
 
 #include "changevector.h"
 #include <vespa/vespalib/util/array.hpp>
-#include <vespa/searchlib/util/memoryusage.h>
+#include <vespa/vespalib/util/memoryusage.h>
 
 namespace search {
 
@@ -73,12 +73,12 @@ ChangeVectorT<T>::linkIn(uint32_t doc, size_t first, size_t last)
 }
 
 template <typename T>
-MemoryUsage
+vespalib::MemoryUsage
 ChangeVectorT<T>::getMemoryUsage() const
 {
     size_t usedBytes = _v.size() * sizeof(T) + _docs.getMemoryUsed();
     size_t allocBytes = _v.capacity() * sizeof(T) + _docs.getMemoryConsumption();
-    return MemoryUsage(allocBytes, usedBytes, 0, 0);
+    return vespalib::MemoryUsage(allocBytes, usedBytes, 0, 0);
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
@@ -9,8 +9,8 @@
 #include <vespa/searchlib/btree/btreenodeallocator.hpp>
 #include <vespa/searchlib/btree/btreeroot.hpp>
 #include <vespa/searchlib/util/bufferwriter.h>
-#include <vespa/searchlib/common/rcuvector.hpp>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/rcuvector.hpp>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 
@@ -112,7 +112,7 @@ EnumStoreBase::getBufferIndex(datastore::BufferState::State status)
     return Index::numBuffers();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 EnumStoreBase::getMemoryUsage() const
 {
     return _store.getMemoryUsage();
@@ -333,7 +333,7 @@ EnumStoreDict<Dictionary>::getNumUniques() const
 
 
 template <typename Dictionary>
-MemoryUsage
+vespalib::MemoryUsage
 EnumStoreDict<Dictionary>::getTreeMemoryUsage() const
 {
     return _dict.getMemoryUsage();
@@ -632,10 +632,6 @@ template class EnumStoreDict<EnumTree>;
 
 template class EnumStoreDict<EnumPostingTree>;
 
-namespace attribute {
-    template class RcuVectorBase<EnumStoreIndex>;
-}
-
 template
 class btree::BTreeNodeT<EnumStoreBase::Index, EnumTreeTraits::INTERNAL_SLOTS>;
 
@@ -723,6 +719,10 @@ class btree::BTree<EnumStoreBase::Index, datastore::EntryRef, btree::NoAggregate
                    const EnumStoreComparatorWrapper, EnumTreeTraits>;
 
 
+}
+
+namespace vespalib {
+template class RcuVectorBase<search::EnumStoreIndex>;
 }
 
 VESPALIB_HASH_MAP_INSTANTIATE_H_E_M(search::EnumStoreIndex, search::EnumStoreIndex,

--- a/searchlib/src/vespa/searchlib/attribute/enumstorebase.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumstorebase.h
@@ -5,8 +5,8 @@
 #include <vespa/searchcommon/attribute/iattributevector.h>
 #include <vespa/searchlib/common/address_space.h>
 #include <vespa/searchlib/datastore/datastore.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/vespalib/util/array.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/searchlib/btree/btree.h>
 #include <set>
@@ -66,7 +66,7 @@ public:
 
     virtual void freezeTree() = 0;
     virtual uint32_t getNumUniques() const = 0;
-    virtual MemoryUsage getTreeMemoryUsage() const = 0;
+    virtual vespalib::MemoryUsage getTreeMemoryUsage() const = 0;
     virtual void reEnumerate() = 0;
     virtual void writeAllValues(BufferWriter &writer, btree::BTreeNode::Ref rootRef) const = 0;
     virtual ssize_t deserialize(const void *src, size_t available, IndexVector &idx) = 0;
@@ -116,7 +116,7 @@ public:
     
     void freezeTree() override;
     uint32_t getNumUniques() const override;
-    MemoryUsage getTreeMemoryUsage() const override;
+    vespalib::MemoryUsage getTreeMemoryUsage() const override;
     void reEnumerate() override;
     void writeAllValues(BufferWriter &writer, btree::BTreeNode::Ref rootRef) const override;
     ssize_t deserialize(const void *src, size_t available, IndexVector &idx) override;
@@ -297,8 +297,8 @@ public:
     uint32_t getCapacity() const {
         return _store.getBufferState(_store.getActiveBufferId(TYPE_ID)).capacity();
     }
-    MemoryUsage getMemoryUsage() const;
-    MemoryUsage getTreeMemoryUsage() const { return _enumDict->getTreeMemoryUsage(); }
+    vespalib::MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getTreeMemoryUsage() const { return _enumDict->getTreeMemoryUsage(); }
 
     AddressSpace getAddressSpaceUsage() const;
 

--- a/searchlib/src/vespa/searchlib/attribute/floatbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/floatbase.cpp
@@ -92,7 +92,7 @@ FloatingPointAttribute::getString(DocId doc, char * s, size_t sz) const {
     return s;
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 FloatingPointAttribute::getChangeVectorMemoryUsage() const
 {
     return _changes.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/attribute/floatbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/floatbase.h
@@ -40,7 +40,7 @@ protected:
     typedef ChangeVectorT< Change > ChangeVector;
     ChangeVector _changes;
 
-    virtual MemoryUsage getChangeVectorMemoryUsage() const override;
+    virtual vespalib::MemoryUsage getChangeVectorMemoryUsage() const override;
 private:
     uint32_t get(DocId doc, vespalib::string * v, uint32_t sz) const override;
     uint32_t get(DocId doc, const char ** v, uint32_t sz) const override;

--- a/searchlib/src/vespa/searchlib/attribute/integerbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/integerbase.cpp
@@ -89,7 +89,7 @@ bool IntegerAttribute::apply(DocId doc, const ArithmeticValueUpdate & op)
     return retval;
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 IntegerAttribute::getChangeVectorMemoryUsage() const
 {
     return _changes.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/attribute/integerbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/integerbase.h
@@ -39,7 +39,7 @@ protected:
     typedef ChangeVectorT< Change > ChangeVector;
     ChangeVector _changes;
 
-    MemoryUsage getChangeVectorMemoryUsage() const override;
+    vespalib::MemoryUsage getChangeVectorMemoryUsage() const override;
 private:
     const char * getString(DocId doc, char * s, size_t sz) const override;
     uint32_t get(DocId doc, vespalib::string * v, uint32_t sz) const override;

--- a/searchlib/src/vespa/searchlib/attribute/ipostinglistattributebase.h
+++ b/searchlib/src/vespa/searchlib/attribute/ipostinglistattributebase.h
@@ -2,12 +2,9 @@
 
 #pragma once
 
+namespace vespalib { class MemoryUsage; }
 
-namespace search
-{
-
-namespace attribute
-{
+namespace search::attribute {
 
 class IPostingListAttributeBase
 {
@@ -23,11 +20,8 @@ public:
                   uint32_t toLid) = 0;
 
     virtual void forwardedShrinkLidSpace(uint32_t newSize) = 0;
-    virtual MemoryUsage getMemoryUsage() const = 0;
+    virtual vespalib::MemoryUsage getMemoryUsage() const = 0;
 };
 
-
-} // namespace attribute
-
-} // namespace search
+} // namespace search::attribute
 

--- a/searchlib/src/vespa/searchlib/attribute/load_utils.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/load_utils.cpp
@@ -18,7 +18,7 @@ template uint32_t loadFromEnumeratedMultiValue(MultiValueMapping<Value<ValueType
 #define INSTANTIATE_WSET(ValueType, Saver) \
 template uint32_t loadFromEnumeratedMultiValue(MultiValueMapping<WeightedValue<ValueType>> &, ReaderBase &, vespalib::ConstArrayRef<ValueType>, Saver)
 #define INSTANTIATE_SINGLE(ValueType, Saver) \
-template void loadFromEnumeratedSingleValue(RcuVectorBase<ValueType> &, vespalib::GenerationHolder &, ReaderBase &, vespalib::ConstArrayRef<ValueType>, Saver)
+template void loadFromEnumeratedSingleValue(vespalib::RcuVectorBase<ValueType> &, vespalib::GenerationHolder &, ReaderBase &, vespalib::ConstArrayRef<ValueType>, Saver)
 
 #define INSTANTIATE_SINGLE_ARRAY_WSET(ValueType, Saver) \
 INSTANTIATE_SINGLE(ValueType, Saver); \

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.h
@@ -27,7 +27,7 @@ public:
     MultiValueMapping(const MultiValueMapping &) = delete;
     MultiValueMapping & operator = (const MultiValueMapping &) = delete;
     MultiValueMapping(const datastore::ArrayStoreConfig &storeCfg,
-                      const GrowStrategy &gs = GrowStrategy());
+                      const vespalib::GrowStrategy &gs = vespalib::GrowStrategy());
     ~MultiValueMapping() override;
     ConstArrayRef get(uint32_t docId) const { return _store.get(_indices[docId]); }
     ConstArrayRef getDataForIdx(EntryRef idx) const { return _store.get(idx); }
@@ -47,7 +47,7 @@ public:
     void compactWorst(bool compactMemory, bool compactAddressSpace) override;
 
     AddressSpace getAddressSpaceUsage() const override;
-    MemoryUsage getArrayStoreMemoryUsage() const override;
+    vespalib::MemoryUsage getArrayStoreMemoryUsage() const override;
 
     static datastore::ArrayStoreConfig optimizedConfigForHugePage(size_t maxSmallArraySize,
                                                                   size_t hugePageSize,

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.hpp
@@ -4,12 +4,13 @@
 
 #include "multi_value_mapping.h"
 #include <vespa/searchlib/datastore/array_store.hpp>
-#include <vespa/searchlib/common/rcuvector.hpp>
+#include <vespa/vespalib/util/rcuvector.hpp>
 
 namespace search::attribute {
 
 template <typename EntryT, typename RefT>
-MultiValueMapping<EntryT,RefT>::MultiValueMapping(const datastore::ArrayStoreConfig &storeCfg, const GrowStrategy &gs)
+MultiValueMapping<EntryT,RefT>::MultiValueMapping(const datastore::ArrayStoreConfig &storeCfg,
+                                                  const vespalib::GrowStrategy &gs)
     : MultiValueMappingBase(gs, _store.getGenerationHolder()),
       _store(storeCfg)
 {
@@ -54,7 +55,7 @@ MultiValueMapping<EntryT,RefT>::compactWorst(bool compactMemory, bool compactAdd
 }
 
 template <typename EntryT, typename RefT>
-MemoryUsage
+vespalib::MemoryUsage
 MultiValueMapping<EntryT,RefT>::getArrayStoreMemoryUsage() const
 {
     return _store.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping_base.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping_base.cpp
@@ -13,8 +13,8 @@ constexpr size_t DEAD_ARRAYS_SLACK = 0x10000u;
 
 }
 
-MultiValueMappingBase::MultiValueMappingBase(const GrowStrategy &gs,
-                                               vespalib::GenerationHolder &genHolder)
+MultiValueMappingBase::MultiValueMappingBase(const vespalib::GrowStrategy &gs,
+                                             vespalib::GenerationHolder &genHolder)
     : _indices(gs, genHolder),
       _totalValues(0u),
       _cachedArrayStoreMemoryUsage(),
@@ -63,19 +63,19 @@ MultiValueMappingBase::clearDocs(uint32_t lidLow, uint32_t lidLimit, std::functi
     }
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 MultiValueMappingBase::getMemoryUsage() const
 {
-    MemoryUsage retval = getArrayStoreMemoryUsage();
+    vespalib::MemoryUsage retval = getArrayStoreMemoryUsage();
     retval.merge(_indices.getMemoryUsage());
     return retval;
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 MultiValueMappingBase::updateStat()
 {
     _cachedArrayStoreAddressSpaceUsage = getAddressSpaceUsage();
-    MemoryUsage retval = getArrayStoreMemoryUsage();
+    vespalib::MemoryUsage retval = getArrayStoreMemoryUsage();
     _cachedArrayStoreMemoryUsage = retval;
     retval.merge(_indices.getMemoryUsage());
     return retval;

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping_base.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping_base.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <vespa/searchlib/datastore/entryref.h>
-#include <vespa/searchlib/common/rcuvector.h>
 #include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <functional>
 
 namespace search { class CompactionStrategy; }
@@ -18,15 +18,15 @@ class MultiValueMappingBase
 {
 public:
     using EntryRef = datastore::EntryRef;
-    using RefVector = RcuVectorBase<EntryRef>;
+    using RefVector = vespalib::RcuVectorBase<EntryRef>;
 
 protected:
     RefVector _indices;
     size_t    _totalValues;
-    MemoryUsage _cachedArrayStoreMemoryUsage;
+    vespalib::MemoryUsage _cachedArrayStoreMemoryUsage;
     AddressSpace _cachedArrayStoreAddressSpaceUsage;
 
-    MultiValueMappingBase(const GrowStrategy &gs, vespalib::GenerationHolder &genHolder);
+    MultiValueMappingBase(const vespalib::GrowStrategy &gs, vespalib::GenerationHolder &genHolder);
     virtual ~MultiValueMappingBase();
 
     void updateValueCount(size_t oldValues, size_t newValues) {
@@ -35,10 +35,10 @@ protected:
 public:
     using RefCopyVector = vespalib::Array<EntryRef>;
 
-    virtual MemoryUsage getArrayStoreMemoryUsage() const = 0;
+    virtual vespalib::MemoryUsage getArrayStoreMemoryUsage() const = 0;
     virtual AddressSpace getAddressSpaceUsage() const = 0;
-    MemoryUsage getMemoryUsage() const;
-    MemoryUsage updateStat();
+    vespalib::MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage updateStat();
     size_t getTotalValueCnt() const { return _totalValues; }
     RefCopyVector getRefCopy(uint32_t size) const;
 

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.h
@@ -79,7 +79,7 @@ protected:
     void fillValues(LoadedVector & loaded) override;
     void fillEnumIdx(ReaderBase &attrReader, const EnumIndexVector &eidxs, LoadedEnumAttributeVector &loaded) override;
     void fillEnumIdx(ReaderBase &attrReader, const EnumIndexVector &eidxs, EnumVector &enumHist) override;
-    virtual void mergeMemoryStats(MemoryUsage & total) { (void) total; }
+    virtual void mergeMemoryStats(vespalib::MemoryUsage & total) { (void) total; }
 
 public:
     MultiValueEnumAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
@@ -183,7 +183,7 @@ void
 MultiValueEnumAttribute<B, M>::onUpdateStat()
 {
     // update statistics
-    MemoryUsage total;
+    vespalib::MemoryUsage total;
     total.merge(this->_enumStore.getMemoryUsage());
     total.merge(this->_enumStore.getTreeMemoryUsage());
     total.merge(this->_mvMapping.updateStat());

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
@@ -75,7 +75,7 @@ MultiValueNumericAttribute<B, M>::onCommit()
 template <typename B, typename M>
 void MultiValueNumericAttribute<B, M>::onUpdateStat()
 {
-    MemoryUsage usage = this->_mvMapping.updateStat();
+    vespalib::MemoryUsage usage = this->_mvMapping.updateStat();
     usage.merge(this->getChangeVectorMemoryUsage());
     this->updateStatistics(this->_mvMapping.getTotalValueCnt(), this->_mvMapping.getTotalValueCnt(), usage.allocatedBytes(),
                            usage.usedBytes(), usage.deadBytes(), usage.allocatedBytesOnHold());

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -77,7 +77,7 @@ private:
     using PostingParent::forwardedOnAddDoc;
 
     void freezeEnumDictionary() override;
-    void mergeMemoryStats(MemoryUsage & total) override;
+    void mergeMemoryStats(vespalib::MemoryUsage & total) override;
     void applyValueChanges(const DocIndices & docIndices, EnumStoreBase::IndexVector & unused) override;
 
 public:

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -15,7 +15,7 @@ MultiValueNumericPostingAttribute<B, M>::freezeEnumDictionary()
 
 template <typename B, typename M>
 void
-MultiValueNumericPostingAttribute<B, M>::mergeMemoryStats(MemoryUsage & total)
+MultiValueNumericPostingAttribute<B, M>::mergeMemoryStats(vespalib::MemoryUsage & total)
 {
     total.merge(this->getPostingList().getMemoryUsage());
 }

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -78,7 +78,7 @@ private:
     using PostingParent::forwardedOnAddDoc;
 
     void freezeEnumDictionary() override;
-    void mergeMemoryStats(MemoryUsage & total) override;
+    void mergeMemoryStats(vespalib::MemoryUsage & total) override;
     void applyValueChanges(const DocIndices & docIndices, EnumStoreBase::IndexVector & unused) override ;
 
 public:

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -61,7 +61,7 @@ MultiValueStringPostingAttributeT<B, T>::freezeEnumDictionary()
 
 template <typename B, typename T>
 void
-MultiValueStringPostingAttributeT<B, T>::mergeMemoryStats(MemoryUsage &total)
+MultiValueStringPostingAttributeT<B, T>::mergeMemoryStats(vespalib::MemoryUsage &total)
 {
     total.merge(this->_postingList.getMemoryUsage());
 }

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -22,7 +22,7 @@ MultiValueAttribute(const vespalib::string &baseFileName,
                                                                multivalueattribute::SMALL_MEMORY_PAGE_SIZE,
                                                                8 * 1024,
                                                                cfg.getGrowStrategy().getMultiValueAllocGrowFactor()),
-                 cfg.getGrowStrategy())
+                 cfg.getGrowStrategy().to_generic_strategy())
 {
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/postinglistattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistattribute.cpp
@@ -203,7 +203,7 @@ PostingListAttributeBase<P>::forwardedShrinkLidSpace(uint32_t newSize)
 }
 
 template <typename P>
-MemoryUsage
+vespalib::MemoryUsage
 PostingListAttributeBase<P>::getMemoryUsage() const
 {
     return _postingList.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
@@ -65,7 +65,7 @@ protected:
                        uint32_t toLid, EnumStoreComparator &cmp);
 
     void forwardedShrinkLidSpace(uint32_t newSize) override;
-    virtual MemoryUsage getMemoryUsage() const override;
+    virtual vespalib::MemoryUsage getMemoryUsage() const override;
 
 public:
     const PostingList & getPostingList() const { return _postingList; }

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.cpp
@@ -615,10 +615,10 @@ PostingStore<DataT>::clear(const EntryRef ref)
 
 
 template <typename DataT>
-MemoryUsage
+vespalib::MemoryUsage
 PostingStore<DataT>::getMemoryUsage() const
 {
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     usage.merge(_allocator.getMemoryUsage());
     usage.merge(_store.getMemoryUsage());
     uint64_t bvExtraBytes = _bvExtraBytes;

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.h
@@ -175,7 +175,7 @@ public:
     }
 
     static inline DataT bitVectorWeight();
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
 private:
     size_t internalSize(uint32_t typeId, const RefType & iRef) const;

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
@@ -58,7 +58,8 @@ int64_t adjustUpperBound(int32_t arity, int64_t upper_bound) {
 }
 
 SimpleIndexConfig createSimpleIndexConfig(const search::attribute::Config &config) {
-    return SimpleIndexConfig(config.predicateParams().dense_posting_list_threshold(), config.getGrowStrategy());
+    return SimpleIndexConfig(config.predicateParams().dense_posting_list_threshold(),
+                             config.getGrowStrategy().to_generic_strategy());
 }
 
 }  // namespace
@@ -72,8 +73,8 @@ PredicateAttribute::PredicateAttribute(const vespalib::string &base_file_name,
                                 _limit_provider, createSimpleIndexConfig(config), config.predicateParams().arity())),
       _lower_bound(adjustLowerBound(config.predicateParams().arity(), config.predicateParams().lower_bound())),
       _upper_bound(adjustUpperBound(config.predicateParams().arity(), config.predicateParams().upper_bound())),
-      _min_feature(config.getGrowStrategy(), getGenerationHolder()),
-      _interval_range_vector(config.getGrowStrategy(), getGenerationHolder()),
+      _min_feature(config.getGrowStrategy().to_generic_strategy(), getGenerationHolder()),
+      _interval_range_vector(config.getGrowStrategy().to_generic_strategy(), getGenerationHolder()),
       _max_interval_range(1)
 {
 }
@@ -105,7 +106,7 @@ void
 PredicateAttribute::onUpdateStat()
 {
     // update statistics
-    MemoryUsage combined;
+    vespalib::MemoryUsage combined;
     combined.merge(_min_feature.getMemoryUsage());
     combined.merge(_interval_range_vector.getMemoryUsage());
     combined.merge(_index->getMemoryUsage());

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
@@ -4,7 +4,7 @@
 
 #include "not_implemented_attribute.h"
 #include <vespa/searchlib/predicate/common.h>
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 namespace document { class PredicateFieldValue; }
 
@@ -36,7 +36,7 @@ public:
     typedef uint8_t MinFeature;
     typedef std::pair<const MinFeature *, size_t> MinFeatureHandle;
     using IntervalRange = uint16_t;
-    using IntervalRangeVector = attribute::RcuVectorBase<IntervalRange>;
+    using IntervalRangeVector = vespalib::RcuVectorBase<IntervalRange>;
 
     DECLARE_IDENTIFIABLE_ABSTRACT(PredicateAttribute);
 
@@ -86,7 +86,7 @@ private:
     int64_t _lower_bound;
     int64_t _upper_bound;
 
-    typedef attribute::RcuVectorBase<uint8_t> MinFeatureVector;
+    typedef vespalib::RcuVectorBase<uint8_t> MinFeatureVector;
     MinFeatureVector _min_feature;
 
     IntervalRangeVector _interval_range_vector;

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.cpp
@@ -180,7 +180,7 @@ ReferenceAttribute::onCommit()
 void
 ReferenceAttribute::onUpdateStat()
 {
-    MemoryUsage total = _store.getMemoryUsage();
+    vespalib::MemoryUsage total = _store.getMemoryUsage();
     _cachedUniqueStoreMemoryUsage = total;
     total.mergeGenerationHeldBytes(getGenerationHolder().getHeldBytes());
     total.merge(_indices.getMemoryUsage());

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
@@ -6,7 +6,7 @@
 #include "reference_mappings.h"
 #include "reference.h"
 #include <vespa/searchlib/datastore/unique_store.h>
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 namespace search { class IGidToLidMapperFactory; }
 
@@ -27,7 +27,7 @@ public:
     using EntryRef = search::datastore::EntryRef;
     using GlobalId = document::GlobalId;
     using ReferenceStore = datastore::UniqueStore<Reference>;
-    using ReferenceStoreIndices = RcuVectorBase<EntryRef>;
+    using ReferenceStoreIndices = vespalib::RcuVectorBase<EntryRef>;
     using IndicesCopyVector = vespalib::Array<EntryRef>;
     // Class used to map from target lid to source lids
     using ReverseMapping = btree::BTreeStore<uint32_t, btree::BTreeNoLeafData,
@@ -41,7 +41,7 @@ public:
 private:
     ReferenceStore _store;
     ReferenceStoreIndices _indices;
-    MemoryUsage _cachedUniqueStoreMemoryUsage;
+    vespalib::MemoryUsage _cachedUniqueStoreMemoryUsage;
     std::shared_ptr<IGidToLidMapperFactory> _gidToLidMapperFactory;
     ReferenceMappings _referenceMappings;
 

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute_saver.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute_saver.h
@@ -6,7 +6,7 @@
 #include <vespa/document/base/globalid.h>
 #include <vespa/searchlib/datastore/unique_store.h>
 #include <vespa/searchlib/datastore/unique_store_saver.h>
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include "reference_attribute.h"
 #include "reference.h"
 

--- a/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
@@ -140,10 +140,10 @@ ReferenceMappings::shrink(uint32_t docIdLimit)
     _targetLids.shrink(docIdLimit);
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 ReferenceMappings::getMemoryUsage()
 {
-    MemoryUsage usage = _reverseMapping.getMemoryUsage();
+    vespalib::MemoryUsage usage = _reverseMapping.getMemoryUsage();
     usage.merge(_reverseMappingIndices.getMemoryUsage());
     usage.merge(_targetLids.getMemoryUsage());
     return usage;

--- a/searchlib/src/vespa/searchlib/attribute/reference_mappings.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_mappings.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <vespa/searchlib/btree/btreestore.h>
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <atomic>
 
 namespace search::attribute {
@@ -18,7 +18,7 @@ class ReferenceMappings
     using GenerationHolder = vespalib::GenerationHolder;
     using EntryRef = search::datastore::EntryRef;
     // Classes used to map from target lid to source lids
-    using ReverseMappingIndices = RcuVectorBase<EntryRef>;
+    using ReverseMappingIndices = vespalib::RcuVectorBase<EntryRef>;
     using ReverseMapping = btree::BTreeStore<uint32_t, btree::BTreeNoLeafData,
                                              btree::NoAggregated,
                                              std::less<uint32_t>,
@@ -35,7 +35,7 @@ class ReferenceMappings
     // source lids.
     ReverseMapping _reverseMapping;
     // vector containing target lid given source lid
-    RcuVectorBase<uint32_t> _targetLids;
+    vespalib::RcuVectorBase<uint32_t> _targetLids;
     const uint32_t &_committedDocIdLimit;
 
     void syncForwardMapping(const Reference &entry);
@@ -74,7 +74,7 @@ public:
     // Setup mapping after load
     void buildReverseMapping(const Reference &entry, const std::vector<ReverseMapping::KeyDataType> &adds);
 
-    MemoryUsage getMemoryUsage();
+    vespalib::MemoryUsage getMemoryUsage();
 
     // Reader API, reader must hold generation guard
     template <typename FunctionType>

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
@@ -83,7 +83,7 @@ SingleBoolAttribute::onAddDocs(DocId docIdLimit) {
 
 void
 SingleBoolAttribute::onUpdateStat() {
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     usage.setAllocatedBytes(_bv.extraByteSize());
     usage.setUsedBytes(_bv.sizeBytes());
     usage.mergeGenerationHeldBytes(getGenerationHolder().getHeldBytes());

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "enumattribute.h"
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 namespace search {
 
@@ -19,7 +19,7 @@ class SingleValueEnumAttributeBase
 {
 protected:
     typedef EnumStoreBase::Index      EnumIndex;
-    typedef search::attribute::RcuVectorBase<EnumIndex> EnumIndexVector;
+    typedef vespalib::RcuVectorBase<EnumIndex> EnumIndexVector;
     typedef AttributeVector::DocId        DocId;
     typedef AttributeVector::EnumHandle   EnumHandle;
     typedef vespalib::GenerationHolder GenerationHolder;
@@ -83,7 +83,7 @@ protected:
         this->getEnumStore().freezeTree();
     }
 
-    virtual void mergeMemoryStats(MemoryUsage & total) { (void) total; }
+    virtual void mergeMemoryStats(vespalib::MemoryUsage & total) { (void) total; }
 
     void fillValues(LoadedVector & loaded) override;
 

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -98,7 +98,7 @@ void
 SingleValueEnumAttribute<B>::onUpdateStat()
 {
     // update statistics
-    MemoryUsage total = _enumIndices.getMemoryUsage();
+    vespalib::MemoryUsage total = _enumIndices.getMemoryUsage();
     total.mergeGenerationHeldBytes(getGenerationHolder().getHeldBytes());
     total.merge(this->_enumStore.getMemoryUsage());
     total.merge(this->_enumStore.getTreeMemoryUsage());

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.h
@@ -4,7 +4,7 @@
 
 #include "integerbase.h"
 #include "floatbase.h"
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <limits>
 
 namespace search {
@@ -24,7 +24,7 @@ private:
     typedef typename B::generation_t generation_t;
     using B::getGenerationHolder;
 
-    typedef attribute::RcuVectorBase<T> DataVector;
+    typedef vespalib::RcuVectorBase<T> DataVector;
     DataVector _data;
 
     T getFromEnum(EnumHandle e) const override {

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
@@ -60,7 +60,7 @@ template <typename B>
 void
 SingleValueNumericAttribute<B>::onUpdateStat()
 {
-    MemoryUsage usage = _data.getMemoryUsage();
+    vespalib::MemoryUsage usage = _data.getMemoryUsage();
     usage.mergeGenerationHeldBytes(getGenerationHolder().getHeldBytes());
     usage.merge(this->getChangeVectorMemoryUsage());
     this->updateStatistics(_data.size(), _data.size(),

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.h
@@ -67,7 +67,7 @@ private:
     using PostingParent::forwardedOnAddDoc;
 
     void freezeEnumDictionary() override;
-    void mergeMemoryStats(MemoryUsage & total) override;
+    void mergeMemoryStats(vespalib::MemoryUsage & total) override;
     void applyUpdateValueChange(const Change & c, EnumStore & enumStore,
                                 std::map<DocId, EnumIndex> & currEnumIndices);
     void makePostingChange(const EnumStoreComparator *cmp,

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
@@ -34,7 +34,7 @@ SingleValueNumericPostingAttribute<B>::freezeEnumDictionary()
 
 template <typename B>
 void
-SingleValueNumericPostingAttribute<B>::mergeMemoryStats(MemoryUsage & total)
+SingleValueNumericPostingAttribute<B>::mergeMemoryStats(vespalib::MemoryUsage & total)
 {
     total.merge(this->_postingList.getMemoryUsage());
 }

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
@@ -94,7 +94,7 @@ SingleValueSmallNumericAttribute::addDoc(DocId & doc) {
 void
 SingleValueSmallNumericAttribute::onUpdateStat()
 {
-    MemoryUsage usage = _wordData.getMemoryUsage();
+    vespalib::MemoryUsage usage = _wordData.getMemoryUsage();
     usage.mergeGenerationHeldBytes(getGenerationHolder().getHeldBytes());
     uint32_t numDocs = B::getNumDocs();
     updateStatistics(numDocs, numDocs,

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.h
@@ -4,7 +4,7 @@
 
 #include "integerbase.h"
 #include "floatbase.h"
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <limits>
 
 namespace search {
@@ -32,7 +32,7 @@ private:
     uint32_t _valueShiftMask;   // 0x1f, 0x0f or 0x07
     uint32_t _wordShift;        // 0x05, 0x04 or 0x03
 
-    typedef search::attribute::RcuVectorBase<Word> DataVector;
+    typedef vespalib::RcuVectorBase<Word> DataVector;
     DataVector _wordData;
 
     T getFromEnum(EnumHandle) const override {

--- a/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.h
@@ -71,7 +71,7 @@ public:
 
 private:
     void freezeEnumDictionary() override;
-    void mergeMemoryStats(MemoryUsage & total) override;
+    void mergeMemoryStats(vespalib::MemoryUsage & total) override;
     void applyUpdateValueChange(const Change & c,
                                 EnumStore & enumStore,
                                 std::map<DocId, EnumIndex> &currEnumIndices);

--- a/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
@@ -31,7 +31,7 @@ SingleValueStringPostingAttributeT<B>::freezeEnumDictionary()
 
 template <typename B>
 void
-SingleValueStringPostingAttributeT<B>::mergeMemoryStats(MemoryUsage & total)
+SingleValueStringPostingAttributeT<B>::mergeMemoryStats(vespalib::MemoryUsage & total)
 {
     total.merge(this->_postingList.getMemoryUsage());
 }

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
@@ -518,7 +518,7 @@ StringAttribute::fixupEnumRefCounts(const EnumVector &)
     fprintf(stderr, "StringAttribute::fixupEnumRefCounts\n");
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 StringAttribute::getChangeVectorMemoryUsage() const
 {
     return _changes.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -71,7 +71,7 @@ protected:
 
     virtual bool onAddDoc(DocId doc) override;
 
-    virtual MemoryUsage getChangeVectorMemoryUsage() const override;
+    virtual vespalib::MemoryUsage getChangeVectorMemoryUsage() const override;
 private:
     typedef attribute::LoadedStringVectorReal LoadedVectorR;
     virtual void fillPostings(LoadedVector & loaded);

--- a/searchlib/src/vespa/searchlib/btree/btree.h
+++ b/searchlib/src/vespa/searchlib/btree/btree.h
@@ -132,7 +132,7 @@ public:
     BTreeNode::Ref getRoot() const {
         return _tree.getRoot();
     }
-    MemoryUsage getMemoryUsage() const {
+    vespalib::MemoryUsage getMemoryUsage() const {
         return _alloc.getMemoryUsage();
     }
 

--- a/searchlib/src/vespa/searchlib/btree/btreenodeallocator.h
+++ b/searchlib/src/vespa/searchlib/btree/btreenodeallocator.h
@@ -7,7 +7,7 @@
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/array.h>
 #include <vespa/vespalib/util/generationhandler.h>
-#include <vespa/searchlib/util/memoryusage.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vector>
 
 namespace search::btree {
@@ -157,7 +157,7 @@ public:
     const KeyT &getLastKey(BTreeNode::Ref node) const;
     const AggrT &getAggregated(BTreeNode::Ref node) const;
 
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     vespalib::string toString(BTreeNode::Ref ref) const;
     vespalib::string toString(const BTreeNode * node) const;

--- a/searchlib/src/vespa/searchlib/btree/btreenodeallocator.hpp
+++ b/searchlib/src/vespa/searchlib/btree/btreenodeallocator.hpp
@@ -376,11 +376,11 @@ getAggregated(BTreeNode::Ref node) const
 
 template <typename KeyT, typename DataT, typename AggrT,
           size_t INTERNAL_SLOTS, size_t LEAF_SLOTS>
-MemoryUsage
+vespalib::MemoryUsage
 BTreeNodeAllocator<KeyT, DataT, AggrT, INTERNAL_SLOTS, LEAF_SLOTS>::
 getMemoryUsage() const
 {
-    MemoryUsage usage = _nodeStore.getMemoryUsage();
+    vespalib::MemoryUsage usage = _nodeStore.getMemoryUsage();
     return usage;
 }
 

--- a/searchlib/src/vespa/searchlib/btree/btreenodestore.h
+++ b/searchlib/src/vespa/searchlib/btree/btreenodestore.h
@@ -177,7 +177,7 @@ public:
     }
 
     // Inherit doc from DataStoreBase
-    MemoryUsage getMemoryUsage() const {
+    vespalib::MemoryUsage getMemoryUsage() const {
         return _store.getMemoryUsage();
     }
 

--- a/searchlib/src/vespa/searchlib/btree/btreestore.h
+++ b/searchlib/src/vespa/searchlib/btree/btreestore.h
@@ -358,8 +358,8 @@ public:
 
 
     // Inherit doc from DataStoreBase
-    MemoryUsage getMemoryUsage() const {
-        MemoryUsage usage;
+    vespalib::MemoryUsage getMemoryUsage() const {
+        vespalib::MemoryUsage usage;
         usage.merge(_allocator.getMemoryUsage());
         usage.merge(_store.getMemoryUsage());
         return usage;

--- a/searchlib/src/vespa/searchlib/common/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/common/CMakeLists.txt
@@ -21,7 +21,6 @@ vespa_add_library(searchlib_common OBJECT
     mapnames.cpp
     packets.cpp
     partialbitvector.cpp
-    rcuvector.cpp
     resultset.cpp
     sequencedtaskexecutor.cpp
     sequencedtaskexecutorobserver.cpp

--- a/searchlib/src/vespa/searchlib/common/condensedbitvectors.cpp
+++ b/searchlib/src/vespa/searchlib/common/condensedbitvectors.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "condensedbitvectors.h"
-#include <vespa/searchlib/common/rcuvector.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 using vespalib::IllegalArgumentException;
 using vespalib::make_string;
@@ -77,7 +77,7 @@ private:
     size_t getCapacity() const override { return _v.capacity(); }
     size_t getSize() const override { return _v.size(); }
     void adjustDocIdLimit(uint32_t docId) override;
-    attribute::RcuVectorBase<T> _v;
+    vespalib::RcuVectorBase<T> _v;
 };
 
 template <typename T>

--- a/searchlib/src/vespa/searchlib/datastore/array_store.h
+++ b/searchlib/src/vespa/searchlib/datastore/array_store.h
@@ -84,7 +84,7 @@ public:
     }
     void remove(EntryRef ref);
     ICompactionContext::UP compactWorst(bool compactMemory, bool compactAddressSpace);
-    MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
+    vespalib::MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
 
     /**
      * Returns the address space usage by this store as the ratio between active buffers

--- a/searchlib/src/vespa/searchlib/datastore/datastore.cpp
+++ b/searchlib/src/vespa/searchlib/datastore/datastore.cpp
@@ -3,7 +3,7 @@
 #include "datastore.h"
 #include "datastore.hpp"
 #include <vespa/vespalib/util/array.hpp>
-#include <vespa/searchlib/common/rcuvector.hpp>
+#include <vespa/vespalib/util/rcuvector.hpp>
 
 namespace search::datastore {
 
@@ -12,6 +12,6 @@ template class DataStoreT<EntryRefT<22> >;
 }
 
 template void vespalib::Array<search::datastore::DataStoreBase::ElemHold1ListElem>::increase(size_t);
-template class search::attribute::RcuVector<search::datastore::EntryRef>;
-template class search::attribute::RcuVectorBase<search::datastore::EntryRef>;
-//template void search::attribute::RcuVectorBase<search::datastore::EntryRef>::expandAndInsert(const search::datastore::EntryRef &);
+template class vespalib::RcuVector<search::datastore::EntryRef>;
+template class vespalib::RcuVectorBase<search::datastore::EntryRef>;
+//template void vespalib::RcuVectorBase<search::datastore::EntryRef>::expandAndInsert(const search::datastore::EntryRef &);

--- a/searchlib/src/vespa/searchlib/datastore/datastorebase.cpp
+++ b/searchlib/src/vespa/searchlib/datastore/datastorebase.cpp
@@ -201,11 +201,11 @@ DataStoreBase::dropBuffers()
     _genHolder.clearHoldLists();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 DataStoreBase::getMemoryUsage() const
 {
     MemStats stats = getMemStats();
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     usage.setAllocatedBytes(stats._allocBytes);
     usage.setUsedBytes(stats._usedBytes);
     usage.setDeadBytes(stats._deadBytes);

--- a/searchlib/src/vespa/searchlib/datastore/datastorebase.h
+++ b/searchlib/src/vespa/searchlib/datastore/datastorebase.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "bufferstate.h"
-#include <vespa/vespalib/util/generationholder.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/generationholder.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vector>
 #include <deque>
 
@@ -228,7 +228,7 @@ public:
 
     void switchOrGrowActiveBuffer(uint32_t typeId, size_t elemsNeeded);
 
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     AddressSpace getAddressSpaceUsage() const;
 

--- a/searchlib/src/vespa/searchlib/datastore/unique_store.h
+++ b/searchlib/src/vespa/searchlib/datastore/unique_store.h
@@ -98,7 +98,7 @@ public:
     }
     void remove(EntryRef ref);
     ICompactionContext::UP compactWorst();
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     // Pass on hold list management to underlying store
     void transferHoldLists(generation_t generation);

--- a/searchlib/src/vespa/searchlib/datastore/unique_store.hpp
+++ b/searchlib/src/vespa/searchlib/datastore/unique_store.hpp
@@ -190,10 +190,10 @@ UniqueStore<EntryT, RefT>::compactWorst()
 }
 
 template <typename EntryT, typename RefT>
-MemoryUsage
+vespalib::MemoryUsage
 UniqueStore<EntryT, RefT>::getMemoryUsage() const
 {
-    MemoryUsage usage = _store.getMemoryUsage();
+    vespalib::MemoryUsage usage = _store.getMemoryUsage();
     usage.merge(_dict.getMemoryUsage());
     return usage;
 }

--- a/searchlib/src/vespa/searchlib/docstore/chunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/chunk.cpp
@@ -131,10 +131,10 @@ Chunk::getUniqueLids() const
     return unique;
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 Chunk::getMemoryUsage() const
 {
-    MemoryUsage result;
+    vespalib::MemoryUsage result;
     result.incAllocatedBytes(_format->getBuffer().capacity());
     result.incUsedBytes(_format->getBuffer().size());
     result.incAllocatedBytes(sizeof(Entry) * _lids.capacity());

--- a/searchlib/src/vespa/searchlib/docstore/chunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/chunk.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/vespalib/util/buffer.h>
 #include <vespa/vespalib/util/compressionconfig.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <memory>
 #include <vector>
 
@@ -102,7 +102,7 @@ public:
     vespalib::ConstBufferRef getLid(uint32_t lid) const;
     const vespalib::nbostream & getData() const;
     bool hasRoom(size_t len) const;
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 private:
     vespalib::nbostream & getData();
 

--- a/searchlib/src/vespa/searchlib/docstore/documentstore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/documentstore.cpp
@@ -422,7 +422,7 @@ DocumentStore::getStorageStats() const
     return _backingStore.getStorageStats();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 DocumentStore::getMemoryUsage() const
 {
     return _backingStore.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/docstore/documentstore.h
+++ b/searchlib/src/vespa/searchlib/docstore/documentstore.h
@@ -90,7 +90,7 @@ public:
                 const document::DocumentTypeRepo &repo) override;
     double getVisitCost() const override;
     DataStoreStorageStats getStorageStats() const override;
-    MemoryUsage getMemoryUsage() const override;
+    vespalib::MemoryUsage getMemoryUsage() const override;
     std::vector<DataStoreFileChunkStats> getFileChunkStats() const override;
 
     /**

--- a/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
@@ -523,10 +523,10 @@ FileChunk::getMemoryMetaFootprint() const
     return sizeof(*this) + _chunkInfo.byteCapacity();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 FileChunk::getMemoryUsage() const
 {
-    MemoryUsage result;
+    vespalib::MemoryUsage result;
     result.incAllocatedBytes(sizeof(*this));
     result.incUsedBytes(sizeof(*this));
     result.incAllocatedBytes(_chunkInfo.byteCapacity());

--- a/searchlib/src/vespa/searchlib/docstore/filechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.h
@@ -6,8 +6,8 @@
 #include "ibucketizer.h"
 #include "lid_info.h"
 #include "randread.h"
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/util/ptrholder.h>
 #include <vespa/vespalib/util/sync.h>
 #include <vespa/vespalib/stllike/hash_map.h>
@@ -117,7 +117,7 @@ public:
     virtual size_t getDiskFootprint() const { return _diskFootprint; }
     virtual size_t getMemoryFootprint() const;
     virtual size_t getMemoryMetaFootprint() const;
-    virtual MemoryUsage getMemoryUsage() const;
+    virtual vespalib::MemoryUsage getMemoryUsage() const;
 
     virtual size_t getDiskHeaderFootprint(void) const { return _dataHeaderLen + _idxHeaderLen; }
     size_t getDiskBloat() const {

--- a/searchlib/src/vespa/searchlib/docstore/idatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/idatastore.h
@@ -5,8 +5,8 @@
 #include "data_store_file_chunk_stats.h"
 #include <vespa/fastos/timestamp.h>
 #include <vespa/searchlib/common/i_compactable_lid_space.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vector>
 
 namespace vespalib { class DataBuffer; }
@@ -165,7 +165,7 @@ public:
     /*
      * Return the memory usage for data store.
      */
-    virtual MemoryUsage getMemoryUsage() const = 0;
+    virtual vespalib::MemoryUsage getMemoryUsage() const = 0;
 
     /*
      * Return detailed stats about underlying files for data store.

--- a/searchlib/src/vespa/searchlib/docstore/idocumentstore.h
+++ b/searchlib/src/vespa/searchlib/docstore/idocumentstore.h
@@ -210,7 +210,7 @@ public:
     /*
      * Return the memory usage for document store.
      */
-    virtual MemoryUsage getMemoryUsage() const = 0;
+    virtual vespalib::MemoryUsage getMemoryUsage() const = 0;
 
     /*
      * Return detailed stats about underlying files for data store.

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -7,8 +7,8 @@
 #include <vespa/vespalib/util/benchmark_timer.h>
 #include <vespa/vespalib/data/fileheader.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
-#include <vespa/searchlib/common/rcuvector.hpp>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/rcuvector.hpp>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -1156,11 +1156,11 @@ LogDataStore::getStorageStats() const
                                  lastSerialNum, lastFlushedSerialNum, docIdLimit);
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 LogDataStore::getMemoryUsage() const
 {
     LockGuard guard(_updateLock);
-    MemoryUsage result;
+    vespalib::MemoryUsage result;
     result.merge(_lidInfo.getMemoryUsage());
     for (const auto &fileChunk : _fileChunks) {
         if (fileChunk) {

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -6,9 +6,10 @@
 #include "lid_info.h"
 #include "writeablefilechunk.h"
 #include <vespa/vespalib/util/compressionconfig.h>
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/searchcommon/common/growstrategy.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/searchlib/transactionlog/syncproxy.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <vespa/vespalib/util/threadexecutor.h>
 
 #include <set>
@@ -163,7 +164,7 @@ public:
     }
 
     DataStoreStorageStats getStorageStats() const override;
-    MemoryUsage getMemoryUsage() const override;
+    vespalib::MemoryUsage getMemoryUsage() const override;
     std::vector<DataStoreFileChunkStats> getFileChunkStats() const override;
 
     void compactLidSpace(uint32_t wantedDocLidLimit) override;
@@ -186,7 +187,7 @@ private:
     void compactWorst(double bloatLimit, double spreadLimit);
     void compactFile(FileId chunkId);
 
-    typedef attribute::RcuVector<uint64_t> LidInfoVector;
+    typedef vespalib::RcuVector<uint64_t> LidInfoVector;
     typedef std::vector<FileChunk::UP> FileChunkVector;
 
     void updateLidMap(uint32_t lastFileChunkDocIdLimit);

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
@@ -600,11 +600,11 @@ WriteableFileChunk::getMemoryMetaFootprint() const
     return mySizeWithoutMyParent + FileChunk::getMemoryMetaFootprint();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 WriteableFileChunk::getMemoryUsage() const
 {
     LockGuard guard(_lock);
-    MemoryUsage result;
+    vespalib::MemoryUsage result;
     for (const auto &chunk : _chunkMap) {
         result.merge(chunk.second->getMemoryUsage());
     }

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -62,7 +62,7 @@ public:
     size_t getDiskFootprint() const override;
     size_t getMemoryFootprint() const override;
     size_t getMemoryMetaFootprint() const override;
-    MemoryUsage getMemoryUsage() const override;
+    vespalib::MemoryUsage getMemoryUsage() const override;
     size_t updateLidMap(const LockGuard &guard, ISetLid &lidMap, uint64_t serialNum, uint32_t docIdLimit) override;
     void waitForDiskToCatchUpToNow() const;
     void flushPendingChunks(uint64_t serialNum);

--- a/searchlib/src/vespa/searchlib/memoryindex/compact_words_store.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/compact_words_store.cpp
@@ -161,10 +161,10 @@ CompactWordsStore::get(uint32_t docId) const
     return Iterator();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 CompactWordsStore::getMemoryUsage() const
 {
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     usage.incAllocatedBytes(_docs.getMemoryConsumption());
     usage.incUsedBytes(_docs.getMemoryUsed());
     usage.merge(_wordsStore.getMemoryUsage());

--- a/searchlib/src/vespa/searchlib/memoryindex/compact_words_store.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/compact_words_store.h
@@ -3,8 +3,8 @@
 
 #include <vespa/searchlib/datastore/datastore.h>
 #include <vespa/searchlib/datastore/entryref.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/vespalib/util/array.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 
 namespace search::memoryindex {
@@ -75,7 +75,7 @@ public:
         ~Store();
         datastore::EntryRef insert(const Builder &builder);
         Iterator get(datastore::EntryRef wordRef) const;
-        MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
+        vespalib::MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
     };
 
     using DocumentWordsMap = vespalib::hash_map<uint32_t, datastore::EntryRef>;
@@ -90,7 +90,7 @@ public:
     void insert(const Builder &builder);
     void remove(uint32_t docId);
     Iterator get(uint32_t docId) const;
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/memoryindex/feature_store.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/feature_store.h
@@ -193,7 +193,7 @@ public:
     void clearHoldLists() { _store.clearHoldLists();}
     std::vector<uint32_t> startCompact() { return _store.startCompact(_typeId); }
     void finishCompact(const std::vector<uint32_t> & toHold) { _store.finishCompact(toHold); }
-    MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
+    vespalib::MemoryUsage getMemoryUsage() const { return _store.getMemoryUsage(); }
     datastore::DataStoreBase::MemStats getMemStats() const { return _store.getMemStats(); }
 };
 

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
@@ -191,10 +191,10 @@ FieldIndex::dump(search::index::IndexBuilder & indexBuilder)
     }
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 FieldIndex::getMemoryUsage() const
 {
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     usage.merge(_wordStore.getMemoryUsage());
     usage.merge(_dict.getMemoryUsage());
     usage.merge(_postingListStore.getMemoryUsage());

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.h
@@ -11,8 +11,8 @@
 #include <vespa/searchlib/btree/btreestore.h>
 #include <vespa/searchlib/index/docidandfeatures.h>
 #include <vespa/searchlib/index/indexbuilder.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/memoryusage.h>
 
 namespace search::memoryindex {
 
@@ -150,7 +150,7 @@ public:
 
     void dump(search::index::IndexBuilder & indexBuilder);
 
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
     DictionaryTree &getDictionaryTree() { return _dict; }
     PostingListStore &getPostingListStore() { return _postingListStore; }
     FieldIndexRemover &getDocumentRemover() { return _remover; }

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.cpp
@@ -50,10 +50,10 @@ FieldIndexCollection::dump(search::index::IndexBuilder &indexBuilder)
     }
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 FieldIndexCollection::getMemoryUsage() const
 {
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     for (auto &fieldIndex : _fieldIndexes) {
         usage.merge(fieldIndex->getMemoryUsage());
     }

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.h
@@ -47,7 +47,7 @@ public:
 
     void dump(search::index::IndexBuilder & indexBuilder);
 
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     FieldIndex *getFieldIndex(uint32_t fieldId) const {
         return _fieldIndexes[fieldId].get();

--- a/searchlib/src/vespa/searchlib/memoryindex/memory_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/memory_index.cpp
@@ -244,10 +244,10 @@ MemoryIndex::createBlueprint(const IRequestContext & requestContext,
     return visitor.getResult();
 }
 
-MemoryUsage
+vespalib::MemoryUsage
 MemoryIndex::getMemoryUsage() const
 {
-    MemoryUsage usage;
+    vespalib::MemoryUsage usage;
     usage.merge(_fieldIndexes->getMemoryUsage());
     return usage;
 }

--- a/searchlib/src/vespa/searchlib/memoryindex/memory_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/memory_index.h
@@ -4,9 +4,9 @@
 
 #include <vespa/searchlib/common/idestructorcallback.h>
 #include <vespa/searchlib/queryeval/searchable.h>
-#include <vespa/searchlib/util/memoryusage.h>
 #include <vespa/searchcommon/common/schema.h>
 #include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/util/memoryusage.h>
 
 namespace search::index { class IndexBuilder; }
 
@@ -162,7 +162,7 @@ public:
     /**
      * Gets an approximation of how much memory the index uses.
      */
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     uint64_t getStaticMemoryFootprint() const { return _staticMemoryFootprint; }
 };

--- a/searchlib/src/vespa/searchlib/memoryindex/word_store.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/word_store.h
@@ -27,7 +27,7 @@ public:
         return _store.getEntry<char>(internalRef);
     }
 
-    MemoryUsage getMemoryUsage() const {
+    vespalib::MemoryUsage getMemoryUsage() const {
         return _store.getMemoryUsage();
     }
 };

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.cpp
@@ -198,8 +198,8 @@ void DocumentFeaturesStore::remove(uint32_t doc_id) {
     }
 }
 
-search::MemoryUsage DocumentFeaturesStore::getMemoryUsage() const {
-    search::MemoryUsage usage;
+vespalib::MemoryUsage DocumentFeaturesStore::getMemoryUsage() const {
+    vespalib::MemoryUsage usage;
     usage.incAllocatedBytes(_docs.getMemoryConsumption());
     usage.incUsedBytes(_docs.getMemoryUsed());
     usage.incAllocatedBytes(_ranges.getMemoryConsumption());

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.h
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.h
@@ -76,7 +76,7 @@ public:
     void insert(const PredicateTreeAnnotations &annotations, uint32_t docId);
     FeatureSet get(uint32_t docId) const;
     void remove(uint32_t docId);
-    search::MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     void serialize(vespalib::DataBuffer &buffer) const;
 };

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.cpp
@@ -224,9 +224,9 @@ void PredicateIndex::transferHoldLists(generation_t generation) {
     _zero_constraint_docs.getAllocator().transferHoldLists(generation);
 }
 
-MemoryUsage PredicateIndex::getMemoryUsage() const {
+vespalib::MemoryUsage PredicateIndex::getMemoryUsage() const {
     // TODO Include bit vector cache memory usage
-    MemoryUsage combined;
+    vespalib::MemoryUsage combined;
     combined.merge(_interval_index.getMemoryUsage());
     combined.merge(_bounds_index.getMemoryUsage());
     combined.merge(_zero_constraint_docs.getMemoryUsage());

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.h
@@ -78,7 +78,7 @@ public:
     void commit();
     void trimHoldLists(generation_t used_generation);
     void transferHoldLists(generation_t generation);
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
 
     int getArity() const { return _arity; }
 

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval_store.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval_store.h
@@ -78,7 +78,7 @@ public:
     /**
      * Return memory usage (only the data store is included)
      */
-    MemoryUsage getMemoryUsage() const {
+    vespalib::MemoryUsage getMemoryUsage() const {
         return _store.getMemoryUsage();
     }
 

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "common.h"
-#include <vespa/searchlib/common/rcuvector.h>
 #include <vespa/searchlib/btree/btreestore.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/rcuvector.h>
 #include <experimental/optional>
 
 namespace search::predicate {
@@ -49,7 +49,7 @@ struct SimpleIndexConfig {
     // Use vector posting list in foreach_frozen if doc frequency is above
     double foreach_vector_threshold = DEFAULT_FOREACH_VECTOR_THRESHOLD;
     // Grow strategy for the posting vectors
-    GrowStrategy grow_strategy = GrowStrategy();
+    vespalib::GrowStrategy grow_strategy = vespalib::GrowStrategy();
 
     SimpleIndexConfig() {}
     SimpleIndexConfig(double upper_docid_freq_threshold_,
@@ -58,7 +58,7 @@ struct SimpleIndexConfig {
                       size_t lower_vector_size_threshold_,
                       size_t vector_prune_frequency_,
                       double foreach_vector_threshold_,
-                      GrowStrategy grow_strategy_)
+                      vespalib::GrowStrategy grow_strategy_)
             : upper_docid_freq_threshold(upper_docid_freq_threshold_),
               lower_docid_freq_threshold(lower_docid_freq_threshold_),
               upper_vector_size_threshold(upper_vector_size_threshold_),
@@ -66,7 +66,7 @@ struct SimpleIndexConfig {
               vector_prune_frequency(vector_prune_frequency_),
               foreach_vector_threshold(foreach_vector_threshold_),
               grow_strategy(grow_strategy_) {}
-    SimpleIndexConfig(double upper_docid_freq_threshold_, GrowStrategy grow_strategy_)
+    SimpleIndexConfig(double upper_docid_freq_threshold_, vespalib::GrowStrategy grow_strategy_)
             : upper_docid_freq_threshold(upper_docid_freq_threshold_),
               lower_docid_freq_threshold(upper_docid_freq_threshold_ * 0.80),
               grow_strategy(grow_strategy_) {}
@@ -74,7 +74,7 @@ struct SimpleIndexConfig {
 
 template <typename Posting, typename Key, typename DocId>
 class PostingVectorIterator {
-    using PostingVector = attribute::RcuVectorBase<Posting>;
+    using PostingVector = vespalib::RcuVectorBase<Posting>;
 
     const Posting * const _vector;
     const size_t _size;
@@ -131,7 +131,7 @@ public:
     using BTreeStore = btree::BTreeStore<
             DocId, Posting, btree::NoAggregated, std::less<DocId>, btree::BTreeDefaultTraits>;
     using BTreeIterator = typename BTreeStore::ConstIterator;
-    using PostingVector = attribute::RcuVectorBase<Posting>;
+    using PostingVector = vespalib::RcuVectorBase<Posting>;
     using VectorStore = btree::BTree<Key, std::shared_ptr<PostingVector>, btree::NoAggregated>;
     using VectorIterator = PostingVectorIterator<Posting, Key, DocId>;
 
@@ -189,7 +189,7 @@ public:
     void commit();
     void trimHoldLists(generation_t used_generation);
     void transferHoldLists(generation_t generation);
-    MemoryUsage getMemoryUsage() const;
+    vespalib::MemoryUsage getMemoryUsage() const;
     template <typename FunctionType>
     void foreach_frozen_key(datastore::EntryRef ref, Key key, FunctionType func) const;
 

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.hpp
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.hpp
@@ -3,7 +3,7 @@
 
 #include "simple_index.h"
 #include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/searchlib/common/rcuvector.hpp>
+#include <vespa/vespalib/util/rcuvector.hpp>
 
 namespace search::predicate {
 
@@ -232,7 +232,7 @@ void SimpleIndex<Posting, Key, DocId>::createVectorIfOverThreshold(datastore::En
     size_t size = getDocumentCount(ref);
     double ratio = getDocumentRatio(size, doc_id_limit);
     if (shouldCreateVectorPosting(size, ratio)) {
-        auto vector = new attribute::RcuVectorBase<Posting>(_config.grow_strategy, _generation_holder);
+        auto vector = new vespalib::RcuVectorBase<Posting>(_config.grow_strategy, _generation_holder);
         vector->unsafe_resize(doc_id_limit);
         _btree_posting_lists.foreach_unfrozen(
                 ref, [&](DocId d, const Posting &p) { (*vector)[d] = p; });
@@ -301,8 +301,8 @@ void SimpleIndex<Posting, Key, DocId>::transferHoldLists(generation_t generation
 }
 
 template <typename Posting, typename Key, typename DocId>
-MemoryUsage SimpleIndex<Posting, Key, DocId>::getMemoryUsage() const {
-    MemoryUsage combined;
+vespalib::MemoryUsage SimpleIndex<Posting, Key, DocId>::getMemoryUsage() const {
+    vespalib::MemoryUsage combined;
     combined.merge(_dictionary.getMemoryUsage());
     combined.merge(_btree_posting_lists.getMemoryUsage());
     combined.merge(_vector_posting_lists.getMemoryUsage());

--- a/searchlib/src/vespa/searchlib/tensor/generic_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/generic_tensor_attribute.cpp
@@ -4,10 +4,10 @@
 #include "generic_tensor_attribute_saver.h"
 #include "tensor_attribute.hpp"
 #include <vespa/eval/tensor/tensor.h>
-#include <vespa/searchlib/common/rcuvector.hpp>
 #include <vespa/fastlib/io/bufferedfile.h>
 #include <vespa/searchlib/attribute/readerbase.h>
 #include <vespa/searchlib/util/fileutil.h>
+#include <vespa/vespalib/util/rcuvector.hpp>
 
 using vespalib::eval::ValueType;
 using vespalib::tensor::Tensor;

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
@@ -7,7 +7,7 @@
 #include <vespa/eval/tensor/dense/dense_tensor.h>
 #include <vespa/eval/tensor/sparse/sparse_tensor.h>
 #include <vespa/eval/tensor/wrapped_simple_tensor.h>
-#include <vespa/searchlib/common/rcuvector.hpp>
+#include <vespa/vespalib/util/rcuvector.hpp>
 
 using vespalib::eval::SimpleTensor;
 using vespalib::eval::ValueType;
@@ -125,7 +125,7 @@ void
 TensorAttribute::onUpdateStat()
 {
     // update statistics
-    MemoryUsage total = _refVector.getMemoryUsage();
+    vespalib::MemoryUsage total = _refVector.getMemoryUsage();
     total.merge(_tensorStore.getMemoryUsage());
     total.mergeGenerationHeldBytes(getGenerationHolder().getHeldBytes());
     this->updateStatistics(_refVector.size(),

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.h
@@ -5,7 +5,7 @@
 #include "i_tensor_attribute.h"
 #include <vespa/searchlib/attribute/not_implemented_attribute.h>
 #include "tensor_store.h"
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
 namespace search::tensor {
 
@@ -16,7 +16,7 @@ class TensorAttribute : public NotImplementedAttribute, public ITensorAttribute
 {
 protected:
     using EntryRef = TensorStore::EntryRef;
-    using RefVector = attribute::RcuVectorBase<EntryRef>;
+    using RefVector = vespalib::RcuVectorBase<EntryRef>;
 
     RefVector _refVector; // docId -> ref in data store for serialized tensor
     TensorStore &_tensorStore; // data store for serialized tensors

--- a/searchlib/src/vespa/searchlib/tensor/tensor_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_store.h
@@ -55,7 +55,7 @@ public:
         _store.clearHoldLists();
     }
 
-    MemoryUsage
+    vespalib::MemoryUsage
     getMemoryUsage() const
     {
         return _store.getMemoryUsage();

--- a/searchlib/src/vespa/searchlib/test/datastore/memstats.h
+++ b/searchlib/src/vespa/searchlib/test/datastore/memstats.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-namespace search {
-namespace datastore {
-namespace test {
+#include <vespa/vespalib/util/memoryusage.h>
+
+namespace search::datastore::test {
 
 /*
  * Class representing expected memory stats in unit tests.
@@ -15,7 +15,7 @@ struct MemStats
     size_t _hold;
     size_t _dead;
     MemStats() : _used(0), _hold(0), _dead(0) {}
-    MemStats(const MemoryUsage &usage)
+    MemStats(const vespalib::MemoryUsage &usage)
         : _used(usage.usedBytes()),
           _hold(usage.allocatedBytesOnHold()),
           _dead(usage.deadBytes()) {}
@@ -34,6 +34,4 @@ struct MemStats
     }
 };
 
-}
-}
 }

--- a/searchlib/src/vespa/searchlib/util/searchable_stats.h
+++ b/searchlib/src/vespa/searchlib/util/searchable_stats.h
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "memoryusage.h"
+#include <vespa/vespalib/util/memoryusage.h>
 
 namespace search {
 
@@ -13,17 +13,17 @@ namespace search {
 class SearchableStats
 {
 private:
-    MemoryUsage _memoryUsage;
+    vespalib::MemoryUsage _memoryUsage;
     size_t _docsInMemory;
     size_t _sizeOnDisk;
 
 public:
     SearchableStats() : _memoryUsage(), _docsInMemory(0), _sizeOnDisk(0) {}
-    SearchableStats &memoryUsage(const MemoryUsage &usage) {
+    SearchableStats &memoryUsage(const vespalib::MemoryUsage &usage) {
         _memoryUsage = usage;
         return *this;
     }
-    const MemoryUsage &memoryUsage() const { return _memoryUsage; }
+    const vespalib::MemoryUsage &memoryUsage() const { return _memoryUsage; }
     SearchableStats &docsInMemory(size_t value) {
         _docsInMemory = value;
         return *this;

--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -120,6 +120,7 @@ vespa_define_module(
     src/tests/util/generationhandler
     src/tests/util/generationhandler_stress
     src/tests/util/md5
+    src/tests/util/rcuvector
     src/tests/valgrind
     src/tests/websocket
     src/tests/zcurve

--- a/vespalib/src/tests/util/rcuvector/.gitignore
+++ b/vespalib/src/tests/util/rcuvector/.gitignore
@@ -1,0 +1,5 @@
+.depend	
+Makefile	
+rcuvector_test	
+vespalib_rcuvector_test_app
+

--- a/vespalib/src/tests/util/rcuvector/CMakeLists.txt
+++ b/vespalib/src/tests/util/rcuvector/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_executable(searchlib_rcuvector_test_app TEST
+vespa_add_executable(vespalib_rcuvector_test_app TEST
     SOURCES
     rcuvector_test.cpp
     DEPENDS
     searchlib
 )
-vespa_add_test(NAME searchlib_rcuvector_test_app COMMAND searchlib_rcuvector_test_app)
+vespa_add_test(NAME vespalib_rcuvector_test_app COMMAND vespalib_rcuvector_test_app)

--- a/vespalib/src/tests/util/rcuvector/rcuvector_test.cpp
+++ b/vespalib/src/tests/util/rcuvector/rcuvector_test.cpp
@@ -1,14 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/testkit/testapp.h>
-#include <vespa/searchlib/common/rcuvector.h>
+#include <vespa/vespalib/util/rcuvector.h>
 
-using namespace search::attribute;
-using search::MemoryUsage;
-using vespalib::alloc::Alloc;
-using vespalib::GenerationHandler;
-using vespalib::GenerationHolder;
-using vespalib::GenerationHeldBase;
+using namespace vespalib;
 
 bool
 assertUsage(const MemoryUsage & exp, const MemoryUsage & act)
@@ -246,7 +241,7 @@ struct ShrinkFixture {
     GenerationHolder g;
     RcuVectorBase<int> vec;
     int *oldPtr;
-    ShrinkFixture() : g(), vec(4096, 50, 0, g, Alloc::allocMMap()), oldPtr()
+    ShrinkFixture() : g(), vec(4096, 50, 0, g, alloc::Alloc::allocMMap()), oldPtr()
     {
         for (size_t i = 0; i < 4000; ++i) {
             vec.push_back(7);

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -31,6 +31,7 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     printable.cpp
     priority_queue.cpp
     random.cpp
+    rcuvector.cpp
     regexp.cpp
     runnable.cpp
     runnable_pair.cpp

--- a/vespalib/src/vespa/vespalib/util/growstrategy.h
+++ b/vespalib/src/vespa/vespalib/util/growstrategy.h
@@ -1,0 +1,47 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vespalib {
+
+class GrowStrategy {
+private:
+    uint32_t _initialCapacity;
+    float    _growFactor;
+    uint32_t _growDelta;
+public:
+    GrowStrategy() noexcept
+        : GrowStrategy(1024, 0.5, 0)
+    {}
+    GrowStrategy(uint32_t initialCapacity, float growPercent, uint32_t growDelta) noexcept
+        : _initialCapacity(initialCapacity),
+          _growFactor(growPercent),
+          _growDelta(growDelta)
+    {
+    }
+
+    static GrowStrategy make(uint32_t initialCapacity, float growFactor, uint32_t growDelta) noexcept {
+        return GrowStrategy(initialCapacity, growFactor, growDelta);
+    }
+
+    uint32_t    getInitialCapacity() const noexcept { return _initialCapacity; }
+    uint32_t        getGrowPercent() const noexcept { return _growFactor*100; }
+    float            getGrowFactor() const noexcept { return _growFactor; }
+    uint32_t          getGrowDelta() const noexcept { return _growDelta; }
+    void    setInitialCapacity(uint32_t v) noexcept { _initialCapacity = v; }
+    void          setGrowDelta(uint32_t v) noexcept { _growDelta = v; }
+
+    bool operator==(const GrowStrategy & rhs) const noexcept {
+        return (_initialCapacity == rhs._initialCapacity &&
+                _growFactor == rhs._growFactor &&
+                _growDelta == rhs._growDelta);
+    }
+    bool operator!=(const GrowStrategy & rhs) const noexcept {
+        return !(operator==(rhs));
+    }
+};
+
+}
+

--- a/vespalib/src/vespa/vespalib/util/growstrategy.h
+++ b/vespalib/src/vespa/vespalib/util/growstrategy.h
@@ -8,30 +8,30 @@ namespace vespalib {
 
 class GrowStrategy {
 private:
-    uint32_t _initialCapacity;
-    float    _growFactor;
-    uint32_t _growDelta;
+    size_t _initialCapacity;
+    float  _growFactor;
+    size_t _growDelta;
 public:
     GrowStrategy() noexcept
         : GrowStrategy(1024, 0.5, 0)
     {}
-    GrowStrategy(uint32_t initialCapacity, float growPercent, uint32_t growDelta) noexcept
+    GrowStrategy(size_t initialCapacity, float growPercent, size_t growDelta) noexcept
         : _initialCapacity(initialCapacity),
           _growFactor(growPercent),
           _growDelta(growDelta)
     {
     }
 
-    static GrowStrategy make(uint32_t initialCapacity, float growFactor, uint32_t growDelta) noexcept {
+    static GrowStrategy make(size_t initialCapacity, float growFactor, size_t growDelta) noexcept {
         return GrowStrategy(initialCapacity, growFactor, growDelta);
     }
 
-    uint32_t    getInitialCapacity() const noexcept { return _initialCapacity; }
-    uint32_t        getGrowPercent() const noexcept { return _growFactor*100; }
-    float            getGrowFactor() const noexcept { return _growFactor; }
-    uint32_t          getGrowDelta() const noexcept { return _growDelta; }
-    void    setInitialCapacity(uint32_t v) noexcept { _initialCapacity = v; }
-    void          setGrowDelta(uint32_t v) noexcept { _growDelta = v; }
+    size_t getInitialCapacity() const noexcept { return _initialCapacity; }
+    size_t     getGrowPercent() const noexcept { return _growFactor*100; }
+    float       getGrowFactor() const noexcept { return _growFactor; }
+    size_t       getGrowDelta() const noexcept { return _growDelta; }
+    void setInitialCapacity(size_t v) noexcept { _initialCapacity = v; }
+    void       setGrowDelta(size_t v) noexcept { _growDelta = v; }
 
     bool operator==(const GrowStrategy & rhs) const noexcept {
         return (_initialCapacity == rhs._initialCapacity &&

--- a/vespalib/src/vespa/vespalib/util/memoryusage.h
+++ b/vespalib/src/vespa/vespalib/util/memoryusage.h
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 
-namespace search {
+namespace vespalib {
 
 class MemoryUsage {
 private:
@@ -57,4 +57,4 @@ public:
     }
 };
 
-} // namespace search
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/rcuvector.cpp
+++ b/vespalib/src/vespa/vespalib/util/rcuvector.cpp
@@ -2,7 +2,7 @@
 
 #include "rcuvector.hpp"
 
-namespace search::attribute {
+namespace vespalib {
 
 template class RcuVectorBase<uint8_t>;
 template class RcuVectorBase<uint16_t>;

--- a/vespalib/src/vespa/vespalib/util/rcuvector.h
+++ b/vespalib/src/vespa/vespalib/util/rcuvector.h
@@ -2,16 +2,16 @@
 
 #pragma once
 
-#include <vespa/vespalib/util/generationholder.h>
-#include <vespa/searchlib/util/memoryusage.h>
-#include <vespa/searchcommon/common/growstrategy.h>
-#include <vespa/vespalib/util/alloc.h>
-#include <vespa/vespalib/util/array.h>
+#include "alloc.h"
+#include "array.h"
+#include "generationholder.h"
+#include "growstrategy.h"
+#include "memoryusage.h"
 
-namespace search::attribute {
+namespace vespalib {
 
 template <typename T>
-class RcuVectorHeld : public vespalib::GenerationHeldBase
+class RcuVectorHeld : public GenerationHeldBase
 {
     std::unique_ptr<T> _data;
 
@@ -37,16 +37,16 @@ private:
     static_assert(std::is_trivially_destructible<T>::value,
                   "Value type must be trivially destructible");
 
-    using Array = vespalib::Array<T>;
-    using Alloc = vespalib::alloc::Alloc;
+    using ArrayType = Array<T>;
+    using Alloc = alloc::Alloc;
 protected:
-    using generation_t = vespalib::GenerationHandler::generation_t;
-    using GenerationHolder = vespalib::GenerationHolder;
+    using generation_t = GenerationHandler::generation_t;
+    using GenerationHolderType = GenerationHolder;
 private:
-    Array              _data;
-    size_t             _growPercent;
-    size_t             _growDelta;
-    GenerationHolder   &_genHolder;
+    ArrayType             _data;
+    size_t                _growPercent;
+    size_t                _growDelta;
+    GenerationHolderType &_genHolder;
 
     size_t calcNewSize(size_t baseSize) const {
         size_t delta = (baseSize * _growPercent / 100) + _growDelta;
@@ -61,7 +61,7 @@ private:
 
 public:
     using ValueType = T;
-    RcuVectorBase(GenerationHolder &genHolder,
+    RcuVectorBase(GenerationHolderType &genHolder,
                   const Alloc &initialAlloc = Alloc::alloc());
 
     /**
@@ -72,11 +72,11 @@ public:
      * nc = oc + (oc * growPercent / 100) + growDelta.
      **/
     RcuVectorBase(size_t initialCapacity, size_t growPercent, size_t growDelta,
-                  GenerationHolder &genHolder,
+                  GenerationHolderType &genHolder,
                   const Alloc &initialAlloc = Alloc::alloc());
 
     RcuVectorBase(GrowStrategy growStrategy,
-                  GenerationHolder &genHolder,
+                  GenerationHolderType &genHolder,
                   const Alloc &initialAlloc = Alloc::alloc());
 
     virtual ~RcuVectorBase();
@@ -121,17 +121,17 @@ public:
 
     void reset();
     void shrink(size_t newSize) __attribute__((noinline));
-    void replaceVector(std::unique_ptr<Array> replacement);
+    void replaceVector(std::unique_ptr<ArrayType> replacement);
 };
 
 template <typename T>
 class RcuVector : public RcuVectorBase<T>
 {
 private:
-    typedef typename RcuVectorBase<T>::generation_t generation_t;
-    typedef typename RcuVectorBase<T>::GenerationHolder GenerationHolder;
-    generation_t       _generation;
-    GenerationHolder   _genHolderStore;
+    using generation_t         = typename RcuVectorBase<T>::generation_t;
+    using GenerationHolderType = typename RcuVectorBase<T>::GenerationHolderType;
+    generation_t         _generation;
+    GenerationHolderType _genHolderStore;
 
     void onReallocation() override;
 


### PR DESCRIPTION
@geirst @toregge @baldersheim please review

Having RCU support available across all our C++ modules open up
new opportunities for optimizations. Also a prerequisite for moving
B-tree/datastore code to vespalib.

This changes the following:
- `RcuVector` moved from `searchlib` to `vespalib`
- `MemoryUsage` moved from `searchlib` to `vespalib`
- Introduce a simplified, more generic `GrowStrategy` in `vespalib`
  used by the moved `RcuVector` which does not have any notion of
  documents. Existing searchlib `GrowStrategy` gets a simple function
  to convert to this generic strategy. I've replaced instances of the searchlib
  strategy with the one in vespalib where these have only been used as
  inputs to RCU vectors. It's quite possible that more could be replaced.