### PR TITLE
Remove flavor as dimension from node metrics

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -163,8 +163,6 @@ public class StorageMaintainer {
         context.node().getVespaVersion().ifPresent(version -> tags.put("vespaVersion", version.toFullString()));
 
         if (! isConfigserverLike(context.nodeType())) {
-            tags.put("flavor", context.node().getFlavor());
-            tags.put("canonicalFlavor", context.node().getCanonicalFlavor());
             tags.put("state", context.node().getState().toString());
             context.node().getParentHostname().ifPresent(parent -> tags.put("parentHostname", parent));
             context.node().getOwner().ifPresent(owner -> {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -566,6 +566,7 @@ public class NodeAgentImpl implements NodeAgent {
                 .withMetric("mem_total.util", 100 * memoryTotalUsageRatio)
                 .withMetric("cpu.util", 100 * cpuUsageRatioOfAllocated)
                 .withMetric("cpu.sys.util", 100 * cpuKernelUsageRatioOfAllocated)
+                .withMetric("cpu.vcpus", totalNumCpuCores)
                 .withMetric("disk.limit", diskTotalBytes);
 
         diskTotalBytesUsed.ifPresent(diskUsed -> systemMetricsBuilder.withMetric("disk.used", diskUsed));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -71,8 +71,6 @@ public class StorageMaintainerTest {
                     "    role: tenants\n" +
                     "    zone: prod.us-north-1\n" +
                     "    vespaVersion: 6.305.12\n" +
-                    "    flavor: d-2-8-50\n" +
-                    "    canonicalFlavor: d-2-8-50\n" +
                     "    state: active\n" +
                     "    parentHostname: host123.test.domain.tld\n" +
                     "    tenantName: tenant\n" +
@@ -103,8 +101,6 @@ public class StorageMaintainerTest {
                     "    role: routing\n" +
                     "    zone: prod.us-north-1\n" +
                     "    vespaVersion: 6.305.12\n" +
-                    "    flavor: d-2-8-50\n" +
-                    "    canonicalFlavor: d-2-8-50\n" +
                     "    state: active\n" +
                     "    parentHostname: host123.test.domain.tld\n" +
                     "    tenantName: tenant\n" +

--- a/node-admin/src/test/resources/expected.container.system.metrics.txt
+++ b/node-admin/src/test/resources/expected.container.system.metrics.txt
@@ -15,6 +15,7 @@ s:
         "disk.used": 39625000000,
         "cpu.sys.util": 3.402,
         "disk.util": 15.85,
+        "cpu.vcpus": 8,
         "cpu.util": 5.4,
         "mem.util": 25.0,
         "disk.limit": 250000000000


### PR DESCRIPTION
This removes `flavor`/`canonicalFlavor` form node metrics and adds a new metric `vespa.node.cpu.vcpus`