### PR TITLE
Bounce Puts when a node is unavailable in the pending cluster state

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -49,6 +49,8 @@ private:
 
     bool shouldImplicitlyActivateReplica(const OperationTargetList& targets) const;
 
+    bool has_unavailable_targets_in_pending_state(const OperationTargetList& targets) const;
+
     std::shared_ptr<api::PutCommand> _msg;
     DistributorComponent& _manager;
     DistributorBucketSpace &_bucketSpace;


### PR DESCRIPTION
@geirst please review

Avoids scheduling Put operations towards nodes that are available in the
current cluster state, but not in the one that is being async processed
in the background. Not only are operations to such nodes highly likely to
be doomed in the first place, we also risk triggering assertion failures
by code that does not expect bucket DB inserts to said nodes to ever
be rejected.

Since we're recently added explicit rejection of inserts to nodes that
are unavailable in the pending state, these assertions have the potential
for triggering in certain edge case scenarios.