### PR TITLE
Jvenstad/zk watcher serialisation

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/GlobalComponentRegistry.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/GlobalComponentRegistry.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.flags.FlagSource;
 
 import java.time.Clock;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Interface representing all global config server components used within the config server.
@@ -44,5 +45,5 @@ public interface GlobalComponentRegistry {
     ConfigServerDB getConfigServerDB();
     StripedExecutor<TenantName> getZkWatcherExecutor();
     FlagSource getFlagSource();
-
+    ExecutorService getZkCacheExecutor();
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/GlobalComponentRegistry.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/GlobalComponentRegistry.java
@@ -2,8 +2,10 @@
 package com.yahoo.vespa.config.server;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
+import com.yahoo.concurrent.StripedExecutor;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.provision.Provisioner;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.config.server.application.PermanentApplicationPackage;
 import com.yahoo.vespa.config.server.host.HostRegistries;
@@ -40,6 +42,7 @@ public interface GlobalComponentRegistry {
     Zone getZone();
     Clock getClock();
     ConfigServerDB getConfigServerDB();
+    StripedExecutor<TenantName> getZkWatcherExecutor();
     FlagSource getFlagSource();
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/InjectedGlobalComponentRegistry.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/InjectedGlobalComponentRegistry.java
@@ -3,8 +3,10 @@ package com.yahoo.vespa.config.server;
 
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
+import com.yahoo.concurrent.StripedExecutor;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.provision.Provisioner;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.config.server.application.PermanentApplicationPackage;
 import com.yahoo.vespa.config.server.host.HostRegistries;
@@ -42,6 +44,7 @@ public class InjectedGlobalComponentRegistry implements GlobalComponentRegistry 
     private final Zone zone;
     private final ConfigServerDB configServerDB;
     private final FlagSource flagSource;
+    private final StripedExecutor<TenantName> zkWatcherExecutor;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
@@ -74,6 +77,7 @@ public class InjectedGlobalComponentRegistry implements GlobalComponentRegistry 
         this.zone = zone;
         this.configServerDB = configServerDB;
         this.flagSource = flagSource;
+        this.zkWatcherExecutor = new StripedExecutor<>();
     }
 
     @Override
@@ -114,6 +118,11 @@ public class InjectedGlobalComponentRegistry implements GlobalComponentRegistry 
 
     @Override
     public ConfigServerDB getConfigServerDB() { return configServerDB; }
+
+    @Override
+    public StripedExecutor<TenantName> getZkWatcherExecutor() {
+        return zkWatcherExecutor;
+    }
 
     @Override
     public FlagSource getFlagSource() { return flagSource; }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/InjectedGlobalComponentRegistry.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/InjectedGlobalComponentRegistry.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.config.server;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.concurrent.StripedExecutor;
+import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.provision.Provisioner;
 import com.yahoo.config.provision.TenantName;
@@ -16,12 +17,15 @@ import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
 import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.session.SessionPreparer;
 import com.yahoo.vespa.config.server.tenant.TenantListener;
+import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.flags.FlagSource;
 
 import java.time.Clock;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Registry containing all the "static"/"global" components in a config server in one place.
@@ -45,6 +49,7 @@ public class InjectedGlobalComponentRegistry implements GlobalComponentRegistry 
     private final ConfigServerDB configServerDB;
     private final FlagSource flagSource;
     private final StripedExecutor<TenantName> zkWatcherExecutor;
+    private final ExecutorService zkCacheExecutor;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
@@ -78,6 +83,7 @@ public class InjectedGlobalComponentRegistry implements GlobalComponentRegistry 
         this.configServerDB = configServerDB;
         this.flagSource = flagSource;
         this.zkWatcherExecutor = new StripedExecutor<>();
+        this.zkCacheExecutor = Executors.newFixedThreadPool(1, ThreadFactoryFactory.getThreadFactory(TenantRepository.class.getName()));
     }
 
     @Override
@@ -126,4 +132,9 @@ public class InjectedGlobalComponentRegistry implements GlobalComponentRegistry 
 
     @Override
     public FlagSource getFlagSource() { return flagSource; }
+
+    @Override
+    public ExecutorService getZkCacheExecutor() {
+        return zkCacheExecutor;
+    }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.application;
 
+import com.yahoo.concurrent.StripedExecutor;
 import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
@@ -8,6 +9,7 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.text.Utf8;
 import com.yahoo.transaction.Transaction;
+import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.ReloadHandler;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
@@ -24,6 +26,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Logger;
@@ -46,26 +49,27 @@ public class TenantApplications {
     private final Curator curator;
     private final Path applicationsPath;
     private final Path locksPath;
-    // One thread pool for all instances of this class
-    private static final ExecutorService pathChildrenExecutor =
-            Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory(TenantApplications.class.getName()));
     private final Curator.DirectoryCache directoryCache;
     private final ReloadHandler reloadHandler;
     private final Map<ApplicationId, Lock> locks;
+    private final Executor zkWatcherExecutor;
 
-    private TenantApplications(Curator curator, ReloadHandler reloadHandler, TenantName tenant) {
+    private TenantApplications(Curator curator, ReloadHandler reloadHandler, TenantName tenant,
+                               ExecutorService zkCacheExecutor, StripedExecutor<TenantName> zkWatcherExecutor) {
         this.curator = curator;
         this.applicationsPath = TenantRepository.getApplicationsPath(tenant);
         this.locksPath = TenantRepository.getLocksPath(tenant);
         this.locks = new ConcurrentHashMap<>(2);
         this.reloadHandler = reloadHandler;
-        this.directoryCache = curator.createDirectoryCache(applicationsPath.getAbsolute(), false, false, pathChildrenExecutor);
+        this.zkWatcherExecutor = command -> zkWatcherExecutor.execute(tenant, command);
+        this.directoryCache = curator.createDirectoryCache(applicationsPath.getAbsolute(), false, false, zkCacheExecutor);
         this.directoryCache.start();
         this.directoryCache.addListener(this::childEvent);
     }
 
-    public static TenantApplications create(Curator curator, ReloadHandler reloadHandler, TenantName tenant) {
-        return new TenantApplications(curator, reloadHandler, tenant);
+    public static TenantApplications create(GlobalComponentRegistry registry, ReloadHandler reloadHandler, TenantName tenant) {
+        return new TenantApplications(registry.getCurator(), reloadHandler, tenant,
+                                      registry.getZkCacheExecutor(), registry.getZkWatcherExecutor());
     }
 
     /**
@@ -153,23 +157,25 @@ public class TenantApplications {
     }
 
     private void childEvent(CuratorFramework client, PathChildrenCacheEvent event) {
-        switch (event.getType()) {
-            case CHILD_ADDED:
-                applicationAdded(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()));
-                break;
-            // Event CHILD_REMOVED will be triggered on all config servers if deleteApplication() above is called on one of them
-            case CHILD_REMOVED:
-                applicationRemoved(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()));
-                break;
-            case CHILD_UPDATED:
-                // do nothing, application just got redeployed
-                break;
-            default:
-                break;
-        }
-        // We may have lost events and may need to remove applications.
-        // New applications are added when session is added, not here. See RemoteSessionRepo.
-        removeUnusedApplications();
+        zkWatcherExecutor.execute(() -> {
+            switch (event.getType()) {
+                case CHILD_ADDED:
+                    applicationAdded(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()));
+                    break;
+                // Event CHILD_REMOVED will be triggered on all config servers if deleteApplication() above is called on one of them
+                case CHILD_REMOVED:
+                    applicationRemoved(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()));
+                    break;
+                case CHILD_UPDATED:
+                    // do nothing, application just got redeployed
+                    break;
+                default:
+                    break;
+            }
+            // We may have lost events and may need to remove applications.
+            // New applications are added when session is added, not here. See RemoteSessionRepo.
+            removeUnusedApplications();
+        });
     }
 
     private void applicationRemoved(ApplicationId applicationId) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSessionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSessionRepo.java
@@ -1,9 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.session;
 
+import com.yahoo.concurrent.InThreadExecutorService;
+import com.yahoo.concurrent.StripedExecutor;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.transaction.NestedTransaction;
+import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.deploy.TenantFileSystemDirs;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;
@@ -12,10 +16,12 @@ import com.yahoo.vespa.curator.Curator;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -33,23 +39,24 @@ public class LocalSessionRepo extends SessionRepo<LocalSession> {
     private final long sessionLifetime; // in seconds
     private final Clock clock;
     private final Curator curator;
+    private final Executor zkWatcherExecutor;
 
-    public LocalSessionRepo(TenantFileSystemDirs tenantFileSystemDirs, LocalSessionLoader loader,
-                            Clock clock, long sessionLifeTime, Curator curator) {
-        this(clock, curator, sessionLifeTime);
+    public LocalSessionRepo(TenantName tenantName, GlobalComponentRegistry registry, TenantFileSystemDirs tenantFileSystemDirs, LocalSessionLoader loader) {
+        this(registry.getClock(), registry.getCurator(), registry.getConfigserverConfig().sessionLifetime(),
+             command -> registry.getZkWatcherExecutor().execute(tenantName, command));
         loadSessions(tenantFileSystemDirs.sessionsPath(), loader);
     }
 
     // Constructor public only for testing
     public LocalSessionRepo(Clock clock, Curator curator) {
-        this(clock, curator, TimeUnit.DAYS.toMillis(1));
+        this(clock, curator, Duration.ofDays(1).toMillis(), Runnable::run);
     }
 
-    // Constructor public only for testing
-    private LocalSessionRepo(Clock clock, Curator curator, long sessionLifetime) {
+    private LocalSessionRepo(Clock clock, Curator curator, long sessionLifetime, Executor zkWatcherExecutor) {
         this.clock = clock;
         this.curator = curator;
         this.sessionLifetime = sessionLifetime;
+        this.zkWatcherExecutor = zkWatcherExecutor;
     }
 
     @Override
@@ -58,7 +65,7 @@ public class LocalSessionRepo extends SessionRepo<LocalSession> {
         Path sessionsPath = TenantRepository.getSessionsPath(session.getTenantName());
         long sessionId = session.getSessionId();
         Curator.FileCache fileCache = curator.createFileCache(sessionsPath.append(String.valueOf(sessionId)).append(ConfigCurator.SESSIONSTATE_ZK_SUBPATH).getAbsolute(), false);
-        sessionStateWatchers.put(sessionId, new LocalSessionStateWatcher(fileCache, session, this));
+        sessionStateWatchers.put(sessionId, new LocalSessionStateWatcher(fileCache, session, this, zkWatcherExecutor));
     }
 
     private void loadSessions(File applicationsDir, LocalSessionLoader loader) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSessionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSessionRepo.java
@@ -206,14 +206,16 @@ public class RemoteSessionRepo extends SessionRepo<RemoteSession> {
     }
 
     private void nodeChanged() {
-        Multiset<Session.Status> sessionMetrics = HashMultiset.create();
-        for (RemoteSession session : listSessions()) {
-            sessionMetrics.add(session.getStatus());
-        }
-        metrics.setNewSessions(sessionMetrics.count(Session.Status.NEW));
-        metrics.setPreparedSessions(sessionMetrics.count(Session.Status.PREPARE));
-        metrics.setActivatedSessions(sessionMetrics.count(Session.Status.ACTIVATE));
-        metrics.setDeactivatedSessions(sessionMetrics.count(Session.Status.DEACTIVATE));
+        zkWatcherExecutor.execute(() -> {
+            Multiset<Session.Status> sessionMetrics = HashMultiset.create();
+            for (RemoteSession session : listSessions()) {
+                sessionMetrics.add(session.getStatus());
+            }
+            metrics.setNewSessions(sessionMetrics.count(Session.Status.NEW));
+            metrics.setPreparedSessions(sessionMetrics.count(Session.Status.PREPARE));
+            metrics.setActivatedSessions(sessionMetrics.count(Session.Status.ACTIVATE));
+            metrics.setDeactivatedSessions(sessionMetrics.count(Session.Status.DEACTIVATE));
+        });
     }
 
     @SuppressWarnings("unused")

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/Tenant.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/Tenant.java
@@ -142,15 +142,20 @@ public class Tenant implements TenantHandlerProvider {
     }
 
     /**
-     * Closes any watchers, thread pools that may react to changes in tenant state, and removes any state
-     * in filesystem and zookeeper
+     * Closes any watchers, thread pools that may react to changes in tenant state,
+     * and removes any session data in filesystem and zookeeper.
+     * Called by watchers as a reaction to {@link #delete()}.
      */
-    public void close() {
-        tenantFileSystemDirs.delete();
-        remoteSessionRepo.close();
-        applicationRepo.close();
-        localSessionRepo.deleteAllSessions();
-        curator.delete(path);
+    void close() {
+        tenantFileSystemDirs.delete();          // Deletes all local files.
+        remoteSessionRepo.close();              // Closes watchers and clears memory.
+        applicationRepo.close();                // Closes watchers.
+        localSessionRepo.deleteAllSessions();   // Closes watchers, clears memory, and deletes some local files and ZK session state.
+    }
+
+    /** Deletes the tenant tree from ZooKeeper (application and session status for the tenant) and triggers {@link #close()}. */
+    void delete() {
+        curator.delete(path);                   // Deletes tenant ZK tree: applications and sessions.
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantBuilder.java
@@ -98,9 +98,7 @@ public class TenantBuilder {
 
 	private void createLocalSessionRepo() {
         if (localSessionRepo == null) {
-            localSessionRepo = new LocalSessionRepo(tenantFileSystemDirs, localSessionLoader, componentRegistry.getClock(),
-                                                    componentRegistry.getConfigserverConfig().sessionLifetime(),
-                                                    componentRegistry.getCurator());
+            localSessionRepo = new LocalSessionRepo(tenant, componentRegistry, tenantFileSystemDirs, localSessionLoader);
         }
     }
 
@@ -129,8 +127,7 @@ public class TenantBuilder {
                                                                  tenant,
                                                                  Collections.singletonList(componentRegistry.getReloadListener()),
                                                                  ConfigResponseFactory.create(componentRegistry.getConfigserverConfig()),
-                                                                 componentRegistry.getHostRegistries(),
-                                                                 componentRegistry.getCurator());
+                                                                 componentRegistry);
             if (hostValidator == null) {
                 this.hostValidator = impl;
             }
@@ -149,13 +146,12 @@ public class TenantBuilder {
 
     private void createRemoteSessionRepo() {
         if (remoteSessionRepo == null) {
-            remoteSessionRepo = new RemoteSessionRepo(componentRegistry.getCurator(),
-                    remoteSessionFactory,
-                    reloadHandler,
-                    tenant,
-                    applicationRepo,
-                    componentRegistry.getMetrics().getOrCreateMetricUpdater(Metrics.createDimensions(tenant)),
-                    componentRegistry.getFlagSource());
+            remoteSessionRepo = new RemoteSessionRepo(componentRegistry,
+                                                      remoteSessionFactory,
+                                                      reloadHandler,
+                                                      tenant,
+                                                      applicationRepo);
+
         }
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -147,7 +147,8 @@ public class TenantRepository {
         return curator.getChildren(tenantsPath).stream().map(TenantName::from).collect(Collectors.toSet());
     }
 
-    private synchronized void updateTenants() {
+    /** Public for testing. */
+    public synchronized void updateTenants() {
         Set<TenantName> allTenants = readTenantsFromZooKeeper(curator);
         log.log(LogLevel.DEBUG, "Create tenants, tenants found in zookeeper: " + allTenants);
         checkForRemovedTenants(allTenants);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -362,6 +362,7 @@ public class TenantRepository {
         try {
             zkCacheExecutor.shutdown();
             checkForRemovedApplicationsService.shutdown();
+            zkWatcherExecutor.shutdownAndWait();
             zkCacheExecutor.awaitTermination(50, TimeUnit.SECONDS);
             checkForRemovedApplicationsService.awaitTermination(50, TimeUnit.SECONDS);
         }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -273,9 +273,8 @@ public class TenantRepository {
      * Removes the given tenant from ZooKeeper and filesystem. Assumes that tenant exists.
      *
      * @param name name of the tenant
-     * @return this TenantRepository instance
      */
-    public synchronized TenantRepository deleteTenant(TenantName name) {
+    public synchronized void deleteTenant(TenantName name) {
         if (name.equals(DEFAULT_TENANT))
             throw new IllegalArgumentException("Deleting 'default' tenant is not allowed");
         log.log(LogLevel.INFO, "Deleting tenant '" + name + "'");
@@ -285,7 +284,6 @@ public class TenantRepository {
         }
         notifyRemovedTenant(name);
         tenant.close();
-        return this;
     }
 
     // For unit testing

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandler.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.config.server.tenant;
 
 import com.yahoo.component.Version;
+import com.yahoo.concurrent.StripedExecutor;
 import com.yahoo.config.FileReference;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
@@ -9,6 +10,7 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.GetConfigRequest;
 import com.yahoo.vespa.config.protocol.ConfigResponse;
+import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.NotFoundException;
 import com.yahoo.vespa.config.server.ReloadHandler;
 import com.yahoo.vespa.config.server.ReloadListener;
@@ -33,6 +35,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -60,15 +63,15 @@ public class TenantRequestHandler implements RequestHandler, ReloadHandler, Host
                                 TenantName tenant,
                                 List<ReloadListener> reloadListeners,
                                 ConfigResponseFactory responseFactory,
-                                HostRegistries hostRegistries,
-                                Curator curator) { // TODO jvenstad: Merge this class with TenantApplications, and straighten this out.
+                                GlobalComponentRegistry registry) { // TODO jvenstad: Merge this class with TenantApplications, and straighten this out.
         this.metrics = metrics;
         this.tenant = tenant;
         this.reloadListeners = List.copyOf(reloadListeners);
         this.responseFactory = responseFactory;
         this.tenantMetricUpdater = metrics.getOrCreateMetricUpdater(Metrics.createDimensions(tenant));
-        this.hostRegistry = hostRegistries.createApplicationHostRegistry(tenant);
-        this.applications = TenantApplications.create(curator, this, tenant);
+        this.hostRegistry = registry.getHostRegistries().createApplicationHostRegistry(tenant);
+        this.applications = TenantApplications.create(registry, this, tenant);
+
     }
 
     /**

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/TestComponentRegistry.java
@@ -5,6 +5,7 @@ import com.google.common.io.Files;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.concurrent.InThreadExecutorService;
 import com.yahoo.concurrent.StripedExecutor;
+import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.config.model.NullConfigModelRegistry;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.provision.Provisioner;
@@ -20,6 +21,7 @@ import com.yahoo.vespa.config.server.session.MockFileDistributionFactory;
 import com.yahoo.vespa.config.server.session.SessionPreparer;
 import com.yahoo.vespa.config.server.tenant.MockTenantListener;
 import com.yahoo.vespa.config.server.tenant.TenantListener;
+import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.server.tenant.TenantRequestHandlerTest;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;
 import com.yahoo.vespa.curator.Curator;
@@ -31,6 +33,7 @@ import com.yahoo.vespa.model.VespaModelFactory;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 
@@ -56,6 +59,7 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
     private final Clock clock;
     private final ConfigServerDB configServerDB;
     private final StripedExecutor<TenantName> zkWatcherExecutor;
+    private final ExecutorService zkCacheExecutor;
 
     private TestComponentRegistry(Curator curator, ConfigCurator configCurator, Metrics metrics,
                                   ModelFactoryRegistry modelFactoryRegistry,
@@ -87,6 +91,7 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
         this.clock = clock;
         this.configServerDB = new ConfigServerDB(configserverConfig);
         this.zkWatcherExecutor = new StripedExecutor<>(new InThreadExecutorService());
+        this.zkCacheExecutor = new InThreadExecutorService();
     }
 
     public static class Builder {
@@ -96,6 +101,7 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
         private ConfigserverConfig configserverConfig = new ConfigserverConfig(
                 new ConfigserverConfig.Builder()
                         .configServerDBDir(Files.createTempDir().getAbsolutePath())
+                        .sessionLifetime(5)
                         .configDefinitionsDir(Files.createTempDir().getAbsolutePath()));
         private ConfigDefinitionRepo defRepo = new StaticConfigDefinitionRepo();
         private TenantRequestHandlerTest.MockReloadListener reloadListener = new TenantRequestHandlerTest.MockReloadListener();
@@ -208,6 +214,11 @@ public class TestComponentRegistry implements GlobalComponentRegistry {
 
     @Override
     public FlagSource getFlagSource() { return new InMemoryFlagSource(); }
+
+    @Override
+    public ExecutorService getZkCacheExecutor() {
+        return zkCacheExecutor;
+    }
 
     public FileDistributionFactory getFileDistributionFactory() { return fileDistributionFactory; }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/TenantApplicationsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/TenantApplicationsTest.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.config.server.MockReloadHandler;
 
+import com.yahoo.vespa.config.server.TestComponentRegistry;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
@@ -115,7 +116,7 @@ public class TenantApplicationsTest {
     }
 
     private TenantApplications createZKAppRepo(MockReloadHandler reloadHandler) {
-        return TenantApplications.create(curator, reloadHandler, tenantName);
+        return TenantApplications.create(new TestComponentRegistry.Builder().curator(curator).build(), reloadHandler, tenantName);
     }
 
     private static ApplicationId createApplicationId(String name) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
@@ -105,7 +105,7 @@ public class SessionActiveHandlerTest extends SessionHandlerTest {
                 .modelFactoryRegistry(new ModelFactoryRegistry(Collections.singletonList(modelFactory)))
                 .build();
         tenantRepository = new TenantRepository(componentRegistry, false);
-        applicationRepo = TenantApplications.create(curator, new MockReloadHandler(), tenantName);
+        applicationRepo = TenantApplications.create(componentRegistry, new MockReloadHandler(), tenantName);
         localRepo = new LocalSessionRepo(clock, curator);
         pathPrefix = "/application/v2/tenant/" + tenantName + "/session/";
         hostProvisioner = new MockProvisioner();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
@@ -72,7 +72,7 @@ public class SessionCreateHandlerTest extends SessionHandlerTest {
     @Before
     public void setupRepo() {
         Curator curator = new MockCurator();
-        applicationRepo = TenantApplications.create(curator, new MockReloadHandler(), tenant);
+        applicationRepo = TenantApplications.create(componentRegistry, new MockReloadHandler(), tenant);
         localSessionRepo = new LocalSessionRepo(Clock.systemUTC(), curator);
         tenantRepository = new TenantRepository(componentRegistry, false);
         sessionFactory = new MockSessionFactory();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -87,7 +87,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
                 .withSessionFactory(new MockSessionFactory())
                 .withLocalSessionRepo(localRepo)
                 .withRemoteSessionRepo(remoteSessionRepo)
-                .withApplicationRepo(TenantApplications.create(curator, new MockReloadHandler(), tenant));
+                .withApplicationRepo(TenantApplications.create(componentRegistry, new MockReloadHandler(), tenant));
         tenantRepository.addTenant(tenantBuilder);
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainerTest.java
@@ -37,6 +37,7 @@ public class TenantsMaintainerTest {
         assertNotNull(tenantRepository.getTenant(shouldNotBeDeleted));
 
         new TenantsMaintainer(applicationRepository, tester.curator(), Duration.ofDays(1)).run();
+        tenantRepository.updateTenants();
 
         // One tenant should now have been deleted
         assertNull(tenantRepository.getTenant(shouldBeDeleted));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionTest.java
@@ -16,7 +16,7 @@ import com.yahoo.path.Path;
 import com.yahoo.slime.Slime;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.config.server.MockReloadHandler;
-import com.yahoo.vespa.config.server.SuperModelGenerationCounter;
+import com.yahoo.vespa.config.server.TestComponentRegistry;
 import com.yahoo.vespa.config.server.application.TenantApplications;
 import com.yahoo.vespa.config.server.deploy.DeployHandlerLogger;
 import com.yahoo.vespa.config.server.deploy.TenantFileSystemDirs;
@@ -192,7 +192,7 @@ public class LocalSessionTest {
         zkClient.write(Collections.singletonMap(new Version(0, 0, 0), new MockFileRegistry()));
         File sessionDir = new File(tenantFileSystemDirs.sessionsPath(), String.valueOf(sessionId));
         sessionDir.createNewFile();
-        TenantApplications applications = TenantApplications.create(curator, new MockReloadHandler(), tenant);
+        TenantApplications applications = TenantApplications.create(new TestComponentRegistry.Builder().curator(curator).build(), new MockReloadHandler(), tenant);
         applications.createApplication(zkc.readApplicationId());
         return new LocalSession(tenant, sessionId, preparer,
                 new SessionContext(

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/RemoteSessionRepoTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/RemoteSessionRepoTest.java
@@ -10,6 +10,7 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
 import com.yahoo.text.Utf8;
 
+import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.MockReloadHandler;
 import com.yahoo.vespa.config.server.TestComponentRegistry;
 import com.yahoo.vespa.config.server.application.TenantApplications;
@@ -100,11 +101,12 @@ public class RemoteSessionRepoTest {
     public void testBadApplicationRepoOnActivate() {
         long sessionId = 3L;
         TenantName mytenant = TenantName.from("mytenant");
-        TenantApplications applicationRepo = TenantApplications.create(curator, new MockReloadHandler(), mytenant);
+        GlobalComponentRegistry registry = new TestComponentRegistry.Builder().curator(curator).build();
+        TenantApplications applicationRepo = TenantApplications.create(registry, new MockReloadHandler(), mytenant);
         curator.set(TenantRepository.getApplicationsPath(mytenant).append("mytenant:appX:default"), new byte[0]); // Invalid data
-        Tenant tenant = TenantBuilder.create(new TestComponentRegistry.Builder().curator(curator).build(), mytenant)
-                .withApplicationRepo(applicationRepo)
-                .build();
+        Tenant tenant = TenantBuilder.create(registry, mytenant)
+                                     .withApplicationRepo(applicationRepo)
+                                     .build();
         curator.create(TenantRepository.getSessionsPath(mytenant));
         remoteSessionRepo = tenant.getRemoteSessionRepo();
         assertThat(remoteSessionRepo.listSessions().size(), is(0));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
@@ -217,7 +217,7 @@ public class SessionPreparerTest {
         return new SessionContext(app,
                                   new SessionZooKeeperClient(curator, sessionsPath),
                                   app.getAppDir(),
-                                  TenantApplications.create(curator, new MockReloadHandler(), TenantName.from("tenant")),
+                                  TenantApplications.create(componentRegistry, new MockReloadHandler(), TenantName.from("tenant")),
                                   new HostRegistry<>(),
                                   flagSource);
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantRequestHandlerTest.java
@@ -93,11 +93,11 @@ public class TenantRequestHandlerTest {
         Metrics sh = Metrics.createTestMetrics();
         List<ReloadListener> listeners = new ArrayList<>();
         listeners.add(listener);
-        server = new TenantRequestHandler(sh, tenant, listeners, new UncompressedConfigResponseFactory(), new HostRegistries(), curator);
         componentRegistry = new TestComponentRegistry.Builder()
                 .curator(curator)
                 .modelFactoryRegistry(createRegistry())
                 .build();
+        server = new TenantRequestHandler(sh, tenant, listeners, new UncompressedConfigResponseFactory(), componentRegistry);
     }
 
     private void feedApp(File appDir, long sessionId, ApplicationId appId, boolean  internalRedeploy) throws IOException {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantTest.java
@@ -38,7 +38,7 @@ public class TenantTest {
         TenantRepository tenantRepository = new TenantRepository(componentRegistry, false);
         TenantName tenantName = TenantName.from(name);
         TenantBuilder tenantBuilder = TenantBuilder.create(componentRegistry, tenantName)
-                .withApplicationRepo(TenantApplications.create(new MockCurator(), new MockReloadHandler(), tenantName));
+                .withApplicationRepo(TenantApplications.create(componentRegistry, new MockReloadHandler(), tenantName));
         tenantRepository.addTenant(tenantBuilder);
         return tenantRepository.getTenant(tenantName);
     }

--- a/vespajlib/src/main/java/com/yahoo/concurrent/InThreadExecutorService.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/InThreadExecutorService.java
@@ -1,0 +1,49 @@
+package com.yahoo.concurrent;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link ExecutorService} implementation that runs all tasks in the calling thread. Useful for tests.
+ *
+ * @author jonmv
+ */
+public class InThreadExecutorService extends AbstractExecutorService {
+
+    private boolean isShutdown = false;
+
+    @Override
+    public void shutdown() {
+        isShutdown = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isShutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+
+}

--- a/vespajlib/src/main/java/com/yahoo/concurrent/StripedExecutor.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/StripedExecutor.java
@@ -1,0 +1,106 @@
+package com.yahoo.concurrent;
+
+import com.yahoo.yolean.Exceptions;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Executor that serializes runnables with the same key, but may parallelize over different keys.
+ *
+ * @author jonmv
+ */
+public class StripedExecutor<Key> {
+
+    private static final Logger logger = Logger.getLogger(StripedExecutor.class.getName());
+
+    private final Map<Key, Deque<Runnable>> commands = new HashMap<>();
+    private final ExecutorService executor;
+
+    /** Creates a new StripedExecutor which delegates to a {@link Executors#newCachedThreadPool(ThreadFactory)}. */
+    public StripedExecutor() {
+        this(Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory(StripedExecutor.class.getName())));
+    }
+
+    /** Creates a new StripedExecutor which delegates to the given executor service. */
+    public StripedExecutor(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * Executes the given command. If other commands are already running or queued for the given key,
+     * execution of this command happens after those, on the same thread as is running them.
+     * <p>
+     * Any exception thrown by the command will only be logged, to allow subsequent commands to run.
+     */
+    public void execute(Key key, Runnable command) {
+        synchronized (commands) {
+            if (null == commands.putIfAbsent(key, new ArrayDeque<>(List.of(command))))
+                executor.execute(() -> runAll(key));
+            else
+                commands.get(key).add(command);
+        }
+    }
+
+    /** Runs all submitted commands for the given key, then removes the queue for the key and returns. */
+    private void runAll(Key key) {
+        while (true) {
+            Runnable command;
+            synchronized (commands) {
+                command = commands.containsKey(key) ? commands.get(key).poll() : null;
+                if (command == null) {
+                    commands.remove(key);
+                    break;
+                }
+            }
+            try {
+                command.run();
+            }
+            catch (RuntimeException e) {
+                logger.log(Level.WARNING, () -> "Exception caught: " + Exceptions.toMessageString(e));
+            }
+        }
+    }
+
+    /** Shuts down the delegate executor and waits for it to terminate. */
+    public void shutdownAndWait() {
+        shutdownAndWait(Duration.ofSeconds(30), Duration.ofSeconds(10));
+    }
+
+    /**
+     * Shuts down the delegate executor and waits for the given grace duration for it to terminate.
+     * If this fails, tells the executor to {@link ExecutorService#shutdownNow()}), and waits for the die duration.
+     */
+    public void shutdownAndWait(Duration grace, Duration die) {
+        executor.shutdown();
+        try {
+            executor.awaitTermination(grace.toMillis(), TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            logger.log(Level.INFO, "Interrupted waiting for executor to complete", e);
+        }
+        if ( ! executor.isTerminated()) {
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(die.toMillis(), TimeUnit.MILLISECONDS);
+            }
+            catch (InterruptedException e) {
+                logger.log(Level.WARNING, "Interrupted waiting for executor to die", e);
+            }
+            if ( ! executor.isTerminated())
+                throw new RuntimeException("Failed to shut down executor");
+        }
+    }
+
+}
+

--- a/vespajlib/src/test/java/com/yahoo/concurrent/StripedExecutorTest.java
+++ b/vespajlib/src/test/java/com/yahoo/concurrent/StripedExecutorTest.java
@@ -1,0 +1,44 @@
+package com.yahoo.concurrent;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author jonmv
+ */
+public class StripedExecutorTest {
+
+    private static final int workers = 1 << 5;
+    private static final int values = 1 << 10;
+
+    @Test
+    public void testSerialization() {
+        AtomicLong counter = new AtomicLong(0);
+        List<Deque<Long>> sequences = new ArrayList<>();
+        for (int j = 0; j < workers; j++)
+            sequences.add(new ConcurrentLinkedDeque<>());
+
+        StripedExecutor<Integer> executor = new StripedExecutor<>();
+        for (int i = 0; i < values; i++)
+            for (int j = 0; j < workers; j++) {
+                Deque<Long> sequence = sequences.get(j);
+                executor.execute(j, () -> sequence.add(counter.incrementAndGet()));
+            }
+        executor.shutdownAndWait();
+
+        for (int j = 0; j < workers; j++) {
+            assertEquals(values, sequences.get(j).size());
+            assertArrayEquals(sequences.get(j).stream().sorted().toArray(Long[]::new),
+                              sequences.get(j).toArray(Long[]::new));
+        }
+    }
+
+}


### PR DESCRIPTION
@hmusum please review. The first three commits are already part of #9539.

This makes all ZK caches run on a single thread, which delegates as quickly as possible to an executor which serialises its commands for each tenant, i.e., it delegates new runnables to an executor service, taking care that the delegate runs any previously enqueued commands for the same tenant first. 
I chose a `newCachedThreadPool` delegate, which should scale to the given load. 