### PR TITLE
Revert "Set environment variable to mimick SD"

### DIFF
--- a/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
+++ b/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
@@ -89,7 +89,6 @@ public class TestRunner {
                          ProcessBuilder builder = new ProcessBuilder(command);
                          builder.environment().merge("MAVEN_OPTS", " -Djansi.force=true", String::concat);
                          builder.directory(vespaHome.resolve("tmp/test").toFile());
-                         builder.environment().put("SCREWDRIVER", "true");
                          builder.redirectErrorStream(true);
                          return builder;
                      });


### PR DESCRIPTION
Reverts vespa-engine/vespa#9547

System-test test for canary-pipeline in CD started to fail with:
`com.yahoo.vespa.hosted.security.athenz.AthenzAuthenticationException: Missing credentials in /tokens` after this. Looks like it tries to get the Athenz token from the path where it exists on Screwdriver. 