### PR TITLE
Report vcpus of the node rather than the host

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -566,7 +566,7 @@ public class NodeAgentImpl implements NodeAgent {
                 .withMetric("mem_total.util", 100 * memoryTotalUsageRatio)
                 .withMetric("cpu.util", 100 * cpuUsageRatioOfAllocated)
                 .withMetric("cpu.sys.util", 100 * cpuKernelUsageRatioOfAllocated)
-                .withMetric("cpu.vcpus", totalNumCpuCores)
+                .withMetric("cpu.vcpus", node.getMinCpuCores())
                 .withMetric("disk.limit", diskTotalBytes);
 
         diskTotalBytesUsed.ifPresent(diskUsed -> systemMetricsBuilder.withMetric("disk.used", diskUsed));

--- a/node-admin/src/test/resources/expected.container.system.metrics.txt
+++ b/node-admin/src/test/resources/expected.container.system.metrics.txt
@@ -15,7 +15,7 @@ s:
         "disk.used": 39625000000,
         "cpu.sys.util": 3.402,
         "disk.util": 15.85,
-        "cpu.vcpus": 8,
+        "cpu.vcpus": 2.0,
         "cpu.util": 5.4,
         "mem.util": 25.0,
         "disk.limit": 250000000000


### PR DESCRIPTION
Metric added in #9540 reports vcpus of the host rather than the node