### PR TITLE
Move `AddressSpace` from searchlib to vespalib

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
@@ -10,13 +10,13 @@ using proton::AttributeUsageStats;
 namespace
 {
 
-search::AddressSpace enumStoreOverLoad(30 * 1024 * 1024 * UINT64_C(1024),
-                                       0,
-                                       32 * 1024 * 1024 * UINT64_C(1024));
+vespalib::AddressSpace enumStoreOverLoad(30 * 1024 * 1024 * UINT64_C(1024),
+                                         0,
+                                         32 * 1024 * 1024 * UINT64_C(1024));
 
-search::AddressSpace multiValueOverLoad(127 * 1024 * 1024,
-                                        0,
-                                        128 * 1024 * 1024);
+vespalib::AddressSpace multiValueOverLoad(127 * 1024 * 1024,
+                                          0,
+                                          128 * 1024 * 1024);
 
 
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/address_space_usage_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/address_space_usage_stats.cpp
@@ -4,17 +4,17 @@
 
 namespace proton {
 
-AddressSpaceUsageStats::AddressSpaceUsageStats(const search::AddressSpace & usage)
+AddressSpaceUsageStats::AddressSpaceUsageStats(const vespalib::AddressSpace & usage)
     : _usage(usage),
       _attributeName(),
       _subDbName()
 {
 }
 
-AddressSpaceUsageStats::~AddressSpaceUsageStats() {}
+AddressSpaceUsageStats::~AddressSpaceUsageStats() = default;
 
 void
-AddressSpaceUsageStats::merge(const search::AddressSpace &usage,
+AddressSpaceUsageStats::merge(const vespalib::AddressSpace &usage,
                               const vespalib::string &attributeName,
                               const vespalib::string &subDbName)
 {

--- a/searchcore/src/vespa/searchcore/proton/attribute/address_space_usage_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/address_space_usage_stats.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/address_space.h>
 #include <vespa/vespalib/stllike/string.h>
 
 namespace proton {
@@ -14,18 +14,18 @@ namespace proton {
  */
 class AddressSpaceUsageStats
 {
-    search::AddressSpace _usage;
+    vespalib::AddressSpace _usage;
     vespalib::string _attributeName;
     vespalib::string _subDbName;
 
 public:
-    AddressSpaceUsageStats(const search::AddressSpace &usage);
+    explicit AddressSpaceUsageStats(const vespalib::AddressSpace &usage);
     ~AddressSpaceUsageStats();
-    void merge(const search::AddressSpace &usage,
+    void merge(const vespalib::AddressSpace &usage,
                const vespalib::string &attributeName,
                const vespalib::string &subDbName);
 
-    const search::AddressSpace &getUsage() const { return _usage; }
+    const vespalib::AddressSpace &getUsage() const { return _usage; }
     const vespalib::string &getAttributeName() const { return _attributeName; }
     const vespalib::string &getSubDbName() const { return _subDbName; }
 };

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_vector_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_vector_explorer.cpp
@@ -8,10 +8,10 @@
 #include <vespa/vespalib/data/slime/cursor.h>
 
 using search::attribute::Status;
-using search::AddressSpace;
 using search::AddressSpaceUsage;
 using search::AttributeVector;
 using search::EnumStoreBase;
+using vespalib::AddressSpace;
 using vespalib::MemoryUsage;
 using search::attribute::MultiValueMappingBase;
 using search::attribute::IPostingListAttributeBase;

--- a/searchlib/src/tests/attribute/compaction/attribute_compaction_test.cpp
+++ b/searchlib/src/tests/attribute/compaction/attribute_compaction_test.cpp
@@ -14,7 +14,7 @@ using search::AttributeVector;
 using search::attribute::Config;
 using search::attribute::BasicType;
 using search::attribute::CollectionType;
-using search::AddressSpace;
+using vespalib::AddressSpace;
 
 using AttributePtr = AttributeVector::SP;
 using AttributeStatus = search::attribute::Status;

--- a/searchlib/src/tests/attribute/enumstore/enumstore_test.cpp
+++ b/searchlib/src/tests/attribute/enumstore/enumstore_test.cpp
@@ -790,6 +790,7 @@ EnumStoreTest::requireThatAddressSpaceUsageIsReported()
     const size_t ADDRESS_LIMIT = 34359738368; // NumericEnumStore::DataStoreType::RefType::offsetSize()
     NumericEnumStore store(200, false);
 
+    using vespalib::AddressSpace;
     EXPECT_EQUAL(AddressSpace(16, 16, ADDRESS_LIMIT), store.getAddressSpaceUsage());
     NumericEnumStore::Index idx1 = addEnum(store, 10);
     EXPECT_EQUAL(AddressSpace(32, 16, ADDRESS_LIMIT), store.getAddressSpaceUsage());

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
@@ -5,6 +5,8 @@
 
 namespace search {
 
+using vespalib::AddressSpace;
+
 AddressSpaceUsage::AddressSpaceUsage()
         : _enumStoreUsage(defaultEnumStoreUsage()),
           _multiValueUsage(defaultMultiValueUsage()) {

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/address_space.h>
 
 namespace search {
 
@@ -12,17 +12,17 @@ namespace search {
 class AddressSpaceUsage
 {
 private:
-    AddressSpace _enumStoreUsage;
-    AddressSpace _multiValueUsage;
+    vespalib::AddressSpace _enumStoreUsage;
+    vespalib::AddressSpace _multiValueUsage;
 
 public:
     AddressSpaceUsage();
-    AddressSpaceUsage(const AddressSpace &enumStoreUsage_,
-                      const AddressSpace &multiValueUsage_);
-    static AddressSpace defaultEnumStoreUsage();
-    static AddressSpace defaultMultiValueUsage();
-    const AddressSpace &enumStoreUsage() const { return _enumStoreUsage; }
-    const AddressSpace &multiValueUsage() const { return _multiValueUsage; }
+    AddressSpaceUsage(const vespalib::AddressSpace &enumStoreUsage_,
+                      const vespalib::AddressSpace &multiValueUsage_);
+    static vespalib::AddressSpace defaultEnumStoreUsage();
+    static vespalib::AddressSpace defaultMultiValueUsage();
+    const vespalib::AddressSpace &enumStoreUsage() const { return _enumStoreUsage; }
+    const vespalib::AddressSpace &multiValueUsage() const { return _multiValueUsage; }
 
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -218,13 +218,13 @@ AttributeVector::updateStatistics(uint64_t numValues, uint64_t numUniqueValue, u
     _status.updateStatistics(numValues, numUniqueValue, allocated, used, dead, onHold);
 }
 
-AddressSpace
+vespalib::AddressSpace
 AttributeVector::getEnumStoreAddressSpaceUsage() const
 {
     return AddressSpaceUsage::defaultEnumStoreUsage();
 }
 
-AddressSpace
+vespalib::AddressSpace
 AttributeVector::getMultiValueAddressSpaceUsage() const
 {
     return AddressSpaceUsage::defaultMultiValueUsage();
@@ -721,7 +721,7 @@ AttributeVector::getEstimatedSaveByteSize() const
     uint64_t idxFileSize = 0;
     uint64_t udatFileSize = 0;
     size_t fixedWidth = getFixedWidth();
-    AddressSpace enumAddressSpace(getEnumStoreAddressSpaceUsage());
+    vespalib::AddressSpace enumAddressSpace(getEnumStoreAddressSpaceUsage());
 
     if (hasMultiValue()) {
         idxFileSize = headerSize + sizeof(uint32_t) * (docIdLimit + 1);

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -13,12 +13,12 @@
 #include <vespa/searchcommon/attribute/status.h>
 #include <vespa/searchcommon/common/range.h>
 #include <vespa/searchcommon/common/undefinedvalues.h>
-#include <vespa/searchlib/common/address_space.h>
 #include <vespa/searchlib/common/i_compactable_lid_space.h>
 #include <vespa/searchlib/common/identifiable.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/vespalib/objects/identifiable.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/address_space.h>
 #include <vespa/vespalib/util/rcuvector.h>
 #include <vespa/fastos/time.h>
 #include <cmath>
@@ -378,8 +378,8 @@ protected:
         return value;
     }
 
-    virtual AddressSpace getEnumStoreAddressSpaceUsage() const;
-    virtual AddressSpace getMultiValueAddressSpaceUsage() const;
+    virtual vespalib::AddressSpace getEnumStoreAddressSpaceUsage() const;
+    virtual vespalib::AddressSpace getMultiValueAddressSpaceUsage() const;
     void logEnumStoreEvent(const char *reason, const char *stage);
 
 public:

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.h
@@ -74,7 +74,7 @@ protected:
     void insertNewUniqueValues(EnumStoreBase::IndexVector & newIndexes);
     virtual void considerAttributeChange(const Change & c, UniqueSet & newUniques) = 0;
     virtual void reEnumerate(const EnumIndexMap &) = 0;
-    AddressSpace getEnumStoreAddressSpaceUsage() const override;
+    vespalib::AddressSpace getEnumStoreAddressSpaceUsage() const override;
 public:
     EnumAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);
     ~EnumAttribute();

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
@@ -133,7 +133,7 @@ EnumAttribute<B>::insertNewUniqueValues(EnumStoreBase::IndexVector & newIndexes)
 
 
 template <typename B>
-AddressSpace
+vespalib::AddressSpace
 EnumAttribute<B>::getEnumStoreAddressSpaceUsage() const
 {
     return _enumStore.getAddressSpaceUsage();

--- a/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumstorebase.cpp
@@ -118,11 +118,11 @@ EnumStoreBase::getMemoryUsage() const
     return _store.getMemoryUsage();
 }
 
-AddressSpace
+vespalib::AddressSpace
 EnumStoreBase::getAddressSpaceUsage() const
 {
     const datastore::BufferState &activeState = _store.getBufferState(_store.getActiveBufferId(TYPE_ID));
-    return AddressSpace(activeState.size(), activeState.getDeadElems(), DataStoreType::RefType::offsetSize());
+    return vespalib::AddressSpace(activeState.size(), activeState.getDeadElems(), DataStoreType::RefType::offsetSize());
 }
 
 void

--- a/searchlib/src/vespa/searchlib/attribute/enumstorebase.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumstorebase.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <vespa/searchcommon/attribute/iattributevector.h>
-#include <vespa/searchlib/common/address_space.h>
 #include <vespa/searchlib/datastore/datastore.h>
+#include <vespa/vespalib/util/address_space.h>
 #include <vespa/vespalib/util/array.h>
 #include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/hash_map.h>
@@ -300,7 +300,7 @@ public:
     vespalib::MemoryUsage getMemoryUsage() const;
     vespalib::MemoryUsage getTreeMemoryUsage() const { return _enumDict->getTreeMemoryUsage(); }
 
-    AddressSpace getAddressSpaceUsage() const;
+    vespalib::AddressSpace getAddressSpaceUsage() const;
 
     void transferHoldLists(generation_t generation);
     void trimHoldLists(generation_t firstUsed);

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.h
@@ -4,7 +4,7 @@
 
 #include "multi_value_mapping_base.h"
 #include <vespa/searchlib/datastore/array_store.h>
-#include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/address_space.h>
 
 namespace search::attribute {
 
@@ -46,7 +46,7 @@ public:
 
     void compactWorst(bool compactMemory, bool compactAddressSpace) override;
 
-    AddressSpace getAddressSpaceUsage() const override;
+    vespalib::AddressSpace getAddressSpaceUsage() const override;
     vespalib::MemoryUsage getArrayStoreMemoryUsage() const override;
 
     static datastore::ArrayStoreConfig optimizedConfigForHugePage(size_t maxSmallArraySize,

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping.hpp
@@ -62,7 +62,7 @@ MultiValueMapping<EntryT,RefT>::getArrayStoreMemoryUsage() const
 }
 
 template <typename EntryT, typename RefT>
-AddressSpace
+vespalib::AddressSpace
 MultiValueMapping<EntryT, RefT>::getAddressSpaceUsage() const {
     return _store.addressSpaceUsage();
 }

--- a/searchlib/src/vespa/searchlib/attribute/multi_value_mapping_base.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_value_mapping_base.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <vespa/searchlib/datastore/entryref.h>
-#include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/address_space.h>
 #include <vespa/vespalib/util/rcuvector.h>
 #include <functional>
 
@@ -24,7 +24,7 @@ protected:
     RefVector _indices;
     size_t    _totalValues;
     vespalib::MemoryUsage _cachedArrayStoreMemoryUsage;
-    AddressSpace _cachedArrayStoreAddressSpaceUsage;
+    vespalib::AddressSpace _cachedArrayStoreAddressSpaceUsage;
 
     MultiValueMappingBase(const vespalib::GrowStrategy &gs, vespalib::GenerationHolder &genHolder);
     virtual ~MultiValueMappingBase();
@@ -36,7 +36,7 @@ public:
     using RefCopyVector = vespalib::Array<EntryRef>;
 
     virtual vespalib::MemoryUsage getArrayStoreMemoryUsage() const = 0;
-    virtual AddressSpace getAddressSpaceUsage() const = 0;
+    virtual vespalib::AddressSpace getAddressSpaceUsage() const = 0;
     vespalib::MemoryUsage getMemoryUsage() const;
     vespalib::MemoryUsage updateStat();
     size_t getTotalValueCnt() const { return _totalValues; }

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
@@ -49,7 +49,7 @@ protected:
      **/
     bool onAddDoc(DocId doc) override { (void) doc; return false; }
 
-    AddressSpace getMultiValueAddressSpaceUsage() const override;
+    vespalib::AddressSpace getMultiValueAddressSpaceUsage() const override;
 
 public:
     MultiValueAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -133,7 +133,7 @@ MultiValueAttribute<B, M>::applyAttributeChanges(DocumentValues & docValues)
 
 
 template <typename B, typename M>
-AddressSpace
+vespalib::AddressSpace
 MultiValueAttribute<B, M>::getMultiValueAddressSpaceUsage() const
 {
     return _mvMapping.getAddressSpaceUsage();

--- a/searchlib/src/vespa/searchlib/common/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/common/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(searchlib_common OBJECT
     SOURCES
-    address_space.cpp
     allocatedbitvector.cpp
     bitvector.cpp
     bitvectorcache.cpp

--- a/searchlib/src/vespa/searchlib/datastore/array_store.h
+++ b/searchlib/src/vespa/searchlib/datastore/array_store.h
@@ -90,7 +90,7 @@ public:
      * Returns the address space usage by this store as the ratio between active buffers
      * and the total number available buffers.
      */
-    AddressSpace addressSpaceUsage() const;
+    vespalib::AddressSpace addressSpaceUsage() const;
 
     // Pass on hold list management to underlying store
     void transferHoldLists(generation_t generation) { _store.transferHoldLists(generation); }

--- a/searchlib/src/vespa/searchlib/datastore/array_store.hpp
+++ b/searchlib/src/vespa/searchlib/datastore/array_store.hpp
@@ -169,7 +169,7 @@ ArrayStore<EntryT, RefT>::compactWorst(bool compactMemory, bool compactAddressSp
 }
 
 template <typename EntryT, typename RefT>
-AddressSpace
+vespalib::AddressSpace
 ArrayStore<EntryT, RefT>::addressSpaceUsage() const
 {
     return _store.getAddressSpaceUsage();

--- a/searchlib/src/vespa/searchlib/datastore/datastorebase.cpp
+++ b/searchlib/src/vespa/searchlib/datastore/datastorebase.cpp
@@ -314,7 +314,7 @@ DataStoreBase::getMemStats() const
     return stats;
 }
 
-AddressSpace
+vespalib::AddressSpace
 DataStoreBase::getAddressSpaceUsage() const
 {
     size_t usedArrays = 0;
@@ -336,7 +336,7 @@ DataStoreBase::getAddressSpaceUsage() const
             LOG_ABORT("should not be reached");
         }
     }
-    return AddressSpace(usedArrays, deadArrays, limitArrays);
+    return vespalib::AddressSpace(usedArrays, deadArrays, limitArrays);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/datastore/datastorebase.h
+++ b/searchlib/src/vespa/searchlib/datastore/datastorebase.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "bufferstate.h"
-#include <vespa/searchlib/common/address_space.h>
+#include <vespa/vespalib/util/address_space.h>
 #include <vespa/vespalib/util/generationholder.h>
 #include <vespa/vespalib/util/memoryusage.h>
 #include <vector>
@@ -230,7 +230,7 @@ public:
 
     vespalib::MemoryUsage getMemoryUsage() const;
 
-    AddressSpace getAddressSpaceUsage() const;
+    vespalib::AddressSpace getAddressSpaceUsage() const;
 
     /**
      * Get active buffer id for the given type id.

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(vespalib_vespalib_util OBJECT
     SOURCES
     active.cpp
+    address_space.cpp
     alloc.cpp
     approx.cpp
     array.cpp

--- a/vespalib/src/vespa/vespalib/util/address_space.cpp
+++ b/vespalib/src/vespa/vespalib/util/address_space.cpp
@@ -4,7 +4,7 @@
 #include <ostream>
 #include <cassert>
 
-namespace search {
+namespace vespalib {
 
 AddressSpace::AddressSpace(size_t used_, size_t dead_, size_t limit_)
     : _used(used_),
@@ -19,5 +19,5 @@ std::ostream &operator << (std::ostream &out, const AddressSpace &rhs)
     return out << "used=" << rhs.used() << ", dead=" << rhs.dead() << ", limit=" << rhs.limit();
 }
 
-} // namespace search
+} // namespace vespalib
 

--- a/vespalib/src/vespa/vespalib/util/address_space.h
+++ b/vespalib/src/vespa/vespalib/util/address_space.h
@@ -4,7 +4,7 @@
 
 #include <iosfwd>
 
-namespace search {
+namespace vespalib {
 
 /**
  * Represents an address space with number of bytes/entries used


### PR DESCRIPTION
@toregge @baldersheim please review. Used by `datastore` classes, so a prerequisite to moving these out.