### PR TITLE
Fix vcpu to shares ratio

### DIFF
--- a/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
+++ b/docker-api/src/main/java/com/yahoo/vespa/hosted/dockerapi/ContainerResources.java
@@ -35,8 +35,8 @@ public class ContainerResources {
 
         if (cpus < 0)
             throw new IllegalArgumentException("CPUs must be a positive number or 0 for unlimited, was " + cpus);
-        if (cpuShares < 0)
-            throw new IllegalArgumentException("CPU shares must be a positive integer or 0 for unlimited, was " + cpuShares);
+        if (cpuShares != 0 && (cpuShares < 2 || cpuShares > 262_144))
+            throw new IllegalArgumentException("CPU shares must be a positive integer in [2, 262144] or 0 for unlimited, was " + cpuShares);
         if (memoryBytes < 0)
             throw new IllegalArgumentException("memoryBytes must be a positive integer or 0 for unlimited, was " + memoryBytes);
     }
@@ -54,7 +54,7 @@ public class ContainerResources {
      */
     public static ContainerResources from(double maxVcpu, double minVcpu, double memoryGb) {
         return new ContainerResources(maxVcpu,
-                                      (int) Math.round(10 * minVcpu),
+                                      (int) Math.round(32 * minVcpu),
                                       (long) ((1L << 30) * memoryGb));
     }
 

--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/ContainerResourcesTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/ContainerResourcesTest.java
@@ -1,0 +1,49 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.dockerapi;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author freva
+ */
+public class ContainerResourcesTest {
+
+    @Test
+    public void verify_unlimited() {
+        assertEquals(-1, ContainerResources.UNLIMITED.cpuQuota());
+        assertEquals(100_000, ContainerResources.UNLIMITED.cpuPeriod());
+        assertEquals(0, ContainerResources.UNLIMITED.cpuShares());
+    }
+
+    @Test
+    public void validate_shares() {
+        new ContainerResources(0, 0, 0);
+        new ContainerResources(0, 2, 0);
+        new ContainerResources(0, 2048, 0);
+        new ContainerResources(0, 262_144, 0);
+
+        assertThrows(IllegalArgumentException.class, () -> new ContainerResources(0, -1, 0)); // Negative shares not allowed
+        assertThrows(IllegalArgumentException.class, () -> new ContainerResources(0, 1, 0)); // 1 share not allowed
+        assertThrows(IllegalArgumentException.class, () -> new ContainerResources(0, 262_145, 0));
+    }
+
+    @Test
+    public void cpu_shares_scaling() {
+        ContainerResources resources = ContainerResources.from(5.3, 2.5, 0);
+        assertEquals(530_000, resources.cpuQuota());
+        assertEquals(100_000, resources.cpuPeriod());
+        assertEquals(80, resources.cpuShares());
+    }
+
+    private static void assertThrows(Class<? extends Throwable> clazz, Runnable runnable) {
+        try {
+            runnable.run();
+            fail("Expected " + clazz);
+        } catch (Throwable e) {
+            if (!clazz.isInstance(e)) throw e;
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/moby/moby/blob/9808f6036acb12ce4b56cd8d1887eada0e4a5ed4/daemon/daemon_unix.go#L64

Ideally, the scaling would be 1024 which is the default. So a container with 1 vcpu would have as many shares as a regular host process, but that limits us to maximum 256 vcpu. We probably not gonna reach any time soon, but I set the scaling factor to 32 anyway since its less likely we ever gonna offer anything less than 1/16 vcpu?