### PR TITLE
Allow multiple rotations per application

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -99,7 +99,7 @@ public class Application {
         this.majorVersion = Objects.requireNonNull(majorVersion, "majorVersion cannot be null");
         this.metrics = Objects.requireNonNull(metrics, "metrics cannot be null");
         this.pemDeployKey = pemDeployKey;
-        this.rotations = Objects.requireNonNull(rotations, "rotations cannot be null");
+        this.rotations = List.copyOf(Objects.requireNonNull(rotations, "rotations cannot be null"));
         this.rotationStatus = ImmutableMap.copyOf(Objects.requireNonNull(rotationStatus, "rotationStatus cannot be null"));
     }
 
@@ -197,7 +197,7 @@ public class Application {
 
     /** Returns the global rotation id of this, if present */
     public List<RotationId> rotations() {
-        return Collections.unmodifiableList(rotations);
+        return rotations;
     }
 
     /** Returns the default global endpoints for this in given system */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -328,7 +328,7 @@ public class ApplicationController {
                 // Include global DNS names
                 cnames = app.endpointsIn(controller.system()).asList().stream().map(Endpoint::dnsName).collect(Collectors.toSet());
                 // Include rotation ID to ensure that deployment can respond to health checks with rotation ID as Host header
-                app.rotation().map(RotationId::asString).ifPresent(cnames::add);
+                app.rotations().stream().map(RotationId::asString).forEach(cnames::add);
 
                 // Update application with information from application package
                 if (   ! preferOldestVersion

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
@@ -27,6 +27,7 @@ import com.yahoo.vespa.hosted.controller.rotation.RotationId;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,7 +56,7 @@ public class LockedApplication {
     private final OptionalInt majorVersion;
     private final ApplicationMetrics metrics;
     private final Optional<String> pemDeployKey;
-    private final Optional<RotationId> rotation;
+    private final List<RotationId> rotations;
     private final Map<HostName, RotationStatus> rotationStatus;
 
     /**
@@ -70,7 +71,7 @@ public class LockedApplication {
              application.deployments(),
              application.deploymentJobs(), application.change(), application.outstandingChange(),
              application.ownershipIssueId(), application.owner(), application.majorVersion(), application.metrics(),
-             application.pemDeployKey(), application.rotation(), application.rotationStatus());
+             application.pemDeployKey(), application.rotations(), application.rotationStatus());
     }
 
     private LockedApplication(Lock lock, ApplicationId id, Instant createdAt,
@@ -78,7 +79,7 @@ public class LockedApplication {
                               Map<ZoneId, Deployment> deployments, DeploymentJobs deploymentJobs, Change change,
                               Change outstandingChange, Optional<IssueId> ownershipIssueId, Optional<User> owner,
                               OptionalInt majorVersion, ApplicationMetrics metrics, Optional<String> pemDeployKey,
-                              Optional<RotationId> rotation, Map<HostName, RotationStatus> rotationStatus) {
+                              List<RotationId> rotations, Map<HostName, RotationStatus> rotationStatus) {
         this.lock = lock;
         this.id = id;
         this.createdAt = createdAt;
@@ -93,7 +94,7 @@ public class LockedApplication {
         this.majorVersion = majorVersion;
         this.metrics = metrics;
         this.pemDeployKey = pemDeployKey;
-        this.rotation = rotation;
+        this.rotations = rotations;
         this.rotationStatus = rotationStatus;
     }
 
@@ -101,35 +102,35 @@ public class LockedApplication {
     public Application get() {
         return new Application(id, createdAt, deploymentSpec, validationOverrides, deployments, deploymentJobs, change,
                                outstandingChange, ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                               rotation, rotationStatus);
+                               rotations, rotationStatus);
     }
 
     public LockedApplication withBuiltInternally(boolean builtInternally) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withBuiltInternally(builtInternally), change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication withProjectId(OptionalLong projectId) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withProjectId(projectId), change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication withDeploymentIssueId(IssueId issueId) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.with(issueId), change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication withJobPause(JobType jobType, OptionalLong pausedUntil) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withPause(jobType, pausedUntil), change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication withJobCompletion(long projectId, JobType jobType, JobStatus.JobRun completion,
@@ -137,14 +138,14 @@ public class LockedApplication {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withCompletion(projectId, jobType, completion, jobError),
                                      change, outstandingChange, ownershipIssueId, owner, majorVersion, metrics,
-                                     pemDeployKey, rotation, rotationStatus);
+                                     pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication withJobTriggering(JobType jobType, JobStatus.JobRun job) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.withTriggering(jobType, job), change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication withNewDeployment(ZoneId zone, ApplicationVersion applicationVersion, Version version,
@@ -195,45 +196,45 @@ public class LockedApplication {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs.without(jobType), change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication with(DeploymentSpec deploymentSpec) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange,
                                      ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     public LockedApplication with(ValidationOverrides validationOverrides) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication withChange(Change change) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication withOutstandingChange(Change outstandingChange) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication withOwnershipIssueId(IssueId issueId) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, Optional.ofNullable(issueId), owner,
-                                     majorVersion, metrics, pemDeployKey, rotation, rotationStatus);
+                                     majorVersion, metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication withOwner(User owner) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId,
                                      Optional.ofNullable(owner), majorVersion, metrics, pemDeployKey,
-                                     rotation, rotationStatus);
+                                     rotations, rotationStatus);
     }
 
     /** Set a major version for this, or set to null to remove any major version override */
@@ -241,31 +242,31 @@ public class LockedApplication {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner,
                                      majorVersion == null ? OptionalInt.empty() : OptionalInt.of(majorVersion),
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication with(MetricsService.ApplicationMetrics metrics) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     public LockedApplication withPemDeployKey(String pemDeployKey) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, Optional.ofNullable(pemDeployKey), rotation, rotationStatus);
+                                     metrics, Optional.ofNullable(pemDeployKey), rotations, rotationStatus);
     }
 
     public LockedApplication with(RotationId rotation) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, Optional.of(rotation), rotationStatus);
+                                     metrics, pemDeployKey, List.of(rotation), rotationStatus);
     }
 
     public LockedApplication withRotationStatus(Map<HostName, RotationStatus> rotationStatus) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     /** Don't expose non-leaf sub-objects. */
@@ -278,7 +279,7 @@ public class LockedApplication {
     private LockedApplication with(Map<ZoneId, Deployment> deployments) {
         return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
                                      deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
-                                     metrics, pemDeployKey, rotation, rotationStatus);
+                                     metrics, pemDeployKey, rotations, rotationStatus);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -526,10 +526,10 @@ public class ApplicationSerializer {
     private List<RotationId> rotationListFromSlime(Inspector field) {
         final var rotations = new ArrayList<RotationId>();
 
-        for (int i = 0; i < field.entries(); ++i) {
-            var entry = field.entry(i);
-            rotations.add(new RotationId(entry.asString()));
-        }
+        field.traverse((ArrayTraverser) (idx, inspector) -> {
+            final var rotation = new RotationId(inspector.asString());
+            rotations.add(rotation);
+        });
 
         return rotations;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -70,7 +70,7 @@ public class ApplicationSerializer {
     private final String writeQualityField = "writeQuality";
     private final String queryQualityField = "queryQuality";
     private final String pemDeployKeyField = "pemDeployKey";
-    private final String rotationsField = "rotations";
+    private final String rotationsField = "endpoints";
     private final String deprecatedRotationField = "rotation";
     private final String rotationStatusField = "rotationStatus";
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -534,6 +534,7 @@ public class ApplicationSerializer {
         return rotations;
     }
 
+    // TODO: Remove after June 2019 once the 'rotation' field is gone from storage
     private Optional<RotationId> legacyRotationFromSlime(Inspector field) {
         return field.valid() ? optionalString(field).map(RotationId::new) : Optional.empty();
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -496,7 +496,8 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
                    .map(URI::toString)
                    .forEach(globalRotationsArray::addString);
 
-        application.rotation().ifPresent(rotation -> object.setString("rotationId", rotation.asString()));
+
+        application.rotations().stream().findFirst().ifPresent(rotation -> object.setString("rotationId", rotation.asString()));
 
         // Per-cluster rotations
         Set<RoutingPolicy> routingPolicies = controller.applications().routingPolicies(application.id());
@@ -515,7 +516,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         for (Deployment deployment : deployments) {
             Cursor deploymentObject = instancesArray.addObject();
 
-            if (application.rotation().isPresent() && deployment.zone().environment() == Environment.prod) {
+            if ((! application.rotations().isEmpty()) && deployment.zone().environment() == Environment.prod) {
                 toSlime(application.rotationStatus(deployment), deploymentObject);
             }
 
@@ -707,7 +708,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         ApplicationId applicationId = ApplicationId.from(tenantName, applicationName, instanceName);
         Application application = controller.applications().require(applicationId);
         ZoneId zone = ZoneId.from(environment, region);
-        if (!application.rotation().isPresent()) {
+        if (application.rotations().isEmpty()) {
             throw new NotExistsException("global rotation does not exist for " + application);
         }
         Deployment deployment = application.deployments().get(zone);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -436,7 +436,7 @@ public class ControllerTest {
                     .build();
             tester.deployCompletely(app1, applicationPackage);
             app1 = tester.applications().require(app1.id());
-            assertEquals("rotation-id-02", app1.rotation().get().asString());
+            assertEquals("rotation-id-02", app1.rotations().get(0).asString());
 
             // Existing DNS records are updated to point to the newly assigned rotation
             assertEquals(6, tester.controllerTester().nameService().records().size());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -257,7 +257,7 @@ public class ApplicationSerializerTest {
 
         cursor.setString("rotation", "single-rotation");
 
-        final var rotations = cursor.setArray("rotations");
+        final var rotations = cursor.setArray("endpoints");
         rotations.addString("multiple-rotation-1");
         rotations.addString("multiple-rotation-2");
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -115,7 +115,7 @@ public class ApplicationSerializerTest {
                                                OptionalInt.of(7),
                                                new MetricsService.ApplicationMetrics(0.5, 0.9),
                                                Optional.of("-----BEGIN PUBLIC KEY-----\n∠( ᐛ 」∠)＿\n-----END PUBLIC KEY-----"),
-                                               Optional.of(new RotationId("my-rotation")),
+                                               List.of(new RotationId("my-rotation")),
                                                rotationStatus);
 
         Application serialized = applicationSerializer.fromSlime(applicationSerializer.toSlime(original));
@@ -151,7 +151,7 @@ public class ApplicationSerializerTest {
         assertEquals(original.change(), serialized.change());
         assertEquals(original.pemDeployKey(), serialized.pemDeployKey());
 
-        assertEquals(original.rotation().get(), serialized.rotation().get());
+        assertEquals(original.rotations(), serialized.rotations());
         assertEquals(original.rotationStatus(), serialized.rotationStatus());
 
         // Test cluster utilization

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepositoryTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepositoryTest.java
@@ -14,10 +14,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Oyvind Gronnesby
@@ -64,7 +65,7 @@ public class RotationRepositoryTest {
         Rotation expected = new Rotation(new RotationId("foo-1"), "foo-1.com");
 
         application = tester.applications().require(application.id());
-        assertEquals(expected.id(), application.rotation().get());
+        assertEquals(List.of(expected.id()), application.rotations());
         assertEquals(URI.create("https://app1--tenant1.global.vespa.oath.cloud:4443/"),
                      application.endpointsIn(SystemName.main).main().get().url());
         try (RotationLock lock = repository.lock()) {
@@ -80,7 +81,7 @@ public class RotationRepositoryTest {
                 .searchDefinition("search foo { }") // Update application package so there is something to deploy
                 .build();
         tester.deployCompletely(application, applicationPackage, 43);
-        assertEquals(expected.id(), tester.applications().require(application.id()).rotation().get());
+        assertEquals(List.of(expected.id()), tester.applications().require(application.id()).rotations());
     }
     
     @Test
@@ -139,8 +140,7 @@ public class RotationRepositoryTest {
                 .build();
         tester.deployCompletely(application, applicationPackage);
         Application app = tester.applications().require(application.id());
-        Optional<RotationId> rotation = app.rotation();
-        assertFalse(rotation.isPresent());
+        assertTrue(app.rotations().isEmpty());
     }
 
     @Test
@@ -153,7 +153,7 @@ public class RotationRepositoryTest {
         Application application = tester.createApplication("app2", "tenant2", 22L,
                                                            2L);
         tester.deployCompletely(application, applicationPackage);
-        assertEquals(new RotationId("foo-1"), tester.applications().require(application.id()).rotation().get());
+        assertEquals(List.of(new RotationId("foo-1")), tester.applications().require(application.id()).rotations());
         assertEquals("https://cd--app2--tenant2.global.vespa.oath.cloud:4443/", tester.applications().require(application.id())
                 .endpointsIn(SystemName.cd).main().get().url().toString());
     }


### PR DESCRIPTION
Update the `Application` class to have a `List<RotationId>` instead of `Optional<RotationId>`, and the update the various classes that follow from that. Some important things to keep in mind:

- `EndpointsList` logic must be updated before this PR can be merged.
- We change how we persist the rotations in the `NodeRepository`. The previous single-value field has been renamed in code (but not persistent) to show it is deprecated. We only write the new multi-value version.
- There may be some REST API changes that follow from this change that we need to discuss.
