### PR TITLE
Only update routing policies for applicable zones

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneFilter.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneFilter.java
@@ -19,6 +19,9 @@ public interface ZoneFilter {
     /** Zones which are upgraded by the controller. */
     ZoneList controllerUpgraded();
 
+    /** Zones which support direct routing through exclusive load balancers. */
+    ZoneList directlyRouted();
+
     /** Zones where config servers are up and running. */
     ZoneList reachable();
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneFilterMock.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneFilterMock.java
@@ -48,6 +48,11 @@ public class ZoneFilterMock implements ZoneList {
     }
 
     @Override
+    public ZoneList directlyRouted() {
+        return all();
+    }
+
+    @Override
     public ZoneList reachable() {
         return all();
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicies.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicies.java
@@ -70,6 +70,8 @@ public class RoutingPolicies {
      * load balancers for given application have changed.
      */
     public void refresh(ApplicationId application, ZoneId zone) {
+        // TODO: Use this to decide how apply routing policies for shared routing layer
+        if (!controller.zoneRegistry().zones().directlyRouted().ids().contains(zone)) return;
         var lbs = new LoadBalancers(application, zone, controller.applications().configServer()
                                                                  .getLoadBalancers(application, zone));
         removeObsoleteEndpointsFromDns(lbs);


### PR DESCRIPTION
Depends on internal PR. This should allow us to safely enable
`SharedLoadBalancerService`.