### PR TITLE
Remove storage dependency on searchlib

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -16,7 +16,6 @@ vespa_define_module(
     vdslib
     persistence
     storageframework
-    searchlib
 
     EXTERNAL_DEPENDS
     Judy


### PR DESCRIPTION
@baldersheim please review
Not needed now that B-tree code has been moved to vespalib.