### PR TITLE
Always return a target version for appropriate node types

### DIFF
--- a/config-provisioning/src/main/resources/configdefinitions/node-repository.def
+++ b/config-provisioning/src/main/resources/configdefinitions/node-repository.def
@@ -5,4 +5,6 @@ namespace=config.provisioning
 # version. Example: my-docker-registry.domain.tld:8080/dist/vespa
 dockerImage string default="dummyImage"
 
+serverNodeType enum {config, controller} default=config
+
 useCuratorClientCache bool default=false

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -97,7 +97,8 @@ public class NodeRepository extends AbstractComponent {
      */
     @Inject
     public NodeRepository(NodeRepositoryConfig config, NodeFlavors flavors, Curator curator, Zone zone) {
-        this(flavors, curator, Clock.systemUTC(), zone, new DnsNameResolver(), DockerImage.fromString(config.dockerImage()), config.useCuratorClientCache());
+        this(flavors, curator, Clock.systemUTC(), zone, new DnsNameResolver(), DockerImage.fromString(config.dockerImage()),
+                NodeType.valueOf(config.serverNodeType().name()), config.useCuratorClientCache());
     }
 
     /**
@@ -105,14 +106,14 @@ public class NodeRepository extends AbstractComponent {
      * which will be used for time-sensitive decisions.
      */
     public NodeRepository(NodeFlavors flavors, Curator curator, Clock clock, Zone zone, NameResolver nameResolver,
-                          DockerImage dockerImage, boolean useCuratorClientCache) {
+                          DockerImage dockerImage, NodeType serverNodeType, boolean useCuratorClientCache) {
         this.db = new CuratorDatabaseClient(flavors, curator, clock, zone, useCuratorClientCache);
         this.zone = zone;
         this.clock = clock;
         this.flavors = flavors;
         this.nameResolver = nameResolver;
         this.osVersions = new OsVersions(db);
-        this.infrastructureVersions = new InfrastructureVersions(db);
+        this.infrastructureVersions = new InfrastructureVersions(db, serverNodeType);
         this.firmwareChecks = new FirmwareChecks(db, clock);
         this.dockerImages = new DockerImages(db, dockerImage);
         this.jobControl = new JobControl(db);
@@ -128,7 +129,7 @@ public class NodeRepository extends AbstractComponent {
     /** Returns the Docker image to use for nodes in this */
     public DockerImage dockerImage(NodeType nodeType) { return dockerImages.dockerImageFor(nodeType); }
 
-    /** @return The name resolver used to resolve hostname and ip addresses */
+    /** Returns the name resolver used to resolve hostname and ip addresses */
     public NameResolver nameResolver() { return nameResolver; }
 
     /** Returns the OS versions to use for nodes in this */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
@@ -81,13 +81,6 @@ public class InfraDeployerImpl implements InfraDeployer {
             try (Mutex lock = nodeRepository.lock(application.getApplicationId())) {
                 NodeType nodeType = application.getCapacity().type();
 
-                Optional<Version> targetVersion = infrastructureVersions.getTargetVersionFor(nodeType);
-                if (targetVersion.isEmpty()) {
-                    logger.log(LogLevel.DEBUG, "No target version set for " + nodeType + ", removing application");
-                    removeApplication(application.getApplicationId());
-                    return;
-                }
-
                 candidateNodes = nodeRepository
                         .getNodes(nodeType, Node.State.ready, Node.State.reserved, Node.State.active, Node.State.inactive);
                 if (candidateNodes.isEmpty()) {
@@ -96,10 +89,11 @@ public class InfraDeployerImpl implements InfraDeployer {
                     return;
                 }
 
-                if (!allActiveNodesOn(targetVersion.get(), candidateNodes)) {
+                Version targetVersion = infrastructureVersions.getTargetVersionFor(nodeType);
+                if (!allActiveNodesOn(targetVersion, candidateNodes)) {
                     hostSpecs = provisioner.prepare(
                             application.getApplicationId(),
-                            application.getClusterSpecWithVersion(targetVersion.get()),
+                            application.getClusterSpecWithVersion(targetVersion),
                             application.getCapacity(),
                             1, // groups
                             logger::log);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -52,6 +52,7 @@ public class MockNodeRepository extends NodeRepository {
         super(flavors, curator, Clock.fixed(Instant.ofEpochMilli(123), ZoneId.of("Z")), Zone.defaultZone(),
               new MockNameResolver().mockAnyLookup(),
               DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+              NodeType.config,
               true);
         this.flavors = flavors;
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
@@ -27,9 +27,12 @@ public class NodeRepositoryTester {
     private final NodeRepository nodeRepository;
     private final Clock clock;
     private final MockCurator curator;
-    
-    
+
     public NodeRepositoryTester() {
+        this(NodeType.config);
+    }
+
+    public NodeRepositoryTester(NodeType nodeType) {
         nodeFlavors = new NodeFlavors(createConfig());
         clock = new ManualClock();
         curator = new MockCurator();
@@ -37,6 +40,7 @@ public class NodeRepositoryTester {
         nodeRepository = new NodeRepository(nodeFlavors, curator, clock, Zone.defaultZone(),
                                             new MockNameResolver().mockAnyLookup(),
                                             DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                            nodeType,
                                             true);
     }
     

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirerTest.java
@@ -9,10 +9,10 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.Flavor;
-import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
@@ -255,6 +255,7 @@ public class FailedExpirerTest {
             this.nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
                                                      new MockNameResolver().mockAnyLookup(),
                                                      DockerImage.fromString("docker-image"),
+                                                     NodeType.config,
                                                      true);
             this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, Zone.defaultZone(), new MockProvisionServiceProvider(), new InMemoryFlagSource());
             this.expirer = new FailedExpirer(nodeRepository, zone, clock, Duration.ofMinutes(30));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostProvisionMaintainerTest.java
@@ -132,7 +132,8 @@ public class HostProvisionMaintainerTest {
 
         private final ManualClock clock = new ManualClock();
         private final NodeRepository nodeRepository = new NodeRepository(
-                nodeFlavors, new MockCurator(), clock, Zone.defaultZone(), new MockNameResolver().mockAnyLookup(), DockerImage.fromString("docker-image"), true);
+                nodeFlavors, new MockCurator(), clock, Zone.defaultZone(), new MockNameResolver().mockAnyLookup(),
+                DockerImage.fromString("docker-image"), NodeType.config, true);
 
         Node addNode(String hostname, Optional<String> parentHostname, NodeType nodeType, Node.State state, Optional<ApplicationId> application) {
             Node node = createNode(hostname, parentHostname, nodeType, state, application);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureVersionsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureVersionsTest.java
@@ -33,9 +33,9 @@ public class InfrastructureVersionsTest {
         assertEquals(version, infrastructureVersions.getTargetVersionFor(NodeType.config));
 
         // Upgrading to new version without force is fine
-        Version new_version = Version.fromString("6.123.457"); // version + 1
-        infrastructureVersions.setTargetVersion(NodeType.config, new_version, false);
-        assertEquals(new_version, infrastructureVersions.getTargetVersionFor(NodeType.config));
+        Version newVersion = Version.fromString("6.123.457"); // version + 1
+        infrastructureVersions.setTargetVersion(NodeType.config, newVersion, false);
+        assertEquals(newVersion, infrastructureVersions.getTargetVersionFor(NodeType.config));
 
         // Downgrading to old version without force fails
         assertThrows(IllegalArgumentException.class,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureVersionsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureVersionsTest.java
@@ -6,9 +6,7 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.NodeRepositoryTester;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -19,9 +17,10 @@ import static org.junit.Assert.fail;
  */
 public class InfrastructureVersionsTest {
 
+    private final Version defaultVersion = Version.fromString("6.13.37");
     private final NodeRepositoryTester tester = new NodeRepositoryTester();
     private final InfrastructureVersions infrastructureVersions =
-            new InfrastructureVersions(tester.nodeRepository().database());
+            new InfrastructureVersions(tester.nodeRepository().database(), NodeType.config, defaultVersion);
 
     private final Version version = Version.fromString("6.123.456");
 
@@ -29,23 +28,21 @@ public class InfrastructureVersionsTest {
     public void can_only_downgrade_with_force() {
         assertTrue(infrastructureVersions.getTargetVersions().isEmpty());
 
-        assertEquals(Optional.empty(), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(defaultVersion, infrastructureVersions.getTargetVersionFor(NodeType.config));
         infrastructureVersions.setTargetVersion(NodeType.config, version, false);
-        assertEquals(Optional.of(version), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(version, infrastructureVersions.getTargetVersionFor(NodeType.config));
 
         // Upgrading to new version without force is fine
         Version new_version = Version.fromString("6.123.457"); // version + 1
         infrastructureVersions.setTargetVersion(NodeType.config, new_version, false);
-        assertEquals(Optional.of(new_version), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(new_version, infrastructureVersions.getTargetVersionFor(NodeType.config));
 
         // Downgrading to old version without force fails
-        try {
-            infrastructureVersions.setTargetVersion(NodeType.config, version, false);
-            fail("Should not be able to downgrade without force");
-        } catch (IllegalArgumentException ignored) { }
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.config, version, false));
 
         infrastructureVersions.setTargetVersion(NodeType.config, version, true);
-        assertEquals(Optional.of(version), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(version, infrastructureVersions.getTargetVersionFor(NodeType.config));
     }
 
     @Test
@@ -53,35 +50,61 @@ public class InfrastructureVersionsTest {
         // We can set version for config
         infrastructureVersions.setTargetVersion(NodeType.config, version, false);
 
-        try {
-            infrastructureVersions.setTargetVersion(NodeType.tenant, version, false);
-            fail("Should not be able to set version for tenant nodes");
-        } catch (IllegalArgumentException ignored) { }
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.tenant, version, false));
 
-        try {
-            // Using 'force' does not help, force only applies to version downgrade
-            infrastructureVersions.setTargetVersion(NodeType.tenant, version, true);
-            fail("Should not be able to set version for tenant nodes");
-        } catch (IllegalArgumentException ignored) { }
+        // Using 'force' does not help, force only applies to version downgrade
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.tenant, version, true));
     }
 
     @Test
-    public void can_store_multiple_versions() {
-        Version version2 = Version.fromString("6.456.123");
-
+    public void store_all_valid_for_config() {
         infrastructureVersions.setTargetVersion(NodeType.config, version, false);
-        infrastructureVersions.setTargetVersion(NodeType.confighost, version2, false);
+        infrastructureVersions.setTargetVersion(NodeType.confighost, version, false);
         infrastructureVersions.setTargetVersion(NodeType.proxyhost, version, false);
-        infrastructureVersions.setTargetVersion(NodeType.controller, version, false);
-        infrastructureVersions.setTargetVersion(NodeType.controllerhost, version2, false);
 
-        Map<NodeType, Version> expected = new HashMap<>();
-        expected.put(NodeType.config, version);
-        expected.put(NodeType.confighost, version2);
-        expected.put(NodeType.proxyhost, version);
-        expected.put(NodeType.controller, version);
-        expected.put(NodeType.controllerhost, version2);
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.controller, version, false));
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.controllerhost, version, false));
+
+        Map<NodeType, Version> expected = Map.of(
+                NodeType.config, version,
+                NodeType.confighost, version,
+                NodeType.proxyhost, version);
 
         assertEquals(expected, infrastructureVersions.getTargetVersions());
+    }
+
+    @Test
+    public void store_all_valid_for_controller() {
+        InfrastructureVersions infrastructureVersions =
+                new InfrastructureVersions(tester.nodeRepository().database(), NodeType.controller, defaultVersion);
+
+        infrastructureVersions.setTargetVersion(NodeType.controller, version, false);
+        infrastructureVersions.setTargetVersion(NodeType.controllerhost, version, false);
+        infrastructureVersions.setTargetVersion(NodeType.proxyhost, version, false);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.config, version, false));
+        assertThrows(IllegalArgumentException.class,
+                () -> infrastructureVersions.setTargetVersion(NodeType.confighost, version, false));
+
+        Map<NodeType, Version> expected = Map.of(
+                NodeType.controller, version,
+                NodeType.controllerhost, version,
+                NodeType.proxyhost, version);
+
+        assertEquals(expected, infrastructureVersions.getTargetVersions());
+    }
+
+    private static void assertThrows(Class<? extends Throwable> clazz, Runnable runnable) {
+        try {
+            runnable.run();
+            fail("Expected " + clazz);
+        } catch (Throwable e) {
+            if (!clazz.isInstance(e)) throw e;
+        }
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceTester.java
@@ -36,6 +36,7 @@ public class MaintenanceTester {
     public final NodeRepository nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
                                                                     new MockNameResolver().mockAnyLookup(),
                                                                     DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                                    NodeType.config,
                                                                     true);
 
     public NodeRepository nodeRepository() { return nodeRepository; }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -54,6 +54,7 @@ public class MetricsReporterTest {
         NodeRepository nodeRepository = new NodeRepository(nodeFlavors, curator, Clock.systemUTC(), Zone.defaultZone(),
                                                            new MockNameResolver().mockAnyLookup(),
                                                            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                           NodeType.config,
                                                            true);
         Node node = nodeRepository.createNode("openStackId", "hostname", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant);
         nodeRepository.addNodes(Collections.singletonList(node));
@@ -115,6 +116,7 @@ public class MetricsReporterTest {
         NodeRepository nodeRepository = new NodeRepository(nodeFlavors, curator, Clock.systemUTC(), Zone.defaultZone(),
                                                            new MockNameResolver().mockAnyLookup(),
                                                            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                           NodeType.config,
                                                            true);
 
         // Allow 4 containers

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -88,7 +88,7 @@ public class NodeFailTester {
         clock = new ManualClock();
         curator = new MockCurator();
         nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, new MockNameResolver().mockAnyLookup(),
-                DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), true);
+                DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), NodeType.config, true);
         provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
         hostLivenessTracker = new TestHostLivenessTracker(clock);
         orchestrator = new OrchestratorMock();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRetirerTester.java
@@ -76,7 +76,7 @@ public class NodeRetirerTester {
     NodeRetirerTester(NodeFlavors nodeFlavors) {
         Curator curator = new MockCurator();
         nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, new MockNameResolver().mockAnyLookup(),
-                                            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), true);
+                                            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), NodeType.config, true);
         NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
         deployer = new MockDeployer(provisioner, clock, apps);
         flavors = nodeFlavors.getFlavors().stream().sorted(Comparator.comparing(Flavor::name)).collect(Collectors.toList());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainerTest.java
@@ -62,6 +62,7 @@ public class OperatorChangeApplicationMaintainerTest {
         this.nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
                                                  new MockNameResolver().mockAnyLookup(),
                                                  DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                 NodeType.config,
                                                  true);
         this.fixture = new Fixture(zone, nodeRepository, nodeFlavors, curator);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -68,6 +68,7 @@ public class PeriodicApplicationMaintainerTest {
         this.nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
                                                  new MockNameResolver().mockAnyLookup(),
                                                  DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                 NodeType.config,
                                                  true);
         this.fixture = new Fixture(zone, nodeRepository, nodeFlavors, curator);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
@@ -48,6 +48,7 @@ public class ReservationExpirerTest {
         NodeRepository nodeRepository = new NodeRepository(flavors, curator, clock, Zone.defaultZone(),
                                                            new MockNameResolver().mockAnyLookup(),
                                                            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                           NodeType.config,
                                                            true);
         NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, flavors, Zone.defaultZone(), new MockProvisionServiceProvider(), new InMemoryFlagSource());
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -65,7 +65,7 @@ public class RetiredExpirerTest {
     private final NodeFlavors nodeFlavors = FlavorConfigBuilder.createDummies("default");
     private final NodeRepository nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone,
             new MockNameResolver().mockAnyLookup(),
-            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), true);
+            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), NodeType.config, true);
     private final NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
     private final Orchestrator orchestrator = mock(Orchestrator.class);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -87,7 +87,7 @@ public class ProvisioningTester {
         this.nodeFlavors = nodeFlavors;
         this.clock = new ManualClock();
         this.nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, nameResolver,
-                DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), true);
+                DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"), NodeType.config, true);
         this.orchestrator = orchestrator;
         ProvisionServiceProvider provisionServiceProvider = new MockProvisionServiceProvider(loadBalancerService, hostProvisioner);
         this.provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, provisionServiceProvider, flagSource);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -636,15 +636,10 @@ public class RestApiTest {
                         Utf8.toBytes("{\"version\": \"6.123.456\"}"),
                         Request.Method.PATCH),
                 "{\"message\":\"Set version to 6.123.456 for nodes of type confighost\"}");
-        assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/controller",
-                                   Utf8.toBytes("{\"version\": \"6.123.456\"}"),
-                                   Request.Method.PATCH),
-                       "{\"message\":\"Set version to 6.123.456 for nodes of type controller\"}");
-
 
         // Verify versions are set
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/"),
-                "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.123.456\",\"controller\":\"6.123.456\"},\"osVersions\":{},\"dockerImages\":{}}");
+                "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.123.456\"},\"osVersions\":{},\"dockerImages\":{}}");
 
         // Setting empty version fails
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/confighost",
@@ -659,6 +654,13 @@ public class RestApiTest {
                                    Request.Method.PATCH),
                        400,
                        "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cannot set version for type tenant\"}");
+
+        // Setting version for controller on a config server fails
+        assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/controller",
+                        Utf8.toBytes("{\"version\": \"6.123.456\"}"),
+                        Request.Method.PATCH),
+                400,
+                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cannot set version for controller on a Config server\"}");
 
         // Omitting version field fails
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/confighost",
@@ -683,7 +685,7 @@ public class RestApiTest {
 
         // Verify version has been updated
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/"),
-                "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.123.1\",\"controller\":\"6.123.456\"},\"osVersions\":{},\"dockerImages\":{}}");
+                "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.123.1\"},\"osVersions\":{},\"dockerImages\":{}}");
 
         // Upgrade OS for confighost and host
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/confighost",
@@ -697,7 +699,7 @@ public class RestApiTest {
 
         // OS versions are set
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/"),
-                       "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.123.1\",\"controller\":\"6.123.456\"},\"osVersions\":{\"host\":\"7.5.2\",\"confighost\":\"7.5.2\"},\"dockerImages\":{}}");
+                       "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.123.1\"},\"osVersions\":{\"host\":\"7.5.2\",\"confighost\":\"7.5.2\"},\"dockerImages\":{}}");
 
         // Upgrade OS and Vespa together
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/confighost",
@@ -743,7 +745,7 @@ public class RestApiTest {
                 "{\"message\":\"Set docker image to my-repo.my-domain.example:1234/repo/image for nodes of type config\"}");
 
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/"),
-                "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.124.42\",\"controller\":\"6.123.456\"},\"osVersions\":{\"host\":\"7.5.2\"},\"dockerImages\":{\"tenant\":\"my-repo.my-domain.example:1234/repo/tenant\",\"config\":\"my-repo.my-domain.example:1234/repo/image\"}}");
+                "{\"versions\":{\"config\":\"6.123.456\",\"confighost\":\"6.124.42\"},\"osVersions\":{\"host\":\"7.5.2\"},\"dockerImages\":{\"tenant\":\"my-repo.my-domain.example:1234/repo/tenant\",\"config\":\"my-repo.my-domain.example:1234/repo/image\"}}");
 
         // Cannot set docker image for non docker node type
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/confighost",


### PR DESCRIPTION
Depends on a PR in `hosted`