### PR TITLE
Support for Endpoints in deployment.xml

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -287,7 +287,7 @@
       "public"
     ],
     "methods": [
-      "public void <init>(java.util.Optional, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, java.util.Optional, java.util.List, java.util.List, java.lang.String, java.util.Optional, java.util.Optional, com.yahoo.config.application.api.Notifications)",
+      "public void <init>(java.util.Optional, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, java.util.Optional, java.util.List, java.util.List, java.lang.String, java.util.Optional, java.util.Optional, com.yahoo.config.application.api.Notifications, java.util.List)",
       "public java.util.Optional globalServiceId()",
       "public com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy upgradePolicy()",
       "public java.util.Optional majorVersion()",
@@ -297,6 +297,7 @@
       "public java.util.List steps()",
       "public java.util.List zones()",
       "public com.yahoo.config.application.api.Notifications notifications()",
+      "public java.util.List endpoints()",
       "public java.lang.String xmlForm()",
       "public boolean includes(com.yahoo.config.provision.Environment, java.util.Optional)",
       "public static com.yahoo.config.application.api.DeploymentSpec fromXml(java.io.Reader)",
@@ -312,6 +313,22 @@
     "fields": [
       "public static final com.yahoo.config.application.api.DeploymentSpec empty"
     ]
+  },
+  "com.yahoo.config.application.api.Endpoint": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(java.util.Optional, java.lang.String, java.util.Set)",
+      "public java.lang.String endpointId()",
+      "public java.lang.String containerId()",
+      "public java.util.Set regions()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()"
+    ],
+    "fields": []
   },
   "com.yahoo.config.application.api.FileRegistry$Entry": {
     "superClass": "java.lang.Object",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/Endpoint.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/Endpoint.java
@@ -1,8 +1,11 @@
 package com.yahoo.config.application.api;
 
+import com.yahoo.config.provision.RegionName;
+
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Represents a (global) endpoint in 'deployments.xml'.  It contains the name of the
@@ -14,12 +17,15 @@ import java.util.Set;
 public class Endpoint {
     private final Optional<String> endpointId;
     private final String containerId;
-    private final Set<String> regions;
+    private final Set<RegionName> regions;
 
     public Endpoint(Optional<String> endpointId, String containerId, Set<String> regions) {
         this.endpointId = endpointId;
         this.containerId = containerId;
-        this.regions = Set.copyOf(regions);
+        this.regions = Set.copyOf(
+                Objects.requireNonNull(
+                        regions.stream().map(RegionName::from).collect(Collectors.toList()),
+                        "Missing 'regions' parameter"));
     }
 
     public String endpointId() {
@@ -30,7 +36,7 @@ public class Endpoint {
         return containerId;
     }
 
-    public Set<String> regions() {
+    public Set<RegionName> regions() {
         return regions;
     }
 

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/Endpoint.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/Endpoint.java
@@ -1,0 +1,51 @@
+package com.yahoo.config.application.api;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Represents a (global) endpoint in 'deployments.xml'.  It contains the name of the
+ * endpoint (endpointId) and the name of the container cluster that the endpoint
+ * should point to.
+ *
+ * If the endpointId is not set, it will default to the same as the containerId.
+ */
+public class Endpoint {
+    private final Optional<String> endpointId;
+    private final String containerId;
+    private final Set<String> regions;
+
+    public Endpoint(Optional<String> endpointId, String containerId, Set<String> regions) {
+        this.endpointId = endpointId;
+        this.containerId = containerId;
+        this.regions = Set.copyOf(regions);
+    }
+
+    public String endpointId() {
+        return endpointId.orElse(containerId);
+    }
+
+    public String containerId() {
+        return containerId;
+    }
+
+    public Set<String> regions() {
+        return regions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Endpoint endpoint = (Endpoint) o;
+        return Objects.equals(endpointId, endpoint.endpointId) &&
+                Objects.equals(containerId, endpoint.containerId) &&
+                Objects.equals(regions, endpoint.regions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpointId, containerId, regions);
+    }
+}

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -177,7 +177,10 @@ public class DeploymentSpecXmlReader {
                 if (region == null || region.isEmpty() || region.isBlank()) {
                     throw new IllegalArgumentException("Empty 'region' element in 'endpoint' tag.");
                 }
-                regions.add(regionElement.getTextContent());
+                if (regions.contains(region)) {
+                    throw new IllegalArgumentException("Duplicate 'region' element in 'endpoint' tag: " + region);
+                }
+                regions.add(region);
             }
 
             endpoints.add(new Endpoint(rotationId, containerId.get(), regions));

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -6,6 +6,7 @@ import com.yahoo.config.application.api.DeploymentSpec.DeclaredZone;
 import com.yahoo.config.application.api.DeploymentSpec.Delay;
 import com.yahoo.config.application.api.DeploymentSpec.ParallelZones;
 import com.yahoo.config.application.api.DeploymentSpec.Step;
+import com.yahoo.config.application.api.Endpoint;
 import com.yahoo.config.application.api.Notifications;
 import com.yahoo.config.application.api.Notifications.Role;
 import com.yahoo.config.application.api.Notifications.When;
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +42,8 @@ public class DeploymentSpecXmlReader {
     private static final String stagingTag = "staging";
     private static final String blockChangeTag = "block-change";
     private static final String prodTag = "prod";
+    private static final String endpointsTag = "endpoints";
+    private static final String endpointTag = "endpoint";
 
     private final boolean validate;
 
@@ -123,7 +127,8 @@ public class DeploymentSpecXmlReader {
                                   xmlForm,
                                   athenzDomain,
                                   athenzService,
-                                  readNotifications(root));
+                                  readNotifications(root),
+                                  readEndpoints(root));
     }
 
     private Notifications readNotifications(Element root) {
@@ -150,6 +155,35 @@ public class DeploymentSpecXmlReader {
             roleAttribute.ifPresent(role -> emailRoles.get(when).add(role));
         }
         return Notifications.of(emailAddresses, emailRoles);
+    }
+
+    private List<Endpoint> readEndpoints(Element root) {
+        final var endpointsElement = XML.getChild(root, endpointsTag);
+        if (endpointsElement == null) { return Collections.emptyList(); }
+
+        final var endpoints = new ArrayList<Endpoint>();
+
+        for (var endpointElement : XML.getChildren(endpointsElement, endpointTag)) {
+            final Optional<String> rotationId = stringAttribute("id", endpointElement);
+            final Optional<String> containerId = stringAttribute("container-id", endpointElement);
+            final var regions = new HashSet<String>();
+
+            if (containerId.isEmpty()) {
+                throw new IllegalArgumentException("Missing 'container-id' from 'endpoint' tag.");
+            }
+
+            for (var regionElement : XML.getChildren(endpointElement, "region")) {
+                var region = regionElement.getTextContent();
+                if (region == null || region.isEmpty() || region.isBlank()) {
+                    throw new IllegalArgumentException("Empty 'region' element in 'endpoint' tag.");
+                }
+                regions.add(regionElement.getTextContent());
+            }
+
+            endpoints.add(new Endpoint(rotationId, containerId.get(), regions));
+        }
+
+        return endpoints;
     }
 
     /**

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -1,9 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.application.api;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import org.junit.Test;
@@ -11,7 +9,11 @@ import org.junit.Test;
 import java.io.StringReader;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.yahoo.config.application.api.Notifications.Role.author;
 import static com.yahoo.config.application.api.Notifications.When.failing;
@@ -452,4 +454,40 @@ public class DeploymentSpecTest {
         assertEquals(Optional.of("d-2-8-50"), spec.steps().get(2).zones().get(0).testerFlavor());
     }
 
+    @Test
+    public void noEndpoints() {
+        assertEquals(Collections.emptyList(), DeploymentSpec.fromXml("<deployment />").endpoints());
+    }
+
+    @Test
+    public void emptyEndpoints() {
+        final var spec = DeploymentSpec.fromXml("<deployment><endpoints/></deployment>");
+        assertEquals(Collections.emptyList(), spec.endpoints());
+    }
+
+    @Test
+    public void someEndpoints() {
+        final var spec = DeploymentSpec.fromXml("" +
+                "<deployment>" +
+                "  <endpoints>" +
+                "    <endpoint id=\"foo\" container-id=\"bar\">" +
+                "      <region>us-east</region>" +
+                "    </endpoint>" +
+                "    <endpoint id=\"nalle\" container-id=\"frosk\" />" +
+                "    <endpoint container-id=\"quux\" />" +
+                "  </endpoints>" +
+                "</deployment>");
+
+        assertEquals(
+                List.of("foo", "nalle", "quux"),
+                spec.endpoints().stream().map(Endpoint::endpointId).collect(Collectors.toList())
+        );
+
+        assertEquals(
+                List.of("bar", "frosk", "quux"),
+                spec.endpoints().stream().map(Endpoint::containerId).collect(Collectors.toList())
+        );
+
+        assertEquals(Set.of("us-east"), spec.endpoints().get(0).regions());
+    }
 }

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -469,6 +469,9 @@ public class DeploymentSpecTest {
     public void someEndpoints() {
         final var spec = DeploymentSpec.fromXml("" +
                 "<deployment>" +
+                "  <prod>" +
+                "    <region active=\"true\">us-east</region>" +
+                "  </prod>" +
                 "  <endpoints>" +
                 "    <endpoint id=\"foo\" container-id=\"bar\">" +
                 "      <region>us-east</region>" +
@@ -488,6 +491,6 @@ public class DeploymentSpecTest {
                 spec.endpoints().stream().map(Endpoint::containerId).collect(Collectors.toList())
         );
 
-        assertEquals(Set.of("us-east"), spec.endpoints().get(0).regions());
+        assertEquals(Set.of(RegionName.from("us-east")), spec.endpoints().get(0).regions());
     }
 }

--- a/config-model/src/main/resources/schema/deployment.rnc
+++ b/config-model/src/main/resources/schema/deployment.rnc
@@ -10,6 +10,7 @@ start = element deployment {
    Upgrade? &
    BlockChange* &
    Notifications? &
+   Endpoints? &
    Test? &
    Staging? &
    Prod*
@@ -72,4 +73,19 @@ Delay = element delay {
 
 Parallel = element parallel {
     Region*
+}
+
+
+EndpointRegion = element region {
+    text
+}
+
+Endpoint = element endpoint {
+    attribute id { xsd:string }? &
+    attribute container-id { xsd:string } &
+    EndpointRegion*
+}
+
+Endpoints = element endpoints {
+    Endpoint*
 }

--- a/config-model/src/main/resources/schema/deployment.rnc
+++ b/config-model/src/main/resources/schema/deployment.rnc
@@ -75,7 +75,6 @@ Parallel = element parallel {
     Region*
 }
 
-
 EndpointRegion = element region {
     text
 }
@@ -87,5 +86,5 @@ Endpoint = element endpoint {
 }
 
 Endpoints = element endpoints {
-    Endpoint*
+    Endpoint+
 }

--- a/config-model/src/test/schema-test-files/deployment.xml
+++ b/config-model/src/test/schema-test-files/deployment.xml
@@ -20,4 +20,10 @@
             <region active='true'>us-south-2</region>
         </parallel>
     </prod>
+    <endpoints>
+        <endpoint id="foo" container-id="bar">
+            <region>us-east</region>
+        </endpoint>
+        <endpoint container-id="bar" />
+    </endpoints>
 </deployment>


### PR DESCRIPTION
This allows for use of `endpoints` tags in `deployment.xml` and exposes them in the `DeploymentSpec` model.