### PR TITLE
Increase timeout for test stability

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -133,7 +133,7 @@ public class DockerTester implements AutoCloseable {
     }
 
     <T> T inOrder(T t) {
-        return inOrder.verify(t, timeout(1000));
+        return inOrder.verify(t, timeout(5000));
     }
 
     @Override


### PR DESCRIPTION
Failed on factory for 7.53.24. The test has never failed on my machine or SDv3 as far as I can tell, the error says it failed after 3sec, so increasing it to 5 should be enough?
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.27 s <<< FAILURE! - in com.yahoo.vespa.hosted.node.admin.integrationTests.MultiDockerTest
[ERROR] test(com.yahoo.vespa.hosted.node.admin.integrationTests.MultiDockerTest)  Time elapsed: 3.238 s  <<< FAILURE!
org.mockito.exceptions.verification.WantedButNotInvoked: 

Wanted but not invoked:
dockerMock.createContainerCommand(
    image1,
    ContainerName { name=host1 }
);
-> at com.yahoo.vespa.hosted.node.admin.integrationTests.MultiDockerTest.addAndWaitForNode(MultiDockerTest.java:62)

However, there were exactly 7 interactions with this mock:
nodeRepoMock.updateNodeRepositoryNode(
    NodeSpec { hostname=host.test.yahoo.com wantedDockerImage=Optional.empty currentDockerImage=Optional.empty state=active nodeType=host flavor=default canonicalFlavor=null wantedVespaVersion=Optional.empty vespaVersion=Optional.empty wantedOsVersion=Optional.empty currentOsVersion=Optional.empty allowedToBeDown=Optional.empty wantToDeprovision=Optional.empty owner=Optional.empty membership=Optional.empty minCpuCores=0.0 wantedRestartGeneration=Optional[1] currentRestartGeneration=Optional[1] wantedRebootGeneration=0 currentRebootGeneration=0 wantedFirmwareCheck=Optional.empty currentFirmwareCheck=Optional.empty minMainMemoryAvailableGb=0.0 minDiskAvailableGb=0.0 fastDisk=false bandwidth=0.0 ipAddresses=[] additionalIpAddresses=[] hardwareFailureDescription=Optional.empty reports=com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeReports@1f parentHostname=Optional.empty }
);
-> at com.yahoo.vespa.hosted.node.admin.integrationTests.DockerTester.<init>(DockerTester.java:90)

nodeRepoMock.getNodes("host.test.yahoo.com");
-> at com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.adjustNodeAgentsToRunFromNodeRepository(NodeAdminStateUpdater.java:166)

nodeRepoMock.updateNodeRepositoryNode(
    NodeSpec { hostname=host1.test.yahoo.com wantedDockerImage=Optional[image1] currentDockerImage=Optional.empty state=active nodeType=tenant flavor=docker canonicalFlavor=null wantedVespaVersion=Optional.empty vespaVersion=Optional.empty wantedOsVersion=Optional.empty currentOsVersion=Optional.empty allowedToBeDown=Optional.empty wantToDeprovision=Optional.empty owner=Optional.empty membership=Optional.empty minCpuCores=2.0 wantedRestartGeneration=Optional[1] currentRestartGeneration=Optional[1] wantedRebootGeneration=0 currentRebootGeneration=0 wantedFirmwareCheck=Optional.empty currentFirmwareCheck=Optional.empty minMainMemoryAvailableGb=4.0 minDiskAvailableGb=1.0 fastDisk=false bandwidth=0.0 ipAddresses=[] additionalIpAddresses=[] hardwareFailureDescription=Optional.empty reports=com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeReports@1f parentHostname=Optional[host.test.yahoo.com] }
);
-> at com.yahoo.vespa.hosted.node.admin.integrationTests.DockerTester.addChildNodeRepositoryNode(DockerTester.java:126)

nodeRepoMock.getAcls("host.test.yahoo.com");
-> at com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.lambda$new$0(NodeAdminStateUpdater.java:73)

nodeRepoMock.getNode("host.test.yahoo.com");
-> at com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.converge(NodeAdminStateUpdater.java:128)

nodeRepoMock.getOptionalNode(
    "host.test.yahoo.com"
);
-> at com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeRepository.getNode(NodeRepository.java:18)

orchestrator.resume("host.test.yahoo.com");
-> at com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater.converge(NodeAdminStateUpdater.java:131)


	at com.yahoo.vespa.hosted.node.admin.integrationTests.MultiDockerTest.addAndWaitForNode(MultiDockerTest.java:62)
	at com.yahoo.vespa.hosted.node.admin.integrationTests.MultiDockerTest.test(MultiDockerTest.java:24)
```