### PR TITLE
Fix bug in lid space compaction where partial updates to attributes w…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/documentbucketmover/documentbucketmover_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentbucketmover/documentbucketmover_test.cpp
@@ -191,7 +191,7 @@ MySubDb::MySubDb(const std::shared_ptr<const DocumentTypeRepo> &repo, std::share
       _metaStore(*_metaStoreSP),
       _realRetriever(std::make_shared<MyDocumentRetriever>(repo)),
       _retriever(_realRetriever),
-      _subDb(_metaStoreSP, _retriever, subDbId), _docs(),
+      _subDb("my_sub_db", subDbId, _metaStoreSP, _retriever, IFeedView::SP()), _docs(),
       _bucketDBHandler(*bucketDB)
 {
     _bucketDBHandler.addDocumentMetaStore(_metaStoreSP.get(), 0);
@@ -238,7 +238,11 @@ struct MoveFixture
     void setupForBucket(const BucketId &bucket,
                         uint32_t sourceSubDbId,
                         uint32_t targetSubDbId) {
-        _source._subDb._subDbId = sourceSubDbId;
+        _source._subDb = MaintenanceDocumentSubDB(_source._subDb.name(),
+                                                  sourceSubDbId,
+                                                  _source._subDb.meta_store(),
+                                                  _source._subDb.retriever(),
+                                                  _source._subDb.feed_view());
         _mover.setupForBucket(bucket, &_source._subDb, targetSubDbId, _handler, _bucketDb);
     }
     void moveDocuments(size_t maxDocsToMove) {

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -523,9 +523,10 @@ MyDocumentSubDB::getSubDB()
 {
     IDocumentRetriever::SP retriever(new MyDocumentRetriever(*this));
 
-    return MaintenanceDocumentSubDB(_metaStoreSP,
+    return MaintenanceDocumentSubDB("my_sub_db", _subDBId,
+                                    _metaStoreSP,
                                     retriever,
-                                    _subDBId);
+                                    IFeedView::SP());
 }
 
 

--- a/searchcore/src/vespa/searchcore/proton/server/bucketmovejob.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/bucketmovejob.cpp
@@ -88,9 +88,9 @@ BucketMoveJob::checkBucket(const BucketId &bucket,
     const MaintenanceDocumentSubDB &source(wantReady ? _notReady : _ready);
     const MaintenanceDocumentSubDB &target(wantReady ? _ready : _notReady);
     LOG(debug, "checkBucket(): mover.setupForBucket(%s, source:%u, target:%u)",
-        bucket.toString().c_str(), source._subDbId, target._subDbId);
-    mover.setupForBucket(bucket, &source, target._subDbId,
-                         _moveHandler, _ready._metaStore->getBucketDB());
+        bucket.toString().c_str(), source.sub_db_id(), target.sub_db_id());
+    mover.setupForBucket(bucket, &source, target.sub_db_id(),
+                         _moveHandler, _ready.meta_store()->getBucketDB());
 }
 
 BucketMoveJob::ScanResult
@@ -98,7 +98,7 @@ BucketMoveJob::scanBuckets(size_t maxBucketsToScan, IFrozenBucketHandler::Exclus
 {
     size_t bucketsScanned = 0;
     bool passDone = false;
-    ScanIterator itr(_ready._metaStore->getBucketDB().takeGuard(),
+    ScanIterator itr(_ready.meta_store()->getBucketDB().takeGuard(),
             _scanPass, _scanPos._lastBucket, _endPos._lastBucket);
     BucketId bucket;
     for (; itr.valid() &&
@@ -250,7 +250,7 @@ BucketMoveJob::deactivateBucket(BucketId bucket)
 void
 BucketMoveJob::activateBucket(BucketId bucket)
 {
-    BucketDBOwner::Guard notReadyBdb(_notReady._metaStore->getBucketDB().takeGuard());
+    BucketDBOwner::Guard notReadyBdb(_notReady.meta_store()->getBucketDB().takeGuard());
     if (notReadyBdb->get(bucket).getDocumentCount() == 0) {
         return; // notready bucket already empty. This is the normal case.
     }
@@ -291,7 +291,7 @@ BucketMoveJob::scanAndMove(size_t maxBucketsToScan,
     while (!_delayedBuckets.empty() && _delayedMover.bucketDone()) {
         const BucketId bucket = *_delayedBuckets.begin();
         _delayedBuckets.erase(_delayedBuckets.begin());
-        ScanIterator itr(_ready._metaStore->getBucketDB().takeGuard(), bucket);
+        ScanIterator itr(_ready.meta_store()->getBucketDB().takeGuard(), bucket);
         if (itr.getBucket() == bucket) {
             checkBucket(bucket, itr, _delayedMover, bucketGuard);
         }

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -207,7 +207,6 @@ DocumentDB::DocumentDB(const vespalib::string &baseDir,
     // Forward changes of cluster state to bucket handler
     _clusterStateHandler.addClusterStateChangedHandler(&_bucketHandler);
 
-    // Lid space compaction handlers are added in the same order as sub dbs are defined in DocumentSubDbCollection.
     _lidSpaceCompactionHandlers.push_back(std::make_unique<LidSpaceCompactionHandler>(_maintenanceController.getReadySubDB(), _docTypeName.getName()));
     _lidSpaceCompactionHandlers.push_back(std::make_unique<LidSpaceCompactionHandler>(_maintenanceController.getRemSubDB(), _docTypeName.getName()));
     _lidSpaceCompactionHandlers.push_back(std::make_unique<LidSpaceCompactionHandler>(_maintenanceController.getNotReadySubDB(), _docTypeName.getName()));

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
@@ -139,18 +139,21 @@ wrapRetriever(const IDocumentRetriever::SP &retriever, ICommitable &commit)
 
 void DocumentSubDBCollection::maintenanceSync(MaintenanceController &mc, ICommitable &commit) {
     RetrieversSP retrievers = getRetrievers();
-    MaintenanceDocumentSubDB readySubDB(
-            getReadySubDB()->getDocumentMetaStoreContext().getSP(),
-            wrapRetriever((*retrievers)[_readySubDbId], commit),
-            _readySubDbId);
-    MaintenanceDocumentSubDB remSubDB(
-            getRemSubDB()->getDocumentMetaStoreContext().getSP(),
-            (*retrievers)[_remSubDbId],
-            _remSubDbId);
-    MaintenanceDocumentSubDB notReadySubDB(
-            getNotReadySubDB()->getDocumentMetaStoreContext().getSP(),
-            wrapRetriever((*retrievers)[_notReadySubDbId], commit),
-            _notReadySubDbId);
+    MaintenanceDocumentSubDB readySubDB(getReadySubDB()->getName(),
+                                        _readySubDbId,
+                                        getReadySubDB()->getDocumentMetaStoreContext().getSP(),
+                                        wrapRetriever((*retrievers)[_readySubDbId], commit),
+                                        getReadySubDB()->getFeedView());
+    MaintenanceDocumentSubDB remSubDB(getRemSubDB()->getName(),
+                                      _remSubDbId,
+                                      getRemSubDB()->getDocumentMetaStoreContext().getSP(),
+                                      (*retrievers)[_remSubDbId],
+                                      getRemSubDB()->getFeedView());
+    MaintenanceDocumentSubDB notReadySubDB(getNotReadySubDB()->getName(),
+                                           _notReadySubDbId,
+                                           getNotReadySubDB()->getDocumentMetaStoreContext().getSP(),
+                                           wrapRetriever((*retrievers)[_notReadySubDbId], commit),
+                                           getNotReadySubDB()->getFeedView());
     mc.syncSubDBs(readySubDB, remSubDB, notReadySubDB);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "i_lid_space_compaction_handler.h"
-#include "idocumentsubdb.h"
+#include "maintenancedocumentsubdb.h"
 
 namespace proton {
 
@@ -12,18 +12,18 @@ namespace proton {
 class LidSpaceCompactionHandler : public ILidSpaceCompactionHandler
 {
 private:
-    IDocumentSubDB  &_subDb;
+    const MaintenanceDocumentSubDB& _subDb;
     vespalib::string _docTypeName;
 
 public:
-    LidSpaceCompactionHandler(IDocumentSubDB &subDb,
-                              const vespalib::string &docTypeName);
+    LidSpaceCompactionHandler(const MaintenanceDocumentSubDB& subDb,
+                              const vespalib::string& docTypeName);
 
     // Implements ILidSpaceCompactionHandler
     virtual vespalib::string getName() const override {
-        return _docTypeName + "." + _subDb.getName();
+        return _docTypeName + "." + _subDb.name();
     }
-    virtual uint32_t getSubDbId() const override { return _subDb.getSubDbId(); }
+    virtual uint32_t getSubDbId() const override { return _subDb.sub_db_id(); }
     virtual search::LidUsageStats getLidStatus() const override;
     virtual IDocumentScanIterator::UP getIterator() const override;
     virtual MoveOperation::UP createMoveOperation(const search::DocumentMetaData &document, uint32_t moveToLid) const override;

--- a/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.cpp
@@ -111,8 +111,8 @@ MaintenanceJobsInjector::injectJobs(MaintenanceController &controller,
         controller.registerJobInMasterThread(MUP(new DocumentDBCommitJob(commit, config.getVisibilityDelay())));
     }
     const MaintenanceDocumentSubDB &mRemSubDB(controller.getRemSubDB());
-    MUP pruneRDjob(new PruneRemovedDocumentsJob(config.getPruneRemovedDocumentsConfig(), *mRemSubDB._metaStore,
-                                                mRemSubDB._subDbId, docTypeName, prdHandler, fbHandler));
+    MUP pruneRDjob(new PruneRemovedDocumentsJob(config.getPruneRemovedDocumentsConfig(), *mRemSubDB.meta_store(),
+                                                mRemSubDB.sub_db_id(), docTypeName, prdHandler, fbHandler));
     controller.registerJobInMasterThread(
             trackJob(jobTrackers.getRemovedDocumentsPrune(), std::move(pruneRDjob)));
     if (!config.getLidSpaceCompactionConfig().isDisabled()) {

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancedocumentsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancedocumentsubdb.cpp
@@ -5,26 +5,37 @@
 namespace proton {
 
 MaintenanceDocumentSubDB::MaintenanceDocumentSubDB()
-    : _metaStore(),
-      _retriever(),
-      _subDbId(0u)
-{ }
+    : _name(""),
+      _sub_db_id(0),
+      _meta_store(nullptr),
+      _retriever(nullptr),
+      _feed_view(nullptr)
+{
+}
 
-MaintenanceDocumentSubDB::~MaintenanceDocumentSubDB() { }
+MaintenanceDocumentSubDB::~MaintenanceDocumentSubDB() = default;
 
-MaintenanceDocumentSubDB::MaintenanceDocumentSubDB(const IDocumentMetaStore::SP & metaStore,
-                                                   const IDocumentRetriever::SP & retriever,
-                                                   uint32_t subDbId)
-    : _metaStore(metaStore),
-      _retriever(retriever),
-      _subDbId(subDbId)
-{ }
+MaintenanceDocumentSubDB::MaintenanceDocumentSubDB(const vespalib::string& name,
+                                                   uint32_t sub_db_id,
+                                                   IDocumentMetaStore::SP meta_store,
+                                                   IDocumentRetriever::SP retriever,
+                                                   IFeedView::SP feed_view)
+    : _name(name),
+      _sub_db_id(sub_db_id),
+      _meta_store(std::move(meta_store)),
+      _retriever(std::move(retriever)),
+      _feed_view(std::move(feed_view))
+{
+}
 
 void
-MaintenanceDocumentSubDB::clear() {
-    _metaStore.reset();
+MaintenanceDocumentSubDB::clear()
+{
+    _name = "";
+    _sub_db_id = 0;
+    _meta_store.reset();
     _retriever.reset();
-    _subDbId = 0u;
-} 
+    _feed_view.reset();
+}
 
-} // namespace proton
+}

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancedocumentsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancedocumentsubdb.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "ifeedview.h"
 #include <vespa/searchcore/proton/documentmetastore/i_document_meta_store.h>
 #include <vespa/searchcore/proton/persistenceengine/i_document_retriever.h>
 
@@ -13,19 +14,30 @@ namespace proton {
  */
 class MaintenanceDocumentSubDB
 {
-public:
-    IDocumentMetaStore::SP   _metaStore;
-    IDocumentRetriever::SP   _retriever;
-    uint32_t                 _subDbId;
+private:
+    vespalib::string       _name;
+    uint32_t               _sub_db_id;
+    IDocumentMetaStore::SP _meta_store;
+    IDocumentRetriever::SP _retriever;
+    IFeedView::SP          _feed_view;
 
+public:
     MaintenanceDocumentSubDB();
     ~MaintenanceDocumentSubDB();
 
-    MaintenanceDocumentSubDB(const IDocumentMetaStore::SP & metaStore,
-                             const IDocumentRetriever::SP & retriever,
-                             uint32_t subDbId);
+    MaintenanceDocumentSubDB(const vespalib::string& name,
+                             uint32_t sub_db_id,
+                             IDocumentMetaStore::SP meta_store,
+                             IDocumentRetriever::SP retriever,
+                             IFeedView::SP feed_view);
 
-    bool valid() const { return bool(_metaStore); }
+    const vespalib::string& name() const { return _name; }
+    uint32_t sub_db_id() const { return _sub_db_id; }
+    const IDocumentMetaStore::SP& meta_store() const { return _meta_store; }
+    const IDocumentRetriever::SP& retriever() const { return _retriever; }
+    const IFeedView::SP& feed_view() const { return _feed_view; }
+
+    bool valid() const { return _meta_store.get() != nullptr; }
 
     void clear();
 };


### PR DESCRIPTION
…ere lost when moving a document.

Instead of using the document store directly (when reading the document to move) the document retriever must be used.
The document retriever patches in attribute values and also correctly waits for the thread writing to the document store.

The job moving documents between the "ready" and "not ready" sub databases was already doing this correctly.

@baldersheim and @toregge please review