### PR TITLE
Default target version v2

### DIFF
--- a/config-provisioning/abi-spec.json
+++ b/config-provisioning/abi-spec.json
@@ -502,7 +502,7 @@
     ],
     "methods": [
       "public abstract java.util.Optional getDeployment(com.yahoo.config.provision.ApplicationId)",
-      "public abstract java.util.List getSupportedInfraApplications()"
+      "public abstract java.util.Map getSupportedInfraDeployments()"
     ],
     "fields": []
   },

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/InfraDeployer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/InfraDeployer.java
@@ -1,7 +1,7 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -17,6 +17,6 @@ public interface InfraDeployer {
      */
     Optional<Deployment> getDeployment(ApplicationId application);
 
-    /** Returns list of infrastructure applications supported in this zone */
-    List<ApplicationId> getSupportedInfraApplications();
+    /** Returns deployments by application id for the supported infrastructure applications in this zone */
+    Map<ApplicationId, Deployment> getSupportedInfraDeployments();
 }

--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -49,9 +49,6 @@ loadBalancerAddress string default=""
 athenzDnsSuffix string default=""
 ztsUrl string default=""
 
-# Node admin
-nodeAdminInContainer bool default=false
-
 # Maintainers
 maintainerIntervalMinutes int default=30
 # TODO: Default set to a high value (1 year) => maintainer will not run, change when maintainer verified out in prod

--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -64,3 +64,4 @@ sleepTimeWhenRedeployingFails long default=30
 buildMinimalSetOfConfigModels bool default=true
 throwIfBootstrappingTenantRepoFails bool default=true
 canReturnEmptySentinelConfig bool default=false
+serverNodeType enum {config, controller} default=config

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -35,12 +35,6 @@ import static com.yahoo.vespa.flags.FetchVector.Dimension.NODE_TYPE;
 public class Flags {
     private static volatile TreeMap<FlagId, FlagDefinition> flags = new TreeMap<>();
 
-    public static final UnboundBooleanFlag MONITOR_TENANT_HOST_HEALTH = defineFeatureFlag(
-            "monitor-tenant-hosts-health", false,
-            "Whether service monitor will monitor /state/v1/health of the host admins on the tenant hosts.",
-            "Flag is read when config server starts",
-            HOSTNAME);
-
     public static final UnboundIntFlag DROP_CACHES = defineIntFlag("drop-caches", 3,
             "The int value to write into /proc/sys/vm/drop_caches for each tick. " +
             "1 is page cache, 2 is dentries inodes, 3 is both page cache and dentries inodes, etc.",

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.InfraDeployer;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -28,13 +27,13 @@ public class InfrastructureProvisioner extends Maintainer {
 
     @Override
     protected void maintain() {
-        for (ApplicationId application : infraDeployer.getSupportedInfraApplications()) {
+        infraDeployer.getSupportedInfraDeployments().forEach((application, deployment) -> {
             try {
-                infraDeployer.getDeployment(application).orElseThrow().activate();
+                deployment.activate();
             } catch (RuntimeException e) {
                 logger.log(LogLevel.INFO, "Failed to activate " + application, e);
                 // loop around to activate the next application
             }
-        }
+        });
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
-import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.HostLivenessTracker;
@@ -68,13 +67,11 @@ public class NodeFailer extends Maintainer {
     private final Instant constructionTime;
     private final ThrottlePolicy throttlePolicy;
     private final Metric metric;
-    private final ConfigserverConfig configserverConfig;
 
     public NodeFailer(Deployer deployer, HostLivenessTracker hostLivenessTracker,
                       ServiceMonitor serviceMonitor, NodeRepository nodeRepository,
                       Duration downTimeLimit, Clock clock, Orchestrator orchestrator,
-                      ThrottlePolicy throttlePolicy, Metric metric,
-                      ConfigserverConfig configserverConfig) {
+                      ThrottlePolicy throttlePolicy, Metric metric) {
         // check ping status every five minutes, but at least twice as often as the down time limit
         super(nodeRepository, min(downTimeLimit.dividedBy(2), Duration.ofMinutes(5)));
         this.deployer = deployer;
@@ -86,7 +83,6 @@ public class NodeFailer extends Maintainer {
         this.constructionTime = clock.instant();
         this.throttlePolicy = throttlePolicy;
         this.metric = metric;
-        this.configserverConfig = configserverConfig;
     }
 
     @Override
@@ -244,7 +240,7 @@ public class NodeFailer extends Maintainer {
     }
 
     private boolean expectConfigRequests(Node node) {
-        return !node.type().isDockerHost() || configserverConfig.nodeAdminInContainer();
+        return !node.type().isDockerHost();
     }
 
     private boolean hasNodeRequestedConfigAfter(Node node, Instant instant) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.google.inject.Inject;
-import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Environment;
@@ -59,21 +58,19 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
     public NodeRepositoryMaintenance(NodeRepository nodeRepository, Deployer deployer, InfraDeployer infraDeployer,
                                      HostLivenessTracker hostLivenessTracker, ServiceMonitor serviceMonitor,
                                      Zone zone, Orchestrator orchestrator, Metric metric,
-                                     ConfigserverConfig configserverConfig,
                                      ProvisionServiceProvider provisionServiceProvider,
                                      FlagSource flagSource) {
         this(nodeRepository, deployer, infraDeployer, hostLivenessTracker, serviceMonitor, zone, Clock.systemUTC(),
-                orchestrator, metric, configserverConfig, provisionServiceProvider, flagSource);
+                orchestrator, metric, provisionServiceProvider, flagSource);
     }
 
     public NodeRepositoryMaintenance(NodeRepository nodeRepository, Deployer deployer, InfraDeployer infraDeployer,
                                      HostLivenessTracker hostLivenessTracker, ServiceMonitor serviceMonitor,
                                      Zone zone, Clock clock, Orchestrator orchestrator, Metric metric,
-                                     ConfigserverConfig configserverConfig,
                                      ProvisionServiceProvider provisionServiceProvider, FlagSource flagSource) {
         DefaultTimes defaults = new DefaultTimes(zone);
 
-        nodeFailer = new NodeFailer(deployer, hostLivenessTracker, serviceMonitor, nodeRepository, durationFromEnv("fail_grace").orElse(defaults.failGrace), clock, orchestrator, throttlePolicyFromEnv().orElse(defaults.throttlePolicy), metric, configserverConfig);
+        nodeFailer = new NodeFailer(deployer, hostLivenessTracker, serviceMonitor, nodeRepository, durationFromEnv("fail_grace").orElse(defaults.failGrace), clock, orchestrator, throttlePolicyFromEnv().orElse(defaults.throttlePolicy), metric);
         periodicApplicationMaintainer = new PeriodicApplicationMaintainer(deployer, nodeRepository, defaults.redeployMaintainerInterval, durationFromEnv("periodic_redeploy_interval").orElse(defaults.periodicRedeployInterval));
         operatorChangeApplicationMaintainer = new OperatorChangeApplicationMaintainer(deployer, nodeRepository, clock, durationFromEnv("operator_change_redeploy_interval").orElse(defaults.operatorChangeRedeployInterval));
         reservationExpirer = new ReservationExpirer(nodeRepository, clock, durationFromEnv("reservation_expiry").orElse(defaults.reservationExpiry));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
@@ -81,13 +81,6 @@ public class InfraDeployerImpl implements InfraDeployer {
             try (Mutex lock = nodeRepository.lock(application.getApplicationId())) {
                 NodeType nodeType = application.getCapacity().type();
 
-                Optional<Version> targetVersion = infrastructureVersions.getTargetVersionFor(nodeType);
-                if (targetVersion.isEmpty()) {
-                    logger.log(LogLevel.DEBUG, "No target version set for " + nodeType + ", removing application");
-                    removeApplication(application.getApplicationId());
-                    return;
-                }
-
                 candidateNodes = nodeRepository
                         .getNodes(nodeType, Node.State.ready, Node.State.reserved, Node.State.active, Node.State.inactive);
                 if (candidateNodes.isEmpty()) {
@@ -96,10 +89,11 @@ public class InfraDeployerImpl implements InfraDeployer {
                     return;
                 }
 
-                if (!allActiveNodesOn(targetVersion.get(), candidateNodes)) {
+                Version targetVersion = infrastructureVersions.getTargetVersionFor(nodeType);
+                if (!allActiveNodesOn(targetVersion, candidateNodes)) {
                     hostSpecs = provisioner.prepare(
                             application.getApplicationId(),
-                            application.getClusterSpecWithVersion(targetVersion.get()),
+                            application.getClusterSpecWithVersion(targetVersion),
                             application.getCapacity(),
                             1, // groups
                             logger::log);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDuperModel.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDuperModel.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -27,6 +28,11 @@ public class MockDuperModel implements DuperModelInfraApi {
     @Override
     public List<InfraApplicationApi> getSupportedInfraApplications() {
         return new ArrayList<>(supportedInfraApps.values());
+    }
+
+    @Override
+    public Optional<InfraApplicationApi> getInfraApplication(ApplicationId applicationId) {
+        return Optional.ofNullable(supportedInfraApps.get(applicationId));
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockInfraDeployer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockInfraDeployer.java
@@ -4,7 +4,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.InfraDeployer;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class MockInfraDeployer implements InfraDeployer {
@@ -14,7 +14,7 @@ public class MockInfraDeployer implements InfraDeployer {
     }
 
     @Override
-    public List<ApplicationId> getSupportedInfraApplications() {
-        return List.of();
+    public Map<ApplicationId, Deployment> getSupportedInfraDeployments() {
+        return Map.of();
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureVersionsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureVersionsTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -19,9 +18,10 @@ import static org.junit.Assert.fail;
  */
 public class InfrastructureVersionsTest {
 
+    private final Version defaultVersion = Version.fromString("6.13.37");
     private final NodeRepositoryTester tester = new NodeRepositoryTester();
     private final InfrastructureVersions infrastructureVersions =
-            new InfrastructureVersions(tester.nodeRepository().database());
+            new InfrastructureVersions(tester.nodeRepository().database(), defaultVersion);
 
     private final Version version = Version.fromString("6.123.456");
 
@@ -29,14 +29,14 @@ public class InfrastructureVersionsTest {
     public void can_only_downgrade_with_force() {
         assertTrue(infrastructureVersions.getTargetVersions().isEmpty());
 
-        assertEquals(Optional.empty(), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(defaultVersion, infrastructureVersions.getTargetVersionFor(NodeType.config));
         infrastructureVersions.setTargetVersion(NodeType.config, version, false);
-        assertEquals(Optional.of(version), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(version, infrastructureVersions.getTargetVersionFor(NodeType.config));
 
         // Upgrading to new version without force is fine
-        Version new_version = Version.fromString("6.123.457"); // version + 1
-        infrastructureVersions.setTargetVersion(NodeType.config, new_version, false);
-        assertEquals(Optional.of(new_version), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        Version newVersion = Version.fromString("6.123.457"); // version + 1
+        infrastructureVersions.setTargetVersion(NodeType.config, newVersion, false);
+        assertEquals(newVersion, infrastructureVersions.getTargetVersionFor(NodeType.config));
 
         // Downgrading to old version without force fails
         try {
@@ -45,7 +45,7 @@ public class InfrastructureVersionsTest {
         } catch (IllegalArgumentException ignored) { }
 
         infrastructureVersions.setTargetVersion(NodeType.config, version, true);
-        assertEquals(Optional.of(version), infrastructureVersions.getTargetVersionFor(NodeType.config));
+        assertEquals(version, infrastructureVersions.getTargetVersionFor(NodeType.config));
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
-import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
@@ -78,13 +77,8 @@ public class NodeFailTester {
     private final Orchestrator orchestrator;
     private final NodeRepositoryProvisioner provisioner;
     private final Curator curator;
-    private final ConfigserverConfig configserverConfig;
 
     private NodeFailTester() {
-        this(new ConfigserverConfig(new ConfigserverConfig.Builder()));
-    }
-
-    private NodeFailTester(ConfigserverConfig configserverConfig) {
         clock = new ManualClock();
         curator = new MockCurator();
         nodeRepository = new NodeRepository(nodeFlavors, curator, clock, zone, new MockNameResolver().mockAnyLookup(),
@@ -92,15 +86,10 @@ public class NodeFailTester {
         provisioner = new NodeRepositoryProvisioner(nodeRepository, nodeFlavors, zone, new MockProvisionServiceProvider(), new InMemoryFlagSource());
         hostLivenessTracker = new TestHostLivenessTracker(clock);
         orchestrator = new OrchestratorMock();
-        this.configserverConfig = configserverConfig;
     }
 
     public static NodeFailTester withTwoApplications() {
-        return withTwoApplications(new ConfigserverConfig(new ConfigserverConfig.Builder()));
-    }
-
-    public static NodeFailTester withTwoApplications(ConfigserverConfig configserverConfig) {
-        NodeFailTester tester = new NodeFailTester(configserverConfig);
+        NodeFailTester tester = new NodeFailTester();
         
         tester.createReadyNodes(16, nodeResources);
         tester.createHostNodes(3);
@@ -209,7 +198,7 @@ public class NodeFailTester {
     }
 
     public NodeFailer createFailer() {
-        return new NodeFailer(deployer, hostLivenessTracker, serviceMonitor, nodeRepository, downtimeLimitOneHour, clock, orchestrator, NodeFailer.ThrottlePolicy.hosted, metric, configserverConfig);
+        return new NodeFailer(deployer, hostLivenessTracker, serviceMonitor, nodeRepository, downtimeLimitOneHour, clock, orchestrator, NodeFailer.ThrottlePolicy.hosted, metric);
     }
 
     public void allNodesMakeAConfigRequestExcept(Node ... deadNodeArray) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
@@ -1,8 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
-import com.yahoo.cloud.config.ConfigserverConfig;
-import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.applicationmodel.ServiceInstance;
@@ -337,34 +335,8 @@ public class NodeFailerTest {
     }
 
     @Test
-    public void docker_host_failed_without_config_requests() {
-        NodeFailTester tester = NodeFailTester.withTwoApplications(
-                new ConfigserverConfig(new ConfigserverConfig.Builder().nodeAdminInContainer(true))
-        );
-
-        // For a day all nodes work so nothing happens
-        for (int minutes = 0, interval = 30; minutes < 24 * 60; minutes += interval) {
-            tester.clock.advance(Duration.ofMinutes(interval));
-            tester.allNodesMakeAConfigRequestExcept();
-            tester.failer.run();
-            assertEquals( 3, tester.nodeRepository.getNodes(NodeType.host, Node.State.ready).size());
-            assertEquals( 0, tester.nodeRepository.getNodes(NodeType.host, Node.State.failed).size());
-        }
-
-
-        // Two ready nodes and a ready docker node die, but only 2 of those are failed out
-        tester.clock.advance(Duration.ofMinutes(180));
-        Node dockerHost = tester.nodeRepository.getNodes(NodeType.host, Node.State.ready).iterator().next();
-        tester.allNodesMakeAConfigRequestExcept(dockerHost);
-        tester.failer.run();
-        assertEquals( 2, tester.nodeRepository.getNodes(NodeType.host, Node.State.ready).size());
-        assertEquals( 1, tester.nodeRepository.getNodes(NodeType.host, Node.State.failed).size());
-    }
-
-    @Test
-    public void not_failed_without_config_requests_if_node_admin_on_host() {
-        NodeFailTester tester = NodeFailTester.withTwoApplications(
-                new ConfigserverConfig(new ConfigserverConfig.Builder().nodeAdminInContainer(false)));
+    public void docker_host_not_failed_without_config_requests() {
+        NodeFailTester tester = NodeFailTester.withTwoApplications();
 
         // For a day all nodes work so nothing happens
         for (int minutes = 0, interval = 30; minutes < 24 * 60; minutes += interval) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImplTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImplTest.java
@@ -68,7 +68,7 @@ public class InfraDeployerImplTest {
     private final NodeType nodeType;
 
     public InfraDeployerImplTest(InfraApplicationApi application) {
-        when(duperModelInfraApi.getSupportedInfraApplications()).thenReturn(List.of(application));
+        when(duperModelInfraApi.getInfraApplication(eq(application.getApplicationId()))).thenReturn(Optional.of(application));
         this.application = application;
         this.nodeType = application.getCapacity().type();
         this.infraDeployer = new InfraDeployerImpl(nodeRepository, provisioner, duperModelInfraApi);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImplTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImplTest.java
@@ -75,15 +75,6 @@ public class InfraDeployerImplTest {
     }
 
     @Test
-    public void remove_application_if_without_target_version() {
-        addNode(1, Node.State.active, Optional.of(target));
-        when(duperModelInfraApi.infraApplicationIsActive(eq(application.getApplicationId()))).thenReturn(true);
-        infraDeployer.getDeployment(application.getApplicationId()).orElseThrow().activate();
-        verify(duperModelInfraApi).infraApplicationRemoved(application.getApplicationId());
-        verifyRemoved(1);
-    }
-
-    @Test
     public void remove_application_if_without_nodes() {
         remove_application_without_nodes(true);
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -658,7 +658,7 @@ public class RestApiTest {
                                    Utf8.toBytes("{\"version\": \"6.123.456\"}"),
                                    Request.Method.PATCH),
                        400,
-                       "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cannot set version for type tenant\"}");
+                       "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Target version for type tenant is not allowed\"}");
 
         // Omitting version field fails
         assertResponse(new Request("http://localhost:8080/nodes/v2/upgrade/confighost",

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -92,6 +93,11 @@ public class DuperModelManager implements DuperModelInfraApi {
     @Override
     public List<InfraApplicationApi> getSupportedInfraApplications() {
         return new ArrayList<>(supportedInfraApplications.values());
+    }
+
+    @Override
+    public Optional<InfraApplicationApi> getInfraApplication(ApplicationId applicationId) {
+        return Optional.ofNullable(supportedInfraApplications.get(applicationId));
     }
 
     /**

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
@@ -9,7 +9,6 @@ import com.yahoo.config.model.api.SuperModelListener;
 import com.yahoo.config.model.api.SuperModelProvider;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.service.monitor.DuperModelInfraApi;
 import com.yahoo.vespa.service.monitor.InfraApplicationApi;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -28,39 +26,41 @@ import java.util.stream.Stream;
  * @author hakonhall
  */
 public class DuperModelManager implements DuperModelInfraApi {
-    private static Logger logger = Logger.getLogger(DuperModelManager.class.getName());
 
     // Infrastructure applications
-    private final ConfigServerHostApplication configServerHostApplication = new ConfigServerHostApplication();
-    private final ProxyHostApplication proxyHostApplication = new ProxyHostApplication();
-    private final ControllerApplication controllerApplication = new ControllerApplication();
-    private final ControllerHostApplication controllerHostApplication = new ControllerHostApplication();
-    private final ConfigServerApplication configServerApplication = new ConfigServerApplication();
+    static final ControllerHostApplication controllerHostApplication = new ControllerHostApplication();
+    static final ControllerApplication controllerApplication = new ControllerApplication();
+    static final ConfigServerHostApplication configServerHostApplication = new ConfigServerHostApplication();
+    static final ConfigServerApplication configServerApplication = new ConfigServerApplication();
+    static final ProxyHostApplication proxyHostApplication = new ProxyHostApplication();
 
-    private final Map<ApplicationId, InfraApplication> supportedInfraApplications = Stream.of(
-            configServerApplication,
-            configServerHostApplication,
-            proxyHostApplication,
-            controllerApplication,
-            controllerHostApplication)
-            .collect(Collectors.toMap(InfraApplication::getApplicationId, Function.identity()));
-
-    private final boolean multitenant;
+    private final Map<ApplicationId, InfraApplication> supportedInfraApplications;
 
     private final Object monitor = new Object();
     private final DuperModel duperModel;
     // The set of active infrastructure ApplicationInfo. Not all are necessarily in the DuperModel for historical reasons.
-    private final Set<ApplicationId> activeInfraInfos = new HashSet<>(2 * supportedInfraApplications.size());
+    private final Set<ApplicationId> activeInfraInfos = new HashSet<>(10);
 
     @Inject
     public DuperModelManager(ConfigserverConfig configServerConfig, FlagSource flagSource, SuperModelProvider superModelProvider) {
-        this(configServerConfig.multitenant(), superModelProvider, new DuperModel());
+        this(configServerConfig.multitenant(),
+                configServerConfig.serverNodeType() == ConfigserverConfig.ServerNodeType.Enum.controller,
+                superModelProvider, new DuperModel(), flagSource);
     }
 
     /** For testing */
-    public DuperModelManager(boolean multitenant, SuperModelProvider superModelProvider, DuperModel duperModel) {
-        this.multitenant = multitenant;
+    DuperModelManager(boolean multitenant, boolean isController, SuperModelProvider superModelProvider, DuperModel duperModel, FlagSource flagSource) {
         this.duperModel = duperModel;
+
+        if (multitenant) {
+            supportedInfraApplications =
+                    (isController ?
+                            Stream.of(controllerHostApplication, controllerApplication) :
+                            Stream.of(configServerHostApplication, configServerApplication, proxyHostApplication)
+                    ).collect(Collectors.toUnmodifiableMap(InfraApplication::getApplicationId, Function.identity()));
+        } else {
+            supportedInfraApplications = Map.of();
+        }
 
         superModelProvider.registerListener(new SuperModelListener() {
             @Override
@@ -87,26 +87,6 @@ public class DuperModelManager implements DuperModelInfraApi {
         synchronized (monitor) {
             duperModel.registerListener(listener);
         }
-    }
-
-    public ConfigServerApplication getConfigServerApplication() {
-        return configServerApplication;
-    }
-
-    public ConfigServerHostApplication getConfigServerHostApplication() {
-        return configServerHostApplication;
-    }
-
-    public ProxyHostApplication getProxyHostApplication() {
-        return proxyHostApplication;
-    }
-
-    public ControllerApplication getControllerApplication() {
-        return controllerApplication;
-    }
-
-    public ControllerHostApplication getControllerHostApplication() {
-        return controllerHostApplication;
     }
 
     @Override
@@ -140,50 +120,25 @@ public class DuperModelManager implements DuperModelInfraApi {
 
         synchronized (monitor) {
             activeInfraInfos.add(applicationId);
-            if (infraApplicationBelongsInDuperModel(applicationId)) {
-                duperModel.add(application.makeApplicationInfo(hostnames));
-            }
+            duperModel.add(application.makeApplicationInfo(hostnames));
         }
     }
 
     @Override
     public void infraApplicationRemoved(ApplicationId applicationId) {
+        if (!supportedInfraApplications.containsKey(applicationId)) {
+            throw new IllegalArgumentException("There is no infrastructure application with ID '" + applicationId + "'");
+        }
+
         synchronized (monitor) {
             activeInfraInfos.remove(applicationId);
-            if (infraApplicationBelongsInDuperModel(applicationId)) {
-                duperModel.remove(applicationId);
-            }
+            duperModel.remove(applicationId);
         }
     }
 
     public List<ApplicationInfo> getApplicationInfos() {
         synchronized (monitor) {
             return duperModel.getApplicationInfos();
-        }
-    }
-
-    private boolean infraApplicationBelongsInDuperModel(ApplicationId applicationId) {
-        // At most 1 of the config server and controller applications can be in the duper model.
-        // The problem of allowing more than 1 is that orchestration will fail since hostname -> application lookup
-        // will not be unique.
-        if (applicationId.equals(controllerApplication.getApplicationId())) {
-            if (!multitenant) return false;
-            if (duperModel.contains(configServerApplication.getApplicationId())) {
-                logger.log(LogLevel.ERROR, "Refusing to add controller application to duper model " +
-                        "since it already contains config server");
-                return false;
-            }
-            return true;
-        } else if (applicationId.equals(configServerApplication.getApplicationId())) {
-            if (!multitenant) return false;
-            if (duperModel.contains(controllerApplication.getApplicationId())) {
-                logger.log(LogLevel.ERROR, "Refusing to add config server application to duper model " +
-                        "since it already contains controller");
-                return false;
-            }
-            return true;
-        } else {
-            return true;
         }
     }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
@@ -9,8 +9,6 @@ import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.applicationmodel.ServiceType;
-import com.yahoo.vespa.flags.FlagSource;
-import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.service.duper.DuperModelManager;
 import com.yahoo.vespa.service.duper.ZoneApplication;
 import com.yahoo.vespa.service.executor.RunletExecutorImpl;
@@ -54,34 +52,26 @@ public class HealthMonitorManager implements MonitorManager, HealthMonitorApi {
 
     private final ConcurrentHashMap<ApplicationId, ApplicationHealthMonitor> healthMonitors = new ConcurrentHashMap<>();
     private final DuperModelManager duperModel;
-    private final boolean monitorTenantHostHealth;
     private final ApplicationHealthMonitorFactory applicationHealthMonitorFactory;
 
     @Inject
-    public HealthMonitorManager(DuperModelManager duperModel, FlagSource flagSource) {
-        this(duperModel, Flags.MONITOR_TENANT_HOST_HEALTH.bindTo(flagSource).value());
-    }
-
-    private HealthMonitorManager(DuperModelManager duperModel, boolean monitorTenantHostHealth) {
-        this(duperModel, monitorTenantHostHealth,
+    public HealthMonitorManager(DuperModelManager duperModel) {
+        this(duperModel,
                 new StateV1HealthModel(
                         TARGET_HEALTH_STALENESS,
                         HEALTH_REQUEST_TIMEOUT,
                         KEEP_ALIVE,
-                        new RunletExecutorImpl(THREAD_POOL_SIZE),
-                        monitorTenantHostHealth));
+                        new RunletExecutorImpl(THREAD_POOL_SIZE)));
     }
 
-    private HealthMonitorManager(DuperModelManager duperModel, boolean monitorTenantHostHealth, StateV1HealthModel healthModel) {
-        this(duperModel, monitorTenantHostHealth, id -> new ApplicationHealthMonitor(id, healthModel));
+    private HealthMonitorManager(DuperModelManager duperModel, StateV1HealthModel healthModel) {
+        this(duperModel, id -> new ApplicationHealthMonitor(id, healthModel));
     }
 
     /** Default access due to testing. */
     HealthMonitorManager(DuperModelManager duperModel,
-                         boolean monitorTenantHostHealth,
                          ApplicationHealthMonitorFactory applicationHealthMonitorFactory) {
         this.duperModel = duperModel;
-        this.monitorTenantHostHealth = monitorTenantHostHealth;
         this.applicationHealthMonitorFactory = applicationHealthMonitorFactory;
     }
 
@@ -109,17 +99,11 @@ public class HealthMonitorManager implements MonitorManager, HealthMonitorApi {
                                        ConfigId configId) {
         ApplicationHealthMonitor monitor = healthMonitors.get(applicationId);
 
-        if (!monitorTenantHostHealth && ZoneApplication.isNodeAdminService(applicationId, clusterId, serviceType)) {
-            // Legacy: The zone app is not health monitored (monitor == null), but the node-admin cluster's services
-            // are hard-coded to be UP
-            return new ServiceStatusInfo(ServiceStatus.UP);
-        }
-
         if (monitor == null) {
             return new ServiceStatusInfo(ServiceStatus.NOT_CHECKED);
         }
 
-        if (monitorTenantHostHealth && applicationId.equals(ZoneApplication.getApplicationId())) {
+        if (applicationId.equals(ZoneApplication.getApplicationId())) {
             // New: The zone app is health monitored (monitor != null), possibly even the routing cluster
             // which is a normal jdisc container (unnecessary but harmless), but the node-admin cluster
             // are tenant Docker hosts running host admin that are monitored via /state/v1/health.
@@ -134,15 +118,7 @@ public class HealthMonitorManager implements MonitorManager, HealthMonitorApi {
     }
 
     private boolean wouldMonitor(ApplicationId id) {
-        if (duperModel.isSupportedInfraApplication(id)) {
-            return true;
-        }
-
-        if (monitorTenantHostHealth && id.equals(ZoneApplication.getApplicationId())) {
-            return true;
-        }
-
-        return false;
+        return duperModel.isSupportedInfraApplication(id) || id.equals(ZoneApplication.getApplicationId());
     }
 
     @Override
@@ -154,7 +130,7 @@ public class HealthMonitorManager implements MonitorManager, HealthMonitorApi {
     public Map<ServiceId, ServiceStatusInfo> getServices(ApplicationId applicationId) {
         ApplicationHealthMonitor applicationHealthMonitor = healthMonitors.get(applicationId);
         if (applicationHealthMonitor == null) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         return applicationHealthMonitor.getAllServiceStatuses();

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/StateV1HealthModel.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/StateV1HealthModel.java
@@ -33,18 +33,15 @@ public class StateV1HealthModel implements AutoCloseable {
     private final Duration requestTimeout;
     private final Duration connectionKeepAlive;
     private final RunletExecutor executor;
-    private final boolean monitorTenantHostHealth;
 
     StateV1HealthModel(Duration targetHealthStaleness,
                        Duration requestTimeout,
                        Duration connectionKeepAlive,
-                       RunletExecutor executor,
-                       boolean monitorTenantHostHealth) {
+                       RunletExecutor executor) {
         this.targetHealthStaleness = targetHealthStaleness;
         this.requestTimeout = requestTimeout;
         this.connectionKeepAlive = connectionKeepAlive;
         this.executor = executor;
-        this.monitorTenantHostHealth = monitorTenantHostHealth;
     }
 
     Map<ServiceId, HealthEndpoint> extractHealthEndpoints(ApplicationInfo application) {
@@ -57,7 +54,7 @@ public class StateV1HealthModel implements AutoCloseable {
             for (ServiceInfo serviceInfo : hostInfo.getServices()) {
 
                 boolean isNodeAdmin = false;
-                if (monitorTenantHostHealth && isZoneApplication) {
+                if (isZoneApplication) {
                     if (ZoneApplication.isNodeAdminServiceInfo(application.getApplicationId(), serviceInfo)) {
                         isNodeAdmin = true;
                     } else {

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelInfraApi.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelInfraApi.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The DuperModel's API for infrastructure applications.
@@ -14,6 +15,9 @@ import java.util.List;
 public interface DuperModelInfraApi {
     /** Returns the list of supported infrastructure applications. */
     List<InfraApplicationApi> getSupportedInfraApplications();
+
+    /** Returns a supported infrastructure with the given application id or empty if not found */
+    Optional<InfraApplicationApi> getInfraApplication(ApplicationId applicationId);
 
     /** Returns true if the DuperModel has registered the infrastructure application as active. */
     boolean infraApplicationIsActive(ApplicationId applicationId);

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/HealthMonitorManagerTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/HealthMonitorManagerTest.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
-import com.yahoo.vespa.service.duper.ConfigServerApplication;
 import com.yahoo.vespa.service.duper.ControllerHostApplication;
 import com.yahoo.vespa.service.duper.DuperModelManager;
 import com.yahoo.vespa.service.duper.InfraApplication;
@@ -14,6 +13,7 @@ import com.yahoo.vespa.service.duper.ProxyHostApplication;
 import com.yahoo.vespa.service.duper.TestZoneApplication;
 import com.yahoo.vespa.service.duper.ZoneApplication;
 import com.yahoo.vespa.service.monitor.ConfigserverUtil;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
@@ -29,21 +29,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HealthMonitorManagerTest {
-    private final ConfigServerApplication configServerApplication = new ConfigServerApplication();
     private final DuperModelManager duperModel = mock(DuperModelManager.class);
     private final ApplicationHealthMonitor monitor = mock(ApplicationHealthMonitor.class);
     private final ApplicationHealthMonitorFactory monitorFactory = mock(ApplicationHealthMonitorFactory.class);
-    private HealthMonitorManager manager;
-
-    public void setUp(boolean monitorTenantHostHealth) {
-        manager = new HealthMonitorManager(duperModel, monitorTenantHostHealth, monitorFactory);
-        when(duperModel.getConfigServerApplication()).thenReturn(configServerApplication);
-        when(monitorFactory.create(any())).thenReturn(monitor);
-    }
+    private final HealthMonitorManager manager = new HealthMonitorManager(duperModel, monitorFactory);
 
     @Test
     public void addAndRemove() {
-        setUp(false);
         ApplicationInfo applicationInfo = ConfigserverUtil.makeExampleConfigServer();
         when(duperModel.isSupportedInfraApplication(applicationInfo.getApplicationId())).thenReturn(true);
 
@@ -57,29 +49,7 @@ public class HealthMonitorManagerTest {
     }
 
     @Test
-    public void withHostAdmin() {
-        setUp(false);
-        ServiceStatus status = manager.getStatus(
-                ZoneApplication.getApplicationId(),
-                ZoneApplication.getNodeAdminClusterId(),
-                ZoneApplication.getNodeAdminServiceType(),
-                new ConfigId("config-id-1")).serviceStatus();
-        assertEquals(ServiceStatus.UP, status);
-    }
-
-    @Test
-    public void verifyZoneApplicationIsNotMonitoredByDefault() {
-        verifyZoneApplicationIsMonitored(false, false);
-    }
-
-    @Test
     public void verifyZoneApplicationIsMonitored() {
-        verifyZoneApplicationIsMonitored(true, true);
-    }
-
-    private void verifyZoneApplicationIsMonitored(boolean monitorTenantHostHealth, boolean isMonitored) {
-        setUp(monitorTenantHostHealth);
-
         ApplicationInfo zoneApplicationInfo = new TestZoneApplication.Builder()
                 .addNodeAdminCluster("h1", "h2")
                 .addRoutingCluster("r1")
@@ -89,18 +59,13 @@ public class HealthMonitorManagerTest {
         verify(monitorFactory, times(0)).create(zoneApplicationInfo.getApplicationId());
         verify(monitor, times(0)).monitor(any());
         manager.applicationActivated(zoneApplicationInfo);
-        verify(monitorFactory, times(isMonitored ? 1 : 0)).create(zoneApplicationInfo.getApplicationId());
-        verify(monitor, times(isMonitored ? 1 : 0)).monitor(any());
+        verify(monitorFactory).create(zoneApplicationInfo.getApplicationId());
+        verify(monitor).monitor(any());
 
         when(monitor.getStatus(any(), any(), any(), any())).thenReturn(new ServiceStatusInfo(ServiceStatus.DOWN));
         verifyNodeAdminGetStatus(0);
-        if (isMonitored) {
-            assertEquals(ServiceStatus.DOWN, getNodeAdminStatus());
-            verifyNodeAdminGetStatus(1);
-        } else {
-            assertEquals(ServiceStatus.UP, getNodeAdminStatus());
-            verifyNodeAdminGetStatus(0);
-        }
+        assertEquals(ServiceStatus.DOWN, getNodeAdminStatus());
+        verifyNodeAdminGetStatus(1);
 
         verifyRoutingGetStatus(0);
         assertEquals(ServiceStatus.NOT_CHECKED, getRoutingStatus());
@@ -141,7 +106,6 @@ public class HealthMonitorManagerTest {
 
     @Test
     public void infrastructureApplication() {
-        setUp(false);
         ProxyHostApplication proxyHostApplication = new ProxyHostApplication();
         when(duperModel.isSupportedInfraApplication(proxyHostApplication.getApplicationId())).thenReturn(true);
         List<HostName> hostnames = Stream.of("proxyhost1", "proxyhost2").map(HostName::from).collect(Collectors.toList());
@@ -160,8 +124,12 @@ public class HealthMonitorManagerTest {
 
     @Test
     public void threadPoolSize() {
-        setUp(false);
         assertEquals(9, HealthMonitorManager.THREAD_POOL_SIZE);
+    }
+
+    @Before
+    public void setup() {
+        when(monitorFactory.create(any())).thenReturn(monitor);
     }
 
     private void assertStatus(ServiceStatus expected, int verifyTimes, InfraApplication infraApplication, String hostname) {

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthModelTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/health/StateV1HealthModelTest.java
@@ -43,14 +43,11 @@ public class StateV1HealthModelTest {
     private final List<HostName> hostnames = Stream.of("host1", "host2").map(HostName::from).collect(Collectors.toList());
     private final ApplicationInfo proxyHostApplicationInfo = proxyHostApplication.makeApplicationInfo(hostnames);
 
-    private StateV1HealthModel model;
-    private Map<ServiceId, HealthEndpoint> endpoints;
+    private final StateV1HealthModel model = new StateV1HealthModel(healthStaleness, requestTimeout, keepAlive, executor);
 
     @Test
     public void test() {
-        model = new StateV1HealthModel(healthStaleness, requestTimeout, keepAlive, executor, false);
-        endpoints = model.extractHealthEndpoints(proxyHostApplicationInfo);
-
+        Map<ServiceId, HealthEndpoint> endpoints = model.extractHealthEndpoints(proxyHostApplicationInfo);
         assertEquals(2, endpoints.size());
 
         ApplicationId applicationId = ApplicationId.from("hosted-vespa", "proxy-host", "default");
@@ -75,14 +72,13 @@ public class StateV1HealthModelTest {
 
     @Test
     public void testMonitoringTenantHostHealth() {
-        model = new StateV1HealthModel(healthStaleness, requestTimeout, keepAlive, executor, true);
         ApplicationInfo zoneApplicationInfo = new TestZoneApplication.Builder()
                 .addNodeAdminCluster("h1")
                 .addRoutingCluster("r1")
                 .build()
                 .makeApplicationInfo();
 
-        endpoints = model.extractHealthEndpoints(zoneApplicationInfo);
+        Map<ServiceId, HealthEndpoint> endpoints = model.extractHealthEndpoints(zoneApplicationInfo);
         assertEquals(1, endpoints.size());
         HealthEndpoint endpoint = endpoints.values().iterator().next();
         assertEquals("http://h1:8080/state/v1/health", endpoint.description());

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/ConfigserverUtil.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/monitor/ConfigserverUtil.java
@@ -15,14 +15,12 @@ import java.util.stream.Stream;
 public class ConfigserverUtil {
     /** Create a ConfigserverConfig with the given settings. */
     public static ConfigserverConfig create(
-            boolean nodeAdminInContainer,
             boolean multitenant,
             String configServerHostname1,
             String configServerHostname2,
             String configServerHostname3) {
         return new ConfigserverConfig(
                 new ConfigserverConfig.Builder()
-                        .nodeAdminInContainer(nodeAdminInContainer)
                         .multitenant(multitenant)
                         .zookeeperserver(new ConfigserverConfig.Zookeeperserver.Builder().hostname(configServerHostname1).port(1))
                         .zookeeperserver(new ConfigserverConfig.Zookeeperserver.Builder().hostname(configServerHostname2).port(2))
@@ -30,7 +28,7 @@ public class ConfigserverUtil {
     }
 
     public static ConfigserverConfig createExampleConfigserverConfig() {
-        return create(false, true, "cfg1", "cfg2", "cfg3");
+        return create(true, "cfg1", "cfg2", "cfg3");
     }
 
     public static ApplicationInfo makeConfigServerApplicationInfo(

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/slobrok/SlobrokMonitorManagerImplTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/slobrok/SlobrokMonitorManagerImplTest.java
@@ -7,7 +7,6 @@ import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceType;
-import com.yahoo.vespa.service.duper.ConfigServerApplication;
 import com.yahoo.vespa.service.duper.DuperModelManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +26,6 @@ public class SlobrokMonitorManagerImplTest {
     @SuppressWarnings("unchecked")
     private final Supplier<SlobrokMonitor> slobrokMonitorFactory = mock(Supplier.class);
 
-    private final ConfigServerApplication configServerApplication = new ConfigServerApplication();
     private final DuperModelManager duperModelManager = mock(DuperModelManager.class);
     private final SlobrokMonitorManagerImpl slobrokMonitorManager =
             new SlobrokMonitorManagerImpl(slobrokMonitorFactory, duperModelManager);
@@ -38,7 +36,6 @@ public class SlobrokMonitorManagerImplTest {
 
     @Before
     public void setup() {
-        when(duperModelManager.getConfigServerApplication()).thenReturn(configServerApplication);
         when(slobrokMonitorFactory.get()).thenReturn(slobrokMonitor);
         when(application.getApplicationId()).thenReturn(applicationId);
     }


### PR DESCRIPTION
Take 2 on #9600, this time with the `DuperModel` as the source of truth. Goes with `vespa/hosted#7835`.