### PR TITLE
Handle tenant-host application in system upgrader 

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -395,7 +395,7 @@ public class ApplicationController {
             deploySystemApplicationPackage(application, zone, version);
         } else {
             // Deploy by calling node repository directly
-            application.nodeTypes().forEach(nodeType -> configServer().nodeRepository().upgrade(zone, nodeType, version));
+            configServer().nodeRepository().upgrade(zone, application.nodeType(), version);
         }
     }
 
@@ -406,7 +406,7 @@ public class ApplicationController {
                     artifactRepository.getSystemApplicationPackage(application.id(), zone, version)
             );
             DeployOptions options = withVersion(version, DeployOptions.none());
-            return deploy(application.id(), applicationPackage, zone, options, Collections.emptySet(), Collections.emptySet());
+            return deploy(application.id(), applicationPackage, zone, options, Set.of(), Set.of());
         } else {
            throw new RuntimeException("This system application does not have an application package: " + application.id().toShortString());
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -24,8 +24,7 @@ public enum SystemApplication {
     proxyHost(ApplicationId.from("hosted-vespa", "proxy-host", "default"), NodeType.proxyhost),
     configServer(ApplicationId.from("hosted-vespa", "zone-config-servers", "default"), NodeType.config),
     tenantHost(ApplicationId.from("hosted-vespa", "tenant-host", "default"), NodeType.host),
-    zone(ApplicationId.from("hosted-vespa", "routing", "default"), NodeType.proxy,
-         configServerHost, proxyHost, configServer);
+    zone(ApplicationId.from("hosted-vespa", "routing", "default"), NodeType.proxy, proxyHost, configServer);
 
     private final ApplicationId id;
     private final NodeType nodeType;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 public enum SystemApplication {
 
     configServerHost(ApplicationId.from("hosted-vespa", "configserver-host", "default"), NodeType.confighost),
-    configServer(ApplicationId.from("hosted-vespa", "proxy-config-servers", "default"), NodeType.config),
+    configServer(ApplicationId.from("hosted-vespa", "zone-config-servers", "default"), NodeType.config),
     proxyHost(ApplicationId.from("hosted-vespa", "proxy-host", "default"), NodeType.proxyhost),
     proxy(ApplicationId.from("hosted-vespa", "routing", "default"), NodeType.proxy, proxyHost, configServer),
     tenantHost(ApplicationId.from("hosted-vespa", "tenant-host", "default"), NodeType.host);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -21,10 +21,10 @@ import java.util.Optional;
 public enum SystemApplication {
 
     configServerHost(ApplicationId.from("hosted-vespa", "configserver-host", "default"), NodeType.confighost),
+    configServer(ApplicationId.from("hosted-vespa", "proxy-config-servers", "default"), NodeType.config),
     proxyHost(ApplicationId.from("hosted-vespa", "proxy-host", "default"), NodeType.proxyhost),
-    configServer(ApplicationId.from("hosted-vespa", "zone-config-servers", "default"), NodeType.config),
-    tenantHost(ApplicationId.from("hosted-vespa", "tenant-host", "default"), NodeType.host),
-    zone(ApplicationId.from("hosted-vespa", "routing", "default"), NodeType.proxy, proxyHost, configServer);
+    proxy(ApplicationId.from("hosted-vespa", "routing", "default"), NodeType.proxy, proxyHost, configServer),
+    tenantHost(ApplicationId.from("hosted-vespa", "tenant-host", "default"), NodeType.host);
 
     private final ApplicationId id;
     private final NodeType nodeType;
@@ -50,7 +50,7 @@ public enum SystemApplication {
 
     /** Returns whether this system application has an application package */
     public boolean hasApplicationPackage() {
-        return this == zone;
+        return this == proxy;
     }
 
     /** Returns whether config for this application has converged in given zone */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
@@ -66,9 +66,12 @@ public abstract class InfrastructureUpgrader extends Maintainer {
         boolean converged = true;
         for (SystemApplication application : applications) {
             if (convergedOn(target, application.dependencies(), zone)) {
-                upgrade(target, application, zone);
+                boolean currentAppConverged = convergedOn(target, application, zone);
+                if (!currentAppConverged) {
+                    upgrade(target, application, zone);
+                }
+                converged &= currentAppConverged;
             }
-            converged &= convergedOn(target, application, zone);
         }
         return converged;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -39,12 +39,11 @@ public class OsUpgrader extends InfrastructureUpgrader {
 
     @Override
     protected void upgrade(Version target, SystemApplication application, ZoneId zone) {
-        if (wantedVersion(zone, application, target).equals(target)) {
+        if (!application.isEligibleForOsUpgrades() || wantedVersion(zone, application, target).equals(target)) {
             return;
         }
         log.info(String.format("Upgrading OS of %s to version %s in %s", application.id(), target, zone));
-        application.nodeTypesWithUpgradableOs().forEach(nodeType -> controller().configServer().nodeRepository()
-                                                                                .upgradeOs(zone, nodeType, target));
+        controller().configServer().nodeRepository().upgradeOs(zone, application.nodeType(), target);
     }
 
     @Override
@@ -77,7 +76,7 @@ public class OsUpgrader extends InfrastructureUpgrader {
     /** Returns whether node in application should be upgraded by this */
     public static boolean eligibleForUpgrade(Node node, SystemApplication application) {
         return upgradableNodeStates.contains(node.state()) &&
-               application.nodeTypesWithUpgradableOs().contains(node.type());
+               application.isEligibleForOsUpgrades();
     }
 
     private static String name(CloudName cloud) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -40,9 +40,12 @@ public class SystemUpgrader extends InfrastructureUpgrader {
 
     @Override
     protected boolean convergedOn(Version target, SystemApplication application, ZoneId zone) {
-        return    minVersion(zone, application, Node::currentVersion).map(target::equals)
-                                                                     .orElse(true)
-               && application.configConvergedIn(zone, controller(), Optional.of(target));
+        Optional<Version> minVersion = minVersion(zone, application, Node::currentVersion);
+        // Skip application convergence check if there are no nodes belonging to the application in the zone
+        if (minVersion.isEmpty()) return true;
+
+        return     minVersion.get().equals(target)
+                && application.configConvergedIn(zone, controller(), Optional.of(target));
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -935,11 +935,11 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         Inspector deployOptions = SlimeUtils.jsonToSlime(dataParts.get("deployOptions")).get();
 
         /*
-         * Special handling of the zone application (the only system application with an application package)
+         * Special handling of the proxy application (the only system application with an application package)
          * Setting any other deployOptions here is not supported for now (e.g. specifying version), but
          * this might be handy later to handle emergency downgrades.
          */
-        boolean isZoneApplication = SystemApplication.zone.id().equals(applicationId);
+        boolean isZoneApplication = SystemApplication.proxy.id().equals(applicationId);
         if (isZoneApplication) { // TODO jvenstad: Separate out.
             // Make it explicit that version is not yet supported here
             String versionStr = deployOptions.field("vespaVersion").asString();
@@ -957,7 +957,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
                 throw new IllegalArgumentException("Deployment of system applications is not permitted until system version is determined");
             }
             ActivateResult result = controller.applications()
-                    .deploySystemApplicationPackage(SystemApplication.zone, zone, systemVersion.get().versionNumber());
+                    .deploySystemApplicationPackage(SystemApplication.proxy, zone, systemVersion.get().versionNumber());
             return new SlimeJsonResponse(toSlime(result));
         }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -67,8 +67,8 @@ public class OsVersionStatus {
         controller.osVersions().forEach(osVersion -> versions.put(osVersion, new ArrayList<>()));
 
         for (SystemApplication application : SystemApplication.all()) {
-            if (application.nodeTypesWithUpgradableOs().isEmpty()) {
-                continue; // Avoid querying applications that do not contain nodes with upgradable OS
+            if (!application.isEligibleForOsUpgrades()) {
+                continue; // Avoid querying applications that are not eligible for OS upgrades
             }
             for (ZoneId zone : zonesToUpgrade(controller)) {
                 controller.configServer().nodeRepository().list(zone, application.id()).stream()

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -60,17 +59,15 @@ public class OsUpgraderTest {
 
         // Bootstrap system
         tester.configServer().bootstrap(List.of(zone1, zone2, zone3, zone4, zone5),
-                                        singletonList(SystemApplication.zone),
-                                        Optional.of(NodeType.host));
+                                        List.of(SystemApplication.tenantHost));
 
         // Add system applications that exist in a real system, but are currently not upgraded
         tester.configServer().addNodes(List.of(zone1, zone2, zone3, zone4, zone5),
-                                       Collections.singletonList(SystemApplication.configServer),
-                                       Optional.empty());
+                                       List.of(SystemApplication.configServer));
 
         // Fail a few nodes. Failed nodes should not affect versions
-        failNodeIn(zone1, SystemApplication.zone);
-        failNodeIn(zone3, SystemApplication.zone);
+        failNodeIn(zone1, SystemApplication.tenantHost);
+        failNodeIn(zone3, SystemApplication.tenantHost);
 
         // New OS version released
         Version version1 = Version.fromString("7.1");
@@ -82,13 +79,13 @@ public class OsUpgraderTest {
 
         // zone 1: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.zone, zone1);
+        assertWanted(version1, SystemApplication.tenantHost, zone1);
 
         // Other zones remain on previous version (none)
         assertWanted(Version.emptyVersion, SystemApplication.zone, zone2, zone3, zone4);
 
         // zone 1: completes upgrade
-        completeUpgrade(version1, SystemApplication.zone, zone1);
+        completeUpgrade(version1, SystemApplication.tenantHost, zone1);
         statusUpdater.maintain();
         assertEquals(2, nodesOn(version1).size());
         assertEquals(11, nodesOn(Version.emptyVersion).size());
@@ -98,21 +95,21 @@ public class OsUpgraderTest {
         assertWanted(version1, SystemApplication.zone, zone2, zone3);
 
         // zone 4: still on previous version
-        assertWanted(Version.emptyVersion, SystemApplication.zone, zone4);
+        assertWanted(Version.emptyVersion, SystemApplication.tenantHost, zone4);
 
         // zone 2 and 3: completes upgrade
-        completeUpgrade(version1, SystemApplication.zone, zone2, zone3);
+        completeUpgrade(version1, SystemApplication.tenantHost, zone2, zone3);
 
         // zone 4: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.zone, zone4);
+        assertWanted(version1, SystemApplication.tenantHost, zone4);
 
         // zone 4: completes upgrade
-        completeUpgrade(version1, SystemApplication.zone, zone4);
+        completeUpgrade(version1, SystemApplication.tenantHost, zone4);
 
         // Next run does nothing as all zones are upgraded
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.zone, zone1, zone2, zone3, zone4);
+        assertWanted(version1, SystemApplication.tenantHost, zone1, zone2, zone3, zone4);
         statusUpdater.maintain();
         assertTrue("All nodes on target version", tester.controller().osVersionStatus().nodesIn(cloud).stream()
                                                         .allMatch(node -> node.version().equals(version1)));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -82,7 +82,7 @@ public class OsUpgraderTest {
         assertWanted(version1, SystemApplication.tenantHost, zone1);
 
         // Other zones remain on previous version (none)
-        assertWanted(Version.emptyVersion, SystemApplication.zone, zone2, zone3, zone4);
+        assertWanted(Version.emptyVersion, SystemApplication.proxy, zone2, zone3, zone4);
 
         // zone 1: completes upgrade
         completeUpgrade(version1, SystemApplication.tenantHost, zone1);
@@ -92,7 +92,7 @@ public class OsUpgraderTest {
 
         // zone 2 and 3: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.zone, zone2, zone3);
+        assertWanted(version1, SystemApplication.proxy, zone2, zone3);
 
         // zone 4: still on previous version
         assertWanted(Version.emptyVersion, SystemApplication.tenantHost, zone4);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
@@ -50,14 +50,14 @@ public class SystemUpgraderTest {
         Version version1 = Version.fromString("6.5");
         // Bootstrap a system without host applications
         tester.configServer().bootstrap(List.of(zone1, zone2, zone3, zone4), SystemApplication.configServer,
-                                        SystemApplication.zone);
+                                        SystemApplication.proxy);
         // Fail a few nodes. Failed nodes should not affect versions
         failNodeIn(zone1, SystemApplication.configServer);
-        failNodeIn(zone3, SystemApplication.zone);
+        failNodeIn(zone3, SystemApplication.proxy);
         tester.upgradeSystem(version1);
         systemUpgrader.maintain();
         assertCurrentVersion(SystemApplication.configServer, version1, zone1, zone2, zone3, zone4);
-        assertCurrentVersion(SystemApplication.zone, version1, zone1, zone2, zone3, zone4);
+        assertCurrentVersion(SystemApplication.proxy, version1, zone1, zone2, zone3, zone4);
 
         // Controller upgrades
         Version version2 = Version.fromString("6.6");
@@ -70,72 +70,72 @@ public class SystemUpgraderTest {
         // Other zones remain on previous version
         assertWantedVersion(SystemApplication.configServer, version1, zone2, zone3, zone4);
         // Zone application is not upgraded yet
-        assertWantedVersion(SystemApplication.zone, version1, zone1, zone2, zone3, zone4);
+        assertWantedVersion(SystemApplication.proxy, version1, zone1, zone2, zone3, zone4);
 
         // zone1: zone-config-server upgrades
         completeUpgrade(SystemApplication.configServer, version2, zone1);
 
-        // zone 1: zone-application upgrades
+        // zone 1: proxy-application upgrades
         systemUpgrader.maintain();
-        assertWantedVersion(SystemApplication.zone, version2, zone1);
-        completeUpgrade(SystemApplication.zone, version2, zone1);
-        assertTrue("Deployed zone application",
-                   tester.configServer().application(SystemApplication.zone.id()).isPresent());
+        assertWantedVersion(SystemApplication.proxy, version2, zone1);
+        completeUpgrade(SystemApplication.proxy, version2, zone1);
+        assertTrue("Deployed proxy application",
+                   tester.configServer().application(SystemApplication.proxy.id()).isPresent());
 
         // zone 2, 3 and 4: still targets old version
         assertWantedVersion(SystemApplication.configServer, version1, zone2, zone3, zone4);
-        assertWantedVersion(SystemApplication.zone, version1, zone2, zone3, zone4);
+        assertWantedVersion(SystemApplication.proxy, version1, zone2, zone3, zone4);
 
         // zone 2 and 3: upgrade does not start until zone 1 zone-application config converges
         systemUpgrader.maintain();
         assertWantedVersion(SystemApplication.configServer, version1, zone2, zone3);
-        convergeServices(SystemApplication.zone, zone1);
+        convergeServices(SystemApplication.proxy, zone1);
 
         // zone 2 and 3: zone-config-server upgrades, first in zone 2, then in zone 3
         systemUpgrader.maintain();
         assertWantedVersion(SystemApplication.configServer, version2, zone2, zone3);
         assertWantedVersion(SystemApplication.configServer, version1, zone4);
-        assertWantedVersion(SystemApplication.zone, version1, zone2, zone3, zone4);
+        assertWantedVersion(SystemApplication.proxy, version1, zone2, zone3, zone4);
         completeUpgrade(SystemApplication.configServer, version2, zone2);
 
         // zone-application starts upgrading in zone 2, while zone-config-server completes upgrade in zone 3
         systemUpgrader.maintain();
-        assertWantedVersion(SystemApplication.zone, version2, zone2);
-        assertWantedVersion(SystemApplication.zone, version1, zone3);
+        assertWantedVersion(SystemApplication.proxy, version2, zone2);
+        assertWantedVersion(SystemApplication.proxy, version1, zone3);
         completeUpgrade(SystemApplication.configServer, version2, zone3);
 
-        // zone 2 and 3: zone-application upgrades in parallel
+        // zone 2 and 3: proxy-application upgrades in parallel
         systemUpgrader.maintain();
-        assertWantedVersion(SystemApplication.zone, version2, zone2, zone3);
-        completeUpgrade(SystemApplication.zone, version2, zone2, zone3);
-        convergeServices(SystemApplication.zone, zone2, zone3);
+        assertWantedVersion(SystemApplication.proxy, version2, zone2, zone3);
+        completeUpgrade(SystemApplication.proxy, version2, zone2, zone3);
+        convergeServices(SystemApplication.proxy, zone2, zone3);
 
         // zone 4: zone-config-server upgrades
         systemUpgrader.maintain();
         assertWantedVersion(SystemApplication.configServer, version2, zone4);
-        assertWantedVersion(SystemApplication.zone, version1, zone4);
+        assertWantedVersion(SystemApplication.proxy, version1, zone4);
         completeUpgrade(SystemApplication.configServer, version2, zone4);
 
         // System version remains unchanged until final application upgrades
         tester.computeVersionStatus();
         assertSystemVersion(version1);
 
-        // zone 4: zone-application upgrades
+        // zone 4: proxy-application upgrades
         systemUpgrader.maintain();
-        assertWantedVersion(SystemApplication.zone, version2, zone4);
-        completeUpgrade(SystemApplication.zone, version2, zone4);
+        assertWantedVersion(SystemApplication.proxy, version2, zone4);
+        completeUpgrade(SystemApplication.proxy, version2, zone4);
 
         // zone 4: System version remains unchanged until config converges
         tester.computeVersionStatus();
         assertSystemVersion(version1);
-        convergeServices(SystemApplication.zone, zone4);
+        convergeServices(SystemApplication.proxy, zone4);
         tester.computeVersionStatus();
         assertSystemVersion(version2);
 
         // Next run does nothing as system is now upgraded
         systemUpgrader.maintain();
         assertWantedVersion(SystemApplication.configServer, version2, zone1, zone2, zone3, zone4);
-        assertWantedVersion(SystemApplication.zone, version2, zone1, zone2, zone3, zone4);
+        assertWantedVersion(SystemApplication.proxy, version2, zone1, zone2, zone3, zone4);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class SystemUpgraderTest {
 
         // Bootstrap system
         tester.configServer().bootstrap(Collections.singletonList(zone1), SystemApplication.configServer,
-                                        SystemApplication.zone);
+                                        SystemApplication.proxy);
         Version version1 = Version.fromString("6.5");
         tester.upgradeSystem(version1);
 
@@ -156,9 +156,9 @@ public class SystemUpgraderTest {
         systemUpgrader.maintain();
         completeUpgrade(SystemApplication.configServer, version2, zone1);
         systemUpgrader.maintain();
-        completeUpgrade(SystemApplication.zone, version2, zone1);
+        completeUpgrade(SystemApplication.proxy, version2, zone1);
         tester.computeVersionStatus();
-        assertSystemVersion(version1); // Unchanged until zone-application converges
+        assertSystemVersion(version1); // Unchanged until proxy-application converges
 
         // Controller upgrades again
         Version version3 = Version.fromString("6.7");
@@ -166,8 +166,8 @@ public class SystemUpgraderTest {
         assertSystemVersion(version1);
         assertControllerVersion(version3);
 
-        // zone 1: zone-application converges and system version changes
-        convergeServices(SystemApplication.zone, zone1);
+        // zone 1: proxy-application converges and system version changes
+        convergeServices(SystemApplication.proxy, zone1);
         tester.computeVersionStatus();
         assertSystemVersion(version2);
         assertControllerVersion(version3);
@@ -201,23 +201,23 @@ public class SystemUpgraderTest {
                                                         SystemApplication.tenantHost);
         completeUpgrade(allExceptZone, version2, zone1);
         systemUpgrader.maintain();
-        completeUpgrade(SystemApplication.zone, version2, zone1);
-        convergeServices(SystemApplication.zone, zone1);
+        completeUpgrade(SystemApplication.proxy, version2, zone1);
+        convergeServices(SystemApplication.proxy, zone1);
         assertWantedVersion(SystemApplication.all(), version1, zone2, zone3, zone4);
 
         // zone 2 and 3:
         systemUpgrader.maintain();
         completeUpgrade(allExceptZone, version2, zone2, zone3);
         systemUpgrader.maintain();
-        completeUpgrade(SystemApplication.zone, version2, zone2, zone3);
-        convergeServices(SystemApplication.zone, zone2, zone3);
+        completeUpgrade(SystemApplication.proxy, version2, zone2, zone3);
+        convergeServices(SystemApplication.proxy, zone2, zone3);
         assertWantedVersion(SystemApplication.all(), version1, zone4);
 
         // zone 4:
         systemUpgrader.maintain();
         completeUpgrade(allExceptZone, version2, zone4);
         systemUpgrader.maintain();
-        completeUpgrade(SystemApplication.zone, version2, zone4);
+        completeUpgrade(SystemApplication.proxy, version2, zone4);
 
         // All done
         systemUpgrader.maintain();
@@ -232,7 +232,7 @@ public class SystemUpgraderTest {
         tester.upgradeSystem(version);
         systemUpgrader.maintain();
         assertWantedVersion(SystemApplication.configServer, version, zone1);
-        assertWantedVersion(SystemApplication.zone, version, zone1);
+        assertWantedVersion(SystemApplication.proxy, version, zone1);
 
         // Controller is downgraded
         tester.upgradeController(Version.fromString("6.4"));
@@ -240,7 +240,7 @@ public class SystemUpgraderTest {
         // Wanted version for zone remains unchanged
         systemUpgrader.maintain();
         assertWantedVersion(SystemApplication.configServer, version, zone1);
-        assertWantedVersion(SystemApplication.zone, version, zone1);
+        assertWantedVersion(SystemApplication.proxy, version, zone1);
     }
 
     @Test
@@ -252,10 +252,10 @@ public class SystemUpgraderTest {
         tester.upgradeSystem(version1);
         systemUpgrader.maintain();
         assertCurrentVersion(List.of(SystemApplication.configServerHost, SystemApplication.proxyHost,
-                                     SystemApplication.configServer, SystemApplication.zone),
+                                     SystemApplication.configServer, SystemApplication.proxy),
                              version1, zone1);
         assertCurrentVersion(List.of(SystemApplication.configServerHost, SystemApplication.proxyHost,
-                                     SystemApplication.configServer, SystemApplication.zone),
+                                     SystemApplication.configServer, SystemApplication.proxy),
                              version1, zone2);
 
         // System starts upgrading to next version
@@ -266,15 +266,15 @@ public class SystemUpgraderTest {
         systemUpgrader.maintain();
         completeUpgrade(SystemApplication.configServer, version2, zone1);
         systemUpgrader.maintain();
-        completeUpgrade(SystemApplication.zone, version2, zone1);
-        convergeServices(SystemApplication.zone, zone1);
+        completeUpgrade(SystemApplication.proxy, version2, zone1);
+        convergeServices(SystemApplication.proxy, zone1);
 
         // Confidence is reduced to broken and next zone is not scheduled for upgrade
         tester.upgrader().overrideConfidence(version2, VespaVersion.Confidence.broken);
         tester.computeVersionStatus();
         systemUpgrader.maintain();
         assertWantedVersion(List.of(SystemApplication.configServerHost, SystemApplication.proxyHost,
-                                    SystemApplication.configServer, SystemApplication.zone), version1, zone2);
+                                    SystemApplication.configServer, SystemApplication.proxy), version1, zone2);
     }
 
     /** Simulate upgrade of nodes allocated to given application. In a real system this is done by the node itself */

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -184,7 +183,7 @@ public class SystemUpgraderTest {
         );
 
         Version version1 = Version.fromString("6.5");
-        tester.configServer().bootstrap(List.of(zone1, zone2, zone3, zone4), SystemApplication.all(), Optional.empty());
+        tester.configServer().bootstrap(List.of(zone1, zone2, zone3, zone4), SystemApplication.all());
         tester.upgradeSystem(version1);
         systemUpgrader.maintain();
         assertCurrentVersion(SystemApplication.all(), version1, zone1, zone2, zone3, zone4);
@@ -198,7 +197,8 @@ public class SystemUpgraderTest {
         systemUpgrader.maintain();
         List<SystemApplication> allExceptZone = List.of(SystemApplication.configServerHost,
                                                         SystemApplication.configServer,
-                                                        SystemApplication.proxyHost);
+                                                        SystemApplication.proxyHost,
+                                                        SystemApplication.tenantHost);
         completeUpgrade(allExceptZone, version2, zone1);
         systemUpgrader.maintain();
         completeUpgrade(SystemApplication.zone, version2, zone1);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
@@ -6,6 +6,11 @@
       "cloud": "cloud1",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "us-east-3"
@@ -18,7 +23,7 @@
         {
           "hostname": "node-1-configserver-host",
           "environment": "prod",
-          "region": "us-east-3"
+          "region": "us-west-1"
         },
         {
           "hostname": "node-3-configserver-host",
@@ -31,17 +36,7 @@
           "region": "us-west-1"
         },
         {
-          "hostname": "node-1-configserver-host",
-          "environment": "prod",
-          "region": "us-west-1"
-        },
-        {
           "hostname": "node-2-proxy-host",
-          "environment": "prod",
-          "region": "us-east-3"
-        },
-        {
-          "hostname": "node-1-proxy-host",
           "environment": "prod",
           "region": "us-east-3"
         },
@@ -51,7 +46,17 @@
           "region": "us-east-3"
         },
         {
+          "hostname": "node-1-proxy-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
           "hostname": "node-2-proxy-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "us-west-1"
         },
@@ -61,7 +66,32 @@
           "region": "us-west-1"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-3-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "us-west-1"
         }
@@ -73,6 +103,11 @@
       "cloud": "cloud2",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "eu-west-1"
@@ -83,12 +118,12 @@
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-1-configserver-host",
+          "hostname": "node-2-proxy-host",
           "environment": "prod",
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-2-proxy-host",
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "eu-west-1"
         },
@@ -98,7 +133,17 @@
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "eu-west-1"
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-initial.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-initial.json
@@ -6,6 +6,11 @@
       "cloud": "cloud1",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "us-east-3"
@@ -18,7 +23,7 @@
         {
           "hostname": "node-1-configserver-host",
           "environment": "prod",
-          "region": "us-east-3"
+          "region": "us-west-1"
         },
         {
           "hostname": "node-3-configserver-host",
@@ -31,17 +36,7 @@
           "region": "us-west-1"
         },
         {
-          "hostname": "node-1-configserver-host",
-          "environment": "prod",
-          "region": "us-west-1"
-        },
-        {
           "hostname": "node-2-proxy-host",
-          "environment": "prod",
-          "region": "us-east-3"
-        },
-        {
-          "hostname": "node-1-proxy-host",
           "environment": "prod",
           "region": "us-east-3"
         },
@@ -51,7 +46,17 @@
           "region": "us-east-3"
         },
         {
+          "hostname": "node-1-proxy-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
           "hostname": "node-2-proxy-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "us-west-1"
         },
@@ -61,7 +66,32 @@
           "region": "us-west-1"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-3-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "us-west-1"
         }
@@ -73,6 +103,11 @@
       "cloud": "cloud2",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "eu-west-1"
@@ -83,12 +118,12 @@
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-1-configserver-host",
+          "hostname": "node-2-proxy-host",
           "environment": "prod",
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-2-proxy-host",
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "eu-west-1"
         },
@@ -98,7 +133,17 @@
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "eu-west-1"
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-partially-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-partially-upgraded.json
@@ -6,6 +6,11 @@
       "cloud": "cloud1",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "us-west-1"
@@ -16,12 +21,12 @@
           "region": "us-west-1"
         },
         {
-          "hostname": "node-1-configserver-host",
+          "hostname": "node-2-proxy-host",
           "environment": "prod",
           "region": "us-west-1"
         },
         {
-          "hostname": "node-2-proxy-host",
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "us-west-1"
         },
@@ -31,7 +36,17 @@
           "region": "us-west-1"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "us-west-1"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "us-west-1"
         }
@@ -43,6 +58,11 @@
       "cloud": "cloud1",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "us-east-3"
@@ -53,12 +73,12 @@
           "region": "us-east-3"
         },
         {
-          "hostname": "node-1-configserver-host",
+          "hostname": "node-2-proxy-host",
           "environment": "prod",
           "region": "us-east-3"
         },
         {
-          "hostname": "node-2-proxy-host",
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "us-east-3"
         },
@@ -68,7 +88,17 @@
           "region": "us-east-3"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "us-east-3"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "us-east-3"
         }
@@ -80,6 +110,11 @@
       "cloud": "cloud2",
       "nodes": [
         {
+          "hostname": "node-1-configserver-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
           "hostname": "node-3-configserver-host",
           "environment": "prod",
           "region": "eu-west-1"
@@ -90,12 +125,12 @@
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-1-configserver-host",
+          "hostname": "node-2-proxy-host",
           "environment": "prod",
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-2-proxy-host",
+          "hostname": "node-3-proxy-host",
           "environment": "prod",
           "region": "eu-west-1"
         },
@@ -105,7 +140,17 @@
           "region": "eu-west-1"
         },
         {
-          "hostname": "node-3-proxy-host",
+          "hostname": "node-2-tenant-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
+          "hostname": "node-1-tenant-host",
+          "environment": "prod",
+          "region": "eu-west-1"
+        },
+        {
+          "hostname": "node-3-tenant-host",
           "environment": "prod",
           "region": "eu-west-1"
         }


### PR DESCRIPTION
This will upgrade the new `tenant-host` application (defined in #9668) from the controller. This is a migration, so for a period controller will either:
1. Upgrade both tenant `host`s & `proxy` by deploying zone-app
2. Upgrade `proxy` by deploying zone-app and upgrade tenant host by setting target version on `host`
3. Upgrade tenant host by setting target version on `host` and not deploy zone-app at all as the zone has no `proxy` nodes.

These cases are handled as follows:
1. Controller will set the target version for `host`, but that has no effect. After all `config` and `proxyhost`s have upgraded, controller will deploy zone-app which will actually update the wanted version both `proxy` and `host`. Once upgraded, controller will be satisfied that both the `proxy` and the `tenantHost` applications have upgraded.
2. After setting the target version, tenant hosts will quickly get their wanted version set and start upgrading. When it deploys the zone-app, only `proxy` nodes will have their wanted version updated.
3. Tenant hosts upgrade as intended through the target version. The zone-app should never be deployed due to the changes in 8b97b04 (If there are no `proxy` nodes in the zone, it is already converged?)

Please verify my reasoning/assumptions, the last one is particularly difficult to test.