### PR TITLE
Add new DB merging API to distributor BucketDatabase 

### DIFF
--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.h
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.h
@@ -39,6 +39,8 @@ public:
     BTreeBucketDatabase();
     ~BTreeBucketDatabase() override;
 
+    void merge(MergingProcessor&) override;
+
     // Ye olde bucket DB API:
     Entry get(const document::BucketId& bucket) const override;
     void remove(const document::BucketId& bucket) override;
@@ -48,7 +50,6 @@ public:
                 std::vector<Entry>& entries) const override;
     void update(const Entry& newEntry) override;
     void forEach(EntryProcessor&, const document::BucketId& after) const override;
-    void forEach(MutableEntryProcessor&, const document::BucketId& after) override;
     Entry upperBound(const document::BucketId& value) const override;
     uint64_t size() const override;
     void clear() override;
@@ -60,11 +61,17 @@ public:
                const std::string& indent) const override;
 
 private:
+    Entry entry_from_value(uint64_t bucket_key, uint64_t value) const;
     Entry entry_from_iterator(const BTree::ConstIterator& iter) const;
+    ConstEntryRef const_entry_ref_from_iterator(const BTree::ConstIterator& iter) const;
     document::BucketId bucket_from_valid_iterator(const BTree::ConstIterator& iter) const;
     void commit_tree_changes();
     BTree::ConstIterator find_parents_internal(const document::BucketId& bucket,
                                                std::vector<Entry>& entries) const;
+
+    friend struct BTreeBuilderMerger;
+    friend struct BTreeMergingBuilder;
+    friend struct BTreeTrailingInserter;
 };
 
 }

--- a/storage/src/vespa/storage/bucketdb/bucketdatabase.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketdatabase.cpp
@@ -4,17 +4,6 @@
 
 namespace storage {
 
-namespace {
-    struct GetNextEntryProcessor : public BucketDatabase::EntryProcessor {
-        BucketDatabase::Entry _entry;
-
-        bool process(const BucketDatabase::Entry& e) override {
-            _entry = e;
-            return false;
-        }
-    };
-}
-
 BucketDatabase::Entry
 BucketDatabase::getNext(const document::BucketId& last) const
 {
@@ -32,7 +21,8 @@ BucketDatabase::createAppropriateBucket(
     return e;
 }
 
-std::ostream& operator<<(std::ostream& o, const BucketDatabase::Entry& e)
+template <typename BucketInfoType>
+std::ostream& operator<<(std::ostream& o, const BucketDatabase::EntryBase<BucketInfoType>& e)
 {
     if (!e.valid()) {
         o << "NONEXISTING";
@@ -42,12 +32,19 @@ std::ostream& operator<<(std::ostream& o, const BucketDatabase::Entry& e)
     return o;
 }
 
+template <typename BucketInfoType>
 std::string
-BucketDatabase::Entry::toString() const
+BucketDatabase::EntryBase<BucketInfoType>::toString() const
 {
     std::ostringstream ost;
     ost << *this;
     return ost.str();
 }
+
+template std::ostream& operator<<(std::ostream& o, const BucketDatabase::Entry& e);
+template std::ostream& operator<<(std::ostream& o, const BucketDatabase::ConstEntryRef& e);
+
+template class BucketDatabase::EntryBase<BucketInfo>;
+template class BucketDatabase::EntryBase<ConstBucketInfoRef>;
 
 }

--- a/storage/src/vespa/storage/bucketdb/bucketdatabase.h
+++ b/storage/src/vespa/storage/bucketdb/bucketdatabase.h
@@ -83,24 +83,69 @@ public:
             EntryProcessor&,
             const document::BucketId& after = document::BucketId()) const = 0;
 
+    /**
+     * Database implementation-specific interface for appending entries
+     * during a merge() operation.
+     */
     struct TrailingInserter {
         virtual ~TrailingInserter() = default;
+        /**
+         * Insert a new database entry at the end of the current bucket space.
+         *
+         * Precondition: the entry's bucket ID must sort after all entries that
+         * have already been iterated over or inserted via insert_at_end().
+         */
         virtual void insert_at_end(const Entry&) = 0;
     };
 
+    /**
+     * Database implementation-specific interface for accessing bucket
+     * entries and prepending entries during a merge() operation.
+     */
     struct Merger {
         virtual ~Merger() = default;
-        // Visibility of changes to this object when MergingProcessor::Result::Update
-        // is _not_ returned is undefined.
+
         // TODO this should ideally be separated into read/write functions, but this
         // will suffice for now to avoid too many changes.
+
+        /**
+         * Bucket key/ID of the currently iterated entry. Unless the information stored
+         * in the DB Entry is needed, using one of these methods should be preferred to
+         * getting the bucket ID via current_entry(). The underlying DB is expected to
+         * have cheap access to the ID but _may_ have expensive access to the entry itself.
+         */
         virtual uint64_t bucket_key() const noexcept = 0;
         virtual document::BucketId bucket_id() const noexcept = 0;
+        /**
+         * Returns a mutable representation of the currently iterated database
+         * entry. If changes are made to this object, Result::Update must be
+         * returned from merge(). Otherwise, mutation visibility is undefined.
+         */
         virtual Entry& current_entry() = 0;
+        /**
+         * Insert a new entry into the bucket database that is ordered before the
+         * currently iterated entry.
+         *
+         * Preconditions:
+         *  - The entry's bucket ID must sort _before_ the currently iterated
+         *    entry's bucket ID, in "reversed bits" bucket key order.
+         *  - The entry's bucket ID must sort _after_ any entries previously
+         *    inserted with insert_before_current().
+         *  - The entry's bucket ID must not be the same as a bucket that was
+         *    already iterated over as part of the DB merge() call or inserted
+         *    via a previous call to insert_before_current().
+         *    Such buckets must be handled by explicitly updating the provided
+         *    entry for the iterated bucket and returning Result::Update.
+         */
         virtual void insert_before_current(const Entry&) = 0;
     };
 
+    /**
+     * Interface to be implemented by callers that wish to receive callbacks
+     * during a bucket merge() operation.
+     */
     struct MergingProcessor {
+        // See merge() for semantics on enum values.
         enum class Result {
             Update,
             KeepUnchanged,
@@ -108,10 +153,51 @@ public:
         };
 
         virtual ~MergingProcessor() = default;
+        /**
+         * Invoked for each existing bucket in the database, in bucket key order.
+         * The provided Merge instance may be used to access the current entry
+         * and prepend entries to the DB.
+         *
+         * Return value semantics:
+         *  - Result::Update:
+         *      when merge() returns, the changes made to the current entry will
+         *      become visible in the bucket database.
+         *  - Result::KeepUnchanged:
+         *      when merge() returns, the entry will remain in the same state as
+         *      it was when merge() was originally called.
+         *  - Result::Skip:
+         *      when merge() returns, the entry will no longer be part of the DB.
+         *      Any entries added via insert_before_current() _will_ be present.
+         *
+         */
         virtual Result merge(Merger&) = 0;
+        /**
+         * Invoked once after all existing buckets have been iterated over.
+         * The provided TrailingInserter instance may be used to append
+         * an arbitrary number of entries to the database.
+         *
+         * This is used to handle elements remaining at the end of a linear
+         * merge operation.
+         */
         virtual void insert_remaining_at_end(TrailingInserter&) {}
     };
 
+    /**
+     * Iterate over the bucket database in bucket key order, allowing an arbitrary
+     * number of buckets to be inserted, updated and skipped in a way that is
+     * optimized for the backing DB implementation.
+     *
+     * Merging happens in two stages:
+     *  1) The MergeProcessor argument's merge() function is invoked for each existing
+     *     bucket in the database. At this point new buckets ordered before the iterated
+     *     bucket may be inserted and the iterated bucket may be skipped or updated.
+     *  2) The MergeProcessor argument's insert_remaining_at_end() function is invoked
+     *     once when all buckets have been iterated over. This enables the caller to
+     *     insert new buckets that sort after the last iterated bucket.
+     *
+     * Changes made to the database are not guaranteed to be visible until
+     * merge() returns.
+     */
     virtual void merge(MergingProcessor&) = 0;
 
     /**

--- a/storage/src/vespa/storage/bucketdb/bucketinfo.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketinfo.cpp
@@ -1,18 +1,18 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "bucketinfo.h"
+#include "bucketinfo.hpp"
 #include <vespa/storage/storageutil/utils.h>
 #include <algorithm>
 
 namespace storage {
 
-BucketInfo::BucketInfo()
-    : _lastGarbageCollection(0),
-      _nodes()
-{}
+template class BucketInfoBase<std::vector<BucketCopy>>;
+template class BucketInfoBase<vespalib::ConstArrayRef<BucketCopy>>;
+
+BucketInfo::BucketInfo() : BucketInfoBase() {}
 
 BucketInfo::BucketInfo(uint32_t lastGarbageCollection, std::vector<BucketCopy> nodes)
-    : _lastGarbageCollection(lastGarbageCollection),
-      _nodes(std::move(nodes))
+    : BucketInfoBase(lastGarbageCollection, std::move(nodes))
 {}
 
 BucketInfo::~BucketInfo() = default;
@@ -21,38 +21,6 @@ BucketInfo::BucketInfo(const BucketInfo&) = default;
 BucketInfo& BucketInfo::operator=(const BucketInfo&) = default;
 BucketInfo::BucketInfo(BucketInfo&&) noexcept = default;
 BucketInfo& BucketInfo::operator=(BucketInfo&&) noexcept = default;
-
-std::string
-BucketInfo::toString() const {
-    std::ostringstream ost;
-    print(ost, true, "");
-    return ost.str();
-}
-
-bool
-BucketInfo::emptyAndConsistent() const {
-    for (uint32_t i = 0; i < _nodes.size(); i++) {
-        if (!_nodes[i].empty()) return false;
-    }
-    return consistentNodes();
-}
-
-bool
-BucketInfo::validAndConsistent() const {
-    for (uint32_t i = 0; i < _nodes.size(); i++) {
-        if (!_nodes[i].valid()) return false;
-    }
-    return consistentNodes();
-}
-
-bool
-BucketInfo::hasInvalidCopy() const
-{
-    for (uint32_t i = 0; i < _nodes.size(); i++) {
-        if (!_nodes[i].valid()) return true;
-    }
-    return false;
-}
 
 void
 BucketInfo::updateTrusted() {
@@ -88,40 +56,6 @@ BucketInfo::resetTrusted() {
         _nodes[i].clearTrusted();
     }
     updateTrusted();
-}
-
-uint16_t
-BucketInfo::getTrustedCount() const {
-    uint32_t trustedCount = 0;
-    for (uint32_t i = 0; i < _nodes.size(); i++) {
-        if (_nodes[i].trusted()) {
-            trustedCount++;
-        }
-    }
-    return trustedCount;
-}
-
-bool
-BucketInfo::consistentNodes(bool countInvalidAsConsistent) const
-{
-    int compareIndex = 0;
-    for (uint32_t i=1; i<_nodes.size(); i++) {
-        if (!_nodes[i].consistentWith(_nodes[compareIndex],
-                                     countInvalidAsConsistent)) return false;
-    }
-    return true;
-}
-
-void
-BucketInfo::print(std::ostream& out, bool verbose, const std::string& indent) const
-{
-    if (_nodes.empty()) {
-        out << "no nodes";
-    }
-    for (uint32_t i=0; i<_nodes.size(); ++i) {
-        if (i != 0) out << ", ";
-        _nodes[i].print(out, verbose, indent);
-    }
 }
 
 namespace {
@@ -225,19 +159,6 @@ BucketInfo::removeNode(unsigned short node, TrustedUpdate update)
     return false;
 }
 
-const BucketCopy*
-BucketInfo::getNode(uint16_t node) const
-{
-    for (std::vector<BucketCopy>::const_iterator iter = _nodes.begin();
-         iter != _nodes.end();
-         iter++) {
-        if (iter->getNode() == node) {
-            return &*iter;
-        }
-    }
-    return 0;
-}
-
 BucketCopy*
 BucketInfo::getNodeInternal(uint16_t node)
 {
@@ -249,94 +170,6 @@ BucketInfo::getNodeInternal(uint16_t node)
         }
     }
     return 0;
-}
-
-std::vector<uint16_t>
-BucketInfo::getNodes() const {
-    std::vector<uint16_t> result;
-
-    for (uint32_t i = 0; i < _nodes.size(); i++) {
-        result.push_back(_nodes[i].getNode());
-    }
-
-    return result;
-}
-
-uint32_t
-BucketInfo::getHighestDocumentCount() const
-{
-    uint32_t highest = 0;
-    for (uint32_t i = 0; i < _nodes.size(); ++i) {
-        highest = std::max(highest, _nodes[i].getDocumentCount());
-    }
-    return highest;
-}
-
-uint32_t
-BucketInfo::getHighestTotalDocumentSize() const
-{
-    uint32_t highest = 0;
-    for (uint32_t i = 0; i < _nodes.size(); ++i) {
-        highest = std::max(highest, _nodes[i].getTotalDocumentSize());
-    }
-    return highest;
-}
-
-uint32_t
-BucketInfo::getHighestMetaCount() const
-{
-    uint32_t highest = 0;
-    for (uint32_t i = 0; i < _nodes.size(); ++i) {
-        highest = std::max(highest, _nodes[i].getMetaCount());
-    }
-    return highest;
-}
-
-uint32_t
-BucketInfo::getHighestUsedFileSize() const
-{
-    uint32_t highest = 0;
-    for (uint32_t i = 0; i < _nodes.size(); ++i) {
-        highest = std::max(highest, _nodes[i].getUsedFileSize());
-    }
-    return highest;
-}
-
-bool
-BucketInfo::hasRecentlyCreatedEmptyCopy() const
-{
-    for (uint32_t i = 0; i < _nodes.size(); ++i) {
-        if (_nodes[i].wasRecentlyCreated()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool
-BucketInfo::operator==(const BucketInfo& other) const
-{
-    if (_nodes.size() != other._nodes.size()) {
-        return false;
-    }
-
-    for (uint32_t i = 0; i < _nodes.size(); ++i) {
-        if (_nodes[i].getNode() != other._nodes[i].getNode()) {
-            return false;
-        }
-
-        if (!(_nodes[i] == other._nodes[i])) {
-            return false;
-        }
-    }
-
-    return true;
-};
-
-std::ostream&
-operator<<(std::ostream& out, const BucketInfo& info) {
-    info.print(out, false, "");
-    return out;
 }
 
 }

--- a/storage/src/vespa/storage/bucketdb/bucketinfo.hpp
+++ b/storage/src/vespa/storage/bucketdb/bucketinfo.hpp
@@ -1,0 +1,165 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "bucketcopy.h"
+#include <vespa/vespalib/util/arrayref.h>
+#include <iostream>
+#include <sstream>
+
+namespace storage {
+
+template <typename NodeSeq>
+std::string BucketInfoBase<NodeSeq>::toString() const {
+    std::ostringstream ost;
+    print(ost, true, "");
+    return ost.str();
+}
+
+template <typename NodeSeq>
+bool BucketInfoBase<NodeSeq>::emptyAndConsistent() const {
+    for (uint32_t i = 0; i < _nodes.size(); i++) {
+        if (!_nodes[i].empty()) {
+            return false;
+        }
+    }
+    return consistentNodes();
+}
+
+template <typename NodeSeq>
+bool BucketInfoBase<NodeSeq>::validAndConsistent() const {
+    for (uint32_t i = 0; i < _nodes.size(); i++) {
+        if (!_nodes[i].valid()) {
+            return false;
+        }
+    }
+    return consistentNodes();
+}
+
+template <typename NodeSeq>
+bool BucketInfoBase<NodeSeq>::hasInvalidCopy() const {
+    for (uint32_t i = 0; i < _nodes.size(); i++) {
+        if (!_nodes[i].valid()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename NodeSeq>
+uint16_t BucketInfoBase<NodeSeq>::getTrustedCount() const {
+    uint32_t trustedCount = 0;
+    for (uint32_t i = 0; i < _nodes.size(); i++) {
+        if (_nodes[i].trusted()) {
+            trustedCount++;
+        }
+    }
+    return trustedCount;
+}
+
+template <typename NodeSeq>
+bool BucketInfoBase<NodeSeq>::consistentNodes(bool countInvalidAsConsistent) const {
+    int compareIndex = 0;
+    for (uint32_t i = 1; i < _nodes.size(); i++) {
+        if (!_nodes[i].consistentWith(_nodes[compareIndex],
+                                      countInvalidAsConsistent)) return false;
+    }
+    return true;
+}
+
+template <typename NodeSeq>
+void BucketInfoBase<NodeSeq>::print(std::ostream& out, bool verbose, const std::string& indent) const {
+    if (_nodes.size() == 0) {
+        out << "no nodes";
+    }
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        if (i != 0) {
+            out << ", ";
+        }
+        _nodes[i].print(out, verbose, indent);
+    }
+}
+
+template <typename NodeSeq>
+const BucketCopy* BucketInfoBase<NodeSeq>::getNode(uint16_t node) const {
+    for (const auto& n : _nodes) {
+        if (n.getNode() == node) {
+            return &n;
+        }
+    }
+    return 0;
+}
+
+template <typename NodeSeq>
+std::vector<uint16_t> BucketInfoBase<NodeSeq>::getNodes() const {
+    std::vector<uint16_t> result;
+    for (uint32_t i = 0; i < _nodes.size(); i++) {
+        result.emplace_back(_nodes[i].getNode());
+    }
+    return result;
+}
+
+template <typename NodeSeq>
+uint32_t BucketInfoBase<NodeSeq>::getHighestDocumentCount() const {
+    uint32_t highest = 0;
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        highest = std::max(highest, _nodes[i].getDocumentCount());
+    }
+    return highest;
+}
+
+template <typename NodeSeq>
+uint32_t BucketInfoBase<NodeSeq>::getHighestTotalDocumentSize() const {
+    uint32_t highest = 0;
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        highest = std::max(highest, _nodes[i].getTotalDocumentSize());
+    }
+    return highest;
+}
+
+template <typename NodeSeq>
+uint32_t BucketInfoBase<NodeSeq>::getHighestMetaCount() const {
+    uint32_t highest = 0;
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        highest = std::max(highest, _nodes[i].getMetaCount());
+    }
+    return highest;
+}
+
+template <typename NodeSeq>
+uint32_t BucketInfoBase<NodeSeq>::getHighestUsedFileSize() const {
+    uint32_t highest = 0;
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        highest = std::max(highest, _nodes[i].getUsedFileSize());
+    }
+    return highest;
+}
+
+template <typename NodeSeq>
+bool BucketInfoBase<NodeSeq>::hasRecentlyCreatedEmptyCopy() const {
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        if (_nodes[i].wasRecentlyCreated()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename NodeSeq>
+bool BucketInfoBase<NodeSeq>::operator==(const BucketInfoBase<NodeSeq>& other) const {
+    if (_nodes.size() != other._nodes.size()) {
+        return false;
+    }
+
+    for (uint32_t i = 0; i < _nodes.size(); ++i) {
+        if (_nodes[i].getNode() != other._nodes[i].getNode()) {
+            return false;
+        }
+
+        if (!(_nodes[i] == other._nodes[i])) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+}

--- a/storage/src/vespa/storage/bucketdb/mapbucketdatabase.h
+++ b/storage/src/vespa/storage/bucketdb/mapbucketdatabase.h
@@ -18,16 +18,16 @@ public:
     void getAll(const document::BucketId& bucket, std::vector<Entry>& entries) const override;
     void update(const Entry& newEntry) override;
     void forEach(EntryProcessor&, const document::BucketId& after = document::BucketId()) const override;
-    void forEach(MutableEntryProcessor&, const document::BucketId& after = document::BucketId()) override;
     uint64_t size() const override { return _values.size() - _freeValues.size(); };
     void clear() override;
 
     uint32_t childCount(const document::BucketId&) const override;
     Entry upperBound(const document::BucketId& value) const override;
 
+    void merge(MergingProcessor&) override;
+
     document::BucketId getAppropriateBucket(uint16_t minBits, const document::BucketId& bid) override;
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
-
 private:
     struct E {
         E() : value(-1), e_0(-1), e_1(-1) {};
@@ -42,14 +42,20 @@ private:
         int e_1;
     };
 
+    template <typename EntryType>
+    void update_internal(EntryType&& new_entry);
+
     BucketDatabase::Entry* find(int idx, uint8_t bitCount, const document::BucketId& bid, bool create);
     bool remove(int index, uint8_t bitCount, const document::BucketId& bId);
     int findFirstInOrderNodeInclusive(int index) const;
     int upperBoundImpl(int index, uint8_t depth, const document::BucketId& value) const;
 
-    template <typename EntryProcessorType>
-    bool forEach(int index, EntryProcessorType& processor, uint8_t bitCount,
-                 const document::BucketId& lowerBound, bool& process);
+    bool forEach(int index, EntryProcessor& processor, uint8_t bitCount,
+                 const document::BucketId& lowerBound, bool& process) const;
+
+    void merge_internal(int index, MergingProcessor& processor,
+                        std::vector<Entry>& to_insert,
+                        std::vector<document::BucketId>& to_remove);
 
     void findParents(int index, uint8_t bitCount, const document::BucketId& bid, std::vector<Entry>& entries) const;
     void findAll(int index, uint8_t bitCount, const document::BucketId& bid, std::vector<Entry>& entries) const;

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
@@ -4,8 +4,8 @@
 #include "bucket_db_prune_elision.h"
 #include "distributor.h"
 #include "distributor_bucket_space.h"
-#include "simpleclusterinformation.h"
 #include "distributormetricsset.h"
+#include "simpleclusterinformation.h"
 #include <vespa/storage/common/bucketoperationlogger.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
@@ -152,26 +152,20 @@ BucketDBUpdater::removeSuperfluousBuckets(
 
         // Remove all buckets not belonging to this distributor, or
         // being on storage nodes that are no longer up.
-        NodeRemover proc(
+        MergingNodeRemover proc(
                 oldClusterState,
                 *new_cluster_state,
                 _distributorComponent.getIndex(),
                 newDistribution,
-                up_states);
-        bucketDb.forEach(proc);
+                up_states,
+                move_to_read_only_db);
 
-        for (const auto & bucket : proc.getBucketsToRemove()) {
-            bucketDb.remove(bucket);
+        bucketDb.merge(proc);
+        // Non-owned entries vector only has contents if move_to_read_only_db is true.
+        // TODO either rewrite in terms of merge() or remove entirely
+        for (const auto& db_entry : proc.getNonOwnedEntries()) {
+            readOnlyDb.update(db_entry); // TODO Entry move support
         }
-        // TODO vec of Entry instead to avoid lookup and remove? Uses more transient memory...
-        for (const auto& bucket : proc.getNonOwnedBuckets()) {
-            if (move_to_read_only_db) {
-                auto db_entry = bucketDb.get(bucket);
-                readOnlyDb.update(db_entry); // TODO Entry move support
-            }
-            bucketDb.remove(bucket);
-        }
-
     }
 }
 
@@ -217,7 +211,6 @@ BucketDBUpdater::storageDistributionChanged()
             std::move(clusterInfo),
             _sender,
             _distributorComponent.getBucketSpaceRepo(),
-            _distributorComponent.getReadOnlyBucketSpaceRepo(),
             _distributorComponent.getUniqueTimestamp());
     _outdatedNodesMap = _pendingClusterState->getOutdatedNodesMap();
 }
@@ -273,7 +266,6 @@ BucketDBUpdater::onSetSystemState(
             std::move(clusterInfo),
             _sender,
             _distributorComponent.getBucketSpaceRepo(),
-            _distributorComponent.getReadOnlyBucketSpaceRepo(),
             cmd,
             _outdatedNodesMap,
             _distributorComponent.getUniqueTimestamp());
@@ -740,40 +732,39 @@ BucketDBUpdater::reportXmlStatus(vespalib::xml::XmlOutputStream& xos,
     return "";
 }
 
-bool
-BucketDBUpdater::BucketListGenerator::process(BucketDatabase::Entry& e)
-{
-    document::BucketId bucketId(e.getBucketId());
-
-    const BucketCopy* copy(e->getNode(_node));
-    if (copy) {
-        _entries.emplace_back(bucketId, copy->getBucketInfo());
-    }
-    return true;
-}
-
-BucketDBUpdater::NodeRemover::NodeRemover(
+BucketDBUpdater::MergingNodeRemover::MergingNodeRemover(
         const lib::ClusterState& oldState,
         const lib::ClusterState& s,
         uint16_t localIndex,
         const lib::Distribution& distribution,
-        const char* upStates)
+        const char* upStates,
+        bool track_non_owned_entries)
     : _oldState(oldState),
       _state(s),
+      _available_nodes(),
       _nonOwnedBuckets(),
-      _removedBuckets(),
+      _removed_buckets(0),
       _localIndex(localIndex),
       _distribution(distribution),
       _upStates(upStates),
+      _track_non_owned_entries(track_non_owned_entries),
       _cachedDecisionSuperbucket(UINT64_MAX),
       _cachedOwned(false)
-{}
+{
+    // TODO intersection of cluster state and distribution config
+    const uint16_t storage_count = s.getNodeCount(lib::NodeType::STORAGE);
+    _available_nodes.resize(storage_count);
+    for (uint16_t i = 0; i < storage_count; ++i) {
+        if (s.getNodeState(lib::Node(lib::NodeType::STORAGE, i)).getState().oneOf(_upStates)) {
+            _available_nodes[i] = true;
+        }
+    }
+}
 
 void
-BucketDBUpdater::NodeRemover::logRemove(const document::BucketId& bucketId, const char* msg) const
+BucketDBUpdater::MergingNodeRemover::logRemove(const document::BucketId& bucketId, const char* msg) const
 {
     LOG(spam, "Removing bucket %s: %s", bucketId.toString().c_str(), msg);
-    LOG_BUCKET_OPERATION_NO_LOCK(bucketId, msg);    
 }
 
 namespace {
@@ -786,7 +777,7 @@ uint64_t superbucket_from_id(const document::BucketId& id, uint16_t distribution
 }
 
 bool
-BucketDBUpdater::NodeRemover::distributorOwnsBucket(
+BucketDBUpdater::MergingNodeRemover::distributorOwnsBucket(
         const document::BucketId& bucketId) const
 {
     // TODO "no distributors available" case is the same for _all_ buckets; cache once in constructor.
@@ -818,7 +809,7 @@ BucketDBUpdater::NodeRemover::distributorOwnsBucket(
 }
 
 void
-BucketDBUpdater::NodeRemover::setCopiesInEntry(
+BucketDBUpdater::MergingNodeRemover::setCopiesInEntry(
         BucketDatabase::Entry& e,
         const std::vector<BucketCopy>& copies) const
 {
@@ -830,77 +821,75 @@ BucketDBUpdater::NodeRemover::setCopiesInEntry(
     e->addNodes(copies, order);
 
     LOG(spam, "Changed %s", e->toString().c_str());
-    LOG_BUCKET_OPERATION_NO_LOCK(
-            e.getBucketId(),
-            vespalib::make_string("updated bucketdb entry to %s",
-                                        e->toString().c_str()));
-}
-
-void
-BucketDBUpdater::NodeRemover::removeEmptyBucket(const document::BucketId& bucketId)
-{
-    _removedBuckets.push_back(bucketId);
-
-    LOG(spam,
-        "After system state change %s, bucket %s now has no copies.",
-        _oldState.getTextualDifference(_state).c_str(),
-        bucketId.toString().c_str());
-    LOG_BUCKET_OPERATION_NO_LOCK(bucketId, "bucket now has no copies");
 }
 
 bool
-BucketDBUpdater::NodeRemover::process(BucketDatabase::Entry& e)
+BucketDBUpdater::MergingNodeRemover::has_unavailable_nodes(const storage::BucketDatabase::Entry& e) const
 {
-    const document::BucketId& bucketId(e.getBucketId());
-
-    LOG(spam, "Check for remove: bucket %s", e.toString().c_str());
-    if (e->getNodeCount() == 0) {
-        removeEmptyBucket(e.getBucketId());
-        return true;
+    const uint16_t n_nodes = e->getNodeCount();
+    for (uint16_t i = 0; i < n_nodes; i++) {
+        const uint16_t node_idx = e->getNodeRef(i).getNode();
+        if (!storage_node_is_available(node_idx)) {
+            return true;
+        }
     }
+    return false;
+}
+
+BucketDatabase::MergingProcessor::Result
+BucketDBUpdater::MergingNodeRemover::merge(storage::BucketDatabase::Merger& merger)
+{
+    using Result = BucketDatabase::MergingProcessor::Result;
+
+    document::BucketId bucketId(merger.bucket_id());
+    LOG(spam, "Check for remove: bucket %s", bucketId.toString().c_str());
     if (!distributorOwnsBucket(bucketId)) {
-        _nonOwnedBuckets.push_back(bucketId);
-        return true;
+        // TODO remove in favor of DB snapshotting
+        if (_track_non_owned_entries) {
+            _nonOwnedBuckets.emplace_back(merger.current_entry());
+        }
+        return Result::Skip;
+    }
+    auto& e = merger.current_entry();
+
+    if (e->getNodeCount() == 0) { // TODO when should this edge ever trigger?
+        return Result::Skip;
+    }
+
+    if (!has_unavailable_nodes(e)) {
+        return Result::KeepUnchanged;
     }
 
     std::vector<BucketCopy> remainingCopies;
     for (uint16_t i = 0; i < e->getNodeCount(); i++) {
-        Node n(NodeType::STORAGE, e->getNodeRef(i).getNode());
-
-        // TODO replace with intersection hash set of config and cluster state
-        if (_state.getNodeState(n).getState().oneOf(_upStates)) {
+        const uint16_t node_idx = e->getNodeRef(i).getNode();
+        if (storage_node_is_available(node_idx)) {
             remainingCopies.push_back(e->getNodeRef(i));
         }
     }
 
-    if (remainingCopies.size() == e->getNodeCount()) {
-        return true;
-    }
-
     if (remainingCopies.empty()) {
-        removeEmptyBucket(bucketId);
+        ++_removed_buckets;
+        return Result::Skip;
     } else {
         setCopiesInEntry(e, remainingCopies);
+        return Result::Update;
     }
-
-    return true;
 }
 
-BucketDBUpdater::NodeRemover::~NodeRemover()
+bool
+BucketDBUpdater::MergingNodeRemover::storage_node_is_available(uint16_t index) const noexcept
 {
-    if ( !_removedBuckets.empty()) {
-        std::ostringstream ost;
-        ost << "After system state change "
-            << _oldState.getTextualDifference(_state) << ", we removed "
-            << "buckets. Data is unavailable until node comes back up. "
-            << _removedBuckets.size() << " buckets removed:";
-        for (uint32_t i=0; i < 10 && i < _removedBuckets.size(); ++i) {
-            ost << " " << _removedBuckets[i];
-        }
-        if (_removedBuckets.size() >= 10) {
-            ost << " ...";
-        }
-        LOGBM(info, "%s", ost.str().c_str());
+    return ((index < _available_nodes.size()) && _available_nodes[index]);
+}
+
+BucketDBUpdater::MergingNodeRemover::~MergingNodeRemover()
+{
+    if (_removed_buckets != 0) {
+        LOGBM(info, "After cluster state change %s, %" PRIu64 " buckets no longer "
+                    "have available replicas. Documents in these buckets will "
+                    "be unavailable until nodes come back up",
+                    _oldState.getTextualDifference(_state).c_str(), _removed_buckets);
     }
 }
 

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
@@ -839,8 +839,6 @@ BucketDBUpdater::MergingNodeRemover::has_unavailable_nodes(const storage::Bucket
 BucketDatabase::MergingProcessor::Result
 BucketDBUpdater::MergingNodeRemover::merge(storage::BucketDatabase::Merger& merger)
 {
-    using Result = BucketDatabase::MergingProcessor::Result;
-
     document::BucketId bucketId(merger.bucket_id());
     LOG(spam, "Check for remove: bucket %s", bucketId.toString().c_str());
     if (!distributorOwnsBucket(bucketId)) {

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -114,7 +114,9 @@ public:
      * Checks whether a bucket needs to be split, and sends a split
      * if so.
      */
-    void checkBucketForSplit(document::BucketSpace bucketSpace, const BucketDatabase::Entry& e, uint8_t priority) override;
+    void checkBucketForSplit(document::BucketSpace bucketSpace,
+                             const BucketDatabase::Entry& e,
+                             uint8_t priority) override;
 
     const lib::ClusterStateBundle& getClusterStateBundle() const override;
 

--- a/storage/src/vespa/storage/distributor/idealstatemanager.cpp
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.cpp
@@ -244,7 +244,7 @@ IdealStateManager::generateAll(const document::Bucket &bucket,
 void
 IdealStateManager::getBucketStatus(
         BucketSpace bucketSpace,
-        const BucketDatabase::Entry& entry,
+        const BucketDatabase::ConstEntryRef& entry,
         NodeMaintenanceStatsTracker& statsTracker,
         std::ostream& out) const
 {

--- a/storage/src/vespa/storage/distributor/idealstatemanager.h
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.h
@@ -128,14 +128,14 @@ private:
         StatusBucketVisitor(const IdealStateManager& ism, document::BucketSpace bucketSpace, std::ostream& out)
             : _statsTracker(), _ism(ism), _bucketSpace(bucketSpace), _out(out) {}
 
-        bool process(const BucketDatabase::Entry& e) override {
+        bool process(const BucketDatabase::ConstEntryRef& e) override {
             _ism.getBucketStatus(_bucketSpace, e, _statsTracker, _out);
             return true;
         }
     };
     friend class StatusBucketVisitor;
 
-    void getBucketStatus(document::BucketSpace bucketSpace, const BucketDatabase::Entry& entry,
+    void getBucketStatus(document::BucketSpace bucketSpace, const BucketDatabase::ConstEntryRef& entry,
                          NodeMaintenanceStatsTracker& statsTracker, std::ostream& out) const;
     void dump_bucket_space_db_status(document::BucketSpace bucket_space, std::ostream& out) const;
 };

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -483,7 +483,7 @@ struct NextEntryFinder : public BucketDatabase::EntryProcessor {
     NextEntryFinder(const document::BucketId& id)
         : _first(true), _last(id), _next() {}
 
-    bool process(const BucketDatabase::Entry& e) override {
+    bool process(const BucketDatabase::ConstEntryRef& e) override {
         document::BucketId bucket(e.getBucketId());
 
         if (_first && bucket == _last) {

--- a/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.cpp
+++ b/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.cpp
@@ -131,24 +131,30 @@ PendingBucketSpaceDbTransition::removeCopiesFromNodesThatWereRequested(BucketDat
     return updated;
 }
 
-// TODO take in bucket key instead
 bool
-PendingBucketSpaceDbTransition::databaseIteratorHasPassedBucketInfoIterator(const document::BucketId& bucketId) const
+PendingBucketSpaceDbTransition::databaseIteratorHasPassedBucketInfoIterator(uint64_t bucket_key) const
 {
-    return (_iter < _entries.size()
-            && _entries[_iter].bucket_key < bucketId.toKey());
-}
-
-// TODO take in bucket key instead
-bool
-PendingBucketSpaceDbTransition::bucketInfoIteratorPointsToBucket(const document::BucketId& bucketId) const
-{
-    return _iter < _entries.size() && _entries[_iter].bucket_id() == bucketId;
+    return ((_iter < _entries.size())
+            && (_entries[_iter].bucket_key < bucket_key));
 }
 
 bool
-PendingBucketSpaceDbTransition::process(BucketDatabase::Entry& e)
+PendingBucketSpaceDbTransition::bucketInfoIteratorPointsToBucket(uint64_t bucket_key) const
 {
+    return _iter < _entries.size() && _entries[_iter].bucket_key == bucket_key;
+}
+
+using MergeResult = BucketDatabase::MergingProcessor::Result;
+
+MergeResult PendingBucketSpaceDbTransition::merge(BucketDatabase::Merger& merger) {
+    const uint64_t bucket_key = merger.bucket_key();
+
+    while (databaseIteratorHasPassedBucketInfoIterator(bucket_key)) {
+        LOG(spam, "Found new bucket %s, adding", _entries[_iter].bucket_id().toString().c_str());
+        addToMerger(merger, skipAllForSameBucket());
+    }
+
+    auto& e = merger.current_entry();
     document::BucketId bucketId(e.getBucketId());
 
     LOG(spam,
@@ -157,19 +163,10 @@ PendingBucketSpaceDbTransition::process(BucketDatabase::Entry& e)
         bucketId.toString().c_str(),
         e.getBucketInfo().toString().c_str());
 
-    while (databaseIteratorHasPassedBucketInfoIterator(bucketId)) {
-        LOG(spam, "Found new bucket %s, adding",
-            _entries[_iter].bucket_id().toString().c_str());
-
-        _missingEntries.push_back(skipAllForSameBucket());
-    }
-
     bool updated(removeCopiesFromNodesThatWereRequested(e, bucketId));
 
-    if (bucketInfoIteratorPointsToBucket(bucketId)) {
-        LOG(spam, "Updating bucket %s",
-            _entries[_iter].bucket_id().toString().c_str());
-
+    if (bucketInfoIteratorPointsToBucket(bucket_key)) {
+        LOG(spam, "Updating bucket %s", _entries[_iter].bucket_id().toString().c_str());
         insertInfo(e, skipAllForSameBucket());
         updated = true;
     }
@@ -177,23 +174,24 @@ PendingBucketSpaceDbTransition::process(BucketDatabase::Entry& e)
     if (updated) {
         // Remove bucket if we've previously removed all nodes from it
         if (e->getNodeCount() == 0) {
-            _removedBuckets.push_back(bucketId);
+            return MergeResult::Skip;
         } else {
             e.getBucketInfo().updateTrusted();
+            return MergeResult::Update;
         }
     }
 
-    LOG(spam,
-        "After merging info from nodes [%s], bucket %s had info %s",
-        requestNodesToString().c_str(),
-        bucketId.toString().c_str(),
-        e.getBucketInfo().toString().c_str());
+    return MergeResult::KeepUnchanged;
+}
 
-    return true;
+void PendingBucketSpaceDbTransition::insert_remaining_at_end(BucketDatabase::TrailingInserter& inserter) {
+    while (_iter < _entries.size()) {
+        addToInserter(inserter, skipAllForSameBucket());
+    }
 }
 
 void
-PendingBucketSpaceDbTransition::addToBucketDB(BucketDatabase& db, const Range& range)
+PendingBucketSpaceDbTransition::addToMerger(BucketDatabase::Merger& merger, const Range& range)
 {
     LOG(spam, "Adding new bucket %s with %d copies",
         _entries[range.first].bucket_id().toString().c_str(),
@@ -204,10 +202,29 @@ PendingBucketSpaceDbTransition::addToBucketDB(BucketDatabase& db, const Range& r
     if (e->getLastGarbageCollectionTime() == 0) {
         e->setLastGarbageCollectionTime(
                 framework::MicroSecTime(_creationTimestamp)
-                    .getSeconds().getTime());
+                        .getSeconds().getTime());
     }
     e.getBucketInfo().updateTrusted();
-    db.update(e);
+    merger.insert_before_current(e);
+}
+
+void
+PendingBucketSpaceDbTransition::addToInserter(BucketDatabase::TrailingInserter& inserter, const Range& range)
+{
+    // TODO dedupe
+    LOG(spam, "Adding new bucket %s with %d copies",
+        _entries[range.first].bucket_id().toString().c_str(),
+        range.second - range.first);
+
+    BucketDatabase::Entry e(_entries[range.first].bucket_id(), BucketInfo());
+    insertInfo(e, range);
+    if (e->getLastGarbageCollectionTime() == 0) {
+        e->setLastGarbageCollectionTime(
+                framework::MicroSecTime(_creationTimestamp)
+                        .getSeconds().getTime());
+    }
+    e.getBucketInfo().updateTrusted();
+    inserter.insert_at_end(e);
 }
 
 void
@@ -215,22 +232,7 @@ PendingBucketSpaceDbTransition::mergeIntoBucketDatabase()
 {
     BucketDatabase &db(_distributorBucketSpace.getBucketDatabase());
     std::sort(_entries.begin(), _entries.end());
-
-    db.forEach(*this);
-
-    for (uint32_t i = 0; i < _removedBuckets.size(); ++i) {
-        db.remove(_removedBuckets[i]);
-    }
-    _removedBuckets.clear();
-
-    // All of the remaining were not already in the bucket database.
-    while (_iter < _entries.size()) {
-        _missingEntries.push_back(skipAllForSameBucket());
-    }
-
-    for (uint32_t i = 0; i < _missingEntries.size(); ++i) {
-        addToBucketDB(db, _missingEntries[i]);
-    }
+    db.merge(*this);
 }
 
 void

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.cpp
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.cpp
@@ -28,7 +28,6 @@ PendingClusterState::PendingClusterState(
         const ClusterInformation::CSP& clusterInfo,
         DistributorMessageSender& sender,
         DistributorBucketSpaceRepo& bucketSpaceRepo,
-        DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
         const std::shared_ptr<api::SetSystemStateCommand>& newStateCmd,
         const OutdatedNodesMap &outdatedNodesMap,
         api::Timestamp creationTimestamp)
@@ -41,7 +40,6 @@ PendingClusterState::PendingClusterState(
       _creationTimestamp(creationTimestamp),
       _sender(sender),
       _bucketSpaceRepo(bucketSpaceRepo),
-      _readOnlyBucketSpaceRepo(readOnlyBucketSpaceRepo),
       _clusterStateVersion(_cmd->getClusterStateBundle().getVersion()),
       _isVersionedTransition(true),
       _bucketOwnershipTransfer(false),
@@ -56,7 +54,6 @@ PendingClusterState::PendingClusterState(
         const ClusterInformation::CSP& clusterInfo,
         DistributorMessageSender& sender,
         DistributorBucketSpaceRepo& bucketSpaceRepo,
-        DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
         api::Timestamp creationTimestamp)
     : _requestedNodes(clusterInfo->getStorageNodeCount()),
       _prevClusterStateBundle(clusterInfo->getClusterStateBundle()),
@@ -66,7 +63,6 @@ PendingClusterState::PendingClusterState(
       _creationTimestamp(creationTimestamp),
       _sender(sender),
       _bucketSpaceRepo(bucketSpaceRepo),
-      _readOnlyBucketSpaceRepo(readOnlyBucketSpaceRepo),
       _clusterStateVersion(0),
       _isVersionedTransition(false),
       _bucketOwnershipTransfer(true),
@@ -76,7 +72,7 @@ PendingClusterState::PendingClusterState(
     initializeBucketSpaceTransitions(true, OutdatedNodesMap());
 }
 
-PendingClusterState::~PendingClusterState() {}
+PendingClusterState::~PendingClusterState() = default;
 
 void
 PendingClusterState::initializeBucketSpaceTransitions(bool distributionChanged, const OutdatedNodesMap &outdatedNodesMap)

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -46,14 +46,13 @@ public:
             const ClusterInformation::CSP& clusterInfo,
             DistributorMessageSender& sender,
             DistributorBucketSpaceRepo& bucketSpaceRepo,
-            DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
             const std::shared_ptr<api::SetSystemStateCommand>& newStateCmd,
             const OutdatedNodesMap &outdatedNodesMap,
             api::Timestamp creationTimestamp)
     {
         // Naked new due to private constructor
         return std::unique_ptr<PendingClusterState>(new PendingClusterState(
-                clock, clusterInfo, sender, bucketSpaceRepo, readOnlyBucketSpaceRepo,
+                clock, clusterInfo, sender, bucketSpaceRepo,
                 newStateCmd, outdatedNodesMap, creationTimestamp));
     }
 
@@ -66,13 +65,11 @@ public:
             const ClusterInformation::CSP& clusterInfo,
             DistributorMessageSender& sender,
             DistributorBucketSpaceRepo& bucketSpaceRepo,
-            DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
             api::Timestamp creationTimestamp)
     {
         // Naked new due to private constructor
         return std::unique_ptr<PendingClusterState>(new PendingClusterState(
-                clock, clusterInfo, sender, bucketSpaceRepo,
-                readOnlyBucketSpaceRepo, creationTimestamp));
+                clock, clusterInfo, sender, bucketSpaceRepo, creationTimestamp));
     }
 
     PendingClusterState(const PendingClusterState &) = delete;
@@ -167,7 +164,6 @@ private:
             const ClusterInformation::CSP& clusterInfo,
             DistributorMessageSender& sender,
             DistributorBucketSpaceRepo& bucketSpaceRepo,
-            DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
             const std::shared_ptr<api::SetSystemStateCommand>& newStateCmd,
             const OutdatedNodesMap &outdatedNodesMap,
             api::Timestamp creationTimestamp);
@@ -181,7 +177,6 @@ private:
             const ClusterInformation::CSP& clusterInfo,
             DistributorMessageSender& sender,
             DistributorBucketSpaceRepo& bucketSpaceRepo,
-            DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
             api::Timestamp creationTimestamp);
 
     struct BucketSpaceAndNode {
@@ -232,7 +227,6 @@ private:
 
     DistributorMessageSender& _sender;
     DistributorBucketSpaceRepo& _bucketSpaceRepo;
-    DistributorBucketSpaceRepo& _readOnlyBucketSpaceRepo;
     uint32_t _clusterStateVersion;
     bool _isVersionedTransition;
     bool _bucketOwnershipTransfer;

--- a/vdslib/src/vespa/vdslib/state/cluster_state_bundle.cpp
+++ b/vdslib/src/vespa/vdslib/state/cluster_state_bundle.cpp
@@ -31,6 +31,11 @@ ClusterStateBundle::ClusterStateBundle(const ClusterState& baselineClusterState,
 {
 }
 
+ClusterStateBundle::ClusterStateBundle(const ClusterStateBundle&) = default;
+ClusterStateBundle& ClusterStateBundle::operator=(const ClusterStateBundle&) = default;
+ClusterStateBundle::ClusterStateBundle(ClusterStateBundle&&) = default;
+ClusterStateBundle& ClusterStateBundle::operator=(ClusterStateBundle&&) = default;
+
 ClusterStateBundle::~ClusterStateBundle() = default;
 
 const std::shared_ptr<const lib::ClusterState> &

--- a/vdslib/src/vespa/vdslib/state/cluster_state_bundle.h
+++ b/vdslib/src/vespa/vdslib/state/cluster_state_bundle.h
@@ -33,6 +33,12 @@ public:
     ClusterStateBundle(const ClusterState& baselineClusterState,
                        BucketSpaceStateMapping derivedBucketSpaceStates,
                        bool deferredActivation);
+
+    ClusterStateBundle(const ClusterStateBundle&);
+    ClusterStateBundle& operator=(const ClusterStateBundle&);
+    ClusterStateBundle(ClusterStateBundle&&);
+    ClusterStateBundle& operator=(ClusterStateBundle&&);
+
     ~ClusterStateBundle();
     const std::shared_ptr<const ClusterState> &getBaselineClusterState() const;
     const std::shared_ptr<const ClusterState> &getDerivedClusterState(document::BucketSpace bucketSpace) const;


### PR DESCRIPTION
@geirst please review

Abstracts away how an ordered merge may be performed with the database
and an arbitrary sorted bucket sequence, with any number of buckets
skipped, updated or inserted as part of the merge.

Such an API is required to allow efficient bulk updates of a B-tree
backed database, as it is suboptimal to require constant tree mutations.

Other changes:
- Removed legacy mutable iteration API. Not needed with new merge API.
- Const-iteration of bucket database now uses an explicit const reference
  entry type to avoid needing to construct a temporary entry when we can
  instead just point directly into the backing ArrayStore.
- Micro-optimizations of node remover pass to avoid going via cluster
  state's node state `std::map` for each bucket replica entry. Now uses
  a precomputed bit vector. Also avoid BucketId bit reversing operations
  as much as possible by using raw bucket keys in more places.
- Changed wording and contents of log message that triggers when buckets
  are removed from the DB due to no remaining nodes containing replicas
  for the bucket. Now more obvious what the message actually means.
- Added several benchmark tests (disabled by default)