### PR TITLE
Revert "Remove dispatch-with-protobuf"

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -54,6 +54,7 @@ public interface ModelContext {
         boolean isFirstTimeDeployment();
         boolean useDedicatedNodeForLogserver();
         boolean useFdispatchByDefault();
+        boolean dispatchWithProtobuf();
         boolean useAdaptiveDispatch();
         boolean enableMetricsProxyContainer();
     }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -35,6 +35,7 @@ public class TestProperties implements ModelContext.Properties {
     private boolean isFirstTimeDeployment = false;
     private boolean useDedicatedNodeForLogserver = false;
     private boolean useFdispatchByDefault = true;
+    private boolean dispatchWithProtobuf = true;
     private boolean useAdaptiveDispatch = false;
     private boolean enableMetricsProxyContainer = false;
 
@@ -53,6 +54,7 @@ public class TestProperties implements ModelContext.Properties {
     @Override public boolean useAdaptiveDispatch() { return useAdaptiveDispatch; }
     @Override public boolean useDedicatedNodeForLogserver() { return useDedicatedNodeForLogserver; }
     @Override public boolean useFdispatchByDefault() { return useFdispatchByDefault; }
+    @Override public boolean dispatchWithProtobuf() { return dispatchWithProtobuf; }
     @Override public boolean enableMetricsProxyContainer() { return enableMetricsProxyContainer; }
 
     public TestProperties setApplicationId(ApplicationId applicationId) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -107,6 +107,7 @@ public class IndexedSearchCluster extends SearchCluster
     private final DispatchGroup rootDispatch;
     private DispatchSpec dispatchSpec;
     private final boolean useFdispatchByDefault;
+    private final boolean dispatchWithProtobuf;
     private final boolean useAdaptiveDispatch;
     private List<SearchNode> searchNodes = new ArrayList<>();
 
@@ -126,6 +127,7 @@ public class IndexedSearchCluster extends SearchCluster
         dispatchParent = new SimpleConfigProducer(this, "dispatchers");
         rootDispatch =  new DispatchGroup(this);
         useFdispatchByDefault = deployState.getProperties().useFdispatchByDefault();
+        dispatchWithProtobuf = deployState.getProperties().dispatchWithProtobuf();
         useAdaptiveDispatch = deployState.getProperties().useAdaptiveDispatch();
     }
 
@@ -437,6 +439,7 @@ public class IndexedSearchCluster extends SearchCluster
         builder.maxNodesDownPerGroup(rootDispatch.getMaxNodesDownPerFixedRow());
         builder.useMultilevelDispatch(useMultilevelDispatchSetup());
         builder.useFdispatchByDefault(useFdispatchByDefault);
+        builder.dispatchWithProtobuf(dispatchWithProtobuf);
         builder.useLocalNode(tuning.dispatch.useLocalNode);
         builder.searchableCopies(rootDispatch.getSearchableCopies());
         if (searchCoverage != null) {

--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -19,6 +19,9 @@ distributionPolicy enum { ROUNDROBIN, ADAPTIVE } default=ROUNDROBIN
 # Should fdispatch be used as the default dispatcher
 useFdispatchByDefault bool default=true
 
+# Should protobuf/jrt be preferred over fs4
+dispatchWithProtobuf bool default=false
+
 # Is multi-level dispatch configured for this cluster
 useMultilevelDispatch bool default=false
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -131,6 +131,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean useDedicatedNodeForLogserver;
         private final boolean useFdispatchByDefault;
         private final boolean useAdaptiveDispatch;
+        private final boolean dispatchWithProtobuf;
         private final boolean enableMetricsProxyContainer;
 
         public Properties(ApplicationId applicationId,
@@ -159,6 +160,8 @@ public class ModelContextImpl implements ModelContext {
             this.useDedicatedNodeForLogserver = Flags.USE_DEDICATED_NODE_FOR_LOGSERVER.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             this.useFdispatchByDefault = Flags.USE_FDISPATCH_BY_DEFAULT.bindTo(flagSource)
+                    .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
+            this.dispatchWithProtobuf = Flags.DISPATCH_WITH_PROTOBUF.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             this.useAdaptiveDispatch = Flags.USE_ADAPTIVE_DISPATCH.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
@@ -208,6 +211,9 @@ public class ModelContextImpl implements ModelContext {
 
         @Override
         public boolean useFdispatchByDefault() { return useFdispatchByDefault; }
+
+        @Override
+        public boolean dispatchWithProtobuf() { return dispatchWithProtobuf; }
 
         @Override
         public boolean useAdaptiveDispatch() { return useAdaptiveDispatch; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -93,6 +93,12 @@ public class Flags {
             "Takes effect at redeployment",
             APPLICATION_ID);
 
+    public static final UnboundBooleanFlag DISPATCH_WITH_PROTOBUF = defineFeatureFlag(
+            "dispatch-with-protobuf", false,
+            "Should the java dispatcher use protobuf/jrt as the default",
+            "Takes effect at redeployment",
+            APPLICATION_ID);
+
     public static final UnboundBooleanFlag ENABLE_DYNAMIC_PROVISIONING = defineFeatureFlag(
             "enable-dynamic-provisioning", false,
             "Provision a new docker host when we otherwise can't allocate a docker node",


### PR DESCRIPTION
Reverts vespa-engine/vespa#9650

It seems to be used by older config models, see https://github.com/vespa-engine/vespa/pull/9650/#issuecomment-498335447

Needed to get a new release out