### PR TITLE
Add tenant host application with feature flag 

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
@@ -150,7 +150,7 @@ public class DomAdminV4Builder extends DomAdminBuilderBase {
 
     private boolean shouldHaveSlobrok(ContainerModel containerModel) {
         // Avoid Slobroks on node-admin container cluster, as node-admin is migrating
-        // TODO: Remove this hack once node-admin has migrated out the zone app
+        // TODO: Remove after removing tenant hosts from zone-app
 
         ApplicationId applicationId = context.getDeployState().getProperties().applicationId();
         if (!applicationId.equals(ZONE_APPLICATION_ID)) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -80,6 +80,7 @@ import java.util.stream.Collectors;
 import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
+import static com.yahoo.vespa.config.server.tenant.TenantRepository.HOSTED_VESPA_TENANT;
 import static java.nio.file.Files.readAttributes;
 
 /**
@@ -605,7 +606,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return tenantRepository.getAllTenantNames().stream()
                 .filter(tenantName -> activeApplications(tenantName).isEmpty())
                 .filter(tenantName -> !tenantName.equals(TenantName.defaultName())) // Not allowed to remove 'default' tenant
-                .filter(tenantName -> !tenantName.equals(TenantRepository.HOSTED_VESPA_TENANT)) // Not allowed to remove 'hosted-vespa' tenant
+                .filter(tenantName -> !tenantName.equals(HOSTED_VESPA_TENANT)) // Not allowed to remove 'hosted-vespa' tenant
                 .filter(tenantName -> tenantRepository.getTenant(tenantName).getCreatedTime().isBefore(now.minus(ttlForUnusedTenant)))
                 .peek(tenantRepository::deleteTenant)
                 .collect(Collectors.toSet());
@@ -777,7 +778,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     static Version decideVersion(ApplicationId application, Environment environment, Version sessionVersion, boolean bootstrap) {
         if (     environment.isManuallyDeployed()
             &&   sessionVersion.getMajor() == Vtag.currentVersion.getMajor()
-            && ! "hosted-vespa".equals(application.tenant().value()) // Never change version of system applications
+            && ! HOSTED_VESPA_TENANT.equals(application.tenant()) // Never change version of system applications
             && ! application.instance().isTester() // Never upgrade tester containers
             && ! bootstrap) { // Do not use current version when bootstrapping config server
             return Vtag.currentVersion;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
@@ -75,6 +75,8 @@ public class ConfigConvergenceChecker extends AbstractComponent {
         application.getModel().getHosts()
                    .forEach(host -> host.getServices().stream()
                                         .filter(service -> serviceTypesToCheck.contains(service.getServiceType()))
+
+                                        // TODO: Remove after removing tenant hosts from zone-app
                                         .filter(service -> ! isHostAdminService(application.getId(), service))
                                         .forEach(service -> getStatePort(service).ifPresent(port -> servicesToCheck.add(service))));
 

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -145,6 +145,11 @@ public class Flags {
             "Configserver RPC authorizer. Allowed values: ['disable', 'log-only', 'enforce']",
             "Takes effect on restart of configserver");
 
+    public static final UnboundBooleanFlag ENABLE_TENANT_HOST_APP = defineFeatureFlag(
+            "enable-tenant-host-app", false,
+            "Enable tenant host infrastructure application",
+            "Takes effect immediately");
+
 
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, String description,

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -122,18 +122,6 @@ public class Flags {
             "Takes effect at redeployment",
             APPLICATION_ID);
 
-    public static final UnboundBooleanFlag USE_LB_STATUS_FILE = defineFeatureFlag(
-            "use-lb-status-file", false,
-            "Serve status.html from the new path",
-            "Takes effect on restart of Docker container",
-            APPLICATION_ID, HOSTNAME);
-
-    public static final UnboundBooleanFlag USE_NEW_LOGROTATE_CONFIGURATION = defineFeatureFlag(
-            "use-new-logrotate-configuration", false,
-            "Set up logrotate configuration without using any proprietary software",
-            "Takes effect on restart of Docker container",
-            APPLICATION_ID, HOSTNAME);
-
     public static final UnboundBooleanFlag USE_HTTPS_LOAD_BALANCER_UPSTREAM = defineFeatureFlag(
             "use-https-load-balancer-upstream", false,
             "Use https between load balancer and upstream containers",

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveExpirer.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.maintenance;
 
+import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
@@ -50,7 +51,8 @@ public class InactiveExpirer extends Expirer {
     @Override
     protected boolean isExpired(Node node) {
         return    super.isExpired(node)
-               || node.allocation().get().owner().instance().isTester();
+               || node.allocation().get().owner().instance().isTester()
+               || node.type() == NodeType.host; // TODO: Remove after removing tenant hosts from zone-app
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/OperatorChangeApplicationMaintainer.java
@@ -61,6 +61,7 @@ public class OperatorChangeApplicationMaintainer extends ApplicationMaintainer {
     private Optional<ApplicationId> owner(Node node) {
         if (node.allocation().isPresent()) return node.allocation().map(Allocation::owner);
 
+        // TODO: Remove after removing tenant hosts from zone-app
         return node.type() == NodeType.host ? Optional.of(ZONE_APPLICATION_ID) : Optional.empty();
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZoneAppMigrationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ZoneAppMigrationTest.java
@@ -1,0 +1,171 @@
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Capacity;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostSpec;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.test.ManualClock;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.yahoo.config.provision.ClusterSpec.Type.container;
+import static com.yahoo.config.provision.ClusterSpec.Type.content;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a temporary test to verify the requirements needed for a successful migration of tenant
+ * host nodes out of the zone-application.
+ *
+ * TODO: Remove after removing tenant hosts from zone-app
+ *
+ * @author freva
+ */
+public class ZoneAppMigrationTest {
+
+    private final ManualClock clock = new ManualClock();
+    private final ProvisioningTester tester = new ProvisioningTester.Builder().build();
+    private final InactiveExpirer inactiveExpirer = new InactiveExpirer(tester.nodeRepository(), clock, Duration.ofDays(99));
+
+    private final Version version = Version.fromString("7.42.23");
+
+    private final ApplicationId zoneApp = ApplicationId.from("hosted-vespa", "routing", "default");
+    private final ApplicationId proxyHostApp = ApplicationId.from("hosted-vespa", "proxy-host", "default");
+    private final ApplicationId tenantHostApp = ApplicationId.from("hosted-vespa", "tenant-host", "default");
+    private final ApplicationId app1 = tester.makeApplicationId();
+    private final ApplicationId app2 = tester.makeApplicationId();
+
+
+    @Test
+    public void tenant_host_deallocation_test() {
+        assertEquals(5, tester.nodeRepository().getNodes(NodeType.proxy, Node.State.active).size());
+        assertEquals(20, tester.nodeRepository().getNodes(NodeType.host, Node.State.active).size());
+        assertEquals(15, tester.nodeRepository().getNodes(NodeType.tenant, Node.State.active).size());
+
+        Set<Node> tenantNodes = Set.copyOf(tester.nodeRepository().getNodes(NodeType.tenant));
+
+        // Activate zone-app with only proxy nodes, all tenant hosts become inactive, no change to other nodes
+        tester.activate(zoneApp, prepareSystemApplication(zoneApp, NodeType.proxy, "routing"));
+        assertEquals(5, tester.nodeRepository().getNodes(NodeType.proxy, Node.State.active).size());
+        assertEquals(20, tester.nodeRepository().getNodes(NodeType.host, Node.State.inactive).size());
+        assertEquals(tenantNodes, Set.copyOf(tester.nodeRepository().getNodes(NodeType.tenant)));
+
+        // All tenant hosts become dirty, no change to other nodes
+        inactiveExpirer.maintain();
+        assertEquals(5, tester.nodeRepository().getNodes(NodeType.proxy, Node.State.active).size());
+        assertEquals(20, tester.nodeRepository().getNodes(NodeType.host, Node.State.dirty).size());
+        assertEquals(tenantNodes, Set.copyOf(tester.nodeRepository().getNodes(NodeType.tenant)));
+        // No reboot generation incrementation
+        assertEquals(0, tester.nodeRepository().getNodes(NodeType.host).stream().mapToLong(node -> node.status().reboot().wanted()).sum());
+
+        tester.nodeRepository().getNodes(NodeType.host)
+                .forEach(node -> tester.nodeRepository().setReady(node.hostname(), Agent.operator, "Readied by host-admin"));
+        assertEquals(5, tester.nodeRepository().getNodes(NodeType.proxy, Node.State.active).size());
+        assertEquals(20, tester.nodeRepository().getNodes(NodeType.host, Node.State.ready).size());
+        assertEquals(tenantNodes, Set.copyOf(tester.nodeRepository().getNodes(NodeType.tenant)));
+
+        tester.activate(tenantHostApp, prepareSystemApplication(tenantHostApp, NodeType.host, "tenant-host"));
+        assertEquals(5, tester.nodeRepository().getNodes(NodeType.proxy, Node.State.active).size());
+        assertEquals(20, tester.nodeRepository().getNodes(NodeType.host, Node.State.active).size());
+        assertEquals(tenantNodes, Set.copyOf(tester.nodeRepository().getNodes(NodeType.tenant)));
+
+        // All tenant hosts are allocated to tenant host application
+        assertEquals(Set.copyOf(tester.nodeRepository().getNodes(NodeType.host)),
+                Set.copyOf(tester.nodeRepository().getNodes(tenantHostApp)));
+
+        // All proxy nodes are still allocated to zone-app
+        assertEquals(Set.copyOf(tester.nodeRepository().getNodes(NodeType.proxy)),
+                Set.copyOf(tester.nodeRepository().getNodes(zoneApp)));
+    }
+
+    @Test
+    public void conflicting_type_allocation_test() {
+        // Re-allocate tenant host from zone-app to tenant-host app
+        tester.activate(zoneApp, prepareSystemApplication(zoneApp, NodeType.proxy, "routing"));
+        inactiveExpirer.maintain();
+        tester.nodeRepository().getNodes(NodeType.host)
+                .forEach(node -> tester.nodeRepository().setReady(node.hostname(), Agent.operator, "Readied by host-admin"));
+        tester.activate(tenantHostApp, prepareSystemApplication(tenantHostApp, NodeType.host, "tenant-host"));
+
+        // Re-deploying zone-app with both type proxy and host has no effect (no tenant hosts are re-allocated from tenant-host app)
+        Set<Node> allNodes = Set.copyOf(tester.nodeRepository().getNodes());
+        List<HostSpec> proxyHostSpecs = prepareSystemApplication(zoneApp, NodeType.proxy, "routing");
+        List<HostSpec> nodeAdminHostSpecs = prepareSystemApplication(zoneApp, NodeType.host, "node-admin");
+        List<HostSpec> zoneAppHostSpecs = concat(proxyHostSpecs, nodeAdminHostSpecs, Collectors.toList());
+        tester.activate(zoneApp, zoneAppHostSpecs);
+        assertEquals(0, nodeAdminHostSpecs.size());
+        assertEquals(allNodes, Set.copyOf(tester.nodeRepository().getNodes()));
+
+        // Provision another host and redeploy zone-app
+        Node newHost = tester.makeReadyNodes(1, "large", NodeType.host).get(0);
+        proxyHostSpecs = prepareSystemApplication(zoneApp, NodeType.proxy, "routing");
+        nodeAdminHostSpecs = prepareSystemApplication(zoneApp, NodeType.host, "node-admin");
+        zoneAppHostSpecs = concat(proxyHostSpecs, nodeAdminHostSpecs, Collectors.toList());
+        tester.activate(zoneApp, zoneAppHostSpecs);
+
+        assertEquals(1, nodeAdminHostSpecs.size()); // The newly provisioned host is prepared
+        newHost = tester.nodeRepository().getNode(newHost.hostname()).orElseThrow(); // Update newHost after it has been allocated
+        Set<Node> allNodesWithNewHost = concat(allNodes, Set.of(newHost), Collectors.toSet());
+        assertEquals(allNodesWithNewHost, Set.copyOf(tester.nodeRepository().getNodes()));
+        // The new host is allocated to zone-app, while the old ones are still allocated to tenant-host app
+        assertEquals(zoneApp, newHost.allocation().get().owner());
+    }
+
+    @Before
+    public void setup() {
+        tester.makeReadyNodes(5, "large", NodeType.proxyhost);
+        tester.makeReadyNodes(5, "large", NodeType.proxy);
+        tester.makeReadyNodes(20, "large", NodeType.host, 3);
+
+        tester.activate(proxyHostApp, prepareSystemApplication(proxyHostApp, NodeType.proxyhost, "proxy-host"));
+        List<HostSpec> proxyHostSpecs = prepareSystemApplication(zoneApp, NodeType.proxy, "routing");
+        List<HostSpec> nodeAdminHostSpecs = prepareSystemApplication(zoneApp, NodeType.host, "node-admin");
+        List<HostSpec> zoneAppHostSpecs = concat(proxyHostSpecs, nodeAdminHostSpecs, Collectors.toList());
+        tester.activate(zoneApp, zoneAppHostSpecs);
+
+        activateTenantApplication(app1, 3, 4);
+        activateTenantApplication(app2, 5, 3);
+    }
+
+    private List<HostSpec> prepareSystemApplication(ApplicationId applicationId, NodeType nodeType, String clusterId) {
+        return tester.prepare(applicationId,
+                ClusterSpec.request(container, ClusterSpec.Id.from(clusterId), version, false, Set.of()),
+                Capacity.fromRequiredNodeType(nodeType),
+                1);
+    }
+
+    private void activateTenantApplication(ApplicationId app, int numContainerNodes, int numContentNodes) {
+        List<HostSpec> combinedHostSpecs = new ArrayList<>(numContainerNodes + numContentNodes);
+
+        combinedHostSpecs.addAll(tester.prepare(app,
+                ClusterSpec.request(container, ClusterSpec.Id.from("web"), version, false, Set.of()),
+                Capacity.fromCount(numContainerNodes, new NodeResources(2, 2, 50)),
+                1));
+
+        combinedHostSpecs.addAll(tester.prepare(app,
+                ClusterSpec.request(content, ClusterSpec.Id.from("store"), version, false, Set.of()),
+                Capacity.fromCount(numContentNodes, new NodeResources(1, 4, 50)),
+                1));
+
+        tester.activate(app, combinedHostSpecs);
+    }
+
+    private <T, R, A> R concat(Collection<T> c1, Collection<T> c2, Collector<? super T, A, R> collector) {
+        return Stream.concat(c1.stream(), c2.stream())
+                .collect(collector);
+    }
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/VespaModelUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/VespaModelUtil.java
@@ -35,6 +35,7 @@ public class VespaModelUtil {
     public static final ApplicationId TENANT_HOST_APPLICATION_ID =
             ApplicationId.from("hosted-vespa", "tenant-host", "default");
 
+    // TODO: Remove after removing tenant hosts from zone-app
     public static final ApplicationId ZONE_APPLICATION_ID =
             ApplicationId.from("hosted-vespa", "routing", "default");
     public static final ClusterId ADMIN_CLUSTER_ID = new ClusterId("admin");

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/VespaModelUtil.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/VespaModelUtil.java
@@ -32,9 +32,11 @@ import static com.yahoo.collections.CollectionUtil.first;
 public class VespaModelUtil {
     private static final Logger log = Logger.getLogger(VespaModelUtil.class.getName());
 
+    public static final ApplicationId TENANT_HOST_APPLICATION_ID =
+            ApplicationId.from("hosted-vespa", "tenant-host", "default");
+
     public static final ApplicationId ZONE_APPLICATION_ID =
             ApplicationId.from("hosted-vespa", "routing", "default");
-
     public static final ClusterId ADMIN_CLUSTER_ID = new ClusterId("admin");
     public static final ClusterId NODE_ADMIN_CLUSTER_ID = new ClusterId("node-admin");
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -80,6 +80,10 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
             return ConcurrentSuspensionLimitForCluster.ALL_NODES;
         }
 
+        if (clusterApi.getApplication().applicationId().equals(VespaModelUtil.TENANT_HOST_APPLICATION_ID)) {
+            return ConcurrentSuspensionLimitForCluster.TWENTY_PERCENT;
+        }
+
         if (clusterApi.getApplication().applicationId().equals(VespaModelUtil.ZONE_APPLICATION_ID) &&
                 clusterApi.clusterId().equals(VespaModelUtil.NODE_ADMIN_CLUSTER_ID)) {
             return ConcurrentSuspensionLimitForCluster.TWENTY_PERCENT;

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -84,6 +84,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
             return ConcurrentSuspensionLimitForCluster.TWENTY_PERCENT;
         }
 
+        // TODO: Remove after removing tenant hosts from zone-app
         if (clusterApi.getApplication().applicationId().equals(VespaModelUtil.ZONE_APPLICATION_ID) &&
                 clusterApi.clusterId().equals(VespaModelUtil.NODE_ADMIN_CLUSTER_ID)) {
             return ConcurrentSuspensionLimitForCluster.TWENTY_PERCENT;

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicyTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicyTest.java
@@ -52,7 +52,7 @@ public class HostedVespaClusterPolicyTest {
                 policy.getConcurrentSuspensionLimit(clusterApi));
     }
 
-    @Test
+    @Test // TODO: Remove after removing tenant hosts from zone-app
     public void testNodeAdminSuspensionLimit() {
         when(applicationApi.applicationId()).thenReturn(VespaModelUtil.ZONE_APPLICATION_ID);
         when(clusterApi.clusterId()).thenReturn(VespaModelUtil.NODE_ADMIN_CLUSTER_ID);

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicyTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicyTest.java
@@ -62,6 +62,14 @@ public class HostedVespaClusterPolicyTest {
     }
 
     @Test
+    public void testTenantHostSuspensionLimit() {
+        when(applicationApi.applicationId()).thenReturn(VespaModelUtil.TENANT_HOST_APPLICATION_ID);
+        when(clusterApi.isStorageCluster()).thenReturn(false);
+        assertEquals(ConcurrentSuspensionLimitForCluster.TWENTY_PERCENT,
+                policy.getConcurrentSuspensionLimit(clusterApi));
+    }
+
+    @Test
     public void testDefaultSuspensionLimit() {
         when(applicationApi.applicationId()).thenReturn(ApplicationId.fromSerializedForm("a:b:c"));
         when(clusterApi.clusterId()).thenReturn(new ClusterId("some-cluster-id"));

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/TenantHostApplication.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/TenantHostApplication.java
@@ -1,0 +1,10 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.duper;
+
+import com.yahoo.config.provision.NodeType;
+
+public class TenantHostApplication extends HostAdminApplication {
+    public TenantHostApplication() {
+        super("tenant-host", NodeType.host);
+    }
+}


### PR DESCRIPTION
# TL;DR
This introduces a new infrastructure application (one that only exists in node-repository and orchestrator) for tenant hosts that will be enabled through a feature flag. The plan is:
* deploy a zone-application that does not have the `<nodes type="host">` element, this will deallocate all tenant hosts, making them `inactive`
* `InactiveExpirer` will expire (non-recursive move to `dirty`) all `host` nodes once run (interval is 2s in CD and 25m in main, the maintainers are evenly spaced across cfgs, so this means max 9m wait)
* Each tenant host will then transition to `ready`
* `InfrastructureProvisioner` will then prepare & activate the new tenant host app which will allocate all nodes of type `host`.

Next step will be to update `Zones` (`vespa/hosted#7846`) to specify to either:
1. Not generate any zone-app for the zone (if the zone doesn't have any `proxy` nodes)
2. Only generate the zone-app that allocates `proxy` nodes.

This is also closely related to #9643 which implements the new upgrade procedure of infrastructure in the controller.