### PR TITLE
State last triggering on unexpected job reports

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -124,14 +124,16 @@ public class DeploymentTrigger {
                 }
             }
             else {
-                triggering = application.get().deploymentJobs().statusOf(report.jobType())
-                                        .filter(job ->    job.lastTriggered().isPresent()
-                                                       && job.lastCompleted()
-                                                             .map(completion -> ! completion.at().isAfter(job.lastTriggered().get().at()))
-                                                             .orElse(true))
-                                        .orElseThrow(() -> new IllegalStateException("Notified of completion of " + report.jobType().jobName() + " for " +
-                                                                                     report.applicationId() + ", but that has neither been triggered nor deployed"))
-                                        .lastTriggered().get();
+                Optional<JobStatus> status = application.get().deploymentJobs().statusOf(report.jobType());
+                triggering = status.filter(job ->    job.lastTriggered().isPresent()
+                                                  && job.lastCompleted()
+                                                        .map(completion -> ! completion.at().isAfter(job.lastTriggered().get().at()))
+                                                        .orElse(true))
+                                   .orElseThrow(() -> new IllegalStateException("Notified of completion of " + report.jobType().jobName() + " for " +
+                                                                                report.applicationId() + ", but that has not been triggered; last was " +
+                                                                                status.flatMap(job -> job.lastTriggered().map(run -> run.at().toString()))
+                                                                                      .orElse("never")))
+                                   .lastTriggered().get();
             }
             application = application.withJobCompletion(report.projectId(),
                                                         report.jobType(),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobreport-unexpected-completion.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobreport-unexpected-completion.json
@@ -1,4 +1,0 @@
-{
-  "error-code": "BAD_REQUEST",
-  "message": "Notified of completion of production-us-east-3 for tenant1.application1, but that has neither been triggered nor deployed"
-}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobreport-unexpected-system-test-completion.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobreport-unexpected-system-test-completion.json
@@ -1,4 +1,0 @@
-{
-  "error-code": "BAD_REQUEST",
-  "message": "Notified of completion of system-test for tenant1.application1, but that has neither been triggered nor deployed"
-}


### PR DESCRIPTION
@mpolden please review and merge.

Trying to find the reason some jobs fail when reporting, stating the jobs haven't been triggered.  
It could be double reporting, but I really can't see how that could happen (in the internal pipeline, unless curator locks don't work);  
or it could be that the triggering event was overwritten ...