### PR TITLE
Fix processing of timeout embedded in YQL query

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -858,23 +858,29 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
             commaSeparated(yql, sources);
         }
         yql.append(" where ");
-        yql.append(VespaSerializer.serialize(this));
+        String insert = serializeSortingAndLimits(includeHitsAndOffset);
+        yql.append(VespaSerializer.serialize(this, insert));
+        yql.append(';');
+        return yql.toString();
+    }
+
+    private String serializeSortingAndLimits(boolean includeHitsAndOffset) {
+        StringBuilder insert = new StringBuilder();
         if (getRanking().getSorting() != null && getRanking().getSorting().fieldOrders().size() > 0) {
-            serializeSorting(yql);
+            serializeSorting(insert);
         }
         if (includeHitsAndOffset) {
             if (getOffset() != 0) {
-                yql.append(" limit ").append(getHits() + getOffset())
-                   .append(" offset ").append(getOffset());
+                insert.append(" limit ").append(getHits() + getOffset())
+                    .append(" offset ").append(getOffset());
             } else if (getHits() != 10) {
-                yql.append(" limit ").append(getHits());
+                insert.append(" limit ").append(getHits());
             }
         }
         if (getTimeout() != defaultTimeout) {
-            yql.append(" timeout ").append(getTimeout());
+            insert.append(" timeout ").append(getTimeout());
         }
-        yql.append(';');
-        return yql.toString();
+        return insert.toString();
     }
 
     private void serializeSorting(StringBuilder yql) {

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -1227,8 +1227,13 @@ public class VespaSerializer {
     }
 
     public static String serialize(Query query) {
+        return serialize(query, "");
+    }
+
+    public static String serialize(Query query, String insertBeforeGrouping) {
         StringBuilder out = new StringBuilder();
         serialize(query.getModel().getQueryTree().getRoot(), out);
+        out.append(insertBeforeGrouping);
         for (GroupingRequest request : query.getSelect().getGrouping()) {
             out.append(" | ");
             serialize(request, out);

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -738,8 +738,8 @@ public class YqlParser implements Parser {
         assertHasOperator(ast, StatementOperator.EXECUTE);
 
         ast = ast.getArgument(0);
-        ast = fetchTimeout(ast);
         ast = fetchPipe(ast);
+        ast = fetchTimeout(ast);
         ast = fetchSummaryFields(ast);
         ast = fetchOffsetAndHits(ast);
         ast = fetchSorting(ast);


### PR DESCRIPTION
Two issues actually: Given a YQL query with groupings, like
`select x from sources * where x > 1 | all(group(x) each(output(count())));`
and a timeout, `Query.yqlRepresentation` produced a serialized form
`select x from sources * where x > 1 | all(group(x) each(output(count()))) timeout 77;`
That query is not valid according to the YQL grammar and should be 
`select x from sources * where x > 1 timeout 77 | all(group(x) each(output(count())));`
But that form didn't work either, because `YqlParser.parseYqlProgram` expected the timeout to be on the other side of the pipe. This patch fixes both behaviors without changing the grammar.