### PR TITLE
Avoid racing lookups in synchronized context. Put in a const one inst..

### DIFF
--- a/searchlib/src/vespa/searchlib/features/attributefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/attributefeature.cpp
@@ -147,7 +147,7 @@ public:
      * @param attribute The attribute vector to use.
      * @param idx       The index used for an array attribute.
      */
-    AttributeExecutor(const search::attribute::IAttributeVector * attribute, uint32_t idx);
+    AttributeExecutor(const attribute::IAttributeVector * attribute, uint32_t idx);
     void execute(uint32_t docId) override;
 };
 
@@ -172,7 +172,7 @@ public:
      * @param key      The key to find a corresponding weight for.
      * @param useKey   Whether we should consider the key.
      */
-    WeightedSetAttributeExecutor(const search::attribute::IAttributeVector * attribute, T key, bool useKey);
+    WeightedSetAttributeExecutor(const attribute::IAttributeVector * attribute, T key, bool useKey);
     void execute(uint32_t docId) override;
 };
 
@@ -183,7 +183,7 @@ SingleAttributeExecutor<T>::execute(uint32_t docId)
     typename T::LoadedValueType v = _attribute.getFast(docId);
     // value
     outputs().set_number(0, __builtin_expect(attribute::isUndefined(v), false)
-                         ? attribute::getUndefined<search::feature_t>()
+                         ? attribute::getUndefined<feature_t>()
                          : util::getAsFeature(v));
     outputs().set_number(1, 0.0f);  // weight
     outputs().set_number(2, 0.0f);  // contains
@@ -267,8 +267,9 @@ WeightedSetAttributeExecutor<BT, T>::execute(uint32_t docId)
 
 
 AttributeBlueprint::AttributeBlueprint() :
-    search::fef::Blueprint("attribute"),
+    fef::Blueprint("attribute"),
     _attrName(),
+    _attrKey(),
     _extra(),
     _tensorType(ValueType::double_type())
 {
@@ -277,18 +278,19 @@ AttributeBlueprint::AttributeBlueprint() :
 AttributeBlueprint::~AttributeBlueprint() = default;
 
 void
-AttributeBlueprint::visitDumpFeatures(const search::fef::IIndexEnvironment &,
-                                      search::fef::IDumpFeatureVisitor &) const
+AttributeBlueprint::visitDumpFeatures(const fef::IIndexEnvironment &,
+                                      fef::IDumpFeatureVisitor &) const
 {
 }
 
 bool
-AttributeBlueprint::setup(const search::fef::IIndexEnvironment & env,
-                          const search::fef::ParameterList & params)
+AttributeBlueprint::setup(const fef::IIndexEnvironment & env,
+                          const fef::ParameterList & params)
 {
     // params[0] = attribute name
     // params[1] = index (array attribute) or key (weighted set attribute)
     _attrName = params[0].getValue();
+    _attrKey = getBaseName() + "." + _attrName;
     if (params.size() == 2) {
         _extra = params[1].getValue();
     }
@@ -315,10 +317,10 @@ AttributeBlueprint::setup(const search::fef::IIndexEnvironment & env,
     return !_tensorType.is_error();
 }
 
-search::fef::Blueprint::UP
+fef::Blueprint::UP
 AttributeBlueprint::createInstance() const
 {
-    return search::fef::Blueprint::UP(new AttributeBlueprint());
+    return fef::Blueprint::UP(new AttributeBlueprint());
 }
 
 #define CREATE_AND_RETURN_IF_SINGLE_NUMERIC(a, T) \
@@ -328,7 +330,7 @@ AttributeBlueprint::createInstance() const
 
 namespace {
 
-search::fef::FeatureExecutor &
+fef::FeatureExecutor &
 createAttributeExecutor(const IAttributeVector *attribute, const vespalib::string &attrName, const vespalib::string &extraParam, vespalib::Stash &stash)
 {
     if (attribute == NULL) {
@@ -375,7 +377,7 @@ createAttributeExecutor(const IAttributeVector *attribute, const vespalib::strin
     }
 }
 
-search::fef::FeatureExecutor &
+fef::FeatureExecutor &
 createTensorAttributeExecutor(const IAttributeVector *attribute, const vespalib::string &attrName,
                               const ValueType &tensorType,
                               vespalib::Stash &stash)
@@ -385,8 +387,8 @@ createTensorAttributeExecutor(const IAttributeVector *attribute, const vespalib:
                 " Returning empty tensor.", attrName.c_str());
         return ConstantTensorExecutor::createEmpty(tensorType, stash);
     }
-    if (attribute->getCollectionType() != search::attribute::CollectionType::SINGLE ||
-            attribute->getBasicType() != search::attribute::BasicType::TENSOR) {
+    if (attribute->getCollectionType() != attribute::CollectionType::SINGLE ||
+            attribute->getBasicType() != attribute::BasicType::TENSOR) {
         LOG(warning, "The attribute vector '%s' is NOT of type tensor."
                 " Returning empty tensor.", attribute->getName().c_str());
         return ConstantTensorExecutor::createEmpty(tensorType, stash);
@@ -413,10 +415,25 @@ createTensorAttributeExecutor(const IAttributeVector *attribute, const vespalib:
 
 }
 
-search::fef::FeatureExecutor &
-AttributeBlueprint::createExecutor(const search::fef::IQueryEnvironment &env, vespalib::Stash &stash) const
+void
+AttributeBlueprint::prepareSharedState(const fef::IQueryEnvironment & env, fef::IObjectStore & store) const
 {
-    const IAttributeVector *attribute = env.getAttributeContext().getAttribute(_attrName);
+    if (store.get(_attrKey) == nullptr) {
+        const IAttributeVector * attribute = env.getAttributeContext().getAttribute(_attrName);
+        store.add(_attrKey, std::make_unique<fef::AnyWrapper<const IAttributeVector *>>(attribute));
+    }
+}
+
+fef::FeatureExecutor &
+AttributeBlueprint::createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const
+{
+    const fef::Anything * attributeArg = env.getObjectStore().get(_attrKey);
+    const IAttributeVector * attribute = (attributeArg != nullptr)
+                                       ? static_cast<const fef::AnyWrapper<const IAttributeVector *> *>(attributeArg)->getValue()
+                                       : nullptr;
+    if (attribute == nullptr) {
+        attribute = env.getAttributeContext().getAttribute(_attrName);
+    }
     if (_tensorType.is_tensor()) {
         return createTensorAttributeExecutor(attribute, _attrName, _tensorType, stash);
     } else {

--- a/searchlib/src/vespa/searchlib/features/attributefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/attributefeature.cpp
@@ -320,7 +320,7 @@ AttributeBlueprint::setup(const fef::IIndexEnvironment & env,
 fef::Blueprint::UP
 AttributeBlueprint::createInstance() const
 {
-    return fef::Blueprint::UP(new AttributeBlueprint());
+    return std::make_unique<AttributeBlueprint>();
 }
 
 #define CREATE_AND_RETURN_IF_SINGLE_NUMERIC(a, T) \

--- a/searchlib/src/vespa/searchlib/features/attributefeature.h
+++ b/searchlib/src/vespa/searchlib/features/attributefeature.h
@@ -16,6 +16,7 @@ namespace search::features {
 class AttributeBlueprint : public fef::Blueprint {
 private:
     vespalib::string _attrName; // the name of the attribute vector
+    vespalib::string _attrKey;  // Used for looking up the attribute in the ObjectStore.
     vespalib::string _extra;    // the index or key
     vespalib::eval::ValueType _tensorType;
 
@@ -25,6 +26,7 @@ public:
     void visitDumpFeatures(const fef::IIndexEnvironment & env, fef::IDumpFeatureVisitor & visitor) const override;
 
     fef::Blueprint::UP createInstance() const override;
+    void prepareSharedState(const fef::IQueryEnvironment & queryEnv, fef::IObjectStore & objectStore) const override;
     fef::FeatureExecutor &createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const override;
     fef::ParameterDescriptions getDescriptions() const  override;
     bool setup(const fef::IIndexEnvironment & env, const fef::ParameterList & params) override;

--- a/searchlib/src/vespa/searchlib/fef/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprint.cpp
@@ -69,4 +69,35 @@ Blueprint::setup(const IIndexEnvironment &indexEnv,
     return false;
 }
 
+const attribute::IAttributeVector *
+Blueprint::lookupAndStoreAttribute(const vespalib::string & key, vespalib::stringref attrName,
+                                   const IQueryEnvironment & env, IObjectStore & store)
+{
+    const Anything * obj = store.get(key);
+    if (obj == nullptr) {
+        const IAttributeVector * attribute = env.getAttributeContext().getAttribute(attrName);
+        store.add(key, std::make_unique<AnyWrapper<const IAttributeVector *>>(attribute));
+        return attribute;
+    }
+    return static_cast<const AnyWrapper<const IAttributeVector *> *>(obj)->getValue();
+}
+
+const attribute::IAttributeVector *
+Blueprint::lookupAttribute(const vespalib::string & key, vespalib::stringref attrName, const IQueryEnvironment & env)
+{
+    const Anything * attributeArg = env.getObjectStore().get(key);
+    const IAttributeVector * attribute = (attributeArg != nullptr)
+                                       ? static_cast<const AnyWrapper<const IAttributeVector *> *>(attributeArg)->getValue()
+                                       : nullptr;
+    if (attribute == nullptr) {
+        attribute = env.getAttributeContext().getAttribute(attrName);
+    }
+    return attribute;;
+}
+
+vespalib::string
+Blueprint::createAttributeKey(vespalib::stringref attrName) {
+    return "fef.attribute.key." + attrName;
+}
+
 }

--- a/searchlib/src/vespa/searchlib/fef/blueprint.h
+++ b/searchlib/src/vespa/searchlib/fef/blueprint.h
@@ -70,6 +70,7 @@ private:
     DependencyHandler       *_dependency_handler;
 
 protected:
+    using IAttributeVector = attribute::IAttributeVector;
     /**
      * Define an input feature for this blueprint. This method should
      * be invoked by the @ref setup method. Note that the order in
@@ -100,6 +101,19 @@ protected:
     void describeOutput(vespalib::stringref outName, vespalib::stringref desc,
                         const FeatureType &type = FeatureType::number());
 
+    /**
+     * Used to store a reference to the attribute during prepareSharedState
+     * for later use in createExecutor
+     **/
+    static const IAttributeVector *
+    lookupAndStoreAttribute(const vespalib::string & key, vespalib::stringref attrName,
+                            const IQueryEnvironment & env, IObjectStore & objectStore);
+    /**
+     * Used to lookup attribute from the most efficient source.
+     **/
+    static const IAttributeVector *
+    lookupAttribute(const vespalib::string & key, vespalib::stringref attrName, const IQueryEnvironment & env);
+    static vespalib::string createAttributeKey(vespalib::stringref attrName);
 public:
     /**
      * Create an empty blueprint. Blueprints in their initial state


### PR DESCRIPTION
…ead.
@geirst @havardpe PR