### PR TITLE
Do not use chunked output for Base64-encoded raw fields in JSON output

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/JsonSerializationHelper.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonSerializationHelper.java
@@ -32,10 +32,10 @@ import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.objects.FieldBase;
-import org.apache.commons.codec.binary.Base64;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -45,7 +45,7 @@ import java.util.Set;
  * @author Vegard Sjonfjell
  */
 public class JsonSerializationHelper {
-    private final static Base64 base64Encoder = new Base64();
+    private final static Base64.Encoder base64Encoder = Base64.getEncoder(); // Important: _basic_ format
 
     static class JsonSerializationException extends RuntimeException {
         public JsonSerializationException(Exception base) {

--- a/document/src/test/java/com/yahoo/document/json/DocumentUpdateJsonSerializerTest.java
+++ b/document/src/test/java/com/yahoo/document/json/DocumentUpdateJsonSerializerTest.java
@@ -485,7 +485,7 @@ public class DocumentUpdateJsonSerializerTest {
                         "    'update': 'DOCUMENT_ID',",
                         "    'fields': {",
                         "        'raw_field': {",
-                        "            'assign': 'RG9uJ3QgYmVsaWV2ZSBoaXMgbGllcw==\\r\\n'",
+                        "            'assign': 'RG9uJ3QgYmVsaWV2ZSBoaXMgbGllcw=='",
                         "        }",
                         "    }",
                         "}"

--- a/document/src/test/java/com/yahoo/document/json/JsonWriterTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonWriterTestCase.java
@@ -26,7 +26,6 @@ import com.yahoo.document.json.readers.DocumentParseInfo;
 import com.yahoo.document.json.readers.VespaJsonDocumentReader;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.text.Utf8;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -273,10 +272,13 @@ public class JsonWriterTestCase {
     }
 
     @Test
-    public final void rawTest() throws IOException {
+    public final void raw_fields_are_emitted_as_basic_base64() throws IOException {
+        // "string long enough to emit more than 76 base64 characters and which should certainly not be newline-delimited!"
         String payload = new String(
-                new JsonStringEncoder().quoteAsString(new Base64()
-                        .encodeToString(Utf8.toBytes("smoketest"))));
+                new JsonStringEncoder().quoteAsString(
+                        "c3RyaW5nIGxvbmcgZW5vdWdoIHRvIGVtaXQgbW9yZSB0aGFuIDc2IGJhc2U2NCBjaGFyYWN0ZXJzIGFuZC" +
+                              "B3aGljaCBzaG91bGQgY2VydGFpbmx5IG5vdCBiZSBuZXdsaW5lLWRlbGltaXRlZCE="));
+
         String docId = "id:unittest:testraw::whee";
 
         String fields = "{ \"actualraw\": \"" + payload + "\"" + " }";


### PR DESCRIPTION
@baldersheim (module owner) and @bratseth please review

Previous code would always insert at least one linebreak in the output.
Replace Apache Commons encoder with explicit basic `java.util.Base64`
encoder to make us less dependent on magic constructor args.

Explicitly test that we still can decode chunked _input_ to ensure
we do not break roundtrip serialization ability for old outputs.