### PR TITLE
Temporary set owner of splunkforwarder log

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -156,7 +156,7 @@ public class DockerOperationsImpl implements DockerOperations {
         // TODO: Remove after all nodes are on Vespa 7
         new UnixPath(context.pathOnHostFromPathInNode("/opt/splunkforwarder/var/log"))
                 .createDirectories()
-                .setOwner(context.vespaUser());
+                .setOwner(context.vespaUserOnHost());
         docker.startContainer(context.containerName());
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.dockerapi.ProcessResult;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeMembership;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.ContainerData;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
+import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixPath;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.IPAddresses;
 
 import java.io.IOException;
@@ -152,6 +153,10 @@ public class DockerOperationsImpl implements DockerOperations {
     @Override
     public void startContainer(NodeAgentContext context) {
         context.log(logger, "Starting container");
+        // TODO: Remove after all nodes are on Vespa 7
+        new UnixPath(context.pathOnHostFromPathInNode("/opt/splunkforwarder/var/log"))
+                .createDirectories()
+                .setOwner(context.vespaUser());
         docker.startContainer(context.containerName());
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/UnixPath.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/UnixPath.java
@@ -141,6 +141,12 @@ public class UnixPath {
         return this;
     }
 
+    public UnixPath createDirectories() {
+        uncheck(() -> Files.createDirectories(path));
+        return this;
+    }
+
+
     public UnixPath createDirectory(String permissions) {
         Set<PosixFilePermission> set = getPosixFilePermissionsFromString(permissions);
         FileAttribute<Set<PosixFilePermission>> attribute = PosixFilePermissions.asFileAttribute(set);


### PR DESCRIPTION
We do this in `start-services.sh`, but unfortunately that change only exists in images after 7.4x, so we need to also do this in `node-admin` just before we start the container. Docker creates the directories on host that are to be mounted in the container (if missing) as part of start. So at this point, if this is the first this time container is started, the directory will not exist.