### PR TITLE
Improve validation of endpoint IDs

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -183,7 +183,11 @@ public class DeploymentSpecXmlReader {
                 regions.add(region);
             }
 
-            endpoints.add(new Endpoint(rotationId, containerId.get(), regions));
+            var endpoint = new Endpoint(rotationId, containerId.get(), regions);
+            if (endpoints.contains(endpoint)) {
+                throw new IllegalArgumentException("Duplicate 'endpoint' in 'endpoints' tag");
+            }
+            endpoints.add(endpoint);
         }
 
         return endpoints;


### PR DESCRIPTION
Same validation rules that are in place for `<rotations/>' in `services.xml`,
which we are removing.