### PR TITLE
Do not block scanning all buckets on first cluster state edge

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -359,12 +359,10 @@ Distributor::enableClusterStateBundle(const lib::ClusterStateBundle& state)
     if (!_doneInitializing &&
         baselineState.getNodeState(myNode).getState() == lib::State::UP)
     {
-        scanAllBuckets();
         _doneInitializing = true;
         _doneInitializeHandler.notifyDoneInitializing();
-    } else {
-        enterRecoveryMode();
     }
+    enterRecoveryMode();
 
     // Clear all active messages on nodes that are down.
     for (uint16_t i = 0; i < baselineState.getNodeCount(lib::NodeType::STORAGE); ++i) {


### PR DESCRIPTION
@geirst please review

Scanning all buckets is expensive and blocks the main distributor thread
during the entire process. Instead, use the standard "recovery mode"
functionality that is triggered for all subsequent state transitions.
Recovery mode scans allow client operations to be scheduled alongside
the scanning, but still tries to scan the DB as quickly as possible.
There shouldn't be anything that special with the first cluster state
that implies a full scan is inherently required.