### PR TITLE
Define ZoneApi

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneApi.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneApi.java
@@ -1,0 +1,20 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision.zone;
+
+import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+
+/**
+ * @author hakonhall
+ */
+public interface ZoneApi {
+    SystemName getSystemName();
+
+    ZoneId getId();
+    default Environment getEnvironment() { return getId().environment(); }
+    default RegionName getRegionName() { return getId().region(); }
+
+    CloudName getCloudName();
+}

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneApi.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneApi.java
@@ -17,4 +17,8 @@ public interface ZoneApi {
     default RegionName getRegionName() { return getId().region(); }
 
     CloudName getCloudName();
+
+    default ZoneId toDeprecatedId() {
+        return ZoneId.from(getEnvironment(), getRegionName(), getCloudName(), getSystemName());
+    }
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneId.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneId.java
@@ -77,6 +77,10 @@ public class ZoneId {
         return new ZoneId(Environment.from(environment), RegionName.from(region), CloudName.from(cloud), SystemName.from(system));
     }
 
+    public static ZoneId defaultId() {
+        return new ZoneId(Environment.defaultEnvironment(), RegionName.defaultName());
+    }
+
     public Environment environment() {
         return environment;
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneList.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneList.java
@@ -29,6 +29,9 @@ public interface ZoneList extends ZoneFilter {
     /** Only the given zones — combine with not() for best effect! */
     ZoneList among(ZoneId... zones);
 
+    /** Returns the ZoneApi of all zones in this list. */
+    List<? extends ZoneApi> zones();
+
     /** Returns the id of all zones in this list as — you guessed it — a list. */
     List<ZoneId> ids();
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -8,6 +8,7 @@ import com.yahoo.component.Vtag;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.flags.FlagSource;
@@ -315,8 +316,8 @@ public class Controller extends AbstractComponent {
     }
 
     private Set<CloudName> clouds() {
-        return zoneRegistry.zones().all().ids().stream()
-                           .map(ZoneId::cloud)
+        return zoneRegistry.zones().all().zones().stream()
+                           .map(ZoneApi::getCloudName)
                            .collect(Collectors.toUnmodifiableSet());
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.AbstractComponent;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.ContactRetriever;
@@ -117,8 +118,8 @@ public class ControllerMaintenance extends AbstractComponent {
 
     /** Create one OS upgrader per cloud found in the zone registry of controller */
     private static List<OsUpgrader> osUpgraders(Controller controller, JobControl jobControl) {
-        return controller.zoneRegistry().zones().controllerUpgraded().ids().stream()
-                         .map(ZoneId::cloud)
+        return controller.zoneRegistry().zones().controllerUpgraded().zones().stream()
+                         .map(ZoneApi::getCloudName)
                          .distinct()
                          .sorted()
                          .map(cloud -> new OsUpgrader(controller, Duration.ofMinutes(1), jobControl, cloud))

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -30,6 +30,7 @@ import com.yahoo.vespa.hosted.controller.application.JobStatus;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.BuildJob;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.rotation.RotationId;
 import com.yahoo.vespa.hosted.controller.rotation.RotationLock;
 import org.junit.Test;
@@ -462,7 +463,7 @@ public class ControllerTest {
         Version six = Version.fromString("6.1");
         tester.upgradeSystem(six);
         tester.controllerTester().zoneRegistry().setSystemName(SystemName.cd);
-        tester.controllerTester().zoneRegistry().setZones(ZoneId.from("prod", "cd-us-central-1"));
+        tester.controllerTester().zoneRegistry().setZones(ZoneApiMock.fromId("prod.cd-us-central-1"));
         ApplicationPackage applicationPackage = new ApplicationPackageBuilder()
                 .environment(Environment.prod)
                 .majorVersion(6)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneApiMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneApiMock.java
@@ -1,0 +1,70 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.integration;
+
+import com.yahoo.cloud.config.SentinelConfig;
+import com.yahoo.config.model.graph.ModelGraphBuilder;
+import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneApi;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.messagebus.MessagebusConfig;
+
+/**
+ * @author hakonhall
+ */
+public class ZoneApiMock implements ZoneApi {
+    private final SystemName systemName;
+    private final ZoneId id;
+    private final CloudName cloudName;
+
+    public static Builder newBuilder() { return new Builder(); }
+
+    private ZoneApiMock(SystemName systemName, ZoneId id, CloudName cloudName) {
+        this.systemName = systemName;
+        this.id = id;
+        this.cloudName = cloudName;
+    }
+
+    public static ZoneApiMock fromId(String id) {
+        return newBuilder().withId(id).build();
+    }
+
+    public static ZoneApiMock from(Environment environment, RegionName region) {
+        return newBuilder().with(ZoneId.from(environment, region)).build();
+    }
+
+    @Override
+    public SystemName getSystemName() { return systemName; }
+
+    @Override
+    public ZoneId getId() { return id; }
+
+    @Override
+    public CloudName getCloudName() { return cloudName; }
+
+    public static class Builder {
+        private SystemName systemName = SystemName.defaultSystem();
+        private ZoneId id = ZoneId.defaultId();
+        private CloudName cloudName = CloudName.defaultName();
+
+        public Builder with(ZoneId id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withId(String id) { return with(ZoneId.from(id)); }
+
+        public Builder with(CloudName cloudName) {
+            this.cloudName = cloudName;
+            return this;
+        }
+
+        public Builder withCloud(String cloud) { return with(CloudName.from(cloud)); }
+
+        public ZoneApiMock build() {
+            return new ZoneApiMock(systemName, id, cloudName);
+        }
+    }
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneFilterMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneFilterMock.java
@@ -1,9 +1,12 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.config.provision.zone;
+package com.yahoo.vespa.hosted.controller.integration;
 
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.zone.ZoneFilter;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.config.provision.zone.ZoneList;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneFilterMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneFilterMock.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.integration;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneFilter;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.config.provision.zone.ZoneList;
@@ -74,6 +75,11 @@ public class ZoneFilterMock implements ZoneList {
     @Override
     public ZoneList among(ZoneId... zones) {
         return filter(zoneId -> new HashSet<>(Arrays.asList(zones)).contains(zoneId));
+    }
+
+    @Override
+    public List<? extends ZoneApi> zones() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.UpgradePolicy;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneFilter;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.athenz.api.AthenzService;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * @author mpolden
@@ -34,7 +36,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     private final Map<ZoneId, Duration> deploymentTimeToLive = new HashMap<>();
     private final Map<Environment, RegionName> defaultRegionForEnvironment = new HashMap<>();
-    private List<ZoneId> zones = new ArrayList<>();
+    private List<ZoneApi> zones = new ArrayList<>();
     private SystemName system;
     private UpgradePolicy upgradePolicy = null;
     private Map<CloudName, UpgradePolicy> osUpgradePolicies = new HashMap<>();
@@ -50,10 +52,11 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     public ZoneRegistryMock(SystemName system) {
         this.system = system;
-        zones.add(ZoneId.from("prod", "us-east-3"));
-        zones.add(ZoneId.from("prod", "us-west-1"));
-        zones.add(ZoneId.from("prod", "us-central-1"));
-        zones.add(ZoneId.from("prod", "eu-west-1"));
+        setZones(List.of(
+                ZoneApiMock.fromId("prod.us-east-3"),
+                ZoneApiMock.fromId("prod.us-west-1"),
+                ZoneApiMock.fromId("prod.us-central-1"),
+                ZoneApiMock.fromId("prod.eu-west-1")));
     }
 
     public ZoneRegistryMock setDeploymentTimeToLive(ZoneId zone, Duration duration) {
@@ -66,12 +69,12 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
         return this;
     }
 
-    public ZoneRegistryMock setZones(List<ZoneId> zones) {
+    public ZoneRegistryMock setZones(List<ZoneApi> zones) {
         this.zones = zones;
         return this;
     }
 
-    public ZoneRegistryMock setZones(ZoneId... zone) {
+    public ZoneRegistryMock setZones(ZoneApi... zone) {
         return setZones(List.of(zone));
     }
 
@@ -97,7 +100,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Override
     public ZoneFilter zones() {
-        return ZoneFilterMock.from(Collections.unmodifiableList(zones));
+        return ZoneFilterMock.from(List.copyOf(zones));
     }
 
     public AthenzService getConfigServerAthenzIdentity(ZoneId zone) {
@@ -146,7 +149,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Override
     public boolean hasZone(ZoneId zoneId) {
-        return zones.contains(zoneId);
+        return zones.stream().anyMatch(zone -> zone.getId().equals(zoneId));
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -12,7 +12,6 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.UpgradePolicy;
 import com.yahoo.config.provision.zone.ZoneFilter;
-import com.yahoo.config.provision.zone.ZoneFilterMock;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.athenz.api.AthenzService;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/CostReportMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/CostReportMaintainerTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryClientMock;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.restapi.cost.CostReportConsumer;
 import com.yahoo.vespa.hosted.controller.restapi.cost.config.SelfHostedCostConfig;
 import org.junit.Assert;
@@ -19,12 +20,11 @@ public class CostReportMaintainerTest {
     @Test
     public void maintain() {
         ControllerTester tester = new ControllerTester();
-        List<ZoneId> zones = new ArrayList<>();
-        zones.add(ZoneId.from("prod", "us-east-3", "yahoo"));
-        zones.add(ZoneId.from("prod", "us-west-1", "yahoo"));
-        zones.add(ZoneId.from("prod", "us-central-1", "yahoo"));
-        zones.add(ZoneId.from("prod", "eu-west-1", "yahoo"));
-        tester.zoneRegistry().setZones(zones);
+        tester.zoneRegistry().setZones(
+                ZoneApiMock.newBuilder().withId("prod.us-east-3").withCloud("yahoo").build(),
+                ZoneApiMock.newBuilder().withId("prod.us-west-1").withCloud("yahoo").build(),
+                ZoneApiMock.newBuilder().withId("prod.us-central-1").withCloud("yahoo").build(),
+                ZoneApiMock.newBuilder().withId("prod.eu-west-1").withCloud("yahoo").build());
 
         CostReportConsumer mockConsumer = csv -> Assert.assertEquals(csv,
                 "Date,Property,Reserved Cpu Cores,Reserved Memory GB,Reserved Disk Space GB,Usage Fraction\n" +

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -3,22 +3,21 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudName;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.config.provision.zone.UpgradePolicy;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryMock;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.versions.OsVersionStatus;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -30,11 +29,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class OsUpgraderTest {
 
-    private static final ZoneId zone1 = ZoneId.from("prod", "eu-west-1");
-    private static final ZoneId zone2 = ZoneId.from("prod", "us-west-1");
-    private static final ZoneId zone3 = ZoneId.from("prod", "us-central-1");
-    private static final ZoneId zone4 = ZoneId.from("prod", "us-east-3");
-    private static final ZoneId zone5 = ZoneId.from("prod", "us-north-1", "other");
+    private static final ZoneApi zone1 = ZoneApiMock.newBuilder().withId("prod.eu-west-1").build();
+    private static final ZoneApi zone2 = ZoneApiMock.newBuilder().withId("prod.us-west-1").build();
+    private static final ZoneApi zone3 = ZoneApiMock.newBuilder().withId("prod.us-central-1").build();
+    private static final ZoneApi zone4 = ZoneApiMock.newBuilder().withId("prod.us-east-3").build();
+    private static final ZoneApi zone5 = ZoneApiMock.newBuilder().withId("prod.us-north-1").withCloud("other").build();
 
     private DeploymentTester tester;
     private OsVersionStatusUpdater statusUpdater;
@@ -50,24 +49,24 @@ public class OsUpgraderTest {
     public void upgrade_os() {
         OsUpgrader osUpgrader = osUpgrader(
                 UpgradePolicy.create()
-                             .upgrade(zone1)
-                             .upgradeInParallel(zone2, zone3)
-                             .upgrade(zone5) // Belongs to a different cloud and is ignored by this upgrader
-                             .upgrade(zone4),
+                             .upgrade(zone1.toDeprecatedId())
+                             .upgradeInParallel(zone2.toDeprecatedId(), zone3.toDeprecatedId())
+                             .upgrade(zone5.toDeprecatedId()) // Belongs to a different cloud and is ignored by this upgrader
+                             .upgrade(zone4.toDeprecatedId()),
                 SystemName.cd
         );
 
         // Bootstrap system
-        tester.configServer().bootstrap(List.of(zone1, zone2, zone3, zone4, zone5),
+        tester.configServer().bootstrap(List.of(zone1.toDeprecatedId(), zone2.toDeprecatedId(), zone3.toDeprecatedId(), zone4.toDeprecatedId(), zone5.toDeprecatedId()),
                                         List.of(SystemApplication.tenantHost));
 
         // Add system applications that exist in a real system, but are currently not upgraded
-        tester.configServer().addNodes(List.of(zone1, zone2, zone3, zone4, zone5),
+        tester.configServer().addNodes(List.of(zone1.toDeprecatedId(), zone2.toDeprecatedId(), zone3.toDeprecatedId(), zone4.toDeprecatedId(), zone5.toDeprecatedId()),
                                        List.of(SystemApplication.configServer));
 
         // Fail a few nodes. Failed nodes should not affect versions
-        failNodeIn(zone1, SystemApplication.tenantHost);
-        failNodeIn(zone3, SystemApplication.tenantHost);
+        failNodeIn(zone1.toDeprecatedId(), SystemApplication.tenantHost);
+        failNodeIn(zone3.toDeprecatedId(), SystemApplication.tenantHost);
 
         // New OS version released
         Version version1 = Version.fromString("7.1");
@@ -79,37 +78,37 @@ public class OsUpgraderTest {
 
         // zone 1: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.tenantHost, zone1);
+        assertWanted(version1, SystemApplication.tenantHost, zone1.toDeprecatedId());
 
         // Other zones remain on previous version (none)
-        assertWanted(Version.emptyVersion, SystemApplication.proxy, zone2, zone3, zone4);
+        assertWanted(Version.emptyVersion, SystemApplication.proxy, zone2.toDeprecatedId(), zone3.toDeprecatedId(), zone4.toDeprecatedId());
 
         // zone 1: completes upgrade
-        completeUpgrade(version1, SystemApplication.tenantHost, zone1);
+        completeUpgrade(version1, SystemApplication.tenantHost, zone1.toDeprecatedId());
         statusUpdater.maintain();
         assertEquals(2, nodesOn(version1).size());
         assertEquals(11, nodesOn(Version.emptyVersion).size());
 
         // zone 2 and 3: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.proxy, zone2, zone3);
+        assertWanted(version1, SystemApplication.proxy, zone2.toDeprecatedId(), zone3.toDeprecatedId());
 
         // zone 4: still on previous version
-        assertWanted(Version.emptyVersion, SystemApplication.tenantHost, zone4);
+        assertWanted(Version.emptyVersion, SystemApplication.tenantHost, zone4.toDeprecatedId());
 
         // zone 2 and 3: completes upgrade
-        completeUpgrade(version1, SystemApplication.tenantHost, zone2, zone3);
+        completeUpgrade(version1, SystemApplication.tenantHost, zone2.toDeprecatedId(), zone3.toDeprecatedId());
 
         // zone 4: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.tenantHost, zone4);
+        assertWanted(version1, SystemApplication.tenantHost, zone4.toDeprecatedId());
 
         // zone 4: completes upgrade
-        completeUpgrade(version1, SystemApplication.tenantHost, zone4);
+        completeUpgrade(version1, SystemApplication.tenantHost, zone4.toDeprecatedId());
 
         // Next run does nothing as all zones are upgraded
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.tenantHost, zone1, zone2, zone3, zone4);
+        assertWanted(version1, SystemApplication.tenantHost, zone1.toDeprecatedId(), zone2.toDeprecatedId(), zone3.toDeprecatedId(), zone4.toDeprecatedId());
         statusUpdater.maintain();
         assertTrue("All nodes on target version", tester.controller().osVersionStatus().nodesIn(cloud).stream()
                                                         .allMatch(node -> node.version().equals(version1)));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainerTest.java
@@ -9,6 +9,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.resource.ResourceSnapsh
 import com.yahoo.vespa.hosted.controller.api.integration.stubs.MockResourceSnapshotConsumer;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryClientMock;
 import com.yahoo.vespa.hosted.controller.integration.MetricsMock;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -32,12 +33,12 @@ public class ResourceMeterMaintainerTest {
     @Test
     public void testMaintainer() {
         ControllerTester tester = new ControllerTester();
-        List<ZoneId> zones = new ArrayList<>();
-        zones.add(ZoneId.from("prod", "us-east-3"));
-        zones.add(ZoneId.from("prod", "us-west-1"));
-        zones.add(ZoneId.from("prod", "us-central-1"));
-        zones.add(ZoneId.from("prod", "aws-us-east-1", "aws"));
-        tester.zoneRegistry().setZones(zones);
+        tester.zoneRegistry().setZones(
+                ZoneApiMock.newBuilder().withId("prod.us-east-3").build(),
+                ZoneApiMock.newBuilder().withId("prod.us-west-1").build(),
+                ZoneApiMock.newBuilder().withId("prod.us-central-1").build(),
+                ZoneApiMock.newBuilder().withId("prod.aws-us-east-1").withCloud("aws").build());
+
         ResourceMeterMaintainer resourceMeterMaintainer = new ResourceMeterMaintainer(tester.controller(), Duration.ofMinutes(5), new JobControl(tester.curator()), nodeRepository, tester.clock(), metrics, snapshotConsumer);
         resourceMeterMaintainer.maintain();
         Map<ApplicationId, ResourceSnapshot> consumedResources = snapshotConsumer.consumedResources();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/cost/CostApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/cost/CostApiTest.java
@@ -4,9 +4,10 @@ package com.yahoo.vespa.hosted.controller.restapi.cost;
 import com.yahoo.application.container.handler.Request;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.athenz.api.AthenzIdentity;
 import com.yahoo.vespa.athenz.api.AthenzUser;
-import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock;
 import com.yahoo.vespa.hosted.controller.restapi.ContainerControllerTester;
 import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerTest;
@@ -22,9 +23,9 @@ public class CostApiTest extends ControllerContainerTest {
     private static final AthenzIdentity operator = AthenzUser.fromUserId("operatorUser");
     private static final CloudName cloud1 = CloudName.from("yahoo");
     private static final CloudName cloud2 = CloudName.from("cloud2");
-    private static final ZoneId zone1 = ZoneId.from("prod", "us-east-3", cloud1.value());
-    private static final ZoneId zone2 = ZoneId.from("prod", "us-west-1", cloud1.value());
-    private static final ZoneId zone3 = ZoneId.from("prod", "eu-west-1", cloud2.value());
+    private static final ZoneApi zone1 = ZoneApiMock.newBuilder().withId("prod.us-east-3").with(cloud1).build();
+    private static final ZoneApi zone2 = ZoneApiMock.newBuilder().withId("prod.us-west-1").with(cloud1).build();
+    private static final ZoneApi zone3 = ZoneApiMock.newBuilder().withId("prod.eu-west-1").with(cloud2).build();
 
     private ContainerControllerTester tester;
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -5,6 +5,7 @@ import com.yahoo.application.container.handler.Request;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.UpgradePolicy;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.athenz.api.AthenzIdentity;
 import com.yahoo.vespa.athenz.api.AthenzUser;
@@ -12,6 +13,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerMock;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryMock;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock;
 import com.yahoo.vespa.hosted.controller.maintenance.JobControl;
 import com.yahoo.vespa.hosted.controller.maintenance.Maintainer;
@@ -38,9 +40,9 @@ public class OsApiTest extends ControllerContainerTest {
     private static final AthenzIdentity operator = AthenzUser.fromUserId("operatorUser");
     private static final CloudName cloud1 = CloudName.from("cloud1");
     private static final CloudName cloud2 = CloudName.from("cloud2");
-    private static final ZoneId zone1 = ZoneId.from("prod", "us-east-3", cloud1.value());
-    private static final ZoneId zone2 = ZoneId.from("prod", "us-west-1", cloud1.value());
-    private static final ZoneId zone3 = ZoneId.from("prod", "eu-west-1", cloud2.value());
+    private static final ZoneApi zone1 = ZoneApiMock.newBuilder().withId("prod.us-east-3").with(cloud1).build();
+    private static final ZoneApi zone2 = ZoneApiMock.newBuilder().withId("prod.us-west-1").with(cloud1).build();
+    private static final ZoneApi zone3 = ZoneApiMock.newBuilder().withId("prod.eu-west-1").with(cloud2).build();
 
     private ContainerControllerTester tester;
     private List<OsUpgrader> osUpgraders;
@@ -51,8 +53,8 @@ public class OsApiTest extends ControllerContainerTest {
         addUserToHostedOperatorRole(operator);
         zoneRegistryMock().setSystemName(SystemName.cd)
                           .setZones(zone1, zone2, zone3)
-                          .setOsUpgradePolicy(cloud1, UpgradePolicy.create().upgrade(zone1).upgrade(zone2))
-                          .setOsUpgradePolicy(cloud2, UpgradePolicy.create().upgrade(zone3));
+                          .setOsUpgradePolicy(cloud1, UpgradePolicy.create().upgrade(zone1.toDeprecatedId()).upgrade(zone2.toDeprecatedId()))
+                          .setOsUpgradePolicy(cloud2, UpgradePolicy.create().upgrade(zone3.toDeprecatedId()));
         osUpgraders = List.of(
                 new OsUpgrader(tester.controller(), Duration.ofDays(1),
                                new JobControl(tester.controller().curator()),
@@ -79,12 +81,12 @@ public class OsApiTest extends ControllerContainerTest {
 
         // Status is updated after some zones are upgraded
         upgradeAndUpdateStatus();
-        completeUpgrade(zone1);
+        completeUpgrade(zone1.toDeprecatedId());
         assertFile(new Request("http://localhost:8080/os/v1/"), "versions-partially-upgraded.json");
 
         // All zones are upgraded
         upgradeAndUpdateStatus();
-        completeUpgrade(zone2, zone3);
+        completeUpgrade(zone2.toDeprecatedId(), zone3.toDeprecatedId());
         assertFile(new Request("http://localhost:8080/os/v1/"), "versions-all-upgraded.json");
 
         // Downgrade with force is permitted

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiTest.java
@@ -3,12 +3,12 @@ package com.yahoo.vespa.hosted.controller.restapi.zone.v1;
 
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
-import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.api.role.Role;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock;
 import com.yahoo.vespa.hosted.controller.restapi.ContainerControllerTester;
 import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerCloudTest;
-import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerTest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,10 +22,12 @@ import java.util.Set;
 public class ZoneApiTest extends ControllerContainerCloudTest {
 
     private static final String responseFiles = "src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/responses/";
-    private static final List<ZoneId> zones = List.of(ZoneId.from(Environment.prod, RegionName.from("us-north-1")),
-                                                      ZoneId.from(Environment.dev, RegionName.from("us-north-2")),
-                                                      ZoneId.from(Environment.test, RegionName.from("us-north-3")),
-                                                      ZoneId.from(Environment.staging, RegionName.from("us-north-4")));
+    private static final List<ZoneApi> zones = List.of(
+            ZoneApiMock.fromId("prod.us-north-1"),
+            ZoneApiMock.fromId("dev.us-north-2"),
+            ZoneApiMock.fromId("test.us-north-3"),
+            ZoneApiMock.fromId("staging.us-north-4"));
+
     private static final Set<Role> everyone = Set.of(Role.everyone());
 
     private ContainerControllerTester tester;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiTest.java
@@ -5,11 +5,12 @@ import com.yahoo.application.container.handler.Request;
 import com.yahoo.application.container.handler.Request.Method;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.athenz.api.AthenzIdentity;
 import com.yahoo.vespa.athenz.api.AthenzUser;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerProxyMock;
+import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock;
 import com.yahoo.vespa.hosted.controller.restapi.ContainerControllerTester;
 import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerTest;
@@ -29,12 +30,11 @@ public class ZoneApiTest extends ControllerContainerTest {
 
     private static final AthenzIdentity HOSTED_VESPA_OPERATOR = AthenzUser.fromUserId("johnoperator");
     private static final String responseFiles = "src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/";
-    private static final List<ZoneId> zones = List.of(
-            ZoneId.from(Environment.prod, RegionName.from("us-north-1")),
-            ZoneId.from(Environment.dev, RegionName.from("us-north-2")),
-            ZoneId.from(Environment.test, RegionName.from("us-north-3")),
-            ZoneId.from(Environment.staging, RegionName.from("us-north-4"))
-                                                           );
+    private static final List<ZoneApi> zones = List.of(
+            ZoneApiMock.fromId("prod.us-north-1"),
+            ZoneApiMock.fromId("dev.us-north-2"),
+            ZoneApiMock.fromId("test.us-north-3"),
+            ZoneApiMock.fromId("staging.us-north-4"));
 
     private ContainerControllerTester tester;
     private ConfigServerProxyMock proxy;


### PR DESCRIPTION
Defines a ZoneApi interface which exposes system, environment, region, and cloud for now. This is similar to the ZoneId and Zone classes. ZoneId will eventually only contain environment & region, as system will (typically) be implicit. ZoneApi is crucially an interface which Zone is not which provides a way to expose more in internal deployments.

Adds a method zones() to return ZoneApi from ZoneList. Eventually returning list of ZoneId will be removed.

The next steps are to migrate osupgrader and node admin to use ZoneApi instead of ZoneId.
