### PR TITLE
Deconstruct component graph at end of test 

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
@@ -119,6 +119,7 @@ public class HandlersConfigurerTestWrapper {
     }
 
     public void shutdown() {
+        configurer.shutdown(getTestDeconstructor());
         // TODO: Remove once tests use ConfigSet rather than dir:
         for (File f : createdFiles) {
             f.delete();


### PR DESCRIPTION
The container-search, QueryProfileIntegrationTestCase tests writes a lot of warnings of the following form:

WARNING: com.yahoo.config.subscription.ConfigSubscriber@515b8b03: Closing subscription from finalizer() - close() has not been called (keys=[name=components,namespace=container,configId=dir:src/test/java/com/yahoo/search/query/profile/config/test/typed, name=bundles,namespace=container,configId=dir:src/test/java/com/yahoo/search/query/profile/config/test/typed])
java.lang.Throwable
	at com.yahoo.config.subscription.ConfigSubscriber.<init>(ConfigSubscriber.java:73)
	at com.yahoo.container.di.CloudSubscriberFactory$CloudSubscriber.<init>(CloudSubscriberFactory.java:76)
	at com.yahoo.container.di.CloudSubscriberFactory.getSubscriber(CloudSubscriberFactory.java:48)
	at com.yahoo.container.di.ConfigRetriever.<init>(ConfigRetriever.java:43)
	at com.yahoo.container.di.Container.<init>(Container.java:60)
	at com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:87)
	at com.yahoo.container.core.config.testutil.HandlersConfigurerTestWrapper.<init>(HandlersConfigurerTestWrapper.java:99)
	at com.yahoo.search.query.profile.config.test.QueryProfileIntegrationTestCase.testTyped(QueryProfileIntegrationTestCase.java:82)

This PR ensures the configurer is shutdown if the test wrapper is shutdown.