### PR TITLE
Let the individual handlers determine if the application is valid

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -10,6 +10,7 @@ import com.yahoo.path.Path;
 import com.yahoo.text.Utf8;
 import com.yahoo.transaction.Transaction;
 import com.yahoo.vespa.config.server.GlobalComponentRegistry;
+import com.yahoo.vespa.config.server.NotFoundException;
 import com.yahoo.vespa.config.server.ReloadHandler;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
@@ -92,7 +93,7 @@ public class TenantApplications {
     /** Returns the id of the currently active session for the given application, if any. Throws on unknown applications. */
     public Optional<Long> activeSessionOf(ApplicationId id) {
         String data = curator.getData(applicationPath(id)).map(Utf8::toString)
-                             .orElseThrow(() -> new IllegalArgumentException("Unknown application '" + id + "'."));
+                             .orElseThrow(() -> new NotFoundException("No such application id: '" + id + "'"));
         return data.isEmpty() ? Optional.empty() : Optional.of(Long.parseLong(data));
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -57,7 +57,6 @@ public class ApplicationHandler extends HttpHandler {
     @Override
     public HttpResponse handleGET(HttpRequest request) {
         ApplicationId applicationId = getApplicationIdFromRequest(request);
-        Tenant tenant = verifyTenantAndApplication(applicationId);
         Duration timeout = HttpHandler.getRequestTimeout(request, Duration.ofSeconds(5));
 
         if (isServiceConvergeRequest(request)) {
@@ -74,10 +73,10 @@ public class ApplicationHandler extends HttpHandler {
         }
 
         if (isContentRequest(request)) {
-            long sessionId = applicationRepository.getSessionIdForApplication(tenant, applicationId);
+            long sessionId = applicationRepository.getSessionIdForApplication(applicationId);
             String contentPath = ApplicationContentRequest.getContentPath(request);
             ApplicationFile applicationFile =
-                    applicationRepository.getApplicationFileFromSession(tenant.getName(),
+                    applicationRepository.getApplicationFileFromSession(applicationId.tenant(),
                                                                         sessionId,
                                                                         contentPath,
                                                                         ContentRequest.getApplicationFileMode(request.getMethod()));
@@ -133,14 +132,6 @@ public class ApplicationHandler extends HttpHandler {
                                request.getProperty("flavor"),
                                request.getProperty("clusterType"),
                                request.getProperty("clusterId"));
-    }
-
-    private Tenant verifyTenantAndApplication(ApplicationId applicationId) {
-        try {
-            return applicationRepository.verifyTenantAndApplication(applicationId);
-        } catch (IllegalArgumentException e) {
-            throw new NotFoundException(e.getMessage());
-        }
     }
 
     private static BindingMatch<?> getBindingMatch(HttpRequest request) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -197,7 +197,7 @@ public class ApplicationHandlerTest {
         ApplicationId unknown = new ApplicationId.Builder().applicationName("unknown").tenant(mytenantName).build();
         HttpResponse responseForUnknown = fileDistributionStatus(unknown, zone);
         assertEquals(404, responseForUnknown.getStatus());
-        assertEquals("{\"error-code\":\"NOT_FOUND\",\"message\":\"No such application id: mytenant.unknown\"}",
+        assertEquals("{\"error-code\":\"NOT_FOUND\",\"message\":\"No such application id: 'mytenant.unknown'\"}",
                      SessionHandlerTest.getRenderedString(responseForUnknown));
     }
 


### PR DESCRIPTION
Getting logs for infrastructure application still fails, this is because at the start of `handleGET()` there is a verification method that checks if tenant + application exists. I noticed that all (except `isIsSuspendedRequest()`, `isContentRequest()`) "handlers" call to `ApplicationRepository::getApplication` very early in their execution anyway, so it should be safe to remove that assertion as long as `getApplication` throws a compatible exception (that will produce the same HTTP status code).

Initially I created a new `NoSuchTenantException`, but then I realized I would need another exception to handle `isContentRequest()`, I saw there was a `NotFoundException`, but that was in `http` package, only later did I see that there is another `NotFoundException` in the `server` package... Why is this not used everywhere?