### PR TITLE
Use ZoneApi instead of ZoneId in UpgradePolicy

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class declares the order to use when upgrading zones in a system.
@@ -20,7 +22,7 @@ public class UpgradePolicy {
     }
 
     public List<List<ZoneId>> asList() {
-        return Collections.unmodifiableList(zones);
+        return List.copyOf(zones);
     }
 
     private UpgradePolicy with(ZoneId... zone) {
@@ -30,13 +32,13 @@ public class UpgradePolicy {
     }
 
     /** Upgrade given zone as the next step */
-    public UpgradePolicy upgrade(ZoneId zone) {
-        return with(zone);
+    public UpgradePolicy upgrade(ZoneApi zone) {
+        return with(zone.toDeprecatedId());
     }
 
     /** Upgrade given zones in parallel as the next step */
-    public UpgradePolicy upgradeInParallel(ZoneId... zone) {
-        return with(zone);
+    public UpgradePolicy upgradeInParallel(ZoneApi... zone) {
+        return with(Stream.of(zone).map(ZoneApi::toDeprecatedId).toArray(ZoneId[]::new));
     }
 
     public static UpgradePolicy create() {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
@@ -21,14 +21,6 @@ public class UpgradePolicy {
         this.zones = zones;
     }
 
-    public List<List<ZoneId>> deprecatedAsList() {
-        return zones.stream()
-                .map(list -> list.stream()
-                        .map(ZoneApi::toDeprecatedId)
-                        .collect(Collectors.toList()))
-                .collect(Collectors.toList());
-    }
-
     public List<List<ZoneApi>> asList() {
         return List.copyOf(zones);
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
@@ -15,30 +15,38 @@ import java.util.stream.Stream;
  */
 public class UpgradePolicy {
 
-    private final List<List<ZoneId>> zones;
+    private final List<List<ZoneApi>> zones;
 
-    private UpgradePolicy(List<List<ZoneId>> zones) {
+    private UpgradePolicy(List<List<ZoneApi>> zones) {
         this.zones = zones;
     }
 
-    public List<List<ZoneId>> asList() {
+    public List<List<ZoneId>> deprecatedAsList() {
+        return zones.stream()
+                .map(list -> list.stream()
+                        .map(ZoneApi::toDeprecatedId)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+    }
+
+    public List<List<ZoneApi>> asList() {
         return List.copyOf(zones);
     }
 
-    private UpgradePolicy with(ZoneId... zone) {
-        List<List<ZoneId>> zones = new ArrayList<>(this.zones);
+    private UpgradePolicy with(ZoneApi... zone) {
+        List<List<ZoneApi>> zones = new ArrayList<>(this.zones);
         zones.add(Arrays.asList(zone));
         return new UpgradePolicy(zones);
     }
 
     /** Upgrade given zone as the next step */
     public UpgradePolicy upgrade(ZoneApi zone) {
-        return with(zone.toDeprecatedId());
+        return with(zone);
     }
 
     /** Upgrade given zones in parallel as the next step */
     public UpgradePolicy upgradeInParallel(ZoneApi... zone) {
-        return with(Stream.of(zone).map(ZoneApi::toDeprecatedId).toArray(ZoneId[]::new));
+        return with(zone);
     }
 
     public static UpgradePolicy create() {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/UpgradePolicy.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class declares the order to use when upgrading zones in a system.

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
@@ -42,7 +42,7 @@ public abstract class InfrastructureUpgrader extends Maintainer {
 
     /** Deploy a list of system applications until they converge on the given version */
     private void upgradeAll(Version target, List<SystemApplication> applications) {
-        for (List<ZoneId> zones : upgradePolicy.asList()) {
+        for (List<ZoneId> zones : upgradePolicy.deprecatedAsList()) {
             boolean converged = true;
             for (ZoneId zone : zones) {
                 try {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
@@ -98,7 +98,7 @@ public abstract class InfrastructureUpgrader extends Maintainer {
         try {
             return controller().configServer()
                                .nodeRepository()
-                               .list(zone.toDeprecatedId(), application.id())
+                               .list(zone.getId(), application.id())
                                .stream()
                                .filter(node -> requireUpgradeOf(node, application, zone))
                                .map(versionField)

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.config.provision.zone.UpgradePolicy;
@@ -42,9 +43,9 @@ public abstract class InfrastructureUpgrader extends Maintainer {
 
     /** Deploy a list of system applications until they converge on the given version */
     private void upgradeAll(Version target, List<SystemApplication> applications) {
-        for (List<ZoneId> zones : upgradePolicy.deprecatedAsList()) {
+        for (List<ZoneApi> zones : upgradePolicy.asList()) {
             boolean converged = true;
-            for (ZoneId zone : zones) {
+            for (ZoneApi zone : zones) {
                 try {
                     converged &= upgradeAll(target, applications, zone);
                 } catch (UnreachableNodeRepositoryException e) {
@@ -62,7 +63,7 @@ public abstract class InfrastructureUpgrader extends Maintainer {
     }
 
     /** Returns whether all applications have converged to the target version in zone */
-    private boolean upgradeAll(Version target, List<SystemApplication> applications, ZoneId zone) {
+    private boolean upgradeAll(Version target, List<SystemApplication> applications, ZoneApi zone) {
         boolean converged = true;
         for (SystemApplication application : applications) {
             if (convergedOn(target, application.dependencies(), zone)) {
@@ -76,28 +77,28 @@ public abstract class InfrastructureUpgrader extends Maintainer {
         return converged;
     }
 
-    private boolean convergedOn(Version target, List<SystemApplication> applications, ZoneId zone) {
+    private boolean convergedOn(Version target, List<SystemApplication> applications, ZoneApi zone) {
         return applications.stream().allMatch(application -> convergedOn(target, application, zone));
     }
 
     /** Upgrade component to target version. Implementation should be idempotent */
-    protected abstract void upgrade(Version target, SystemApplication application, ZoneId zone);
+    protected abstract void upgrade(Version target, SystemApplication application, ZoneApi zone);
 
     /** Returns whether application has converged to target version in zone */
-    protected abstract boolean convergedOn(Version target, SystemApplication application, ZoneId zone);
+    protected abstract boolean convergedOn(Version target, SystemApplication application, ZoneApi zone);
 
     /** Returns the target version for the component upgraded by this, if any */
     protected abstract Optional<Version> targetVersion();
 
     /** Returns whether the upgrader should require given node to upgrade */
-    protected abstract boolean requireUpgradeOf(Node node, SystemApplication application, ZoneId zone);
+    protected abstract boolean requireUpgradeOf(Node node, SystemApplication application, ZoneApi zone);
 
     /** Find the minimum value of a version field in a zone */
-    protected final Optional<Version> minVersion(ZoneId zone, SystemApplication application, Function<Node, Version> versionField) {
+    protected final Optional<Version> minVersion(ZoneApi zone, SystemApplication application, Function<Node, Version> versionField) {
         try {
             return controller().configServer()
                                .nodeRepository()
-                               .list(zone, application.id())
+                               .list(zone.toDeprecatedId(), application.id())
                                .stream()
                                .filter(node -> requireUpgradeOf(node, application, zone))
                                .map(versionField)

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -7,7 +7,6 @@ import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.versions.OsVersion;
 
@@ -44,7 +43,7 @@ public class OsUpgrader extends InfrastructureUpgrader {
             return;
         }
         log.info(String.format("Upgrading OS of %s to version %s in %s in cloud %s", application.id(), target, zone.getId(), zone.getCloudName()));
-        controller().configServer().nodeRepository().upgradeOs(zone.toDeprecatedId(), application.nodeType(), target);
+        controller().configServer().nodeRepository().upgradeOs(zone.getId(), application.nodeType(), target);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -43,7 +43,7 @@ public class OsUpgrader extends InfrastructureUpgrader {
         if (!application.isEligibleForOsUpgrades() || wantedVersion(zone, application, target).equals(target)) {
             return;
         }
-        log.info(String.format("Upgrading OS of %s to version %s in %s", application.id(), target, zone));
+        log.info(String.format("Upgrading OS of %s to version %s in %s in cloud %s", application.id(), target, zone.getId(), zone.getCloudName()));
         controller().configServer().nodeRepository().upgradeOs(zone.toDeprecatedId(), application.nodeType(), target);
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.google.common.collect.ImmutableSet;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -38,22 +39,22 @@ public class OsUpgrader extends InfrastructureUpgrader {
     }
 
     @Override
-    protected void upgrade(Version target, SystemApplication application, ZoneId zone) {
+    protected void upgrade(Version target, SystemApplication application, ZoneApi zone) {
         if (!application.isEligibleForOsUpgrades() || wantedVersion(zone, application, target).equals(target)) {
             return;
         }
         log.info(String.format("Upgrading OS of %s to version %s in %s", application.id(), target, zone));
-        controller().configServer().nodeRepository().upgradeOs(zone, application.nodeType(), target);
+        controller().configServer().nodeRepository().upgradeOs(zone.toDeprecatedId(), application.nodeType(), target);
     }
 
     @Override
-    protected boolean convergedOn(Version target, SystemApplication application, ZoneId zone) {
+    protected boolean convergedOn(Version target, SystemApplication application, ZoneApi zone) {
         return currentVersion(zone, application, target).equals(target);
     }
 
     @Override
-    protected boolean requireUpgradeOf(Node node, SystemApplication application, ZoneId zone) {
-        return cloud.equals(zone.cloud()) && eligibleForUpgrade(node, application);
+    protected boolean requireUpgradeOf(Node node, SystemApplication application, ZoneApi zone) {
+        return cloud.equals(zone.getCloudName()) && eligibleForUpgrade(node, application);
     }
 
     @Override
@@ -65,11 +66,11 @@ public class OsUpgrader extends InfrastructureUpgrader {
                            .map(OsVersion::version);
     }
 
-    private Version currentVersion(ZoneId zone, SystemApplication application, Version defaultVersion) {
+    private Version currentVersion(ZoneApi zone, SystemApplication application, Version defaultVersion) {
         return minVersion(zone, application, Node::currentOsVersion).orElse(defaultVersion);
     }
 
-    private Version wantedVersion(ZoneId zone, SystemApplication application, Version defaultVersion) {
+    private Version wantedVersion(ZoneApi zone, SystemApplication application, Version defaultVersion) {
         return minVersion(zone, application, Node::wantedOsVersion).orElse(defaultVersion);
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -34,7 +34,7 @@ public class SystemUpgrader extends InfrastructureUpgrader {
     protected void upgrade(Version target, SystemApplication application, ZoneApi zone) {
         if (minVersion(zone, application, Node::wantedVersion).map(target::isAfter)
                                                               .orElse(true)) {
-            log.info(String.format("Deploying %s version %s in %s", application.id(), target, zone));
+            log.info(String.format("Deploying %s version %s in %s", application.id(), target, zone.getId()));
             controller().applications().deploy(application, zone.toDeprecatedId(), target);
         }
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.zone.ZoneApi;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -87,7 +87,7 @@ public class OsVersionStatus {
 
     private static List<ZoneId> zonesToUpgrade(Controller controller) {
         return controller.zoneRegistry().osUpgradePolicies().stream()
-                         .flatMap(upgradePolicy -> upgradePolicy.asList().stream())
+                         .flatMap(upgradePolicy -> upgradePolicy.deprecatedAsList().stream())
                          .flatMap(Collection::stream)
                          .collect(Collectors.toUnmodifiableList());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -72,7 +72,7 @@ public class OsVersionStatus {
                 continue; // Avoid querying applications that are not eligible for OS upgrades
             }
             for (ZoneApi zone : zonesToUpgrade(controller)) {
-                controller.configServer().nodeRepository().list(zone.toDeprecatedId(), application.id()).stream()
+                controller.configServer().nodeRepository().list(zone.getId(), application.id()).stream()
                           .filter(node -> OsUpgrader.eligibleForUpgrade(node, application))
                           .map(node -> new Node(node.hostname(), node.currentOsVersion(), zone.getEnvironment(), zone.getRegionName()))
                           .forEach(node -> {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -49,10 +49,10 @@ public class OsUpgraderTest {
     public void upgrade_os() {
         OsUpgrader osUpgrader = osUpgrader(
                 UpgradePolicy.create()
-                             .upgrade(zone1.toDeprecatedId())
-                             .upgradeInParallel(zone2.toDeprecatedId(), zone3.toDeprecatedId())
-                             .upgrade(zone5.toDeprecatedId()) // Belongs to a different cloud and is ignored by this upgrader
-                             .upgrade(zone4.toDeprecatedId()),
+                             .upgrade(zone1)
+                             .upgradeInParallel(zone2, zone3)
+                             .upgrade(zone5) // Belongs to a different cloud and is ignored by this upgrader
+                             .upgrade(zone4),
                 SystemName.cd
         );
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.config.provision.zone.UpgradePolicy;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -32,7 +33,7 @@ public class OsVersionStatusUpdaterTest {
                                                                           new JobControl(new MockCuratorDb()));
         // Add all zones to upgrade policy
         UpgradePolicy upgradePolicy = UpgradePolicy.create();
-        for (ZoneId zone : tester.zoneRegistry().zones().controllerUpgraded().ids()) {
+        for (ZoneApi zone : tester.zoneRegistry().zones().controllerUpgraded().zones()) {
             upgradePolicy = upgradePolicy.upgrade(zone);
         }
         tester.zoneRegistry().setOsUpgradePolicy(CloudName.defaultName(), upgradePolicy);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
@@ -299,7 +299,7 @@ public class SystemUpgraderTest {
         for (ZoneApi zone : zones) {
             for (Node node : listNodes(zone, application)) {
                 nodeRepository().putByHostname(
-                        zone.toDeprecatedId(),
+                        zone.getId(),
                         new Node(node.hostname(), node.state(), node.type(), node.owner(), node.wantedVersion(), node.wantedVersion()));
             }
 
@@ -318,13 +318,13 @@ public class SystemUpgraderTest {
     }
 
     private void failNodeIn(ZoneApi zone, SystemApplication application) {
-        List<Node> nodes = nodeRepository().list(zone.toDeprecatedId(), application.id());
+        List<Node> nodes = nodeRepository().list(zone.getId(), application.id());
         if (nodes.isEmpty()) {
             throw new IllegalArgumentException("No nodes allocated to " + application.id());
         }
         Node node = nodes.get(0);
         nodeRepository().putByHostname(
-                zone.toDeprecatedId(),
+                zone.getId(),
                 new Node(node.hostname(), Node.State.failed, node.type(), node.owner(), node.currentVersion(), node.wantedVersion()));
     }
 
@@ -362,7 +362,7 @@ public class SystemUpgraderTest {
     }
 
     private List<Node> listNodes(ZoneApi zone, SystemApplication application) {
-        return nodeRepository().list(zone.toDeprecatedId(), application.id()).stream()
+        return nodeRepository().list(zone.getId(), application.id()).stream()
                                .filter(SystemUpgrader::eligibleForUpgrade)
                                .collect(Collectors.toList());
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -53,8 +53,8 @@ public class OsApiTest extends ControllerContainerTest {
         addUserToHostedOperatorRole(operator);
         zoneRegistryMock().setSystemName(SystemName.cd)
                           .setZones(zone1, zone2, zone3)
-                          .setOsUpgradePolicy(cloud1, UpgradePolicy.create().upgrade(zone1.toDeprecatedId()).upgrade(zone2.toDeprecatedId()))
-                          .setOsUpgradePolicy(cloud2, UpgradePolicy.create().upgrade(zone3.toDeprecatedId()));
+                          .setOsUpgradePolicy(cloud1, UpgradePolicy.create().upgrade(zone1).upgrade(zone2))
+                          .setOsUpgradePolicy(cloud2, UpgradePolicy.create().upgrade(zone3));
         osUpgraders = List.of(
                 new OsUpgrader(tester.controller(), Duration.ofDays(1),
                                new JobControl(tester.controller().curator()),


### PR DESCRIPTION
This is part of a series of changes intended to make ZoneId container env and region only, and pass additional information through an interface (ZoneApi) that will typically be implemented by a fully-featured zone base class.

I have to leave some calls to ZoneApi::toDeprecatedId for code that requires ZoneId w/system and cloud, until it can be removed in later PRs