### PR TITLE
Remove serialization of ClusterSpec rotations

### DIFF
--- a/config-provisioning/abi-spec.json
+++ b/config-provisioning/abi-spec.json
@@ -260,7 +260,6 @@
       "public com.yahoo.component.Version vespaVersion()",
       "public java.util.Optional group()",
       "public boolean isExclusive()",
-      "public java.util.Set rotations()",
       "public com.yahoo.config.provision.ClusterSpec with(java.util.Optional)",
       "public com.yahoo.config.provision.ClusterSpec exclusive(boolean)",
       "public static com.yahoo.config.provision.ClusterSpec request(com.yahoo.config.provision.ClusterSpec$Type, com.yahoo.config.provision.ClusterSpec$Id, com.yahoo.component.Version, boolean)",

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -22,7 +22,7 @@ public class ClusterMembership {
         String[] components = stringValue.split("/");
         if (components.length < 4)
             throw new RuntimeException("Could not parse '" + stringValue + "' to a cluster membership. " +
-                                       "Expected 'clusterType/clusterId/groupId/index[/retired][/exclusive][/rotationId,...]'");
+                                       "Expected 'clusterType/clusterId/groupId/index[/retired][/exclusive]'");
 
         boolean exclusive = false;
         if (components.length > 4) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
-import com.google.common.collect.ImmutableSortedSet;
 import com.yahoo.component.Version;
 
 import java.util.Objects;
@@ -23,19 +22,13 @@ public final class ClusterSpec {
     private final Optional<Group> groupId;
     private final Version vespaVersion;
     private boolean exclusive;
-    private final Set<RotationName> rotations;
 
-    private ClusterSpec(Type type, Id id, Optional<Group> groupId, Version vespaVersion, boolean exclusive,
-                        Set<RotationName> rotations) {
-        if (type != Type.container && !rotations.isEmpty()) {
-            throw new IllegalArgumentException("Rotations can only be declared for clusters of type " + Type.container);
-        }
+    private ClusterSpec(Type type, Id id, Optional<Group> groupId, Version vespaVersion, boolean exclusive) {
         this.type = type;
         this.id = id;
         this.groupId = groupId;
         this.vespaVersion = vespaVersion;
         this.exclusive = exclusive;
-        this.rotations = ImmutableSortedSet.copyOf(rotations);
     }
 
     /** Returns the cluster type */
@@ -57,35 +50,30 @@ public final class ClusterSpec {
      */
     public boolean isExclusive() { return exclusive; }
 
-    /** Returns the rotations of which this cluster should be a member */
-    public Set<RotationName> rotations() {
-        return rotations;
-    }
-
     public ClusterSpec with(Optional<Group> newGroup) {
-        return new ClusterSpec(type, id, newGroup, vespaVersion, exclusive, rotations);
+        return new ClusterSpec(type, id, newGroup, vespaVersion, exclusive);
     }
 
     public ClusterSpec exclusive(boolean exclusive) {
-        return new ClusterSpec(type, id, groupId, vespaVersion, exclusive, rotations);
+        return new ClusterSpec(type, id, groupId, vespaVersion, exclusive);
     }
 
     public static ClusterSpec request(Type type, Id id, Version vespaVersion, boolean exclusive) {
-        return new ClusterSpec(type, id, Optional.empty(), vespaVersion, exclusive, Set.of());
+        return new ClusterSpec(type, id, Optional.empty(), vespaVersion, exclusive);
     }
 
     // TODO: Remove after June 2019
     public static ClusterSpec request(Type type, Id id, Version vespaVersion, boolean exclusive, Set<RotationName> rotations) {
-        return new ClusterSpec(type, id, Optional.empty(), vespaVersion, exclusive, rotations);
+        return new ClusterSpec(type, id, Optional.empty(), vespaVersion, exclusive);
     }
 
     public static ClusterSpec from(Type type, Id id, Group groupId, Version vespaVersion, boolean exclusive) {
-        return new ClusterSpec(type, id, Optional.of(groupId), vespaVersion, exclusive, Set.of());
+        return new ClusterSpec(type, id, Optional.of(groupId), vespaVersion, exclusive);
     }
 
     // TODO: Remove after June 2019
     public static ClusterSpec from(Type type, Id id, Group groupId, Version vespaVersion, boolean exclusive, Set<RotationName> rotations) {
-        return new ClusterSpec(type, id, Optional.of(groupId), vespaVersion, exclusive, rotations);
+        return new ClusterSpec(type, id, Optional.of(groupId), vespaVersion, exclusive);
     }
 
     @Override

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
@@ -6,7 +6,6 @@ import com.yahoo.component.Vtag;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -37,26 +36,25 @@ public class ClusterMembershipTest {
             assertTrue(instance.cluster().isExclusive());
         }
 
+        // TODO: Remove after June 2019. This ensures stale rotation data is handled
         {
             ClusterMembership instance = ClusterMembership.from("container/id1/4/37/rotation1,rotation2", Vtag.currentVersion);
             assertFalse(instance.retired());
             assertFalse(instance.cluster().isExclusive());
-            assertEquals(Set.of(RotationName.from("rotation1"), RotationName.from("rotation2")), instance.cluster().rotations());
         }
 
         {
             ClusterMembership instance = ClusterMembership.from("container/id1/4/37/exclusive/rotation1,rotation2", Vtag.currentVersion);
             assertFalse(instance.retired());
             assertTrue(instance.cluster().isExclusive());
-            assertEquals(Set.of(RotationName.from("rotation1"), RotationName.from("rotation2")), instance.cluster().rotations());
         }
 
         {
             ClusterMembership instance = ClusterMembership.from("container/id1/4/37/exclusive/retired/rotation1,rotation2", Vtag.currentVersion);
             assertTrue(instance.retired());
             assertTrue(instance.cluster().isExclusive());
-            assertEquals(Set.of(RotationName.from("rotation1"), RotationName.from("rotation2")), instance.cluster().rotations());
         }
+        // end TODO
     }
 
     @Test
@@ -101,7 +99,6 @@ public class ClusterMembershipTest {
         assertFalse(instance.cluster().group().isPresent());
         assertEquals(3, instance.index());
         assertEquals("container/id1/3", instance.stringValue());
-        assertTrue(instance.cluster().rotations().isEmpty());
     }
 
     private void assertContentService(ClusterMembership instance) {
@@ -111,7 +108,6 @@ public class ClusterMembershipTest {
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
         assertEquals("content/id1/37", instance.stringValue());
-        assertTrue(instance.cluster().rotations().isEmpty());
     }
 
     private void assertContentServiceWithGroup(ClusterMembership instance) {
@@ -121,7 +117,6 @@ public class ClusterMembershipTest {
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
         assertEquals("content/id1/4/37", instance.stringValue());
-        assertTrue(instance.cluster().rotations().isEmpty());
     }
 
     /** Serializing a spec without a group assigned works, but not deserialization */
@@ -131,7 +126,6 @@ public class ClusterMembershipTest {
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
         assertEquals("content/id1/37/retired", instance.stringValue());
-        assertTrue(instance.cluster().rotations().isEmpty());
     }
 
     private void assertContentServiceWithGroupAndRetire(ClusterMembership instance) {
@@ -141,7 +135,6 @@ public class ClusterMembershipTest {
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
         assertEquals("content/id1/4/37/retired", instance.stringValue());
-        assertTrue(instance.cluster().rotations().isEmpty());
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
@@ -1,12 +1,9 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.lb;
 
-import com.google.common.collect.ImmutableSortedSet;
-import com.yahoo.config.provision.RotationName;
 import com.yahoo.vespa.hosted.provision.maintenance.LoadBalancerExpirer;
 
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Represents a load balancer for an application's cluster. This is immutable.
@@ -17,24 +14,17 @@ public class LoadBalancer {
 
     private final LoadBalancerId id;
     private final LoadBalancerInstance instance;
-    private final Set<RotationName> rotations;
     private final boolean inactive;
 
-    public LoadBalancer(LoadBalancerId id, LoadBalancerInstance instance, Set<RotationName> rotations, boolean inactive) {
+    public LoadBalancer(LoadBalancerId id, LoadBalancerInstance instance, boolean inactive) {
         this.id = Objects.requireNonNull(id, "id must be non-null");
         this.instance = Objects.requireNonNull(instance, "instance must be non-null");
-        this.rotations = ImmutableSortedSet.copyOf(Objects.requireNonNull(rotations, "rotations must be non-null"));
         this.inactive = inactive;
     }
 
     /** An identifier for this load balancer. The ID is unique inside the zone */
     public LoadBalancerId id() {
         return id;
-    }
-
-    /** The rotations of which this is a member */
-    public Set<RotationName> rotations() {
-        return rotations;
     }
 
     /** The instance associated with this */
@@ -52,7 +42,7 @@ public class LoadBalancer {
 
     /** Return a copy of this that is set inactive */
     public LoadBalancer deactivate() {
-        return new LoadBalancer(id, instance, rotations, true);
+        return new LoadBalancer(id, instance, true);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.provision.persistence;
 
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.RotationName;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
@@ -35,7 +34,6 @@ public class LoadBalancerSerializer {
     private static final String portsField = "ports";
     private static final String networksField = "networks";
     private static final String realsField = "reals";
-    private static final String rotationsField = "rotations";
     private static final String nameField = "name";
     private static final String ipAddressField = "ipAddress";
     private static final String portField = "port";
@@ -57,11 +55,6 @@ public class LoadBalancerSerializer {
             realObject.setString(hostnameField, real.hostname().value());
             realObject.setString(ipAddressField, real.ipAddress());
             realObject.setLong(portField, real.port());
-        });
-        Cursor rotationArray = root.setArray(rotationsField);
-        loadBalancer.rotations().forEach(rotation -> {
-            Cursor rotationObject = rotationArray.addObject();
-            rotationObject.setString(nameField, rotation.value());
         });
         root.setBool(inactiveField, loadBalancer.inactive());
 
@@ -89,11 +82,6 @@ public class LoadBalancerSerializer {
         Set<String> networks = new LinkedHashSet<>();
         object.field(networksField).traverse((ArrayTraverser) (i, network) -> networks.add(network.asString()));
 
-        Set<RotationName> rotations = new LinkedHashSet<>();
-        object.field(rotationsField).traverse((ArrayTraverser) (i, rotation) -> {
-            rotations.add(RotationName.from(rotation.field(nameField).asString()));
-        });
-
         return new LoadBalancer(LoadBalancerId.fromSerializedForm(object.field(idField).asString()),
                                 new LoadBalancerInstance(
                                         HostName.from(object.field(hostnameField).asString()),
@@ -102,7 +90,6 @@ public class LoadBalancerSerializer {
                                         networks,
                                         reals
                                 ),
-                                rotations,
                                 object.field(inactiveField).asBool());
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -57,7 +57,7 @@ public class LoadBalancerProvisioner {
                     LoadBalancerInstance instance = create(application, kv.getKey().id(), kv.getValue());
                     // Load balancer is always re-activated here to avoid reallocation if an application/cluster is
                     // deleted and then redeployed.
-                    LoadBalancer loadBalancer = new LoadBalancer(id, instance, kv.getKey().rotations(), false);
+                    LoadBalancer loadBalancer = new LoadBalancer(id, instance, false);
                     loadBalancers.put(loadBalancer.id(), loadBalancer);
                     db.writeLoadBalancer(loadBalancer);
                 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/LoadBalancersResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/LoadBalancersResponse.java
@@ -76,11 +76,7 @@ public class LoadBalancersResponse extends HttpResponse {
                 realObject.setLong("port", real.port());
             });
 
-            Cursor rotationArray = lbObject.setArray("rotations");
-            lb.rotations().forEach(rotation -> {
-                Cursor rotationObject = rotationArray.addObject();
-                rotationObject.setString("name", rotation.value());
-            });
+            lbObject.setArray("rotations"); // To avoid changing the API. This can be removed when clients stop expecting this
 
             lbObject.setBool("inactive", lb.inactive());
         });

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.RotationName;
 import com.yahoo.vespa.hosted.provision.lb.DnsZone;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerId;
@@ -39,8 +38,6 @@ public class LoadBalancerSerializerTest {
                                                                              new Real(HostName.from("real-2"),
                                                                                       "127.0.0.2",
                                                                                       4080))),
-                                                     ImmutableSet.of(RotationName.from("eu-cluster"),
-                                                                     RotationName.from("us-cluster")),
                                                      false);
 
         LoadBalancer serialized = LoadBalancerSerializer.fromJson(LoadBalancerSerializer.toJson(loadBalancer));
@@ -49,7 +46,6 @@ public class LoadBalancerSerializerTest {
         assertEquals(loadBalancer.instance().dnsZone(), serialized.instance().dnsZone());
         assertEquals(loadBalancer.instance().ports(), serialized.instance().ports());
         assertEquals(loadBalancer.instance().networks(), serialized.instance().networks());
-        assertEquals(loadBalancer.rotations(), serialized.rotations());
         assertEquals(loadBalancer.inactive(), serialized.inactive());
         assertEquals(loadBalancer.instance().reals(), serialized.instance().reals());
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
@@ -61,7 +61,6 @@ public class LoadBalancerProvisionerTest {
         assertEquals(4080, get(loadBalancers.get().get(0).instance().reals(), 0).port());
         assertEquals("127.0.0.2", get(loadBalancers.get().get(0).instance().reals(), 1).ipAddress());
         assertEquals(4080, get(loadBalancers.get().get(0).instance().reals(), 1).port());
-        assertEquals(rotationsCluster1, loadBalancers.get().get(0).rotations());
 
         // A container is failed
         Supplier<List<Node>> containers = () -> tester.getNodes(app1).type(ClusterSpec.Type.container).asList();
@@ -105,7 +104,6 @@ public class LoadBalancerProvisionerTest {
                                             .map(Real::hostname)
                                             .sorted()
                                             .collect(Collectors.toList());
-        assertEquals(rotationsCluster2, loadBalancers.get().get(1).rotations());
         assertEquals(activeContainers, reals);
 
         // Application is removed and load balancer is deactivated


### PR DESCRIPTION
This data is only stored when `<rotations/>` is specified through
`services.xml`. Since we're removing that element, we can also remove the
serialization. It's not used in our shared routing layer.

The `rotations` field is still present in the `/loadbalancers/v1/` response as
the client of this API still expects it.

FYI @oyving