### PR TITLE
Trim hits more eagerly

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -124,7 +124,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
     }
 
     private void trimResult(Execution execution) {
-        if (trimResult) {
+        if (trimResult || result.hits().size() > query.getHits()) {
             result.hits().trim(query.getOffset(), query.getHits());
         }
     }


### PR DESCRIPTION
Currently the code leaks through more hits than it should when there are more content nodes. The hits are trimmed later on, but there are likely unnecessary fill requests before that.