### PR TITLE
Reserve host resources

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -204,28 +204,16 @@ public class MetricsReporter extends Maintainer {
         // Capacity flavors for docker
         DockerHostCapacity capacity = new DockerHostCapacity(nodes);
         metric.set("hostedVespa.docker.totalCapacityCpu",
-                   capacity.getCapacityTotal(NodeResources.DiskSpeed.any).vcpu(), null);
+                capacity.getCapacityTotal(NodeResources.DiskSpeed.any).vcpu(), null);
         metric.set("hostedVespa.docker.totalCapacityMem",
-                   capacity.getCapacityTotal(NodeResources.DiskSpeed.any).memoryGb(), null);
+                capacity.getCapacityTotal(NodeResources.DiskSpeed.any).memoryGb(), null);
         metric.set("hostedVespa.docker.totalCapacityDisk",
-                   capacity.getCapacityTotal(NodeResources.DiskSpeed.any).diskGb(), null);
+                capacity.getCapacityTotal(NodeResources.DiskSpeed.any).diskGb(), null);
         metric.set("hostedVespa.docker.freeCapacityCpu",
-                   capacity.getFreeCapacityTotal(NodeResources.DiskSpeed.any).vcpu(), null);
+                capacity.getFreeCapacityTotal(NodeResources.DiskSpeed.any).vcpu(), null);
         metric.set("hostedVespa.docker.freeCapacityMem",
-                   capacity.getFreeCapacityTotal(NodeResources.DiskSpeed.any).memoryGb(), null);
+                capacity.getFreeCapacityTotal(NodeResources.DiskSpeed.any).memoryGb(), null);
         metric.set("hostedVespa.docker.freeCapacityDisk",
-                   capacity.getFreeCapacityTotal(NodeResources.DiskSpeed.any).diskGb(), null);
-
-        List<Flavor> dockerFlavors = nodeRepository().getAvailableFlavors().getFlavors().stream()
-                .filter(f -> f.getType().equals(Flavor.Type.DOCKER_CONTAINER))
-                .collect(Collectors.toList());
-        for (Flavor flavor : dockerFlavors) {
-            Metric.Context context = getContextAt("flavor", flavor.name());
-            metric.set("hostedVespa.docker.freeCapacityFlavor",
-                       capacity.freeCapacityInFlavorEquivalence(flavor), context);
-            metric.set("hostedVespa.docker.hostsAvailableFlavor",
-                       capacity.getNofHostsAvailableFor(flavor), context);
-        }
+                capacity.getFreeCapacityTotal(NodeResources.DiskSpeed.any).diskGb(), null);
     }
-
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
@@ -25,7 +25,7 @@ public class DockerHostCapacity {
     }
 
     int compareWithoutInactive(Node hostA, Node hostB) {
-        int result = compare(freeCapacityOf(hostB,  true), freeCapacityOf(hostA, true));
+        int result = compare(freeCapacityOf(hostB, true), freeCapacityOf(hostA, true));
         if (result != 0) return result;
 
         // If resources are equal we want to assign to the one with the most IPaddresses free
@@ -59,7 +59,7 @@ public class DockerHostCapacity {
      */
     public NodeResources freeCapacityOf(Node dockerHost, boolean includeInactive) {
         // Only hosts have free capacity
-        if ( ! dockerHost.type().equals(NodeType.host)) return new NodeResources(0, 0, 0);
+        if (dockerHost.type() != NodeType.host) return new NodeResources(0, 0, 0);
 
         // Subtract used resources without taking disk speed into account since existing allocations grandfathered in
         // may not use reflect the actual disk speed (as of May 2019). This (the 3 diskSpeed assignments below)
@@ -71,8 +71,8 @@ public class DockerHostCapacity {
                 .withDiskSpeed(dockerHost.flavor().resources().diskSpeed());
     }
 
-    private boolean isInactiveOrRetired(Node node) {
-        if (node.state().equals(Node.State.inactive)) return true;
+    private static boolean isInactiveOrRetired(Node node) {
+        if (node.state() == Node.State.inactive) return true;
         if (node.allocation().isPresent() && node.allocation().get().membership().retired()) return true;
         return false;
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
@@ -62,6 +62,7 @@ public class DockerHostCapacity {
     NodeResources freeCapacityOf(Node dockerHost, boolean excludeInactive) {
         // Only hosts have free capacity
         if (dockerHost.type() != NodeType.host) return new NodeResources(0, 0, 0);
+        NodeResources hostResources = hostResourcesCalculator.availableCapacityOf(dockerHost.flavor().resources());
 
         // Subtract used resources without taking disk speed into account since existing allocations grandfathered in
         // may not use reflect the actual disk speed (as of May 2019). This (the 3 diskSpeed assignments below)
@@ -69,7 +70,7 @@ public class DockerHostCapacity {
         return allNodes.childrenOf(dockerHost).asList().stream()
                 .filter(node -> !(excludeInactive && isInactiveOrRetired(node)))
                 .map(node -> node.flavor().resources().withDiskSpeed(NodeResources.DiskSpeed.any))
-                .reduce(dockerHost.flavor().resources().withDiskSpeed(NodeResources.DiskSpeed.any), NodeResources::subtract)
+                .reduce(hostResources.withDiskSpeed(NodeResources.DiskSpeed.any), NodeResources::subtract)
                 .withDiskSpeed(dockerHost.flavor().resources().diskSpeed());
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
@@ -57,7 +57,7 @@ public class DockerHostCapacity {
      * @param dockerHost The host to find free capacity of.
      * @return A default (empty) capacity if not a docker host, otherwise the free/unallocated/rest capacity
      */
-    public NodeResources freeCapacityOf(Node dockerHost, boolean includeInactive) {
+    NodeResources freeCapacityOf(Node dockerHost, boolean excludeInactive) {
         // Only hosts have free capacity
         if (dockerHost.type() != NodeType.host) return new NodeResources(0, 0, 0);
 
@@ -65,7 +65,7 @@ public class DockerHostCapacity {
         // may not use reflect the actual disk speed (as of May 2019). This (the 3 diskSpeed assignments below)
         // can be removed when all node allocations accurately reflect the true host disk speed
         return allNodes.childrenOf(dockerHost).asList().stream()
-                .filter(node -> !(includeInactive && isInactiveOrRetired(node)))
+                .filter(node -> !(excludeInactive && isInactiveOrRetired(node)))
                 .map(node -> node.flavor().resources().withDiskSpeed(NodeResources.DiskSpeed.any))
                 .reduce(dockerHost.flavor().resources().withDiskSpeed(NodeResources.DiskSpeed.any), NodeResources::subtract)
                 .withDiskSpeed(dockerHost.flavor().resources().diskSpeed());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerHostCapacity.java
@@ -19,9 +19,11 @@ import java.util.Objects;
 public class DockerHostCapacity {
 
     private final LockedNodeList allNodes;
+    private final HostResourcesCalculator hostResourcesCalculator;
 
-    DockerHostCapacity(LockedNodeList allNodes) {
+    DockerHostCapacity(LockedNodeList allNodes, HostResourcesCalculator hostResourcesCalculator) {
         this.allNodes = Objects.requireNonNull(allNodes, "allNodes must be non-null");
+        this.hostResourcesCalculator = Objects.requireNonNull(hostResourcesCalculator, "hostResourcesCalculator must be non-null");
     }
 
     int compareWithoutInactive(Node hostA, Node hostB) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/EmptyProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/EmptyProvisionServiceProvider.java
@@ -1,6 +1,7 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerService;
 
 import java.util.Optional;
@@ -9,6 +10,8 @@ import java.util.Optional;
  * @author freva
  */
 public class EmptyProvisionServiceProvider implements ProvisionServiceProvider {
+    private final HostResourcesCalculator hostResourcesCalculator = new NoopHostResourcesCalculator();
+
     @Override
     public Optional<LoadBalancerService> getLoadBalancerService() {
         return Optional.empty();
@@ -17,5 +20,18 @@ public class EmptyProvisionServiceProvider implements ProvisionServiceProvider {
     @Override
     public Optional<HostProvisioner> getHostProvisioner() {
         return Optional.empty();
+    }
+
+    @Override
+    public HostResourcesCalculator getHostResourcesCalculator() {
+        return hostResourcesCalculator;
+    }
+
+    public static class NoopHostResourcesCalculator implements HostResourcesCalculator {
+
+        @Override
+        public NodeResources availableCapacityOf(NodeResources hostResources) {
+            return hostResources;
+        }
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -25,12 +25,14 @@ public class GroupPreparer {
 
     private final NodeRepository nodeRepository;
     private final Optional<HostProvisioner> hostProvisioner;
+    private final HostResourcesCalculator hostResourcesCalculator;
     private final BooleanFlag dynamicProvisioningEnabledFlag;
 
     public GroupPreparer(NodeRepository nodeRepository, Optional<HostProvisioner> hostProvisioner,
-                         BooleanFlag dynamicProvisioningEnabledFlag) {
+                         HostResourcesCalculator hostResourcesCalculator, BooleanFlag dynamicProvisioningEnabledFlag) {
         this.nodeRepository = nodeRepository;
         this.hostProvisioner = hostProvisioner;
+        this.hostResourcesCalculator = hostResourcesCalculator;
         this.dynamicProvisioningEnabledFlag = dynamicProvisioningEnabledFlag;
     }
 
@@ -65,7 +67,8 @@ public class GroupPreparer {
                 LockedNodeList nodeList = nodeRepository.list(allocationLock);
                 NodePrioritizer prioritizer = new NodePrioritizer(nodeList, application, cluster, requestedNodes,
                                                                   spareCount, nodeRepository.nameResolver(),
-                                                                  nodeRepository.getAvailableFlavors());
+                                                                  nodeRepository.getAvailableFlavors(),
+                                                                  hostResourcesCalculator);
 
                 prioritizer.addApplicationNodes();
                 prioritizer.addSurplusNodes(surplusActiveNodes);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostResourcesCalculator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostResourcesCalculator.java
@@ -1,0 +1,13 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.provisioning;
+
+import com.yahoo.config.provision.NodeResources;
+
+/**
+ * @author freva
+ */
+public interface HostResourcesCalculator {
+
+    /** Calculates the resources that are reserved for host level processes and returns the remainder. */
+    NodeResources availableCapacityOf(NodeResources hostResources);
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -51,9 +51,9 @@ class NodePrioritizer {
     private final Set<Node> spareHosts;
 
     NodePrioritizer(LockedNodeList allNodes, ApplicationId appId, ClusterSpec clusterSpec, NodeSpec nodeSpec,
-                    int spares, NameResolver nameResolver, NodeFlavors flavors) {
+                    int spares, NameResolver nameResolver, NodeFlavors flavors, HostResourcesCalculator hostResourcesCalculator) {
         this.allNodes = allNodes;
-        this.capacity = new DockerHostCapacity(allNodes);
+        this.capacity = new DockerHostCapacity(allNodes, hostResourcesCalculator);
         this.requestedNodes = nodeSpec;
         this.clusterSpec = clusterSpec;
         this.appId = appId;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -6,10 +6,10 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
-import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.HostFilter;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.ProvisionLogger;
 import com.yahoo.config.provision.Provisioner;
@@ -27,7 +27,6 @@ import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +63,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
         this.capacityPolicies = new CapacityPolicies(zone, flavors);
         this.zone = zone;
         this.preparer = new Preparer(nodeRepository,
-                zone.environment().equals(Environment.prod) ? SPARE_CAPACITY_PROD : SPARE_CAPACITY_NONPROD,
+                zone.environment() == Environment.prod ? SPARE_CAPACITY_PROD : SPARE_CAPACITY_NONPROD,
                 provisionServiceProvider.getHostProvisioner(),
                 Flags.ENABLE_DYNAMIC_PROVISIONING.bindTo(flagSource));
         this.activator = new Activator(nodeRepository);
@@ -140,7 +139,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
             log.log(LogLevel.DEBUG, () -> "Prepared node " + node.hostname() + " - " + node.flavor());
             Allocation nodeAllocation = node.allocation().orElseThrow(IllegalStateException::new);
             hosts.add(new HostSpec(node.hostname(),
-                                   Collections.emptyList(),
+                                   List.of(),
                                    Optional.of(node.flavor()),
                                    Optional.of(nodeAllocation.membership()),
                                    node.status().vespaVersion(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -65,6 +65,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
         this.preparer = new Preparer(nodeRepository,
                 zone.environment() == Environment.prod ? SPARE_CAPACITY_PROD : SPARE_CAPACITY_NONPROD,
                 provisionServiceProvider.getHostProvisioner(),
+                provisionServiceProvider.getHostResourcesCalculator(),
                 Flags.ENABLE_DYNAMIC_PROVISIONING.bindTo(flagSource));
         this.activator = new Activator(nodeRepository);
         this.loadBalancerProvisioner = provisionServiceProvider.getLoadBalancerService().map(lbService ->

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
@@ -27,10 +27,10 @@ class Preparer {
     private final int spareCount;
 
     public Preparer(NodeRepository nodeRepository, int spareCount, Optional<HostProvisioner> hostProvisioner,
-                    BooleanFlag dynamicProvisioningEnabled) {
+                    HostResourcesCalculator hostResourcesCalculator, BooleanFlag dynamicProvisioningEnabled) {
         this.nodeRepository = nodeRepository;
         this.spareCount = spareCount;
-        this.groupPreparer = new GroupPreparer(nodeRepository, hostProvisioner, dynamicProvisioningEnabled);
+        this.groupPreparer = new GroupPreparer(nodeRepository, hostProvisioner, hostResourcesCalculator, dynamicProvisioningEnabled);
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionServiceProvider.java
@@ -15,4 +15,6 @@ public interface ProvisionServiceProvider {
     Optional<LoadBalancerService> getLoadBalancerService();
 
     Optional<HostProvisioner> getHostProvisioner();
+
+    HostResourcesCalculator getHostResourcesCalculator();
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockProvisionServiceProvider.java
@@ -4,7 +4,9 @@ package com.yahoo.vespa.hosted.provision.testutils;
 import com.google.inject.Inject;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerService;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerServiceMock;
+import com.yahoo.vespa.hosted.provision.provisioning.EmptyProvisionServiceProvider;
 import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+import com.yahoo.vespa.hosted.provision.provisioning.HostResourcesCalculator;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisionServiceProvider;
 
 import java.util.Optional;
@@ -16,6 +18,7 @@ public class MockProvisionServiceProvider implements ProvisionServiceProvider {
 
     private final Optional<LoadBalancerService> loadBalancerService;
     private final Optional<HostProvisioner> hostProvisioner;
+    private final HostResourcesCalculator hostResourcesCalculator;
 
     @Inject
     public MockProvisionServiceProvider() {
@@ -23,8 +26,14 @@ public class MockProvisionServiceProvider implements ProvisionServiceProvider {
     }
 
     public MockProvisionServiceProvider(LoadBalancerService loadBalancerService, HostProvisioner hostProvisioner) {
+        this(loadBalancerService, hostProvisioner, new EmptyProvisionServiceProvider.NoopHostResourcesCalculator());
+    }
+
+    public MockProvisionServiceProvider(LoadBalancerService loadBalancerService, HostProvisioner hostProvisioner,
+                                        HostResourcesCalculator hostResourcesCalculator) {
         this.loadBalancerService = Optional.ofNullable(loadBalancerService);
         this.hostProvisioner = Optional.ofNullable(hostProvisioner);
+        this.hostResourcesCalculator = hostResourcesCalculator;
     }
 
     @Override
@@ -35,5 +44,10 @@ public class MockProvisionServiceProvider implements ProvisionServiceProvider {
     @Override
     public Optional<HostProvisioner> getHostProvisioner() {
         return hostProvisioner;
+    }
+
+    @Override
+    public HostResourcesCalculator getHostResourcesCalculator() {
+        return hostResourcesCalculator;
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -163,27 +163,6 @@ public class MetricsReporterTest {
         assertEquals(6.0, metric.values.get("hostedVespa.docker.freeCapacityDisk"));
         assertEquals(3.0, metric.values.get("hostedVespa.docker.freeCapacityMem"));
         assertEquals(4.0, metric.values.get("hostedVespa.docker.freeCapacityCpu"));
-
-        assertContext(metric, "hostedVespa.docker.freeCapacityFlavor", 1, 0);
-        assertContext(metric, "hostedVespa.docker.hostsAvailableFlavor", 1l, 0l);
-    }
-
-    private void assertContext(TestMetric metric, String key, Number dockerValue, Number docker2Value) {
-        List<Metric.Context> freeCapacityFlavor = metric.context.get(key);
-        assertEquals(freeCapacityFlavor.size(), 2);
-
-        // Get the value for the two flavors
-        TestMetric.TestContext contextFlavorDocker = (TestMetric.TestContext)freeCapacityFlavor.get(0);
-        TestMetric.TestContext contextFlavorDocker2 = (TestMetric.TestContext)freeCapacityFlavor.get(1);
-        if (!contextFlavorDocker.properties.containsValue("docker")) {
-            TestMetric.TestContext temp = contextFlavorDocker;
-            contextFlavorDocker = contextFlavorDocker2;
-            contextFlavorDocker2 = temp;
-        }
-
-        assertEquals(dockerValue, contextFlavorDocker.value);
-        assertEquals(docker2Value, contextFlavorDocker2.value);
-
     }
 
     private ApplicationId app(String tenant) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,19 +55,19 @@ public class MetricsReporterTest {
                                                            DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
                                                            true);
         Node node = nodeRepository.createNode("openStackId", "hostname", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.tenant);
-        nodeRepository.addNodes(Collections.singletonList(node));
+        nodeRepository.addNodes(List.of(node));
         Node hostNode = nodeRepository.createNode("openStackId2", "parent", Optional.empty(), nodeFlavors.getFlavorOrThrow("default"), NodeType.proxy);
-        nodeRepository.addNodes(Collections.singletonList(hostNode));
+        nodeRepository.addNodes(List.of(hostNode));
 
         Map<String, Number> expectedMetrics = new HashMap<>();
-        expectedMetrics.put("hostedVespa.provisionedHosts", 1L);
-        expectedMetrics.put("hostedVespa.parkedHosts", 0L);
-        expectedMetrics.put("hostedVespa.readyHosts", 0L);
-        expectedMetrics.put("hostedVespa.reservedHosts", 0L);
-        expectedMetrics.put("hostedVespa.activeHosts", 0L);
-        expectedMetrics.put("hostedVespa.inactiveHosts", 0L);
-        expectedMetrics.put("hostedVespa.dirtyHosts", 0L);
-        expectedMetrics.put("hostedVespa.failedHosts", 0L);
+        expectedMetrics.put("hostedVespa.provisionedHosts", 1);
+        expectedMetrics.put("hostedVespa.parkedHosts", 0);
+        expectedMetrics.put("hostedVespa.readyHosts", 0);
+        expectedMetrics.put("hostedVespa.reservedHosts", 0);
+        expectedMetrics.put("hostedVespa.activeHosts", 0);
+        expectedMetrics.put("hostedVespa.inactiveHosts", 0);
+        expectedMetrics.put("hostedVespa.dirtyHosts", 0);
+        expectedMetrics.put("hostedVespa.failedHosts", 0);
         expectedMetrics.put("hostedVespa.pendingRedeployments", 42);
         expectedMetrics.put("hostedVespa.docker.totalCapacityDisk", 0.0);
         expectedMetrics.put("hostedVespa.docker.totalCapacityMem", 0.0);
@@ -92,7 +91,7 @@ public class MetricsReporterTest {
         when(orchestrator.getNodeStatuses()).thenReturn(hostName -> Optional.of(HostStatus.NO_REMARKS));
         ServiceModel serviceModel = mock(ServiceModel.class);
         when(serviceMonitor.getServiceModelSnapshot()).thenReturn(serviceModel);
-        when(serviceModel.getServiceInstancesByHostName()).thenReturn(Collections.emptyMap());
+        when(serviceModel.getServiceInstancesByHostName()).thenReturn(Map.of());
 
         TestMetric metric = new TestMetric();
         MetricsReporter metricsReporter = new MetricsReporter(
@@ -120,18 +119,18 @@ public class MetricsReporterTest {
         // Allow 4 containers
         Set<String> ipAddressPool = ImmutableSet.of("::2", "::3", "::4", "::5");
 
-        Node dockerHost = Node.create("openStackId1", Collections.singleton("::1"), ipAddressPool, "dockerHost",
+        Node dockerHost = Node.create("openStackId1", Set.of("::1"), ipAddressPool, "dockerHost",
                                       Optional.empty(), Optional.empty(), nodeFlavors.getFlavorOrThrow("host"), NodeType.host);
-        nodeRepository.addNodes(Collections.singletonList(dockerHost));
+        nodeRepository.addNodes(List.of(dockerHost));
         nodeRepository.dirtyRecursively("dockerHost", Agent.system, getClass().getSimpleName());
         nodeRepository.setReady("dockerHost", Agent.system, getClass().getSimpleName());
 
-        Node container1 = Node.createDockerNode(Collections.singleton("::2"), Collections.emptySet(), "container1",
+        Node container1 = Node.createDockerNode(Set.of("::2"), Set.of(), "container1",
                                                 Optional.of("dockerHost"), new NodeResources(1, 3, 2), NodeType.tenant);
         container1 = container1.with(allocation(Optional.of("app1")).get());
         nodeRepository.addDockerNodes(new LockedNodeList(List.of(container1), nodeRepository.lockAllocation()));
 
-        Node container2 = Node.createDockerNode(Collections.singleton("::3"), Collections.emptySet(), "container2",
+        Node container2 = Node.createDockerNode(Set.of("::3"), Set.of(), "container2",
                                                 Optional.of("dockerHost"), new NodeResources(2, 4, 4), NodeType.tenant);
         container2 = container2.with(allocation(Optional.of("app2")).get());
         nodeRepository.addDockerNodes(new LockedNodeList(List.of(container2), nodeRepository.lockAllocation()));
@@ -141,7 +140,7 @@ public class MetricsReporterTest {
         when(orchestrator.getNodeStatuses()).thenReturn(hostName -> Optional.of(HostStatus.NO_REMARKS));
         ServiceModel serviceModel = mock(ServiceModel.class);
         when(serviceMonitor.getServiceModelSnapshot()).thenReturn(serviceModel);
-        when(serviceModel.getServiceInstancesByHostName()).thenReturn(Collections.emptyMap());
+        when(serviceModel.getServiceInstancesByHostName()).thenReturn(Map.of());
 
         TestMetric metric = new TestMetric();
         MetricsReporter metricsReporter = new MetricsReporter(
@@ -154,8 +153,8 @@ public class MetricsReporterTest {
         );
         metricsReporter.maintain();
 
-        assertEquals(0L, metric.values.get("hostedVespa.readyHosts")); /** Only tenants counts **/
-        assertEquals(2L, metric.values.get("hostedVespa.reservedHosts"));
+        assertEquals(0, metric.values.get("hostedVespa.readyHosts")); // Only tenants counts
+        assertEquals(2, metric.values.get("hostedVespa.reservedHosts"));
 
         assertEquals(12.0, metric.values.get("hostedVespa.docker.totalCapacityDisk"));
         assertEquals(10.0, metric.values.get("hostedVespa.docker.totalCapacityMem"));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
@@ -19,7 +19,6 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
-import com.yahoo.vespa.hosted.provision.LockedNodeList;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.node.Agent;
@@ -37,7 +36,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -221,17 +219,13 @@ public class DynamicDockerAllocationTest {
         List<HostSpec> hosts = tester.prepare(application1, clusterSpec, 3, 1, flavor);
         tester.activate(application1, ImmutableSet.copyOf(hosts));
 
-        DockerHostCapacity capacity = new DockerHostCapacity(new LockedNodeList(tester.nodeRepository().getNodes(Node.State.values()), () -> {}));
-        assertThat(capacity.freeCapacityInFlavorEquivalence(new Flavor(flavor)), greaterThan(0));
-
         List<Node> initialSpareCapacity = findSpareCapacity(tester);
         assertThat(initialSpareCapacity.size(), is(2));
 
         try {
             hosts = tester.prepare(application1, clusterSpec, 4, 1, flavor);
             fail("Was able to deploy with 4 nodes, should not be able to use spare capacity");
-        } catch (OutOfCapacityException e) {
-        }
+        } catch (OutOfCapacityException ignored) { }
 
         tester.fail(hosts.get(0));
         hosts = tester.prepare(application1, clusterSpec, 3, 1, flavor);


### PR DESCRIPTION
This defines an interface that will calculate how much resources should be reserved for the host and makes `DockerHostCapacity` use it to determine if a host has free capacity for additional node(s).

First few commits clean up `DockerHostCapacity` a bit by moving methods used exclusively by `MetricsReporter`: These methods will always have to be careful to reset disk speed to `any` when doing their calculations, and are therefore not general. Additionally, I removed `hostedVespa.docker.freeCapacityFlavor`, `hostedVespa.docker.hostsAvailableFlavor` metrics since they generate metric based on traditional flavors for docker containers which we are moving away from.