### PR TITLE
Avoid using classpath to read test data

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/TestConfigSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/TestConfigSerializerTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +30,7 @@ public class TestConfigSerializerTest {
                                                                                Map.of(zone, Map.of(ClusterSpec.Id.from("ai"),
                                                                                                    URI.create("https://server/"))),
                                                                                Map.of(zone, List.of("facts")));
-        byte[] expected = InternalStepRunnerTest.class.getResourceAsStream("/testConfig.json").readAllBytes();
+        byte[] expected = Files.readAllBytes(Paths.get("src/test/resources/testConfig.json"));
         assertEquals(new String(SlimeUtils.toJsonBytes(SlimeUtils.jsonToSlime(expected))),
                      new String(json));
     }


### PR DESCRIPTION
I figured out why tests like this occasionally throw NPE in IntelliJ.

Using `getResourceAsStream` to read a file depends on the file being on the
classpath. To appear on the class path the file has to be copied from
`src/test/resources` to `target/test-classes/`, this is done by the Maven phase
`process-test-sources` (happens before `test`).

When I pull in changes from master, IntelliJ will throw a NPE in tests like this
one since `target/test-classes/<file>` does not exist until I run `mvn test`.

Just using a relative path works every time though, so I think we should prefer
that. :-)