### PR TITLE
Use eclipse collections as gs collection was rebranded to eclipse and…

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -441,9 +441,14 @@
                 <version>${asm.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.goldmansachs</groupId>
-                <artifactId>gs-collections</artifactId>
-                <version>6.1.0</version>
+                <groupId>org.eclipse.collections</groupId>
+                <artifactId>eclipse-collections</artifactId>
+                <version>9.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.collections</groupId>
+                <artifactId>eclipse-collections-api</artifactId>
+                <version>9.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.infradna.tool</groupId>

--- a/predicate-search/pom.xml
+++ b/predicate-search/pom.xml
@@ -34,8 +34,12 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.goldmansachs</groupId>
-            <artifactId>gs-collections</artifactId>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/index/CachedPostingListCounter.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/index/CachedPostingListCounter.java
@@ -2,9 +2,9 @@
 package com.yahoo.search.predicate.index;
 
 import com.google.common.collect.MinMaxPriorityQueue;
-import com.gs.collections.api.tuple.primitive.ObjectLongPair;
-import com.gs.collections.impl.map.mutable.primitive.ObjectIntHashMap;
-import com.gs.collections.impl.map.mutable.primitive.ObjectLongHashMap;
+import org.eclipse.collections.api.tuple.primitive.ObjectLongPair;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,7 +119,7 @@ public class CachedPostingListCounter {
 
     private static class Entry implements Comparable<Entry> {
         public final int[] docIds;
-        public final double cost;
+        final double cost;
 
         private Entry(int[] docIds, long frequency) {
             this.docIds = docIds;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/index/SimpleIndex.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/index/SimpleIndex.java
@@ -1,10 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate.index;
 
-import com.gs.collections.api.map.primitive.LongObjectMap;
-import com.gs.collections.api.tuple.primitive.LongObjectPair;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import com.yahoo.search.predicate.serialization.SerializationHelper;
+import org.eclipse.collections.api.map.primitive.LongObjectMap;
+import org.eclipse.collections.api.tuple.primitive.LongObjectPair;
+import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/index/conjunction/ConjunctionIndex.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/index/conjunction/ConjunctionIndex.java
@@ -1,17 +1,17 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate.index.conjunction;
 
-import com.gs.collections.api.map.primitive.IntObjectMap;
-import com.gs.collections.api.map.primitive.LongObjectMap;
-import com.gs.collections.api.tuple.primitive.IntObjectPair;
-import com.gs.collections.api.tuple.primitive.LongObjectPair;
-import com.gs.collections.impl.map.mutable.primitive.IntObjectHashMap;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import com.yahoo.document.predicate.FeatureConjunction;
 import com.yahoo.search.predicate.PredicateQuery;
 import com.yahoo.search.predicate.SubqueryBitmap;
 import com.yahoo.search.predicate.serialization.SerializationHelper;
 import com.yahoo.search.predicate.utils.PrimitiveArraySorter;
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
+import org.eclipse.collections.api.map.primitive.LongObjectMap;
+import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
+import org.eclipse.collections.api.tuple.primitive.LongObjectPair;
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/index/conjunction/ConjunctionIndexBuilder.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/index/conjunction/ConjunctionIndexBuilder.java
@@ -3,9 +3,9 @@ package com.yahoo.search.predicate.index.conjunction;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
-import com.gs.collections.api.map.primitive.IntObjectMap;
-import com.gs.collections.impl.map.mutable.primitive.IntObjectHashMap;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/predicate-search/src/test/java/com/yahoo/search/predicate/index/CachedPostingListCounterTest.java
+++ b/predicate-search/src/test/java/com/yahoo/search/predicate/index/CachedPostingListCounterTest.java
@@ -1,8 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate.index;
 
-import com.gs.collections.impl.map.mutable.primitive.ObjectIntHashMap;
 import org.apache.commons.lang.ArrayUtils;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
 import org.junit.Test;
 
 import java.util.ArrayList;


### PR DESCRIPTION
… received continous development.

@bjorncs or @gjoranv PR
