### PR TITLE
Gjoranv/metricsproxy cleanup

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -56,7 +56,7 @@ public interface ModelContext {
         boolean useFdispatchByDefault();
         boolean dispatchWithProtobuf();
         boolean useAdaptiveDispatch();
-        // TODO: Remove when 7.60 is the oldest model in use
+        // TODO: Remove when 7.61 is the oldest model in use
         default boolean enableMetricsProxyContainer() { return false; }
     }
 

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -56,7 +56,8 @@ public interface ModelContext {
         boolean useFdispatchByDefault();
         boolean dispatchWithProtobuf();
         boolean useAdaptiveDispatch();
-        boolean enableMetricsProxyContainer();
+        // TODO: Remove when 7.60 is the oldest model in use
+        default boolean enableMetricsProxyContainer() { return false; }
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -37,7 +37,6 @@ public class TestProperties implements ModelContext.Properties {
     private boolean useFdispatchByDefault = true;
     private boolean dispatchWithProtobuf = true;
     private boolean useAdaptiveDispatch = false;
-    private boolean enableMetricsProxyContainer = false;
 
 
     @Override public boolean multitenant() { return multitenant; }
@@ -55,7 +54,6 @@ public class TestProperties implements ModelContext.Properties {
     @Override public boolean useDedicatedNodeForLogserver() { return useDedicatedNodeForLogserver; }
     @Override public boolean useFdispatchByDefault() { return useFdispatchByDefault; }
     @Override public boolean dispatchWithProtobuf() { return dispatchWithProtobuf; }
-    @Override public boolean enableMetricsProxyContainer() { return enableMetricsProxyContainer; }
 
     public TestProperties setApplicationId(ApplicationId applicationId) {
         this.applicationId = applicationId;
@@ -87,10 +85,6 @@ public class TestProperties implements ModelContext.Properties {
         return this;
     }
 
-    public TestProperties setEnableMetricsProxyContainer(boolean enableMetricsProxyContainer) {
-        this.enableMetricsProxyContainer = enableMetricsProxyContainer;
-        return this;
-    }
 
     public static class Spec implements ConfigServerSpec {
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
@@ -32,7 +32,6 @@ public class MetricsProxyContainerTest {
     public void one_metrics_proxy_container_is_added_to_every_node() {
         var numberOfHosts = 4;
         var tester = new VespaModelTester();
-        tester.enableMetricsProxyContainer(true);
         tester.addHosts(numberOfHosts);
 
         VespaModel model = tester.createModel(servicesWithManyNodes(), true);

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
@@ -36,7 +36,6 @@ class MetricsProxyModelTester {
     static VespaModel getModel(String servicesXml) {
         var numberOfHosts = 1;
         var tester = new VespaModelTester();
-        tester.enableMetricsProxyContainer(true);
         tester.addHosts(numberOfHosts);
         tester.setHosted(false);
         return tester.createModel(servicesXml, true);
@@ -45,7 +44,6 @@ class MetricsProxyModelTester {
     static VespaModel getHostedModel(String servicesXml) {
         var numberOfHosts = 2;
         var tester = new VespaModelTester();
-        tester.enableMetricsProxyContainer(true);
         tester.addHosts(numberOfHosts);
         tester.setHosted(true);
         tester.setApplicationId(MY_TENANT, MY_APPLICATION, MY_INSTANCE);

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -48,7 +48,6 @@ public class VespaModelTester {
     private Map<NodeResources, Collection<Host>> hostsByResources = new HashMap<>();
     private ApplicationId applicationId = ApplicationId.defaultId();
     private boolean useDedicatedNodeForLogserver = false;
-    private boolean enableMetricsProxyContainer = false;
 
     public VespaModelTester() {
         this(new NullConfigModelRegistry());
@@ -105,10 +104,6 @@ public class VespaModelTester {
         this.useDedicatedNodeForLogserver = useDedicatedNodeForLogserver;
     }
 
-    public void enableMetricsProxyContainer(boolean enableMetricsProxyContainer) {
-        this.enableMetricsProxyContainer = enableMetricsProxyContainer;
-    }
-
     /** Creates a model which uses 0 as start index and fails on out of capacity */
     public VespaModel createModel(String services, String ... retiredHostNames) {
         return createModel(Zone.defaultZone(), services, true, retiredHostNames);
@@ -149,8 +144,7 @@ public class VespaModelTester {
                 .setMultitenant(true)
                 .setHostedVespa(hosted)
                 .setApplicationId(applicationId)
-                .setUseDedicatedNodeForLogserver(useDedicatedNodeForLogserver)
-                .setEnableMetricsProxyContainer(enableMetricsProxyContainer);
+                .setUseDedicatedNodeForLogserver(useDedicatedNodeForLogserver);
 
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(appPkg)

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -132,7 +132,6 @@ public class ModelContextImpl implements ModelContext {
         private final boolean useFdispatchByDefault;
         private final boolean useAdaptiveDispatch;
         private final boolean dispatchWithProtobuf;
-        private final boolean enableMetricsProxyContainer;
 
         public Properties(ApplicationId applicationId,
                           boolean multitenantFromConfig,
@@ -164,8 +163,6 @@ public class ModelContextImpl implements ModelContext {
             this.dispatchWithProtobuf = Flags.DISPATCH_WITH_PROTOBUF.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             this.useAdaptiveDispatch = Flags.USE_ADAPTIVE_DISPATCH.bindTo(flagSource)
-                    .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
-            this.enableMetricsProxyContainer = Flags.ENABLE_METRICS_PROXY_CONTAINER.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
         }
 
@@ -218,8 +215,6 @@ public class ModelContextImpl implements ModelContext {
         @Override
         public boolean useAdaptiveDispatch() { return useAdaptiveDispatch; }
 
-        @Override
-        public boolean enableMetricsProxyContainer() { return enableMetricsProxyContainer; }
     }
 
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -40,7 +40,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.ContainerState.ABSENT;
@@ -601,27 +600,13 @@ public class NodeAgentImpl implements NodeAgent {
             for (DimensionMetrics dimensionMetrics : metrics) {
                 params.append(dimensionMetrics.toSecretAgentReport());
             }
-        } catch (JsonProcessingException e) {
-            // TODO: wrap everything into one try-block (to avoid 'return') when old metrics proxy is discontinued
-            context.log(logger, LogLevel.WARNING, "Failed to wrap metrics in secret agent report", e);
-            return;
-        }
-        String wrappedMetrics = "s:" + params.toString();
+            String wrappedMetrics = "s:" + params.toString();
 
-        // Push metrics to the metrics proxy in each container
-        runPushMetricsCommand(context, wrappedMetrics, true);
-        runPushMetricsCommand(context, wrappedMetrics, false);
-    }
-
-    // TODO: Clean up and inline method when old metrics proxy has been discontinued.
-    private void runPushMetricsCommand(NodeAgentContext context, String wrappedMetrics, boolean newMetricsProxy) {
-        int port = newMetricsProxy ? 19095 : 19091;
-        String[] command = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:" + port,  "setExtraMetrics", wrappedMetrics};
-        try {
+            // Push metrics to the metrics proxy in each container
+            String[] command = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:19095",  "setExtraMetrics", wrappedMetrics};
             dockerOperations.executeCommandInContainerAsRoot(context, 5L, command);
-        } catch (DockerExecTimeoutException  e) {
-            Level level = newMetricsProxy ? LogLevel.DEBUG : LogLevel.WARNING;
-            context.log(logger, level, "Failed to push metrics to container", e);
+        } catch (JsonProcessingException | DockerExecTimeoutException  e) {
+            context.log(logger, LogLevel.WARNING, "Failed to push metrics to container", e);
         }
 
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -40,7 +40,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.ContainerState.ABSENT;
@@ -620,8 +619,7 @@ public class NodeAgentImpl implements NodeAgent {
         try {
             dockerOperations.executeCommandInContainerAsRoot(context, 5L, command);
         } catch (DockerExecTimeoutException  e) {
-            Level level = newMetricsProxy ? LogLevel.DEBUG : LogLevel.WARNING;
-            context.log(logger, level, "Failed to push metrics to container", e);
+            context.log(logger, LogLevel.DEBUG, "Failed to push metrics to container", e);
         }
 
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.ContainerState.ABSENT;
@@ -600,13 +601,27 @@ public class NodeAgentImpl implements NodeAgent {
             for (DimensionMetrics dimensionMetrics : metrics) {
                 params.append(dimensionMetrics.toSecretAgentReport());
             }
-            String wrappedMetrics = "s:" + params.toString();
+        } catch (JsonProcessingException e) {
+            // TODO: wrap everything into one try-block (to avoid 'return') when old metrics proxy is discontinued
+            context.log(logger, LogLevel.WARNING, "Failed to wrap metrics in secret agent report", e);
+            return;
+        }
+        String wrappedMetrics = "s:" + params.toString();
 
-            // Push metrics to the metrics proxy in each container
-            String[] command = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:19095",  "setExtraMetrics", wrappedMetrics};
+        // Push metrics to the metrics proxy in each container
+        runPushMetricsCommand(context, wrappedMetrics, true);
+        runPushMetricsCommand(context, wrappedMetrics, false);
+    }
+
+    // TODO: Clean up and inline method when old metrics proxy has been discontinued.
+    private void runPushMetricsCommand(NodeAgentContext context, String wrappedMetrics, boolean newMetricsProxy) {
+        int port = newMetricsProxy ? 19095 : 19091;
+        String[] command = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:" + port,  "setExtraMetrics", wrappedMetrics};
+        try {
             dockerOperations.executeCommandInContainerAsRoot(context, 5L, command);
-        } catch (JsonProcessingException | DockerExecTimeoutException  e) {
-            context.log(logger, LogLevel.WARNING, "Failed to push metrics to container", e);
+        } catch (DockerExecTimeoutException  e) {
+            Level level = newMetricsProxy ? LogLevel.DEBUG : LogLevel.WARNING;
+            context.log(logger, level, "Failed to push metrics to container", e);
         }
 
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -688,6 +688,9 @@ public class NodeAgentImplTest {
                     .replaceAll("\"timestamp\":\\d+", "\"timestamp\":0")
                     .replaceAll("([0-9]+\\.[0-9]{1,3})([0-9]*)", "$1"); // Only keep the first 3 decimals
 
+            // TODO: Remove when old metrics proxy is discontinued.
+            calledCommand[3] = calledCommand[3].replaceFirst("19091", "19095");
+
             assertEquals(context, calledContainerName);
             assertEquals(5L, calledTimeout);
             assertArrayEquals(expectedCommand, calledCommand);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -688,9 +688,6 @@ public class NodeAgentImplTest {
                     .replaceAll("\"timestamp\":\\d+", "\"timestamp\":0")
                     .replaceAll("([0-9]+\\.[0-9]{1,3})([0-9]*)", "$1"); // Only keep the first 3 decimals
 
-            // TODO: Remove when old metrics proxy is discontinued.
-            calledCommand[3] = calledCommand[3].replaceFirst("19091", "19095");
-
             assertEquals(context, calledContainerName);
             assertEquals(5L, calledTimeout);
             assertArrayEquals(expectedCommand, calledCommand);


### PR DESCRIPTION
FYI @freva: This removes the dual metricsproxy mode in node-admin, so it just uses the new one at port 19095.  