### PR TITLE
Update ContainerModelBuilder to add rotations

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ContainerEndpoint.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ContainerEndpoint.java
@@ -1,5 +1,5 @@
 // Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.config.server.tenant;
+package com.yahoo.config.model.api;
 
 import java.util.List;
 import java.util.Objects;

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -50,6 +50,7 @@ public interface ModelContext {
         boolean hostedVespa();
         Zone zone();
         Set<Rotation> rotations();
+        Set<ContainerEndpoint> endpoints();
         boolean isBootstrap();
         boolean isFirstTimeDeployment();
         boolean useDedicatedNodeForLogserver();

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -118,7 +118,7 @@ public class DeployState implements ConfigDefinitionStore {
         this.permanentApplicationPackage = permanentApplicationPackage;
         this.configDefinitionRepo = configDefinitionRepo;
         this.rotations = rotations;
-        this.endpoints = endpoints;
+        this.endpoints = Set.copyOf(endpoints);
         this.zone = zone;
         this.queryProfiles = queryProfiles; // TODO: Remove this by seeing how pagetemplates are propagated
         this.semanticRules = semanticRules; // TODO: Remove this by seeing how pagetemplates are propagated
@@ -236,6 +236,10 @@ public class DeployState implements ConfigDefinitionStore {
 
     public Set<Rotation> getRotations() {
         return this.rotations; // todo: consider returning a copy or immutable view
+    }
+
+    public Set<ContainerEndpoint> getEndpoints() {
+        return endpoints;
     }
 
     /** Returns the zone in which this is currently running */

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -11,6 +11,7 @@ import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.application.api.UnparsedConfigDefinition;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ModelContext;
@@ -67,6 +68,7 @@ public class DeployState implements ConfigDefinitionStore {
     private final ModelContext.Properties properties;
     private final Version vespaVersion;
     private final Set<Rotation> rotations;
+    private final Set<ContainerEndpoint> endpoints;
     private final Zone zone;
     private final QueryProfiles queryProfiles;
     private final SemanticRules semanticRules;
@@ -96,6 +98,7 @@ public class DeployState implements ConfigDefinitionStore {
                         Optional<ConfigDefinitionRepo> configDefinitionRepo,
                         java.util.Optional<Model> previousModel,
                         Set<Rotation> rotations,
+                        Set<ContainerEndpoint> endpoints,
                         Collection<MlModelImporter> modelImporters,
                         Zone zone,
                         QueryProfiles queryProfiles,
@@ -115,6 +118,7 @@ public class DeployState implements ConfigDefinitionStore {
         this.permanentApplicationPackage = permanentApplicationPackage;
         this.configDefinitionRepo = configDefinitionRepo;
         this.rotations = rotations;
+        this.endpoints = endpoints;
         this.zone = zone;
         this.queryProfiles = queryProfiles; // TODO: Remove this by seeing how pagetemplates are propagated
         this.semanticRules = semanticRules; // TODO: Remove this by seeing how pagetemplates are propagated
@@ -260,6 +264,7 @@ public class DeployState implements ConfigDefinitionStore {
         private Optional<ConfigDefinitionRepo> configDefinitionRepo = Optional.empty();
         private Optional<Model> previousModel = Optional.empty();
         private Set<Rotation> rotations = new HashSet<>();
+        private Set<ContainerEndpoint> endpoints = Set.of();
         private Collection<MlModelImporter> modelImporters = Collections.emptyList();
         private Zone zone = Zone.defaultZone();
         private Instant now = Instant.now();
@@ -315,6 +320,11 @@ public class DeployState implements ConfigDefinitionStore {
             return this;
         }
 
+        public Builder endpoints(Set<ContainerEndpoint> endpoints) {
+            this.endpoints = endpoints;
+            return this;
+        }
+
         public Builder modelImporters(Collection<MlModelImporter> modelImporters) {
             this.modelImporters = modelImporters;
             return this;
@@ -356,6 +366,7 @@ public class DeployState implements ConfigDefinitionStore {
                                    configDefinitionRepo,
                                    previousModel,
                                    rotations,
+                                   endpoints,
                                    modelImporters,
                                    zone,
                                    queryProfiles,

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -3,6 +3,7 @@ package com.yahoo.config.model.deploy;
 
 import com.google.common.collect.ImmutableList;
 import com.yahoo.config.model.api.ConfigServerSpec;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
@@ -31,6 +32,7 @@ public class TestProperties implements ModelContext.Properties {
     private boolean hostedVespa = false;
     private Zone zone;
     private Set<Rotation> rotations;
+    private Set<ContainerEndpoint> endpoints;
     private boolean isBootstrap = false;
     private boolean isFirstTimeDeployment = false;
     private boolean useDedicatedNodeForLogserver = false;
@@ -49,6 +51,8 @@ public class TestProperties implements ModelContext.Properties {
     @Override public boolean hostedVespa() { return hostedVespa; }
     @Override public Zone zone() { return zone; }
     @Override public Set<Rotation> rotations() { return rotations; }
+    @Override public Set<ContainerEndpoint> endpoints() { return endpoints; }
+
     @Override public boolean isBootstrap() { return isBootstrap; }
     @Override public boolean isFirstTimeDeployment() { return isFirstTimeDeployment; }
     @Override public boolean useAdaptiveDispatch() { return useAdaptiveDispatch; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -32,7 +32,7 @@ public class TestProperties implements ModelContext.Properties {
     private boolean hostedVespa = false;
     private Zone zone;
     private Set<Rotation> rotations;
-    private Set<ContainerEndpoint> endpoints;
+    private Set<ContainerEndpoint> endpoints = Collections.emptySet();
     private boolean isBootstrap = false;
     private boolean isFirstTimeDeployment = false;
     private boolean useDedicatedNodeForLogserver = false;

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -139,6 +139,7 @@ public class VespaModelFactory implements ModelFactory {
             .vespaVersion(version())
             .modelHostProvisioner(createHostProvisioner(modelContext))
             .rotations(modelContext.properties().rotations())
+            .endpoints(modelContext.properties().endpoints())
             .modelImporters(modelImporters)
             .zone(zone)
             .now(clock.instant())

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -7,6 +7,7 @@ import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.model.api.ConfigServerSpec;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ModelContext;
@@ -126,6 +127,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean hostedVespa;
         private final Zone zone;
         private final Set<Rotation> rotations;
+        private final Set<ContainerEndpoint> endpoints;
         private final boolean isBootstrap;
         private final boolean isFirstTimeDeployment;
         private final boolean useDedicatedNodeForLogserver;
@@ -143,6 +145,7 @@ public class ModelContextImpl implements ModelContext {
                           boolean hostedVespa,
                           Zone zone,
                           Set<Rotation> rotations,
+                          Set<ContainerEndpoint> endpoints,
                           boolean isBootstrap,
                           boolean isFirstTimeDeployment,
                           FlagSource flagSource) {
@@ -155,6 +158,7 @@ public class ModelContextImpl implements ModelContext {
             this.hostedVespa = hostedVespa;
             this.zone = zone;
             this.rotations = rotations;
+            this.endpoints = endpoints;
             this.isBootstrap = isBootstrap;
             this.isFirstTimeDeployment = isFirstTimeDeployment;
             this.useDedicatedNodeForLogserver = Flags.USE_DEDICATED_NODE_FOR_LOGSERVER.bindTo(flagSource)
@@ -199,6 +203,9 @@ public class ModelContextImpl implements ModelContext {
 
         @Override
         public Set<Rotation> rotations() { return rotations; }
+
+        @Override
+        public Set<ContainerEndpoint> endpoints() { return endpoints; }
 
         @Override
         public boolean isBootstrap() { return isBootstrap; }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.modelfactory;
 
+import com.google.common.collect.ImmutableSet;
 import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
@@ -24,6 +25,7 @@ import com.yahoo.vespa.config.server.monitoring.Metrics;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
 import com.yahoo.vespa.config.server.session.SessionZooKeeperClient;
 import com.yahoo.vespa.config.server.session.SilentDeployLogger;
+import com.yahoo.vespa.config.server.tenant.ContainerEndpointsCache;
 import com.yahoo.vespa.config.server.tenant.Rotations;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
@@ -127,6 +129,7 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                                                configserverConfig.hostedVespa(),
                                                zone(),
                                                new Rotations(curator, TenantRepository.getTenantPath(tenant)).readRotationsFromZooKeeper(applicationId),
+                                               ImmutableSet.copyOf(new ContainerEndpointsCache(TenantRepository.getTenantPath(tenant), curator).read(applicationId)),
                                                false, // We may be bootstrapping, but we only know and care during prepare
                                                false, // Always false, assume no one uses it when activating
                                                flagSource);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
@@ -10,7 +10,7 @@ import com.yahoo.slime.Slime;
 import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.config.server.TimeoutBudget;
 import com.yahoo.vespa.config.server.http.SessionHandler;
-import com.yahoo.vespa.config.server.tenant.ContainerEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.vespa.config.server.tenant.ContainerEndpointSerializer;
 
 import java.time.Clock;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -20,7 +20,6 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.lang.SettableOptional;
 import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.config.server.ConfigServerSpec;
 import com.yahoo.vespa.config.server.application.ApplicationSet;
 import com.yahoo.vespa.config.server.application.PermanentApplicationPackage;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -30,7 +30,7 @@ import com.yahoo.vespa.config.server.http.InvalidApplicationException;
 import com.yahoo.vespa.config.server.modelfactory.ModelFactoryRegistry;
 import com.yahoo.vespa.config.server.modelfactory.PreparedModelsBuilder;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
-import com.yahoo.vespa.config.server.tenant.ContainerEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.vespa.config.server.tenant.ContainerEndpointsCache;
 import com.yahoo.vespa.config.server.tenant.Rotations;
 import com.yahoo.vespa.curator.Curator;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -269,7 +269,7 @@ public class SessionPreparer {
     }
 
     private static List<ContainerEndpoint> toContainerEndpoints(String globalServceId, Set<Rotation> rotations) {
-        return List.of(new ContainerEndpoint(new ClusterId(globalServceId),
+        return List.of(new ContainerEndpoint(globalServceId,
                                              rotations.stream()
                                                       .map(Rotation::getId)
                                                       .collect(Collectors.toUnmodifiableList())));

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpoint.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpoint.java
@@ -1,8 +1,6 @@
 // Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.tenant;
 
-import com.yahoo.vespa.applicationmodel.ClusterId;
-
 import java.util.List;
 import java.util.Objects;
 
@@ -15,15 +13,15 @@ import java.util.Objects;
  */
 public class ContainerEndpoint {
 
-    private final ClusterId clusterId;
+    private final String clusterId;
     private final List<String> names;
 
-    public ContainerEndpoint(ClusterId clusterId, List<String> names) {
+    public ContainerEndpoint(String clusterId, List<String> names) {
         this.clusterId = Objects.requireNonNull(clusterId);
         this.names = List.copyOf(Objects.requireNonNull(names));
     }
 
-    public ClusterId clusterId() {
+    public String clusterId() {
         return clusterId;
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializer.java
@@ -5,7 +5,6 @@ import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializer.java
@@ -42,7 +42,7 @@ public class ContainerEndpointSerializer {
             names.add(containerName);
         });
 
-        return new ContainerEndpoint(new ClusterId(clusterId), names);
+        return new ContainerEndpoint(clusterId, names);
     }
 
     public static List<ContainerEndpoint> endpointListFromSlime(Slime slime) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializer.java
@@ -1,6 +1,7 @@
 // Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.tenant;
 
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCache.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCache.java
@@ -1,6 +1,7 @@
 // Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.tenant;
 
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.config.SlimeUtils;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.config.server;
 
 import com.yahoo.component.Version;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
@@ -14,6 +15,7 @@ import com.yahoo.vespa.flags.InMemoryFlagSource;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -33,6 +35,10 @@ public class ModelContextImplTest {
 
         final Rotation rotation = new Rotation("this.is.a.mock.rotation");
         final Set<Rotation> rotations = Collections.singleton(rotation);
+
+        final ContainerEndpoint endpoint = new ContainerEndpoint("foo", List.of("a", "b"));
+        final Set<ContainerEndpoint> endpoints = Collections.singleton(endpoint);
+
         final InMemoryFlagSource flagSource = new InMemoryFlagSource();
 
         ModelContext context = new ModelContextImpl(
@@ -53,6 +59,7 @@ public class ModelContextImplTest {
                         false,
                         Zone.defaultZone(),
                         rotations,
+                        endpoints,
                         false,
                         false,
                         flagSource),
@@ -71,6 +78,7 @@ public class ModelContextImplTest {
         assertNotNull(context.properties().zone());
         assertFalse(context.properties().hostedVespa());
         assertThat(context.properties().rotations(), equalTo(rotations));
+        assertThat(context.properties().endpoints(), equalTo(endpoints));
         assertThat(context.properties().isFirstTimeDeployment(), equalTo(false));
         assertThat(context.properties().useDedicatedNodeForLogserver(), equalTo(true));
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/model/LbServicesProducerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/model/LbServicesProducerTest.java
@@ -39,6 +39,8 @@ import java.util.Set;
 import static com.yahoo.config.model.api.container.ContainerServiceType.QRSERVER;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Ulf Lilleengen
@@ -139,6 +141,8 @@ public class LbServicesProducerTest {
 
     @Test
     public void testConfigAliasesWithRotations() throws IOException, SAXException {
+        assumeTrue(useGlobalServiceId);
+
         Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder()
                                                                                   .rotations(rotations)
                                                                                   .properties(new TestProperties().setHostedVespa(true)));
@@ -150,14 +154,14 @@ public class LbServicesProducerTest {
                 .hosts("foo.foo.yahoo.com")
                 .services(QRSERVER.serviceName);
 
-        if (useGlobalServiceId) {
-            assertThat(services.servicealiases(), contains("service1"));
-            assertThat("Missing rotations in list: " + services.endpointaliases(), services.endpointaliases(), containsInAnyOrder("foo1.bar1.com", "foo2.bar2.com", rotation1, rotation2));
-        }
+        assertThat(services.servicealiases(), contains("service1"));
+        assertThat("Missing rotations in list: " + services.endpointaliases(), services.endpointaliases(), containsInAnyOrder("foo1.bar1.com", "foo2.bar2.com", rotation1, rotation2));
     }
 
     @Test
     public void testConfigAliasesWithEndpoints() throws IOException, SAXException {
+        assumeFalse(useGlobalServiceId);
+
         Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder()
                 .endpoints(endpoints)
                 .properties(new TestProperties().setHostedVespa(true)));
@@ -169,10 +173,8 @@ public class LbServicesProducerTest {
                 .hosts("foo.foo.yahoo.com")
                 .services(QRSERVER.serviceName);
 
-        if (! useGlobalServiceId) {
-            assertThat(services.servicealiases(), contains("service1"));
-            assertThat("Missing endpoints in list: " + services.endpointaliases(), services.endpointaliases(), containsInAnyOrder("foo1.bar1.com", "foo2.bar2.com", rotation1, rotation2));
-        }
+        assertThat(services.servicealiases(), contains("service1"));
+        assertThat("Missing endpoints in list: " + services.endpointaliases(), services.endpointaliases(), containsInAnyOrder("foo1.bar1.com", "foo2.bar2.com", rotation1, rotation2));
     }
 
     private Map<TenantName, Set<ApplicationInfo>> randomizeApplications(Map<TenantName, Set<ApplicationInfo>> testModel, int seed) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
@@ -6,7 +6,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.vespa.config.server.tenant.ContainerEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import org.junit.Test;
 
 import java.net.URLEncoder;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
@@ -84,10 +84,10 @@ public class PrepareParamsTest {
 
     @Test
     public void testCorrectParsingWithContainerEndpoints() {
-        var endpoints = List.of(new ContainerEndpoint(new ClusterId("qrs1"),
+        var endpoints = List.of(new ContainerEndpoint("qrs1",
                                                       List.of("c1.example.com",
                                                               "c2.example.com")),
-                                new ContainerEndpoint(new ClusterId("qrs2"),
+                                new ContainerEndpoint("qrs2",
                                                       List.of("c3.example.com",
                                                               "c4.example.com")));
         var param = "[\n" +

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Rotation;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.config.server.tenant.ContainerEndpoint;
 import org.junit.Test;
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
@@ -15,7 +15,6 @@ import com.yahoo.io.IOUtils;
 import com.yahoo.log.LogLevel;
 import com.yahoo.path.Path;
 import com.yahoo.slime.Slime;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.config.server.MockReloadHandler;
 import com.yahoo.vespa.config.server.TestComponentRegistry;
 import com.yahoo.vespa.config.server.TimeoutBudgetTest;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
@@ -218,7 +218,7 @@ public class SessionPreparerTest {
         var params = new PrepareParams.Builder().applicationId(applicationId).rotations(rotations).build();
         prepare(new File("src/test/resources/deploy/hosted-app"), params);
 
-        var expected = List.of(new ContainerEndpoint(new ClusterId("qrs"),
+        var expected = List.of(new ContainerEndpoint("qrs",
                                                      List.of("app1.tenant1.global.vespa.example.com",
                                                              "rotation-042.vespa.global.routing")));
         assertEquals(expected, readContainerEndpoints(applicationId));
@@ -248,10 +248,10 @@ public class SessionPreparerTest {
                                                 .build();
         prepare(new File("src/test/resources/deploy/hosted-app"), params);
 
-        var expected = List.of(new ContainerEndpoint(new ClusterId("foo"),
+        var expected = List.of(new ContainerEndpoint("foo",
                                                      List.of("foo.app1.tenant1.global.vespa.example.com",
                                                              "rotation-042.vespa.global.routing")),
-                               new ContainerEndpoint(new ClusterId("bar"),
+                               new ContainerEndpoint("bar",
                                                      List.of("bar.app1.tenant1.global.vespa.example.com",
                                                              "rotation-043.vespa.global.routing")));
         assertEquals(expected, readContainerEndpoints(applicationId));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionPreparerTest.java
@@ -26,7 +26,7 @@ import com.yahoo.vespa.config.server.http.InvalidApplicationException;
 import com.yahoo.vespa.config.server.model.TestModelFactory;
 import com.yahoo.vespa.config.server.modelfactory.ModelFactoryRegistry;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
-import com.yahoo.vespa.config.server.tenant.ContainerEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.vespa.config.server.tenant.ContainerEndpointsCache;
 import com.yahoo.vespa.config.server.tenant.Rotations;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializerTest.java
@@ -1,5 +1,6 @@
 package com.yahoo.vespa.config.server.tenant;
 
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.slime.Slime;
 import org.junit.Test;
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializerTest.java
@@ -1,7 +1,6 @@
 package com.yahoo.vespa.config.server.tenant;
 
 import com.yahoo.slime.Slime;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 import org.junit.Test;
 
 import java.util.List;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointSerializerTest.java
@@ -30,7 +30,7 @@ public class ContainerEndpointSerializerTest {
 
     @Test
     public void writeReadSingleEndpoint() {
-        final var endpoint = new ContainerEndpoint(new ClusterId("foo"), List.of("a", "b"));
+        final var endpoint = new ContainerEndpoint("foo", List.of("a", "b"));
         final var serialized = new Slime();
         ContainerEndpointSerializer.endpointToSlime(serialized.setObject(), endpoint);
         final var deserialized = ContainerEndpointSerializer.endpointFromSlime(serialized.get());
@@ -40,7 +40,7 @@ public class ContainerEndpointSerializerTest {
 
     @Test
     public void writeReadEndpoints() {
-        final var endpoints = List.of(new ContainerEndpoint(new ClusterId("foo"), List.of("a", "b")));
+        final var endpoints = List.of(new ContainerEndpoint("foo", List.of("a", "b")));
         final var serialized = ContainerEndpointSerializer.endpointListToSlime(endpoints);
         final var deserialized = ContainerEndpointSerializer.endpointListFromSlime(serialized);
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCacheTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCacheTest.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.config.server.tenant;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.path.Path;
-import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import org.junit.Test;
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCacheTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCacheTest.java
@@ -17,7 +17,7 @@ public class ContainerEndpointsCacheTest {
     public void readWriteFromCache() {
         final var cache = new ContainerEndpointsCache(Path.createRoot(), new MockCurator());
         final var endpoints = List.of(
-                new ContainerEndpoint(new ClusterId("the-cluster-1"), List.of("a", "b", "c"))
+                new ContainerEndpoint("the-cluster-1", List.of("a", "b", "c"))
         );
 
         cache.write(ApplicationId.defaultId(), endpoints);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCacheTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/ContainerEndpointsCacheTest.java
@@ -1,6 +1,7 @@
 // Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.tenant;
 
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.curator.mock.MockCurator;


### PR DESCRIPTION
- Some minor lifting to remove dependency on `ClusterId` as this class was not available.
- Make the `ContainerEndpoint` set available to `ContainerModelBuilder`
- Use it to populate the `rotations` property in the `Container`.