### PR TITLE
Upgrade maven-assembly-plugin to 3.1.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,7 +92,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
3.1.1 fixes https://issues.apache.org/jira/browse/MASSEMBLY-873 which caused the slowness of packaging (at least) bouncycastle.