### PR TITLE
Replace GCC-only `std::_Identity` and `std::_Select1st` with own code

### DIFF
--- a/searchlib/src/vespa/searchlib/expression/resultvector.h
+++ b/searchlib/src/vespa/searchlib/expression/resultvector.h
@@ -11,6 +11,7 @@
 #include "stringbucketresultnode.h"
 #include "rawbucketresultnode.h"
 #include <vespa/vespalib/objects/visit.hpp>
+#include <vespa/vespalib/stllike/identity.h>
 #include <algorithm>
 
 namespace search::expression {
@@ -214,7 +215,7 @@ struct GetString {
 };
 
 template <typename B>
-class NumericResultNodeVectorT : public ResultNodeVectorT<B, cmpT<ResultNode>, std::_Identity<ResultNode> >
+class NumericResultNodeVectorT : public ResultNodeVectorT<B, cmpT<ResultNode>, vespalib::Identity>
 {
 public:
     ResultNode & flattenMultiply(ResultNode & r) const override {
@@ -366,7 +367,7 @@ public:
     const FloatBucketResultNode& getNullBucket() const override { return FloatBucketResultNode::getNull(); }
 };
 
-class StringResultNodeVector : public ResultNodeVectorT<StringResultNode, cmpT<ResultNode>, std::_Identity<ResultNode> >
+class StringResultNodeVector : public ResultNodeVectorT<StringResultNode, cmpT<ResultNode>, vespalib::Identity>
 {
 public:
     StringResultNodeVector() { }
@@ -375,7 +376,7 @@ public:
     const StringBucketResultNode& getNullBucket() const override { return StringBucketResultNode::getNull(); }
 };
 
-class RawResultNodeVector : public ResultNodeVectorT<RawResultNode, cmpT<ResultNode>, std::_Identity<ResultNode> >
+class RawResultNodeVector : public ResultNodeVectorT<RawResultNode, cmpT<ResultNode>, vespalib::Identity>
 {
 public:
     RawResultNodeVector() { }

--- a/staging_vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/staging_vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -3,6 +3,7 @@
 
 #include <vespa/vespalib/stllike/hashtable.h>
 #include <vespa/vespalib/stllike/hash_fun.h>
+#include <vespa/vespalib/stllike/select.h>
 #include <vector>
 
 namespace vespalib {
@@ -29,7 +30,7 @@ struct LruParam
 {
     typedef LinkedValue<V> LV;
     typedef std::pair< K, LV > value_type;
-    typedef std::_Select1st< value_type > select_key;
+    typedef vespalib::Select1st< value_type > select_key;
     typedef K Key;
     typedef V Value;
     typedef H Hash;

--- a/vespalib/src/tests/stllike/hashtable_test.cpp
+++ b/vespalib/src/tests/stllike/hashtable_test.cpp
@@ -3,6 +3,7 @@
 
 #include <vespa/vespalib/stllike/hashtable.hpp>
 #include <vespa/vespalib/stllike/hash_fun.h>
+#include <vespa/vespalib/stllike/identity.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <memory>
 #include <vector>
@@ -63,7 +64,7 @@ TEST("require that hashtable can store pairs of <key, unique_ptr to value>") {
 }
 
 template<typename K> using set_hashtable =
-    hashtable<K, K, vespalib::hash<K>, std::equal_to<K>, std::_Identity<K>>;
+    hashtable<K, K, vespalib::hash<K>, std::equal_to<K>, Identity>;
 
 TEST("require that hashtable<int> can be copied") {
     set_hashtable<int> table(100);

--- a/vespalib/src/vespa/vespalib/stllike/hash_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_map.h
@@ -3,6 +3,7 @@
 
 #include "hashtable.h"
 #include "hash_fun.h"
+#include "select.h"
 
 namespace vespalib {
 
@@ -13,7 +14,7 @@ public:
     typedef std::pair<K, V> value_type;
     typedef K key_type;
     typedef V mapped_type;
-    using HashTable = hashtable< K, value_type, H, EQ, std::_Select1st< value_type >, M >;
+    using HashTable = hashtable< K, value_type, H, EQ, Select1st<value_type>, M >;
 private:
     HashTable _ht;
 public:

--- a/vespalib/src/vespa/vespalib/stllike/hash_map.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/hash_map.hpp
@@ -3,6 +3,7 @@
 
 #include "hash_map_insert.hpp"
 #include "hashtable.hpp"
+#include "select.h"
 
 namespace vespalib {
 
@@ -68,11 +69,11 @@ hash_map<K, V, H, EQ, M>::getMemoryUsed() const
 
 #define VESPALIB_HASH_MAP_INSTANTIATE_H_E_M(K, V, H, E, M) \
     template class vespalib::hash_map<K, V, H, E, M>; \
-    template class vespalib::hashtable<K, std::pair<K,V>, H, E, std::_Select1st<std::pair<K,V>>, M>; \
-    template vespalib::hashtable<K, std::pair<K,V>, H, E, std::_Select1st<std::pair<K,V>>, M>::insert_result \
-             vespalib::hashtable<K, std::pair<K,V>, H, E, std::_Select1st<std::pair<K,V>>, M>::insert(std::pair<K,V> &&); \
-    template vespalib::hashtable<K, std::pair<K,V>, H, E, std::_Select1st<std::pair<K,V>>, M>::insert_result \
-             vespalib::hashtable<K, std::pair<K,V>, H, E, std::_Select1st<std::pair<K,V>>, M>::insertInternal(std::pair<K,V> &&); \
+    template class vespalib::hashtable<K, std::pair<K,V>, H, E, vespalib::Select1st<std::pair<K,V>>, M>; \
+    template vespalib::hashtable<K, std::pair<K,V>, H, E, vespalib::Select1st<std::pair<K,V>>, M>::insert_result \
+             vespalib::hashtable<K, std::pair<K,V>, H, E, vespalib::Select1st<std::pair<K,V>>, M>::insert(std::pair<K,V> &&); \
+    template vespalib::hashtable<K, std::pair<K,V>, H, E, vespalib::Select1st<std::pair<K,V>>, M>::insert_result \
+             vespalib::hashtable<K, std::pair<K,V>, H, E, vespalib::Select1st<std::pair<K,V>>, M>::insertInternal(std::pair<K,V> &&); \
     template class vespalib::Array<vespalib::hash_node<std::pair<K,V>>>;
 
 #define VESPALIB_HASH_MAP_INSTANTIATE_H_E(K, V, H, E) \

--- a/vespalib/src/vespa/vespalib/stllike/hash_set.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_set.h
@@ -3,6 +3,7 @@
 
 #include "hashtable.h"
 #include "hash_fun.h"
+#include "identity.h"
 #include <initializer_list>
 
 namespace vespalib {
@@ -11,7 +12,7 @@ template< typename K, typename H = vespalib::hash<K>, typename EQ = std::equal_t
 class hash_set
 {
 private:
-    using HashTable = hashtable< K, K, H, EQ, std::_Identity<K>, M>;
+    using HashTable = hashtable< K, K, H, EQ, Identity, M>;
     HashTable _ht;
 public:
     typedef typename HashTable::iterator iterator;

--- a/vespalib/src/vespa/vespalib/stllike/hash_set.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/hash_set.hpp
@@ -3,6 +3,7 @@
 
 #include "hash_set_insert.hpp"
 #include "hashtable.hpp"
+#include "identity.h"
 
 namespace vespalib {
 
@@ -84,11 +85,11 @@ hash_set<K, H, EQ, M>::insert(K &&value) {
 
 #define VESPALIB_HASH_SET_INSTANTIATE(K) \
     template class vespalib::hash_set<K>; \
-    template class vespalib::hashtable<K, K, vespalib::hash<K>, std::equal_to<>, std::_Identity<K>>; \
+    template class vespalib::hashtable<K, K, vespalib::hash<K>, std::equal_to<>, vespalib::Identity>; \
     template class vespalib::Array<vespalib::hash_node<K>>;
 
 #define VESPALIB_HASH_SET_INSTANTIATE_H(K, H) \
     template class vespalib::hash_set<K, H>; \
-    template class vespalib::hashtable<K, K, H, std::equal_to<>, std::_Identity<K>>; \
+    template class vespalib::hashtable<K, K, H, std::equal_to<>, vespalib::Identity>; \
     template class vespalib::Array<vespalib::hash_node<K>>;
 

--- a/vespalib/src/vespa/vespalib/stllike/identity.h
+++ b/vespalib/src/vespa/vespalib/stllike/identity.h
@@ -1,0 +1,18 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <utility>
+
+namespace vespalib {
+
+// Functor which returns its argument unchanged.
+// Functionally identical to C++20's std::identity
+// TODO remove and replace with std::identity once it is available.
+struct Identity {
+    template <typename T>
+    constexpr T&& operator()(T&& v) const noexcept {
+        return std::forward<T>(v);
+    }
+};
+
+}

--- a/vespalib/src/vespa/vespalib/stllike/select.h
+++ b/vespalib/src/vespa/vespalib/stllike/select.h
@@ -1,0 +1,17 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+namespace vespalib {
+
+// Convenience functor for extracting the first element of a std::pair (or compatible type)
+template <typename Pair>
+struct Select1st {
+    constexpr typename Pair::first_type& operator()(Pair& p) const noexcept {
+        return p.first;
+    }
+    constexpr const typename Pair::first_type& operator()(const Pair& p) const noexcept {
+        return p.first;
+    }
+};
+
+}


### PR DESCRIPTION
@baldersheim and @toregge please review

Put in `stllike` submodule since it's technically hoisted from _an_ STL implementation...!

`vespalib::Identity` can be replaced with `std::identity` once on a C++20 compiler.
