### PR TITLE
Increase ZK client session timeout from 10s to 30s

### DIFF
--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
@@ -39,7 +39,7 @@ public class MasterElectionTest extends FleetControllerTest {
     @Rule
     public TestRule cleanupZookeeperLogsOnSuccess = new CleanupZookeeperLogsOnSuccess();
 
-    private static int defaultZkSessionTimeoutInMillis() { return 10_000; }
+    private static int defaultZkSessionTimeoutInMillis() { return 30_000; }
 
     protected void setUpFleetController(int count, boolean useFakeTimer, FleetControllerOptions options) throws Exception {
         if (zooKeeperServer == null) {


### PR DESCRIPTION
@geirst please review

Have a suspicion that 10s ends up being too short when ZK's
write-ahead log flushing is taking a long time due to a heavily
loaded CI container. Should still be short enough for a network
hiccup to hopefully trigger a reconnect before the test itself
times out.

