### PR TITLE
less scary warning when running on Docker

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
@@ -56,7 +56,8 @@ public class HostSystem extends AbstractConfigProducer<Host> {
         }
         if (! hostname.contains(".")) {
             deployLogger.log(Level.WARNING, "Host named '" + hostname + "' may not receive any config " +
-                                            "since it is not a canonical hostname");
+                                            "since it is not a canonical hostname." +
+                                            "Disregard this warning when testing in a Docker container.");
         }
     }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

we think it is not trivial to remove the warning, as it makes sense in some cases. make the message itself a little less scary