### PR TITLE
Node-Admin: Shorten NodeSpec method names

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -157,7 +157,7 @@ public class NodeRepositoryNode {
         this.flavor = flavor;
     }
 
-    public String getCanonicalFlavor() {
+    public String canonicalFlavor() {
         return canonicalFlavor;
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeMembership.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeMembership.java
@@ -19,19 +19,19 @@ public class NodeMembership {
         this.retired = retired;
     }
 
-    public String getClusterType() {
+    public String clusterType() {
         return clusterType;
     }
 
-    public String getClusterId() {
+    public String clusterId() {
         return clusterId;
     }
 
-    public String getGroup() {
+    public String group() {
         return group;
     }
 
-    public int getIndex() {
+    public int index() {
         return index;
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeOwner.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeOwner.java
@@ -17,15 +17,15 @@ public class NodeOwner {
         this.instance = instance;
     }
 
-    public String getTenant() {
+    public String tenant() {
         return tenant;
     }
 
-    public String getApplication() {
+    public String application() {
         return application;
     }
 
-    public String getInstance() {
+    public String instance() {
         return instance;
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class NodeSpec {
     private final String hostname;
     private final NodeState state;
-    private final NodeType nodeType;
+    private final NodeType type;
     private final String flavor;
     private final String canonicalFlavor;
 
@@ -25,7 +25,7 @@ public class NodeSpec {
     private final Optional<DockerImage> currentDockerImage;
 
     private final Optional<Version> wantedVespaVersion;
-    private final Optional<Version> vespaVersion;
+    private final Optional<Version> currentVespaVersion;
 
     private final Optional<Version> wantedOsVersion;
     private final Optional<Version> currentOsVersion;
@@ -46,9 +46,9 @@ public class NodeSpec {
     private final Optional<NodeOwner> owner;
     private final Optional<NodeMembership> membership;
 
-    private final double minCpuCores;
-    private final double minMainMemoryAvailableGb;
-    private final double minDiskAvailableGb;
+    private final double vcpus;
+    private final double memoryGb;
+    private final double diskGb;
 
     private final boolean fastDisk;
     private final double bandwidth;
@@ -64,11 +64,11 @@ public class NodeSpec {
             Optional<DockerImage> wantedDockerImage,
             Optional<DockerImage> currentDockerImage,
             NodeState state,
-            NodeType nodeType,
+            NodeType type,
             String flavor,
             String canonicalFlavor,
             Optional<Version> wantedVespaVersion,
-            Optional<Version> vespaVersion,
+            Optional<Version> currentVespaVersion,
             Optional<Version> wantedOsVersion,
             Optional<Version> currentOsVersion,
             Optional<Boolean> allowedToBeDown,
@@ -82,9 +82,9 @@ public class NodeSpec {
             Optional<Instant> wantedFirmwareCheck,
             Optional<Instant> currentFirmwareCheck,
             Optional<String> modelName,
-            double minCpuCores,
-            double minMainMemoryAvailableGb,
-            double minDiskAvailableGb,
+            double vcpus,
+            double memoryGb,
+            double diskGb,
             boolean fastDisk,
             double bandwidth,
             Set<String> ipAddresses,
@@ -102,12 +102,12 @@ public class NodeSpec {
         this.wantedDockerImage = Objects.requireNonNull(wantedDockerImage);
         this.currentDockerImage = Objects.requireNonNull(currentDockerImage);
         this.state = Objects.requireNonNull(state);
-        this.nodeType = Objects.requireNonNull(nodeType);
+        this.type = Objects.requireNonNull(type);
         this.flavor = Objects.requireNonNull(flavor);
         this.canonicalFlavor = canonicalFlavor;
         this.modelName = modelName;
         this.wantedVespaVersion = Objects.requireNonNull(wantedVespaVersion);
-        this.vespaVersion = Objects.requireNonNull(vespaVersion);
+        this.currentVespaVersion = Objects.requireNonNull(currentVespaVersion);
         this.wantedOsVersion = Objects.requireNonNull(wantedOsVersion);
         this.currentOsVersion = Objects.requireNonNull(currentOsVersion);
         this.allowedToBeDown = Objects.requireNonNull(allowedToBeDown);
@@ -120,9 +120,9 @@ public class NodeSpec {
         this.currentRebootGeneration = currentRebootGeneration;
         this.wantedFirmwareCheck = Objects.requireNonNull(wantedFirmwareCheck);
         this.currentFirmwareCheck = Objects.requireNonNull(currentFirmwareCheck);
-        this.minCpuCores = minCpuCores;
-        this.minMainMemoryAvailableGb = minMainMemoryAvailableGb;
-        this.minDiskAvailableGb = minDiskAvailableGb;
+        this.vcpus = vcpus;
+        this.memoryGb = memoryGb;
+        this.diskGb = diskGb;
         this.fastDisk = fastDisk;
         this.bandwidth = bandwidth;
         this.ipAddresses = Objects.requireNonNull(ipAddresses);
@@ -131,125 +131,125 @@ public class NodeSpec {
         this.parentHostname = Objects.requireNonNull(parentHostname);
     }
 
-    public String getHostname() {
+    public String hostname() {
         return hostname;
     }
 
-    public NodeState getState() {
+    public NodeState state() {
         return state;
     }
 
-    public NodeType getNodeType() {
-        return nodeType;
+    public NodeType type() {
+        return type;
     }
 
-    public String getFlavor() {
+    public String flavor() {
         return flavor;
     }
 
-    public String getCanonicalFlavor() {
+    public String canonicalFlavor() {
         return canonicalFlavor;
     }
 
-    public Optional<DockerImage> getWantedDockerImage() {
+    public Optional<DockerImage> wantedDockerImage() {
         return wantedDockerImage;
     }
 
-    public Optional<DockerImage> getCurrentDockerImage() {
+    public Optional<DockerImage> currentDockerImage() {
         return currentDockerImage;
     }
 
-    public Optional<Version> getWantedVespaVersion() {
+    public Optional<Version> wantedVespaVersion() {
         return wantedVespaVersion;
     }
 
-    public Optional<Version> getVespaVersion() {
-        return vespaVersion;
+    public Optional<Version> currentVespaVersion() {
+        return currentVespaVersion;
     }
 
-    public Optional<Version> getCurrentOsVersion() {
+    public Optional<Version> currentOsVersion() {
         return currentOsVersion;
     }
 
-    public Optional<Version> getWantedOsVersion() {
+    public Optional<Version> wantedOsVersion() {
         return wantedOsVersion;
     }
 
-    public Optional<Long> getWantedRestartGeneration() {
+    public Optional<Long> wantedRestartGeneration() {
         return wantedRestartGeneration;
     }
 
-    public Optional<Long> getCurrentRestartGeneration() {
+    public Optional<Long> currentRestartGeneration() {
         return currentRestartGeneration;
     }
 
-    public long getWantedRebootGeneration() {
+    public long wantedRebootGeneration() {
         return wantedRebootGeneration;
     }
 
-    public long getCurrentRebootGeneration() {
+    public long currentRebootGeneration() {
         return currentRebootGeneration;
     }
 
-    public Optional<Instant> getWantedFirmwareCheck() {
+    public Optional<Instant> wantedFirmwareCheck() {
         return wantedFirmwareCheck;
     }
 
-    public Optional<Instant> getCurrentFirmwareCheck() {
+    public Optional<Instant> currentFirmwareCheck() {
         return currentFirmwareCheck;
     }
 
-    public Optional<String> getModelName() {
+    public Optional<String> modelName() {
         return modelName;
     }
 
-    public Optional<Boolean> getAllowedToBeDown() {
+    public Optional<Boolean> allowedToBeDown() {
         return allowedToBeDown;
     }
 
-    public Optional<Boolean> getWantToDeprovision() {
+    public Optional<Boolean> wantToDeprovision() {
         return wantToDeprovision;
     }
 
-    public Optional<NodeOwner> getOwner() {
+    public Optional<NodeOwner> owner() {
         return owner;
     }
 
-    public Optional<NodeMembership> getMembership() {
+    public Optional<NodeMembership> membership() {
         return membership;
     }
 
-    public double getMinCpuCores() {
-        return minCpuCores;
+    public double vcpus() {
+        return vcpus;
     }
 
-    public double getMinMainMemoryAvailableGb() {
-        return minMainMemoryAvailableGb;
+    public double memoryGb() {
+        return memoryGb;
     }
 
-    public double getMinDiskAvailableGb() {
-        return minDiskAvailableGb;
+    public double diskGb() {
+        return diskGb;
     }
 
     public boolean isFastDisk() {
         return fastDisk;
     }
 
-    public double getBandwidth() {
+    public double bandwidth() {
         return bandwidth;
     }
 
-    public Set<String> getIpAddresses() {
+    public Set<String> ipAddresses() {
         return ipAddresses;
     }
 
-    public Set<String> getAdditionalIpAddresses() {
+    public Set<String> additionalIpAddresses() {
         return additionalIpAddresses;
     }
 
-    public NodeReports getReports() { return reports; }
+    public NodeReports reports() { return reports; }
 
-    public Optional<String> getParentHostname() {
+    public Optional<String> parentHostname() {
         return parentHostname;
     }
 
@@ -264,11 +264,11 @@ public class NodeSpec {
                 Objects.equals(wantedDockerImage, that.wantedDockerImage) &&
                 Objects.equals(currentDockerImage, that.currentDockerImage) &&
                 Objects.equals(state, that.state) &&
-                Objects.equals(nodeType, that.nodeType) &&
+                Objects.equals(type, that.type) &&
                 Objects.equals(flavor, that.flavor) &&
                 Objects.equals(canonicalFlavor, that.canonicalFlavor) &&
                 Objects.equals(wantedVespaVersion, that.wantedVespaVersion) &&
-                Objects.equals(vespaVersion, that.vespaVersion) &&
+                Objects.equals(currentVespaVersion, that.currentVespaVersion) &&
                 Objects.equals(wantedOsVersion, that.wantedOsVersion) &&
                 Objects.equals(currentOsVersion, that.currentOsVersion) &&
                 Objects.equals(allowedToBeDown, that.allowedToBeDown) &&
@@ -281,9 +281,9 @@ public class NodeSpec {
                 Objects.equals(currentRebootGeneration, that.currentRebootGeneration) &&
                 Objects.equals(wantedFirmwareCheck, that.wantedFirmwareCheck) &&
                 Objects.equals(currentFirmwareCheck, that.currentFirmwareCheck) &&
-                Objects.equals(minCpuCores, that.minCpuCores) &&
-                Objects.equals(minMainMemoryAvailableGb, that.minMainMemoryAvailableGb) &&
-                Objects.equals(minDiskAvailableGb, that.minDiskAvailableGb) &&
+                Objects.equals(vcpus, that.vcpus) &&
+                Objects.equals(memoryGb, that.memoryGb) &&
+                Objects.equals(diskGb, that.diskGb) &&
                 Objects.equals(fastDisk, that.fastDisk) &&
                 Objects.equals(bandwidth, that.bandwidth) &&
                 Objects.equals(ipAddresses, that.ipAddresses) &&
@@ -299,11 +299,11 @@ public class NodeSpec {
                 wantedDockerImage,
                 currentDockerImage,
                 state,
-                nodeType,
+                type,
                 flavor,
                 canonicalFlavor,
                 wantedVespaVersion,
-                vespaVersion,
+                currentVespaVersion,
                 wantedOsVersion,
                 currentOsVersion,
                 allowedToBeDown,
@@ -316,9 +316,9 @@ public class NodeSpec {
                 currentRebootGeneration,
                 wantedFirmwareCheck,
                 currentFirmwareCheck,
-                minCpuCores,
-                minMainMemoryAvailableGb,
-                minDiskAvailableGb,
+                vcpus,
+                memoryGb,
+                diskGb,
                 fastDisk,
                 bandwidth,
                 ipAddresses,
@@ -334,26 +334,26 @@ public class NodeSpec {
                 + " wantedDockerImage=" + wantedDockerImage
                 + " currentDockerImage=" + currentDockerImage
                 + " state=" + state
-                + " nodeType=" + nodeType
+                + " type=" + type
                 + " flavor=" + flavor
                 + " canonicalFlavor=" + canonicalFlavor
                 + " wantedVespaVersion=" + wantedVespaVersion
-                + " vespaVersion=" + vespaVersion
+                + " currentVespaVersion=" + currentVespaVersion
                 + " wantedOsVersion=" + wantedOsVersion
                 + " currentOsVersion=" + currentOsVersion
                 + " allowedToBeDown=" + allowedToBeDown
                 + " wantToDeprovision=" + wantToDeprovision
                 + " owner=" + owner
                 + " membership=" + membership
-                + " minCpuCores=" + minCpuCores
+                + " vcpus=" + vcpus
                 + " wantedRestartGeneration=" + wantedRestartGeneration
                 + " currentRestartGeneration=" + currentRestartGeneration
                 + " wantedRebootGeneration=" + wantedRebootGeneration
                 + " currentRebootGeneration=" + currentRebootGeneration
                 + " wantedFirmwareCheck=" + wantedFirmwareCheck
                 + " currentFirmwareCheck=" + currentFirmwareCheck
-                + " minMainMemoryAvailableGb=" + minMainMemoryAvailableGb
-                + " minDiskAvailableGb=" + minDiskAvailableGb
+                + " memoryGb=" + memoryGb
+                + " diskGb=" + diskGb
                 + " fastDisk=" + fastDisk
                 + " bandwidth=" + bandwidth
                 + " ipAddresses=" + ipAddresses
@@ -365,14 +365,14 @@ public class NodeSpec {
 
     public static class Builder {
         private String hostname;
-        private Optional<DockerImage> wantedDockerImage = Optional.empty();
-        private Optional<DockerImage> currentDockerImage = Optional.empty();
         private NodeState state;
-        private NodeType nodeType;
+        private NodeType type;
         private String flavor;
         private String canonicalFlavor;
+        private Optional<DockerImage> wantedDockerImage = Optional.empty();
+        private Optional<DockerImage> currentDockerImage = Optional.empty();
         private Optional<Version> wantedVespaVersion = Optional.empty();
-        private Optional<Version> vespaVersion = Optional.empty();
+        private Optional<Version> currentVespaVersion = Optional.empty();
         private Optional<Version> wantedOsVersion = Optional.empty();
         private Optional<Version> currentOsVersion = Optional.empty();
         private Optional<Boolean> allowedToBeDown = Optional.empty();
@@ -386,10 +386,10 @@ public class NodeSpec {
         private Optional<Instant> wantedFirmwareCheck = Optional.empty();
         private Optional<Instant> currentFirmwareCheck = Optional.empty();
         private Optional<String> modelName = Optional.empty();
-        private double minCpuCores;
-        private double minMainMemoryAvailableGb;
-        private double minDiskAvailableGb;
-        private boolean fastDisk = false;
+        private double vcpus;
+        private double memoryGb;
+        private double diskGb;
+        private boolean fastDisk;
         private double bandwidth;
         private Set<String> ipAddresses = Set.of();
         private Set<String> additionalIpAddresses = Set.of();
@@ -401,12 +401,12 @@ public class NodeSpec {
         public Builder(NodeSpec node) {
             hostname(node.hostname);
             state(node.state);
-            nodeType(node.nodeType);
+            type(node.type);
             flavor(node.flavor);
             canonicalFlavor(node.canonicalFlavor);
-            minCpuCores(node.minCpuCores);
-            minMainMemoryAvailableGb(node.minMainMemoryAvailableGb);
-            minDiskAvailableGb(node.minDiskAvailableGb);
+            vcpus(node.vcpus);
+            memoryGb(node.memoryGb);
+            diskGb(node.diskGb);
             fastDisk(node.fastDisk);
             bandwidth(node.bandwidth);
             ipAddresses(node.ipAddresses);
@@ -418,7 +418,7 @@ public class NodeSpec {
             node.wantedDockerImage.ifPresent(this::wantedDockerImage);
             node.currentDockerImage.ifPresent(this::currentDockerImage);
             node.wantedVespaVersion.ifPresent(this::wantedVespaVersion);
-            node.vespaVersion.ifPresent(this::vespaVersion);
+            node.currentVespaVersion.ifPresent(this::currentVespaVersion);
             node.wantedOsVersion.ifPresent(this::wantedOsVersion);
             node.currentOsVersion.ifPresent(this::currentOsVersion);
             node.allowedToBeDown.ifPresent(this::allowedToBeDown);
@@ -452,8 +452,8 @@ public class NodeSpec {
             return this;
         }
 
-        public Builder nodeType(NodeType nodeType) {
-            this.nodeType = nodeType;
+        public Builder type(NodeType nodeType) {
+            this.type = nodeType;
             return this;
         }
 
@@ -472,8 +472,8 @@ public class NodeSpec {
             return this;
         }
 
-        public Builder vespaVersion(Version vespaVersion) {
-            this.vespaVersion = Optional.of(vespaVersion);
+        public Builder currentVespaVersion(Version vespaVersion) {
+            this.currentVespaVersion = Optional.of(vespaVersion);
             return this;
         }
 
@@ -537,18 +537,18 @@ public class NodeSpec {
             return this;
         }
 
-        public Builder minCpuCores(double minCpuCores) {
-            this.minCpuCores = minCpuCores;
+        public Builder vcpus(double minCpuCores) {
+            this.vcpus = minCpuCores;
             return this;
         }
 
-        public Builder minMainMemoryAvailableGb(double minMainMemoryAvailableGb) {
-            this.minMainMemoryAvailableGb = minMainMemoryAvailableGb;
+        public Builder memoryGb(double minMainMemoryAvailableGb) {
+            this.memoryGb = minMainMemoryAvailableGb;
             return this;
         }
 
-        public Builder minDiskAvailableGb(double minDiskAvailableGb) {
-            this.minDiskAvailableGb = minDiskAvailableGb;
+        public Builder diskGb(double minDiskAvailableGb) {
+            this.diskGb = minDiskAvailableGb;
             return this;
         }
 
@@ -603,127 +603,127 @@ public class NodeSpec {
             return this;
         }
 
-        public String getHostname() {
+        public String hostname() {
             return hostname;
         }
 
-        public Optional<DockerImage> getWantedDockerImage() {
+        public Optional<DockerImage> wantedDockerImage() {
             return wantedDockerImage;
         }
 
-        public Optional<DockerImage> getCurrentDockerImage() {
+        public Optional<DockerImage> currentDockerImage() {
             return currentDockerImage;
         }
 
-        public NodeState getState() {
+        public NodeState state() {
             return state;
         }
 
-        public NodeType getNodeType() {
-            return nodeType;
+        public NodeType type() {
+            return type;
         }
 
-        public String getFlavor() {
+        public String flavor() {
             return flavor;
         }
 
-        public String getCanonicalFlavor() {
+        public String canonicalFlavor() {
             return canonicalFlavor;
         }
 
-        public Optional<Version> getWantedVespaVersion() {
+        public Optional<Version> wantedVespaVersion() {
             return wantedVespaVersion;
         }
 
-        public Optional<Version> getVespaVersion() {
-            return vespaVersion;
+        public Optional<Version> currentVespaVersion() {
+            return currentVespaVersion;
         }
 
-        public Optional<Version> getWantedOsVersion() {
+        public Optional<Version> wantedOsVersion() {
             return wantedOsVersion;
         }
 
-        public Optional<Version> getCurrentOsVersion() {
+        public Optional<Version> currentOsVersion() {
             return currentOsVersion;
         }
 
-        public Optional<Boolean> getAllowedToBeDown() {
+        public Optional<Boolean> allowedToBeDown() {
             return allowedToBeDown;
         }
 
-        public Optional<Boolean> getWantToDeprovision() {
+        public Optional<Boolean> wantToDeprovision() {
             return wantToDeprovision;
         }
 
-        public Optional<NodeOwner> getOwner() {
+        public Optional<NodeOwner> owner() {
             return owner;
         }
 
-        public Optional<NodeMembership> getMembership() {
+        public Optional<NodeMembership> membership() {
             return membership;
         }
 
-        public Optional<Long> getWantedRestartGeneration() {
+        public Optional<Long> wantedRestartGeneration() {
             return wantedRestartGeneration;
         }
 
-        public Optional<Long> getCurrentRestartGeneration() {
+        public Optional<Long> currentRestartGeneration() {
             return currentRestartGeneration;
         }
 
-        public long getWantedRebootGeneration() {
+        public long wantedRebootGeneration() {
             return wantedRebootGeneration;
         }
 
-        public long getCurrentRebootGeneration() {
+        public long currentRebootGeneration() {
             return currentRebootGeneration;
         }
 
-        public double getMinCpuCores() {
-            return minCpuCores;
+        public double vcpus() {
+            return vcpus;
         }
 
-        public double getMinMainMemoryAvailableGb() {
-            return minMainMemoryAvailableGb;
+        public double memoryGb() {
+            return memoryGb;
         }
 
-        public double getMinDiskAvailableGb() {
-            return minDiskAvailableGb;
+        public double diskGb() {
+            return diskGb;
         }
 
         public boolean isFastDisk() {
             return fastDisk;
         }
 
-        public double getBandwidth() {
+        public double bandwidth() {
             return bandwidth;
         }
 
-        public Set<String> getIpAddresses() {
+        public Set<String> ipAddresses() {
             return ipAddresses;
         }
 
-        public Set<String> getAdditionalIpAddresses() {
+        public Set<String> additionalIpAddresses() {
             return additionalIpAddresses;
         }
 
-        public NodeReports getReports() {
+        public NodeReports reports() {
             return reports;
         }
 
-        public Optional<String> getParentHostname() {
+        public Optional<String> parentHostname() {
             return parentHostname;
         }
 
         public NodeSpec build() {
-            return new NodeSpec(hostname, wantedDockerImage, currentDockerImage, state, nodeType,
+            return new NodeSpec(hostname, wantedDockerImage, currentDockerImage, state, type,
                     flavor, canonicalFlavor,
-                    wantedVespaVersion, vespaVersion, wantedOsVersion, currentOsVersion, allowedToBeDown, wantToDeprovision,
+                    wantedVespaVersion, currentVespaVersion, wantedOsVersion, currentOsVersion, allowedToBeDown, wantToDeprovision,
                     owner, membership,
                     wantedRestartGeneration, currentRestartGeneration,
                     wantedRebootGeneration, currentRebootGeneration,
                     wantedFirmwareCheck, currentFirmwareCheck, modelName,
-                    minCpuCores, minMainMemoryAvailableGb, minDiskAvailableGb,
+                    vcpus, memoryGb, diskGb,
                     fastDisk, bandwidth, ipAddresses, additionalIpAddresses,
                     reports, parentHostname);
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -158,23 +158,23 @@ public class StorageMaintainer {
     private Map<String, Object> generateTags(NodeAgentContext context) {
         Map<String, String> tags = new LinkedHashMap<>();
         tags.put("namespace", "Vespa");
-        tags.put("role", nodeTypeToRole(context.node().getNodeType()));
+        tags.put("role", nodeTypeToRole(context.node().type()));
         tags.put("zone", context.zone().getId().value());
-        context.node().getVespaVersion().ifPresent(version -> tags.put("vespaVersion", version.toFullString()));
+        context.node().currentVespaVersion().ifPresent(version -> tags.put("vespaVersion", version.toFullString()));
 
         if (! isConfigserverLike(context.nodeType())) {
-            tags.put("state", context.node().getState().toString());
-            context.node().getParentHostname().ifPresent(parent -> tags.put("parentHostname", parent));
-            context.node().getOwner().ifPresent(owner -> {
-                tags.put("tenantName", owner.getTenant());
-                tags.put("app", owner.getApplication() + "." + owner.getInstance());
-                tags.put("applicationName", owner.getApplication());
-                tags.put("instanceName", owner.getInstance());
-                tags.put("applicationId", owner.getTenant() + "." + owner.getApplication() + "." + owner.getInstance());
+            tags.put("state", context.node().state().toString());
+            context.node().parentHostname().ifPresent(parent -> tags.put("parentHostname", parent));
+            context.node().owner().ifPresent(owner -> {
+                tags.put("tenantName", owner.tenant());
+                tags.put("app", owner.application() + "." + owner.instance());
+                tags.put("applicationName", owner.application());
+                tags.put("instanceName", owner.instance());
+                tags.put("applicationId", owner.tenant() + "." + owner.application() + "." + owner.instance());
             });
-            context.node().getMembership().ifPresent(membership -> {
-                tags.put("clustertype", membership.getClusterType());
-                tags.put("clusterid", membership.getClusterId());
+            context.node().membership().ifPresent(membership -> {
+                tags.put("clustertype", membership.clusterType());
+                tags.put("clusterid", membership.clusterId());
             });
         }
 
@@ -260,20 +260,20 @@ public class StorageMaintainer {
 
     private Map<String, Object> getCoredumpNodeAttributes(NodeAgentContext context, Optional<Container> container) {
         Map<String, String> attributes = new HashMap<>();
-        attributes.put("hostname", context.node().getHostname());
+        attributes.put("hostname", context.node().hostname());
         attributes.put("region", context.zone().getRegionName().value());
         attributes.put("environment", context.zone().getEnvironment().value());
-        attributes.put("flavor", context.node().getFlavor());
+        attributes.put("flavor", context.node().flavor());
         attributes.put("kernel_version", System.getProperty("os.version"));
         attributes.put("cpu_microcode_version", getMicrocodeVersion());
 
         container.map(c -> c.image).ifPresent(image -> attributes.put("docker_image", image.asString()));
-        context.node().getParentHostname().ifPresent(parent -> attributes.put("parent_hostname", parent));
-        context.node().getVespaVersion().ifPresent(version -> attributes.put("vespa_version", version.toFullString()));
-        context.node().getOwner().ifPresent(owner -> {
-            attributes.put("tenant", owner.getTenant());
-            attributes.put("application", owner.getApplication());
-            attributes.put("instance", owner.getInstance());
+        context.node().parentHostname().ifPresent(parent -> attributes.put("parent_hostname", parent));
+        context.node().currentVespaVersion().ifPresent(version -> attributes.put("vespa_version", version.toFullString()));
+        context.node().owner().ifPresent(owner -> {
+            attributes.put("tenant", owner.tenant());
+            attributes.put("application", owner.application());
+            attributes.put("instance", owner.instance());
         });
         return Collections.unmodifiableMap(attributes);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -125,7 +125,7 @@ public class NodeAdminStateUpdater {
             throw new ConvergenceException("NodeAdmin is not yet " + (wantFrozen ? "frozen" : "unfrozen"));
         }
 
-        boolean hostIsActiveInNR = nodeRepository.getNode(hostHostname).getState() == NodeState.active;
+        boolean hostIsActiveInNR = nodeRepository.getNode(hostHostname).state() == NodeState.active;
         switch (wantedState) {
             case RESUMED:
                 if (hostIsActiveInNR) orchestrator.resume(hostHostname);
@@ -164,7 +164,7 @@ public class NodeAdminStateUpdater {
     void adjustNodeAgentsToRunFromNodeRepository() {
         try {
             Map<String, NodeSpec> nodeSpecByHostname = nodeRepository.getNodes(hostHostname).stream()
-                    .collect(Collectors.toMap(NodeSpec::getHostname, Function.identity()));
+                    .collect(Collectors.toMap(NodeSpec::hostname, Function.identity()));
             Map<String, Acl> aclByHostname = Optional.of(cachedAclSupplier.get())
                     .filter(acls -> acls.keySet().containsAll(nodeSpecByHostname.keySet()))
                     .orElseGet(cachedAclSupplier::invalidateAndGet);
@@ -183,8 +183,8 @@ public class NodeAdminStateUpdater {
     private List<String> getNodesInActiveState() {
         return nodeRepository.getNodes(hostHostname)
                              .stream()
-                             .filter(node -> node.getState() == NodeState.active)
-                             .map(NodeSpec::getHostname)
+                             .filter(node -> node.state() == NodeState.active)
+                             .map(NodeSpec::hostname)
                              .collect(Collectors.toList());
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContext.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContext.java
@@ -26,11 +26,11 @@ public interface NodeAgentContext extends TaskContext {
 
     /** @return hostname of the docker container this context applies to */
     default HostName hostname() {
-        return HostName.from(node().getHostname());
+        return HostName.from(node().hostname());
     }
 
     default NodeType nodeType() {
-        return node().getNodeType();
+        return node().type();
     }
 
     AthenzIdentity identity();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
@@ -1,9 +1,7 @@
 package com.yahoo.vespa.hosted.node.admin.nodeagent;
 
 import com.yahoo.config.provision.CloudName;
-import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -47,7 +45,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
                                 String vespaUser, String vespaUserOnHost) {
         this.node = Objects.requireNonNull(node);
         this.acl = Objects.requireNonNull(acl);
-        this.containerName = ContainerName.fromHostname(node.getHostname());
+        this.containerName = ContainerName.fromHostname(node.hostname());
         this.identity = Objects.requireNonNull(identity);
         this.dockerNetworking = Objects.requireNonNull(dockerNetworking);
         this.zone = Objects.requireNonNull(zone);
@@ -181,12 +179,12 @@ public class NodeAgentContextImpl implements NodeAgentContext {
             this.nodeSpecBuilder
                     .hostname(hostname)
                     .state(NodeState.active)
-                    .nodeType(NodeType.tenant)
+                    .type(NodeType.tenant)
                     .flavor("d-2-8-50");
         }
 
         public Builder nodeType(NodeType nodeType) {
-            this.nodeSpecBuilder.nodeType(nodeType);
+            this.nodeSpecBuilder.type(nodeType);
             return this;
         }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -118,7 +118,7 @@ public class NodeAgentImpl implements NodeAgent {
         this.healthChecker = healthChecker;
 
         this.containerCpuCap = Flags.CONTAINER_CPU_CAP.bindTo(flagSource)
-                .with(FetchVector.Dimension.HOSTNAME, contextSupplier.currentContext().node().getHostname());
+                .with(FetchVector.Dimension.HOSTNAME, contextSupplier.currentContext().node().hostname());
 
         this.loopThread = new Thread(() -> {
             while (!terminated.get()) {
@@ -172,20 +172,20 @@ public class NodeAgentImpl implements NodeAgent {
         final NodeAttributes currentNodeAttributes = new NodeAttributes();
         final NodeAttributes newNodeAttributes = new NodeAttributes();
 
-        if (context.node().getWantedRestartGeneration().isPresent() &&
-                !Objects.equals(context.node().getCurrentRestartGeneration(), currentRestartGeneration)) {
-            currentNodeAttributes.withRestartGeneration(context.node().getCurrentRestartGeneration());
+        if (context.node().wantedRestartGeneration().isPresent() &&
+                !Objects.equals(context.node().currentRestartGeneration(), currentRestartGeneration)) {
+            currentNodeAttributes.withRestartGeneration(context.node().currentRestartGeneration());
             newNodeAttributes.withRestartGeneration(currentRestartGeneration);
         }
 
-        if (!Objects.equals(context.node().getCurrentRebootGeneration(), currentRebootGeneration)) {
-            currentNodeAttributes.withRebootGeneration(context.node().getCurrentRebootGeneration());
+        if (!Objects.equals(context.node().currentRebootGeneration(), currentRebootGeneration)) {
+            currentNodeAttributes.withRebootGeneration(context.node().currentRebootGeneration());
             newNodeAttributes.withRebootGeneration(currentRebootGeneration);
         }
 
-        Optional<DockerImage> actualDockerImage = context.node().getWantedDockerImage().filter(n -> containerState == UNKNOWN);
-        if (!Objects.equals(context.node().getCurrentDockerImage(), actualDockerImage)) {
-            DockerImage currentImage = context.node().getCurrentDockerImage().orElse(DockerImage.EMPTY);
+        Optional<DockerImage> actualDockerImage = context.node().wantedDockerImage().filter(n -> containerState == UNKNOWN);
+        if (!Objects.equals(context.node().currentDockerImage(), actualDockerImage)) {
+            DockerImage currentImage = context.node().currentDockerImage().orElse(DockerImage.EMPTY);
             DockerImage newImage = actualDockerImage.orElse(DockerImage.EMPTY);
 
             currentNodeAttributes.withDockerImage(currentImage);
@@ -228,7 +228,7 @@ public class NodeAgentImpl implements NodeAgent {
             shouldRestartServices(context.node()).ifPresent(restartReason -> {
                 context.log(logger, "Will restart services: " + restartReason);
                 restartServices(context, existingContainer.get());
-                currentRestartGeneration = context.node().getWantedRestartGeneration();
+                currentRestartGeneration = context.node().wantedRestartGeneration();
             });
         }
 
@@ -236,18 +236,18 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     private Optional<String> shouldRestartServices(NodeSpec node) {
-        if (!node.getWantedRestartGeneration().isPresent()) return Optional.empty();
+        if (!node.wantedRestartGeneration().isPresent()) return Optional.empty();
 
         // Restart generation is only optional because it does not exist for unallocated nodes
-        if (currentRestartGeneration.get() < node.getWantedRestartGeneration().get()) {
+        if (currentRestartGeneration.get() < node.wantedRestartGeneration().get()) {
             return Optional.of("Restart requested - wanted restart generation has been bumped: "
-                    + currentRestartGeneration.get() + " -> " + node.getWantedRestartGeneration().get());
+                    + currentRestartGeneration.get() + " -> " + node.wantedRestartGeneration().get());
         }
         return Optional.empty();
     }
 
     private void restartServices(NodeAgentContext context, Container existingContainer) {
-        if (existingContainer.state.isRunning() && context.node().getState() == NodeState.active) {
+        if (existingContainer.state.isRunning() && context.node().state() == NodeState.active) {
             context.log(logger, "Restarting services");
             // Since we are restarting the services we need to suspend the node.
             orchestratorSuspendNode(context);
@@ -290,22 +290,22 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     private Optional<String> shouldRemoveContainer(NodeAgentContext context, Container existingContainer) {
-        final NodeState nodeState = context.node().getState();
+        final NodeState nodeState = context.node().state();
         if (nodeState == NodeState.dirty || nodeState == NodeState.provisioned) {
             return Optional.of("Node in state " + nodeState + ", container should no longer be running");
         }
-        if (context.node().getWantedDockerImage().isPresent() &&
-                !context.node().getWantedDockerImage().get().equals(existingContainer.image)) {
+        if (context.node().wantedDockerImage().isPresent() &&
+                !context.node().wantedDockerImage().get().equals(existingContainer.image)) {
             return Optional.of("The node is supposed to run a new Docker image: "
-                    + existingContainer.image.asString() + " -> " + context.node().getWantedDockerImage().get().asString());
+                    + existingContainer.image.asString() + " -> " + context.node().wantedDockerImage().get().asString());
         }
         if (!existingContainer.state.isRunning()) {
             return Optional.of("Container no longer running");
         }
 
-        if (currentRebootGeneration < context.node().getWantedRebootGeneration()) {
+        if (currentRebootGeneration < context.node().wantedRebootGeneration()) {
             return Optional.of(String.format("Container reboot wanted. Current: %d, Wanted: %d",
-                    currentRebootGeneration, context.node().getWantedRebootGeneration()));
+                    currentRebootGeneration, context.node().wantedRebootGeneration()));
         }
 
         // Even though memory can be easily changed with docker update, we need to restart the container
@@ -330,7 +330,7 @@ public class NodeAgentImpl implements NodeAgent {
             }
 
             try {
-                if (context.node().getState() != NodeState.dirty) {
+                if (context.node().state() != NodeState.dirty) {
                     suspend();
                 }
                 stopServices();
@@ -341,7 +341,7 @@ public class NodeAgentImpl implements NodeAgent {
 
         storageMaintainer.handleCoreDumpsForContainer(context, Optional.of(existingContainer));
         dockerOperations.removeContainer(context, existingContainer);
-        currentRebootGeneration = context.node().getWantedRebootGeneration();
+        currentRebootGeneration = context.node().wantedRebootGeneration();
         containerState = ABSENT;
         context.log(logger, "Container successfully removed, new containerState is " + containerState);
     }
@@ -361,13 +361,13 @@ public class NodeAgentImpl implements NodeAgent {
     private ContainerResources getContainerResources(NodeAgentContext context) {
         double cpuCap = noCpuCap(context.zone()) ?
                 0 :
-                context.node().getOwner()
+                context.node().owner()
                         .map(NodeOwner::asApplicationId)
                         .map(appId -> containerCpuCap.with(FetchVector.Dimension.APPLICATION_ID, appId.serializedForm()))
                         .orElse(containerCpuCap)
-                        .value() * context.node().getMinCpuCores();
+                        .value() * context.node().vcpus();
 
-        return ContainerResources.from(cpuCap, context.node().getMinCpuCores(), context.node().getMinMainMemoryAvailableGb());
+        return ContainerResources.from(cpuCap, context.node().vcpus(), context.node().memoryGb());
     }
 
     private boolean noCpuCap(ZoneApi zone) {
@@ -376,9 +376,9 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     private boolean downloadImageIfNeeded(NodeSpec node, Optional<Container> container) {
-        if (node.getWantedDockerImage().equals(container.map(c -> c.image))) return false;
+        if (node.wantedDockerImage().equals(container.map(c -> c.image))) return false;
 
-        return node.getWantedDockerImage().map(dockerOperations::pullImageAsyncIfNeeded).orElse(false);
+        return node.wantedDockerImage().map(dockerOperations::pullImageAsyncIfNeeded).orElse(false);
     }
 
     public void converge(NodeAgentContext context) {
@@ -406,14 +406,14 @@ public class NodeAgentImpl implements NodeAgent {
             logChangesToNodeSpec(context, lastNode, node);
 
             // Current reboot generation uninitialized or incremented from outside to cancel reboot
-            if (currentRebootGeneration < node.getCurrentRebootGeneration())
-                currentRebootGeneration = node.getCurrentRebootGeneration();
+            if (currentRebootGeneration < node.currentRebootGeneration())
+                currentRebootGeneration = node.currentRebootGeneration();
 
             // Either we have changed allocation status (restart gen. only available to allocated nodes), or
             // restart generation has been incremented from outside to cancel restart
-            if (currentRestartGeneration.isPresent() != node.getCurrentRestartGeneration().isPresent() ||
-                    currentRestartGeneration.map(current -> current < node.getCurrentRestartGeneration().get()).orElse(false))
-                currentRestartGeneration = node.getCurrentRestartGeneration();
+            if (currentRestartGeneration.isPresent() != node.currentRestartGeneration().isPresent() ||
+                    currentRestartGeneration.map(current -> current < node.currentRestartGeneration().get()).orElse(false))
+                currentRestartGeneration = node.currentRestartGeneration();
 
             // Every time the node spec changes, we should clear the metrics for this container as the dimensions
             // will change and we will be reporting duplicate metrics.
@@ -424,7 +424,7 @@ public class NodeAgentImpl implements NodeAgent {
             lastNode = node;
         }
 
-        switch (node.getState()) {
+        switch (node.state()) {
             case ready:
             case reserved:
             case parked:
@@ -437,12 +437,12 @@ public class NodeAgentImpl implements NodeAgent {
                 storageMaintainer.handleCoreDumpsForContainer(context, container);
 
                 storageMaintainer.getDiskUsageFor(context)
-                        .map(diskUsage -> (double) diskUsage / BYTES_IN_GB / node.getMinDiskAvailableGb())
+                        .map(diskUsage -> (double) diskUsage / BYTES_IN_GB / node.diskGb())
                         .filter(diskUtil -> diskUtil >= 0.8)
                         .ifPresent(diskUtil -> storageMaintainer.removeOldFilesFromNode(context));
 
                 if (downloadImageIfNeeded(node, container)) {
-                    context.log(logger, "Waiting for image to download " + context.node().getWantedDockerImage().get().asString());
+                    context.log(logger, "Waiting for image to download " + context.node().wantedDockerImage().get().asString());
                     return;
                 }
                 container = removeContainerIfNeededUpdateContainerState(context, container);
@@ -479,20 +479,20 @@ public class NodeAgentImpl implements NodeAgent {
                 break;
             case dirty:
                 removeContainerIfNeededUpdateContainerState(context, container);
-                context.log(logger, "State is " + node.getState() + ", will delete application storage and mark node as ready");
+                context.log(logger, "State is " + node.state() + ", will delete application storage and mark node as ready");
                 credentialsMaintainer.ifPresent(maintainer -> maintainer.clearCredentials(context));
                 storageMaintainer.archiveNodeStorage(context);
                 updateNodeRepoWithCurrentAttributes(context);
                 nodeRepository.setNodeState(context.hostname().value(), NodeState.ready);
                 break;
             default:
-                throw new ConvergenceException("UNKNOWN STATE " + node.getState().name());
+                throw new ConvergenceException("UNKNOWN STATE " + node.state().name());
         }
     }
 
     private static void logChangesToNodeSpec(NodeAgentContext context, NodeSpec lastNode, NodeSpec node) {
         StringBuilder builder = new StringBuilder();
-        appendIfDifferent(builder, "state", lastNode, node, NodeSpec::getState);
+        appendIfDifferent(builder, "state", lastNode, node, NodeSpec::state);
         if (builder.length() > 0) {
             context.log(logger, LogLevel.INFO, "Changes to node: " + builder.toString());
         }
@@ -525,9 +525,9 @@ public class NodeAgentImpl implements NodeAgent {
         Dimensions.Builder dimensionsBuilder = new Dimensions.Builder()
                 .add("host", context.hostname().value())
                 .add("role", SecretAgentCheckConfig.nodeTypeToRole(context.nodeType()))
-                .add("state", node.getState().toString());
-        node.getParentHostname().ifPresent(parent -> dimensionsBuilder.add("parentHostname", parent));
-        node.getAllowedToBeDown().ifPresent(allowed ->
+                .add("state", node.state().toString());
+        node.parentHostname().ifPresent(parent -> dimensionsBuilder.add("parentHostname", parent));
+        node.allowedToBeDown().ifPresent(allowed ->
                 dimensionsBuilder.add("orchestratorState", allowed ? "ALLOWED_TO_BE_DOWN" : "NO_REMARKS"));
         Dimensions dimensions = dimensionsBuilder.build();
 
@@ -540,13 +540,13 @@ public class NodeAgentImpl implements NodeAgent {
         final long memoryTotalBytes = stats.getMemoryStats().getLimit();
         final long memoryTotalBytesUsage = stats.getMemoryStats().getUsage();
         final long memoryTotalBytesCache = stats.getMemoryStats().getCache();
-        final long diskTotalBytes = (long) (node.getMinDiskAvailableGb() * BYTES_IN_GB);
+        final long diskTotalBytes = (long) (node.diskGb() * BYTES_IN_GB);
         final Optional<Long> diskTotalBytesUsed = storageMaintainer.getDiskUsageFor(context);
 
         lastCpuMetric.updateCpuDeltas(cpuSystemTotalTime, cpuContainerTotalTime, cpuContainerKernelTime);
 
         // Ratio of CPU cores allocated to this container to total number of CPU cores on this host
-        final double allocatedCpuRatio = node.getMinCpuCores() / totalNumCpuCores;
+        final double allocatedCpuRatio = node.vcpus() / totalNumCpuCores;
         double cpuUsageRatioOfAllocated = lastCpuMetric.getCpuUsageRatio() / allocatedCpuRatio;
         double cpuKernelUsageRatioOfAllocated = lastCpuMetric.getCpuKernelUsageRatio() / allocatedCpuRatio;
 
@@ -564,7 +564,7 @@ public class NodeAgentImpl implements NodeAgent {
                 .withMetric("mem_total.util", 100 * memoryTotalUsageRatio)
                 .withMetric("cpu.util", 100 * cpuUsageRatioOfAllocated)
                 .withMetric("cpu.sys.util", 100 * cpuKernelUsageRatioOfAllocated)
-                .withMetric("cpu.vcpus", node.getMinCpuCores())
+                .withMetric("cpu.vcpus", node.vcpus())
                 .withMetric("disk.limit", diskTotalBytes);
 
         diskTotalBytesUsed.ifPresent(diskUsed -> systemMetricsBuilder.withMetric("disk.used", diskUsed));
@@ -597,7 +597,7 @@ public class NodeAgentImpl implements NodeAgent {
 
             // Push metrics to the metrics proxy in each container.
             // TODO Remove port selection logic when all hosted apps have upgraded to Vespa 7.
-            int port = context.node().getVespaVersion().map(version -> version.getMajor() == 6).orElse(false) ? 19091 : 19095;
+            int port = context.node().currentVespaVersion().map(version -> version.getMajor() == 6).orElse(false) ? 19091 : 19095;
             String[] command = {"vespa-rpc-invoke",  "-t", "2",  "tcp/localhost:" + port,  "setExtraMetrics", wrappedMetrics};
             dockerOperations.executeCommandInContainerAsRoot(context, 5L, command);
         } catch (JsonProcessingException | DockerExecTimeoutException  e) {
@@ -666,7 +666,7 @@ public class NodeAgentImpl implements NodeAgent {
     // to allow the node admin to make decisions that depend on the docker image. Or, each docker image
     // needs to contain routines for drain and suspend. For many images, these can just be dummy routines.
     private void orchestratorSuspendNode(NodeAgentContext context) {
-        if (context.node().getState() != NodeState.active) return;
+        if (context.node().state() != NodeState.active) return;
 
         context.log(logger, "Ask Orchestrator for permission to suspend node");
         try {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -105,14 +105,14 @@ public class RealNodeRepositoryTest {
         List<NodeSpec> containersToRun = nodeRepositoryApi.getNodes(dockerHostHostname);
         assertThat(containersToRun.size(), is(1));
         NodeSpec node = containersToRun.get(0);
-        assertThat(node.getHostname(), is("host4.yahoo.com"));
-        assertThat(node.getWantedDockerImage().get(), is(DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa:6.42.0")));
-        assertThat(node.getState(), is(NodeState.active));
-        assertThat(node.getWantedRestartGeneration().get(), is(0L));
-        assertThat(node.getCurrentRestartGeneration().get(), is(0L));
-        assertEquals(1, node.getMinCpuCores(), delta);
-        assertEquals(1, node.getMinMainMemoryAvailableGb(), delta);
-        assertEquals(100, node.getMinDiskAvailableGb(), delta);
+        assertThat(node.hostname(), is("host4.yahoo.com"));
+        assertThat(node.wantedDockerImage().get(), is(DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa:6.42.0")));
+        assertThat(node.state(), is(NodeState.active));
+        assertThat(node.wantedRestartGeneration().get(), is(0L));
+        assertThat(node.currentRestartGeneration().get(), is(0L));
+        assertEquals(1, node.vcpus(), delta);
+        assertEquals(1, node.memoryGb(), delta);
+        assertEquals(100, node.diskGb(), delta);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class RealNodeRepositoryTest {
         String hostname = "host4.yahoo.com";
         Optional<NodeSpec> node = nodeRepositoryApi.getOptionalNode(hostname);
         assertTrue(node.isPresent());
-        assertEquals(hostname, node.get().getHostname());
+        assertEquals(hostname, node.get().hostname());
     }
 
     @Test
@@ -176,8 +176,8 @@ public class RealNodeRepositoryTest {
         NodeSpec hostSpecInNodeRepo = nodeRepositoryApi.getOptionalNode("host123.domain.tld")
                 .orElseThrow(RuntimeException::new);
 
-        assertEquals(host.nodeFlavor, hostSpecInNodeRepo.getFlavor());
-        assertEquals(host.nodeType, hostSpecInNodeRepo.getNodeType());
+        assertEquals(host.nodeFlavor, hostSpecInNodeRepo.flavor());
+        assertEquals(host.nodeType, hostSpecInNodeRepo.type());
 
         assertTrue(nodeRepositoryApi.getOptionalNode("host123-1.domain.tld").isPresent());
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
@@ -29,13 +29,13 @@ public class DockerFailTest {
                     .wantedDockerImage(dockerImage)
                     .currentDockerImage(dockerImage)
                     .state(NodeState.active)
-                    .nodeType(NodeType.tenant)
+                    .type(NodeType.tenant)
                     .flavor("docker")
                     .wantedRestartGeneration(1L)
                     .currentRestartGeneration(1L)
-                    .minCpuCores(1)
-                    .minMainMemoryAvailableGb(1)
-                    .minDiskAvailableGb(1)
+                    .vcpus(1)
+                    .memoryGb(1)
+                    .diskGb(1)
                     .build());
 
             tester.inOrder(tester.docker).createContainerCommand(eq(dockerImage), eq(containerName));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -81,7 +81,7 @@ public class DockerTester implements AutoCloseable {
         NodeSpec hostSpec = new NodeSpec.Builder()
                 .hostname(HOST_HOSTNAME.value())
                 .state(NodeState.active)
-                .nodeType(NodeType.host)
+                .type(NodeType.host)
                 .flavor("default")
                 .wantedRestartGeneration(1L)
                 .currentRestartGeneration(1L)

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -28,15 +28,15 @@ public class MultiDockerTest {
             tester.addChildNodeRepositoryNode(
                     new NodeSpec.Builder(nodeSpec2)
                             .state(NodeState.dirty)
-                            .minCpuCores(1)
-                            .minMainMemoryAvailableGb(1)
-                            .minDiskAvailableGb(1)
+                            .vcpus(1)
+                            .memoryGb(1)
+                            .diskGb(1)
                             .build());
 
             tester.inOrder(tester.docker).deleteContainer(eq(new ContainerName("host2")));
             tester.inOrder(tester.storageMaintainer).archiveNodeStorage(
                     argThat(context -> context.containerName().equals(new ContainerName("host2"))));
-            tester.inOrder(tester.nodeRepository).setNodeState(eq(nodeSpec2.getHostname()), eq(NodeState.ready));
+            tester.inOrder(tester.nodeRepository).setNodeState(eq(nodeSpec2.hostname()), eq(NodeState.ready));
 
             addAndWaitForNode(tester, "host3.test.yahoo.com", DockerImage.fromString("image1"));
         }
@@ -47,13 +47,13 @@ public class MultiDockerTest {
                 .hostname(hostName)
                 .wantedDockerImage(dockerImage)
                 .state(NodeState.active)
-                .nodeType(NodeType.tenant)
+                .type(NodeType.tenant)
                 .flavor("docker")
                 .wantedRestartGeneration(1L)
                 .currentRestartGeneration(1L)
-                .minCpuCores(2)
-                .minMainMemoryAvailableGb(4)
-                .minDiskAvailableGb(1)
+                .vcpus(2)
+                .memoryGb(4)
+                .diskGb(1)
                 .build();
 
         tester.addChildNodeRepositoryNode(nodeSpec);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/NodeRepoMock.java
@@ -32,7 +32,7 @@ public class NodeRepoMock implements NodeRepository {
     public List<NodeSpec> getNodes(String baseHostName) {
         synchronized (monitor) {
             return nodeRepositoryNodesByHostname.values().stream()
-                    .filter(node -> baseHostName.equals(node.getParentHostname().orElse(null)))
+                    .filter(node -> baseHostName.equals(node.parentHostname().orElse(null)))
                     .collect(Collectors.toList());
         }
     }
@@ -69,7 +69,7 @@ public class NodeRepoMock implements NodeRepository {
 
     void updateNodeRepositoryNode(NodeSpec nodeSpec) {
         synchronized (monitor) {
-            nodeRepositoryNodesByHostname.put(nodeSpec.getHostname(), nodeSpec);
+            nodeRepositoryNodesByHostname.put(nodeSpec.hostname(), nodeSpec);
         }
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
@@ -52,9 +52,9 @@ public class RebootTest {
                 .hostname(hostname)
                 .wantedDockerImage(dockerImage)
                 .state(NodeState.active)
-                .nodeType(NodeType.tenant)
+                .type(NodeType.tenant)
                 .flavor("docker")
-                .vespaVersion(Version.fromString("6.50.0"))
+                .currentVespaVersion(Version.fromString("6.50.0"))
                 .wantedRestartGeneration(1L)
                 .currentRestartGeneration(1L)
                 .build();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -30,7 +30,7 @@ public class RestartTest {
                     .hostname(hostname)
                     .state(NodeState.active)
                     .wantedDockerImage(dockerImage)
-                    .nodeType(NodeType.tenant)
+                    .type(NodeType.tenant)
                     .flavor("docker")
                     .wantedRestartGeneration(1)
                     .currentRestartGeneration(1)

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -157,12 +157,12 @@ public class StorageMaintainerTest {
 
             NodeSpec nodeSpec = new NodeSpec.Builder()
                     .hostname("host123-5.test.domain.tld")
-                    .nodeType(nodeType)
+                    .type(nodeType)
                     .state(NodeState.active)
                     .parentHostname("host123.test.domain.tld")
                     .owner(new NodeOwner("tenant", "application", "instance"))
                     .membership(new NodeMembership("clusterType", "clusterId", null, 0, false))
-                    .vespaVersion(Version.fromString("6.305.12"))
+                    .currentVespaVersion(Version.fromString("6.305.12"))
                     .flavor("d-2-8-50")
                     .canonicalFlavor("d-2-8-50")
                     .build();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImplTest.java
@@ -160,7 +160,7 @@ public class NodeAdminImplTest {
         NodeSpec nodeSpec = new NodeSpec.Builder()
                 .hostname(hostname)
                 .state(NodeState.active)
-                .nodeType(NodeType.tenant)
+                .type(NodeType.tenant)
                 .flavor("default")
                 .build();
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterTest.java
@@ -59,7 +59,7 @@ public class NodeAdminStateUpdaterTest {
     public void state_convergence() {
         mockNodeRepo(NodeState.active, 4);
         List<String> activeHostnames = nodeRepository.getNodes(hostHostname.value()).stream()
-                .map(NodeSpec::getHostname)
+                .map(NodeSpec::hostname)
                 .collect(Collectors.toList());
         List<String> suspendHostnames = new ArrayList<>(activeHostnames);
         suspendHostnames.add(hostHostname.value());
@@ -170,7 +170,7 @@ public class NodeAdminStateUpdaterTest {
 
         // When doing batch suspend, only suspend the containers if the host is not active
         List<String> activeHostnames = nodeRepository.getNodes(hostHostname.value()).stream()
-                .map(NodeSpec::getHostname)
+                .map(NodeSpec::hostname)
                 .collect(Collectors.toList());
         updater.converge(SUSPENDED);
         verify(orchestrator, times(1)).suspend(eq(hostHostname.value()), eq(activeHostnames));
@@ -206,9 +206,9 @@ public class NodeAdminStateUpdaterTest {
         updater.adjustNodeAgentsToRunFromNodeRepository();
         updater.adjustNodeAgentsToRunFromNodeRepository();
 
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host1.yahoo.com")), eq(acl));
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host2.yahoo.com")), eq(acl));
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host3.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host1.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host2.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host3.yahoo.com")), eq(acl));
         verify(nodeRepository, times(3)).getNodes(eq(hostHostname.value()));
         verify(nodeRepository, times(1)).getAcls(eq(hostHostname.value()));
     }
@@ -224,9 +224,9 @@ public class NodeAdminStateUpdaterTest {
         updater.adjustNodeAgentsToRunFromNodeRepository();
         updater.adjustNodeAgentsToRunFromNodeRepository();
 
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host1.yahoo.com")), eq(acl));
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host2.yahoo.com")), eq(acl));
-        verify(nodeAgentContextFactory, times(1)).create(argThat(spec -> spec.getHostname().equals("host3.yahoo.com")), eq(Acl.EMPTY));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host1.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host2.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(1)).create(argThat(spec -> spec.hostname().equals("host3.yahoo.com")), eq(Acl.EMPTY));
         verify(nodeRepository, times(3)).getNodes(eq(hostHostname.value()));
         verify(nodeRepository, times(2)).getAcls(eq(hostHostname.value())); // During the first tick, the cache is invalidated and retried
     }
@@ -241,8 +241,8 @@ public class NodeAdminStateUpdaterTest {
         updater.adjustNodeAgentsToRunFromNodeRepository();
         updater.adjustNodeAgentsToRunFromNodeRepository();
 
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host1.yahoo.com")), eq(acl));
-        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.getHostname().equals("host2.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host1.yahoo.com")), eq(acl));
+        verify(nodeAgentContextFactory, times(3)).create(argThat(spec -> spec.hostname().equals("host2.yahoo.com")), eq(acl));
         verify(nodeRepository, times(3)).getNodes(eq(hostHostname.value()));
         verify(nodeRepository, times(1)).getAcls(eq(hostHostname.value()));
     }
@@ -261,11 +261,11 @@ public class NodeAdminStateUpdaterTest {
                 .mapToObj(i -> new NodeSpec.Builder()
                         .hostname("host" + i + ".yahoo.com")
                         .state(NodeState.active)
-                        .nodeType(NodeType.tenant)
+                        .type(NodeType.tenant)
                         .flavor("docker")
-                        .minCpuCores(1)
-                        .minMainMemoryAvailableGb(1)
-                        .minDiskAvailableGb(1)
+                        .vcpus(1)
+                        .memoryGb(1)
+                        .diskGb(1)
                         .build())
                 .collect(Collectors.toList());
 
@@ -274,11 +274,11 @@ public class NodeAdminStateUpdaterTest {
         when(nodeRepository.getNode(eq(hostHostname.value()))).thenReturn(new NodeSpec.Builder()
                 .hostname(hostHostname.value())
                 .state(hostState)
-                .nodeType(NodeType.tenant)
+                .type(NodeType.tenant)
                 .flavor("default")
-                .minCpuCores(1)
-                .minMainMemoryAvailableGb(1)
-                .minDiskAvailableGb(1)
+                .vcpus(1)
+                .memoryGb(1)
+                .diskGb(1)
                 .build());
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -64,11 +64,11 @@ public class NodeAgentImplTest {
     private final String hostName = "host1.test.yahoo.com";
     private final NodeSpec.Builder nodeBuilder = new NodeSpec.Builder()
             .hostname(hostName)
-            .nodeType(NodeType.tenant)
+            .type(NodeType.tenant)
             .flavor("docker")
-            .minCpuCores(MIN_CPU_CORES)
-            .minMainMemoryAvailableGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
-            .minDiskAvailableGb(MIN_DISK_AVAILABLE_GB);
+            .vcpus(MIN_CPU_CORES)
+            .memoryGb(MIN_MAIN_MEMORY_AVAILABLE_GB)
+            .diskGb(MIN_DISK_AVAILABLE_GB);
 
     private final NodeAgentContextSupplier contextSupplier = mock(NodeAgentContextSupplier.class);
     private final DockerImage dockerImage = DockerImage.fromString("dockerImage");
@@ -90,7 +90,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -119,7 +119,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -140,7 +140,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -214,7 +214,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -241,7 +241,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion);
+                .currentVespaVersion(vespaVersion);
 
         NodeAgentContext firstContext = createContext(specBuilder.build());
         NodeAgentImpl nodeAgent = makeNodeAgent(dockerImage, true);
@@ -250,9 +250,9 @@ public class NodeAgentImplTest {
         when(storageMaintainer.getDiskUsageFor(any())).thenReturn(Optional.of(201326592000L));
 
         nodeAgent.doConverge(firstContext);
-        NodeAgentContext secondContext = createContext(specBuilder.minDiskAvailableGb(200).build());
+        NodeAgentContext secondContext = createContext(specBuilder.diskGb(200).build());
         nodeAgent.doConverge(secondContext);
-        NodeAgentContext thirdContext = createContext(specBuilder.minCpuCores(4).build());
+        NodeAgentContext thirdContext = createContext(specBuilder.vcpus(4).build());
         nodeAgent.doConverge(thirdContext);
         ContainerResources resourcesAfterThird = ContainerResources.from(0, 4, 16);
         mockGetContainer(dockerImage, resourcesAfterThird, true);
@@ -288,7 +288,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion);
+                .currentVespaVersion(vespaVersion);
 
         NodeAgentContext firstContext = createContext(specBuilder.build());
         NodeAgentImpl nodeAgent = makeNodeAgent(dockerImage, true);
@@ -297,7 +297,7 @@ public class NodeAgentImplTest {
         when(storageMaintainer.getDiskUsageFor(any())).thenReturn(Optional.of(201326592000L));
 
         nodeAgent.doConverge(firstContext);
-        NodeAgentContext secondContext = createContext(specBuilder.minMainMemoryAvailableGb(20).build());
+        NodeAgentContext secondContext = createContext(specBuilder.memoryGb(20).build());
         nodeAgent.doConverge(secondContext);
         ContainerResources resourcesAfterThird = ContainerResources.from(0, 2, 20);
         mockGetContainer(dockerImage, resourcesAfterThird, true);
@@ -325,7 +325,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .wantedRestartGeneration(wantedRestartGeneration)
                 .currentRestartGeneration(currentRestartGeneration)
                 .build();
@@ -357,7 +357,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .wantedRebootGeneration(wantedRebootGeneration)
                 .currentRebootGeneration(currentRebootGeneration)
                 .build();
@@ -400,7 +400,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.failed)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -446,7 +446,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .state(NodeState.inactive)
                 .wantedVespaVersion(vespaVersion)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -548,7 +548,7 @@ public class NodeAgentImplTest {
                 .currentDockerImage(dockerImage)
                 .wantedDockerImage(dockerImage)
                 .state(NodeState.active)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -570,7 +570,7 @@ public class NodeAgentImplTest {
                 .wantedDockerImage(dockerImage)
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -651,10 +651,10 @@ public class NodeAgentImplTest {
                 .wantedDockerImage(dockerImage)
                 .currentDockerImage(dockerImage)
                 .state(NodeState.active)
-                .vespaVersion(vespaVersion)
+                .currentVespaVersion(vespaVersion)
                 .owner(owner)
                 .membership(membership)
-                .minMainMemoryAvailableGb(2)
+                .memoryGb(2)
                 .allowedToBeDown(true)
                 .parentHostname("parent.host.name.yahoo.com")
                 .build();
@@ -713,7 +713,7 @@ public class NodeAgentImplTest {
     @Test
     public void testRunningConfigServer() {
         final NodeSpec node = nodeBuilder
-                .nodeType(NodeType.config)
+                .type(NodeType.config)
                 .wantedDockerImage(dockerImage)
                 .state(NodeState.active)
                 .wantedVespaVersion(vespaVersion)


### PR DESCRIPTION
Drops `get` prefix from method names in `NodeSpec`, `NodeOwner` and `NodeMembership`
Additionally, following methods are renamed beyond the `get` prefix drop:
  * `nodeType` -> `type`
  * `minCpuCores` -> `vcpus`
  * `minMainMemoryAvailableGb` -> `memoryGb`
  * `minDiskAvailableGb` -> `diskGb`
  * `vespaVersion` -> `currentVespaVersion` (To match the other current/wanted method pairs)