### PR TITLE
Don't use fake timers for master election tests

### DIFF
--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
@@ -123,7 +123,7 @@ public class MasterElectionTest extends FleetControllerTest {
         log.log(LogLevel.INFO, "STARTING TEST: MasterElectionTest::testMasterElection()");
         FleetControllerOptions options = defaultOptions("mycluster");
         options.masterZooKeeperCooldownPeriod = 1;
-        setUpFleetController(5, true, options);
+        setUpFleetController(5, false, options);
         waitForMaster(0);
         log.log(LogLevel.INFO, "SHUTTING DOWN FLEET CONTROLLER 0");
         fleetControllers.get(0).shutdown();
@@ -227,10 +227,10 @@ public class MasterElectionTest extends FleetControllerTest {
         startingTest("MasterElectionTest::testClusterStateVersionIncreasesAcrossMasterElections");
         FleetControllerOptions options = defaultOptions("mycluster");
         options.masterZooKeeperCooldownPeriod = 1;
-        setUpFleetController(5, true, options);
+        setUpFleetController(5, false, options);
         // Currently need to have content nodes present for the cluster controller to even bother
         // attempting to persisting its cluster state version to ZK.
-        setUpVdsNodes(true, new DummyVdsNodeOptions());
+        setUpVdsNodes(false, new DummyVdsNodeOptions());
         fleetController = fleetControllers.get(0); // Required to prevent waitForStableSystem from NPE'ing
         waitForStableSystem();
         waitForMaster(0);
@@ -254,7 +254,7 @@ public class MasterElectionTest extends FleetControllerTest {
         // "Magic" port value is in range allocated to module for testing.
         zooKeeperServer = ZooKeeperTestServer.createWithFixedPort(18342);
         options.masterZooKeeperCooldownPeriod = 100;
-        setUpFleetController(2, true, options);
+        setUpFleetController(2, false, options);
         waitForMaster(0);
 
         zooKeeperServer.shutdown(true);
@@ -276,7 +276,7 @@ public class MasterElectionTest extends FleetControllerTest {
         FleetControllerOptions options = defaultOptions("mycluster");
         options.masterZooKeeperCooldownPeriod = 100;
         options.zooKeeperServerAddress = "localhost";
-        setUpFleetController(5, true, options);
+        setUpFleetController(5, false, options);
         waitForMaster(0);
 
         log.log(LogLevel.INFO, "STOPPING ZOOKEEPER SERVER AT " + zooKeeperServer.getAddress());
@@ -310,7 +310,7 @@ public class MasterElectionTest extends FleetControllerTest {
         startingTest("MasterElectionTest::testMasterZooKeeperCooldown");
         FleetControllerOptions options = defaultOptions("mycluster");
         options.masterZooKeeperCooldownPeriod = 3600 * 1000; // An hour
-        setUpFleetController(3, true, options);
+        setUpFleetController(3, false, options);
         waitForMaster(0);
         timer.advanceTime(24 * 3600 * 1000); // A day
         waitForCompleteCycle(1);
@@ -351,7 +351,7 @@ public class MasterElectionTest extends FleetControllerTest {
         startingTest("MasterElectionTest::testGetMaster");
         FleetControllerOptions options = defaultOptions("mycluster");
         options.masterZooKeeperCooldownPeriod = 3600 * 1000; // An hour
-        setUpFleetController(3, true, options);
+        setUpFleetController(3, false, options);
         waitForMaster(0);
 
         supervisor = new Supervisor(new Transport());
@@ -431,7 +431,7 @@ public class MasterElectionTest extends FleetControllerTest {
         startingTest("MasterElectionTest::testReconfigure");
         FleetControllerOptions options = defaultOptions("mycluster");
         options.masterZooKeeperCooldownPeriod = 1;
-        setUpFleetController(3, true, options);
+        setUpFleetController(3, false, options);
         waitForMaster(0);
 
         FleetControllerOptions newOptions = options.clone();
@@ -460,8 +460,8 @@ public class MasterElectionTest extends FleetControllerTest {
         options.minRatioOfStorageNodesUp = 0;
         options.minDistributorNodesUp = 0;
         options.minStorageNodesUp = 1;
-        setUpFleetController(3, true, options);
-        setUpVdsNodes(true, new DummyVdsNodeOptions());
+        setUpFleetController(3, false, options);
+        setUpVdsNodes(false, new DummyVdsNodeOptions());
         fleetController = fleetControllers.get(0); // Required to prevent waitForStableSystem from NPE'ing
         waitForStableSystem();
         waitForMaster(0);
@@ -504,8 +504,8 @@ public class MasterElectionTest extends FleetControllerTest {
         options.clusterHasGlobalDocumentTypes = true;
         options.masterZooKeeperCooldownPeriod = 1;
         options.minTimeBeforeFirstSystemStateBroadcast = 100000;
-        setUpFleetController(3, true, options);
-        setUpVdsNodes(true, new DummyVdsNodeOptions());
+        setUpFleetController(3, false, options);
+        setUpVdsNodes(false, new DummyVdsNodeOptions());
         fleetController = fleetControllers.get(0); // Required to prevent waitForStableSystem from NPE'ing
         waitForMaster(0);
         waitForStableSystem();
@@ -547,8 +547,8 @@ public class MasterElectionTest extends FleetControllerTest {
         options.clusterHasGlobalDocumentTypes = false;
         options.masterZooKeeperCooldownPeriod = 1;
         options.minTimeBeforeFirstSystemStateBroadcast = 100000;
-        setUpFleetController(3, true, options);
-        setUpVdsNodes(true, new DummyVdsNodeOptions());
+        setUpFleetController(3, false, options);
+        setUpVdsNodes(false, new DummyVdsNodeOptions());
         fleetController = fleetControllers.get(0); // Required to prevent waitForStableSystem from NPE'ing
         waitForMaster(0);
         waitForStableSystem();


### PR DESCRIPTION
@geirst please review

When using fake timers there's a catch-22 edge case during transient
ZooKeeper disconnects. The test will not progress and increase the
fake timer value until ZK is connected, but ZK will not attempt to
reconnect until the reconnection cooldown period has passed (which
depends on the faked timer).
