### PR TITLE
Gjoranv/add default public metrics consumer

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
@@ -66,7 +66,7 @@ class ConsumersConfigGenerator {
         return original != null ? newMetric.addDimensionsFrom(original) : newMetric;
     }
 
-    private static Consumer.Builder toConsumerBuilder(MetricsConsumer consumer) {
+    static Consumer.Builder toConsumerBuilder(MetricsConsumer consumer) {
         Consumer.Builder builder = new Consumer.Builder().name(consumer.getId());
         consumer.getMetrics().values().forEach(metric -> builder.metric(toConsumerMetricBuilder(metric)));
         return builder;

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -41,12 +41,14 @@ import java.util.logging.Logger;
 
 import static com.yahoo.vespa.model.admin.metricsproxy.ConsumersConfigGenerator.addMetrics;
 import static com.yahoo.vespa.model.admin.metricsproxy.ConsumersConfigGenerator.generateConsumers;
+import static com.yahoo.vespa.model.admin.metricsproxy.ConsumersConfigGenerator.toConsumerBuilder;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames.APPLICATION;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames.APPLICATION_ID;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames.INSTANCE;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames.LEGACY_APPLICATION;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames.TENANT;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames.ZONE;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicConsumer.getDefaultPublicConsumer;
 import static com.yahoo.vespa.model.admin.monitoring.VespaMetricsConsumer.getVespaMetricsConsumer;
 import static com.yahoo.vespa.model.admin.monitoring.MetricSet.emptyMetricSet;
 import static com.yahoo.vespa.model.container.xml.BundleMapper.JarSuffix.JAR_WITH_DEPS;
@@ -128,8 +130,10 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
 
     @Override
     public void getConfig(ConsumersConfig.Builder builder) {
-        var amendedDefaultConsumer = addMetrics(getVespaMetricsConsumer(), getAdditionalDefaultMetrics().getMetrics());
-        builder.consumer.addAll(generateConsumers(amendedDefaultConsumer, getUserMetricsConsumers()));
+        var amendedVespaConsumer = addMetrics(getVespaMetricsConsumer(), getAdditionalDefaultMetrics().getMetrics());
+        builder.consumer.addAll(generateConsumers(amendedVespaConsumer, getUserMetricsConsumers()));
+
+        if (! isHostedVespa()) builder.consumer.add(toConsumerBuilder(getDefaultPublicConsumer()));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableList;
 
 import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicMetrics.defaultPublicMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
-import static com.yahoo.vespa.model.admin.monitoring.NetworkMetrics.networkMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
 import static java.util.Collections.emptyList;
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+ */
+
+package com.yahoo.vespa.model.admin.monitoring;
+
+import ai.vespa.metricsproxy.http.GenericMetricsHandler;
+import com.google.common.collect.ImmutableList;
+
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicMetrics.defaultPublicMetricSet;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
+import static com.yahoo.vespa.model.admin.monitoring.NetworkMetrics.networkMetricSet;
+import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
+import static java.util.Collections.emptyList;
+
+/**
+ * @author gjoranv
+ */
+public class DefaultPublicConsumer {
+
+    public static final String DEFAULT_PUBLIC_CONSUMER_ID = GenericMetricsHandler.DEFAULT_PUBLIC_CONSUMER_ID.id;
+
+    private static final MetricSet publicConsumerMetrics = new MetricSet("public-consumer-metrics",
+                                                                         emptyList(),
+                                                                         ImmutableList.of(defaultPublicMetricSet,
+                                                                                          defaultVespaMetricSet,
+                                                                                          systemMetricSet,
+                                                                                          networkMetricSet));
+
+    public static MetricsConsumer getDefaultPublicConsumer() {
+        return new MetricsConsumer(DEFAULT_PUBLIC_CONSUMER_ID, publicConsumerMetrics);
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
@@ -24,8 +24,7 @@ public class DefaultPublicConsumer {
                                                                          emptyList(),
                                                                          ImmutableList.of(defaultPublicMetricSet,
                                                                                           defaultVespaMetricSet,
-                                                                                          systemMetricSet,
-                                                                                          networkMetricSet));
+                                                                                          systemMetricSet));
 
     public static MetricsConsumer getDefaultPublicConsumer() {
         return new MetricsConsumer(DEFAULT_PUBLIC_CONSUMER_ID, publicConsumerMetrics);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import static java.util.Collections.emptyList;
 
 /**
+ * TODO: Add content metrics.
+ *
  * @author gjoranv
  */
 public class DefaultPublicMetrics {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+ */
+
+package com.yahoo.vespa.model.admin.monitoring;
+
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * @author gjoranv
+ */
+public class DefaultPublicMetrics {
+
+    public static MetricSet defaultPublicMetricSet = createMetricSet();
+
+    private static MetricSet createMetricSet() {
+        return new MetricSet("default-public",
+                             getAllMetrics(),
+                             emptyList());
+    }
+
+    private static Set<Metric> getAllMetrics() {
+        return ImmutableSet.<Metric>builder()
+                .addAll(getContainerMetrics())
+                .addAll(getQrserverMetrics())
+                .build();
+    }
+
+    private static Set<Metric> getContainerMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+
+        metrics.add(new Metric("http.status.1xx.rate"));
+        metrics.add(new Metric("http.status.2xx.rate"));
+        metrics.add(new Metric("http.status.3xx.rate"));
+        metrics.add(new Metric("http.status.4xx.rate"));
+        metrics.add(new Metric("http.status.5xx.rate"));
+        metrics.add(new Metric("jdisc.gc.ms.average"));
+        metrics.add(new Metric("mem.heap.free.average"));
+
+        return metrics;
+    }
+
+    private static Set<Metric> getQrserverMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+
+        metrics.add(new Metric("queries.rate"));
+        metrics.add(new Metric("query_latency.average")); // TODO: Remove in Vespa 8?
+        metrics.add(new Metric("query_latency.95percentile"));
+        metrics.add(new Metric("query_latency.99percentile"));
+        metrics.add(new Metric("hits_per_query.average")); // TODO: Remove in Vespa 8?
+        metrics.add(new Metric("totalhits_per_query.average")); // TODO: Remove in Vespa 8?
+        metrics.add(new Metric("degraded_queries.rate"));
+        metrics.add(new Metric("failed_queries.rate"));
+        metrics.add(new Metric("serverActiveThreads.average")); // TODO: Remove in Vespa 8?
+
+        return metrics;
+    }
+
+    private DefaultPublicMetrics() { }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -52,14 +52,14 @@ public class DefaultPublicMetrics {
         Set<Metric> metrics = new LinkedHashSet<>();
 
         metrics.add(new Metric("queries.rate"));
-        metrics.add(new Metric("query_latency.average")); // TODO: Remove in Vespa 8?
+        metrics.add(new Metric("query_latency.average"));
         metrics.add(new Metric("query_latency.95percentile"));
         metrics.add(new Metric("query_latency.99percentile"));
-        metrics.add(new Metric("hits_per_query.average")); // TODO: Remove in Vespa 8?
-        metrics.add(new Metric("totalhits_per_query.average")); // TODO: Remove in Vespa 8?
+        metrics.add(new Metric("hits_per_query.average"));
+        metrics.add(new Metric("totalhits_per_query.average"));
         metrics.add(new Metric("degraded_queries.rate"));
         metrics.add(new Metric("failed_queries.rate"));
-        metrics.add(new Metric("serverActiveThreads.average")); // TODO: Remove in Vespa 8?
+        metrics.add(new Metric("serverActiveThreads.average"));
 
         return metrics;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -22,7 +22,7 @@ public class DefaultPublicMetrics {
     public static MetricSet defaultPublicMetricSet = createMetricSet();
 
     private static MetricSet createMetricSet() {
-        return new MetricSet("default-public",
+        return new MetricSet("public",
                              getAllMetrics(),
                              emptyList());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/SystemMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/SystemMetrics.java
@@ -8,7 +8,6 @@ import java.util.Set;
 /**
  * @author gjoranv
  */
-@SuppressWarnings("UnusedDeclaration") // Used by model amenders
 public class SystemMetrics {
     public static final String CPU_UTIL = "cpu.util";
     public static final String CPU_SYS_UTIL = "cpu.sys.util";

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -13,7 +13,6 @@ import static java.util.Collections.singleton;
  *
  * @author gjoranv
  */
-@SuppressWarnings("UnusedDeclaration") // Used by model amenders
 public class VespaMetricSet {
 
     public static final MetricSet vespaMetricSet = new MetricSet("vespa",

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricsConsumer.java
@@ -10,7 +10,7 @@ import static com.yahoo.vespa.model.admin.monitoring.VespaMetricSet.vespaMetricS
 import static java.util.Collections.emptyList;
 
 /**
- * This class sets up the 'Vespa' metrics consumer.
+ * This class sets up the 'Vespa' metrics consumer, which is mainly used for Yamas in hosted Vespa.
  *
  * @author trygve
  * @author gjoranv
@@ -19,14 +19,14 @@ public class VespaMetricsConsumer {
 
     public static final String VESPA_CONSUMER_ID = VespaMetrics.VESPA_CONSUMER_ID.id;
 
-    private static final MetricSet defaultConsumerMetrics = new MetricSet("vespa-consumer-metrics",
-                                                                          emptyList(),
-                                                                          ImmutableList.of(vespaMetricSet,
-                                                                                           systemMetricSet,
-                                                                                           networkMetricSet));
+    private static final MetricSet vespaConsumerMetrics = new MetricSet("vespa-consumer-metrics",
+                                                                        emptyList(),
+                                                                        ImmutableList.of(vespaMetricSet,
+                                                                                         systemMetricSet,
+                                                                                         networkMetricSet));
 
     public static MetricsConsumer getVespaMetricsConsumer() {
-        return new MetricsConsumer(VESPA_CONSUMER_ID, defaultConsumerMetrics);
+        return new MetricsConsumer(VESPA_CONSUMER_ID, vespaConsumerMetrics);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicMetrics.defaultPublicMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.NetworkMetrics.networkMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
@@ -20,6 +21,7 @@ import static com.yahoo.vespa.model.admin.monitoring.VespaMetricSet.vespaMetricS
 public class PredefinedMetricSets {
 
     public static final Map<String, MetricSet> predefinedMetricSets = toMapById(
+            defaultPublicMetricSet,
             defaultVespaMetricSet,
             vespaMetricSet,
             systemMetricSet,

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/PredefinedMetricSets.java
@@ -28,8 +28,11 @@ public class PredefinedMetricSets {
 
     private static Map<String, MetricSet> toMapById(MetricSet... metricSets) {
         Map<String, MetricSet> availableMetricSets = new LinkedHashMap<>();
-        for (MetricSet metricSet : metricSets)
-            availableMetricSets.put(metricSet.getId(), metricSet);
+        for (MetricSet metricSet : metricSets) {
+            var existing = availableMetricSets.put(metricSet.getId(), metricSet);
+            if (existing != null)
+                throw new IllegalArgumentException("There are two predefined metric sets with id " + existing.getId());
+        }
         return Collections.unmodifiableMap(availableMetricSets);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicConsumer.DEFAULT_PUBLIC_CONSUMER_ID;
 import static com.yahoo.vespa.model.admin.monitoring.VespaMetricsConsumer.VESPA_CONSUMER_ID;
 import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.SystemMetrics.systemMetricSet;
@@ -77,6 +78,10 @@ public class MetricsBuilder {
     private void throwIfIllegalConsumerId(Metrics metrics, String consumerId) {
         if (consumerId.equalsIgnoreCase(VESPA_CONSUMER_ID) && applicationType != ApplicationType.HOSTED_INFRASTRUCTURE)
             throw new IllegalArgumentException("'Vespa' is not allowed as metrics consumer id (case is ignored.)");
+
+        if (consumerId.equalsIgnoreCase(DEFAULT_PUBLIC_CONSUMER_ID))
+            throw new IllegalArgumentException("'" + DEFAULT_PUBLIC_CONSUMER_ID + "' is not allowed as metrics consumer id (case is ignored.)");
+
         if (metrics.hasConsumerIgnoreCase(consumerId))
             throw new IllegalArgumentException("'" + consumerId + "' is used as id for two metrics consumers (case is ignored.)");
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -97,7 +97,7 @@ public class MetricsProxyContainerClusterTest {
         assertEquals(2, config.consumer().size());
         assertEquals(config.consumer(1).name(), DEFAULT_PUBLIC_CONSUMER_ID);
 
-        int numMetricsForPublicDefaultConsumer = defaultPublicMetricSet.getMetrics().size() + numDefaultVespaMetrics + numSystemMetrics + numNetworkMetrics;
+        int numMetricsForPublicDefaultConsumer = defaultPublicMetricSet.getMetrics().size() + numDefaultVespaMetrics + numSystemMetrics;
         assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(1).metric().size());
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -134,8 +134,8 @@ public class MetricsProxyContainerClusterTest {
     }
 
     @Test
-    public void default_public_is_a_reserved_consumer_id() {
-        assertReservedConsumerId("default-public");
+    public void public_is_a_reserved_consumer_id() {
+        assertReservedConsumerId("default");
     }
 
     private void assertReservedConsumerId(String consumerId) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -25,14 +25,17 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.C
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.MY_APPLICATION;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.MY_INSTANCE;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.MY_TENANT;
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.hosted;
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.checkMetric;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.consumersConfigFromModel;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.consumersConfigFromXml;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getApplicationDimensionsConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getCustomConsumer;
-import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getHostedModel;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getModel;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getQrStartConfig;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicConsumer.DEFAULT_PUBLIC_CONSUMER_ID;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicMetrics.defaultPublicMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.VespaMetricsConsumer.VESPA_CONSUMER_ID;
 import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
 import static com.yahoo.vespa.model.admin.monitoring.NetworkMetrics.networkMetricSet;
@@ -54,14 +57,14 @@ public class MetricsProxyContainerClusterTest {
     private static int numVespaMetrics = vespaMetricSet.getMetrics().size();
     private static int numSystemMetrics = systemMetricSet.getMetrics().size();
     private static int numNetworkMetrics = networkMetricSet.getMetrics().size();
-    private static int numMetricsForDefaultConsumer = numVespaMetrics + numSystemMetrics + numNetworkMetrics;
+    private static int numMetricsForVespaConsumer = numVespaMetrics + numSystemMetrics + numNetworkMetrics;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void metrics_proxy_bundle_is_included_in_bundles_config() {
-        VespaModel model = getModel(servicesWithAdminOnly());
+        VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
         var builder = new BundlesConfig.Builder();
         model.getConfig(builder, CLUSTER_CONFIG_ID);
         BundlesConfig config = builder.build();
@@ -71,7 +74,7 @@ public class MetricsProxyContainerClusterTest {
 
     @Test
     public void cluster_is_prepared_so_that_application_metadata_config_is_produced() {
-        VespaModel model = getModel(servicesWithAdminOnly());
+        VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
         var builder = new ApplicationMetadataConfig.Builder();
         model.getConfig(builder, CLUSTER_CONFIG_ID);
         ApplicationMetadataConfig config = builder.build();
@@ -82,26 +85,44 @@ public class MetricsProxyContainerClusterTest {
 
     @Test
     public void verbose_gc_logging_is_disabled() {
-        VespaModel model = getModel(servicesWithAdminOnly());
+        VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
         QrStartConfig config = getQrStartConfig(model);
         assertFalse(config.jvm().verbosegc());
     }
 
+
     @Test
-    public void default_consumer_is_always_present_and_has_all_vespa_metrics_and_all_system_metrics() {
-        ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly());
-        assertEquals(config.consumer(0).name(), VESPA_CONSUMER_ID);
-        assertEquals(numMetricsForDefaultConsumer, config.consumer(0).metric().size());
+    public void default_public_consumer_is_set_up_for_self_hosted() {
+        ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), self_hosted);
+        assertEquals(2, config.consumer().size());
+        assertEquals(config.consumer(1).name(), DEFAULT_PUBLIC_CONSUMER_ID);
+
+        int numMetricsForPublicDefaultConsumer = defaultPublicMetricSet.getMetrics().size() + numDefaultVespaMetrics + numSystemMetrics + numNetworkMetrics;
+        assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(1).metric().size());
     }
 
     @Test
-    public void default_consumer_can_be_amended_via_admin_object() {
-        VespaModel model = getModel(servicesWithAdminOnly());
+    public void default_public_consumer_is_not_set_up_for_hosted() {
+        ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), hosted);
+        assertEquals(1, config.consumer().size());
+        assertEquals(config.consumer(0).name(), VESPA_CONSUMER_ID);
+    }
+
+    @Test
+    public void vespa_consumer_is_always_present_and_has_all_vespa_metrics_and_all_system_metrics() {
+        ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), self_hosted);
+        assertEquals(config.consumer(0).name(), VESPA_CONSUMER_ID);
+        assertEquals(numMetricsForVespaConsumer, config.consumer(0).metric().size());
+    }
+
+    @Test
+    public void vespa_consumer_can_be_amended_via_admin_object() {
+        VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
         var additionalMetric = new Metric("additional-metric");
         model.getAdmin().setAdditionalDefaultMetrics(new MetricSet("amender-metrics", singleton(additionalMetric)));
 
         ConsumersConfig config = consumersConfigFromModel(model);
-        assertEquals(numMetricsForDefaultConsumer + 1, config.consumer(0).metric().size());
+        assertEquals(numMetricsForVespaConsumer + 1, config.consumer(0).metric().size());
 
         ConsumersConfig.Consumer vespaConsumer = config.consumer(0);
         assertTrue("Did not contain additional metric", checkMetric(vespaConsumer, additionalMetric));
@@ -109,19 +130,28 @@ public class MetricsProxyContainerClusterTest {
 
     @Test
     public void vespa_is_a_reserved_consumer_id() {
+        assertReservedConsumerId("Vespa");
+    }
+
+    @Test
+    public void default_public_is_a_reserved_consumer_id() {
+        assertReservedConsumerId("default-public");
+    }
+
+    private void assertReservedConsumerId(String consumerId) {
         String services = String.join("\n",
-                "<services>",
-                "    <admin version='2.0'>",
-                "        <adminserver hostalias='node1'/>",
-                "        <metrics>",
-                "            <consumer id='vespa'/>",
-                "        </metrics>",
-                "    </admin>",
-                "</services>"
+                                      "<services>",
+                                      "    <admin version='2.0'>",
+                                      "        <adminserver hostalias='node1'/>",
+                                      "        <metrics>",
+                                      "            <consumer id='"  + consumerId + "'/>",
+                                      "        </metrics>",
+                                      "    </admin>",
+                                      "</services>"
         );
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("'Vespa' is not allowed as metrics consumer id");
-        consumersConfigFromXml(services);
+        thrown.expectMessage("'" + consumerId + "' is not allowed as metrics consumer id");
+        consumersConfigFromXml(services, self_hosted);
     }
 
     @Test
@@ -138,12 +168,13 @@ public class MetricsProxyContainerClusterTest {
                 "    </admin>",
                 "</services>"
         );
-        ConsumersConfig config = consumersConfigFromXml(services);
+        VespaModel hostedModel = getModel(services, hosted);
+        ConsumersConfig config = consumersConfigFromModel(hostedModel);
         assertEquals(1, config.consumer().size());
 
         // All default metrics are retained
         ConsumersConfig.Consumer vespaConsumer = config.consumer(0);
-        assertEquals(numMetricsForDefaultConsumer + 1, vespaConsumer.metric().size());
+        assertEquals(numMetricsForVespaConsumer + 1, vespaConsumer.metric().size());
 
         Metric customMetric1 = new Metric("custom.metric1");
         assertTrue("Did not contain metric: " + customMetric1, checkMetric(vespaConsumer, customMetric1));
@@ -164,7 +195,7 @@ public class MetricsProxyContainerClusterTest {
         );
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("'a' is used as id for two metrics consumers");
-        consumersConfigFromXml(services);
+        consumersConfigFromXml(services, self_hosted);
     }
 
     @Test
@@ -216,7 +247,7 @@ public class MetricsProxyContainerClusterTest {
 
     @Test
     public void hosted_application_propagates_application_dimensions() {
-        VespaModel hostedModel = getHostedModel(servicesWithAdminOnly());
+        VespaModel hostedModel = getModel(servicesWithAdminOnly(), hosted);
         ApplicationDimensionsConfig config = getApplicationDimensionsConfig(hostedModel);
 
         assertEquals(zoneString(Zone.defaultZone()), config.dimensions(AppDimensionNames.ZONE));

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
@@ -11,7 +11,8 @@ import org.junit.Test;
 import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.CLUSTER_CONFIG_ID;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.CONTAINER_CONFIG_ID;
-import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getHostedModel;
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.hosted;
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getModel;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getNodeDimensionsConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getRpcConnectorConfig;
@@ -49,7 +50,7 @@ public class MetricsProxyContainerTest {
 
     @Test
     public void metrics_proxy_requires_less_memory_than_other_containers() {
-        VespaModel model = getModel(servicesWithContent());
+        VespaModel model = getModel(servicesWithContent(), self_hosted);
         MetricsProxyContainer container = (MetricsProxyContainer)model.id2producer().get(CONTAINER_CONFIG_ID);
         assertThat(container.getStartupCommand(), containsString("-Xms32m"));
         assertThat(container.getStartupCommand(), containsString("-Xmx512m"));
@@ -57,7 +58,7 @@ public class MetricsProxyContainerTest {
 
     @Test
     public void http_server_is_running_on_expected_port() {
-        VespaModel model = getModel(servicesWithContent());
+        VespaModel model = getModel(servicesWithContent(), self_hosted);
         MetricsProxyContainer container = (MetricsProxyContainer)model.id2producer().get(CONTAINER_CONFIG_ID);
         assertEquals(19092, container.getSearchPort());
         assertEquals(19092, container.getHealthPort());
@@ -69,7 +70,7 @@ public class MetricsProxyContainerTest {
 
     @Test
     public void metrics_rpc_server_is_running_on_expected_port() {
-        VespaModel model = getModel(servicesWithContent());
+        VespaModel model = getModel(servicesWithContent(), self_hosted);
         MetricsProxyContainer container = (MetricsProxyContainer)model.id2producer().get(CONTAINER_CONFIG_ID);
 
         int offset = container.metricsRpcPortOffset();
@@ -85,7 +86,7 @@ public class MetricsProxyContainerTest {
 
     @Test
     public void admin_rpc_server_is_running() {
-        VespaModel model = getModel(servicesWithContent());
+        VespaModel model = getModel(servicesWithContent(), self_hosted);
         MetricsProxyContainer container = (MetricsProxyContainer)model.id2producer().get(CONTAINER_CONFIG_ID);
 
         int offset = container.metricsRpcPortOffset() - 1;
@@ -99,7 +100,7 @@ public class MetricsProxyContainerTest {
     @Test
     public void hosted_application_propagates_node_dimensions() {
         String services = servicesWithContent();
-        VespaModel hostedModel = getHostedModel(services);
+        VespaModel hostedModel = getModel(services, hosted);
         assertEquals(1, hostedModel.getHosts().size());
         String configId = CLUSTER_CONFIG_ID + "/" + hostedModel.getHosts().iterator().next().getHostname();
         NodeDimensionsConfig config = getNodeDimensionsConfig(hostedModel, configId);

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
@@ -16,6 +16,9 @@ import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.admin.monitoring.Metric;
 import com.yahoo.vespa.model.test.VespaModelTester;
 
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.hosted;
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
+import static com.yahoo.vespa.model.admin.monitoring.DefaultPublicConsumer.DEFAULT_PUBLIC_CONSUMER_ID;
 import static com.yahoo.vespa.model.admin.monitoring.VespaMetricsConsumer.VESPA_CONSUMER_ID;
 import static org.junit.Assert.assertEquals;
 
@@ -33,20 +36,17 @@ class MetricsProxyModelTester {
     // Used for all configs that are produced by the container, not the cluster.
     static final String CONTAINER_CONFIG_ID = CLUSTER_CONFIG_ID + "/localhost";
 
-    static VespaModel getModel(String servicesXml) {
-        var numberOfHosts = 1;
-        var tester = new VespaModelTester();
-        tester.addHosts(numberOfHosts);
-        tester.setHosted(false);
-        return tester.createModel(servicesXml, true);
+    enum TestMode {
+        self_hosted,
+        hosted
     }
 
-    static VespaModel getHostedModel(String servicesXml) {
-        var numberOfHosts = 2;
+    static VespaModel getModel(String servicesXml, TestMode testMode) {
+        var numberOfHosts = testMode == hosted ? 2 : 1;
         var tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        tester.setHosted(true);
-        tester.setApplicationId(MY_TENANT, MY_APPLICATION, MY_INSTANCE);
+        tester.setHosted(testMode == hosted);
+        if (testMode == hosted) tester.setApplicationId(MY_TENANT, MY_APPLICATION, MY_INSTANCE);
         return tester.createModel(servicesXml, true);
     }
 
@@ -59,17 +59,16 @@ class MetricsProxyModelTester {
     }
 
     static ConsumersConfig.Consumer getCustomConsumer(String servicesXml) {
-        ConsumersConfig config = consumersConfigFromXml(servicesXml);
-        assertEquals(2, config.consumer().size());
+        ConsumersConfig config = consumersConfigFromXml(servicesXml, self_hosted);
         for (ConsumersConfig.Consumer consumer : config.consumer()) {
-            if (! consumer.name().equals(VESPA_CONSUMER_ID))
+            if (! consumer.name().equals(VESPA_CONSUMER_ID) && ! consumer.name().equals(DEFAULT_PUBLIC_CONSUMER_ID))
                 return consumer;
         }
-        throw new RuntimeException("Two consumers with the reserved id - this cannot happen.");
+        throw new RuntimeException("Custom consumer not found!");
     }
 
-    static ConsumersConfig consumersConfigFromXml(String servicesXml) {
-        return consumersConfigFromModel(getModel(servicesXml));
+    static ConsumersConfig consumersConfigFromXml(String servicesXml, TestMode testMode) {
+        return consumersConfigFromModel(getModel(servicesXml, testMode));
     }
 
     static ConsumersConfig consumersConfigFromModel(VespaModel model) {
@@ -89,7 +88,7 @@ class MetricsProxyModelTester {
     }
 
     static VespaServicesConfig getVespaServicesConfig(String servicesXml) {
-        VespaModel model = getModel(servicesXml);
+        VespaModel model = getModel(servicesXml, self_hosted);
         return new VespaServicesConfig((VespaServicesConfig.Builder) model.getConfig(new VespaServicesConfig.Builder(), CONTAINER_CONFIG_ID));
     }
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/VespaMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/VespaMetrics.java
@@ -117,7 +117,8 @@ public class VespaMetrics {
                 .statusCode(health.getStatus().ordinal())  // TODO: MetricsPacket should use StatusCode instead of int
                 .statusMessage(health.getMessage())
                 .putDimensions(service.getDimensions())
-                .putDimension(INSTANCE_DIMENSION_ID, service.getInstanceName());
+                .putDimension(INSTANCE_DIMENSION_ID, service.getInstanceName())
+                .addConsumers(metricsConsumers.getAllConsumers());
     }
 
     /**

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/GenericMetricsHandler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/GenericMetricsHandler.java
@@ -5,6 +5,7 @@
 package ai.vespa.metricsproxy.http;
 
 import ai.vespa.metricsproxy.core.MetricsManager;
+import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
 import ai.vespa.metricsproxy.metric.model.json.JsonRenderingException;
 import ai.vespa.metricsproxy.service.VespaServices;
@@ -20,6 +21,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import static ai.vespa.metricsproxy.metric.model.ConsumerId.toConsumerId;
 import static ai.vespa.metricsproxy.metric.model.json.GenericJsonUtil.toGenericJsonModel;
 
 /**
@@ -28,6 +30,8 @@ import static ai.vespa.metricsproxy.metric.model.json.GenericJsonUtil.toGenericJ
  * @author gjoranv
  */
 public class GenericMetricsHandler extends ThreadedHttpRequestHandler {
+
+    public static final ConsumerId DEFAULT_PUBLIC_CONSUMER_ID = toConsumerId("default-public");
 
     private final MetricsManager metricsManager;
     private final VespaServices vespaServices;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/GenericMetricsHandler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/GenericMetricsHandler.java
@@ -35,7 +35,7 @@ import static ai.vespa.metricsproxy.metric.model.json.GenericJsonUtil.toGenericJ
 public class GenericMetricsHandler extends ThreadedHttpRequestHandler {
     private static final Logger log = Logger.getLogger(GenericMetricsHandler.class.getName());
 
-    public static final ConsumerId DEFAULT_PUBLIC_CONSUMER_ID = toConsumerId("default-public");
+    public static final ConsumerId DEFAULT_PUBLIC_CONSUMER_ID = toConsumerId("default");
 
     private final MetricsConsumers metricsConsumers;
     private final MetricsManager metricsManager;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
@@ -53,6 +53,8 @@ public class ExternalMetrics {
     }
 
     public void setExtraMetrics(List<MetricsPacket.Builder> externalPackets) {
+        // TODO: Metrics filtering per consumer is not yet implemented.
+        //       Split each packet per metric, and re-aggregate based on the metrics each consumer wants. Then filter out all packages with no consumers.
         log.log(DEBUG, () -> "Setting new external metrics with " + externalPackets.size() + " metrics packets.");
         externalPackets.forEach(packet -> {
             packet.addConsumers(consumers.getAllConsumers())

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
@@ -140,6 +140,7 @@ public class MetricsManagerTest {
         service0.setSystemMetrics(oldSystemMetrics);
     }
 
+    // TODO: test that non-whitelisted metrics are filtered out, but this is currently not the case, see ExternalMetrics.setExtraMetrics
     @Test
     public void extra_metrics_packets_containing_whitelisted_metrics_are_added() {
         metricsManager.setExtraMetrics(ImmutableList.of(

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/GenericMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/GenericMetricsHandlerTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.concurrent.Executors;
 
 import static ai.vespa.metricsproxy.core.VespaMetrics.INSTANCE_DIMENSION_ID;
-import static ai.vespa.metricsproxy.core.VespaMetrics.VESPA_CONSUMER_ID;
 import static ai.vespa.metricsproxy.http.GenericMetricsHandler.DEFAULT_PUBLIC_CONSUMER_ID;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static ai.vespa.metricsproxy.metric.model.StatusCode.DOWN;

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/GenericMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/GenericMetricsHandlerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Executors;
 
 import static ai.vespa.metricsproxy.core.VespaMetrics.INSTANCE_DIMENSION_ID;
 import static ai.vespa.metricsproxy.core.VespaMetrics.VESPA_CONSUMER_ID;
+import static ai.vespa.metricsproxy.http.GenericMetricsHandler.DEFAULT_PUBLIC_CONSUMER_ID;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static ai.vespa.metricsproxy.metric.model.StatusCode.DOWN;
 import static ai.vespa.metricsproxy.metric.model.json.JacksonUtil.createObjectMapper;
@@ -64,13 +65,13 @@ public class GenericMetricsHandlerTest {
     private static RequestHandlerTestDriver testDriver;
 
     @BeforeClass
-    public static void setupMetricsManager() {
+    public static void setup() {
         MetricsManager metricsManager = TestUtil.createMetricsManager(vespaServices, getMetricsConsumers(), getApplicationDimensions(), getNodeDimensions());
         metricsManager.setExtraMetrics(ImmutableList.of(
                 new MetricsPacket.Builder(toServiceId("foo"))
                         .timestamp(Instant.now().getEpochSecond())
                         .putMetrics(ImmutableList.of(new Metric(CPU_METRIC, 12.345)))));
-        GenericMetricsHandler handler = new GenericMetricsHandler(Executors.newSingleThreadExecutor(), metricsManager, vespaServices);
+        GenericMetricsHandler handler = new GenericMetricsHandler(Executors.newSingleThreadExecutor(), metricsManager, vespaServices, getMetricsConsumers());
         testDriver = new RequestHandlerTestDriver(handler);
     }
 
@@ -152,7 +153,7 @@ public class GenericMetricsHandlerTest {
 
         return new MetricsConsumers(new ConsumersConfig.Builder()
                                             .consumer(new ConsumersConfig.Consumer.Builder()
-                                                              .name(VESPA_CONSUMER_ID.id)
+                                                              .name(DEFAULT_PUBLIC_CONSUMER_ID.id)
                                                               .metric(new ConsumersConfig.Consumer.Metric.Builder()
                                                                               .name(CPU_METRIC)
                                                                               .outputname(CPU_METRIC))


### PR DESCRIPTION
FYI: @bratseth 

The name and metrics contained in the `default-public` metrics consumer, hereunder the metric set with the same name, are new public apis (names and contents, not the code itself). They are not set in stone yet, so this is just a heads up.

The metric set and consumer names are equal to make it more obvious for users to create a custom consumer with some metrics added along with all metrics given to the default consumer.
```
  <consumer id='my-consumer' />
    <metric-set id='default-public' />
    <metric ... />
```

URL:
`host:19092/metrics/v1/values?consumer=default-public` vs.
`host:19092/metrics/v1/values?consumer=my-consumer`