### PR TITLE
Fix orchestrator exception bug

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerApiImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConfigServerApiImpl.java
@@ -116,7 +116,7 @@ public class ConfigServerApiImpl implements ConfigServerApi {
                 if (configServers.size() == 1) break;
 
                 // Failure to communicate with a config server is not abnormal during upgrades
-                if (HttpConnectionException.isKnownConnectionException(e)) {
+                if (ConnectionException.isKnownConnectionException(e)) {
                     logger.info("Failed to connect to " + configServer + " (upgrading?), will try next: " + e.getMessage());
                 } else {
                     logger.warning("Failed to communicate with " + configServer + ", will try next: " + e.getMessage());
@@ -127,7 +127,7 @@ public class ConfigServerApiImpl implements ConfigServerApi {
         String prefix = configServers.size() == 1 ?
                 "Request against " + configServers.get(0) + " failed: " :
                 "All requests against the config servers (" + configServers + ") failed, last as follows: ";
-        throw HttpConnectionException.handleException(prefix, lastException);
+        throw ConnectionException.handleException(prefix, lastException);
     }
 
     @Override

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConnectionException.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/ConnectionException.java
@@ -12,19 +12,19 @@ import java.net.SocketTimeoutException;
  * @author freva
  */
 @SuppressWarnings("serial")
-public class HttpConnectionException extends ConvergenceException {
+public class ConnectionException extends ConvergenceException {
 
-    private HttpConnectionException(String message) {
+    private ConnectionException(String message) {
         super(message);
     }
 
     /**
-     * Returns {@link HttpConnectionException} if the given Throwable is of a known and well understood error or
+     * Returns {@link ConnectionException} if the given Throwable is of a known and well understood error or
      * a RuntimeException with the given exception as cause otherwise.
      */
     public static RuntimeException handleException(String prefix, Throwable t) {
         if (isKnownConnectionException(t))
-            return new HttpConnectionException(prefix + t.getMessage());
+            return new ConnectionException(prefix + t.getMessage());
 
         return new RuntimeException(prefix, t);
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/HttpConnectionException.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/HttpConnectionException.java
@@ -1,0 +1,43 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.configserver;
+
+import com.yahoo.vespa.hosted.node.admin.nodeadmin.ConvergenceException;
+import org.apache.http.NoHttpResponseException;
+
+import java.io.EOFException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+
+/**
+ * @author freva
+ */
+@SuppressWarnings("serial")
+public class HttpConnectionException extends ConvergenceException {
+
+    private HttpConnectionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Returns {@link HttpConnectionException} if the given Throwable is of a known and well understood error or
+     * a RuntimeException with the given exception as cause otherwise.
+     */
+    public static RuntimeException handleException(String prefix, Throwable t) {
+        if (isKnownConnectionException(t))
+            return new HttpConnectionException(prefix + t.getMessage());
+
+        return new RuntimeException(prefix, t);
+    }
+
+    static boolean isKnownConnectionException(Throwable t) {
+        for (; t != null; t = t.getCause()) {
+            if (t instanceof SocketException ||
+                    t instanceof SocketTimeoutException ||
+                    t instanceof NoHttpResponseException ||
+                    t instanceof EOFException)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/HttpException.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/HttpException.java
@@ -2,12 +2,8 @@
 package com.yahoo.vespa.hosted.node.admin.configserver;
 
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.ConvergenceException;
-import org.apache.http.NoHttpResponseException;
 
 import javax.ws.rs.core.Response;
-import java.io.EOFException;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
 
 /**
  * @author hakonhall
@@ -64,22 +60,6 @@ public class HttpException extends ConvergenceException {
 
         // Other errors like server-side errors are assumed to be retryable.
         throw new HttpException(status, message, true);
-    }
-
-    /**
-     * Returns {@link HttpException} if the given Throwable is of a known and well understood error or
-     * a RuntimeException with the given exception as cause otherwise.
-     */
-    public static RuntimeException handleException(String prefix, Throwable t) {
-        for (; t != null; t = t.getCause()) {
-            if (t instanceof SocketException ||
-                t instanceof SocketTimeoutException ||
-                t instanceof NoHttpResponseException ||
-                t instanceof EOFException)
-                return new HttpException(prefix + t.getMessage());
-        }
-
-        return new RuntimeException(prefix, t);
     }
 
     public static class NotFoundException extends HttpException {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/orchestrator/OrchestratorImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/orchestrator/OrchestratorImpl.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.orchestrator;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
-import com.yahoo.vespa.hosted.node.admin.configserver.HttpConnectionException;
+import com.yahoo.vespa.hosted.node.admin.configserver.ConnectionException;
 import com.yahoo.vespa.hosted.node.admin.configserver.HttpException;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.ConvergenceException;
 import com.yahoo.vespa.orchestrator.restapi.HostApi;
@@ -43,7 +43,7 @@ public class OrchestratorImpl implements Orchestrator {
             throw new OrchestratorNotFoundException("Failed to suspend " + hostName + ", host not found");
         } catch (HttpException e) {
             throw new OrchestratorException("Failed to suspend " + hostName + ": " + e.toString());
-        } catch (HttpConnectionException e) {
+        } catch (ConnectionException e) {
             throw new ConvergenceException("Failed to suspend " + hostName + ": " + e.getMessage());
         } catch (RuntimeException e) {
             throw new RuntimeException("Got error on suspend", e);
@@ -64,7 +64,7 @@ public class OrchestratorImpl implements Orchestrator {
             batchOperationResult = configServerApi.put(url, Optional.empty(), BatchOperationResult.class);
         } catch (HttpException e) {
             throw new OrchestratorException("Failed to batch suspend for " + parentHostName + ": " + e.toString());
-        } catch (HttpConnectionException e) {
+        } catch (ConnectionException e) {
             throw new ConvergenceException("Failed to batch suspend for " + parentHostName + ": " + e.getMessage());
         } catch (RuntimeException e) {
             throw new RuntimeException("Got error on batch suspend for " + parentHostName + ", with nodes " + hostNames, e);
@@ -85,7 +85,7 @@ public class OrchestratorImpl implements Orchestrator {
             throw new OrchestratorNotFoundException("Failed to resume " + hostName + ", host not found");
         } catch (HttpException e) {
             throw new OrchestratorException("Failed to resume " + hostName + ": " + e.toString());
-        } catch (HttpConnectionException e) {
+        } catch (ConnectionException e) {
             throw new ConvergenceException("Failed to resume " + hostName + ": " + e.getMessage());
         } catch (RuntimeException e) {
             throw new RuntimeException("Got error on resume", e);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/orchestrator/OrchestratorImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/orchestrator/OrchestratorImpl.java
@@ -2,7 +2,9 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.orchestrator;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
+import com.yahoo.vespa.hosted.node.admin.configserver.HttpConnectionException;
 import com.yahoo.vespa.hosted.node.admin.configserver.HttpException;
+import com.yahoo.vespa.hosted.node.admin.nodeadmin.ConvergenceException;
 import com.yahoo.vespa.orchestrator.restapi.HostApi;
 import com.yahoo.vespa.orchestrator.restapi.HostSuspensionApi;
 import com.yahoo.vespa.orchestrator.restapi.wire.BatchOperationResult;
@@ -41,6 +43,8 @@ public class OrchestratorImpl implements Orchestrator {
             throw new OrchestratorNotFoundException("Failed to suspend " + hostName + ", host not found");
         } catch (HttpException e) {
             throw new OrchestratorException("Failed to suspend " + hostName + ": " + e.toString());
+        } catch (HttpConnectionException e) {
+            throw new ConvergenceException("Failed to suspend " + hostName + ": " + e.getMessage());
         } catch (RuntimeException e) {
             throw new RuntimeException("Got error on suspend", e);
         }
@@ -60,6 +64,8 @@ public class OrchestratorImpl implements Orchestrator {
             batchOperationResult = configServerApi.put(url, Optional.empty(), BatchOperationResult.class);
         } catch (HttpException e) {
             throw new OrchestratorException("Failed to batch suspend for " + parentHostName + ": " + e.toString());
+        } catch (HttpConnectionException e) {
+            throw new ConvergenceException("Failed to batch suspend for " + parentHostName + ": " + e.getMessage());
         } catch (RuntimeException e) {
             throw new RuntimeException("Got error on batch suspend for " + parentHostName + ", with nodes " + hostNames, e);
         }
@@ -78,7 +84,9 @@ public class OrchestratorImpl implements Orchestrator {
         } catch (HttpException.NotFoundException n) {
             throw new OrchestratorNotFoundException("Failed to resume " + hostName + ", host not found");
         } catch (HttpException e) {
-            throw new OrchestratorException("Failed to suspend " + hostName + ": " + e.toString());
+            throw new OrchestratorException("Failed to resume " + hostName + ": " + e.toString());
+        } catch (HttpConnectionException e) {
+            throw new ConvergenceException("Failed to resume " + hostName + ": " + e.getMessage());
         } catch (RuntimeException e) {
             throw new RuntimeException("Got error on resume", e);
         }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImpl.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.state;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
+import com.yahoo.vespa.hosted.node.admin.configserver.HttpConnectionException;
 import com.yahoo.vespa.hosted.node.admin.configserver.HttpException;
 import com.yahoo.vespa.hosted.node.admin.configserver.state.bindings.HealthResponse;
 
@@ -20,7 +21,7 @@ public class StateImpl implements State {
         try {
             HealthResponse response = configServerApi.get("/state/v1/health", HealthResponse.class);
             return HealthCode.fromString(response.status.code);
-        } catch (HttpException e) {
+        } catch (HttpConnectionException | HttpException e) {
             return HealthCode.DOWN;
         }
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImpl.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.state;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
-import com.yahoo.vespa.hosted.node.admin.configserver.HttpConnectionException;
+import com.yahoo.vespa.hosted.node.admin.configserver.ConnectionException;
 import com.yahoo.vespa.hosted.node.admin.configserver.HttpException;
 import com.yahoo.vespa.hosted.node.admin.configserver.state.bindings.HealthResponse;
 
@@ -21,7 +21,7 @@ public class StateImpl implements State {
         try {
             HealthResponse response = configServerApi.get("/state/v1/health", HealthResponse.class);
             return HealthCode.fromString(response.status.code);
-        } catch (HttpConnectionException | HttpException e) {
+        } catch (ConnectionException | HttpException e) {
             return HealthCode.DOWN;
         }
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImplTest.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.state;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
-import com.yahoo.vespa.hosted.node.admin.configserver.HttpException;
+import com.yahoo.vespa.hosted.node.admin.configserver.HttpConnectionException;
 import com.yahoo.vespa.hosted.node.admin.configserver.state.bindings.HealthResponse;
 import org.junit.Test;
 
@@ -29,7 +29,8 @@ public class StateImplTest {
 
     @Test
     public void connectException() {
-        RuntimeException exception = HttpException.handleException("Error: ", new ConnectException("connection refused"));
+        RuntimeException exception =
+                HttpConnectionException.handleException("Error: ", new ConnectException("connection refused"));
         when(api.get(any(), any())).thenThrow(exception);
 
         HealthCode code = state.getHealth();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/state/StateImplTest.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.configserver.state;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
-import com.yahoo.vespa.hosted.node.admin.configserver.HttpConnectionException;
+import com.yahoo.vespa.hosted.node.admin.configserver.ConnectionException;
 import com.yahoo.vespa.hosted.node.admin.configserver.state.bindings.HealthResponse;
 import org.junit.Test;
 
@@ -30,7 +30,7 @@ public class StateImplTest {
     @Test
     public void connectException() {
         RuntimeException exception =
-                HttpConnectionException.handleException("Error: ", new ConnectException("connection refused"));
+                ConnectionException.handleException("Error: ", new ConnectException("connection refused"));
         when(api.get(any(), any())).thenThrow(exception);
 
         HealthCode code = state.getHealth();


### PR DESCRIPTION
Due to change in #9813 various connection exceptions are now thrown as `HttpException`. `OrchestratorImpl` will rethrow these as `OrchestratorException` which are specially handled in internal code.