### PR TITLE
Prepare nodes before load balancers

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
@@ -30,8 +30,12 @@ public class LoadBalancerServiceMock implements LoadBalancerService {
 
     @Override
     public LoadBalancerInstance create(ApplicationId application, ClusterSpec.Id cluster, Set<Real> reals) {
-        LoadBalancerId id = new LoadBalancerId(application, cluster);
-        LoadBalancerInstance instance = new LoadBalancerInstance(
+        var id = new LoadBalancerId(application, cluster);
+        var oldInstance = instances.get(id);
+        if (oldInstance != null && !oldInstance.reals().isEmpty() && reals.isEmpty()) {
+            throw new IllegalArgumentException("Refusing to remove all reals from load balancer " + id);
+        }
+        var instance = new LoadBalancerInstance(
                 HostName.from("lb-" + application.toShortString() + "-" + cluster.value()),
                 Optional.of(new DnsZone("zone-id-1")),
                 Collections.singleton(4443),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
@@ -38,8 +38,9 @@ class Preparer {
 
     /** Prepare all required resources for the given application and cluster */
     public List<Node> prepare(ApplicationId application, ClusterSpec cluster, NodeSpec requestedNodes, int wantedGroups) {
+        var nodes = prepareNodes(application, cluster, requestedNodes, wantedGroups);
         prepareLoadBalancer(application, cluster, requestedNodes);
-        return prepareNodes(application, cluster, requestedNodes, wantedGroups);
+        return nodes;
     }
 
     /**

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/load-balancers.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/load-balancers.json
@@ -17,7 +17,18 @@
       "ports": [
         4443
       ],
-      "reals": [],
+      "reals": [
+        {
+          "hostname": "host1.yahoo.com",
+          "ipAddress": "127.0.1.1",
+          "port": 4080
+        },
+        {
+          "hostname": "host10.yahoo.com",
+          "ipAddress": "127.0.10.1",
+          "port": 4080
+        }
+      ],
       "rotations": [],
       "inactive": false
     },


### PR DESCRIPTION
In case we're reactivating a inactive load balancer, we need a non-empty set of
nodes when re-configuring (a guard in the `LoadBalancerService` implementation
enforces this).