### PR TITLE
Get available limit from cgroups if set

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -71,6 +71,11 @@ configure_memory() {
             available="$VESPA_TOTAL_MEMORY_MB"
         else
             available=`free -m | grep Mem | tr -s ' ' | cut -f2 -d' '`
+            if [ -x "$(command -v cgget)" ]; then
+                available_cgroup_bytes=$(cgget -nv -r memory.limit_in_bytes /)
+                available_cgroup=$((available_cgroup_bytes >> 20))
+                available=$((available > available_cgroup ? available_cgroup : available))
+            fi
         fi
 
         jvm_heapsize=$((available * jvm_heapSizeAsPercentageOfPhysicalMemory / 100))

--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -71,7 +71,7 @@ configure_memory() {
             available="$VESPA_TOTAL_MEMORY_MB"
         else
             available=`free -m | grep Mem | tr -s ' ' | cut -f2 -d' '`
-            if [ -x "$(command -v cgget)" ]; then
+            if hash cgget 2>/dev/null; then
                 available_cgroup_bytes=$(cgget -nv -r memory.limit_in_bytes /)
                 available_cgroup=$((available_cgroup_bytes >> 20))
                 available=$((available > available_cgroup ? available_cgroup : available))

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -118,6 +118,7 @@ public class DockerOperationsImpl implements DockerOperations {
         if (minMainMemoryAvailableMb > 0) {
             // VESPA_TOTAL_MEMORY_MB is used to make any jdisc container think the machine
             // only has this much physical memory (overrides total memory reported by `free -m`).
+            // TODO: Remove after all tenants are running > 7.67
             command.withEnvironment("VESPA_TOTAL_MEMORY_MB", Long.toString(minMainMemoryAvailableMb));
         }
 


### PR DESCRIPTION
Returns 2^63 if uncapped.

After we get rid of `VESPA_TOTAL_MEMORY_MB`, I think we can change memory in container by just changing cgroup limit and restarting Vespa.