### PR TITLE
Change default endpoint-id to be "default"

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/Endpoint.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/Endpoint.java
@@ -29,6 +29,7 @@ public class Endpoint {
      */
     private static final Pattern endpointPattern = Pattern.compile("^[a-z](?:-?[a-z0-9]+)*$");
     private static final int endpointMaxLength = 12;
+    private static final String defaultEndpointId = "default";
 
     private final Optional<String> endpointId;
     private final String containerId;
@@ -48,7 +49,7 @@ public class Endpoint {
     }
 
     public String endpointId() {
-        return endpointId.orElse(containerId);
+        return endpointId.orElse(defaultEndpointId);
     }
 
     public String containerId() {

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -482,7 +482,7 @@ public class DeploymentSpecTest {
                 "</deployment>");
 
         assertEquals(
-                List.of("foo", "nalle", "quux"),
+                List.of("foo", "nalle", "default"),
                 spec.endpoints().stream().map(Endpoint::endpointId).collect(Collectors.toList())
         );
 
@@ -507,8 +507,8 @@ public class DeploymentSpecTest {
 
     @Test
     public void validEndpoints() {
-        assertEquals(List.of("qrs"), endpointIds("<endpoint container-id='qrs'/>"));
-        assertEquals(List.of("qrs"), endpointIds("<endpoint id='' container-id='qrs'/>"));
+        assertEquals(List.of("default"), endpointIds("<endpoint container-id='qrs'/>"));
+        assertEquals(List.of("default"), endpointIds("<endpoint id='' container-id='qrs'/>"));
         assertEquals(List.of("f"), endpointIds("<endpoint id='f' container-id='qrs'/>"));
         assertEquals(List.of("foo"), endpointIds("<endpoint id='foo' container-id='qrs'/>"));
         assertEquals(List.of("foo-bar"), endpointIds("<endpoint id='foo-bar' container-id='qrs'/>"));


### PR DESCRIPTION
Previously this defaulted to the value of the container-id, but using `default` makes the feature behave more closely to the existing `global-service-id` feature.

Previously you needed to write:
```
  <endpoint endpoint-id="default" container-id="qrs" />
```
to mirror the existing behavior.  Now you can do
```
  <endpoint container-id="qrs" />
```
to get the same behavior.