### PR TITLE
Return true not null by default.

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/ranking/SoftTimeout.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/SoftTimeout.java
@@ -45,7 +45,11 @@ public class SoftTimeout implements Cloneable {
         this.enabled = enable;
     }
 
-    public Boolean getEnable() { return enabled; }
+    /** Returns whether softtimeout is enabled. Defauyt is true. */
+    public Boolean getEnable() {
+        if (enabled == null) return Boolean.TRUE;
+        return enabled;
+    }
 
     /** Override the adaptive factor determined on the content nodes */
     public void setFactor(double factor) {

--- a/container-search/src/test/java/com/yahoo/search/query/SoftTimeoutTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/SoftTimeoutTestCase.java
@@ -13,7 +13,7 @@ public class SoftTimeoutTestCase {
     @Test
     public void testDefaultsInQuery() {
         Query query=new Query("?query=test");
-        assertNull(query.getRanking().getSoftTimeout().getEnable());
+        assertTrue(query.getRanking().getSoftTimeout().getEnable());
         assertNull(query.getRanking().getSoftTimeout().getFactor());
         assertNull(query.getRanking().getSoftTimeout().getTailcost());
     }
@@ -21,7 +21,7 @@ public class SoftTimeoutTestCase {
     @Test
     public void testQueryOverride() {
         Query query=new Query("?query=test&ranking.softtimeout.factor=0.7&ranking.softtimeout.tailcost=0.3");
-        assertNull(query.getRanking().getSoftTimeout().getEnable());
+        assertTrue(query.getRanking().getSoftTimeout().getEnable());
         assertEquals(Double.valueOf(0.7), query.getRanking().getSoftTimeout().getFactor());
         assertEquals(Double.valueOf(0.3), query.getRanking().getSoftTimeout().getTailcost());
         query.prepare();


### PR DESCRIPTION
@baldersheim I think we should say what'll actually happen by default and that it is not useful to know whether this is overridden.

In an overly strict sense this is an API change, but I think it's fine as this class don't even document what it would return. 

Ideally we should do this for the other values too, and document in the API doc what softtimeout means.