### PR TITLE
Add support for upgrades of values in maps.

### DIFF
--- a/docproc/src/main/java/com/yahoo/docproc/AbstractConcreteDocumentFactory.java
+++ b/docproc/src/main/java/com/yahoo/docproc/AbstractConcreteDocumentFactory.java
@@ -10,6 +10,7 @@ import com.yahoo.document.Field;
 import com.yahoo.document.annotation.Annotation;
 import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.datatypes.MapFieldValue;
 import com.yahoo.document.datatypes.Struct;
 import com.yahoo.document.datatypes.StructuredFieldValue;
 
@@ -56,11 +57,16 @@ public abstract class AbstractConcreteDocumentFactory extends com.yahoo.componen
         } else if (fv instanceof Array) {
             Array<FieldValue> array = (Array<FieldValue>) fv;
             DataType nestedType = array.getDataType().getNestedType();
-            for (int i=0; i < array.size(); i++) {
-                array.set(i, optionallyUpgrade(nestedType, array.get(i)));
+            if (nestedType.getPrimitiveType() == null) {
+                array.replaceAll((item) -> optionallyUpgrade(nestedType, item));
+            }
+        } else if (fv instanceof MapFieldValue) {
+            MapFieldValue<FieldValue, FieldValue> map = (MapFieldValue<FieldValue, FieldValue>) fv;
+            DataType valueTypeType = map.getDataType().getValueType();
+            if (valueTypeType.getPrimitiveType() == null) {
+                map.replaceAll((key, value) -> optionallyUpgrade(valueTypeType, value));
             }
         }
-        // TODO We also need specialhandling for weighted set/map. Limiting to array until verified.
         return fv;
     }
 }

--- a/documentgen-test/src/test/java/com/yahoo/vespa/config/DocumentGenPluginTest.java
+++ b/documentgen-test/src/test/java/com/yahoo/vespa/config/DocumentGenPluginTest.java
@@ -316,9 +316,7 @@ public class DocumentGenPluginTest {
         verifyArrayOfStruct(toBook(copyBySerialization(book)));
     }
 
-    @Test
-    public void testMaps() {
-        Book book = getBook();
+    private void verifyMaps(Book book) {
         assertTrue(book.getField("stringmap").getDataType() instanceof MapDataType);
         MapFieldValue mfv = (MapFieldValue) book.getFieldValue("stringmap");
         assertEquals(mfv.get(new StringFieldValue("Melville")), new StringFieldValue("Moby Dick"));
@@ -328,12 +326,21 @@ public class DocumentGenPluginTest {
         assertEquals(mfv.keySet().size(), 2);
         book.getStringmap().put("Melville", "MD");
         assertEquals(mfv.keySet().size(), 3);
+        book.getStringmap().put("Melville", "Moby Dick");
+        assertEquals(mfv.keySet().size(), 3);
 
         assertEquals(book.getStructmap().get(50).getS1(), "test s1");
         MapFieldValue mfv2 = (MapFieldValue) book.getFieldValue("structmap");
         Struct fifty = (Struct)(mfv2.get(new IntegerFieldValue(50)));
         assertEquals(fifty.getFieldValue("s1").getWrappedValue(), "test s1");
         assertEquals(((Ss1)mfv2.get(new IntegerFieldValue(50))).getS1(), "test s1");
+    }
+
+    @Test
+    public void testMaps() {
+        Book book = getBook();
+        verifyMaps(book);
+        verifyMaps(toBook(copyBySerialization(book)));
     }
 
     @Test


### PR DESCRIPTION
Since keys in maps and weighted sets must be primitives we should be complete here.

@bratseth PR This should make upgrades complete.
