### PR TITLE
Dynamic provisioning internal redeploy

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
@@ -5,10 +5,12 @@ import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
+import com.yahoo.config.provision.TransientException;
 import com.yahoo.log.LogLevel;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.yolean.Exceptions;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -88,6 +90,8 @@ public abstract class ApplicationMaintainer extends Maintainer {
             if ( ! deployment.isPresent()) return; // this will be done at another config server
             log.log(LogLevel.DEBUG, this.getClass().getSimpleName() + " deploying " + application);
             deployment.get().activate();
+        } catch (TransientException e) {
+            log.log(LogLevel.INFO, "Failed to redeploy " + application + " with a transient error: " + Exceptions.toMessageString(e));
         } catch (RuntimeException e) {
             log.log(LogLevel.WARNING, "Exception on maintenance redeploy", e);
         } finally {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -65,7 +65,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
 
         nodeFailer = new NodeFailer(deployer, hostLivenessTracker, serviceMonitor, nodeRepository, durationFromEnv("fail_grace").orElse(defaults.failGrace), clock, orchestrator, throttlePolicyFromEnv().orElse(defaults.throttlePolicy), metric);
         periodicApplicationMaintainer = new PeriodicApplicationMaintainer(deployer, nodeRepository, defaults.redeployMaintainerInterval, durationFromEnv("periodic_redeploy_interval").orElse(defaults.periodicRedeployInterval));
-        operatorChangeApplicationMaintainer = new OperatorChangeApplicationMaintainer(deployer, nodeRepository, clock, durationFromEnv("operator_change_redeploy_interval").orElse(defaults.operatorChangeRedeployInterval));
+        operatorChangeApplicationMaintainer = new OperatorChangeApplicationMaintainer(deployer, nodeRepository, durationFromEnv("operator_change_redeploy_interval").orElse(defaults.operatorChangeRedeployInterval));
         reservationExpirer = new ReservationExpirer(nodeRepository, clock, durationFromEnv("reservation_expiry").orElse(defaults.reservationExpiry));
         retiredExpirer = new RetiredExpirer(nodeRepository, orchestrator, deployer, clock, durationFromEnv("retired_interval").orElse(defaults.retiredInterval), durationFromEnv("retired_expiry").orElse(defaults.retiredExpiry));
         inactiveExpirer = new InactiveExpirer(nodeRepository, clock, durationFromEnv("inactive_expiry").orElse(defaults.inactiveExpiry));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
@@ -4,12 +4,15 @@ package com.yahoo.vespa.hosted.provision.maintenance;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
+import com.yahoo.config.provision.TransientException;
+import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.orchestrator.OrchestrationException;
 import com.yahoo.vespa.orchestrator.Orchestrator;
+import com.yahoo.yolean.Exceptions;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -73,6 +76,9 @@ public class RetiredExpirer extends Maintainer {
 
                 String nodeList = nodesToRemove.stream().map(Node::hostname).collect(Collectors.joining(", "));
                 log.info("Redeployed " + application + " to deactivate retired nodes: " +  nodeList);
+            } catch (TransientException e) {
+                log.log(LogLevel.INFO, "Failed to redeploy " + application +
+                        " with a transient error, will be retried by application maintainer: " + Exceptions.toMessageString(e));
             } catch (RuntimeException e) {
                 String nodeList = retiredNodes.stream().map(Node::hostname).collect(Collectors.joining(", "));
                 log.log(Level.WARNING, "Exception trying to deactivate retired nodes from " + application

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -312,11 +312,6 @@ public class PeriodicApplicationMaintainerTest {
                     : super.nodesNeedingMaintenance();
         }
 
-        @Override
-        protected boolean shouldBeDeployedOnThisServer(ApplicationId application) {
-            return true;
-        }
-
     }
 
 }


### PR DESCRIPTION
This should fix most of the issues with VESPA-15754.

This PR simplifies/makes `ApplicationMaintainer` tests more accurate by using `MockDeployer` to perform application activation (thereby always setting last deploy time). This makes it possible to simplify the actual maintainers by always using last deploy time, f.ex. in `OperatorChangeApplicationMaintainer`. This should also fix a minor bug where an operator has performed a change, but the redeployment failed - in that case it would not be retried until `PeriodicApplicationMaintainer` picked it up.

The rest is just logging a nicer stack trace on transient errors.

What's not covered in this PR (and possibly that ticket):
1. `PeriodicApplicationMaintainer` is still too infrequent (30m), which makes it quite likely that it will not redeploy until the initial `reserved` nodes are expired.
2. `ApplicationMaintainer`s redeployment interval can be further delayed if there are some big applications being redeployed before it in the queue (VESPA-15694).

I don't see an easy fix for either of these, and fixing these is related to several other issues. For example, if all config servers could redeploy an application (VESPA-12393, VESPA-14176 and VESPA-15671): 
1. We could remove `OperatorChangeApplicationMaintainer` entirely and just do the redeployment as part of the state transition
2. `PeriodicApplicationMaintainer` could be made more frequent