### PR TITLE
round -> ceil to avoid premature timeout

### DIFF
--- a/fnet/src/vespa/fnet/scheduler.cpp
+++ b/fnet/src/vespa/fnet/scheduler.cpp
@@ -3,6 +3,7 @@
 #include "scheduler.h"
 #include "task.h"
 #include <sstream>
+#include <cmath>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".fnet.scheduler");
@@ -68,7 +69,7 @@ FNET_Scheduler::~FNET_Scheduler()
 void
 FNET_Scheduler::Schedule(FNET_Task *task, double seconds)
 {
-    uint32_t ticks = 1 + (uint32_t) (seconds * (1000 / SLOT_TICK) + 0.5);
+    uint32_t ticks = 1 + (uint32_t) std::ceil(seconds * (1000.0 / SLOT_TICK));
 
     std::lock_guard<std::mutex> guard(_lock);
     if (!task->_killed) {

--- a/jrt/src/com/yahoo/jrt/Scheduler.java
+++ b/jrt/src/com/yahoo/jrt/Scheduler.java
@@ -61,7 +61,7 @@ class Scheduler {
         if (seconds < 0.0) {
             throw new IllegalArgumentException("cannot schedule a Task in the past");
         }
-        int ticks = 1 + (int) (seconds * 10.0 + 0.5);
+        int ticks = 1 + (int) Math.ceil(seconds * (1000.0 / TICK));
         if (isActive(task)) {
             linkOut(task);
         }


### PR DESCRIPTION
in the cases where the timeout is not divisible by the tick size.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review