### PR TITLE
only equal types can be assigned

### DIFF
--- a/document/src/vespa/document/datatype/tensor_data_type.cpp
+++ b/document/src/vespa/document/datatype/tensor_data_type.cpp
@@ -58,22 +58,10 @@ TensorDataType::isAssignableType(const ValueType &tensorType) const
 bool
 TensorDataType::isAssignableType(const ValueType &fieldTensorType, const ValueType &tensorType)
 {
-    const auto &dimensions = fieldTensorType.dimensions();
-    const auto &rhsDimensions = tensorType.dimensions();
-    if (!tensorType.is_tensor() || dimensions.size() != rhsDimensions.size()) {
+    if (fieldTensorType.is_error()) {
         return false;
     }
-    for (size_t i = 0; i < dimensions.size(); ++i) {
-        const auto &dim = dimensions[i];
-        const auto &rhsDim = rhsDimensions[i];
-        if ((dim.name != rhsDim.name) ||
-            (dim.is_indexed() != rhsDim.is_indexed()) ||
-            (rhsDim.is_indexed() && !rhsDim.is_bound()) || 
-            (dim.is_bound() && (dim.size != rhsDim.size))) {
-            return false;
-        }
-    }
-    return true;
+    return (fieldTensorType == tensorType);
 }
 
 } // document


### PR DESCRIPTION
error type fields can not be assigned to

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review