### PR TITLE
Shade all vespa-hadoop dependencies

### DIFF
--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -126,16 +126,54 @@
                         </goals>
                         <configuration>
                             <minimizeJar>false</minimizeJar>
+
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache.http</pattern>
-                                    <shadedPattern>com.yahoo.vespa.feeder.shaded.internal.apache.http</shadedPattern>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.commons</pattern>
-                                    <shadedPattern>com.yahoo.vespa.feeder.shaded.internal.apache.commons</shadedPattern>
+                                    <pattern>commons-codec</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>commons-logging</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.apache.hadoop.**</exclude>
+                                        <exclude>org.apache.pig.**</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.airlift</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc.wstx</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>edu.umd.cs</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jcip.annotations</pattern>
+                                    <shadedPattern>shaded.vespa</shadedPattern>
                                 </relocation>
                             </relocations>
+
                         </configuration>
                     </execution>
                 </executions>

--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -164,14 +164,6 @@
                                     <pattern>com.ctc.wstx</pattern>
                                     <shadedPattern>shaded.vespa</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>edu.umd.cs</pattern>
-                                    <shadedPattern>shaded.vespa</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.jcip.annotations</pattern>
-                                    <shadedPattern>shaded.vespa</shadedPattern>
-                                </relocation>
                             </relocations>
 
                         </configuration>


### PR DESCRIPTION
@gjoranv or @bjorncs Please review.

Fairly cumbersome to list each dependency and transitive dependency. The following alternative also works. Preference?

```
<relocations>
    <relocation>
        <shadedPattern>shaded.internal.</shadedPattern>
        <excludes>
            <exclude>com.yahoo.**</exclude>
            <exclude>org.apache.hadoop.**</exclude>
            <exclude>org.apache.pig.**</exclude>
            <exclude>java.**</exclude>
        </excludes>
    </relocation>
</relocations>
```