### PR TITLE
Bratseth/dont wait

### DIFF
--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
@@ -13,13 +13,9 @@ import java.util.concurrent.TimeUnit;
  */
 public final class FeedParams {
 
-    public boolean getDenyIfBusyV3() {
-        return denyIfBusyV3;
-    }
+    public boolean getDenyIfBusyV3() { return denyIfBusyV3; }
 
-    public long getMaxSleepTimeMs() {
-        return maxSleepTimeMs;
-    }
+    public long getMaxSleepTimeMs() { return maxSleepTimeMs; }
 
     public boolean getSilentUpgrade() { return silentUpgrade; }
 
@@ -36,6 +32,7 @@ public final class FeedParams {
      * Mutable class used to instantiate a {@link FeedParams}.
      */
     public static final class Builder {
+
         private DataFormat dataFormat = DataFormat.JSON_UTF8;
         private long serverTimeout = TimeUnit.SECONDS.toMillis(180);
         private long clientTimeout = TimeUnit.SECONDS.toMillis(20);
@@ -57,7 +54,7 @@ public final class FeedParams {
          * @return this, for chaining
          */
         @Beta
-        public Builder withSilentUpgrade(boolean silentUpgrade) {
+        public Builder setSilentUpgrade(boolean silentUpgrade) {
             this.silentUpgrade = silentUpgrade;
             return this;
         }
@@ -165,6 +162,7 @@ public final class FeedParams {
 
         /**
          * Sets the maximum number of operations to be in-flight.
+         *
          * @param maxInFlightRequests max number of operations.
          * @return this, for chaining
          */
@@ -246,10 +244,13 @@ public final class FeedParams {
             return maxChunkSizeBytes;
         }
 
-        public int getmaxInFlightRequests() {
+        public int getMaxInFlightRequests() {
             return maxInFlightRequests;
         }
+
     }
+
+    // NOTE! See toBuilder at the end of this class if you add fields here
 
     private final DataFormat dataFormat;
     private final long serverTimeoutMillis;
@@ -262,7 +263,6 @@ public final class FeedParams {
     private final boolean denyIfBusyV3;
     private final long maxSleepTimeMs;
     private final boolean silentUpgrade;
-
 
     private FeedParams(DataFormat dataFormat, long serverTimeout, long clientTimeout, String route,
                        int maxChunkSizeBytes, final int maxInFlightRequests,
@@ -317,6 +317,22 @@ public final class FeedParams {
 
     public long getLocalQueueTimeOut() {
         return localQueueTimeOut;
+    }
+
+    /** Returns a builder initialized to the values of this */
+    public FeedParams.Builder toBuilder() {
+        Builder b = new Builder();
+        b.setDataFormat(dataFormat);
+        b.setServerTimeout(serverTimeoutMillis, TimeUnit.MILLISECONDS);
+        b.setClientTimeout(clientTimeoutMillis, TimeUnit.MILLISECONDS);
+        b.setRoute(route);
+        b.setMaxChunkSizeBytes(maxChunkSizeBytes);
+        b.setMaxInFlightRequests(maxInFlightRequests);
+        b.setPriority(priority);
+        b.setDenyIfBusyV3(denyIfBusyV3);
+        b.setMaxSleepTimeMs(maxSleepTimeMs);
+        b.setSilentUpgrade(silentUpgrade);
+        return b;
     }
 
 }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/SessionParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/SessionParams.java
@@ -133,6 +133,8 @@ public final class SessionParams {
         }
     }
 
+    // NOTE! See toBuilder at the end of this class if you add fields here
+
     private final List<Cluster> clusters;
     private final FeedParams feedParams;
     private final ConnectionParams connectionParams;
@@ -177,6 +179,17 @@ public final class SessionParams {
 
     public ErrorReporter getErrorReport() {
         return errorReport;
+    }
+
+    public Builder toBuilder() {
+        Builder b = new Builder();
+        clusters.forEach(c -> b.addCluster(c));
+        b.setFeedParams(feedParams);
+        b.setConnectionParams(connectionParams);
+        b.setClientQueueSize(clientQueueSize);
+        b.setErrorReporter(errorReport);
+        b.setThrottlerMinSize(throttlerMinSize);
+        return b;
     }
 
 }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
@@ -70,16 +70,15 @@ public class ClusterConnection implements AutoCloseable {
                 if (documentQueue == null) {
                     documentQueue = new DocumentQueue(clientQueueSizePerCluster);
                 }
-                IOThread ioThread = new IOThread(
-                        operationProcessor.getIoThreadGroup(),
-                        endpointResultQueue,
-                        gatewayConnection,
-                        clusterId,
-                        feedParams.getMaxChunkSizeBytes(),
-                        maxInFlightPerSession,
-                        feedParams.getLocalQueueTimeOut(),
-                        documentQueue,
-                        feedParams.getMaxSleepTimeMs());
+                IOThread ioThread = new IOThread(operationProcessor.getIoThreadGroup(),
+                                                 endpointResultQueue,
+                                                 gatewayConnection,
+                                                 clusterId,
+                                                 feedParams.getMaxChunkSizeBytes(),
+                                                 maxInFlightPerSession,
+                                                 feedParams.getLocalQueueTimeOut(),
+                                                 documentQueue,
+                                                 feedParams.getMaxSleepTimeMs());
                 ioThreads.add(ioThread);
             }
         }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Class for handling asynchronous feeding of new documents and processing of results.
+ * Thread which feeds document operations asynchronously and processes the results.
  * 
  * @author Einar M R Rosenvinge
  */
@@ -56,16 +56,15 @@ class IOThread implements Runnable, AutoCloseable {
     private final AtomicInteger successfullHandshakes = new AtomicInteger(0);
     private final AtomicInteger lastGatewayProcessTimeMillis = new AtomicInteger(0);
 
-    IOThread(
-            ThreadGroup ioThreadGroup,
-            EndpointResultQueue endpointResultQueue,
-            GatewayConnection client,
-            int clusterId,
-            int maxChunkSizeBytes,
-            int maxInFlightRequests,
-            long localQueueTimeOut,
-            DocumentQueue documentQueue,
-            long maxSleepTimeMs) {
+    IOThread(ThreadGroup ioThreadGroup,
+             EndpointResultQueue endpointResultQueue,
+             GatewayConnection client,
+             int clusterId,
+             int maxChunkSizeBytes,
+             int maxInFlightRequests,
+             long localQueueTimeOut,
+             DocumentQueue documentQueue,
+             long maxSleepTimeMs) {
         this.documentQueue = documentQueue;
         this.endpoint = client.getEndpoint();
         this.client = client;
@@ -85,27 +84,26 @@ class IOThread implements Runnable, AutoCloseable {
         return endpoint;
     }
 
-    public static class ConnectionStats {
-        public final int wrongSessionDetectedCounter;
-        public final int wrongVersionDetectedCounter;
-        public final int problemStatusCodeFromServerCounter;
-        public final int executeProblemsCounter;
-        public final int docsReceivedCounter;
-        public final int statusReceivedCounter;
-        public final int pendingDocumentStatusCount;
-        public final int successfullHandshakes;
-        public final int lastGatewayProcessTimeMillis;
+    static class ConnectionStats {
+        final int wrongSessionDetectedCounter;
+        final int wrongVersionDetectedCounter;
+        final int problemStatusCodeFromServerCounter;
+        final int executeProblemsCounter;
+        final int docsReceivedCounter;
+        final int statusReceivedCounter;
+        final int pendingDocumentStatusCount;
+        final int successfullHandshakes;
+        final int lastGatewayProcessTimeMillis;
 
-        protected ConnectionStats(
-                final int wrongSessionDetectedCounter,
-                final int wrongVersionDetectedCounter,
-                final int problemStatusCodeFromServerCounter,
-                final int executeProblemsCounter,
-                final int docsReceivedCounter,
-                final int statusReceivedCounter,
-                final int pendingDocumentStatusCount,
-                final int successfullHandshakes,
-                final int lastGatewayProcessTimeMillis) {
+        ConnectionStats(int wrongSessionDetectedCounter,
+                        int wrongVersionDetectedCounter,
+                        int problemStatusCodeFromServerCounter,
+                        int executeProblemsCounter,
+                        int docsReceivedCounter,
+                        int statusReceivedCounter,
+                        int pendingDocumentStatusCount,
+                        int successfullHandshakes,
+                        int lastGatewayProcessTimeMillis) {
             this.wrongSessionDetectedCounter = wrongSessionDetectedCounter;
             this.wrongVersionDetectedCounter = wrongVersionDetectedCounter;
             this.problemStatusCodeFromServerCounter = problemStatusCodeFromServerCounter;
@@ -137,9 +135,7 @@ class IOThread implements Runnable, AutoCloseable {
     @Override
     public void close() {
         documentQueue.close();
-        if (stopSignal.getCount() == 0) {
-            return;
-        }
+        if (stopSignal.getCount() == 0) return;
 
         stopSignal.countDown();
         log.finer("Closed called.");
@@ -166,8 +162,7 @@ class IOThread implements Runnable, AutoCloseable {
         log.fine("Session to " + endpoint + " closed.");
     }
 
-
-    public void post(final Document document) throws InterruptedException {
+    public void post(Document document) throws InterruptedException {
         documentQueue.put(document, Thread.currentThread().getThreadGroup() == ioThreadGroup);
     }
 
@@ -178,7 +173,7 @@ class IOThread implements Runnable, AutoCloseable {
 
 
     List<Document> getNextDocsForFeeding(int maxWaitUnits, TimeUnit timeUnit) {
-        final List<Document> docsForSendChunk = new ArrayList<>();
+        List<Document> docsForSendChunk = new ArrayList<>();
         int chunkSizeBytes = 0;
         try {
             drainFirstDocumentsInQueueIfOld();
@@ -214,8 +209,7 @@ class IOThread implements Runnable, AutoCloseable {
         }
     }
 
-    private void markDocumentAsFailed(
-            List<Document> docs, ServerResponseException servletException) {
+    private void markDocumentAsFailed(List<Document> docs, ServerResponseException servletException) {
         for (Document doc : docs) {
             resultQueue.failOperation(
                     EndPointResultFactory.createTransientError(
@@ -223,8 +217,7 @@ class IOThread implements Runnable, AutoCloseable {
         }
     }
 
-    private InputStream sendAndReceive(List<Document> docs)
-            throws IOException, ServerResponseException {
+    private InputStream sendAndReceive(List<Document> docs) throws IOException, ServerResponseException {
         try {
             // Post the new docs and get async responses for other posts.
             return client.writeOperations(docs);
@@ -238,17 +231,19 @@ class IOThread implements Runnable, AutoCloseable {
     }
 
     private static class ProcessResponse {
+
         private final int transitiveErrorCount;
         private final int processResultsCount;
+
         ProcessResponse(int transitiveErrorCount, int processResultsCount) {
             this.transitiveErrorCount = transitiveErrorCount;
             this.processResultsCount = processResultsCount;
         }
+
     }
 
     private ProcessResponse processResponse(InputStream serverResponse) throws IOException {
-        final Collection<EndpointResult> endpointResults =
-                EndPointResultFactory.createResult(endpoint, serverResponse);
+        Collection<EndpointResult> endpointResults = EndPointResultFactory.createResult(endpoint, serverResponse);
         statusReceivedCounter.addAndGet(endpointResults.size());
         int transientErrors = 0;
         for (EndpointResult endpointResult : endpointResults) {
@@ -271,9 +266,8 @@ class IOThread implements Runnable, AutoCloseable {
         return processResponse;
     }
 
-    private ProcessResponse pullAndProcessData(int maxWaitTimeMilliSecs)
-            throws ServerResponseException, IOException {
-        final int pendingResultQueueSize = resultQueue.getPendingSize();
+    private ProcessResponse pullAndProcessData(int maxWaitTimeMilliSecs) throws ServerResponseException, IOException {
+        int pendingResultQueueSize = resultQueue.getPendingSize();
         pendingDocumentStatusCount.set(pendingResultQueueSize);
 
         List<Document> nextDocsForFeeding = (pendingResultQueueSize > maxInFlightRequests)
@@ -387,9 +381,8 @@ class IOThread implements Runnable, AutoCloseable {
     private void drainFirstDocumentsInQueueIfOld() {
         while (true) {
             Optional<Document> document = documentQueue.pollDocumentIfTimedoutInQueue(localQueueTimeOut);
-            if (! document.isPresent()) {
-                return;
-            }
+            if ( ! document.isPresent()) return;
+
             EndpointResult endpointResult = EndPointResultFactory.createTransientError(
                     endpoint, document.get().getOperationId(),
                     new Exception("Not sending document operation, timed out in queue after "

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
@@ -84,16 +84,19 @@ class IOThread implements Runnable, AutoCloseable {
         return endpoint;
     }
 
-    static class ConnectionStats {
-        final int wrongSessionDetectedCounter;
-        final int wrongVersionDetectedCounter;
-        final int problemStatusCodeFromServerCounter;
-        final int executeProblemsCounter;
-        final int docsReceivedCounter;
-        final int statusReceivedCounter;
-        final int pendingDocumentStatusCount;
-        final int successfullHandshakes;
-        final int lastGatewayProcessTimeMillis;
+    public static class ConnectionStats {
+
+        // NOTE: These fields are accessed by reflection in JSON serialization
+
+        public final int wrongSessionDetectedCounter;
+        public final int wrongVersionDetectedCounter;
+        public final int problemStatusCodeFromServerCounter;
+        public final int executeProblemsCounter;
+        public final int docsReceivedCounter;
+        public final int statusReceivedCounter;
+        public final int pendingDocumentStatusCount;
+        public final int successfullHandshakes;
+        public final int lastGatewayProcessTimeMillis;
 
         ConnectionStats(int wrongSessionDetectedCounter,
                         int wrongVersionDetectedCounter,

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
@@ -252,7 +252,6 @@ public class OperationProcessor {
     }
 
     private void sendToClusters(Document document) {
-
         synchronized (monitor) {
             boolean traceThisDoc = traceEveryXOperation > 0 && traceCounter++ % traceEveryXOperation == 0;
             docSendInfoByOperationId.put(document.getOperationId(), new DocumentSendInfo(document, traceThisDoc));

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/operationProcessor/OperationProcessor.java
@@ -56,41 +56,34 @@ public class OperationProcessor {
     private final ThreadGroup ioThreadGroup;
     private final String clientId = new BigInteger(130, random).toString(32);
 
-    public OperationProcessor(
-            IncompleteResultsThrottler incompleteResultsThrottler,
-            FeedClient.ResultCallback resultCallback,
-            SessionParams sessionParams,
-            ScheduledThreadPoolExecutor timeoutExecutor) {
+    public OperationProcessor(IncompleteResultsThrottler incompleteResultsThrottler,
+                              FeedClient.ResultCallback resultCallback,
+                              SessionParams sessionParams,
+                              ScheduledThreadPoolExecutor timeoutExecutor) {
         this.numDestinations = sessionParams.getClusters().size();
         this.resultCallback = resultCallback;
         this.incompleteResultsThrottler = incompleteResultsThrottler;
         this.timeoutExecutor = timeoutExecutor;
         this.ioThreadGroup = new ThreadGroup("operationprocessor");
 
-        if (sessionParams.getClusters().isEmpty()) {
+        if (sessionParams.getClusters().isEmpty())
             throw new IllegalArgumentException("Cannot feed to 0 clusters.");
-        }
 
         for (Cluster cluster : sessionParams.getClusters()) {
-            if (cluster.getEndpoints().isEmpty()) {
+            if (cluster.getEndpoints().isEmpty())
                 throw new IllegalArgumentException("Cannot feed to empty cluster.");
-            }
         }
 
         for (int i = 0; i < sessionParams.getClusters().size(); i++) {
             Cluster cluster = sessionParams.getClusters().get(i);
-
-            clusters.add(new ClusterConnection(
-                    this,
-                    sessionParams.getFeedParams(),
-                    sessionParams.getConnectionParams(),
-                    sessionParams.getErrorReport(),
-                    cluster,
-                    i,
-                    sessionParams.getClientQueueSize() / sessionParams.getClusters().size(),
-                    timeoutExecutor));
-
-            }
+            clusters.add(new ClusterConnection(this,
+                                               sessionParams.getFeedParams(),
+                                               sessionParams.getConnectionParams(),
+                                               cluster,
+                                               i,
+                                               sessionParams.getClientQueueSize() / sessionParams.getClusters().size(),
+                                               timeoutExecutor));
+        }
         operationStats = new OperationStats(sessionParams, clusters, incompleteResultsThrottler);
         maxRetries = sessionParams.getConnectionParams().getMaxRetries();
         minTimeBetweenRetriesMs = sessionParams.getConnectionParams().getMinTimeBetweenRetriesMs();
@@ -122,21 +115,16 @@ public class OperationProcessor {
     }
 
     private boolean retriedThis(EndpointResult endpointResult, DocumentSendInfo documentSendInfo, int clusterId) {
-        final Result.Detail detail = endpointResult.getDetail();
-        // If success, no retries to do.
-        if (detail.getResultType() == Result.ResultType.OPERATION_EXECUTED) {
-            return false;
-        }
+        Result.Detail detail = endpointResult.getDetail();
+        if (detail.getResultType() == Result.ResultType.OPERATION_EXECUTED) return false; // Success: No retries
 
         int retries = documentSendInfo.incRetries(clusterId, detail);
-        if (retries > maxRetries) {
-            return false;
-        }
+        if (retries > maxRetries) return false;
 
         String exceptionMessage = detail.getException() == null ? "" : detail.getException().getMessage();
-        if (exceptionMessage == null) {
+        if (exceptionMessage == null)
             exceptionMessage = "";
-        }
+
         // TODO: Return proper error code in structured data in next version of internal API.
         // Error codes from messagebus/src/cpp/messagebus/errorcode.h
         boolean retryThisOperation =
@@ -151,12 +139,10 @@ public class OperationProcessor {
 
         if (retryThisOperation) {
             int waitTime = (int) (minTimeBetweenRetriesMs * (1 + random.nextDouble() / 3));
-            log.finest("Retrying due to " + detail.toString() + " attempt " + retries
-                    + " in " + waitTime + " ms.");
-            timeoutExecutor.schedule(
-                    () -> postToCluster(clusters.get(clusterId), documentSendInfo.getDocument()),
-                    waitTime,
-                    TimeUnit.MILLISECONDS);
+            log.finest("Retrying due to " + detail.toString() + " attempt " + retries + " in " + waitTime + " ms.");
+            timeoutExecutor.schedule(() -> postToCluster(clusters.get(clusterId), documentSendInfo.getDocument()),
+                                     waitTime,
+                                     TimeUnit.MILLISECONDS);
             return true;
         }
 
@@ -173,28 +159,20 @@ public class OperationProcessor {
             }
             DocumentSendInfo documentSendInfo = docSendInfoByOperationId.get(endpointResult.getOperationId());
 
-            if (retriedThis(endpointResult, documentSendInfo, clusterId)) {
-                return null;
-            }
+            if (retriedThis(endpointResult, documentSendInfo, clusterId)) return null;
 
-            if (!documentSendInfo.addIfNotAlreadyThere(endpointResult.getDetail(), clusterId)) {
-                // Duplicate message, we have seen this operation before.
-                return null;
-            }
+            // Duplicate message
+            if ( ! documentSendInfo.addIfNotAlreadyThere(endpointResult.getDetail(), clusterId)) return null;
 
             // Is this the last operation we are waiting for?
-            if (documentSendInfo.detailCount() != numDestinations) {
-                return null;
-            }
+            if (documentSendInfo.detailCount() != numDestinations) return null;
 
             result = documentSendInfo.createResult();
             docSendInfoByOperationId.remove(endpointResult.getOperationId());
 
             String documentId = documentSendInfo.getDocument().getDocumentId();
-            /**
-             * If we got a pending operation against this document
-             * dont't remove it from inflightDocuments and send blocked document operation
-             */
+            // If we got a pending operation against this document
+            // dont't remove it from inflightDocuments and send blocked document operation
             List<Document> blockedDocuments = blockedDocumentsByDocumentId.get(documentId);
             if (blockedDocuments.isEmpty()) {
                 inflightDocumentIds.remove(documentId);
@@ -210,7 +188,6 @@ public class OperationProcessor {
 
     public void resultReceived(EndpointResult endpointResult, int clusterId) {
         Result result = process(endpointResult, clusterId);
-
         if (result != null) {
             incompleteResultsThrottler.resultReady(result.isSuccess());
             resultCallback.onCompletion(result.getDocumentId(), result);
@@ -318,4 +295,5 @@ public class OperationProcessor {
             throw new RuntimeException("Did not manage to shut down retry threads. Please report problem.");
         }
     }
+
 }

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/FeedClientTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/FeedClientTest.java
@@ -55,6 +55,7 @@ public class FeedClientTest {
         feedClient.stream(DOCID, "blob");
         while (resultsReceived.get() == 0) {Thread.sleep(3); }
         String stats = feedClient.getStatsAsJson();
+        System.out.println("Stats: "+ stats);
         assertTrue(stats.contains("\"dryRun\":true"));
         feedClient.close();
     }

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/FeedClientTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/FeedClientTest.java
@@ -55,7 +55,6 @@ public class FeedClientTest {
         feedClient.stream(DOCID, "blob");
         while (resultsReceived.get() == 0) {Thread.sleep(3); }
         String stats = feedClient.getStatsAsJson();
-        System.out.println("Stats: "+ stats);
         assertTrue(stats.contains("\"dryRun\":true"));
         feedClient.close();
     }

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/SyncFeedClientTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/SyncFeedClientTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.http.client;
 import com.yahoo.vespa.http.client.config.Cluster;
 import com.yahoo.vespa.http.client.config.ConnectionParams;
 import com.yahoo.vespa.http.client.config.Endpoint;
+import com.yahoo.vespa.http.client.config.FeedParams;
 import com.yahoo.vespa.http.client.config.SessionParams;
 import org.junit.Test;
 
@@ -35,7 +36,6 @@ public class SyncFeedClientTest {
                                                                            .build())
                                               .build();
         SyncFeedClient feedClient = new SyncFeedClient(sessionParams);
-
 
         assertFeedSuccessful(feedClient);
         assertFeedSuccessful(feedClient); // ensure the client can be reused

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/communication/IOThreadTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/communication/IOThreadTest.java
@@ -162,7 +162,7 @@ public class IOThreadTest {
 
     @Test
     public void requireThatEndpointConnectExceptionsArePropagated()
-        throws IOException, ServerResponseException, InterruptedException, TimeoutException, ExecutionException {
+            throws IOException, ServerResponseException, InterruptedException, TimeoutException, ExecutionException {
         when(apacheGatewayConnection.connect()).thenReturn(true);
         String errorMessage = "generic error message";
         IOException cause = new IOException(errorMessage);


### PR DESCRIPTION
@vekterli please review

The IO thread both sends documents and handles responses.
At the start of each cycle it would wait for at most 100 ms for incoming documents before progressing to handling responses. This cause the min time of a cycle to be 100 ms. This is usually ok, but not when the client uses the sync API and is both latency and throughput sensitive (depending on whether it writes few or many documents, in the same code path). 

I don't see a good reason to wait 100 ms so this PR just lowers this to 1 ms at line 338 in IOThread.

I initially thought I needed to do something more complicated so there are more changes here but no other changes to functionality.