### PR TITLE
Remove feature flag for new metrics-proxy.

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -57,8 +57,6 @@ public interface ModelContext {
         boolean useFdispatchByDefault();
         boolean dispatchWithProtobuf();
         boolean useAdaptiveDispatch();
-        // TODO: Remove when 7.61 is the oldest model in use
-        default boolean enableMetricsProxyContainer() { return false; }
         // TODO: Remove temporary default implementation
         default Optional<TlsSecrets> tlsSecrets() { return Optional.empty(); }
     }


### PR DESCRIPTION
- Oldest vespa in hosted is now 7.67

