### PR TITLE
Ensure that NGramExpression can be executed multiple times, where spa…

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NGramExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NGramExpression.java
@@ -48,6 +48,10 @@ public final class NGramExpression extends Expression {
     @Override
     protected void doExecute(ExecutionContext ctx) {
         StringFieldValue input = (StringFieldValue)ctx.getValue();
+        if (input.getSpanTree(SpanTrees.LINGUISTICS) != null) {
+            // This expression is already executed for this input instance
+            return;
+        }
         SpanList spanList = input.setSpanTree(new SpanTree(SpanTrees.LINGUISTICS)).spanList();
         int lastPosition = 0;
         for (Iterator<GramSplitter.Gram> it = linguistics.getGramSplitter().split(input.getString(), gramSize); it.hasNext();) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/NGramTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/NGramTestCase.java
@@ -77,6 +77,22 @@ public class NGramTestCase {
         assertFalse(i.hasNext());
     }
 
+    @Test
+    public void requireThatExecuteCanBeCalledMultipleTimes() {
+        ExecutionContext context = new ExecutionContext(new SimpleTestAdapter());
+        context.setValue(new StringFieldValue("some random text string"));
+        NGramExpression expression = new NGramExpression(new SimpleLinguistics(), 3);
+
+        expression.execute(context);
+        SpanTree firstTree = ((StringFieldValue)context.getValue()).getSpanTree(SpanTrees.LINGUISTICS);
+        assertNotNull(firstTree);
+
+        expression.execute(context);
+        SpanTree secondTree = ((StringFieldValue)context.getValue()).getSpanTree(SpanTrees.LINGUISTICS);
+        // The span tree instance should be the same.
+        assertEquals(firstTree, secondTree);
+    }
+
     private void assertSpan(int from, int length, boolean gram, Iterator<SpanNode> i, SpanTree tree) {
         assertSpan(from, length, gram, i, tree, null);
     }


### PR DESCRIPTION
…n tree from first execution is used.

This can happen when we have multiple UpdateAdapters (e.g. regular updates + field path updates)
and then all scripts are executed per adapter in Expression.execute().

@arnej27959 please review
