### PR TITLE
Stop replacing service/application id from setExtraMetrics packets

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
@@ -35,11 +35,12 @@ import static java.util.stream.Collectors.toCollection;
 public class ExternalMetrics {
     private static final Logger log = Logger.getLogger(ExternalMetrics.class.getName());
 
+    // NOTE: node service id must be kept in sync with the same constant _value_ used in docker-api:Metrics.java
+    public static final ServiceId VESPA_NODE_SERVICE_ID = toServiceId("vespa.node");
+
     public static final DimensionId ROLE_DIMENSION = toDimensionId("role");
     public static final DimensionId STATE_DIMENSION = toDimensionId("state");
     public static final DimensionId ORCHESTRATOR_STATE_DIMENSION = toDimensionId("orchestratorState");
-
-    public static final ServiceId VESPA_NODE_SERVICE_ID = toServiceId("vespa.node");
 
     private volatile List<MetricsPacket.Builder> metrics = new ArrayList<>();
     private final MetricsConsumers consumers;
@@ -58,7 +59,6 @@ public class ExternalMetrics {
         log.log(DEBUG, () -> "Setting new external metrics with " + externalPackets.size() + " metrics packets.");
         externalPackets.forEach(packet -> {
             packet.addConsumers(consumers.getAllConsumers())
-                    .service(VESPA_NODE_SERVICE_ID)
                     .retainMetrics(metricsToRetain())
                     .applyOutputNames(outputNamesById());
         });

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
@@ -15,6 +15,7 @@ import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
+import ai.vespa.metricsproxy.metric.model.ServiceId;
 import ai.vespa.metricsproxy.service.DownService;
 import ai.vespa.metricsproxy.service.DummyService;
 import ai.vespa.metricsproxy.service.VespaService;
@@ -38,6 +39,7 @@ import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -159,6 +161,21 @@ public class MetricsManagerTest {
 
         List<MetricsPacket> packets = metricsManager.getMetrics(testServices, Instant.EPOCH);
         assertThat(packets.size(), is(2));
+    }
+
+    @Test
+    public void application_from_extra_metrics_packets_is_used_as_service_in_result_packets() {
+        final ServiceId serviceId = toServiceId("custom-service");
+        metricsManager.setExtraMetrics(ImmutableList.of(
+                new MetricsPacket.Builder(serviceId)
+                        .putMetrics(ImmutableList.of(new Metric(WHITELISTED_METRIC_ID, 0)))));
+
+        List<MetricsPacket> packets = metricsManager.getMetrics(testServices, Instant.EPOCH);
+        MetricsPacket extraPacket = null;
+        for (MetricsPacket packet : packets) {
+            if (packet.service.equals(serviceId)) extraPacket = packet;
+        }
+        assertNotNull(extraPacket);
     }
 
     @Test

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/GenericMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/GenericMetricsHandlerTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 
 import static ai.vespa.metricsproxy.core.VespaMetrics.INSTANCE_DIMENSION_ID;
 import static ai.vespa.metricsproxy.http.GenericMetricsHandler.DEFAULT_PUBLIC_CONSUMER_ID;
+import static ai.vespa.metricsproxy.metric.ExternalMetrics.VESPA_NODE_SERVICE_ID;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static ai.vespa.metricsproxy.metric.model.StatusCode.DOWN;
 import static ai.vespa.metricsproxy.metric.model.json.JacksonUtil.createObjectMapper;
@@ -74,7 +75,7 @@ public class GenericMetricsHandlerTest {
     public static void setup() {
         MetricsManager metricsManager = TestUtil.createMetricsManager(vespaServices, getMetricsConsumers(), getApplicationDimensions(), getNodeDimensions());
         metricsManager.setExtraMetrics(ImmutableList.of(
-                new MetricsPacket.Builder(toServiceId("foo"))
+                new MetricsPacket.Builder(VESPA_NODE_SERVICE_ID)
                         .timestamp(Instant.now().getEpochSecond())
                         .putMetrics(ImmutableList.of(new Metric(CPU_METRIC, 12.345)))));
         GenericMetricsHandler handler = new GenericMetricsHandler(Executors.newSingleThreadExecutor(), metricsManager, vespaServices, getMetricsConsumers());

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/ExternalMetricsTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/ExternalMetricsTest.java
@@ -8,6 +8,7 @@ import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
+import ai.vespa.metricsproxy.metric.model.ServiceId;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
@@ -38,15 +39,17 @@ public class ExternalMetricsTest {
     }
 
     @Test
-    public void service_id_is_set_to_vespa_node_id() {
+    public void service_id_from_extra_packets_is_not_replaced() {
+        final ServiceId SERVICE_ID = toServiceId("do-not-replace");
+
         MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
         ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
         externalMetrics.setExtraMetrics(ImmutableList.of(
-                new MetricsPacket.Builder(toServiceId("replace_with_vespa_node_id"))));
+                new MetricsPacket.Builder(SERVICE_ID)));
 
         List<MetricsPacket.Builder> packets = externalMetrics.getMetrics();
         assertEquals(1, packets.size());
-        assertEquals(VESPA_NODE_SERVICE_ID, packets.get(0).build().service);
+        assertEquals(SERVICE_ID, packets.get(0).build().service);
     }
 
     @Test


### PR DESCRIPTION
I should have done the test refactoring in a separate commit, but it was unfortunately too late.

