### PR TITLE
Revert "Bjorncs/tls vespa deploy"

### DIFF
--- a/config-model/src/main/perl/vespa-deploy
+++ b/config-model/src/main/perl/vespa-deploy
@@ -87,7 +87,7 @@ readConfFile();
 use strict;
 use warnings;
 use feature qw(switch say);
-use vars qw/ $opt_c $opt_h $opt_n $opt_v $opt_f $opt_t $opt_a $opt_e $opt_E $opt_r $opt_i $opt_p $opt_H $opt_R $opt_F $opt_V /;
+use vars qw/ $opt_c $opt_h $opt_n $opt_v $opt_f $opt_t $opt_a $opt_e $opt_E $opt_r $opt_i $opt_p $opt_z $opt_H $opt_R $opt_F $opt_V /;
 use Env qw($HOME);
 use JSON;
 use Getopt::Std;
@@ -101,6 +101,9 @@ my $configsource_url_used_file = "$cloudconfig_dir/deploy-configsource-url-used"
 
 
 my $pathPrefix;
+my $siaPath;
+my $siaCertsPath;
+my $siaKeysPath;
 my $tenant = "default";
 my $application = "default";
 my $environment = "prod";
@@ -109,7 +112,8 @@ my $instance = "default";
 my $version = "v2";
 my $configserver = "";
 my $port = "19071";
-getopts('c:fhnt:ve:E:r:a:i:p:HR:F:V:');
+my $cert = "";
+getopts('c:fhnt:ve:E:r:a:i:p:z:HR:F:V:');
 
 if ($opt_h) {
   usage();
@@ -144,7 +148,17 @@ if ($opt_p) {
   $port = $opt_p;
 }
 
+if ($opt_z) {
+  $cert = $opt_z;
+}
+
 $pathPrefix = "/application/v2/tenant/$tenant/session";
+
+$siaPath = "/var/lib/sia/";
+
+$siaCertsPath = $siaPath . "certs/";
+
+$siaKeysPath = $siaPath . "keys/";
 
 create_cloudconfig_dir();
 
@@ -153,7 +167,10 @@ $session_id_file = "$cloudconfig_dir/$tenant/deploy-session-id";
 my $command = shift;
 $command ||= "help";
 
-my $curl_command = $VESPA_HOME . '/libexec/vespa/vespa-curl-wrapper -A vespa-deploy --silent --show-error --connect-timeout 30 --max-time 1200';
+my $curl_command = 'curl -A vespa-deploy --silent --show-error --connect-timeout 30 --max-time 1200';
+if ($cert) {
+    $curl_command = $curl_command . " -k --cert " . $siaCertsPath .  $cert . ".cert.pem --key " . $siaKeysPath . $cert . ".key.pem ";
+}
 
 my $CURL_PUT = $curl_command . ' --write-out \%{http_code} --request PUT';
 my $CURL_GET = $curl_command . ' --request GET';
@@ -247,6 +264,8 @@ sub usage {
     print "    '-t <timeout>' (timeout in seconds)\n";
     print "    '-c <server>' (config server hostname)\n";
     print "    '-p <port>' (config server http port)\n";
+    print "    '-z <cert>' (cert/key name)\n\n";
+
 
     print "Try 'vespa-deploy help <command>' to get more help\n";
   }
@@ -328,7 +347,11 @@ sub get_configsource_url {
 
   my @configsources;
   if ($configserver and $configserver ne "") {
-      @configsources = ('http://' . $configserver . ':' . $port . '/');
+      if ($cert and $cert ne "") {
+          @configsources = ('https://' . $configserver . ':' . $port . '/');
+      } else {
+          @configsources = ('http://' . $configserver . ':' . $port . '/');
+      }
   } else {
       @configsources = split(' ', `$VESPA_HOME/bin/vespa-print-default configservers_http`);
   }

--- a/security-tools/src/main/java/com/yahoo/vespa/security/tool/securityenv/Main.java
+++ b/security-tools/src/main/java/com/yahoo/vespa/security/tool/securityenv/Main.java
@@ -51,15 +51,17 @@ public class Main {
 
             Map<OutputVariable, String> outputVariables = new TreeMap<>();
             Optional<TransportSecurityOptions> options = TransportSecurityUtils.getOptions(envVars);
-            MixedMode mixedMode = TransportSecurityUtils.getInsecureMixedMode(envVars);
-            if (options.isPresent() && mixedMode != MixedMode.PLAINTEXT_CLIENT_MIXED_SERVER) {
+            if (options.isPresent()) {
                 outputVariables.put(OutputVariable.TLS_ENABLED, "1");
                 options.get().getCaCertificatesFile()
                         .ifPresent(caCertFile -> outputVariables.put(OutputVariable.CA_CERTIFICATE, caCertFile.toString()));
-                options.get().getCertificatesFile()
-                        .ifPresent(certificateFile -> outputVariables.put(OutputVariable.CERTIFICATE, certificateFile.toString()));
-                options.get().getPrivateKeyFile()
-                        .ifPresent(privateKeyFile -> outputVariables.put(OutputVariable.PRIVATE_KEY, privateKeyFile.toString()));
+                MixedMode mixedMode = TransportSecurityUtils.getInsecureMixedMode(envVars);
+                if (mixedMode != MixedMode.PLAINTEXT_CLIENT_MIXED_SERVER) {
+                    options.get().getCertificatesFile()
+                            .ifPresent(certificateFile -> outputVariables.put(OutputVariable.CERTIFICATE, certificateFile.toString()));
+                    options.get().getPrivateKeyFile()
+                            .ifPresent(privateKeyFile -> outputVariables.put(OutputVariable.PRIVATE_KEY, privateKeyFile.toString()));
+                }
             }
             shell.writeOutputVariables(stdOut, outputVariables);
             EnumSet<OutputVariable> unusedVariables = outputVariables.isEmpty()

--- a/security-tools/src/main/sh/vespa-curl-wrapper
+++ b/security-tools/src/main/sh/vespa-curl-wrapper
@@ -6,23 +6,26 @@
 
 set -e
 
-eval $(vespa-security-env)
+. $(vespa-security-env)
 
-CURL_PARAMETERS=("$@")
+CURL_PARAMETERS=$1
+CONFIGSERVER_URI_WITHOUT_SCHEME=$2
 
 if [ -n "${VESPA_TLS_ENABLED}" ]
 then
-  CURL_PARAMETERS=("${CURL_PARAMETERS[@]/http:/https:}")
+  CONFIGSERVER_URI="https://${CONFIGSERVER_URI_WITHOUT_SCHEME}"
+else
+  CONFIGSERVER_URI="http://${CONFIGSERVER_URI_WITHOUT_SCHEME}"
 fi
 
 if [ -n "${VESPA_TLS_CA_CERT}" ]
 then
-  CURL_PARAMETERS=("--cacert" "${VESPA_TLS_CA_CERT}" "${CURL_PARAMETERS[@]}")
+  CURL_PARAMETERS="--cacert \"${VESPA_TLS_CA_CERT}\" ${CURL_PARAMETERS}"
 fi
 
 if [[ -n "${VESPA_TLS_CERT}" && -n "${VESPA_TLS_PRIVATE_KEY}" ]]
 then
-  CURL_PARAMETERS=("--cert" "${VESPA_TLS_CERT}" "--key" "${VESPA_TLS_PRIVATE_KEY}" "${CURL_PARAMETERS[@]}")
+  CURL_PARAMETERS="--cert \"${VESPA_TLS_CERT}\" --key \"${VESPA_TLS_PRIVATE_KEY}\" ${CURL_PARAMETERS}"
 fi
 
-curl "${CURL_PARAMETERS[@]}"
+curl ${CURL_PARAMETERS} "${CONFIGSERVER_URI}"


### PR DESCRIPTION
Reverts vespa-engine/vespa#9973

All system tests fail with `curl: (60) Peer certificate cannot be authenticated with known CA certificates` when vespa-deploy is called