### PR TITLE
Clean up mount paths 2

### DIFF
--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -135,7 +135,7 @@ vespa-run-as-vespa-user ${VESPA_HOME}/libexec/vespa/start-logd
 
 appdir="${VESPA_HOME}/conf/configserver-app"
 pidfile="${VESPA_HOME}/var/run/configserver.pid"
-cfpfile="${VESPA_HOME}/var/jdisc_core/configserver.properties"
+cfpfile="${VESPA_HOME}/var/jdisc_container/configserver.properties"
 bundlecachedir="${VESPA_HOME}/var/vespa/bundlecache/configserver"
 
 export JAVAVM_LD_PRELOAD=

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -285,11 +285,8 @@ public class DockerOperationsImpl implements DockerOperations {
                 context.pathInNodeUnderVespaHome("var/db/vespa"),
                 context.pathInNodeUnderVespaHome("var/jdisc_container"),
                 context.pathInNodeUnderVespaHome("var/mediasearch"), // TODO: Remove when Vespa 6 is gone
-                context.pathInNodeUnderVespaHome("var/run"), // TODO: Remove? Only contains .pid files
-                context.pathInNodeUnderVespaHome("var/service"), // TODO: Remove? Contains 1 link to unmounted directory
                 context.pathInNodeUnderVespaHome("var/vespa"),
                 context.pathInNodeUnderVespaHome("var/yca"),
-                context.pathInNodeUnderVespaHome("var/yinst/tmp"), // TODO: Remove? Used during start up, then cleared
                 context.pathInNodeUnderVespaHome("var/zookeeper") // Tenant content nodes, config server and controller
         ));
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -283,6 +283,7 @@ public class DockerOperationsImpl implements DockerOperations {
                 context.pathInNodeUnderVespaHome("var/crash"), // core dumps
                 context.pathInNodeUnderVespaHome("var/container-data"),
                 context.pathInNodeUnderVespaHome("var/db/vespa"),
+                context.pathInNodeUnderVespaHome("var/jdisc_container"),
                 context.pathInNodeUnderVespaHome("var/mediasearch"), // TODO: Remove when Vespa 6 is gone
                 context.pathInNodeUnderVespaHome("var/run"), // TODO: Remove? Only contains .pid files
                 context.pathInNodeUnderVespaHome("var/service"), // TODO: Remove? Contains 1 link to unmounted directory
@@ -297,13 +298,6 @@ public class DockerOperationsImpl implements DockerOperations {
             paths.add(context.pathInNodeUnderVespaHome("var/vespa-hosted/routing"));
         } else if (context.nodeType() == NodeType.tenant)
             paths.add(varLibSia);
-
-        if (isInfrastructureHost(context.nodeType())) {
-            // configserver/src/main/sh/start-configserver, standalone-container/src/main/sh/standalone-container.sh
-            paths.add(context.pathInNodeUnderVespaHome("var/jdisc_core"));
-        } else {
-            paths.add(context.pathInNodeUnderVespaHome("var/jdisc_container")); // container-disc/src/main/sh/vespa-start-container-daemon.sh
-        }
 
         paths.forEach(path -> command.withVolume(context.pathOnHostFromPathInNode(path), path));
 

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -122,7 +122,7 @@ StartCommand() {
 
     # stuff for the process:
     local appdir="$VESPA_HOME/conf/$service-app"
-    local cfpfile="$VESPA_HOME/var/jdisc_core/$service.properties"
+    local cfpfile="$VESPA_HOME/var/jdisc_container/$service.properties"
     local bundlecachedir="$VESPA_HOME/var/vespa/bundlecache/$service"
 
     cd "$VESPA_HOME" || Fail "Cannot cd to $VESPA_HOME"

--- a/vespabase/src/rhel-prestart.sh
+++ b/vespabase/src/rhel-prestart.sh
@@ -111,7 +111,7 @@ fixdir ${VESPA_USER} wheel  755  var/db/vespa/filedistribution
 fixdir ${VESPA_USER} wheel  755  var/db/vespa/index
 fixdir ${VESPA_USER} wheel  755  var/db/vespa/logcontrol
 fixdir ${VESPA_USER} wheel  755  var/db/vespa/search
-fixdir ${VESPA_USER} wheel  755  var/jdisc_core
+fixdir ${VESPA_USER} wheel  755  var/jdisc_container
 fixdir ${VESPA_USER} wheel  755  var/vespa
 fixdir ${VESPA_USER} wheel  755  var/vespa/application
 fixdir ${VESPA_USER} wheel  755  var/vespa/bundlecache


### PR DESCRIPTION
Continuation of #9990 
* Always use `$VESPA_HOME/var/jdisc_container` rather than `$VESPA_HOME/var/jdisc_core` for standalone and `$VESPA_HOME/var/jdisc_container` for rest.
* Remove other unneeded mounts

Will merge after #9990 has been released.