### PR TITLE
Add rest endpoint for metering data 

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
@@ -76,7 +76,8 @@ enum PathGroup {
                     "/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/logs",
                     "/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/suspended",
                     "/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/service/{*}",
-                    "/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/global-rotation/{*}"),
+                    "/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/global-rotation/{*}",
+                    "/application/v4/tenant/{tenant}/application/{application}/metering"),
 
     /** Path used to restart development nodes. */
     developmentRestart(Matcher.tenant,

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -773,7 +773,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         return new SlimeJsonResponse(slime);
     }
 
-    HttpResponse metering(String tenant, String application, HttpRequest request) {
+    private HttpResponse metering(String tenant, String application, HttpRequest request) {
         Slime slime = new Slime();
         Cursor root = slime.setObject();
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -176,6 +176,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}")) return application(path.get("tenant"), path.get("application"), "default", request);
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/deploying")) return deploying(path.get("tenant"), path.get("application"), "default", request);
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/deploying/pin")) return deploying(path.get("tenant"), path.get("application"), "default", request);
+        if (path.matches("/application/v4/tenant/{tenant}/application/{application}/metering")) return metering(path.get("tenant"), path.get("application"), request);
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/nodes")) return nodes(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"));
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/logs")) return logs(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"), request.propertyMap());
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance")) return applications(path.get("tenant"), Optional.of(path.get("application")), request);
@@ -769,6 +770,45 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         Slime slime = new Slime();
         Cursor response = slime.setObject();
         toSlime(application.rotationStatus(deployment), response);
+        return new SlimeJsonResponse(slime);
+    }
+
+    HttpResponse metering(String tenant, String application, HttpRequest request) {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+
+        Cursor currentRate = root.setObject("currentrate");
+        currentRate.setDouble("cpu", 0);
+        currentRate.setDouble("mem", 0);
+        currentRate.setDouble("disk", 0);
+
+        Cursor thismonth = root.setObject("thismonth");
+        thismonth.setDouble("cpu", 0);
+        thismonth.setDouble("mem", 0);
+        thismonth.setDouble("disk", 0);
+
+        Cursor lastmonth = root.setObject("lastmonth");
+        lastmonth.setDouble("cpu", 0);
+        lastmonth.setDouble("mem", 0);
+        lastmonth.setDouble("disk", 0);
+
+        Cursor details = root.setObject("details");
+
+        Cursor detailsCpu = details.setObject("cpu");
+        Cursor detailsCpuDummyApp = detailsCpu.setObject("dummy");
+        Cursor detailsCpuDummyData = detailsCpuDummyApp.setArray("data");
+
+        // The data array should be filled with objects like: { unixms: <number>, valur: <number }
+
+        Cursor detailsMem = details.setObject("mem");
+        Cursor detailsMemDummyApp = detailsMem.setObject("dummy");
+        Cursor detailsMemDummyData = detailsMemDummyApp.setArray("data");
+
+        Cursor detailsDisk = details.setObject("disk");
+        Cursor detailsDiskDummyApp = detailsDisk.setObject("dummy");
+        Cursor detailsDiskDummyData = detailsDiskDummyApp.setArray("data");
+
+
         return new SlimeJsonResponse(slime);
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -857,7 +857,6 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               new File("application-without-change-multiple-deployments.json"));
     }
 
-
     @Test
     public void  testMeteringResponses() {
         tester.assertResponse(request("/application/v4/tenant/doesnotexist/application/doesnotexist/metering", GET)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -860,7 +860,6 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
     @Test
     public void  testMeteringResponses() {
-        // TODO - why does this request (for a tenant and application that does not exist) go through?
         tester.assertResponse(request("/application/v4/tenant/doesnotexist/application/doesnotexist/metering", GET)
                                       .userIdentity(USER_ID)
                                       .oktaAccessToken(OKTA_AT),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -856,7 +856,17 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                       .userIdentity(USER_ID),
                               new File("application-without-change-multiple-deployments.json"));
     }
-    
+
+
+    @Test
+    public void  testMeteringResponses() {
+        // TODO - why does this request (for a tenant and application that does not exist) go through?
+        tester.assertResponse(request("/application/v4/tenant/doesnotexist/application/doesnotexist/metering", GET)
+                                      .userIdentity(USER_ID)
+                                      .oktaAccessToken(OKTA_AT),
+                              new File("application1-metering.json"));
+    }
+
     @Test
     public void testErrorResponses() throws Exception {
         tester.computeVersionStatus();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-metering.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application1-metering.json
@@ -1,0 +1,34 @@
+{
+  "currentrate": {
+    "cpu": 0.0,
+    "mem": 0.0,
+    "disk": 0.0
+  },
+  "thismonth": {
+    "cpu": 0.0,
+    "mem": 0.0,
+    "disk": 0.0
+  },
+  "lastmonth": {
+    "cpu": 0.0,
+    "mem": 0.0,
+    "disk": 0.0
+  },
+  "details": {
+    "cpu": {
+      "dummy": {
+        "data": []
+      }
+    },
+    "mem": {
+      "dummy": {
+        "data": []
+      }
+    },
+    "disk": {
+      "dummy": {
+        "data": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
The data is a 0 response with a dummy entry and should be replaced by metering data at a later stage. 

The new api url /application/v4/tenant/mytenant/application/myapplication/metering is not included in the parent response yet. 