### PR TITLE
Do not log missing container stats error

### DIFF
--- a/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImplTest.java
+++ b/docker-api/src/test/java/com/yahoo/vespa/hosted/dockerapi/DockerImplTest.java
@@ -37,7 +37,7 @@ public class DockerImplTest {
 
     private final DockerClient dockerClient = mock(DockerClient.class);
     private final Metrics metrics = new Metrics();
-    private final DockerImpl docker = new DockerImpl(dockerClient, metrics);
+    private final DockerImpl docker = new DockerImpl(dockerClient, c -> null, metrics);
 
     @Test
     public void testExecuteCompletes() {


### PR DESCRIPTION
Recently did some refactoring that had the side effect of always asking docker daemon for container stats instead of relying on some internal state that could tell if container definitely was not running. In some cases this caused 404s with ugly stack traces in host-admin log, they are coming from `docker-java`: https://github.com/docker-java/docker-java/blob/f6a2d49767022447e63dda31676fd5fd1cedd8f6/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java#L54

I tried to override the log level for that class, but still ended up with other stack trace due to closing of the stream. This PR creates a new hack to avoid having streaming in the first place.

Quick summary of the original problem:
Docker stats command, by default, is streaming stats: https://docs.docker.com/engine/api/v1.26/#operation/ContainerStats, we can get a one-off if we use `stream=false`. `docker-api` does not support setting `stream`, so what we did up until now was to start the stream, then close it on the first frame. This PR introduces a hack that bypasses most of `docker-java` and issues a non-streaming request directly. 