### PR TITLE
Remove VESPA_TOTAL_MEMORY_MB

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -109,15 +109,6 @@ public class DockerOperationsImpl implements DockerOperations {
 
         addMounts(context, command);
 
-        // TODO: Enforce disk constraints
-        long minMainMemoryAvailableMb = (long) (context.node().memoryGb() * 1024);
-        if (minMainMemoryAvailableMb > 0) {
-            // VESPA_TOTAL_MEMORY_MB is used to make any jdisc container think the machine
-            // only has this much physical memory (overrides total memory reported by `free -m`).
-            // TODO: Remove after all tenants are running > 7.67
-            command.withEnvironment("VESPA_TOTAL_MEMORY_MB", Long.toString(minMainMemoryAvailableMb));
-        }
-
         logger.info("Creating new container with args: " + command);
         command.create();
     }


### PR DESCRIPTION
This shouldn't be needed since #9879, except for Vespa 6 nodes (see `vespa/hosted#8080`).

With this, we can update container memory limit with a simple Vespa restart rather than entire container restart.