### PR TITLE
Guard critical cluster state version ZK writes with an atomic CaS

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/CasWriteFailed.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/CasWriteFailed.java
@@ -1,0 +1,23 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core.database;
+
+/**
+ * Exception used to signal that a write intended to overwrite a value previously
+ * read encountered an underlying version conflict during an atomic compare-and-swap
+ * operation. This generally means that another node has written to the value since
+ * we last read it, and that the information we hold may be stale.
+ *
+ * Upon receiving such an exception, the caller should no longer assume it holds
+ * up-to-date information and should drop and roles that build on top of such an
+ * assumption (such as leadership sessions).
+ */
+public class CasWriteFailed extends RuntimeException {
+
+    public CasWriteFailed(String message) {
+        super(message);
+    }
+
+    public CasWriteFailed(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/Database.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/Database.java
@@ -46,7 +46,12 @@ public abstract class Database {
      * store the version in the database, such that if another fleetcontroller takes over as master it will use a
      * higher version system state.
      *
+     * Precondition: retrieveLatestSystemStateVersion() MUST have been called at least once prior to calling
+     *               this method.
+     *
      * @return True if request succeeded. False if not.
+     * @throws CasWriteFailed if the expected version of the znode did not match what was actually stored in the DB.
+     *                        In this case, the write has NOT been applied.
      */
     public abstract boolean storeLatestSystemStateVersion(int version) throws InterruptedException;
 
@@ -84,6 +89,17 @@ public abstract class Database {
      */
     public abstract Map<Node, Long> retrieveStartTimestamps() throws InterruptedException;
 
+    /**
+     * Stores the last published cluster state bundle synchronously into ZooKeeper.
+     *
+     * Precondition: retrieveLastPublishedStateBundle() MUST have been called at least once prior to calling
+     *               this method.
+     *
+     * @return true if the write is known to have been successful, false otherwise. If false is returned, the
+     *         write may or may not have taken place.
+     * @throws CasWriteFailed if the expected version of the znode did not match what was actually stored in the DB.
+     *                        In this case, the write has NOT been applied.
+     */
     public abstract boolean storeLastPublishedStateBundle(ClusterStateBundle stateBundle) throws InterruptedException;
 
     public abstract ClusterStateBundle retrieveLastPublishedStateBundle() throws InterruptedException;


### PR DESCRIPTION
@geirst please review

Lets a controller discover that another controller also believes it is
the leader by tracking the expected znode versions for cluster state
version and bundle znodes.

If a CaS failure is triggered, the controller will drop its database
and election state, forcing a state refresh.
