### PR TITLE
Gjoranv/bundle plugin improvements

### DIFF
--- a/bundle-plugin-test/src/test/java/com/yahoo/BundleIT.java
+++ b/bundle-plugin-test/src/test/java/com/yahoo/BundleIT.java
@@ -18,6 +18,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
+import static com.yahoo.osgi.maven.ProjectBundleClassPaths.CLASSPATH_MAPPINGS_FILENAME;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -143,9 +144,9 @@ public class BundleIT {
     @SuppressWarnings("unchecked")
     @Test
     public void bundle_class_path_mappings_are_generated() throws URISyntaxException, IOException {
-        URL mappingsUrl = getClass().getResource("/" + com.yahoo.osgi.maven.ProjectBundleClassPaths.CLASSPATH_MAPPINGS_FILENAME);
+        URL mappingsUrl = getClass().getResource("/" + CLASSPATH_MAPPINGS_FILENAME);
         assertNotNull(
-                "Could not find " + ProjectBundleClassPaths.CLASSPATH_MAPPINGS_FILENAME + " in the test output directory",
+                "Could not find " + CLASSPATH_MAPPINGS_FILENAME + " in the test output directory",
                 mappingsUrl);
 
         ProjectBundleClassPaths bundleClassPaths = ProjectBundleClassPaths.load(Paths.get(mappingsUrl.toURI()));

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
@@ -26,10 +27,18 @@ public class AnalyzeBundle {
         public final List<Export> exports;
         public final List<String> globals;
 
-        public PublicPackages(List<Export> exports, List<String> globals) {
+        PublicPackages(List<Export> exports, List<String> globals) {
             this.exports = exports;
             this.globals = globals;
         }
+
+        public Set<String> exportedPackageNames() {
+            return exports.stream()
+                    .map(Export::getPackageNames)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+        }
+
     }
 
     public static PublicPackages publicPackagesAggregated(Collection<File> jarFiles) {

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
@@ -15,6 +15,9 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 /**
+ * "Public package" in this context means a package that is either exported or declared as "Global-Package"
+ * in a bundle's manifest.
+ *
  * @author Tony Vaagenes
  * @author ollivir
  */

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.plugin.classanalysis;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.yahoo.container.plugin.util.Maps;
 
@@ -20,7 +21,8 @@ public class PackageTally {
     private final Map<String, Optional<ExportPackageAnnotation>> definedPackagesMap;
     private final Set<String> referencedPackagesUnfiltered;
 
-    private PackageTally(Map<String, Optional<ExportPackageAnnotation>> definedPackagesMap, Set<String> referencedPackagesUnfiltered) {
+    @VisibleForTesting
+    PackageTally(Map<String, Optional<ExportPackageAnnotation>> definedPackagesMap, Set<String> referencedPackagesUnfiltered) {
         this.definedPackagesMap = definedPackagesMap;
         this.referencedPackagesUnfiltered = referencedPackagesUnfiltered;
     }

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
@@ -19,7 +19,7 @@ public class PackageTally {
     private final Map<String, Optional<ExportPackageAnnotation>> definedPackagesMap;
     private final Set<String> referencedPackagesUnfiltered;
 
-    public PackageTally(Map<String, Optional<ExportPackageAnnotation>> definedPackagesMap, Set<String> referencedPackagesUnfiltered) {
+    private PackageTally(Map<String, Optional<ExportPackageAnnotation>> definedPackagesMap, Set<String> referencedPackagesUnfiltered) {
         this.definedPackagesMap = definedPackagesMap;
         this.referencedPackagesUnfiltered = referencedPackagesUnfiltered;
     }

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Tony Vaagenes
@@ -38,6 +39,18 @@ public class PackageTally {
             v.ifPresent(annotation -> ret.put(k, annotation));
         });
         return ret;
+    }
+
+    /**
+     * Returns the set of packages that is referenced from this tally, but not included in the given set of available packages.
+     *
+     * @param definedAndExportedPackages Set of available packages (usually all packages defined in the generated bundle's project + all exported packages of dependencies)
+     * @return The set of missing packages, that may cause problem when the bundle is deployed in an OSGi container runtime.
+     */
+    public Set<String> referencedPackagesMissingFrom(Set<String> definedAndExportedPackages) {
+        return Sets.difference(referencedPackages(), definedAndExportedPackages).stream()
+                .filter(pkg -> !pkg.startsWith("java."))
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageTally.java
@@ -50,6 +50,7 @@ public class PackageTally {
     public Set<String> referencedPackagesMissingFrom(Set<String> definedAndExportedPackages) {
         return Sets.difference(referencedPackages(), definedAndExportedPackages).stream()
                 .filter(pkg -> !pkg.startsWith("java."))
+                .filter(pkg -> !pkg.equals(com.yahoo.api.annotations.PublicApi.class.getPackageName()))
                 .collect(Collectors.toSet());
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/Artifacts.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/Artifacts.java
@@ -12,8 +12,8 @@ import java.util.List;
  * @author Tony Vaagenes
  * @author ollivir
  */
-public class Artifacts {
-    public static class ArtifactSet {
+class Artifacts {
+    static class ArtifactSet {
         private final List<Artifact> jarArtifactsToInclude;
         private final List<Artifact> jarArtifactsProvided;
         private final List<Artifact> nonJarArtifacts;
@@ -24,20 +24,20 @@ public class Artifacts {
             this.nonJarArtifacts = nonJarArtifacts;
         }
 
-        public List<Artifact> getJarArtifactsToInclude() {
+        List<Artifact> getJarArtifactsToInclude() {
             return jarArtifactsToInclude;
         }
 
-        public List<Artifact> getJarArtifactsProvided() {
+        List<Artifact> getJarArtifactsProvided() {
             return jarArtifactsProvided;
         }
 
-        public List<Artifact> getNonJarArtifacts() {
+        List<Artifact> getNonJarArtifacts() {
             return nonJarArtifacts;
         }
     }
 
-    public static ArtifactSet getArtifacts(MavenProject project) {
+    static ArtifactSet getArtifacts(MavenProject project) {
 
         List<Artifact> jarArtifactsToInclude = new ArrayList<>();
         List<Artifact> jarArtifactsProvided = new ArrayList<>();
@@ -63,7 +63,7 @@ public class Artifacts {
         return new ArtifactSet(jarArtifactsToInclude, jarArtifactsProvided, nonJarArtifactsToInclude);
     }
 
-    public static Collection<Artifact> getArtifactsToInclude(MavenProject project) {
+    static Collection<Artifact> getArtifactsToInclude(MavenProject project) {
         return getArtifacts(project).getJarArtifactsToInclude();
     }
 }

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -308,7 +308,4 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
         return Optional.ofNullable(str).map(String::trim).filter(s -> ! s.isEmpty());
     }
 
-    private static boolean isClassToAnalyze(String name) {
-        return name.endsWith(".class") && ! name.endsWith("module-info.class");
-    }
 }

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -90,7 +90,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
     @Parameter(alias = "X-Jersey-Binding")
     private String jerseyBinding = null;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void execute() throws MojoExecutionException {
         try {
             Artifacts.ArtifactSet artifactSet = Artifacts.getArtifacts(project);
             warnOnUnsupportedArtifacts(artifactSet.getNonJarArtifacts());
@@ -133,7 +133,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
     private static void warnIfPackagesDefinedOverlapsGlobalPackages(Set<String> internalPackages, List<String> globalPackages)
             throws MojoExecutionException {
         Set<String> overlap = Sets.intersection(internalPackages, new HashSet<>(globalPackages));
-        if (overlap.isEmpty() == false) {
+        if (! overlap.isEmpty()) {
             throw new MojoExecutionException(
                     "The following packages are both global and included in the bundle:\n   " + String.join("\n   ", overlap));
         }
@@ -173,7 +173,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
                 Pair.of("WebInfUrl", webInfUrl), //
                 Pair.of("Import-Package", importPackage), //
                 Pair.of("Export-Package", exportPackage))) {
-            if (element.getValue() != null && element.getValue().isEmpty() == false) {
+            if (element.getValue() != null && ! element.getValue().isEmpty()) {
                 ret.put(element.getKey(), element.getValue());
             }
         }
@@ -232,7 +232,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
     }
 
     private void warnOnUnsupportedArtifacts(Collection<Artifact> nonJarArtifacts) {
-        List<Artifact> unsupportedArtifacts = nonJarArtifacts.stream().filter(a -> "pom".equals(a.getType()) == false)
+        List<Artifact> unsupportedArtifacts = nonJarArtifacts.stream().filter(a -> ! a.getType().equals("pom"))
                 .collect(Collectors.toList());
 
         unsupportedArtifacts.forEach(artifact -> getLog()
@@ -258,7 +258,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
         List<ClassFileMetaData> analyzedClasses = new ArrayList<>();
         for (Enumeration<JarEntry> entries = jarFile.entries(); entries.hasMoreElements();) {
             JarEntry entry = entries.nextElement();
-            if (entry.isDirectory() == false && entry.getName().endsWith(".class")) {
+            if (! entry.isDirectory() && entry.getName().endsWith(".class")) {
                 analyzedClasses.add(analyzeClass(jarFile, entry));
             }
         }
@@ -305,10 +305,10 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
     }
 
     private static Optional<String> emptyToNone(String str) {
-        return Optional.ofNullable(str).map(String::trim).filter(s -> s.isEmpty() == false);
+        return Optional.ofNullable(str).map(String::trim).filter(s -> ! s.isEmpty());
     }
 
     private static boolean isClassToAnalyze(String name) {
-        return name.endsWith(".class") && name.endsWith("module-info.class") == false;
+        return name.endsWith(".class") && ! name.endsWith("module-info.class");
     }
 }

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.yahoo.container.plugin.bundle.AnalyzeBundle.publicPackagesAggregated;
+import static com.yahoo.container.plugin.osgi.ExportPackages.exportsByPackageName;
+import static com.yahoo.container.plugin.osgi.ImportPackages.calculateImports;
 import static com.yahoo.container.plugin.util.Files.allDescendantFiles;
 import static com.yahoo.container.plugin.util.IO.withFileOutputStream;
 import static com.yahoo.container.plugin.util.JarFiles.withInputStream;
@@ -114,8 +116,9 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
                         .map(e -> "(" + e.getPackageNames().toString() + ", " + e.version().orElse("")).collect(Collectors.joining(", ")));
             }
 
-            Map<String, Import> calculatedImports = ImportPackages.calculateImports(includedPackages.referencedPackages(),
-                    includedPackages.definedPackages(), ExportPackages.exportsByPackageName(publicPackagesFromProvidedJars.exports));
+            Map<String, Import> calculatedImports = calculateImports(includedPackages.referencedPackages(),
+                                                                     includedPackages.definedPackages(),
+                                                                     exportsByPackageName(publicPackagesFromProvidedJars.exports));
 
             Map<String, Optional<String>> manualImports = emptyToNone(importPackage).map(GenerateOsgiManifestMojo::getManualImports)
                     .orElseGet(HashMap::new);

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -107,11 +107,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
             // The union of packages in the bundle's project and its compile scoped jars.
             PackageTally pluginPackageTally = projectPackageTally.combine(includedJarPackageTally);
 
-            // TODO: isn't 'definedPackages' the same as pluginPackageTally.definedPackages()?
-            Set<String> definedPackages = new HashSet<>(projectPackageTally.definedPackages());
-            definedPackages.addAll(includedJarPackageTally.definedPackages());
-
-            warnIfPackagesDefinedOverlapsGlobalPackages(definedPackages, publicPackagesFromProvidedJars.globals);
+            warnIfPackagesDefinedOverlapsGlobalPackages(pluginPackageTally.definedPackages(), publicPackagesFromProvidedJars.globals);
 
             if (getLog().isDebugEnabled()) {
                 getLog().debug("Referenced packages = " + pluginPackageTally.referencedPackages());
@@ -132,7 +128,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
                     artifactSet.getJarArtifactsToInclude(), manualImports, calculatedImports.values(), pluginPackageTally));
 
         } catch (Exception e) {
-            throw new MojoExecutionException("Failed generating osgi manifest.", e);
+            throw new MojoExecutionException("Failed generating osgi manifest", e);
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -111,12 +111,7 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
 
             warnIfPackagesDefinedOverlapsGlobalPackages(includedPackages.definedPackages(), publicPackagesFromProvidedJars.globals);
 
-            if (getLog().isDebugEnabled()) {
-                getLog().debug("Referenced packages = " + includedPackages.referencedPackages());
-                getLog().debug("Defined packages = " + includedPackages.definedPackages());
-                getLog().debug("Exported packages of dependencies = " + publicPackagesFromProvidedJars.exports.stream()
-                        .map(e -> "(" + e.getPackageNames().toString() + ", " + e.version().orElse("")).collect(Collectors.joining(", ")));
-            }
+            logDebugPackageSets(publicPackagesFromProvidedJars, includedPackages);
 
             if (hasJdiscCoreProvided(artifactSet.getJarArtifactsProvided())) {
                 // If jdisc_core is not provided, log output may contain packages that _are_ available runtime.
@@ -140,6 +135,15 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
 
         } catch (Exception e) {
             throw new MojoExecutionException("Failed generating osgi manifest", e);
+        }
+    }
+
+    private void logDebugPackageSets(AnalyzeBundle.PublicPackages publicPackagesFromProvidedJars, PackageTally includedPackages) {
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Referenced packages = " + includedPackages.referencedPackages());
+            getLog().debug("Defined packages = " + includedPackages.definedPackages());
+            getLog().debug("Exported packages of dependencies = " + publicPackagesFromProvidedJars.exports.stream()
+                    .map(e -> "(" + e.getPackageNames().toString() + ", " + e.version().orElse("")).collect(Collectors.joining(", ")));
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -114,8 +114,8 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
             logDebugPackageSets(publicPackagesFromProvidedJars, includedPackages);
 
             if (hasJdiscCoreProvided(artifactSet.getJarArtifactsProvided())) {
-                // If jdisc_core is not provided, log output may contain packages that _are_ available runtime.
-                logMissingPackages(publicPackagesFromProvidedJars, projectPackages, compileJarsPackages, includedPackages);
+                // jdisc_core being provided, guarantees that log output does not contain its exported packages
+                logMissingPackages(publicPackagesFromProvidedJars.exports, projectPackages, compileJarsPackages, includedPackages);
             } else {
                 getLog().warn("This project does not have jdisc_core as provided dependency, so the " +
                                       "generated 'Import-Package' OSGi header may be missing important packages.");
@@ -151,8 +151,11 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
         return providedArtifacts.stream().anyMatch(artifact -> artifact.getArtifactId().equals("jdisc_core"));
     }
 
-    private void logMissingPackages(AnalyzeBundle.PublicPackages publicPackagesFromProvidedJars, PackageTally projectPackages, PackageTally compileJarPackages, PackageTally includedPackages) {
-        Set<String> exportedPackagesFromProvidedDeps = publicPackagesFromProvidedJars.exports
+    private void logMissingPackages(List<Export> exportedPackagesFromProvidedJars,
+                                    PackageTally projectPackages,
+                                    PackageTally compileJarPackages,
+                                    PackageTally includedPackages) {
+        Set<String> exportedPackagesFromProvidedDeps = exportedPackagesFromProvidedJars
                 .stream()
                 .map(Export::getPackageNames)
                 .flatMap(Collection::stream)

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -156,23 +156,17 @@ public class GenerateOsgiManifestMojo extends AbstractMojo {
 
         Set<String> definedAndExportedPackages = Sets.union(includedPackages.definedPackages(), exportedPackagesFromProvidedDeps);
 
-        Set<String> missingProjectPackages = missingPackages(projectPackages, definedAndExportedPackages);
+        Set<String> missingProjectPackages = projectPackages.referencedPackagesMissingFrom(definedAndExportedPackages);
         if (! missingProjectPackages.isEmpty()) {
             getLog().warn("Packages unavailable runtime are referenced from project classes " +
                                   "(annotations can usually be ignored): " + missingProjectPackages);
         }
 
-        Set<String> missingCompilePackages = missingPackages(compileJarPackages, definedAndExportedPackages);
+        Set<String> missingCompilePackages = compileJarPackages.referencedPackagesMissingFrom(definedAndExportedPackages);
         if (! missingCompilePackages.isEmpty()) {
             getLog().info("Packages unavailable runtime are referenced from compile scoped jars " +
                                   "(annotations can usually be ignored): " + missingCompilePackages);
         }
-    }
-
-    private static Set<String> missingPackages(PackageTally projectPackages, Set<String> definedAndExportedPackages) {
-        return Sets.difference(projectPackages.referencedPackages(), definedAndExportedPackages).stream()
-                .filter(pkg -> !pkg.startsWith("java."))
-                .collect(Collectors.toSet());
     }
 
     private static void warnIfPackagesDefinedOverlapsGlobalPackages(Set<String> internalPackages, List<String> globalPackages)

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/osgi/ImportPackages.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/osgi/ImportPackages.java
@@ -74,8 +74,9 @@ public class ImportPackages {
         }
     }
 
-    public static Map<String, Import> calculateImports(Set<String> referencedPackages, Set<String> implementedPackages,
-            Map<String, ExportPackages.Export> exportedPackages) {
+    public static Map<String, Import> calculateImports(Set<String> referencedPackages,
+                                                       Set<String> implementedPackages,
+                                                       Map<String, ExportPackages.Export> exportedPackages) {
         Map<String, Import> ret = new HashMap<>();
         for (String undefinedPackage : Sets.difference(referencedPackages, implementedPackages)) {
             ExportPackages.Export export = exportedPackages.get(undefinedPackage);

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/util/JdkPackages.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/util/JdkPackages.java
@@ -1,0 +1,39 @@
+package com.yahoo.container.plugin.util;
+
+import java.net.URL;
+
+/**
+ * @author gjoranv
+ */
+public class JdkPackages {
+
+    /**
+     * Returns a boolean indicating (via best effort) if the given package is part of the JDK.
+     */
+    public static boolean isJdkPackage(String pkg) {
+        return hasJdkExclusivePrefix(pkg)
+                || isResourceInPlatformClassLoader(pkg); // TODO: must be a class, not a package, due to module encapsulation
+    }
+
+    private static boolean isResourceInPlatformClassLoader(String klass) {
+        String klassAsPath = klass.replaceAll("\\.", "/") + ".class";
+        URL resource = getPlatformClassLoader().getResource(klassAsPath);
+        return !(resource == null);
+    }
+
+    private static ClassLoader getPlatformClassLoader() {
+        ClassLoader platform = JdkPackages.class.getClassLoader().getParent();
+
+        // Will fail upon changes in classloader hierarchy between JDK versions
+        assert (platform.getName().equals("platform"));
+
+        return platform;
+    }
+
+    private static boolean hasJdkExclusivePrefix(String pkg) {
+        return pkg.startsWith("java.")
+                || pkg.startsWith("sun.");
+    }
+
+}
+

--- a/bundle-plugin/src/test/java/com/yahoo/container/plugin/bundle/AnalyzeBundleTest.java
+++ b/bundle-plugin/src/test/java/com/yahoo/container/plugin/bundle/AnalyzeBundleTest.java
@@ -11,8 +11,10 @@ import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.yahoo.container.plugin.classanalysis.TestUtilities.throwableMessage;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -28,6 +30,7 @@ import static org.junit.Assert.assertThat;
  */
 public class AnalyzeBundleTest {
     private final List<ExportPackages.Export> exports;
+    private final Set<String> exportedPackageNames;
     private final Map<String, ExportPackages.Export> exportsByPackageName;
 
     File jarDir = new File("src/test/resources/jar");
@@ -37,6 +40,7 @@ public class AnalyzeBundleTest {
         File simple = new File(jarDir, "simple1.jar");
         PublicPackages pp = AnalyzeBundle.publicPackagesAggregated(Arrays.asList(notOsgi, simple));
         this.exports = pp.exports;
+        this.exportedPackageNames = pp.exportedPackageNames();
         this.exportsByPackageName = ExportPackages.exportsByPackageName(exports);
     }
 
@@ -53,6 +57,11 @@ public class AnalyzeBundleTest {
     public void require_that_exports_are_retrieved_from_manifest_in_jars() {
         assertThat(exportsByPackageName.keySet().size(), is(1));
         assertThat(exportsByPackageName.keySet(), hasItem("com.yahoo.sample.exported.package"));
+    }
+
+    @Test
+    public void exported_class_names_can_be_retrieved() {
+        assertThat(exportedPackageNames, is(new HashSet<>(exports.get(0).getPackageNames())));
     }
 
     @Rule

--- a/bundle-plugin/src/test/java/com/yahoo/container/plugin/classanalysis/PackageTallyTest.java
+++ b/bundle-plugin/src/test/java/com/yahoo/container/plugin/classanalysis/PackageTallyTest.java
@@ -1,0 +1,23 @@
+package com.yahoo.container.plugin.classanalysis;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author gjoranv
+ */
+public class PackageTallyTest {
+
+    @Test
+    public void referenced_packages_missing_from_are_detected() {
+        PackageTally tally = new PackageTally(emptyMap(), Set.of("p1", "java.util", "com.yahoo.api.annotations", "missing"));
+        Set<String> missingPackages = tally.referencedPackagesMissingFrom(Set.of("p1"));
+        assertThat(missingPackages, is(Set.of("missing")));
+    }
+
+}

--- a/bundle-plugin/src/test/java/com/yahoo/container/plugin/classanalysis/PackageTallyTest.java
+++ b/bundle-plugin/src/test/java/com/yahoo/container/plugin/classanalysis/PackageTallyTest.java
@@ -1,3 +1,4 @@
+// Copyright 2019 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.plugin.classanalysis;
 
 import org.junit.Test;

--- a/bundle-plugin/src/test/java/com/yahoo/container/plugin/osgi/ImportPackageTest.java
+++ b/bundle-plugin/src/test/java/com/yahoo/container/plugin/osgi/ImportPackageTest.java
@@ -109,8 +109,9 @@ public class ImportPackageTest {
                 is("com.yahoo.exported;version=\"[1.2.3,2)\""));
     }
 
-    private static Set<Import> calculateImports(Set<String> referencedPackages, Set<String> implementedPackages,
-            Map<String, Export> exportedPackages) {
+    private static Set<Import> calculateImports(Set<String> referencedPackages,
+                                                Set<String> implementedPackages,
+                                                Map<String, Export> exportedPackages) {
         return new HashSet<>(ImportPackages.calculateImports(referencedPackages, implementedPackages, exportedPackages).values());
     }
 


### PR DESCRIPTION
Before this PR, the plugin outputs 3 sets of packages when run with maven's -X debug option:

R = Referenced packages
D = Defined packages
E = Exported packages by dependencies

For the following we need to split D into:

D_p = Defined packages in the project's class files
D_c = Defined packages in the project's compile scoped deps

This PR is a best effort to output sets of packages that can cause problems when the bundle is deployed in a jdisc container runtime:

#### 1. The set of packages M_p 
(missing in project classes) that are referenced in the project's own class files, but not available runtime:

M_p = R ∉ (D_p ∪ E)

This set is usually empty, so it's output as WARNING..

####  2. The set of packages M_c 
(missing in compile scoped deps) that are referenced in the project's compile scoped deps, but not available runtime:

M_c = R ∉ (D_c ∪ E)

This set is usually rather small, and does not constitute a problem as long as the code in those packages are not loaded at runtime. Hence, it's output as INFO.

#### 3. The set of packages O
(overlapping) that are defined in the project's class files _and_ exported by provided scoped deps. This is most likely a bug and is likely to cause a class loading error runtime. Hence, it's output as WARNING. This set  is defined as:

O = D_p ∩ E

(This set could also be denominated U_p for symmetry with U_c below, but doing so would downplay the size of the problem.)

#### 4. The set of packages U_c
(unnecessary) that are defined in the project's compile scoped deps _and_ exported by provided scoped deps. This is most often ok, but will cause an error if the bundle is using APIs in another bundle that have classes from these packages in their signature. It also signals that the bundle can be slimmed down by setting these deps as provided. This set is output as INFO and is defined as:

U_c = D_c ∩ E
