### PR TITLE
Made the capacity endpoint accept a comma-separated list instead of JSON

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/HostCapacityResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/HostCapacityResponse.java
@@ -42,14 +42,7 @@ public class HostCapacityResponse extends HttpResponse {
     }
 
     private List<Node> parseHostList(String hosts) {
-        ObjectMapper om = new ObjectMapper();
-        String[] hostsArray;
-        try {
-            hostsArray = om.readValue(hosts, String[].class);
-        } catch (Exception e) {
-            throw new IllegalArgumentException(e.getMessage());
-        }
-        List<String> hostNames = Arrays.asList(hostsArray);
+        List<String> hostNames = Arrays.asList(hosts.split(","));
         try {
             return capacityChecker.nodesFromHostnames(hostNames);
         } catch (IllegalArgumentException e) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -102,7 +102,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
         if (path.equals(    "/nodes/v2/command/")) return ResourcesResponse.fromStrings(request.getUri(), "restart", "reboot");
         if (path.equals(    "/nodes/v2/maintenance/")) return new JobsResponse(nodeRepository.jobControl());
         if (path.equals(    "/nodes/v2/upgrade/")) return new UpgradeResponse(nodeRepository.infrastructureVersions(), nodeRepository.osVersions(), nodeRepository.dockerImages());
-        if (path.startsWith("/nodes/v2/capacity/")) return new HostCapacityResponse(nodeRepository, request);
+        if (path.startsWith("/nodes/v2/capacity")) return new HostCapacityResponse(nodeRepository, request);
         throw new NotFoundException("Nothing at path '" + path + "'");
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -823,17 +823,15 @@ public class RestApiTest {
     @Test
     public void test_capacity() throws Exception {
         assertFile(new Request("http://localhost:8080/nodes/v2/capacity/?json=true"), "capacity-zone.json");
+        assertFile(new Request("http://localhost:8080/nodes/v2/capacity?json=true"), "capacity-zone.json");
 
         List<String> hostsToRemove = List.of(
-                "%22dockerhost1.yahoo.com%22",
-                "%22dockerhost2.yahoo.com%22",
-                "%22dockerhost3.yahoo.com%22",
-                "%22dockerhost4.yahoo.com%22"
+                "dockerhost1.yahoo.com",
+                "dockerhost2.yahoo.com",
+                "dockerhost3.yahoo.com",
+                "dockerhost4.yahoo.com"
         );
-        String requestUriTemplate =
-                "http://localhost:8080/nodes/v2/capacity/?json=true&hosts=[%s]"
-                        .replaceAll("\\[", "%%5B")
-                        .replaceAll("]", "%%5D");
+        String requestUriTemplate = "http://localhost:8080/nodes/v2/capacity/?json=true&hosts=%s";
 
         assertFile(new Request(String.format(requestUriTemplate,
                 String.join(",", hostsToRemove.subList(0, 3)))),


### PR DESCRIPTION
Made the endpoint accept calls which do not end with a trailing slash.
