### PR TITLE
Support cluster parameter for document v1 get operations

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/OperationHandler.java
@@ -101,6 +101,10 @@ public interface OperationHandler {
     default Optional<String> get(RestUri restUri, Optional<String> fieldSet) throws RestApiException {
         return get(restUri);
     }
+
+    default Optional<String> get(RestUri restUri, Optional<String> fieldSet, Optional<String> cluster) throws RestApiException {
+        return get(restUri, fieldSet);
+    }
     
     /** Called just before this is disposed of */
     default void shutdown() {}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
@@ -262,8 +262,9 @@ public class RestApi extends LoggingRequestHandler {
     }
 
     private HttpResponse handleGet(RestUri restUri, HttpRequest request) throws RestApiException {
-        final Optional<String> fieldSet = requestProperty("fieldSet", request);
-        final Optional<String> getDocument = operationHandler.get(restUri, fieldSet);
+        final Optional<String> fieldSet = requestProperty(FIELD_SET, request);
+        final Optional<String> cluster  = requestProperty(CLUSTER, request);
+        final Optional<String> getDocument = operationHandler.get(restUri, fieldSet, cluster);
         final ObjectNode resultNode = mapper.createObjectNode();
         if (getDocument.isPresent()) {
             final JsonNode parseNode;

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/OperationHandlerImplTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/OperationHandlerImplTest.java
@@ -107,7 +107,7 @@ public class OperationHandlerImplTest {
         VisitorControlHandler.CompletionCode completionCode = VisitorControlHandler.CompletionCode.SUCCESS;
         int bucketsVisited = 0;
         Map<String, String> bucketSpaces = new HashMap<>();
-        SyncSession mockSyncSession = mock(MessageBusSyncSession.class); // MBus session needed to avoid setRoute throwing.
+        MessageBusSyncSession mockSyncSession = mock(MessageBusSyncSession.class); // MBus session needed to avoid setRoute throwing.
 
         OperationHandlerImplFixture() {
             bucketSpaces.put("foo", "global");
@@ -314,6 +314,25 @@ public class OperationHandlerImplTest {
         handler.get(dummyGetUri(), Optional.of("donald,duck"));
 
         verify(fixture.mockSyncSession).get(any(), eq("donald,duck"), any());
+    }
+
+    @Test
+    public void get_route_has_default_value_if_no_cluster_is_provided() throws Exception {
+        OperationHandlerImplFixture fixture = new OperationHandlerImplFixture();
+        OperationHandlerImpl handler = fixture.createHandler();
+        handler.get(dummyGetUri(), Optional.empty(), Optional.empty());
+
+        // TODO shouldn't this be default-get?
+        verify(fixture.mockSyncSession).setRoute(eq("default"));
+    }
+
+    @Test
+    public void provided_get_cluster_is_propagated_as_route_to_sync_session() throws Exception {
+        OperationHandlerImplFixture fixture = new OperationHandlerImplFixture();
+        OperationHandlerImpl handler = fixture.createHandler();
+        handler.get(dummyGetUri(), Optional.empty(), Optional.of("foo"));
+
+        verify(fixture.mockSyncSession).setRoute(eq("[Storage:cluster=foo;clusterconfigid=configId]"));
     }
 
     @Test

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/MockedOperationHandler.java
@@ -58,11 +58,20 @@ public class MockedOperationHandler implements OperationHandler {
     }
 
     @Override
-    public Optional<String> get(RestUri restUri, Optional<String> fieldSet) throws RestApiException {
+    public Optional<String> get(RestUri restUri, Optional<String> fieldSet, Optional<String> cluster) throws RestApiException {
         log.append("GET: " + restUri.generateFullId());
         // This is _not_ an elegant way to return data back to the test.
         // An alternative is removing this entire class in favor of explicit mock expectations.
-        return fieldSet.map(fs -> String.format("{\"fields\": {\"fieldset\": \"%s\"}}", fs));
+        if (!fieldSet.isPresent() && !cluster.isPresent()) {
+            return Optional.empty();
+        }
+        return Optional.of(String.format("{\"fields\": {\"fieldset\": \"%s\",\"cluster\":\"%s\"}}",
+                                         fieldSet.orElse(""), cluster.orElse("")));
+    }
+
+    @Override
+    public Optional<String> get(RestUri restUri, Optional<String> fieldSet) throws RestApiException {
+        return get(restUri, fieldSet, Optional.empty());
     }
 
     @Override

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
@@ -288,10 +288,17 @@ public class RestApiTest {
     }
 
     @Test
-    public void get_fieldset_parameter_is_propagated() throws IOException {
+    public void get_fieldset_parameter_is_propagated() {
         Request request = new Request(String.format("http://localhost:%s/document/v1/namespace/document-type/docid/bar?fieldSet=foo,baz", getFirstListenPort()));
         HttpGet get = new HttpGet(request.getUri());
         assertHttp200ResponseContains(doRest(get), "\"fieldset\":\"foo,baz\"");
+    }
+
+    @Test
+    public void get_cluster_parameter_is_propagated() {
+        Request request = new Request(String.format("http://localhost:%s/document/v1/namespace/document-type/docid/bar?cluster=my_cool_cluster", getFirstListenPort()));
+        HttpGet get = new HttpGet(request.getUri());
+        assertHttp200ResponseContains(doRest(get), "\"cluster\":\"my_cool_cluster\"");
     }
 
     String visit_test_uri = "/document/v1/namespace/document-type/docid/?continuation=abc";


### PR DESCRIPTION
@baldersheim please review. This adds symmetry in the behavior between gets and visits. I'm not happy with the workaround added to `MessageBusAsyncSession`, so this should be refactored/redesigned. Preferably route selection should be done by the client (which knows the semantics), not the inner guts of MessageBus.

This also needs a system test.