### PR TITLE
Remove support for namespace as attribute for config in services.xml

### DIFF
--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -41,7 +41,7 @@ OptionalDedicatedNodes = element nodes {
 
 GenericConfig = element config {
     attribute name { text },
-    attribute namespace { text }?,
+    attribute namespace { text }?, # TODO: Remove in Vespa 8
     attribute version { text }?,
     anyElement +
 }

--- a/config-model/src/test/cfg/admin/userconfigs/functiontest-defaultvalues.xml
+++ b/config-model/src/test/cfg/admin/userconfigs/functiontest-defaultvalues.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
-<config name="function-test">
+<config name="test.function-test">
   <bool_val>false</bool_val>
   <int_val>5</int_val>
   <long_val>1234567890123</long_val>

--- a/config-model/src/test/cfg/admin/userconfigs/whitespace-test.xml
+++ b/config-model/src/test/cfg/admin/userconfigs/whitespace-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
-<config name="function-test">
+<config name="test.function-test">
   <stringVal> This is a string
   that contains different kinds of whitespace </stringVal>
 </config>

--- a/config-model/src/test/cfg/application/app_genericservices/services.xml
+++ b/config-model/src/test/cfg/application/app_genericservices/services.xml
@@ -3,11 +3,11 @@
 <services version="1.0">
 
   <service version="1.0" name="myservice" command="mycmd1.sh">
-    <config name="myconfig">
+    <config name="a.myconfig">
       <mysetting>bar</mysetting>
     </config>
     <node hostalias="node1">
-      <config name="myconfig">
+      <config name="a.myconfig">
         <mysetting>baz</mysetting>
       </config>
     </node>
@@ -17,11 +17,11 @@
   </service>
 
   <service version="1.0" name="myotherservice" command="/home/vespa/bin/mycmd2.sh --ytest $FOO_BAR">
-    <config name="myconfig">
+    <config name="a.myconfig">
       <mysetting>bar2</mysetting>
     </config>
     <node hostalias="node3">
-      <config name="myconfig">
+      <config name="a.myconfig">
         <mysetting>baz2</mysetting>
       </config>
     </node>

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/UserConfigBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/UserConfigBuilderTest.java
@@ -8,7 +8,6 @@ import com.yahoo.config.model.deploy.ConfigDefinitionStore;
 import com.yahoo.test.SimpletypesConfig;
 import com.yahoo.config.model.producer.UserConfigRepo;
 import com.yahoo.config.model.builder.xml.XmlHelper;
-import com.yahoo.vespa.config.ConfigDefinition;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.ConfigPayloadBuilder;
@@ -18,7 +17,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Optional;
@@ -28,47 +26,42 @@ import static org.junit.Assert.*;
 
 /**
  * @author Ulf Lilleengen
- * @since 5.1
  */
 public class UserConfigBuilderTest {
 
-    private final ConfigDefinitionStore configDefinitionStore = new ConfigDefinitionStore() {
-        @Override
-        public Optional<ConfigDefinition> getConfigDefinition(ConfigDefinitionKey defKey) { return Optional.empty(); }
-    };
+    private final ConfigDefinitionStore configDefinitionStore = defKey -> Optional.empty();
 
     @Test
-    public void require_that_simple_config_is_resolved() throws ParserConfigurationException {
-        Element configRoot = getDocument("<config name=\"simpletypes\">" +
+    public void require_that_simple_config_is_resolved() {
+        Element configRoot = getDocument("<config name=\"test.simpletypes\">" +
                                          "    <intval>13</intval>" +
                                          "</config>" +
-                                         "<config name=\"simpletypes\" version=\"1\">" +
+                                         "<config name=\"test.simpletypes\" version=\"1\">" +
                                          "    <stringval>foolio</stringval>" +
                                          "</config>");
         UserConfigRepo map = UserConfigBuilder.build(configRoot, configDefinitionStore, new BaseDeployLogger());
         assertFalse(map.isEmpty());
-        ConfigDefinitionKey key = new ConfigDefinitionKey("simpletypes", "config");
+        ConfigDefinitionKey key = new ConfigDefinitionKey("simpletypes", "test");
         assertNotNull(map.get(key));
         SimpletypesConfig config = createConfig(SimpletypesConfig.class, map.get(key));
         assertThat(config.intval(), is(13));
         assertThat(config.stringval(), is("foolio"));
     }
 
-    public static <ConfigType extends ConfigInstance> ConfigType createConfig(Class<ConfigType> clazz, ConfigPayloadBuilder builder) {
+    private static <ConfigType extends ConfigInstance> ConfigType createConfig(Class<ConfigType> clazz, ConfigPayloadBuilder builder) {
         return ConfigPayload.fromBuilder(builder).toInstance(clazz, "");
     }
 
-
     @Test
-    public void require_that_arrays_config_is_resolved() throws ParserConfigurationException {
-        Element configRoot = getDocument("<config name=\"arraytypes\">" +
+    public void require_that_arrays_config_is_resolved() {
+        Element configRoot = getDocument("<config name=\"test.arraytypes\">" +
                 "    <intarr operation=\"append\">13</intarr>" +
                 "    <intarr operation=\"append\">10</intarr>" +
                 "    <intarr operation=\"append\">1337</intarr>" +
                 "</config>");
         UserConfigRepo map = UserConfigBuilder.build(configRoot, configDefinitionStore, new BaseDeployLogger());
         assertFalse(map.isEmpty());
-        ConfigDefinitionKey key = new ConfigDefinitionKey("arraytypes", "config");
+        ConfigDefinitionKey key = new ConfigDefinitionKey("arraytypes", "test");
         assertNotNull(map.get(key));
         ArraytypesConfig config = createConfig(ArraytypesConfig.class, map.get(key));
         assertThat(config.intarr().size(), is(3));
@@ -78,7 +71,7 @@ public class UserConfigBuilderTest {
     }
 
     @Test
-    public void require_that_arrays_of_structs_are_resolved() throws ParserConfigurationException {
+    public void require_that_arrays_of_structs_are_resolved() {
         Element configRoot = getDocument(
                 "  <config name='vespa.configdefinition.specialtokens'>" +
                         "    <tokenlist operation='append'>" +
@@ -105,12 +98,12 @@ public class UserConfigBuilderTest {
     }
 
     @Test
-    public void no_exception_when_config_class_does_not_exist() throws ParserConfigurationException {
-        Element configRoot = getDocument("<config name=\"unknown\">" +
+    public void no_exception_when_config_class_does_not_exist() {
+        Element configRoot = getDocument("<config name=\"is.unknown\">" +
                 "    <foo>1</foo>" +
                 "</config>");
         UserConfigRepo repo = UserConfigBuilder.build(configRoot, configDefinitionStore, new BaseDeployLogger());
-        ConfigPayloadBuilder builder = repo.get(new ConfigDefinitionKey("unknown", "config"));
+        ConfigPayloadBuilder builder = repo.get(new ConfigDefinitionKey("unknown", "is"));
         assertNotNull(builder);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/LegacyConfigModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/LegacyConfigModelBuilderTest.java
@@ -3,15 +3,14 @@ package com.yahoo.vespa.model.builder.xml.dom;
 
 import com.yahoo.config.model.ConfigModel;
 import com.yahoo.config.model.ConfigModelContext;
-import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
+import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.text.XML;
 import org.junit.Test;
 import org.w3c.dom.Element;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -19,12 +18,12 @@ import static org.junit.Assert.assertThat;
 
 /**
  * @author Ulf Lilleengen
- * @since 5.1
  */
 public class LegacyConfigModelBuilderTest {
+
     @Test
     public void testThatProducerIsInserted() {
-        String services = "<foo><config name=\"bar\"><key>value</key></config></foo>";
+        String services = "<foo><config name=\"bar.foo\"><key>value</key></config></foo>";
         ModelBuilder builder = new ModelBuilder();
         Model model = builder.build(DeployState.createTestState(new MockApplicationPackage.Builder().withServices(services).build()),
                                     null, null, new MockRoot(), XML.getDocument(services).getDocumentElement());
@@ -51,7 +50,7 @@ public class LegacyConfigModelBuilderTest {
     }
     private static class ModelBuilder extends LegacyConfigModelBuilder<Model> {
 
-        public ModelBuilder() {
+        ModelBuilder() {
             super(Model.class);
         }
 
@@ -61,7 +60,7 @@ public class LegacyConfigModelBuilderTest {
 
         @Override
         public List<ConfigModelId> handlesElements() {
-            return Arrays.asList(ConfigModelId.fromName("foo"));
+            return List.of(ConfigModelId.fromName("foo"));
         }
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilderTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertThat;
  */
 public class VespaDomBuilderTest {
 
-    final static String hosts = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+    private final static String hosts = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
             "<hosts>" +
             "  <host name=\"localhost\">" +
             "    <alias>node1</alias>" +
@@ -33,9 +33,9 @@ public class VespaDomBuilderTest {
             "  </host>" +
             "</hosts>";
 
-    final static String services = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+    private final static String services = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
             "<services>" +
-            "  <config name=\"standard\">" +
+            "  <config name=\"a.standard\">" +
             "    <basicStruct>" +
             "      <stringVal>default</stringVal>" +
             "    </basicStruct>" +
@@ -45,7 +45,7 @@ public class VespaDomBuilderTest {
             "    <adminserver hostalias=\"node1\" />" +
             "  </admin>" +
             "  <container version=\"1.0\">" +
-            "      <config name=\"standard\">" +
+            "      <config name=\"a.standard\">" +
             "        <basicStruct>" +
             "          <stringVal>qrservers</stringVal>" +
             "        </basicStruct>" +
@@ -56,19 +56,7 @@ public class VespaDomBuilderTest {
             "  </container>\n" +
             "</services>";
 
-    final static String servicesWithNamespace = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
-            "<services>" +
-            "  <config name=\"testnamespace\" namespace=\"foo\">" +
-            "    <basicStruct>" +
-            "      <stringVal>default</stringVal>" +
-            "    </basicStruct>" +
-            "  </config> " +
-            "  <admin version=\"2.0\">" +
-            "    <adminserver hostalias=\"node1\" />" +
-            "  </admin>" +
-            "</services>";
-
-    final static String servicesWithNamespace2 = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+    private final static String servicesWithNamespace = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
             "<services>" +
             "  <config name=\"foo.testnamespace\">" +
             "    <basicStruct>" +
@@ -87,16 +75,6 @@ public class VespaDomBuilderTest {
 
         GenericConfig.GenericConfigBuilder builder = 
                 new GenericConfig.GenericConfigBuilder(new ConfigDefinitionKey("testnamespace", "foo"), new ConfigPayloadBuilder());
-        model.getConfig(builder, "admin");
-        assertEquals(builder.getPayload().toString(), "{\n" + 
-        		" \"basicStruct\": {\n" + 
-        		"  \"stringVal\": \"default\"\n" + 
-        		" }\n" + 
-        		"}\n");
-        
-        model = createModel(hosts, servicesWithNamespace2);
-
-        builder = new GenericConfig.GenericConfigBuilder(new ConfigDefinitionKey("testnamespace", "foo"), new ConfigPayloadBuilder());
         model.getConfig(builder, "admin");
         assertEquals(builder.getPayload().toString(), "{\n" + 
         		" \"basicStruct\": {\n" + 

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTestCase.java
@@ -66,13 +66,9 @@ public class VespaModelTestCase {
             "</host>" +
             "</hosts>";
 
-    public static VespaModel getVespaModel(String configPath) {
-        return getVespaModel(configPath, true);
-    }
-
-    public static VespaModel getVespaModel(String configPath, boolean validateXml) {
+    private static VespaModel getVespaModel(String configPath) {
         VespaModelCreatorWithFilePkg creator = new VespaModelCreatorWithFilePkg(configPath);
-        return creator.create(validateXml);
+        return creator.create(true);
     }
 
     // Debugging
@@ -232,7 +228,7 @@ public class VespaModelTestCase {
     public void testDeployLogger() throws IOException, SAXException {
         final String services = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
                 "<services  version=\"1.0\">" +
-                "<config name=\"unknsownfoo\">" +
+                "<config name=\"bar.unknsownfoo\">" +
                 "<logserver><host>foo</host></logserver>" +
                 "</config>" +
                 "<admin  version=\"2.0\">" +


### PR DESCRIPTION
Customers use 'name' attribute in config element, 'namespace' is not documented and 'name' started requiring namespace in Vespa 6

