### PR TITLE
Use 2.5 Gb memory for nodes in admin cluster in CD

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -83,7 +83,7 @@ public class CapacityPolicies {
 
     private NodeResources defaultNodeResources(ClusterSpec.Type clusterType) {
         if (clusterType == ClusterSpec.Type.admin)
-            return new NodeResources(0.5, 3, 50);
+            return new NodeResources(0.5, zone.system().isCd() ? 2.5 : 3, 50);
 
         return new NodeResources(1.5, 8, 50);
     }


### PR DESCRIPTION
We have reduced max heap sizes for logserver-container and
metricsproxy-container since we started using 3 Gb, so it should
be possible to reduce memory for these nodes, trying with 0.5 Gb less
