### PR TITLE
Avoid the compiler reloading the base register for every store.

### DIFF
--- a/searchlib/src/vespa/searchlib/features/attributefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/attributefeature.cpp
@@ -201,7 +201,7 @@ SingleAttributeExecutor<T>::execute(uint32_t docId)
 {
     typename T::LoadedValueType v = _attribute.getFast(docId);
     // value
-    fef::NumberOrObject * o = outputs().get_raw(0);
+    auto o = outputs().get_bound();
     o[0].as_number = __builtin_expect(attribute::isUndefined(v), false)
                      ? attribute::getUndefined<feature_t>()
                      : util::getAsFeature(v);
@@ -217,7 +217,7 @@ MultiAttributeExecutor<T>::execute(uint32_t docId)
     const multivalue::Value<typename T::BaseType> * values = nullptr;
     uint32_t numValues = _attribute.getRawValues(docId, values);
 
-    fef::NumberOrObject * o = outputs().get_raw(0);
+    auto o = outputs().get_bound();
     o[0].as_number = __builtin_expect(_idx < numValues, true) ? values[_idx].value() : 0;
     o[1].as_number = 0;  // weight
     o[2].as_number = 0;  // contains
@@ -227,7 +227,7 @@ MultiAttributeExecutor<T>::execute(uint32_t docId)
 void
 CountOnlyAttributeExecutor::execute(uint32_t docId)
 {
-    fef::NumberOrObject * o = outputs().get_raw(0);
+    auto o = outputs().get_bound();
     o[0].as_number = 0;  // value
     o[1].as_number = 0;  // weight
     o[2].as_number = 0;  // contains
@@ -255,7 +255,7 @@ AttributeExecutor<T>::execute(uint32_t docId)
     if (_idx < _buffer.size()) {
         value = considerUndefined(_buffer[_idx], _attrType);
     }
-    fef::NumberOrObject * o = outputs().get_raw(0);
+    auto o = outputs().get_bound();
     o[0].as_number = value;  // value
     o[1].as_number = 0;  // weight
     o[2].as_number = 0;  // contains

--- a/searchlib/src/vespa/searchlib/fef/featureexecutor.h
+++ b/searchlib/src/vespa/searchlib/fef/featureexecutor.h
@@ -83,6 +83,9 @@ public:
         const NumberOrObject *get_raw(size_t idx) const {
             return &_outputs[idx];
         }
+        NumberOrObject *get_raw(size_t idx) {
+            return &_outputs[idx];
+        }
         size_t size() const { return _outputs.size(); }
     };
 

--- a/searchlib/src/vespa/searchlib/fef/featureexecutor.h
+++ b/searchlib/src/vespa/searchlib/fef/featureexecutor.h
@@ -58,10 +58,10 @@ public:
     };
 
     class Outputs {
-        vespalib::ArrayRef<NumberOrObject> _outputs;
     public:
+        using OutputArray = vespalib::ArrayRef<NumberOrObject>;
         Outputs() : _outputs() {}
-        void bind(vespalib::ArrayRef<NumberOrObject> outputs) { _outputs = outputs; }
+        void bind(OutputArray  outputs) { _outputs = outputs; }
         void set_number(size_t idx, feature_t value) {
             _outputs[idx].as_number = value;
         }
@@ -83,10 +83,12 @@ public:
         const NumberOrObject *get_raw(size_t idx) const {
             return &_outputs[idx];
         }
-        NumberOrObject *get_raw(size_t idx) {
-            return &_outputs[idx];
+        OutputArray get_bound() const {
+            return _outputs;
         }
         size_t size() const { return _outputs.size(); }
+    private:
+        vespalib::ArrayRef<NumberOrObject> _outputs;
     };
 
 private:


### PR DESCRIPTION
Removes 3 unnecessary loads in a very small leaf function.
Instead of
2c:   48 8b 47 20             mov    0x20(%rdi),%rax
30:   f2 0f 11 00             movsd  %xmm0,(%rax)
34:   48 8b 47 20             mov    0x20(%rdi),%rax
38:   48 c7 40 08 00 00 00    movq   $0x0,0x8(%rax)
3f:   00
40:   48 8b 47 20             mov    0x20(%rdi),%rax
44:   48 c7 40 10 00 00 00    movq   $0x0,0x10(%rax)
4b:   00
4c:   48 8b 47 20             mov    0x20(%rdi),%rax
50:   48 89 48 18             mov    %rcx,0x18(%rax)
54:   c3                      retq

We get
23c:       48 8b 47 20             mov    0x20(%rdi),%rax
240:       f2 0f 11 00             movsd  %xmm0,(%rax)
244:       48 c7 40 08 00 00 00    movq   $0x0,0x8(%rax)
24b:       00
24c:       48 c7 40 10 00 00 00    movq   $0x0,0x10(%rax)
253:       00
254:       48 89 48 18             mov    %rcx,0x18(%rax)
258:       c3                      retq

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
