### PR TITLE
Cleanup MakeConfig

### DIFF
--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfig.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfig.java
@@ -18,14 +18,14 @@ public class MakeConfig {
         classBuilder = createClassBuilder(root, nd, properties);
     }
 
-    public static ClassBuilder createClassBuilder(InnerCNode root, NormalizedDefinition nd, MakeConfigProperties properties) {
+    private static ClassBuilder createClassBuilder(InnerCNode root, NormalizedDefinition nd, MakeConfigProperties properties) {
         if (isCpp(properties))
             return new CppClassBuilder(root, nd, properties.destDir, properties.dirInRoot);
         else
             return new JavaClassBuilder(root, nd, properties.destDir, properties.javaPackagePrefix);
     }
 
-    public static boolean makeConfig(MakeConfigProperties properties) throws FileNotFoundException {
+    private static boolean makeConfig(MakeConfigProperties properties) throws FileNotFoundException {
         for (File specFile : properties.specFiles) {
             String name = specFile.getName();
             if (name.endsWith(".def")) name = name.substring(0, name.length() - 4);
@@ -49,7 +49,7 @@ public class MakeConfig {
     /**
      * Generates the code and print it to this.out.
      */
-    void buildClasses() {
+    private void buildClasses() {
         classBuilder.createConfigClasses();
     }
 
@@ -58,7 +58,7 @@ public class MakeConfig {
         out.println("       (default language for generated code is Java)");
     }
 
-    public static void main(String[] args) throws IOException, InterruptedException {
+    public static void main(String[] args) throws IOException {
         try {
             MakeConfigProperties props = new MakeConfigProperties();
             boolean success = makeConfig(props);
@@ -81,7 +81,7 @@ public class MakeConfig {
     }
 
     private static boolean isCpp(MakeConfigProperties properties) {
-        return (properties.language.equals("cppng") || properties.language.equals("cpp"));
+        return properties.language.equals("cpp");
     }
 
     // The Exceptions class below is copied from vespajlib/com.yahoo.protect.Exceptions
@@ -100,7 +100,7 @@ public class MakeConfig {
          * <code>e.getMessage(): e.getCause().getMessage(): e.getCause().getCause().getMessage()...</code>
          * In addition, some heuristics are used to clean up common cases where exception nesting causes bad messages.
          */
-        public static String toMessageString(Throwable t) {
+        static String toMessageString(Throwable t) {
             StringBuilder b = new StringBuilder();
             String lastMessage = null;
             String message;

--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfig.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfig.java
@@ -25,7 +25,8 @@ public class MakeConfig {
             return new JavaClassBuilder(root, nd, properties.destDir, properties.javaPackagePrefix);
     }
 
-    private static boolean makeConfig(MakeConfigProperties properties) throws FileNotFoundException {
+    @SuppressWarnings("WeakerAccess") // Used by ConfigGenMojo
+    public static boolean makeConfig(MakeConfigProperties properties) throws FileNotFoundException {
         for (File specFile : properties.specFiles) {
             String name = specFile.getName();
             if (name.endsWith(".def")) name = name.substring(0, name.length() - 4);

--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
@@ -11,7 +11,8 @@ import java.util.StringTokenizer;
  *
  * @author gjoranv
  */
-class MakeConfigProperties {
+@SuppressWarnings("WeakerAccess") // Used by ConfigGenMojo
+public class MakeConfigProperties {
 
     private static final List<String> legalLanguages = Arrays.asList("java", "cpp" );
 

--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
@@ -11,9 +11,9 @@ import java.util.StringTokenizer;
  *
  * @author gjoranv
  */
-public class MakeConfigProperties {
+class MakeConfigProperties {
 
-    private static final List<String> legalLanguages = Arrays.asList("java", "cpp", "cppng" );
+    private static final List<String> legalLanguages = Arrays.asList("java", "cpp" );
 
     final File destDir;
     final File[] specFiles;
@@ -33,13 +33,13 @@ public class MakeConfigProperties {
              System.getProperty("config.packagePrefix"));
     }
 
-    public MakeConfigProperties(String destDir,
-                         String specFiles,
-                         String language,
-                         String dirInRoot,
-                         String dumpTree,
-                         String generateFrameworkCode,
-                         String javaPackagePrefix) throws PropertyException {
+    private MakeConfigProperties(String destDir,
+                                 String specFiles,
+                                 String language,
+                                 String dirInRoot,
+                                 String dumpTree,
+                                 String generateFrameworkCode,
+                                 String javaPackagePrefix) throws PropertyException {
         this.destDir = checkDestinationDir(destDir);
         this.specFiles = checkSpecificationFiles(specFiles);
         this.language = checkLanguage(language);

--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
@@ -33,13 +33,14 @@ class MakeConfigProperties {
              System.getProperty("config.packagePrefix"));
     }
 
-    private MakeConfigProperties(String destDir,
-                                 String specFiles,
-                                 String language,
-                                 String dirInRoot,
-                                 String dumpTree,
-                                 String generateFrameworkCode,
-                                 String javaPackagePrefix) throws PropertyException {
+    @SuppressWarnings("WeakerAccess") // Used by ConfigGenMojo
+    public MakeConfigProperties(String destDir,
+                                String specFiles,
+                                String language,
+                                String dirInRoot,
+                                String dumpTree,
+                                String generateFrameworkCode,
+                                String javaPackagePrefix) throws PropertyException {
         this.destDir = checkDestinationDir(destDir);
         this.specFiles = checkSpecificationFiles(specFiles);
         this.language = checkLanguage(language);

--- a/configgen/src/test/java/com/yahoo/config/codegen/MakeConfigTest.java
+++ b/configgen/src/test/java/com/yahoo/config/codegen/MakeConfigTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 public class MakeConfigTest {
 
-    File dest;
+    private File dest;
     
     @Before
     public void setUp() {
@@ -29,8 +29,9 @@ public class MakeConfigTest {
         if (dir.isDirectory()) {
             String[] children = dir.list();
 
-            for (int i = 0; i < children.length; i++) {
-                boolean success = recursiveDeleteDir(new File(dir, children[i]));
+            assert children != null;
+            for (String child : children) {
+                boolean success = recursiveDeleteDir(new File(dir, child));
 
                 if (!success) return false;
             }
@@ -42,10 +43,8 @@ public class MakeConfigTest {
     
     @Test
     public void testProps() throws PropertyException {
-        long ts = System.currentTimeMillis();
         System.setProperty("config.dumpTree", "true");
         System.setProperty("config.useFramework", "true");
-        System.setProperty("config.requireNamespace", "true");
         System.setProperty("config.dest", dest.getAbsolutePath());
         System.setProperty("config.spec", "src/test/resources/allfeatures.def");
         MakeConfigProperties p = new MakeConfigProperties();
@@ -57,7 +56,6 @@ public class MakeConfigTest {
         
         System.setProperty("config.dumpTree", "false");
         System.setProperty("config.useFramework", "false");
-        System.setProperty("config.requireNamespace", "false");
         System.setProperty("config.dest", dest.getAbsolutePath());
         System.setProperty("config.spec", "src/test/resources/allfeatures.def,src/test/resources/bar.foo.def");
         p = new MakeConfigProperties();
@@ -71,7 +69,6 @@ public class MakeConfigTest {
     public void testMake() throws IOException, InterruptedException {
         System.setProperty("config.dumpTree", "true");
         System.setProperty("config.useFramework", "true");
-        System.setProperty("config.requireNamespace", "true");
         System.setProperty("config.dest", dest.getAbsolutePath());
         System.setProperty("config.spec", "src/test/resources/allfeatures.def");
         MakeConfig.main(new String[]{});

--- a/functions.cmake
+++ b/functions.cmake
@@ -132,7 +132,7 @@ function(vespa_generate_config TARGET RELATIVE_CONFIG_DEF_PATH)
 
     add_custom_command(
         OUTPUT ${CONFIG_H_PATH} ${CONFIG_CPP_PATH}
-        COMMAND java -Dconfig.spec=${CONFIG_DEF_PATH} -Dconfig.dest=${CONFIG_DEST_PARENT_DIR} -Dconfig.lang=cppng -Dconfig.requireNamespace=false -Dconfig.subdir=${CONFIG_DEST_DIRNAME} -Dconfig.dumpTree=false -Xms64m -Xmx64m -jar ${PROJECT_SOURCE_DIR}/configgen/target/configgen.jar
+        COMMAND java -Dconfig.spec=${CONFIG_DEF_PATH} -Dconfig.dest=${CONFIG_DEST_PARENT_DIR} -Dconfig.lang=cpp -Dconfig.subdir=${CONFIG_DEST_DIRNAME} -Dconfig.dumpTree=false -Xms64m -Xmx64m -jar ${PROJECT_SOURCE_DIR}/configgen/target/configgen.jar
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
         MAIN_DEPENDENCY ${CONFIG_DEF_PATH}
         )


### PR DESCRIPTION
Languages 'cppng' and 'cpp' are identical now, remove use of 'cppng'.
Remove unused property 'config.requireNamespace'.
