### PR TITLE
Add explicit delete of copy/move constructor/assignment for gid filter test fixture.

### DIFF
--- a/document/src/tests/gid_filter_test.cpp
+++ b/document/src/tests/gid_filter_test.cpp
@@ -19,8 +19,10 @@ protected:
         Fixture(vespalib::stringref selection);
         ~Fixture();
 
-        Fixture(Fixture&&) = default;
-        Fixture& operator=(Fixture&&) = default;
+        Fixture(const Fixture&) = delete;
+        Fixture(Fixture&&) = delete;
+        Fixture& operator=(const Fixture&) = delete;
+        Fixture& operator=(Fixture&&) = delete;
 
         static Fixture for_selection(vespalib::stringref s) {
             return Fixture(s);


### PR DESCRIPTION
@baldersheim : please review
