### PR TITLE
Set memory for admin cluster node to 2 Gb in CD

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -83,7 +83,7 @@ public class CapacityPolicies {
 
     private NodeResources defaultNodeResources(ClusterSpec.Type clusterType) {
         if (clusterType == ClusterSpec.Type.admin)
-            return new NodeResources(0.5, zone.system().isCd() ? 2.5 : 3, 50);
+            return nodeResourcesForAdminCluster();
 
         return new NodeResources(1.5, 8, 50);
     }
@@ -109,6 +109,11 @@ public class CapacityPolicies {
                 zone.environment().isProduction())
             throw new IllegalArgumentException("Deployments to prod require at least 2 nodes per cluster for redundancy");
         return nodeCount;
+    }
+
+    private NodeResources nodeResourcesForAdminCluster() {
+        double memoryInGb = (zone.system().isCd() ? 2 : 3);
+        return new NodeResources(0.5, memoryInGb, 50);
     }
 
 }


### PR DESCRIPTION
Java processes running on the node have combined max heap of 1,5 Gb, in addition there is logd and config sentinel, so I think 2 Gb should be enough.
