### PR TITLE
Return 409 with error code LOAD_BALANCER_NOT_READY if deployment fail…

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/exception/LoadBalancerServiceException.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/exception/LoadBalancerServiceException.java
@@ -1,10 +1,10 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.hosted.provision.lb;
+package com.yahoo.config.provision.exception;
 
 import com.yahoo.config.provision.TransientException;
 
 /**
- * Transient exception thrown on behalf of a {@link LoadBalancerService}.
+ * Transient exception thrown on behalf of a load balancer service
  *
  * @author mpolden
  */

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/exception/package-info.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/exception/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.config.provision.exception;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpErrorResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpErrorResponse.java
@@ -49,7 +49,8 @@ public class HttpErrorResponse extends HttpResponse {
         REQUEST_TIMEOUT,
         UNKNOWN_VESPA_VERSION,
         PARENT_HOST_NOT_READY,
-        CERTIFICATE_NOT_READY
+        CERTIFICATE_NOT_READY,
+        LOAD_BALANCER_NOT_READY
     }
 
     public static HttpErrorResponse notFoundError(String msg) {
@@ -98,6 +99,10 @@ public class HttpErrorResponse extends HttpResponse {
 
     public static HttpErrorResponse certificateNotReady(String msg) {
         return new HttpErrorResponse(CONFLICT, errorCodes.CERTIFICATE_NOT_READY.name(), msg);
+    }
+
+    public static HttpErrorResponse loadBalancerNotReady(String msg) {
+        return new HttpErrorResponse(CONFLICT, errorCodes.LOAD_BALANCER_NOT_READY.name(), msg);
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.config.server.http;
 import com.yahoo.config.provision.ApplicationLockException;
 import com.yahoo.config.provision.CertificateNotReadyException;
 import com.yahoo.config.provision.ParentHostUnavailableException;
+import com.yahoo.config.provision.exception.LoadBalancerServiceException;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.LoggingRequestHandler;
@@ -67,6 +68,8 @@ public class HttpHandler extends LoggingRequestHandler {
             return HttpErrorResponse.parentHostNotReady(getMessage(e, request));
         } catch (CertificateNotReadyException e) {
             return HttpErrorResponse.certificateNotReady(getMessage(e, request));
+        } catch (LoadBalancerServiceException e) {
+            return HttpErrorResponse.loadBalancerNotReady(getMessage(e, request));
         } catch (Exception e) {
             log.log(LogLevel.WARNING, "Unexpected exception handling a config server request", e);
             return HttpErrorResponse.internalServerError(getMessage(e, request));

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServerException.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServerException.java
@@ -38,7 +38,8 @@ public class ConfigServerException extends RuntimeException {
         REQUEST_TIMEOUT,
         UNKNOWN_VESPA_VERSION,
         PARENT_HOST_NOT_READY,
-        CERTIFICATE_NOT_READY
+        CERTIFICATE_NOT_READY,
+        LOAD_BALANCER_NOT_READY
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -62,6 +62,7 @@ import static com.yahoo.vespa.hosted.controller.api.integration.configserver.Con
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.BAD_REQUEST;
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.CERTIFICATE_NOT_READY;
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.INVALID_APPLICATION_PACKAGE;
+import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.LOAD_BALANCER_NOT_READY;
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.OUT_OF_CAPACITY;
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.PARENT_HOST_NOT_READY;
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.Node.State.active;
@@ -232,7 +233,8 @@ public class InternalStepRunner implements StepRunner {
                 || e.getErrorCode() == ACTIVATION_CONFLICT
                 || e.getErrorCode() == APPLICATION_LOCK_FAILURE
                 || e.getErrorCode() == PARENT_HOST_NOT_READY
-                || e.getErrorCode() == CERTIFICATE_NOT_READY) {
+                || e.getErrorCode() == CERTIFICATE_NOT_READY
+                || e.getErrorCode() == LOAD_BALANCER_NOT_READY) {
                 logger.log("Will retry, because of '" + e.getErrorCode() + "' deploying:\n" + e.getMessage());
                 return Optional.empty();
             }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -14,7 +14,7 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerId;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerInstance;
-import com.yahoo.vespa.hosted.provision.lb.LoadBalancerServiceException;
+import com.yahoo.config.provision.exception.LoadBalancerServiceException;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerService;
 import com.yahoo.vespa.hosted.provision.lb.Real;
 import com.yahoo.vespa.hosted.provision.node.IP;


### PR DESCRIPTION
…s due to that

Move LoadBalancerServiceException to config-provisioning so that it can be used from
config server as well.
Return 409 and LOAD_BALANCER_NOT_READY as error code if we get a LoadBalancerServiceException.
Retry deploy on LOAD_BALANCER_NOT_READY.
