### PR TITLE
Remove support for gcc version < 7 in vespamalloc unit test for atomics.

### DIFF
--- a/vespamalloc/src/tests/test1/testatomic.cpp
+++ b/vespamalloc/src/tests/test1/testatomic.cpp
@@ -14,12 +14,8 @@ TEST("verify lock freeness of atomics"){
     {
         std::atomic<vespamalloc::TaggedPtr> taggedPtr;
         ASSERT_EQUAL(16u, sizeof(vespamalloc::TaggedPtr));
-#if __GNUC__ < 7
         // See https://gcc.gnu.org/ml/gcc-patches/2017-01/msg02344.html for background
-        ASSERT_TRUE(taggedPtr.is_lock_free());
-#else
         ASSERT_TRUE(taggedPtr.is_lock_free() || !taggedPtr.is_lock_free());
-#endif
     }
 
 }


### PR DESCRIPTION
@baldersheim : please review
