### PR TITLE
As redundancy and searchable copies depends on group setup normally,

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -233,7 +233,7 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
         Optional<Tuning> tuning = Optional.ofNullable(this.tuning);
         if (element == null) {
             snode = SearchNode.create(parent, "" + node.getDistributionKey(), node.getDistributionKey(), spec,
-                                      clusterName, node, flushOnShutdown, tuning, parentGroup.getOwner().isHostedVespa());
+                                      clusterName, node, flushOnShutdown, tuning, parentGroup.isHosted());
             snode.setHostResource(node.getHostResource());
             snode.initService(deployState.getDeployLogger());
 
@@ -283,12 +283,12 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
             if (usesHierarchicDistribution()) {
                 indexedCluster.setMaxNodesDownPerFixedRow((redundancy.effectiveFinalRedundancy() / groupToSpecMap.size()) - 1);
             }
-            indexedCluster.setSearchableCopies(redundancy.searchableCopies());
+            indexedCluster.setSearchableCopies(redundancy.readyCopies());
         }
         this.redundancy = redundancy;
         for (SearchNode node : getSearchNodes()) {
-            node.setRedundancy(redundancy.redundancyFromSearchNodePerspective());
-            node.setSearchableCopies(redundancy.searchableCopies());
+            node.setRedundancy(redundancy.finalRedundancy());
+            node.setSearchableCopies(redundancy.readyCopies());
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
@@ -2,22 +2,22 @@
 package com.yahoo.vespa.model.content.cluster;
 
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
+import com.yahoo.vespa.model.content.IndexedHierarchicDistributionValidator;
 import com.yahoo.vespa.model.content.Redundancy;
 
 /**
  * Builds redundancy config for a content cluster.
  */
 public class RedundancyBuilder {
+    Integer initialRedundancy = 2;
+    Integer finalRedundancy = 2;
+    Integer readyCopies = 2;
 
-    Redundancy build(ModelElement clusterXml) {
-        Integer initialRedundancy = 2;
-        Integer finalRedundancy = 3;
-        Integer readyCopies = 2;
-
+    RedundancyBuilder(ModelElement clusterXml) {
         ModelElement redundancyElement = clusterXml.child("redundancy");
         if (redundancyElement != null) {
             initialRedundancy = redundancyElement.integerAttribute("reply-after");
-            finalRedundancy = (int)redundancyElement.asLong();
+            finalRedundancy = (int) redundancyElement.asLong();
 
             if (initialRedundancy == null) {
                 initialRedundancy = finalRedundancy;
@@ -35,8 +35,16 @@ public class RedundancyBuilder {
                 throw new IllegalArgumentException("Number of searchable copies can not be higher than final redundancy");
             }
         }
-
-        return new Redundancy(initialRedundancy, finalRedundancy, readyCopies);
+    }
+    public Redundancy build(String clusterName, boolean isHosted, int subGroups, int leafGroups,  int totalNodes) {
+        if (isHosted) {
+            return new Redundancy(initialRedundancy, finalRedundancy, readyCopies, leafGroups, totalNodes);
+        } else {
+            subGroups = Math.max(1, subGroups);
+            IndexedHierarchicDistributionValidator.validateThatLeafGroupsCountIsAFactorOfRedundancy(clusterName, finalRedundancy, subGroups);
+            IndexedHierarchicDistributionValidator.validateThatReadyCopiesIsCompatibleWithRedundancy(clusterName, finalRedundancy, readyCopies, subGroups);
+            return new Redundancy(initialRedundancy/leafGroups, finalRedundancy/leafGroups, readyCopies/leafGroups, leafGroups, totalNodes);
+        }
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
@@ -10,7 +10,7 @@ import com.yahoo.vespa.model.content.Redundancy;
  */
 public class RedundancyBuilder {
     Integer initialRedundancy = 2;
-    Integer finalRedundancy = 2;
+    Integer finalRedundancy = 3;
     Integer readyCopies = 2;
 
     RedundancyBuilder(ModelElement clusterXml) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
@@ -113,6 +113,7 @@ public class DistributorTest {
         assertEquals(true, conf.inlinebucketsplitting());
 
         cluster = parseCluster("<cluster id=\"storage\">\n" +
+                "  <redundancy>2</redundancy>" +
                 "  <documents/>" +
                 "    <tuning>" +
                 "      <distribution type=\"legacy\"/>" +

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/RedundancyTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/RedundancyTest.java
@@ -22,9 +22,7 @@ public class RedundancyTest {
     }
 
     private static Redundancy createRedundancy(int redundancy, int implicitGroups, int totalNodes) {
-        Redundancy r = new Redundancy(1, redundancy, 1);
-        r.setImplicitGroups(implicitGroups);
-        r.setTotalNodes(totalNodes);
+        Redundancy r = new Redundancy(1, redundancy, 1, implicitGroups, totalNodes);
         return r;
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
@@ -305,7 +305,8 @@ public class StorageClusterTest {
     public void requireThatGroupNamesMustBeUniqueAmongstSiblings() {
         String xml =
                 "<cluster id=\"storage\">\n" +
-                "<documents/>\n" +
+                 "  <redundancy>2</redundancy>" +
+                "  <documents/>\n" +
                 "  <group>\n" +
                 "    <distribution partitions=\"*\"/>\n" +
                 "    <group distribution-key=\"0\" name=\"bar\">\n" +
@@ -330,6 +331,7 @@ public class StorageClusterTest {
     public void requireThatGroupNamesCanBeDuplicatedAcrossLevels() {
         String xml =
                 "<cluster id=\"storage\">\n" +
+                "  <redundancy>2</redundancy>" +
                 "<documents/>\n" +
                 "  <group>\n" +
                 "    <distribution partitions=\"*\"/>\n" +

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/StorageGroupTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/StorageGroupTest.java
@@ -80,6 +80,7 @@ public class StorageGroupTest {
         StorDistributionConfig.Builder builder = new StorDistributionConfig.Builder();
         parse(
                 "<content version=\"1.0\" id=\"storage\">\n" +
+                        "  <redundancy>4</redundancy>" +
                         "  <documents/>" +
                         "  <group>\n" +
                         "    <distribution partitions=\"1|*\"/>\n" +
@@ -134,6 +135,7 @@ public class StorageGroupTest {
         StorDistributionConfig.Builder builder = new StorDistributionConfig.Builder();
         parse(
                 "<content version=\"1.0\" id=\"storage\">\n" +
+                        "  <redundancy>2</redundancy>" +
                         "  <documents/>" +
                         "  <group>\n" +
                         "    <distribution partitions=\"1|*\"/>\n" +

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
@@ -124,6 +124,8 @@ public class ClusterTest {
                         "    </engine>",
                         "    <group>",
                         "      <node hostalias='my_host' distribution-key='0' />",
+                        "      <node hostalias='my_host' distribution-key='1' />",
+                        "      <node hostalias='my_host' distribution-key='2' />",
                         "    </group>",
                         contentSearchXml,
                         "  </content>",


### PR DESCRIPTION
but in hosted it is within a group, we have had some very dirty and incorrect code for reasoning here.
Now this is taken care of at constrution of the Redundancy object, so that use is identical later on.

@hmusum or @bratseth or @vekterli or @bjorncs PR
