### PR TITLE
Repair vespamalloc doubledelete test for clang.

### DIFF
--- a/vespamalloc/src/tests/doubledelete/doubledelete.cpp
+++ b/vespamalloc/src/tests/doubledelete/doubledelete.cpp
@@ -1,11 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <stdlib.h>
 
+void *savedptr;
+
 int main(int argc, char *argv[])
 {
     (void) argc;
     (void) argv;
-    char * a = new char [100];
+    char * a = new char;
+    savedptr = a;
     delete a;
     delete a;
 }


### PR DESCRIPTION
@baldersheim : please review
