### PR TITLE
Added prometheus formatted output option to metric-proxy

### DIFF
--- a/metrics-proxy/pom.xml
+++ b/metrics-proxy/pom.xml
@@ -123,6 +123,14 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_common</artifactId>
+    </dependency>
 
     <!-- test scope -->
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/TextResponse.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/TextResponse.java
@@ -1,0 +1,21 @@
+package ai.vespa.metricsproxy.http;
+
+import com.yahoo.container.jdisc.HttpResponse;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+public class TextResponse extends HttpResponse {
+  private final byte[] data;
+
+  TextResponse(int code, String data) {
+      super(code);
+      this.data = data.getBytes(Charset.forName(DEFAULT_CHARACTER_ENCODING));
+  }
+
+  @Override
+  public void render(OutputStream outputStream) throws IOException {
+      outputStream.write(data);
+  }
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/ResponseFormat.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/ResponseFormat.java
@@ -1,0 +1,22 @@
+package ai.vespa.metricsproxy.metric.model;
+
+import java.util.logging.Logger;
+
+public enum ResponseFormat {
+    JSON,
+    PROMETHEUS;
+
+    private static Logger logger = Logger.getLogger(ResponseFormat.class.getName());
+
+    public static ResponseFormat getResponseFormat(String val) {
+        if (val == null) {
+            return JSON;
+        }
+        try {
+            return valueOf(val.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            logger.warning("unknown format " + val + " requested.");
+            return JSON;
+        }
+    }
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusModel.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusModel.java
@@ -1,0 +1,43 @@
+package ai.vespa.metricsproxy.metric.model.prometheus;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.exporter.common.TextFormat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class PrometheusModel implements Enumeration<Collector.MetricFamilySamples> {
+    private static Logger log = Logger.getLogger(PrometheusModel.class.getName());
+
+    private final Iterator<Collector.MetricFamilySamples> metricFamilySamplesIterator;
+
+    PrometheusModel(List<Collector.MetricFamilySamples> metricFamilySamples) {
+        this.metricFamilySamplesIterator = metricFamilySamples.iterator();
+    }
+
+    @Override
+    public boolean hasMoreElements() {
+      return metricFamilySamplesIterator.hasNext();
+    }
+
+    @Override
+    public Collector.MetricFamilySamples nextElement() {
+      return metricFamilySamplesIterator.next();
+    }
+
+    public String serialize() {
+        var writer = new StringWriter();
+        try {
+            TextFormat.write004(writer, this);
+        } catch (IOException e) {
+            log.log(Level.WARNING, "Got exception when rendering metrics:", e);
+            throw new PrometheusRenderingException("Could not render metrics. Check the log for details.");
+        }
+        return writer.toString();
+    }
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusRenderingException.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusRenderingException.java
@@ -1,0 +1,9 @@
+package ai.vespa.metricsproxy.metric.model.prometheus;
+
+public class PrometheusRenderingException extends RuntimeException {
+
+    PrometheusRenderingException(String message) {
+    super(message);
+  }
+
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
@@ -1,0 +1,67 @@
+package ai.vespa.metricsproxy.metric.model.prometheus;
+
+import ai.vespa.metricsproxy.metric.model.MetricsPacket;
+import ai.vespa.metricsproxy.metric.model.ServiceId;
+import io.prometheus.client.Collector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class PrometheusUtil {
+    private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_]");
+    private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_]");
+
+    public static PrometheusModel toPrometheusModel(List<MetricsPacket> metricsPackets) {
+        Map<ServiceId, List<MetricsPacket>> packetsByService = metricsPackets.stream()
+            .collect(Collectors.groupingBy(packet -> packet.service));
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = new ArrayList<>(packetsByService.size());
+
+        packetsByService.forEach(((serviceId, packets) -> {
+            Map<String, List<Collector.MetricFamilySamples.Sample>> samples = new HashMap<>();
+            
+            var serviceName = Collector.sanitizeMetricName(serviceId.id);
+            for (var packet : packets) {
+                var dimensions = packet.dimensions();
+                List<String> labels = new ArrayList<>(dimensions.size());
+                List<String> labelValues = new ArrayList<>(dimensions.size());
+                for (var entry : dimensions.entrySet()) {
+                    var labelName = Collector.sanitizeMetricName(entry.getKey().id);
+                    labels.add(labelName);
+                    labelValues.add(entry.getValue());
+                }
+
+                for (var metric : packet.metrics().entrySet()) {
+                    var metricName = serviceName + "_" + Collector.sanitizeMetricName(metric.getKey().id);
+                    List<Collector.MetricFamilySamples.Sample> sampleList;
+                    if (samples.containsKey(metricName)) {
+                        sampleList = samples.get(metricName);
+                    } else {
+                        sampleList = new ArrayList<>();
+                        samples.put(metricName, sampleList);
+                        metricFamilySamples.add(new Collector.MetricFamilySamples(metricName, Collector.Type.UNTYPED, "", sampleList));
+                    }
+                    sampleList.add(new Collector.MetricFamilySamples.Sample(metricName, labels, labelValues, metric.getValue().doubleValue(), packet.timestamp * 1000));
+                }
+            }
+            // convert status message to 0,1 metric
+            var firstPacket = packets.get(0);
+            String statusMetricName = serviceName + "_status";
+            double statusMetricValue = "up".equals(firstPacket.statusCode) ? 1.0 : 0.0;
+            List<Collector.MetricFamilySamples.Sample> sampleList = Collections.singletonList(new Collector.MetricFamilySamples.Sample(statusMetricName, Collections.emptyList(), Collections.emptyList(), statusMetricValue, firstPacket.timestamp * 1000));
+            metricFamilySamples.add(new Collector.MetricFamilySamples(statusMetricName, Collector.Type.UNTYPED, "status of service", sampleList));
+        }));
+
+        return new PrometheusModel(metricFamilySamples);
+    }
+
+    public static String sanitizeMetricLabelName(String labelName) {
+        // same as Collector.sanitizeMetricName...
+        return SANITIZE_BODY_PATTERN.matcher(SANITIZE_PREFIX_PATTERN.matcher(labelName).replaceFirst("_")).replaceAll("_");
+    }
+}

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
@@ -12,13 +12,16 @@ import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.service.VespaService;
 import ai.vespa.metricsproxy.service.VespaServices;
+import io.prometheus.client.Collector;
 
+import java.awt.*;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
@@ -12,16 +12,13 @@ import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.service.VespaService;
 import ai.vespa.metricsproxy.service.VespaServices;
-import io.prometheus.client.Collector;
 
-import java.awt.*;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -747,6 +747,16 @@
                 <artifactId>aws-java-sdk-core</artifactId>
                 <version>${aws.sdk.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient</artifactId>
+                <version>${prometheus.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_common</artifactId>
+                <version>${prometheus.client.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -778,6 +788,7 @@
         <surefire.version>2.22.0</surefire.version>
         <junit.version>5.4.2</junit.version>
         <protobuf.version>3.7.0</protobuf.version>
+        <prometheus.client.version>0.6.0</prometheus.client.version>
     </properties>
 
 </project>


### PR DESCRIPTION
Since metrics-proxy outputs metrics only by JSON format, we cannot collect metrics by Prometheus directly from it and it needs additional exporter now. (And the additional exporter will probably be self-making one because existing [vespa_exporter](https://github.com/vespa-engine/vespa_exporter) is not for metrics-proxy.)

So I added `format` parameter to MetricsHandler, and make metrics-proxy render metrics by [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) when `format=metrics`.

Similar issue #4149 says we should re-implement metrics by Prometheus Collectors like Gauges in each service, but I just modified metrics-proxy renders metrics by prometheus format (hence snapshot value keep unchanged) because what metrics-proxy doing is just assembling, filtering, and rendering metrics from each service.

Discussion:
Following [vespa_exporter](https://github.com/vespa-engine/vespa_exporter), the format of metric names in my implementation is `${service_name}_${metric_name}`.
But by putting service name into labels and eliminating it from metric names, we can treat common metrics like `cpu` and 'memory_rss` as metrics in the same metrics family.

TODO:
Writing test code, after the specification is decided.