### PR TITLE
Use std::_Exit instead of std::quick_exit.

### DIFF
--- a/config/src/vespa/config/helper/configpoller.cpp
+++ b/config/src/vespa/config/helper/configpoller.cpp
@@ -27,7 +27,7 @@ ConfigPoller::run()
         }
     } catch (config::InvalidConfigException & e) {
         LOG(fatal, "Got exception, will just exit quickly : %s", e.what());
-        std::quick_exit(17);
+        std::_Exit(17);
     }
 }
 

--- a/slobrok/src/vespa/slobrok/server/reconfigurable_stateserver.cpp
+++ b/slobrok/src/vespa/slobrok/server/reconfigurable_stateserver.cpp
@@ -52,7 +52,7 @@ ReconfigurableStateServer::configure(std::unique_ptr<vespa::config::core::States
         } catch (vespalib::PortListenException & e) {
             LOG(error, "Failed listening to network port(%d) with protocol(%s): '%s', giving up and restarting.",
                 e.get_port(), e.get_protocol().c_str(), e.what());
-            std::quick_exit(17);
+            std::_Exit(17);
         }
     }
 

--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
@@ -59,7 +59,7 @@ void StatusWebServer::configure(std::unique_ptr<vespa::config::content::core::St
         } catch (const vespalib::PortListenException & e) {
             LOG(error, "Failed listening to network port(%d) with protocol(%s): '%s', giving up and restarting.",
                 e.get_port(), e.get_protocol().c_str(), e.what());
-            std::quick_exit(17);
+            std::_Exit(17);
         }
         // Now that we know config update went well, update internal state
         _port = server->getListenPort();

--- a/vespalib/src/vespa/vespalib/net/crypto_engine.cpp
+++ b/vespalib/src/vespa/vespalib/net/crypto_engine.cpp
@@ -234,7 +234,7 @@ CryptoEngine::SP try_create_default_crypto_engine() {
         return create_default_crypto_engine();
     } catch (net::tls::CryptoException &e) {
         LOG(error, "failed to create default crypto engine: %s", e.what());
-        std::quick_exit(78);
+        std::_Exit(78);
     }
 }
 

--- a/vespalib/src/vespa/vespalib/util/exceptions.cpp
+++ b/vespalib/src/vespa/vespalib/util/exceptions.cpp
@@ -33,7 +33,7 @@ vespalib::string _G_what;
 void silent_terminate() {
     std::lock_guard<std::mutex> guard(_G_silence_mutex);
     LOG(fatal, "Will exit with code 66 due to: %s", _G_what.c_str());
-    std::quick_exit(66);
+    std::_Exit(66);
 }
 
 }


### PR DESCRIPTION
@baldersheim : please review
