### PR TITLE
Ensure advancing past log ttl 

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLoggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLoggerTest.java
@@ -76,8 +76,8 @@ public class AuditLoggerTest {
             assertEntry(Entry.Method.POST, 5, "/controller/v1/jobs/upgrader/confidence/6.42");
         }
 
-        { // 14 days pass and another PATCH request is logged. Older entries are removed due to expiry
-            tester.clock().advance(Duration.ofDays(14));
+        { // 15 days pass and another PATCH request is logged. Older entries are removed due to expiry
+            tester.clock().advance(Duration.ofDays(15));
             HttpRequest request = testRequest(Method.PATCH, URI.create("http://localhost:8080/os/v1/"),
                                               "{\"cloud\":\"cloud9\",\"version\":\"44.0\"}");
             tester.controller().auditLogger().log(request);


### PR DESCRIPTION
Once in a blue moon, the previous log will be exactly 14 days old, on the millisecond, and thus won't be pruned away.