### PR TITLE
Public deployments have no valid web cert yet — work around this

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -413,7 +413,9 @@ public class JobController {
                          .stream().findAny()
                          .or(() -> controller.applications().routingPolicies().get(testerId).stream()
                                              .findAny()
-                                             .map(policy -> policy.endpointIn(controller.system()).url()));
+                                             .map(policy -> policy.endpointIn(controller.system()).url()))
+                         // TODO jvenstad: Remove ugly thing when public deployments have a valid web certificate.
+                         .map(uri -> controller.system().isPublic() ? URI.create("http://" + uri.getHost() + ":443/") : uri);
     }
 
     /** Returns a set containing the zone of the deployment tested in the given run, and all production zones for the application. */


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@kkraune please review. 