### PR TITLE
Hmusum/remove header and body from searchdefinitions

### DIFF
--- a/config-model/src/test/cfg/admin/metricconfig/searchdefinitions/music.sd
+++ b/config-model/src/test/cfg/admin/metricconfig/searchdefinitions/music.sd
@@ -4,12 +4,10 @@ search music      {
                 field f1 type string    {
                         indexing: summary | index
                         # index-to: f1, all
-                        header
                 }
                 field f2 type string    {
                         indexing: summary | index
                         # index-to: f2, all
-                        body
                 }
         }
 }

--- a/config-model/src/test/cfg/application/app1/searchdefinitions/music.sd
+++ b/config-model/src/test/cfg/application/app1/searchdefinitions/music.sd
@@ -9,35 +9,28 @@ search music {
       indexing: summary | index   # How this field should be indexed
       # index-to: title, default    # Create two indexes
       rank-type: about            # Type of ranking settings to apply
-      header
     }
 
     field artist type string {
       indexing: summary | attribute | index
       # index-to: artist, default
       rank-type:about
-      header
     }
 
     field year type int {
       indexing: summary | attribute
-      header
     }
 
     # Increase rank score of popular documents regardless of query
     field popularity type int {
       indexing: summary | attribute
-      body
     }
 
     field url type uri {
       indexing: summary | index
-      header
     }
 
-    field cover type raw {
-      body
-    }
+    field cover type raw {}
 
   }
 

--- a/config-model/src/test/cfg/application/app_genericservices/searchdefinitions/music.sd
+++ b/config-model/src/test/cfg/application/app_genericservices/searchdefinitions/music.sd
@@ -9,35 +9,28 @@ search music {
       indexing: summary | index   # How this field should be indexed
       # index-to: title, default    # Create two indexes
       rank-type: about            # Type of ranking settings to apply
-      header
     }
 
     field artist type string {
       indexing: summary | attribute | index
       # index-to: artist, default
       rank-type:about
-      header
     }
 
     field year type int {
       indexing: summary | attribute
-      header
     }
 
     # Increase rank score of popular documents regardless of query
     field popularity type int {
       indexing: summary | attribute
-      body
     }
 
     field url type uri {
       indexing: summary | index
-      header
     }
 
-    field cover type raw {
-      body
-    }
+    field cover type raw {}
 
   }
 

--- a/config-model/src/test/cfg/routing/content_two_clusters/searchdefinitions/mobile.sd
+++ b/config-model/src/test/cfg/routing/content_two_clusters/searchdefinitions/mobile.sd
@@ -4,12 +4,10 @@ search mobile      {
                 field f1 type string    {
                         indexing: summary | index
                         # index-to: f1, all
-                        header
                 }
                 field f2 type string    {
                         indexing: summary | index
                         # index-to: f2, all
-                        body
                 }
         }
 }

--- a/config-model/src/test/cfg/search/data/travel/searchdefinitions/TTEdge.sd
+++ b/config-model/src/test/cfg/search/data/travel/searchdefinitions/TTEdge.sd
@@ -4,7 +4,6 @@ document TTEdge {
 # This field will contain a colon separate map for travel times per transport mode
     field TransportMode type array<string> {
         indexing: summary | index
-        header
     }
 }
 

--- a/config-model/src/test/cfg/search/data/travel/searchdefinitions/TTPOI.sd
+++ b/config-model/src/test/cfg/search/data/travel/searchdefinitions/TTPOI.sd
@@ -5,14 +5,12 @@ document TTPOI {
     field Categories type array<string> {
         indexing: summary | index
         # index-to: Categories
-        header
     }
 
 # sub catagories associated with the POI
     field SubCategories type array<string> {
         indexing: summary | index
         # index-to: SubCategories
-        header
     }
 }
 

--- a/config-model/src/test/cfg/search/data/v2/inherited_rankprofiles/searchdefinitions/music.sd
+++ b/config-model/src/test/cfg/search/data/v2/inherited_rankprofiles/searchdefinitions/music.sd
@@ -4,12 +4,10 @@ search music      {
                 field f1 type string    {
                         indexing: summary | index
                         # index-to: f1, all
-                        header
                 }
                 field f2 type string    {
                         indexing: summary | index
                         # index-to: f2, all
-                        body
                 }
         }
 }

--- a/config-model/src/test/cfg/storage/app_index_higher_than_num_nodes/searchdefinitions/music.sd
+++ b/config-model/src/test/cfg/storage/app_index_higher_than_num_nodes/searchdefinitions/music.sd
@@ -4,12 +4,10 @@ search music      {
                 field f1 type string    {
                         indexing: summary | index
                         # index-to: f1, all
-                        header
                 }
                 field f2 type string    {
                         indexing: summary | index
                         # index-to: f2, all
-                        body
                 }
         }
 }

--- a/config-model/src/test/cfg/storage/clustercontroller_advanced/searchdefinitions/music.sd
+++ b/config-model/src/test/cfg/storage/clustercontroller_advanced/searchdefinitions/music.sd
@@ -4,12 +4,10 @@ search music      {
                 field f1 type string    {
                         indexing: summary | index
                         # index-to: f1, all
-                        header
                 }
                 field f2 type string    {
                         indexing: summary | index
                         # index-to: f2, all
-                        body
                 }
         }
 }

--- a/config-model/src/test/configmodel/types/types.sd
+++ b/config-model/src/test/configmodel/types/types.sd
@@ -90,9 +90,9 @@ search types {
     #field wildcardfield2 type map<?,?> {
     #}
 
-    field arrarr type array<array<array<string>>> {header}
-    field maparr type array<map<string, string>> {header}
-    field complexarray type array< map<int, array<array<string>>> > {body}
+    field arrarr type array<array<array<string>>> {}
+    field maparr type array<map<string, string>> {}
+    field complexarray type array< map<int, array<array<string>>> > {}
 
     struct mystruct {
       field bytearr type array<byte>{}
@@ -101,9 +101,9 @@ search types {
       field structfield type string {}
     }
 
-    field mystructfield type mystruct {header}
-    field mystructmap type map<int, mystruct> {header}
-    field mystructarr type array<mystruct> {header}
+    field mystructfield type mystruct {}
+    field mystructmap type map<int, mystruct> {}
+    field mystructarr type array<mystruct> {}
 
     struct folder {
       field Version                   type int {}
@@ -130,7 +130,6 @@ search types {
         create-if-nonexistent
         remove-if-zero
       }
-      header
     }
 
     # Field defined same way as tag    
@@ -140,7 +139,6 @@ search types {
         create-if-nonexistent
         remove-if-zero
       }
-      header
     }
 
   }

--- a/config-model/src/test/derived/inheritstruct/child.sd
+++ b/config-model/src/test/derived/inheritstruct/child.sd
@@ -3,7 +3,6 @@ search child {
     document child inherits parent {
       field child_struct_field type my_struct {
         indexing: summary | index
-        header
         match: prefix
       }
     }

--- a/config-model/src/test/derived/mail/mail.sd
+++ b/config-model/src/test/derived/mail/mail.sd
@@ -54,39 +54,31 @@ search mail {
     field body type string {
       indexing: summary | index
       match: substring
-      body
     }
 
     field attachmentcount type int {
       indexing: summary | index
-      body
     }
 
     field attachmentnames type string {
       indexing: index
-      body
     }
 
     field attachmenttypes type string {
       indexing: index
-      body
     }
 
     field attachmentlanguages type string {
       indexing: index
       match: prefix
-      body
     }
 
     field attachmentcontent type string {
       indexing: summary | index
       match: prefix
-      body
     }
 
-    field attachments type raw[] {
-      body
-    }
+    field attachments type raw[] {}
 
   }
 

--- a/config-model/src/test/derived/music3/music3.sd
+++ b/config-model/src/test/derived/music3/music3.sd
@@ -7,35 +7,25 @@ search music3 {
       indexing: summary | index
       # index-to: title, default
       rank-type: about
-
-      header
     }
 
     field artist type string {
       indexing: summary | attribute | index
       # index-to: artist, default
       rank-type:about
-
-      header
     }
 
     field year type int {
       indexing: summary | attribute
-
-      header
     }
 
     # Increase rank score of popular documents regardless of query
     field popularity type int {
       indexing: summary | attribute
-
-      header
     }
 
     field url type uri {
       indexing: summary | index
-
-      header
     }
 
   }

--- a/config-model/src/test/derived/streamingjuniper/streamingjuniper.sd
+++ b/config-model/src/test/derived/streamingjuniper/streamingjuniper.sd
@@ -3,12 +3,10 @@ search streamingjuniper {
   document streamingjuniper {
     field f1 type string {
       indexing: index | summary
-      header
       bolding: on
     }
     field f2 type string {
       indexing: index | summary
-      header
       summary: dynamic
     }
   }

--- a/config-model/src/test/derived/streamingstructdefault/streamingstructdefault.sd
+++ b/config-model/src/test/derived/streamingstructdefault/streamingstructdefault.sd
@@ -8,11 +8,9 @@ search streamingstructdefault {
     field f1 type array<string> {
       indexing: index | summary
       summary-to: default
-      header
     }
     field f2 type array<sct> {
       indexing: index | summary
-      header
     }
   }
   document-summary default {

--- a/config-model/src/test/derived/types/types.sd
+++ b/config-model/src/test/derived/types/types.sd
@@ -93,9 +93,9 @@ search types {
     #field wildcardfield2 type map<?,?> {
     #}
 
-    field arrarr type array<array<array<string>>> {header}
-    field maparr type array<map<string, string>> {header}
-    field complexarray type array< map<int, array<array<string>>> > {body}
+    field arrarr type array<array<array<string>>> {}
+    field maparr type array<map<string, string>> {}
+    field complexarray type array< map<int, array<array<string>>> > {}
 
     struct mystruct {
       field bytearr type array<byte>{}
@@ -104,9 +104,9 @@ search types {
       field structfield type string {}
     }
 
-    field mystructfield type mystruct {header}
-    field mystructmap type map<int, mystruct> {header}
-    field mystructarr type array<mystruct> {header}
+    field mystructfield type mystruct {}
+    field mystructmap type map<int, mystruct> {}
+    field mystructarr type array<mystruct> {}
 
     struct folder {
       field Version                   type int {}
@@ -133,7 +133,6 @@ search types {
         create-if-nonexistent
         remove-if-zero
       }
-      header
     }
 
     # Field defined same way as tag    
@@ -143,14 +142,11 @@ search types {
         create-if-nonexistent
         remove-if-zero
       }
-      header
     }
 
   }
 
-  field pst_sta_boldingoff_nomatch_tag_01 type tag {
-    body
-  } 
+  field pst_sta_boldingoff_nomatch_tag_01 type tag {} 
 
   field other type long {
     indexing: input along | attribute

--- a/config-model/src/test/examples/header_body.sd
+++ b/config-model/src/test/examples/header_body.sd
@@ -1,4 +1,4 @@
-# Copyright 2019 Verizon Media Inc.. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 # Search definition with (ignored) header and body statements
 # TODO: Remove in Vespa 8
 search header_body {

--- a/config-model/src/test/examples/header_body.sd
+++ b/config-model/src/test/examples/header_body.sd
@@ -1,0 +1,18 @@
+# Copyright 2019 Verizon Media Inc.. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Search definition with (ignored) header and body statements
+# TODO: Remove in Vespa 8
+search header_body {
+
+  document header_body {
+
+    field title type string {
+      indexing: summary | index
+      header
+    }
+
+    field description type string {
+      indexing: summary | index
+      body
+    }
+  }
+}

--- a/config-model/src/test/examples/rankpropvars.sd
+++ b/config-model/src/test/examples/rankpropvars.sd
@@ -52,28 +52,22 @@ document music {
 
     field title type string {
       indexing: index | summary
-      body
     }
 
     field artist type string {
       ## index-to: a
       indexing: index | summary
-      body
     }
 
     field year type int {
       indexing: attribute | summary
       ## index-to: y
-      body
     }
 
-    field url type uri {
-      body
-    }
+    field url type uri {}
 
     field Popularity type string {
       indexing: attribute | summary
-      body
     }
 }
 

--- a/config-model/src/test/examples/simple.sd
+++ b/config-model/src/test/examples/simple.sd
@@ -47,7 +47,6 @@ search simple {
       rank-type: tags
       stemming: none
       normalizing: none
-      header
     }
 
     field popularity type int {
@@ -81,7 +80,6 @@ search simple {
 
   field categories type string {
     indexing: input categories_src | lowercase | normalize | index
-    body
   }
 
   field categoriesagain type string {

--- a/config-model/src/test/examples/structoutsideofdocument.sd
+++ b/config-model/src/test/examples/structoutsideofdocument.sd
@@ -11,6 +11,5 @@ search structoutsideofdocument {
 
    field nallestruct type array<nalle> {
      indexing: summary
-     body
    }
   }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/SearchDefinitionsParsingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/SearchDefinitionsParsingTestCase.java
@@ -80,4 +80,10 @@ public class SearchDefinitionsParsingTestCase extends SearchDefinitionTestCase {
         }
     }
 
+    // TODO: Remove in Vespa 8
+    @Test
+    public void requireThatParserHandlesHeadAndBody() throws IOException, ParseException {
+        assertNotNull(SearchBuilder.buildFromFile("src/test/examples/header_body.sd"));
+    }
+
 }


### PR DESCRIPTION
Remove from .sd files used in tests, add test that checks that
header and body still is allowed
