### PR TITLE
[VESPA-16037] Resource down size fix

### DIFF
--- a/config-provisioning/abi-spec.json
+++ b/config-provisioning/abi-spec.json
@@ -621,6 +621,7 @@
       "public int hashCode()",
       "public java.lang.String toString()",
       "public boolean satisfies(com.yahoo.config.provision.NodeResources)",
+      "public boolean compatibleWith(com.yahoo.config.provision.NodeResources)",
       "public static com.yahoo.config.provision.NodeResources fromLegacyName(java.lang.String)"
     ],
     "fields": []

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
@@ -149,13 +149,26 @@ public class NodeResources {
         if (this.allocateByLegacyName || other.allocateByLegacyName) // resources are not available
             return Objects.equals(this.legacyName, other.legacyName);
 
-        if (this.vcpu < other.vcpu()) return false;
+        if (this.vcpu < other.vcpu) return false;
         if (this.memoryGb < other.memoryGb) return false;
         if (this.diskGb < other.diskGb) return false;
 
         // Why doesn't a fast disk satisfy a slow disk? Because if slow disk is explicitly specified
         // (i.e not "any"), you should not randomly, sometimes get a faster disk as that means you may
         // draw conclusions about performance on the basis of better resources than you think you have
+        if (other.diskSpeed != DiskSpeed.any && other.diskSpeed != this.diskSpeed) return false;
+
+        return true;
+    }
+
+    /** Returns true if all the resources of this are the same as or compatible with the given resources */
+    public boolean compatibleWith(NodeResources other) {
+        if (this.allocateByLegacyName || other.allocateByLegacyName) // resources are not available
+            return Objects.equals(this.legacyName, other.legacyName);
+
+        if (this.vcpu != other.vcpu) return false;
+        if (this.memoryGb != other.memoryGb) return false;
+        if (this.diskGb != other.diskGb) return false;
         if (other.diskSpeed != DiskSpeed.any && other.diskSpeed != this.diskSpeed) return false;
 
         return true;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
@@ -1,10 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
-import com.yahoo.config.provision.NodeResources;
-import com.yahoo.config.provision.NodeFlavors;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.NodeFlavors;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.Node;
 
 import java.util.Objects;
@@ -98,7 +98,7 @@ public interface NodeSpec {
             }
             else {
                 if (flavor.isDocker()) { // Docker nodes can satisfy a request for parts of their resources
-                    if (flavor.resources().satisfies(requestedNodeResources))
+                    if (flavor.resources().compatibleWith(requestedNodeResources))
                         return true;
                 }
                 else { // Other nodes must be matched exactly

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -139,7 +139,7 @@ public class InactiveAndFailedExpirerTest {
         {
             Node toRetire = tester.getNodes(applicationId, Node.State.active).asList().get(0);
             tester.patchNode(toRetire.with(toRetire.status().withWantToRetire(true)));
-            List<HostSpec> hostSpecs = tester.prepare(applicationId, cluster, Capacity.fromNodeCount(2), 1);
+            List<HostSpec> hostSpecs = tester.prepare(applicationId, cluster, Capacity.fromCount(2, nodeResources), 1);
             tester.activate(applicationId, new HashSet<>(hostSpecs));
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -90,16 +90,17 @@ public class NodeFailTester {
         // Create applications
         ClusterSpec clusterApp1 = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("test"), Version.fromString("6.42"), false);
         ClusterSpec clusterApp2 = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test"), Version.fromString("6.42"), false);
-        int wantedNodesApp1 = 5;
-        int wantedNodesApp2 = 7;
-        tester.activate(app1, clusterApp1, wantedNodesApp1);
-        tester.activate(app2, clusterApp2, wantedNodesApp2);
-        assertEquals(wantedNodesApp1, tester.nodeRepository.getNodes(app1, Node.State.active).size());
-        assertEquals(wantedNodesApp2, tester.nodeRepository.getNodes(app2, Node.State.active).size());
+        Capacity capacity1 = Capacity.fromCount(5, nodeResources, false, true);
+        Capacity capacity2 = Capacity.fromCount(7, nodeResources, false, true);
+
+        tester.activate(app1, clusterApp1, capacity1);
+        tester.activate(app2, clusterApp2, capacity2);
+        assertEquals(capacity1.nodeCount(), tester.nodeRepository.getNodes(app1, Node.State.active).size());
+        assertEquals(capacity2.nodeCount(), tester.nodeRepository.getNodes(app2, Node.State.active).size());
 
         Map<ApplicationId, MockDeployer.ApplicationContext> apps = Map.of(
-                app1, new MockDeployer.ApplicationContext(app1, clusterApp1, Capacity.fromCount(wantedNodesApp1, nodeResources, false, true), 1),
-                app2, new MockDeployer.ApplicationContext(app2, clusterApp2, Capacity.fromCount(wantedNodesApp2, nodeResources, false, true), 1));
+                app1, new MockDeployer.ApplicationContext(app1, clusterApp1, capacity1, 1),
+                app2, new MockDeployer.ApplicationContext(app2, clusterApp2, capacity2, 1));
         tester.deployer = new MockDeployer(tester.provisioner, tester.clock(), apps);
         tester.serviceMonitor = new ServiceMonitorStub(apps, tester.nodeRepository);
         tester.metric = new MetricsReporterTest.TestMetric();
@@ -252,10 +253,6 @@ public class NodeFailTester {
         nodes = nodeRepository.addNodes(nodes);
         nodes = nodeRepository.setDirty(nodes, Agent.system, getClass().getSimpleName());
         return nodeRepository.setReady(nodes, Agent.system, getClass().getSimpleName());
-    }
-
-    private void activate(ApplicationId applicationId, ClusterSpec cluster, int nodeCount) {
-        activate(applicationId, cluster, Capacity.fromNodeCount(nodeCount));
     }
 
     private void activate(ApplicationId applicationId, ClusterSpec cluster, Capacity capacity) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DockerProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DockerProvisioningTest.java
@@ -7,9 +7,9 @@ import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
-import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.ParentHostUnavailableException;
 import com.yahoo.config.provision.RegionName;
@@ -74,7 +74,7 @@ public class DockerProvisioningTest {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
 
         ApplicationId zoneApplication = tester.makeApplicationId();
-        List<Node> parents = tester.makeDockerHosts(10, new NodeResources(2, 2, 2));
+        List<Node> parents = tester.makeReadyNodes(10, new NodeResources(2, 2, 2), NodeType.host, 1);
         for (Node parent : parents)
             tester.makeReadyVirtualDockerNodes(1, dockerFlavor, parent.hostname());
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
@@ -280,7 +280,7 @@ public class DynamicDockerAllocationTest {
         tester.activate(application, hosts);
 
         List<Node> activeNodes = tester.nodeRepository().getNodes(application);
-        assertEquals(ImmutableSet.of("127.0.127.12", "::12"), activeNodes.get(0).ipAddresses());
+        assertEquals(ImmutableSet.of("127.0.127.13", "::13"), activeNodes.get(0).ipAddresses());
         assertEquals(ImmutableSet.of("127.0.127.2", "::2"), activeNodes.get(1).ipAddresses());
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -143,11 +143,11 @@ public class ProvisioningTest {
     public void nodeVersionIsReturnedIfSet() {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.dev, RegionName.from("us-east"))).build();
 
-        ApplicationId application1 = tester.makeApplicationId();
-
-        tester.makeReadyNodes(4, "d-1-1-1");
+        tester.makeReadyNodes(4, new NodeResources(1, 1, 1), NodeType.host, 1);
+        tester.prepareAndActivateInfraApplication(tester.makeApplicationId(), NodeType.host);
 
         // deploy
+        ApplicationId application1 = tester.makeApplicationId();
         SystemState state1 = prepare(application1, 1, 1, 1, 1, new NodeResources(1, 1, 1), tester);
         tester.activate(application1, state1.allHosts);
 
@@ -366,11 +366,13 @@ public class ProvisioningTest {
     }
 
     @Test
-    public void dev_deployment_size() {
+    public void dev_deployment_node_size() {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.dev, RegionName.from("us-east"))).build();
 
+        tester.makeReadyNodes(4, new NodeResources(1, 1, 1), NodeType.host, 1);
+        tester.prepareAndActivateInfraApplication(tester.makeApplicationId(), NodeType.host);
+
         ApplicationId application = tester.makeApplicationId();
-        tester.makeReadyNodes(4, "d-1-1-1");
         SystemState state = prepare(application, 2, 2, 3, 3,
                                     new NodeResources(1, 1, 1), tester);
         assertEquals(4, state.allHosts.size());
@@ -381,8 +383,10 @@ public class ProvisioningTest {
     public void deploy_specific_vespa_version() {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.dev, RegionName.from("us-east"))).build();
 
+        tester.makeReadyNodes(4, new NodeResources(1, 1, 1), NodeType.host, 1);
+        tester.prepareAndActivateInfraApplication(tester.makeApplicationId(), NodeType.host);
+
         ApplicationId application = tester.makeApplicationId();
-        tester.makeReadyNodes(4, "d-1-1-1");
         SystemState state = prepare(application, 2, 2, 3, 3, new NodeResources(1, 1, 1), Version.fromString("6.91"), tester);
         assertEquals(4, state.allHosts.size());
         tester.activate(application, state.allHosts);
@@ -415,8 +419,10 @@ public class ProvisioningTest {
     public void dev_deployment_flavor() {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.dev, RegionName.from("us-east"))).build();
 
+        tester.makeReadyNodes(4, new NodeResources(2, 2, 2), NodeType.host, 1);
+        tester.prepareAndActivateInfraApplication(tester.makeApplicationId(), NodeType.host);
+
         ApplicationId application = tester.makeApplicationId();
-        tester.makeReadyNodes(4, "d-2-2-2");
         SystemState state = prepare(application, 2, 2, 3, 3,
                                     new NodeResources(2, 2, 2), tester);
         assertEquals(4, state.allHosts.size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -9,10 +9,10 @@ import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.Flavor;
-import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.HostFilter;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.OutOfCapacityException;
 import com.yahoo.config.provision.RegionName;
@@ -819,13 +819,13 @@ public class ProvisioningTest {
     }
 
     private SystemState prepare(ApplicationId application, int container0Size, int container1Size, int content0Size,
-                                int content1Size, NodeResources flavor, Version wantedVersion, ProvisioningTester tester) {
-        return prepare(application, container0Size, container1Size, content0Size, content1Size, false, flavor,
+                                int content1Size, NodeResources nodeResources, Version wantedVersion, ProvisioningTester tester) {
+        return prepare(application, container0Size, container1Size, content0Size, content1Size, false, nodeResources,
                        wantedVersion, tester);
     }
 
     private SystemState prepare(ApplicationId application, int container0Size, int container1Size, int content0Size,
-                                int content1Size, boolean required, NodeResources flavor, Version wantedVersion,
+                                int content1Size, boolean required, NodeResources nodeResources, Version wantedVersion,
                                 ProvisioningTester tester) {
         // "deploy prepare" with a two container clusters and a storage cluster having of two groups
         ClusterSpec containerCluster0 = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("container0"), wantedVersion, false);
@@ -833,10 +833,10 @@ public class ProvisioningTest {
         ClusterSpec contentCluster0 = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("content0"), wantedVersion, false);
         ClusterSpec contentCluster1 = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("content1"), wantedVersion, false);
 
-        Set<HostSpec> container0 = prepare(application, containerCluster0, container0Size, 1, required, flavor, tester);
-        Set<HostSpec> container1 = prepare(application, containerCluster1, container1Size, 1, required, flavor, tester);
-        Set<HostSpec> content0 = prepare(application, contentCluster0, content0Size, 1, required, flavor, tester);
-        Set<HostSpec> content1 = prepare(application, contentCluster1, content1Size, 1, required, flavor, tester);
+        Set<HostSpec> container0 = prepare(application, containerCluster0, container0Size, 1, required, nodeResources, tester);
+        Set<HostSpec> container1 = prepare(application, containerCluster1, container1Size, 1, required, nodeResources, tester);
+        Set<HostSpec> content0 = prepare(application, contentCluster0, content0Size, 1, required, nodeResources, tester);
+        Set<HostSpec> content1 = prepare(application, contentCluster1, content1Size, 1, required, nodeResources, tester);
 
         Set<HostSpec> allHosts = new HashSet<>();
         allHosts.addAll(container0);
@@ -868,9 +868,9 @@ public class ProvisioningTest {
     }
 
     private Set<HostSpec> prepare(ApplicationId application, ClusterSpec cluster, int nodeCount, int groups,
-                                  boolean required, NodeResources flavor, ProvisioningTester tester) {
+                                  boolean required, NodeResources nodeResources, ProvisioningTester tester) {
         if (nodeCount == 0) return Collections.emptySet(); // this is a shady practice
-        return new HashSet<>(tester.prepare(application, cluster, nodeCount, groups, required, flavor));
+        return new HashSet<>(tester.prepare(application, cluster, nodeCount, groups, required, nodeResources));
     }
 
     private static class SystemState {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -279,7 +279,7 @@ public class ProvisioningTester {
             hostIps.add(ipv6);
 
             Set<String> ipAddressPool = new LinkedHashSet<>();
-            for (int poolIp = 1; poolIp < ipAddressPoolSize; poolIp++) {
+            for (int poolIp = 1; poolIp <= ipAddressPoolSize; poolIp++) {
                 nextIP++;
                 String ipv6Addr = String.format("::%d", nextIP);
                 ipAddressPool.add(ipv6Addr);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
@@ -5,8 +5,9 @@ import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
-import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.HostSpec;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.OutOfCapacityException;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
@@ -83,7 +84,8 @@ public class VirtualNodeProvisioningTest {
         {
             NodeResources flavor = new NodeResources(1, 1, 1);
             tester = new ProvisioningTester.Builder().zone(new Zone(Environment.dev, RegionName.from("us-east"))).build();
-            tester.makeReadyVirtualDockerNodes(4, flavor, "parentHost1");
+            tester.makeReadyNodes(4, flavor, NodeType.host, 1);
+            tester.prepareAndActivateInfraApplication(tester.makeApplicationId(), NodeType.host);
 
             List<HostSpec> containerHosts = prepare(containerClusterSpec, containerNodeCount, groups, flavor);
             List<HostSpec> contentHosts = prepare(contentClusterSpec, contentNodeCount, groups, flavor);
@@ -96,7 +98,8 @@ public class VirtualNodeProvisioningTest {
         // Allowed to use same parent host for several nodes in same cluster in CD (even if prod env)
         {
             tester = new ProvisioningTester.Builder().zone(new Zone(SystemName.cd, Environment.prod, RegionName.from("us-east"))).build();
-            tester.makeReadyVirtualDockerNodes(4, flavor, "parentHost1");
+            tester.makeReadyNodes(4, flavor, NodeType.host, 1);
+            tester.prepareAndActivateInfraApplication(tester.makeApplicationId(), NodeType.host);
 
             List<HostSpec> containerHosts = prepare(containerClusterSpec, containerNodeCount, groups);
             List<HostSpec> contentHosts = prepare(contentClusterSpec, contentNodeCount, groups);


### PR DESCRIPTION
First 4 commits is just fixing/cleaning up test. In particular:
* 7eb4731: fixes an issue where a test first deployed using resources, but later deployed without (falling back to default resources). This was originally written with `d-2-8-50`, and then changed to `NodeResources(2, 8, 50)`, but those are not the same. `d-2-8-50` is actually `NodeResources(1.5, 8, 50)`. This worked fine before, since there was no reallocation when the later resources were smaller.
* e8d3781: Deployments to dev get their vcpus overwritten to 0.1, so instead of creating a ready docker node with the expected resources, I changed the test to create docker hosts that can fit the resulting resources.