### PR TITLE
Add config setting for throwing if active session cannot be loaded

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -63,5 +63,6 @@ sleepTimeWhenRedeployingFails long default=30
 # Features (to be overridden in configserver-config.xml if needed)
 buildMinimalSetOfConfigModels bool default=true
 throwIfBootstrappingTenantRepoFails bool default=true
+throwIfActiveSessionCannotBeLoaded bool default=true
 canReturnEmptySentinelConfig bool default=false
 serverNodeType enum {config, controller} default=config


### PR DESCRIPTION
THe feature flag that controlled this earlier has been removed, there might
still be exceptional cases where one might need to do this to get a config
server to start. Zookeeper server will not start if an exception is thrown,
so it is not possible to fix anything if the state somehow has become bad

See https://github.com/vespa-engine/vespa/pull/10241 for the PR that removed the feature flag.
