### PR TITLE
Add free-list support to ArrayStore

### DIFF
--- a/vespalib/src/vespa/vespalib/datastore/array_store_config.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/array_store_config.cpp
@@ -6,7 +6,8 @@
 namespace search::datastore {
 
 ArrayStoreConfig::ArrayStoreConfig(size_t maxSmallArraySize, const AllocSpec &defaultSpec)
-    : _allocSpecs()
+    : _allocSpecs(),
+      _enable_free_lists(false)
 {
     for (size_t i = 0; i < (maxSmallArraySize + 1); ++i) {
         _allocSpecs.push_back(defaultSpec);
@@ -14,7 +15,8 @@ ArrayStoreConfig::ArrayStoreConfig(size_t maxSmallArraySize, const AllocSpec &de
 }
 
 ArrayStoreConfig::ArrayStoreConfig(const AllocSpecVector &allocSpecs)
-    : _allocSpecs(allocSpecs)
+    : _allocSpecs(allocSpecs),
+      _enable_free_lists(false)
 {
 }
 

--- a/vespalib/src/vespa/vespalib/datastore/array_store_config.h
+++ b/vespalib/src/vespa/vespalib/datastore/array_store_config.h
@@ -39,6 +39,7 @@ public:
 
 private:
     AllocSpecVector _allocSpecs;
+    bool _enable_free_lists;
 
     /**
      * Setup an array store with arrays of size [1-(allocSpecs.size()-1)] allocated in buffers and
@@ -56,6 +57,15 @@ public:
 
     size_t maxSmallArraySize() const { return _allocSpecs.size() - 1; }
     const AllocSpec &specForSize(size_t arraySize) const;
+    ArrayStoreConfig& enable_free_lists(bool enable) & noexcept {
+        _enable_free_lists = enable;
+        return *this;
+    }
+    ArrayStoreConfig&& enable_free_lists(bool enable) && noexcept {
+        _enable_free_lists = enable;
+        return std::move(*this);
+    }
+    [[nodiscard]] bool enable_free_lists() const noexcept { return _enable_free_lists; }
 
     /**
      * Generate a config that is optimized for the given memory huge page size.

--- a/vespalib/src/vespa/vespalib/datastore/datastore.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.hpp
@@ -19,9 +19,7 @@ DataStoreT<RefT>::DataStoreT()
 }
 
 template <typename RefT>
-DataStoreT<RefT>::~DataStoreT()
-{
-}
+DataStoreT<RefT>::~DataStoreT() = default;
 
 template <typename RefT>
 void
@@ -30,7 +28,7 @@ DataStoreT<RefT>::freeElem(EntryRef ref, size_t numElems)
     RefType intRef(ref);
     BufferState &state = getBufferState(intRef.bufferId());
     if (state.isActive()) {
-        if (state.freeListList() != NULL && numElems == state.getArraySize()) {
+        if (state.freeListList() != nullptr && numElems == state.getArraySize()) {
             if (state.freeList().empty()) {
                 state.addToFreeListList();
             }

--- a/vespalib/src/vespa/vespalib/test/datastore/buffer_stats.h
+++ b/vespalib/src/vespa/vespalib/test/datastore/buffer_stats.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
 
 namespace search::datastore::test {
 


### PR DESCRIPTION
@geirst @toregge please review very carefully 🙂

* Add support for enabling freelists via `ArrayStoreConfig`. Currently defaults to false.
* Small array allocations from freelist reuse both entry ref and array buffer
* Large array allocations from freelist reuse entry ref only

