### PR TITLE
Revert "Add custom path to PATH to run mvn?"

### DIFF
--- a/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
+++ b/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
@@ -102,7 +102,6 @@ public class TestRunner {
 
         ProcessBuilder builder = new ProcessBuilder(command);
         builder.environment().merge("MAVEN_OPTS", " -Djansi.force=true", String::concat);
-        builder.environment().merge("PATH", ":" + vespaHome.resolve("local/maven/bin/"), String::concat);
         builder.directory(vespaHome.resolve("tmp/test").toFile());
         builder.redirectErrorStream(true);
         return builder;

--- a/vespa-testrunner-components/src/test/java/com/yahoo/vespa/hosted/testrunner/TestRunnerTest.java
+++ b/vespa-testrunner-components/src/test/java/com/yahoo/vespa/hosted/testrunner/TestRunnerTest.java
@@ -15,6 +15,7 @@ import java.util.logging.LogRecord;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests relying on a UNIX shell >_<


### PR DESCRIPTION
Reverts vespa-engine/vespa#10279

@hmusum or @hakonhall please merge. 

This attempted to solve the correct problem, but the solution was incorrect:

It is the `$PATH` of the _Java_ process that needs to be updated to include `mvn`, but this change only affected the `$PATH` for the spawned (`mvn`) process, which was never actually spawned. 