### PR TITLE
Preserve PATH for Vespa services

### DIFF
--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -107,6 +107,13 @@ populate_environment () {
     fi
 }
 
+prepend_path () {
+    case ":$PATH:" in
+        *:"$1":*) ;;
+	*) PATH="$1:$PATH" ;;
+    esac
+}
+
 add_valgrind_suppressions_file() {
     if [ -f "$1" ]
     then
@@ -116,14 +123,16 @@ add_valgrind_suppressions_file() {
 
 populate_environment
 
-PATH=$VESPA_HOME/bin64:$VESPA_HOME/bin:/usr/local/bin:/usr/X11R6/bin:/sbin:/bin:/usr/sbin:/usr/bin
 export LD_LIBRARY_PATH=$VESPA_HOME/lib64
 export MALLOC_ARENA_MAX=1
+
+prepend_path "$VESPA_HOME/bin64"
+prepend_path "$VESPA_HOME/bin"
 
 # how to find the "java" program?
 # should be available in $VESPA_HOME/bin or JAVA_HOME
 if [ "$JAVA_HOME" ] && [ -f "${JAVA_HOME}/bin/java" ]; then
-    PATH="${JAVA_HOME}/bin:${PATH}"
+    prepend_path "${JAVA_HOME}/bin"
 fi
 
 VESPA_VALGRIND_SUPPREESSIONS_OPT=""


### PR DESCRIPTION
common-env.sh sets PATH, instead of adding to it. This means binaries
reachable via PATH, but not in these whitelisted locations, are lost. For our
tester application we have a custom image containing a custom maven
installation, reachable with the PATH.

The effect of setting PATH seems to have been to add VESPA_HOME/bin[64] only.

To ensure all programs reachable with the earlier code, is still reachable
after this code change, all earlier paths are prepended to PATH.