### PR TITLE
Keep files and directories in vespa home when installing Vespa

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -178,7 +178,7 @@ make %{_smp_mflags}
 
 %install
 %if 0%{?installdir:1}
-cp -r %{installdir} %{buildroot}
+cp -r %{installdir}/* %{buildroot}
 %else
 make install DESTDIR=%{buildroot}
 %endif

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -177,8 +177,6 @@ make %{_smp_mflags}
 %endif
 
 %install
-rm -rf %{buildroot}
-
 %if 0%{?installdir:1}
 cp -r %{installdir} %{buildroot}
 %else


### PR DESCRIPTION
In %pre of vespa.spec (pre-installation), the vespa home directory is installed
with .bashrc, necessary for e.g. 'docker exec -it NAME bash' to pick up
/etc/profile.d/*.sh environment settings.

It is therefore important to avoid deletion of vespa home, as was done in %install
before installing Vespa to vespa home.