### PR TITLE
Revert "Print debug info and use absolute path in public image for now"

### DIFF
--- a/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
+++ b/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.yahoo.log.LogLevel.ERROR;
-import static java.util.logging.Level.INFO;
 
 /**
  * @author valerijf
@@ -83,12 +82,8 @@ public class TestRunner {
     }
 
     static ProcessBuilder mavenProcessFrom(TestProfile profile, TestRunnerConfig config) {
-        logger.log(INFO, System.getenv().toString());
         List<String> command = new ArrayList<>();
-        if (Path.of("/opt/vespa").equals(Path.of(Defaults.getDefaults().vespaHome())))
-            command.add("/opt/vespa/local/maven/bin/mvn");
-        else
-            command.add("mvn");
+        command.add("mvn");
         command.add("test");
 
         command.add("--batch-mode"); // Run in non-interactive (batch) mode (disables output color)


### PR DESCRIPTION
Reverts vespa-engine/vespa#10318

@hakonhall please review, and let's merge when we have found and fixed the issue. 