### PR TITLE
Add minimal bucket DB read snapshot guard interface

### DIFF
--- a/storage/src/tests/distributor/bucketdatabasetest.cpp
+++ b/storage/src/tests/distributor/bucketdatabasetest.cpp
@@ -170,7 +170,14 @@ BucketDatabaseTest::doFindParents(const std::vector<document::BucketId>& ids,
     }
 
     std::vector<BucketDatabase::Entry> entries;
+    // TODO remove in favor of only read guard once legacy DB usage has been ported over
     db().getParents(searchId, entries);
+
+    std::vector<BucketDatabase::Entry> checked_entries;
+    db().acquire_read_guard()->find_parents_and_self(searchId, checked_entries);
+    if(entries != checked_entries) {
+        return "Mismatch between results from getParents() and ReadGuard!";
+    }
 
     std::ostringstream ost;
     for (uint32_t i = 0; i < ids.size(); ++i) {

--- a/storage/src/tests/distributor/bucketdatabasetest.cpp
+++ b/storage/src/tests/distributor/bucketdatabasetest.cpp
@@ -175,7 +175,7 @@ BucketDatabaseTest::doFindParents(const std::vector<document::BucketId>& ids,
 
     std::vector<BucketDatabase::Entry> checked_entries;
     db().acquire_read_guard()->find_parents_and_self(searchId, checked_entries);
-    if(entries != checked_entries) {
+    if (entries != checked_entries) {
         return "Mismatch between results from getParents() and ReadGuard!";
     }
 

--- a/storage/src/vespa/storage/bucketdb/bucketdatabase.h
+++ b/storage/src/vespa/storage/bucketdb/bucketdatabase.h
@@ -232,6 +232,23 @@ public:
             const document::BucketId& bid);
 
     virtual uint32_t childCount(const document::BucketId&) const = 0;
+
+    struct ReadGuard {
+        ReadGuard() = default;
+        virtual ~ReadGuard() = default;
+        
+        ReadGuard(ReadGuard&&) = delete;
+        ReadGuard& operator=(ReadGuard&&) = delete;
+        ReadGuard(const ReadGuard&) = delete;
+        ReadGuard& operator=(const ReadGuard&) = delete;
+
+        virtual void find_parents_and_self(const document::BucketId& bucket,
+                                           std::vector<Entry>& entries) const = 0;
+    };
+
+    virtual std::unique_ptr<ReadGuard> acquire_read_guard() const {
+        return std::unique_ptr<ReadGuard>();
+    }
 };
 
 template <typename BucketInfoType>

--- a/storage/src/vespa/storage/bucketdb/mapbucketdatabase.cpp
+++ b/storage/src/vespa/storage/bucketdb/mapbucketdatabase.cpp
@@ -584,4 +584,14 @@ MapBucketDatabase::print(std::ostream& out, bool verbose,
     out << ')';
 }
 
+std::unique_ptr<BucketDatabase::ReadGuard> MapBucketDatabase::acquire_read_guard() const {
+    return std::make_unique<ReadGuardImpl>(*this);
+}
+
+void MapBucketDatabase::ReadGuardImpl::find_parents_and_self(const document::BucketId& bucket,
+                                                             std::vector<Entry>& entries) const
+{
+    _db->getParents(bucket, entries);
+}
+
 } // storage


### PR DESCRIPTION
@geirst please review Only exposes enough functionality to be used for Get operations for now.

* Enable free-lists for underlying replica `ArrayStore`.
* Legacy `MapBucketDatabase` read guard is _not_ thread safe, as it will never be used for non-blocking reads.
* Use snapshot read guard for Get operations