### PR TITLE
Revert "Use new jvm element for tester container JDisc memory setting"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -670,9 +670,7 @@ public class InternalStepRunner implements StepRunner {
                 "            </filtering>\n" +
                 "        </http>\n" +
                 "\n" +
-                "        <nodes count=\"1\" flavor=\"" + flavor  + "\">\n" +
-                "            <jvm allocated-memory=\"" + jdiscMemoryPercentage + "%\" />\n" +
-                "        </nodes>\n" +
+                "        <nodes count=\"1\" flavor=\"" + flavor + "\" allocated-memory=\"" + jdiscMemoryPercentage + "%\" />\n" +
                 "    </container>\n" +
                 "</services>\n";
 

--- a/controller-server/src/test/resources/test_runner_services.xml-cd
+++ b/controller-server/src/test/resources/test_runner_services.xml-cd
@@ -39,8 +39,6 @@
             </filtering>
         </http>
 
-        <nodes count="1" flavor="d-2-12-75">
-            <jvm allocated-memory="17%" />
-        </nodes>
+        <nodes count="1" flavor="d-2-12-75" allocated-memory="17%" />
     </container>
 </services>


### PR DESCRIPTION
Reverts vespa-engine/vespa#9651

@hmusum We need the old syntax until Vespa 6 is complete removed. I assume the old syntax is still supported?