### PR TITLE
Suppress array bounds warning when compiling generated protobuf code

### DIFF
--- a/logd/src/logd/CMakeLists.txt
+++ b/logd/src/logd/CMakeLists.txt
@@ -7,8 +7,8 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(logd_PROTOBUF_SRCS logd_PROTOBUF_HDRS ../../../logserver/src/protobuf/log_protocol.proto)
 
 # protoc-generated files emit compiler warnings that we normally treat as errors.
-if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set_source_files_properties(${logd_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-suggest-override")
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  set_source_files_properties(${logd_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-array-bounds -Wno-suggest-override")
 endif()
 
 vespa_add_library(logd STATIC

--- a/searchlib/src/vespa/searchlib/engine/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/engine/CMakeLists.txt
@@ -4,9 +4,9 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(searchlib_engine_PROTOBUF_SRCS searchlib_engine_PROTOBUF_HDRS ../../../../src/protobuf/search_protocol.proto)
 
 # protoc-generated files emit compiler warnings that we normally treat as errors.
-if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
   set_source_files_properties(${searchlib_engine_PROTOBUF_SRCS}
-    PROPERTIES COMPILE_FLAGS "-Wno-suggest-override")
+    PROPERTIES COMPILE_FLAGS "-Wno-array-bounds -Wno-suggest-override")
 endif()
 
 vespa_add_library(searchlib_engine OBJECT

--- a/storageapi/src/vespa/storageapi/mbusprot/CMakeLists.txt
+++ b/storageapi/src/vespa/storageapi/mbusprot/CMakeLists.txt
@@ -9,8 +9,8 @@ PROTOBUF_GENERATE_CPP(storageapi_PROTOBUF_SRCS storageapi_PROTOBUF_HDRS
 
 # protoc-generated files emit compiler warnings that we normally treat as errors.
 # Instead of rolling our own compiler plugin we'll pragmatically disable the noise.
-if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set_source_files_properties(${storageapi_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-suggest-override -Wno-inline")
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  set_source_files_properties(${storageapi_PROTOBUF_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-array-bounds -Wno-suggest-override -Wno-inline")
 endif()
 # protoc explicitly annotates methods with inline, which triggers -Werror=inline when
 # the header file grows over a certain size.


### PR DESCRIPTION
@baldersheim : please review
