### PR TITLE
Only pass container endpoints in deploy

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -239,6 +239,10 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
         if (nodeRepository().list(deployment.zoneId(), deployment.applicationId()).isEmpty())
             provision(deployment.zoneId(), deployment.applicationId());
 
+        if (!rotationNames.isEmpty() && !containerEndpoints.isEmpty()) {
+            throw new IllegalArgumentException("Cannot set both rotations and containerEndpoints"); // Same constraint as a real config server
+        }
+
         this.rotationNames.put(
                 deployment,
                 Stream.concat(


### PR DESCRIPTION
Since we removed the multiple-global endpoints feature flags, everything is
translated to container endpoints in deploy. However, we cannot pass both legacy
rotation names and container endpoints.

FYI @oyving