### PR TITLE
Add bandwidthGbps

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -84,6 +84,8 @@ public class NodeRepositoryNode {
     private Double minCpuCores;
     @JsonProperty("bandwidth")
     private Double bandwidth;
+    @JsonProperty("bandwidthGbps")
+    private Double bandwidthGbps;
     @JsonProperty("fastDisk")
     private Boolean fastDisk;
     @JsonProperty("description")
@@ -359,6 +361,14 @@ public class NodeRepositoryNode {
         this.bandwidth = bandwidth;
     }
 
+    public Double getBandwidthGbps() {
+        return bandwidthGbps;
+    }
+
+    public void setBandwidthGbps(Double bandwidthGbps) {
+        this.bandwidthGbps = bandwidthGbps;
+    }
+
     public Boolean getFastDisk() {
         return fastDisk;
     }
@@ -457,6 +467,7 @@ public class NodeRepositoryNode {
                ", cost=" + cost +
                ", minCpuCores=" + minCpuCores +
                ", bandwidth=" + bandwidth +
+               ", bandwidthGbps=" + bandwidthGbps +
                ", fastDisk=" + fastDisk +
                ", description='" + description + '\'' +
                ", history=" + Arrays.toString(history) +

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
@@ -60,6 +60,8 @@ public class NodeRepositoryNode {
     public Boolean fastDisk;
     @JsonProperty("bandwidth")
     public Double bandwidth;
+    @JsonProperty("bandwidthGbps")
+    public Double bandwidthGbps;
     @JsonProperty("environment")
     public String environment;
     @JsonProperty("type")
@@ -111,6 +113,7 @@ public class NodeRepositoryNode {
                 ", failCount=" + failCount +
                 ", fastDisk=" + fastDisk +
                 ", bandwidth=" + bandwidth +
+                ", bandwidthGbps=" + bandwidthGbps +
                 ", environment='" + environment + '\'' +
                 ", type='" + type + '\'' +
                 ", wantedDockerImage='" + wantedDockerImage + '\'' +

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -158,9 +158,10 @@ public class NodePatcher {
                 return node.with(node.flavor().with(node.flavor().resources().withVcpu(value.asDouble())));
             case "fastDisk":
                 return node.with(node.flavor().with(node.flavor().resources().withDiskSpeed(value.asBool() ? fast : slow)));
-            case "bandwidthGbps":
             case "bandwidth":
                 return node.with(node.flavor().with(node.flavor().resources().withBandwidthGbps(value.asDouble() / 1000)));
+            case "bandwidthGbps":
+                return node.with(node.flavor().with(node.flavor().resources().withBandwidthGbps(value.asDouble())));
             case "modelName":
                 if (value.type() == Type.NIX) {
                     return node.withoutModelName();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -242,7 +242,9 @@ public class NodesApiHandler extends LoggingRequestHandler {
                     requiredField(inspector, "minCpuCores", Inspector::asDouble),
                     requiredField(inspector, "minMainMemoryAvailableGb", Inspector::asDouble),
                     requiredField(inspector, "minDiskAvailableGb", Inspector::asDouble),
-                    requiredField(inspector, "bandwidth", Inspector::asDouble) / 1000,
+                    inspector.field("bandwidth").valid() ?
+                            requiredField(inspector, "bandwidth", Inspector::asDouble) / 1000 :
+                            requiredField(inspector, "bandwidthGbps", Inspector::asDouble),
                     requiredField(inspector, "fastDisk", Inspector::asBool) ? fast : slow));
         }
 
@@ -255,6 +257,8 @@ public class NodesApiHandler extends LoggingRequestHandler {
             flavor = flavor.with(flavor.resources().withDiskGb(inspector.field("minDiskAvailableGb").asDouble()));
         if (inspector.field("bandwidth").valid())
             flavor = flavor.with(flavor.resources().withBandwidthGbps(inspector.field("bandwidth").asDouble() / 1000));
+        if (inspector.field("bandwidthGbps").valid())
+            flavor = flavor.with(flavor.resources().withBandwidthGbps(inspector.field("bandwidthGbps").asDouble()));
         if (inspector.field("fastDisk").valid())
             flavor = flavor.with(flavor.resources().withDiskSpeed(inspector.field("fastDisk").asBool() ? fast : slow));
         log.info("should not be here");

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -152,7 +152,8 @@ class NodesResponse extends HttpResponse {
         if (node.flavor().cost() > 0)
             object.setLong("cost", node.flavor().cost());
         object.setBool("fastDisk", node.flavor().hasFastDisk());
-        object.setDouble("bandwidth", 1000 * node.flavor().getBandwidthGbps());
+        object.setDouble("bandwidth", 1000 * node.flavor().getBandwidthGbps()); // TODO: Remove after all clients migrated to bandwidthGbps
+        object.setDouble("bandwidthGbps", node.flavor().getBandwidthGbps());
         object.setString("environment", node.flavor().getType().name());
         node.allocation().ifPresent(allocation -> {
             toSlime(allocation.owner(), object.setObject("owner"));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg1.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 10000.0,
+  "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg2.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 10000.0,
+  "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/controller1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/controller1.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 10000.0,
+  "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-container1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-container1.json
@@ -13,6 +13,7 @@
   "minCpuCores": 1.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant3",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade-complete.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node2.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node3.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node4.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node5.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/dockerhost1-with-firmware-data.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/dockerhost1-with-firmware-data.json
@@ -12,6 +12,7 @@
   "minCpuCores": 4.0,
   "fastDisk": true,
   "bandwidth": 20000.0,
+  "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {
     "tenant": "zoneapp",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant1",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -13,6 +13,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant1",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
@@ -13,6 +13,7 @@
   "minCpuCores": 1.0,
   "fastDisk": true,
   "bandwidth": 300.0,
+  "bandwidthGbps": 0.3,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 0,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node13.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node13.json
@@ -12,6 +12,7 @@
   "minCpuCores": 10.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant4",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node14.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node14.json
@@ -12,6 +12,7 @@
   "minCpuCores": 10.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant4",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
@@ -12,6 +12,7 @@
   "minCpuCores": 0.5,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -13,6 +13,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant3",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
@@ -13,6 +13,7 @@
   "minCpuCores": 1.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant3",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
@@ -13,6 +13,7 @@
   "minCpuCores": 1.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
@@ -13,6 +13,7 @@
   "minCpuCores": 1.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-after-changes.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-2.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-3.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {
     "tenant": "tenant2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 1000.0,
+  "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 0,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk": true,
   "bandwidth": 10000.0,
+  "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
@@ -12,6 +12,7 @@
   "minCpuCores": 64.0,
   "fastDisk": true,
   "bandwidth": 15000.0,
+  "bandwidthGbps": 15.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
@@ -12,6 +12,7 @@
   "minCpuCores": 2.0,
   "fastDisk":true,
   "bandwidth":0.0,
+  "bandwidthGbps": 0.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 1,
   "currentRebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
@@ -12,6 +12,7 @@
   "minCpuCores": 64.0,
   "fastDisk":true,
   "bandwidth": 15000.0,
+  "bandwidthGbps": 15.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,
   "currentRebootGeneration": 0,


### PR DESCRIPTION
The `bandwidth` is in Mbps whereas we use Gbps through the code (f.ex. `NodeResources`), so this leads to a lot of conversion. Additionally, the field lacks unit in the name, creating even more confusion. This PR introduces `bandwidthGbps` with the intention to migrate all clients to use this and eventually remove `bandwidth`.