### PR TITLE
Revert "Upgrade to zookeeper 3.4.14, take 5"

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>container-search-gui</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>zkfacade</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Because these are provided in jdisc_http_service and just preinstalled: -->
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/athenz-identity-provider-service/pom.xml
+++ b/athenz-identity-provider-service/pom.xml
@@ -127,13 +127,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <!-- Needed for node repo mock -->
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>zkfacade</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/Cluster.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/Cluster.java
@@ -6,18 +6,22 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * Model a single cluster of services in the Vespa model.
  *
- * @author Steinar Knutsen
+ * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
  */
 public final class Cluster implements Comparable<Cluster> {
-
+    @NonNull
     public final String name;
+    @NonNull
     public final String type;
     /**
      * An ordered list of the service instances in this cluster.
      */
+    @NonNull
     public final ImmutableList<Service> services;
 
     public Cluster(String name, String type, List<Service> services) {

--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/Service.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/Service.java
@@ -1,31 +1,37 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.serviceview;
 
-import com.google.common.collect.ImmutableList;
-import com.yahoo.text.Utf8;
-
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+import com.yahoo.text.Utf8;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * Model a single service instance as a sortable object.
  *
- * @author Steinar Knutsen
+ * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
  */
 public final class Service implements Comparable<Service> {
-
+    @NonNull
     public final String serviceType;
+    @NonNull
     public final String host;
     public final int statePort;
+    @NonNull
     public final String configId;
+    @NonNull
     public final List<Integer> ports;
+    @NonNull
     public final String name;
 
     public Service(String serviceType, String host, int statePort, String clusterName, String clusterType,
-                   String configId, List<Integer> ports, String name) {
+            String configId, List<Integer> ports, String name) {
         this.serviceType = serviceType;
         this.host = host.toLowerCase();
         this.statePort = statePort;
@@ -53,7 +59,8 @@ public final class Service implements Comparable<Service> {
      * Generate an identifier string for one of the ports of this service
      * suitable for using in an URL.
      *
-     * @param port port which this identifier pertains to
+     * @param port
+     *            port which this identifier pertains to
      * @return an opaque identifier string for this service
      */
     public String getIdentifier(int port) {

--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/ServiceModel.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/ServiceModel.java
@@ -1,6 +1,12 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.serviceview;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -13,11 +19,7 @@ import com.yahoo.vespa.serviceview.bindings.ModelResponse;
 import com.yahoo.vespa.serviceview.bindings.ServicePort;
 import com.yahoo.vespa.serviceview.bindings.ServiceView;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 
@@ -35,6 +37,7 @@ public final class ServiceModel {
     /**
      * An ordered list of the clusters in this config model.
      */
+    @NonNull
     public final ImmutableList<Cluster> clusters;
 
     ServiceModel(ModelResponse modelConfig) {
@@ -152,7 +155,7 @@ public final class ServiceModel {
         }
     }
 
-    private Service getFirstServiceInstanceByType(String typeName) {
+    private Service getFirstServiceInstanceByType(@NonNull String typeName) {
         for (Cluster c : clusters) {
             for (Service s : c.services) {
                 if (typeName.equals(s.serviceType)) {

--- a/node-admin/pom.xml
+++ b/node-admin/pom.xml
@@ -137,13 +137,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Needed for node repo mock -->
-        <dependency>
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>zkfacade</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -495,14 +495,14 @@
                 <artifactId>commons-pool</artifactId>
                 <version>1.5.6</version>
             </dependency>
-            <!-- Explicitly included to get Zookeeper version 3.4.14,
+            <!-- Explicitly included to get Zookeeper version 3.4.13,
                  can be excluded if you want the Zookeeper version
                  used by curator by default
             -->
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.14</version>
+                <version>3.4.13</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>

--- a/serviceview/src/main/java/com/yahoo/vespa/serviceview/bindings/ServicePort.java
+++ b/serviceview/src/main/java/com/yahoo/vespa/serviceview/bindings/ServicePort.java
@@ -6,11 +6,13 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Splitter;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * View of {@link com.yahoo.cloud.config.ModelConfig.Hosts.Services.Ports}.
  *
  * @author mortent
- * @author Steinar Knutsen
+ * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
  */
 @JsonIgnoreProperties(value = { "splitOnSpace" }, ignoreUnknown = true)
 public class ServicePort {
@@ -26,7 +28,7 @@ public class ServicePort {
      * @return true if all argument tags are present for this port, false
      *         otherwise
      */
-    public boolean hasTags(String... tag) {
+    public boolean hasTags(@NonNull String... tag) {
         if (tags == null) {
             return false;
         }

--- a/zkfacade/pom.xml
+++ b/zkfacade/pom.xml
@@ -65,10 +65,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Reverts vespa-engine/vespa#10435

Now fails in controller:
`	Caused by: org.osgi.framework.BundleException: Unable to resolve controller-clients [66](R 66.0): missing requirement [controller-clients [66](R 66.0)] osgi.wiring.package; (osgi.wiring.package=edu.umd.cs.findbugs.annotations) Unresolved requirements: [[controller-clients [66](R 66.0)] osgi.wiring.package; (osgi.wiring.package=edu.umd.cs.findbugs.annotations)]`