### PR TITLE
Call addFieldSets for genrated document types in order for fieldSet a…

### DIFF
--- a/document/src/main/java/com/yahoo/document/DocumentType.java
+++ b/document/src/main/java/com/yahoo/document/DocumentType.java
@@ -398,6 +398,13 @@ public class DocumentType extends StructuredDataType {
         return field;
     }
 
+    /**
+     * All fields defined in the document and its parents
+     * This is for internal use
+     * Use {@link #fieldSet()} instead or {@link #fieldSetAll()} if you really want all fields
+     * @return All fields defined in the document and its parents
+     */
+    @Override
     public Collection<Field> getFields() {
         Collection<Field> collection = new LinkedList<>();
 
@@ -439,7 +446,7 @@ public class DocumentType extends StructuredDataType {
     }
 
     /**
-     * This is identical to @link fieldSet, but in addition extra hidden synthetic fields are returned.
+     * This is identical to {@link #fieldSet()} fieldSet}, but in addition extra hidden synthetic fields are returned.
      * @return an unmodifiable snapshot of the all fields in this type
      */
     public Set<Field> fieldSetAll() {

--- a/documentgen-test/etc/complex/music4.sd
+++ b/documentgen-test/etc/complex/music4.sd
@@ -2,10 +2,10 @@
 search music4 {
     document music4 inherits music3 {
         field mu4 type string {
-
+            indexing:attribute|summary
         }
         field pos type position {
-
+            indexing:attribute|summary
         }
     }
 }

--- a/documentgen-test/src/test/java/com/yahoo/vespa/config/DocumentGenPluginTest.java
+++ b/documentgen-test/src/test/java/com/yahoo/vespa/config/DocumentGenPluginTest.java
@@ -15,6 +15,7 @@ import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.Field;
 import com.yahoo.document.Generated;
 import com.yahoo.document.MapDataType;
+import com.yahoo.document.PositionDataType;
 import com.yahoo.document.ReferenceDataType;
 import com.yahoo.document.StructDataType;
 import com.yahoo.document.WeightedSetDataType;
@@ -1014,6 +1015,18 @@ public class DocumentGenPluginTest {
         Music4 book = new Music4(new DocumentId("id:music4:music4::0"));
         book.setPos(new Music4.Position().setX(7).setY(8));
         assertEquals(new Music4.Position().setX(7).setY(8), book.getPos());
+        assertEquals(1, book.getFieldCount());
+        int numIteratedValues = 0;
+        for (Iterator<Map.Entry<Field, FieldValue>> it = book.iterator(); it.hasNext(); numIteratedValues++) {
+            Map.Entry<Field, FieldValue> entry = it.next();
+        }
+        assertEquals(book.getFieldCount(), numIteratedValues);
+        Field posZcurve = book.getField(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(posZcurve);
+        assertNotEquals(book.getDataType().fieldSet(), book.getDataType().fieldSetAll());
+        assertFalse(book.getDataType().fieldSet().contains(posZcurve));
+        assertTrue(book.getDataType().fieldSetAll().contains(posZcurve));
+        assertTrue(book.getDataType().getFields().contains(posZcurve));
     }
     
 }

--- a/vespa-documentgen-plugin/src/main/java/com/yahoo/vespa/DocumentGenMojo.java
+++ b/vespa-documentgen-plugin/src/main/java/com/yahoo/vespa/DocumentGenMojo.java
@@ -19,6 +19,7 @@ import com.yahoo.documentmodel.NewDocumentType;
 import com.yahoo.documentmodel.VespaDocumentType;
 import com.yahoo.searchdefinition.Search;
 import com.yahoo.searchdefinition.SearchBuilder;
+import com.yahoo.searchdefinition.document.FieldSet;
 import com.yahoo.searchdefinition.parser.ParseException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Component;
@@ -35,6 +36,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -463,7 +465,7 @@ public class DocumentGenMojo extends AbstractMojo {
         exportStructTypeGetter(docType.getName()+".body", docType.allBody().getFields(), out, 1, "getBodyStructType", "com.yahoo.document.StructDataType");
 
         Collection<Field> allUniqueFields = getAllUniqueFields(multiExtends, docType.getAllFields());
-        exportExtendedStructTypeGetter(className, docType.getName(), allUniqueFields, out, 1, "getDocumentType", "com.yahoo.document.DocumentType");
+        exportExtendedStructTypeGetter(className, docType.getName(), allUniqueFields, docType.getFieldSets(),out, 1, "getDocumentType", "com.yahoo.document.DocumentType");
         exportCopyConstructor(className, out, 1, true);
 
         exportFieldsAndAccessors(className, "com.yahoo.document.Document".equals(superType) ? allUniqueFields : docType.getFields(), out, 1, true);
@@ -567,7 +569,7 @@ public class DocumentGenMojo extends AbstractMojo {
             out.write(ind(ind)+"public "+className+"(com.yahoo.document.datatypes.StructuredFieldValue src) {\n"+
                     ind(ind+1)+"super("+className+".type);\n");
         }
-        out.write(ind() + "ConcreteDocumentFactory factory = new ConcreteDocumentFactory();");
+        out.write(ind() + "ConcreteDocumentFactory factory = new ConcreteDocumentFactory();\n");
         out.write(
                 ind(ind+1)+"for (java.util.Iterator<java.util.Map.Entry<com.yahoo.document.Field, com.yahoo.document.datatypes.FieldValue>>i=src.iterator() ; i.hasNext() ; ) {\n" +
                 ind(ind+2)+"java.util.Map.Entry<com.yahoo.document.Field, com.yahoo.document.datatypes.FieldValue> e = i.next();\n" +
@@ -608,9 +610,25 @@ public class DocumentGenMojo extends AbstractMojo {
         out.write(ind(ind+1) + "}\n");
         out.write(ind(ind) + "));\n");
     }
-    private static void exportExtendedStructTypeGetter(String className, String name, Collection<Field> fields, Writer out, int ind, String methodName, String retType) throws IOException {
-        out.write(ind(ind)+"private static "+retType+" "+methodName+"() {\n" +
-                ind(ind+1)+retType+" ret = new "+retType+"(\""+name+"\");\n");
+    private static void exportFieldSetDefinition(Set<FieldSet> fieldSets, Writer out, int ind) throws IOException {
+        out.write(ind(ind) + "java.util.Map<java.lang.String, java.util.Collection<java.lang.String>> fieldSets = new java.util.HashMap<>();\n");
+        for (FieldSet fieldSet : fieldSets) {
+            out.write(ind(ind) + "fieldSets.put(\"" + fieldSet.getName() + "\", java.util.Arrays.asList(");
+            int count = 0;
+            for (String field : fieldSet.getFieldNames()) {
+                out.write("\"" + field + "\"");
+                if (++count != fieldSet.getFieldNames().size()) {
+                    out.write(",");
+                }
+            }
+            out.write("));\n");
+        }
+        out.write(ind(ind) + "ret.addFieldSets(fieldSets);\n");
+    }
+    private static void exportExtendedStructTypeGetter(String className, String name, Collection<Field> fields, Set<FieldSet> fieldSets,
+                                                       Writer out, int ind, String methodName, String retType) throws IOException {
+        out.write(ind(ind)+"private static "+retType+" "+methodName+"() {\n");
+        out.write(ind(ind+1)+retType+" ret = new "+retType+"(\""+name+"\");\n");
         for (Field f : fields) {
             if (f.getDataType().equals(DataType.STRING)) {
                 addExtendedStringField(className, f, out, ind + 1);
@@ -618,6 +636,10 @@ public class DocumentGenMojo extends AbstractMojo {
                 addExtendedField(className, f, out, ind + 1);
             }
         }
+        if (fieldSets != null) {
+            exportFieldSetDefinition(fieldSets, out, ind+1);
+        }
+
         out.write(ind(ind+1)+"return ret;\n");
         out.write(ind(ind)+"}\n\n");
     }
@@ -759,7 +781,7 @@ public class DocumentGenMojo extends AbstractMojo {
                 ind(ind+2)+"super("+structClassName+".type);\n" +
                 ind(ind+1)+"}\n\n");
                 exportCopyConstructor(structClassName, out, ind+1, false);
-                exportExtendedStructTypeGetter(structClassName, structType.getName(), structType.getFields(), out, ind+1, "getStructType", "com.yahoo.document.StructDataType");
+                exportExtendedStructTypeGetter(structClassName, structType.getName(), structType.getFields(), null, out, ind+1, "getStructType", "com.yahoo.document.StructDataType");
                 exportAssign(structType, structClassName, out, ind+1);
                 exportFieldsAndAccessors(structClassName, structType.getFields(), out, ind+1, true);
 


### PR DESCRIPTION
…nd fieldSetAll to work.

Verify that _zcurve generated fields are not exposet in the default fieldSet().

@bratseth PR
