### PR TITLE
Introduce ServiceRegistry in controller

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/ServiceRegistry.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/ServiceRegistry.java
@@ -1,0 +1,23 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration;
+
+import com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServer;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.api.integration.routing.GlobalRoutingService;
+
+/**
+ * This provides access to all service dependencies of the controller. Implementations of this are responsible for
+ * constructing and configuring service implementations suitable for use by the controller.
+ *
+ * @author mpolden
+ */
+// TODO(mpolden): Access all services through this
+public interface ServiceRegistry {
+
+    ConfigServer configServer();
+
+    NameService nameService();
+
+    GlobalRoutingService globalRoutingService();
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.application;
 
 import com.yahoo.component.Version;
@@ -58,7 +58,7 @@ public enum SystemApplication {
         if (!hasApplicationPackage()) {
             return true;
         }
-        return controller.configServer().serviceConvergence(new DeploymentId(id(), zone), version)
+        return controller.serviceRegistry().configServer().serviceConvergence(new DeploymentId(id(), zone), version)
                          .map(ServiceConvergence::converged)
                          .orElse(false);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.google.common.collect.ImmutableList;
@@ -342,7 +342,7 @@ public class InternalStepRunner implements StepRunner {
     }
 
     private boolean nodesConverged(ApplicationId id, JobType type, Version target, DualLogger logger) {
-        List<Node> nodes = controller.configServer().nodeRepository().list(type.zone(controller.system()), id, ImmutableSet.of(active, reserved));
+        List<Node> nodes = controller.serviceRegistry().configServer().nodeRepository().list(type.zone(controller.system()), id, ImmutableSet.of(active, reserved));
         List<String> statuses = nodes.stream()
                 .map(node -> String.format("%70s: %-16s%-25s%-32s%s",
                                            node.hostname(),
@@ -361,7 +361,7 @@ public class InternalStepRunner implements StepRunner {
     }
 
     private boolean servicesConverged(ApplicationId id, JobType type, Version platform, DualLogger logger) {
-        var convergence = controller.configServer().serviceConvergence(new DeploymentId(id, type.zone(controller.system())),
+        var convergence = controller.serviceRegistry().configServer().serviceConvergence(new DeploymentId(id, type.zone(controller.system())),
                                                                        Optional.of(platform));
         if (convergence.isEmpty()) {
             logger.log("Config status not currently available -- will retry.");
@@ -461,7 +461,7 @@ public class InternalStepRunner implements StepRunner {
             try {
                 logger.log("Copying Vespa log from nodes of " + id.application() + " in " + zone + " ...");
                 List<LogEntry> entries = new ArrayList<>();
-                String logs = IOUtils.readAll(controller.configServer().getLogs(new DeploymentId(id.application(), zone),
+                String logs = IOUtils.readAll(controller.serviceRegistry().configServer().getLogs(new DeploymentId(id.application(), zone),
                                                                                      Collections.emptyMap()), // Get all logs.
                                               StandardCharsets.UTF_8);
                 for (String line : logs.split("\n")) {
@@ -619,7 +619,7 @@ public class InternalStepRunner implements StepRunner {
     private Map<ZoneId, List<String>> listClusters(ApplicationId id, Iterable<ZoneId> zones) {
         ImmutableMap.Builder<ZoneId, List<String>> clusters = ImmutableMap.builder();
         for (ZoneId zone : zones)
-            clusters.put(zone, ImmutableList.copyOf(controller.configServer().getContentClusters(new DeploymentId(id, zone))));
+            clusters.put(zone, ImmutableList.copyOf(controller.serviceRegistry().configServer().getContentClusters(new DeploymentId(id, zone))));
         return clusters.build();
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.google.common.collect.ImmutableMap;
@@ -377,7 +377,7 @@ public class JobController {
 
     public void deactivateTester(TesterId id, JobType type) {
         try {
-            controller.configServer().deactivate(new DeploymentId(id.id(), type.zone(controller.system())));
+            controller.serviceRegistry().configServer().deactivate(new DeploymentId(id.id(), type.zone(controller.system())));
         }
         catch (NotFoundException ignored) {
             // Already gone -- great!

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainer.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.config.provision.ClusterSpec;
@@ -37,7 +37,7 @@ public class ClusterInfoMaintainer extends Maintainer {
     ClusterInfoMaintainer(Controller controller, Duration duration, JobControl jobControl) {
         super(controller, duration, jobControl);
         this.controller = controller;
-        this.nodeRepository = controller.configServer().nodeRepository();
+        this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
     }
 
     private static String clusterId(NodeRepositoryNode node) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.AbstractComponent;
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.aws.AwsEventFetcher;
-import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.Billing;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.ContactRetriever;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.DeploymentIssues;
@@ -62,7 +61,6 @@ public class ControllerMaintenance extends AbstractComponent {
     public ControllerMaintenance(MaintainerConfig maintainerConfig, ApiAuthorityConfig apiAuthorityConfig, Controller controller, CuratorDb curator,
                                  JobControl jobControl, Metric metric,
                                  DeploymentIssues deploymentIssues, OwnershipIssues ownershipIssues,
-                                 NameService nameService,
                                  ContactRetriever contactRetriever,
                                  CostReportConsumer reportConsumer,
                                  MeteringClient meteringClient,
@@ -88,7 +86,7 @@ public class ControllerMaintenance extends AbstractComponent {
         osUpgraders = osUpgraders(controller, jobControl);
         osVersionStatusUpdater = new OsVersionStatusUpdater(controller, maintenanceInterval, jobControl);
         contactInformationMaintainer = new ContactInformationMaintainer(controller, Duration.ofHours(12), jobControl, contactRetriever);
-        nameServiceDispatcher = new NameServiceDispatcher(controller, Duration.ofSeconds(10), jobControl, nameService);
+        nameServiceDispatcher = new NameServiceDispatcher(controller, Duration.ofSeconds(10), jobControl);
         costReportMaintainer = new CostReportMaintainer(controller, Duration.ofHours(2), reportConsumer, jobControl, selfHostedCostConfig);
         resourceMeterMaintainer = new ResourceMeterMaintainer(controller, Duration.ofMinutes(30), jobControl, metric, meteringClient);
         billingMaintainer = new BillingMaintainer(controller, Duration.ofDays(3), jobControl, billing);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/CostReportMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/CostReportMaintainer.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.google.inject.Inject;
@@ -35,7 +35,7 @@ public class CostReportMaintainer extends Maintainer {
                                 SelfHostedCostConfig selfHostedCostConfig) {
         super(controller, interval, jobControl, "CostReportMaintainer", EnumSet.of(SystemName.main));
         this.consumer = consumer;
-        this.nodeRepository = controller.configServer().nodeRepository();
+        this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.clock = controller.clock();
         this.selfHostedCostConfig = selfHostedCostConfig;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/InfrastructureUpgrader.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.component.Version;
@@ -97,7 +97,7 @@ public abstract class InfrastructureUpgrader extends Maintainer {
     /** Find the minimum value of a version field in a zone */
     protected final Optional<Version> minVersion(ZoneApi zone, SystemApplication application, Function<Node, Version> versionField) {
         try {
-            return controller().configServer()
+            return controller().serviceRegistry().configServer()
                                .nodeRepository()
                                .list(zone.getId(), application.id())
                                .stream()

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/NameServiceDispatcher.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/NameServiceDispatcher.java
@@ -23,16 +23,14 @@ public class NameServiceDispatcher extends Maintainer {
     private final NameService nameService;
     private final int requestCount;
 
-    public NameServiceDispatcher(Controller controller, Duration interval, JobControl jobControl,
-                                 NameService nameService) {
-        this(controller, interval, jobControl, nameService, defaultRequestCount);
+    public NameServiceDispatcher(Controller controller, Duration interval, JobControl jobControl) {
+        this(controller, interval, jobControl, defaultRequestCount);
     }
 
-    public NameServiceDispatcher(Controller controller, Duration interval, JobControl jobControl,
-                                 NameService nameService, int requestCount) {
+    public NameServiceDispatcher(Controller controller, Duration interval, JobControl jobControl, int requestCount) {
         super(controller, interval, jobControl);
         this.db = controller.curator();
-        this.nameService = nameService;
+        this.nameService = controller.serviceRegistry().nameService();
         this.requestCount = requestCount;
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.google.common.collect.ImmutableSet;
@@ -43,7 +43,7 @@ public class OsUpgrader extends InfrastructureUpgrader {
             return;
         }
         log.info(String.format("Upgrading OS of %s to version %s in %s in cloud %s", application.id(), target, zone.getId(), zone.getCloudName()));
-        controller().configServer().nodeRepository().upgradeOs(zone.getId(), application.nodeType(), target);
+        controller().serviceRegistry().configServer().nodeRepository().upgradeOs(zone.getId(), application.nodeType(), target);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainer.java
@@ -40,7 +40,7 @@ public class ResourceMeterMaintainer extends Maintainer {
                                    MeteringClient meteringClient) {
         super(controller, interval, jobControl, null, SystemName.all());
         this.clock = controller.clock();
-        this.nodeRepository = controller.configServer().nodeRepository();
+        this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.metric = metric;
         this.meteringClient = meteringClient;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RotationStatusUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RotationStatusUpdater.java
@@ -35,7 +35,7 @@ public class RotationStatusUpdater extends Maintainer {
 
     public RotationStatusUpdater(Controller controller, Duration interval, JobControl jobControl) {
         super(controller, interval, jobControl);
-        this.service = controller.globalRoutingService();
+        this.service = controller.serviceRegistry().globalRoutingService();
         this.applications = controller.applications();
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicies.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPolicies.java
@@ -74,7 +74,7 @@ public class RoutingPolicies {
      */
     public void refresh(ApplicationId application, DeploymentSpec deploymentSpec, ZoneId zone) {
         if (!controller.zoneRegistry().zones().directlyRouted().ids().contains(zone)) return;
-        var lbs = new AllocatedLoadBalancers(application, zone, controller.configServer().getLoadBalancers(application, zone));
+        var lbs = new AllocatedLoadBalancers(application, zone, controller.serviceRegistry().configServer().getLoadBalancers(application, zone));
         try (var lock = db.lockRoutingPolicies()) {
             removeObsoleteEndpointsFromDns(lbs, deploymentSpec, lock);
             storePoliciesOf(lbs, deploymentSpec, lock);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi.application;
 
 import ai.vespa.hosted.api.Signatures;
@@ -380,7 +380,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
     private HttpResponse nodes(String tenantName, String applicationName, String instanceName, String environment, String region) {
         ApplicationId id = ApplicationId.from(tenantName, applicationName, instanceName);
         ZoneId zone = ZoneId.from(environment, region);
-        List<Node> nodes = controller.configServer().nodeRepository().list(zone, id);
+        List<Node> nodes = controller.serviceRegistry().configServer().nodeRepository().list(zone, id);
 
         Slime slime = new Slime();
         Cursor nodesArray = slime.setObject().setArray("nodes");
@@ -438,7 +438,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         ApplicationId application = ApplicationId.from(tenantName, applicationName, instanceName);
         ZoneId zone = ZoneId.from(environment, region);
         DeploymentId deployment = new DeploymentId(application, zone);
-        InputStream logStream = controller.configServer().getLogs(deployment, queryParameters);
+        InputStream logStream = controller.serviceRegistry().configServer().getLogs(deployment, queryParameters);
         return new HttpResponse(200) {
             @Override
             public void render(OutputStream outputStream) throws IOException {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/cost/CostApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/cost/CostApiHandler.java
@@ -28,7 +28,7 @@ public class CostApiHandler extends LoggingRequestHandler {
     public CostApiHandler(Context ctx, Controller controller, SelfHostedCostConfig selfHostedCostConfig) {
         super(ctx);
         this.controller = controller;
-        this.nodeRepository = controller.configServer().nodeRepository();
+        this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.selfHostedCostConfig = selfHostedCostConfig;
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiHandler.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi.os;
 
 import com.yahoo.component.Version;
@@ -102,7 +102,7 @@ public class OsApiHandler extends AuditLoggingRequestHandler {
 
         StringJoiner response = new StringJoiner(", ", "Requested firmware checks in ", ".");
         for (ZoneId zone : zones) {
-            controller.configServer().nodeRepository().requestFirmwareCheck(zone);
+            controller.serviceRegistry().configServer().nodeRepository().requestFirmwareCheck(zone);
             response.add(zone.value());
         }
         return new MessageResponse(response.toString());
@@ -115,7 +115,7 @@ public class OsApiHandler extends AuditLoggingRequestHandler {
 
         StringJoiner response = new StringJoiner(", ", "Cancelled firmware checks in ", ".");
         for (ZoneId zone : zones) {
-            controller.configServer().nodeRepository().cancelFirmwareCheck(zone);
+            controller.serviceRegistry().configServer().nodeRepository().cancelFirmwareCheck(zone);
             response.add(zone.value());
         }
         return new MessageResponse(response.toString());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.versions;
 
 import com.google.common.collect.ImmutableMap;
@@ -9,7 +9,6 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.Controller;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.maintenance.OsUpgrader;
 
@@ -72,7 +71,7 @@ public class OsVersionStatus {
                 continue; // Avoid querying applications that are not eligible for OS upgrades
             }
             for (ZoneApi zone : zonesToUpgrade(controller)) {
-                controller.configServer().nodeRepository().list(zone.getId(), application.id()).stream()
+                controller.serviceRegistry().configServer().nodeRepository().list(zone.getId(), application.id()).stream()
                           .filter(node -> OsUpgrader.eligibleForUpgrade(node, application))
                           .map(node -> new Node(node.hostname(), node.currentOsVersion(), zone.getEnvironment(), zone.getRegionName()))
                           .forEach(node -> {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.versions;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -154,7 +154,7 @@ public class VersionStatus {
         ListMultimap<Version, HostName> versions = ArrayListMultimap.create();
         for (ZoneApi zone : controller.zoneRegistry().zones().controllerUpgraded().zones()) {
             for (SystemApplication application : SystemApplication.all()) {
-                List<Node> eligibleForUpgradeApplicationNodes = controller.configServer().nodeRepository()
+                List<Node> eligibleForUpgradeApplicationNodes = controller.serviceRegistry().configServer().nodeRepository()
                         .list(zone.getId(), application.id()).stream()
                         .filter(SystemUpgrader::eligibleForUpgrade)
                         .collect(Collectors.toList());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.yahoo.component.Version;
@@ -76,7 +76,6 @@ public class DeploymentTester {
         this.readyJobTrigger = new ReadyJobsTrigger(tester.controller(), maintenanceInterval, jobControl);
         this.nameServiceDispatcher = new NameServiceDispatcher(tester.controller(), Duration.ofHours(12),
                                                                new JobControl(tester.controller().curator()),
-                                                               controllerTester().nameService(),
                                                                Integer.MAX_VALUE);
     }
 
@@ -98,7 +97,7 @@ public class DeploymentTester {
 
     public ControllerTester controllerTester() { return tester; }
 
-    public ConfigServerMock configServer() { return tester.configServer(); }
+    public ConfigServerMock configServer() { return tester.serviceRegistry().configServerMock(); }
 
     public ArtifactRepositoryMock artifactRepository() { return tester.artifactRepository(); }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ServiceRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ServiceRegistryMock.java
@@ -1,0 +1,54 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.integration;
+
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.vespa.hosted.controller.api.integration.ServiceRegistry;
+import com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServer;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.MemoryNameService;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.vespa.hosted.controller.api.integration.routing.GlobalRoutingService;
+import com.yahoo.vespa.hosted.controller.api.integration.routing.MemoryGlobalRoutingService;
+
+/**
+ * A mock implementation of a {@link ServiceRegistry} for testing purposes.
+ *
+ * @author mpolden
+ */
+public class ServiceRegistryMock extends AbstractComponent implements ServiceRegistry {
+
+    private final ZoneRegistryMock zoneRegistryMock = new ZoneRegistryMock();
+    private final ConfigServerMock configServerMock = new ConfigServerMock(zoneRegistryMock);
+    private final MemoryNameService memoryNameService = new MemoryNameService();
+    private final MemoryGlobalRoutingService memoryGlobalRoutingService = new MemoryGlobalRoutingService();
+
+    @Override
+    public ConfigServer configServer() {
+        return configServerMock;
+    }
+
+    @Override
+    public GlobalRoutingService globalRoutingService() {
+        return memoryGlobalRoutingService;
+    }
+
+    @Override
+    public NameService nameService() {
+        return memoryNameService;
+    }
+
+    public ZoneRegistryMock zoneRegistryMock() {
+        return zoneRegistryMock;
+    }
+
+    public ConfigServerMock configServerMock() {
+        return configServerMock;
+    }
+
+    public MemoryNameService nameServiceMock() {
+        return memoryNameService;
+    }
+
+    public MemoryGlobalRoutingService globalRoutingServiceMock() {
+        return memoryGlobalRoutingService;
+    }
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RotationStatusUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RotationStatusUpdaterTest.java
@@ -25,7 +25,7 @@ public class RotationStatusUpdaterTest {
     @Test
     public void updates_rotation_status() {
         var tester = new DeploymentTester();
-        var globalRotationService = tester.controllerTester().globalRoutingService();
+        var globalRotationService = tester.controllerTester().serviceRegistry().globalRoutingServiceMock();
         var updater = new RotationStatusUpdater(tester.controller(), Duration.ofDays(1), new JobControl(tester.controller().curator()));
 
         var application = tester.createApplication("app1", "tenant1", 1, 1L);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ContainerTester.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi;
 
 import com.yahoo.application.container.JDisc;
@@ -13,6 +13,7 @@ import com.yahoo.jdisc.http.filter.SecurityRequestFilterChain;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerMock;
+import com.yahoo.vespa.hosted.controller.integration.ServiceRegistryMock;
 import com.yahoo.vespa.hosted.controller.versions.ControllerVersion;
 import com.yahoo.vespa.hosted.controller.versions.VersionStatus;
 import org.junit.ComparisonFailure;
@@ -52,7 +53,11 @@ public class ContainerTester {
     }
 
     public ConfigServerMock configServer() {
-        return (ConfigServerMock) container.components().getComponent(ConfigServerMock.class.getName());
+        return serviceRegistry().configServerMock();
+    }
+
+    public ServiceRegistryMock serviceRegistry() {
+        return (ServiceRegistryMock) container.components().getComponent(ServiceRegistryMock.class.getName());
     }
 
     public void computeVersionStatus() {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi;
 
 import com.yahoo.application.Networking;
@@ -64,9 +64,7 @@ public class ControllerContainerTest {
                "  <component id='com.yahoo.vespa.curator.mock.MockCurator'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.athenz.mock.AthenzClientFactoryMock'/>\n" +
-               "  <component id='com.yahoo.vespa.hosted.controller.api.integration.dns.MemoryNameService'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.entity.MemoryEntityService'/>\n" +
-               "  <component id='com.yahoo.vespa.hosted.controller.api.integration.routing.MemoryGlobalRoutingService'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.stubs.LoggingDeploymentIssues'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.restapi.cost.NoopCostReportConsumer'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.stubs.DummyOwnershipIssues'/>\n" +
@@ -76,8 +74,8 @@ public class ControllerContainerTest {
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.aws.MockAwsEventFetcher' />\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.organization.MockBilling'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.stubs.MockMeteringClient'/>\n" +
-               "  <component id='com.yahoo.vespa.hosted.controller.integration.ConfigServerMock'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock'/>\n" +
+               "  <component id='com.yahoo.vespa.hosted.controller.integration.ServiceRegistryMock'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.Controller'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.api.integration.stubs.MockBuildService'/>\n" +
                "  <component id='com.yahoo.vespa.hosted.controller.integration.ConfigServerProxyMock'/>\n" +

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi.os;
 
 import com.yahoo.application.container.handler.Request;
@@ -11,7 +11,6 @@ import com.yahoo.vespa.athenz.api.AthenzIdentity;
 import com.yahoo.vespa.athenz.api.AthenzUser;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
-import com.yahoo.vespa.hosted.controller.integration.ConfigServerMock;
 import com.yahoo.vespa.hosted.controller.integration.NodeRepositoryMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock;
@@ -164,8 +163,7 @@ public class OsApiTest extends ControllerContainerTest {
     }
 
     private NodeRepositoryMock nodeRepository() {
-        return ((ConfigServerMock) tester.containerTester().container().components()
-                                         .getComponent(ConfigServerMock.class.getName())).nodeRepository();
+        return tester.containerTester().serviceRegistry().configServerMock().nodeRepository();
     }
 
     private void assertResponse(Request request, @Language("JSON") String body, int statusCode) {


### PR DESCRIPTION
This change introduces a `ServiceRegistry` interface which will eventually
provide access to all service dependencies of the controller. `ServiceRegistry`
will have a single internal implementation that programmatically configures all
service implementations relevant to the system.

Setup of service implementations thus becomes code and reduces the pain of
associated with service integration (i.e. no more component setup needed).

Additionally this will reduce the complexity of generating `services.xml` for
controllers in each system.