### PR TITLE
Let controller create application summary 

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/organization/ApplicationSummary.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/organization/ApplicationSummary.java
@@ -1,0 +1,73 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.organization;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.zone.ZoneId;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A summary of activity in an application.
+ *
+ * @author mpolden
+ */
+public class ApplicationSummary {
+
+    private final ApplicationId application;
+    private final Optional<Instant> lastQueried;
+    private final Optional<Instant> lastWritten;
+    private final Map<ZoneId, Metric> metrics;
+
+    public ApplicationSummary(ApplicationId application, Optional<Instant> lastQueried, Optional<Instant> lastWritten, Map<ZoneId, Metric> metrics) {
+        this.application = Objects.requireNonNull(application);
+        this.lastQueried = Objects.requireNonNull(lastQueried);
+        this.lastWritten = Objects.requireNonNull(lastWritten);
+        this.metrics = Map.copyOf(Objects.requireNonNull(metrics));
+    }
+
+    public ApplicationId application() {
+        return application;
+    }
+
+    public Optional<Instant> lastQueried() {
+        return lastQueried;
+    }
+
+    public Optional<Instant> lastWritten() {
+        return lastWritten;
+    }
+
+    public Map<ZoneId, Metric> metrics() {
+        return metrics;
+    }
+
+    public static class Metric {
+
+        private final double documentCount;
+        private final double queriesPerSecond;
+        private final double writesPerSecond;
+
+        public Metric(double documentCount, double queriesPerSecond, double writesPerSecond) {
+            this.documentCount = documentCount;
+            this.queriesPerSecond = queriesPerSecond;
+            this.writesPerSecond = writesPerSecond;
+        }
+
+        public double documentCount() {
+            return documentCount;
+        }
+
+        public double queriesPerSecond() {
+            return queriesPerSecond;
+        }
+
+        public double writesPerSecond() {
+            return writesPerSecond;
+        }
+
+    }
+
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/organization/OwnershipIssues.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/organization/OwnershipIssues.java
@@ -1,8 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.api.integration.organization;
 
-import com.yahoo.config.provision.ApplicationId;
-
 import java.util.Optional;
 
 /**
@@ -21,12 +19,12 @@ public interface OwnershipIssues {
      * Ensure ownership of the given application has been recently confirmed by the given user.
      *
      * @param issueId ID of the previous ownership issue filed for the given application.
-     * @param applicationId ID of the application for which to file an issue.
-     * @param asignee Issue asignee
+     * @param summary Summary of an application for which to file an issue.
+     * @param assignee Issue assignee
      * @param contact Contact info for the application tenant
      * @return ID of the created issue, if one was created.
      */
-    Optional<IssueId> confirmOwnership(Optional<IssueId> issueId, ApplicationId applicationId, User asignee, Contact contact);
+    Optional<IssueId> confirmOwnership(Optional<IssueId> issueId, ApplicationSummary summary, User assignee, Contact contact);
 
     /**
      * Make sure the given ownership confirmation request is acted upon, unless it is already acknowledged.
@@ -41,4 +39,5 @@ public interface OwnershipIssues {
      * @return The owner of the application, if it has been confirmed.
      */
     Optional<User> getConfirmedOwner(IssueId issueId);
+
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/stubs/DummyOwnershipIssues.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/stubs/DummyOwnershipIssues.java
@@ -1,7 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.api.integration.stubs;
 
-import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.ApplicationSummary;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.Contact;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueId;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.OwnershipIssues;
@@ -9,20 +9,23 @@ import com.yahoo.vespa.hosted.controller.api.integration.organization.User;
 
 import java.util.Optional;
 
+/**
+ * @author jonmv
+ */
 public class DummyOwnershipIssues implements OwnershipIssues {
 
     @Override
-    public Optional<IssueId> confirmOwnership(Optional<IssueId> issueId, ApplicationId applicationId, User asignee, Contact contact) {
+    public Optional<IssueId> confirmOwnership(Optional<IssueId> issueId, ApplicationSummary summary, User assignee, Contact contact) {
         return Optional.empty();
     }
 
     @Override
     public void ensureResponse(IssueId issueId, Optional<Contact> contact) {
-
     }
 
     @Override
     public Optional<User> getConfirmedOwner(IssueId issueId) {
         return Optional.empty();
     }
+
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ApplicationOwnershipConfirmerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ApplicationOwnershipConfirmerTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.ApplicationSummary;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.Contact;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueId;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.OwnershipIssues;
@@ -107,7 +108,7 @@ public class ApplicationOwnershipConfirmerTest {
         private Optional<User> owner = Optional.empty();
 
         @Override
-        public Optional<IssueId> confirmOwnership(Optional<IssueId> issueId, ApplicationId applicationId, User asignee, Contact contact) {
+        public Optional<IssueId> confirmOwnership(Optional<IssueId> issueId, ApplicationSummary summary, User assignee, Contact contact) {
             return response;
         }
 


### PR DESCRIPTION
`ApplicationOwnershipConfirmer` now creates a summary of an application up
front, instead of leaving it to the implementation of `OwnershipIssues`.

This allows us to remove the `Controller` dependency in the implementation of
`OwnershipIssues`.