### PR TITLE
Add simple probabilistic query tracing and logging for streaming searches that time out.

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
@@ -1,0 +1,65 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors;
+
+import com.yahoo.vespa.streamingvisitors.tracing.LoggingTraceExporter;
+import com.yahoo.vespa.streamingvisitors.tracing.MaxSamplesPerPeriod;
+import com.yahoo.vespa.streamingvisitors.tracing.MonotonicNanoClock;
+import com.yahoo.vespa.streamingvisitors.tracing.ProbabilisticSampleRate;
+import com.yahoo.vespa.streamingvisitors.tracing.SamplingStrategy;
+import com.yahoo.vespa.streamingvisitors.tracing.SamplingTraceExporter;
+import com.yahoo.vespa.streamingvisitors.tracing.TraceExporter;
+
+import java.util.concurrent.TimeUnit;
+
+public class TracingOptions {
+
+    private final SamplingStrategy samplingStrategy;
+    private final TraceExporter traceExporter;
+    private final MonotonicNanoClock clock;
+    private final int traceLevelOverride;
+    private final double traceTimeoutMultiplierThreshold;
+
+    public TracingOptions(SamplingStrategy samplingStrategy, TraceExporter traceExporter,
+                          MonotonicNanoClock clock, int traceLevelOverride, double traceTimeoutMultiplierThreshold)
+    {
+        this.samplingStrategy = samplingStrategy;
+        this.traceExporter = traceExporter;
+        this.clock = clock;
+        this.traceLevelOverride = traceLevelOverride;
+        this.traceTimeoutMultiplierThreshold = traceTimeoutMultiplierThreshold;
+    }
+
+    public static final TracingOptions DEFAULT;
+    public static final int DEFAULT_TRACE_LEVEL_OVERRIDE = 7; // TODO determine appropriate trace level
+    // Traces won't be exported unless the query has timed out with a duration that is > timeout * multiplier
+    public static final double TRACE_TIMEOUT_MULTIPLIER_THRESHOLD = 5.0;
+
+    static {
+        SamplingStrategy queryTraceSampler = ProbabilisticSampleRate.withSystemDefaults(0.5);
+        SamplingStrategy logExportSampler  = MaxSamplesPerPeriod.withSteadyClock(TimeUnit.SECONDS.toNanos(10), 1);
+        TraceExporter    traceExporter     = new SamplingTraceExporter(new LoggingTraceExporter(), logExportSampler);
+        DEFAULT = new TracingOptions(queryTraceSampler, traceExporter, System::nanoTime,
+                                     DEFAULT_TRACE_LEVEL_OVERRIDE, TRACE_TIMEOUT_MULTIPLIER_THRESHOLD);
+    }
+
+    public SamplingStrategy getSamplingStrategy() {
+        return samplingStrategy;
+    }
+
+    public TraceExporter getTraceExporter() {
+        return traceExporter;
+    }
+
+    public MonotonicNanoClock getClock() {
+        return clock;
+    }
+
+    public int getTraceLevelOverride() {
+        return traceLevelOverride;
+    }
+
+    public double getTraceTimeoutMultiplierThreshold() {
+        return traceTimeoutMultiplierThreshold;
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
@@ -11,6 +11,17 @@ import com.yahoo.vespa.streamingvisitors.tracing.TraceExporter;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Encapsulates all trace-related components and options used by the streaming search Searcher.
+ *
+ * Provides a DEFAULT static instance which has the following characteristics:
+ *   - Approximately 1 query every 2 seconds is traced
+ *   - Trace level is set to 7 for traced queries
+ *   - Only emits traces for queries that have timed out and where the elapsed time is at least 5x
+ *     of the timeout specified in the query itself
+ *   - Emits traces to the Vespa log
+ *   - Only 1 trace every 10 seconds may be emitted to the log
+ */
 public class TracingOptions {
 
     private final SamplingStrategy samplingStrategy;
@@ -19,6 +30,13 @@ public class TracingOptions {
     private final int traceLevelOverride;
     private final double traceTimeoutMultiplierThreshold;
 
+    /**
+     * @param samplingStrategy used for choosing if a query should have its trace level implicitly altered.
+     * @param traceExporter used for emitting a visitor session trace to someplace it may be debugged later.
+     * @param clock monotonic clock used for relative time tracking.
+     * @param traceLevelOverride if a query is trace-sampled, its traceLevel will be set to this value
+     * @param traceTimeoutMultiplierThreshold only export traces if the elapsed time is > query timeout * this value
+     */
     public TracingOptions(SamplingStrategy samplingStrategy, TraceExporter traceExporter,
                           MonotonicNanoClock clock, int traceLevelOverride, double traceTimeoutMultiplierThreshold)
     {

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
@@ -35,7 +35,7 @@ public class TracingOptions {
      * @param traceExporter used for emitting a visitor session trace to someplace it may be debugged later.
      * @param clock monotonic clock used for relative time tracking.
      * @param traceLevelOverride if a query is trace-sampled, its traceLevel will be set to this value
-     * @param traceTimeoutMultiplierThreshold only export traces if the elapsed time is > query timeout * this value
+     * @param traceTimeoutMultiplierThreshold only export traces if the elapsed time is greater than the query timeout * this value
      */
     public TracingOptions(SamplingStrategy samplingStrategy, TraceExporter traceExporter,
                           MonotonicNanoClock clock, int traceLevelOverride, double traceTimeoutMultiplierThreshold)

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -163,8 +163,8 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
             double elapsedMillis = durationInMillisFromNanoTime(timeStartedNanos);
             if ((effectiveTraceLevel > 0) && timeoutBadEnoughToBeReported(query, elapsedMillis)) {
                 tracingOptions.getTraceExporter().maybeExport(() -> new TraceDescription(visitor.getTrace(),
-                        String.format("Trace of %s which timed out after %.2g ms",
-                                      query.toString(), elapsedMillis)));
+                        String.format("Trace of %s which timed out after %.3g seconds",
+                                      query.toString(), elapsedMillis / 1000.0)));
             }
             return new Result(query, ErrorMessage.createTimeout(e.getMessage()));
         } catch (InterruptedException|IllegalArgumentException e) {

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.streamingvisitors;
 
 import com.yahoo.document.select.parser.ParseException;
+import com.yahoo.messagebus.Trace;
 import com.yahoo.prelude.fastsearch.TimeoutException;
 import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
@@ -29,4 +30,7 @@ interface Visitor {
     int getTotalHitCount();
 
     List<Grouping> getGroupings();
+
+    Trace getTrace();
+
 }

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VisitorFactory.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VisitorFactory.java
@@ -10,5 +10,7 @@ import com.yahoo.search.Query;
  * @author <a href="mailto:ulf@yahoo-inc.com">Ulf Carlin</a>
  */
 interface VisitorFactory {
-    public Visitor createVisitor(Query query, String searchCluster, Route route, String documentType);
+
+    Visitor createVisitor(Query query, String searchCluster, Route route, String documentType, int traceLevelOverride);
+
 }

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/LoggingTraceExporter.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/LoggingTraceExporter.java
@@ -1,0 +1,25 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import com.yahoo.log.LogLevel;
+
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+/**
+ * Trace exporter which dumps traces and their description as warning-entries in the Vespa log.
+ */
+public class LoggingTraceExporter implements TraceExporter {
+
+    private static final Logger log = Logger.getLogger(LoggingTraceExporter.class.getName());
+
+    @Override
+    public void maybeExport(Supplier<TraceDescription> traceDescriptionSupplier) {
+        var traceDescription = traceDescriptionSupplier.get();
+        if (traceDescription.getTrace() != null) {
+            log.log(LogLevel.WARNING, String.format("%s: %s", traceDescription.getDescription(),
+                    traceDescription.getTrace().toString()));
+        }
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/MaxSamplesPerPeriod.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/MaxSamplesPerPeriod.java
@@ -1,0 +1,46 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+/**
+ * Very basic sampling strategy which allows for sampling N requests within a fixed
+ * time window. No attempt is made to distribute the samples evenly within the time
+ * period; this is on a first-come, first-serve basis.
+ */
+public class MaxSamplesPerPeriod implements SamplingStrategy {
+
+    private final MonotonicNanoClock nanoClock;
+    private final long maxSamplesPerPeriod;
+    private final long periodLengthInNanos;
+    private long currentSamplingPeriod = 0;
+    private long samplesInCurrentPeriod = 0;
+
+    public MaxSamplesPerPeriod(MonotonicNanoClock nanoClock, long periodLengthInNanos, long maxSamplesPerPeriod) {
+        this.nanoClock = nanoClock;
+        this.periodLengthInNanos = periodLengthInNanos;
+        this.maxSamplesPerPeriod = maxSamplesPerPeriod;
+    }
+
+    public static MaxSamplesPerPeriod withSteadyClock(long periodLengthInNanos, long maxSamplesPerPeriod) {
+        // We make a reasonable assumption that System.nanoTime uses the underlying steady clock.
+        return new MaxSamplesPerPeriod(System::nanoTime, periodLengthInNanos, maxSamplesPerPeriod);
+    }
+
+    @Override
+    public boolean shouldSample() {
+        long now = nanoClock.nanoTimeNow();
+        long period = now / periodLengthInNanos;
+        synchronized (this) {
+            if (period != currentSamplingPeriod) {
+                currentSamplingPeriod = period;
+                samplesInCurrentPeriod = 1;
+                return true;
+            }
+            if (samplesInCurrentPeriod >= maxSamplesPerPeriod) {
+                return false;
+            }
+            ++samplesInCurrentPeriod;
+            return true;
+        }
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/MonotonicNanoClock.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/MonotonicNanoClock.java
@@ -1,0 +1,15 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+/*
+ * Clock which returns a monotonically increasing timestamp from an undefined epoch.
+ * The epoch is guaranteed to be stable within a single JVM execution, but not across
+ * processes. Should therefore only be used for relative duration tracking, not absolute
+ * wall clock time events.
+ */
+@FunctionalInterface
+public interface MonotonicNanoClock {
+
+    long nanoTimeNow();
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/MonotonicNanoClock.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/MonotonicNanoClock.java
@@ -1,7 +1,7 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors.tracing;
 
-/*
+/**
  * Clock which returns a monotonically increasing timestamp from an undefined epoch.
  * The epoch is guaranteed to be stable within a single JVM execution, but not across
  * processes. Should therefore only be used for relative duration tracking, not absolute

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/ProbabilisticSampleRate.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/ProbabilisticSampleRate.java
@@ -1,0 +1,52 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Simple implementation of OpenCensus algorithm for probabilistic rate limiting as outlined in
+ * https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md
+ */
+public class ProbabilisticSampleRate implements SamplingStrategy {
+
+    private final MonotonicNanoClock nanoClock;
+    private final Supplier<Random> randomSupplier;
+    private final double desiredSamplesPerSec;
+    private final AtomicLong lastSampledAtNanoTime = new AtomicLong(0);
+
+    public ProbabilisticSampleRate(MonotonicNanoClock nanoClock,
+                                   Supplier<Random> randomSupplier,
+                                   double desiredSamplesPerSec)
+    {
+        this.nanoClock = nanoClock;
+        this.randomSupplier = randomSupplier;
+        this.desiredSamplesPerSec = desiredSamplesPerSec;
+    }
+
+    public static ProbabilisticSampleRate withSystemDefaults(double desiredSamplesPerSec) {
+        return new ProbabilisticSampleRate(System::nanoTime, ThreadLocalRandom::current, desiredSamplesPerSec);
+    }
+
+    @Override
+    public boolean shouldSample() {
+        // This load might race with the store below, causing multiple threads to get a sample
+        // since the new timestamp has not been written yet, but it is extremely unlikely and
+        // the consequences are not severe since this is a probabilistic sampler that does not
+        // provide hard lower or upper bounds.
+        long lastSampledAt = lastSampledAtNanoTime.get(); // TODO getPlain? No transitive visibility requirements
+        long now = nanoClock.nanoTimeNow();
+        double secsSinceLastSample = (now - lastSampledAt) / 1_000_000_000.0;
+        // As the time elapsed since last sample increases, so does the probability of a new sample
+        // being selected.
+        double sampleProb = Math.min(secsSinceLastSample * desiredSamplesPerSec, 1.0);
+        if (randomSupplier.get().nextDouble() < sampleProb) {
+            lastSampledAtNanoTime.set(now); // TODO setPlain? No transitive visibility requirements
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingStrategy.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingStrategy.java
@@ -1,0 +1,16 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+/**
+ * A sampling strategy makes the high-level decision of whether or not a query
+ * should be traced.
+ *
+ * Callers should be able to expect that calling shouldSample() is a cheap operation
+ * with little or no underlying locking. This in turn means that the sampling strategy
+ * may be consulted for each query with minimal overhead.
+ */
+public interface SamplingStrategy {
+
+    boolean shouldSample();
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporter.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporter.java
@@ -1,0 +1,26 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import java.util.function.Supplier;
+
+/**
+ * Trace exporter which only exports a subset of traces as decided by the provided sampling strategy.
+ */
+public class SamplingTraceExporter implements TraceExporter {
+
+    private final TraceExporter wrappedExporter;
+    private final SamplingStrategy samplingStrategy;
+
+    public SamplingTraceExporter(TraceExporter wrappedExporter, SamplingStrategy samplingStrategy) {
+        this.wrappedExporter = wrappedExporter;
+        this.samplingStrategy = samplingStrategy;
+    }
+
+    @Override
+    public void maybeExport(Supplier<TraceDescription> traceDescriptionSupplier) {
+        if (samplingStrategy.shouldSample()) {
+            wrappedExporter.maybeExport(traceDescriptionSupplier);
+        }
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/TraceDescription.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/TraceDescription.java
@@ -1,0 +1,29 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import com.yahoo.messagebus.Trace;
+
+/**
+ * High-level description of a trace and the actual trace itself. Used to provide more
+ * information to logs etc than just the trace tree. The description will usually contain
+ * context for the trace, such as the orginal query string, desired timeout etc.
+ */
+public class TraceDescription {
+
+    private final Trace trace;
+    private final String description;
+
+    public TraceDescription(Trace trace, String description) {
+        this.trace = trace;
+        this.description = description;
+    }
+
+    public Trace getTrace() {
+        return trace;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/TraceExporter.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/TraceExporter.java
@@ -1,0 +1,15 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import java.util.function.Supplier;
+
+/**
+ * Potentially exports a trace to an underlying consumer. "Potentially" here means
+ * that the exporter may itself sample or otherwise limit which queries are actually
+ * exported.
+ */
+public interface TraceExporter {
+
+    void maybeExport(Supplier<TraceDescription> traceDescriptionSupplier);
+
+}

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
@@ -363,7 +363,7 @@ public class VdsVisitorTestCase {
     }
 
     private void verifyVisitorOk(MockVisitorSessionFactory factory, QueryArguments qa, Route route, String searchCluster) throws Exception {
-        VdsVisitor visitor = new VdsVisitor(buildQuery(qa), searchCluster, route, "mytype", factory);
+        VdsVisitor visitor = new VdsVisitor(buildQuery(qa), searchCluster, route, "mytype", factory, 0);
         visitor.doSearch();
         verifyVisitorParameters(factory.getParams(), qa, searchCluster, "mytype", route);
         supplyResults(visitor);
@@ -371,7 +371,7 @@ public class VdsVisitorTestCase {
     }
 
     private void verifyVisitorFails(MockVisitorSessionFactory factory, QueryArguments qa, Route route, String searchCluster) throws Exception {
-        VdsVisitor visitor = new VdsVisitor(buildQuery(qa), searchCluster, route, "mytype", factory);
+        VdsVisitor visitor = new VdsVisitor(buildQuery(qa), searchCluster, route, "mytype", factory, 0);
         try {
             visitor.doSearch();
             assertTrue("Visitor did not fail", false);

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/MaxSamplesPerPeriodTest.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/MaxSamplesPerPeriodTest.java
@@ -1,0 +1,37 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MaxSamplesPerPeriodTest {
+
+    @Test
+    public void first_sample_in_period_returns_true() {
+        var clock = MockUtils.mockedClockReturning(1000L);
+        var sampler = new MaxSamplesPerPeriod(clock, 1000L, 1L);
+        assertTrue(sampler.shouldSample());
+    }
+
+    @Test
+    public void samples_exceeding_period_count_return_false() {
+        var clock = MockUtils.mockedClockReturning(1000L, 1100L, 1200L);
+        var sampler = new MaxSamplesPerPeriod(clock, 1000L, 2L);
+        assertTrue(sampler.shouldSample());
+        assertTrue(sampler.shouldSample());
+        assertFalse(sampler.shouldSample());
+    }
+
+    @Test
+    public void sample_in_new_period_returns_true() {
+        var clock = MockUtils.mockedClockReturning(1000L, 1900L, 2000L, 2900L);
+        var sampler = new MaxSamplesPerPeriod(clock, 1000L, 1L);
+        assertTrue(sampler.shouldSample());
+        assertFalse(sampler.shouldSample());
+        assertTrue(sampler.shouldSample());
+        assertFalse(sampler.shouldSample());
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/MockUtils.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/MockUtils.java
@@ -1,0 +1,24 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import java.util.Random;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockUtils {
+
+    public static MonotonicNanoClock mockedClockReturning(Long ts, Long... additionalTimestamps) {
+        var clock = mock(MonotonicNanoClock.class);
+        when(clock.nanoTimeNow()).thenReturn(ts, additionalTimestamps);
+        return clock;
+    }
+
+    // Extremely high quality randomness :D
+    public static Random mockedRandomReturning(Double v, Double... additionalValues) {
+        var rng = mock(Random.class);
+        when(rng.nextDouble()).thenReturn(v, additionalValues);
+        return rng;
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/ProbabilisticSampleRateTest.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/ProbabilisticSampleRateTest.java
@@ -1,0 +1,41 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProbabilisticSampleRateTest {
+
+    private static long ms2ns(long ms) {
+        return TimeUnit.MILLISECONDS.toNanos(ms);
+    }
+
+    @Test
+    public void samples_are_rate_limited_per_second() {
+        var clock = MockUtils.mockedClockReturning(ms2ns(10_000), ms2ns(10_500), ms2ns(10_500), ms2ns(10_501));
+        var rng = MockUtils.mockedRandomReturning(0.1, 0.51, 0.49, 0.01);
+        var sampler = new ProbabilisticSampleRate(clock, () -> rng, 1.0);
+        // 1st invocation, 10 seconds (technically "infinity") since last sample. P = 1.0, sampled
+        assertTrue(sampler.shouldSample());
+        // 2nd invocation, 0.5 seconds since last sample. rng = 0.51 >= P = 0.5, not sampled
+        assertFalse(sampler.shouldSample());
+        // 3rd invocation, 0.5 seconds since last sample. rng = 0.49 < P = 0.5, sampled
+        assertTrue(sampler.shouldSample());
+        // 4th invocation, 0.001 seconds since last sample. rng = 0.01 >= P = 0.001, not sampled
+        assertFalse(sampler.shouldSample());
+    }
+
+    @Test
+    public void zero_desired_sample_rate_returns_false() {
+        var clock = MockUtils.mockedClockReturning(ms2ns(10_000));
+        var rng = MockUtils.mockedRandomReturning(0.99999999); // [0, 1)
+        var sampler = new ProbabilisticSampleRate(clock, () -> rng, 0.0);
+
+        assertFalse(sampler.shouldSample());
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporterTest.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporterTest.java
@@ -1,0 +1,28 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.streamingvisitors.tracing;
+
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SamplingTraceExporterTest {
+
+    @Test
+    public void sampling_decision_is_deferred_to_provided_sampler() {
+        var exporter = mock(TraceExporter.class);
+        var sampler = mock(SamplingStrategy.class);
+        when(sampler.shouldSample()).thenReturn(true, false);
+        var samplingExporter = new SamplingTraceExporter(exporter, sampler);
+
+        samplingExporter.maybeExport(() -> new TraceDescription(null, ""));
+        verify(exporter, times(1)).maybeExport(any());
+
+        samplingExporter.maybeExport(() -> new TraceDescription(null, ""));
+        verify(exporter, times(1)).maybeExport(any()); // No further invocations since last
+    }
+
+}


### PR DESCRIPTION
@baldersheim @geirst please review. This is a poor man's version of distributed tracing, meant as a stop-gap for debugging until we have any integrations of OpenTelemetry et al.

This currently only catches the cases where a query has not respected its
expected timeout and therefore has an actual timeout that is at least a
5x multiple of its expected one. Due to the response payload nature of
MessageBus traces it's not given that the trace will contain any
information from the backend nodes. But it is highly likely to contain
useful information from the client-local policy instances, as well as
resending info.

To test this very conservatively, only allows approximately 1 query to be
traced every 2 seconds and only dumps traces to logs once every 10 seconds.
