### PR TITLE
Revert "Remove SSH and fix TODO in node-repo ACL rules "

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -381,6 +381,11 @@ public class RestApiTest {
     }
 
     @Test
+    public void acl_request_by_docker_host() throws Exception {
+        assertFile(new Request("http://localhost:8080/nodes/v2/acl/dockerhost1.yahoo.com?children=true"), "acl-docker-host.json");
+    }
+
+    @Test
     public void test_invalid_requests() throws Exception {
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/node-does-not-exist",
                                    new byte[0], Request.Method.GET),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/acl-config-server.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/acl-config-server.json
@@ -226,6 +226,10 @@
   "trustedNetworks": [],
   "trustedPorts": [
     {
+      "port": 22,
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
       "port": 4443,
       "trustedBy": "cfg1.yahoo.com"
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/acl-docker-host.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/acl-docker-host.json
@@ -1,0 +1,77 @@
+{
+  "trustedNodes": [
+    {
+      "hostname": "cfg1.yahoo.com",
+      "type": "config",
+      "ipAddress": "127.0.201.1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "cfg1.yahoo.com",
+      "type": "config",
+      "ipAddress": "::201:1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "cfg2.yahoo.com",
+      "type": "config",
+      "ipAddress": "127.0.202.1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "cfg2.yahoo.com",
+      "type": "config",
+      "ipAddress": "::202:1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost1.yahoo.com",
+      "type": "host",
+      "ipAddress": "127.0.100.1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost1.yahoo.com",
+      "type": "host",
+      "ipAddress": "::100:1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost2.yahoo.com",
+      "type": "host",
+      "ipAddress": "127.0.101.1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost2.yahoo.com",
+      "type": "host",
+      "ipAddress": "::101:1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "host4.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.4.1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "host4.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::4:1",
+      "trustedBy": "host4.yahoo.com"
+    },
+    {
+      "hostname": "test-node-pool-101-2",
+      "type": "tenant",
+      "ipAddress": "::101:2",
+      "trustedBy": "host4.yahoo.com"
+    }
+  ],
+  "trustedNetworks": [],
+  "trustedPorts": [
+    {
+      "port": 22,
+      "trustedBy": "host4.yahoo.com"
+    }
+  ]
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/acl-tenant-node.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/acl-tenant-node.json
@@ -170,5 +170,10 @@
     }
   ],
   "trustedNetworks": [],
-  "trustedPorts": []
+  "trustedPorts": [
+    {
+      "port": 22,
+      "trustedBy": "foo.yahoo.com"
+    }
+  ]
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#10512

The original PR had the effect of removing the Docker host as a trusted node, and so the health checks from host-admin to the container were refused.