### PR TITLE
Use bandwidthGbps in clients

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
@@ -88,7 +88,7 @@ public interface NodeRepository {
                         toDouble(node.getMinCpuCores()),
                         toDouble(node.getMinMainMemoryAvailableGb()),
                         toDouble(node.getMinDiskAvailableGb()),
-                        toDouble(node.getBandwidth()) / 1000,
+                        toDouble(node.getBandwidthGbps()),
                         toBoolean(node.getFastDisk()),
                         toInt(node.getCost()),
                         node.getCanonicalFlavor(),

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -82,8 +82,6 @@ public class NodeRepositoryNode {
     private Integer cost;
     @JsonProperty("minCpuCores")
     private Double minCpuCores;
-    @JsonProperty("bandwidth")
-    private Double bandwidth;
     @JsonProperty("bandwidthGbps")
     private Double bandwidthGbps;
     @JsonProperty("fastDisk")
@@ -353,14 +351,6 @@ public class NodeRepositoryNode {
         this.minCpuCores = minCpuCores;
     }
 
-    public Double getBandwidth() {
-        return bandwidth;
-    }
-
-    public void setBandwidth(Double bandwidth) {
-        this.bandwidth = bandwidth;
-    }
-
     public Double getBandwidthGbps() {
         return bandwidthGbps;
     }
@@ -466,7 +456,6 @@ public class NodeRepositoryNode {
                ", minMainMemoryAvailableGb=" + minMainMemoryAvailableGb +
                ", cost=" + cost +
                ", minCpuCores=" + minCpuCores +
-               ", bandwidth=" + bandwidth +
                ", bandwidthGbps=" + bandwidthGbps +
                ", fastDisk=" + fastDisk +
                ", description='" + description + '\'' +

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -179,7 +179,7 @@ public class RealNodeRepository implements NodeRepository {
                         node.minCpuCores,
                         node.minMainMemoryAvailableGb,
                         node.minDiskAvailableGb,
-                        node.bandwidth / 1000,
+                        node.bandwidthGbps,
                         node.fastDisk ? fast : slow),
                 node.ipAddresses,
                 node.additionalIpAddresses,
@@ -198,7 +198,7 @@ public class RealNodeRepository implements NodeRepository {
             node.minCpuCores = resources.vcpu();
             node.minMainMemoryAvailableGb = resources.memoryGb();
             node.minDiskAvailableGb = resources.diskGb();
-            node.bandwidth = resources.bandwidthGbps() * 1000;
+            node.bandwidthGbps = resources.bandwidthGbps();
             node.fastDisk = resources.diskSpeed() == NodeResources.DiskSpeed.fast;
         });
         node.type = addNode.nodeType.name();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
@@ -58,8 +58,6 @@ public class NodeRepositoryNode {
     public Integer failCount;
     @JsonProperty("fastDisk")
     public Boolean fastDisk;
-    @JsonProperty("bandwidth")
-    public Double bandwidth;
     @JsonProperty("bandwidthGbps")
     public Double bandwidthGbps;
     @JsonProperty("environment")
@@ -112,7 +110,6 @@ public class NodeRepositoryNode {
                 ", wantedFirmwareCheck=" + wantedFirmwareCheck +
                 ", failCount=" + failCount +
                 ", fastDisk=" + fastDisk +
-                ", bandwidth=" + bandwidth +
                 ", bandwidthGbps=" + bandwidthGbps +
                 ", environment='" + environment + '\'' +
                 ", type='" + type + '\'' +


### PR DESCRIPTION
Use `bandwidthGbps` instead of `bandwidth` in nodes response in controller's and node-admin's configserver clients.