### PR TITLE
See unfinished run over finished copy when inconsistent state

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -173,7 +173,7 @@ public class JobController {
     /** Returns an immutable map of all known runs for the given application and job type. */
     public Map<RunId, Run> runs(ApplicationId id, JobType type) {
         SortedMap<RunId, Run> runs = curator.readHistoricRuns(id, type);
-        last(id, type).ifPresent(run -> runs.putIfAbsent(run.id(), run));
+        last(id, type).ifPresent(run -> runs.put(run.id(), run));
         return ImmutableMap.copyOf(runs);
     }
 


### PR DESCRIPTION
@oyving please review.

When a writing a run as finished fails, it may still get a finished copy in the historic list. This PR makes sure the unfinished copy, which is in the work space for the job that finishes runs, is viewed by all accessors, to make the view consistent. The run will eventually finish, and the historic copy is overwritten at that point.