### PR TITLE
Export net.jpountz.xxhash

### DIFF
--- a/document/src/main/java/net/jpountz/xxhash/package-info.java
+++ b/document/src/main/java/net/jpountz/xxhash/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage(version = @Version(major = 1, minor = 3, micro = 0))
+package net.jpountz.xxhash;
+import com.yahoo.osgi.annotation.ExportPackage;
+import com.yahoo.osgi.annotation.Version;


### PR DESCRIPTION
Export net.jpountz.xxhash as well as net.jpountz.lz4, they are both
needed and from the same artifact.
