### PR TITLE
Use server id in config for singlenode zookeeper setups 

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -64,6 +64,8 @@ public class ConfigserverCluster extends AbstractConfigProducer
         }
 
         String myhostname = HostName.getLocalhost();
+        // TODO: Server index should be in interval [1, 254] according to doc,
+        // however, we cannot change this id for an existing server
         for (int i = 0; i < configServers.length; i++) {
             if (zookeeperIds[i] < 0) {
                 throw new IllegalArgumentException(String.format("Zookeeper ids cannot be negative, was %d for %s",

--- a/zkfacade/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperServer.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperServer.java
@@ -70,12 +70,8 @@ public class ZooKeeperServer extends AbstractComponent implements Runnable {
         // Includes all available commands in 3.4, except 'wchc' and 'wchp'
         // Mandatory when using ZooKeeper 3.5
         sb.append("4lw.commands.whitelist=conf,cons,crst,dump,envi,mntr,ruok,srst,srvr,stat,wchs").append("\n");
-        if (config.server().size() > 1) {
-            ensureThisServerIsRepresented(config.myid(), config.server());
-            for (ZookeeperServerConfig.Server server : config.server()) {
-                addServerToCfg(sb, server);
-            }
-        }
+        ensureThisServerIsRepresented(config.myid(), config.server());
+        config.server().forEach(server -> addServerToCfg(sb, server));
         return sb.toString();
     }
 

--- a/zkfacade/src/test/java/com/yahoo/vespa/zookeeper/ZooKeeperServerTest.java
+++ b/zkfacade/src/test/java/com/yahoo/vespa/zookeeper/ZooKeeperServerTest.java
@@ -29,8 +29,8 @@ public class ZooKeeperServerTest {
         ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
         builder.zooKeeperConfigFile(cfgFile.getAbsolutePath());
         builder.myidFile(idFile.getAbsolutePath());
-        builder.server(newServer(1, "foo", 123, 321));
-        builder.myid(1);
+        builder.server(newServer(0, "foo", 123, 321));
+        builder.myid(0);
         createServer(builder);
         validateConfigFileSingleHost(cfgFile);
         validateIdFile(idFile, "");
@@ -42,9 +42,9 @@ public class ZooKeeperServerTest {
         File idFile = folder.newFile();
         ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
         builder.zooKeeperConfigFile(cfgFile.getAbsolutePath());
-        builder.server(newServer(1, "foo", 123, 321));
-        builder.server(newServer(2, "bar", 234, 432));
-        builder.server(newServer(3, "baz", 345, 543));
+        builder.server(newServer(0, "foo", 123, 321));
+        builder.server(newServer(1, "bar", 234, 432));
+        builder.server(newServer(2, "baz", 345, 543));
         builder.myidFile(idFile.getAbsolutePath());
         builder.myid(1);
         createServer(builder);
@@ -59,16 +59,16 @@ public class ZooKeeperServerTest {
     @Test(expected = RuntimeException.class)
     public void require_that_this_id_must_be_present_amongst_servers() {
         ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
-        builder.server(newServer(2, "bar", 234, 432));
-        builder.server(newServer(3, "baz", 345, 543));
-        builder.myid(1);
+        builder.server(newServer(1, "bar", 234, 432));
+        builder.server(newServer(2, "baz", 345, 543));
+        builder.myid(0);
         createServer(builder);
     }
 
     @Test
     public void juteMaxBufferCanBeSet() throws IOException {
         ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
-        builder.myid(1);
+        builder.myid(0);
         File idFile = folder.newFile();
         File cfgFile = folder.newFile();
 
@@ -110,7 +110,8 @@ public class ZooKeeperServerTest {
             "clientPort=2181\n" +
             "autopurge.purgeInterval=1\n" +
             "autopurge.snapRetainCount=15\n" +
-            "4lw.commands.whitelist=conf,cons,crst,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n";
+            "4lw.commands.whitelist=conf,cons,crst,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n" +
+            "server.0=foo:321:123\n";
         validateConfigFile(cfgFile, expected);
     }
 
@@ -126,9 +127,9 @@ public class ZooKeeperServerTest {
                         "autopurge.purgeInterval=1\n" +
                         "autopurge.snapRetainCount=15\n" +
                         "4lw.commands.whitelist=conf,cons,crst,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n" +
-                        "server.1=foo:321:123\n" +
-                        "server.2=bar:432:234\n" +
-                        "server.3=baz:543:345\n";
+                        "server.0=foo:321:123\n" +
+                        "server.1=bar:432:234\n" +
+                        "server.2=baz:543:345\n";
         validateConfigFile(cfgFile, expected);
     }
 


### PR DESCRIPTION
Update tests accordingly and start numbering at 0, as will be done
by the code that creates zookeeper-server config.
