### PR TITLE
Remove findbugs annotations from code and build path.

### DIFF
--- a/bundle-plugin/pom.xml
+++ b/bundle-plugin/pom.xml
@@ -68,10 +68,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/chain/pom.xml
+++ b/chain/pom.xml
@@ -16,14 +16,6 @@
   <version>7-SNAPSHOT</version>
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>annotations</artifactId>
       <version>${project.version}</version>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -38,6 +38,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!-- Needed by guava, which has an optional dependency on jsr305.
+      Not optional here, to avoid the need to add it to a lot of dependent modules. -->
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-lib</artifactId>
       <version>${project.version}</version>

--- a/config-lib/pom.xml
+++ b/config-lib/pom.xml
@@ -17,14 +17,6 @@
   <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -22,10 +22,6 @@
 
     <!-- compile scope -->
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>annotations</artifactId>
       <version>${project.version}</version>

--- a/container-accesslogging/pom.xml
+++ b/container-accesslogging/pom.xml
@@ -51,11 +51,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>

--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedRequestHandler.java
@@ -27,8 +27,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import static java.util.Collections.singletonMap;
 
-import javax.annotation.concurrent.GuardedBy;
-
 /**
  * A request handler which assigns a worker thread to handle each request.
  * This is mean to be subclasses by handlers who does work by executing each
@@ -48,9 +46,11 @@ public abstract class ThreadedRequestHandler extends AbstractRequestHandler {
     private final boolean allowAsyncResponse;
 
     private static final Object rejectedExecutionsLock = new Object();
-    @GuardedBy("rejectedExecutionsLock")
+
+    // GuardedBy("rejectedExecutionsLock")
     private static volatile int numRejectedRequests = 0;
-    @GuardedBy("rejectedExecutionsLock")
+
+    // GuardedBy("rejectedExecutionsLock")
     private static long currentFailureIntervalStartedMillis = 0L;
 
     protected ThreadedRequestHandler(Executor executor) {

--- a/container-di/pom.xml
+++ b/container-di/pom.xml
@@ -16,14 +16,6 @@
   <packaging>container-plugin</packaging>
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>annotations</artifactId>
       <version>${project.version}</version>

--- a/container-di/src/main/java/com/yahoo/container/bundle/BundleInstantiationSpecification.java
+++ b/container-di/src/main/java/com/yahoo/container/bundle/BundleInstantiationSpecification.java
@@ -3,15 +3,15 @@ package com.yahoo.container.bundle;
 
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
-import net.jcip.annotations.Immutable;
 
 
 /**
  * Specifies how a component should be instantiated from a bundle.
  *
+ * Immutable
+ *
  * @author Tony Vaagenes
  */
-@Immutable
 public final class BundleInstantiationSpecification {
 
     public final ComponentId id;

--- a/container-di/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
+++ b/container-di/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
@@ -17,7 +17,6 @@ import com.yahoo.container.di.componentgraph.cycle.CycleFinder;
 import com.yahoo.container.di.componentgraph.cycle.Graph;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
-import net.jcip.annotations.NotThreadSafe;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
@@ -42,8 +41,9 @@ import static com.yahoo.container.di.componentgraph.core.Exceptions.removeStackT
  * @author Tony Vaagenes
  * @author gjoranv
  * @author ollivir
+ *
+ * Not thread safe.
  */
-@NotThreadSafe
 public class ComponentGraph {
 
     private static final Logger log = Logger.getLogger(ComponentGraph.class.getName());

--- a/container-di/src/main/java/com/yahoo/osgi/provider/model/ComponentModel.java
+++ b/container-di/src/main/java/com/yahoo/osgi/provider/model/ComponentModel.java
@@ -4,14 +4,14 @@ package com.yahoo.osgi.provider.model;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
-import net.jcip.annotations.Immutable;
 
 /**
  * Describes how a component should be created.
  *
+ * Immutable
+ *
  * @author gjoranv
  */
-@Immutable
 public class ComponentModel {
 
     public final BundleInstantiationSpecification bundleInstantiationSpec;

--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -47,7 +47,7 @@
       <artifactId>airline</artifactId>
       <exclusions>
         <exclusion>
-          <!-- Prevent pulling in newer version than what we use -->
+          <!-- We need the version used by guava -->
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>annotations</artifactId>
         </exclusion>

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/test/ServerProviderConformanceTest.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/test/ServerProviderConformanceTest.java
@@ -17,7 +17,6 @@ import com.yahoo.jdisc.handler.ContentChannel;
 import com.yahoo.jdisc.handler.ResponseHandler;
 import com.yahoo.jdisc.service.ServerProvider;
 
-import javax.annotation.CheckReturnValue;
 import java.io.Closeable;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -2936,7 +2935,6 @@ public abstract class ServerProviderConformanceTest {
             }
         }
 
-        @CheckReturnValue
         private TaskHandle addTask() {
             final TaskHandle taskHandle = new TaskHandle();
             synchronized (taskMonitor) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/RequestView.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/RequestView.java
@@ -3,7 +3,6 @@ package com.yahoo.jdisc.http.filter;
 
 import com.yahoo.jdisc.http.HttpRequest.Method;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +27,6 @@ public interface RequestView {
      * Returns an immutable view of all values of a named header field.
      * Returns an empty list if no such header is present.
      */
-    @Nonnull
     List<String> getHeaders(String name);
 
     /**

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/SecurityFilterInvoker.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/SecurityFilterInvoker.java
@@ -9,7 +9,6 @@ import com.yahoo.jdisc.http.servlet.ServletRequest;
 import com.yahoo.jdisc.http.servlet.ServletResponse;
 import com.yahoo.jdisc.http.server.jetty.FilterInvoker;
 
-import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
@@ -85,8 +84,7 @@ public class SecurityFilterInvoker implements FilterInvoker {
             return request.getAttribute(name);
         }
 
-
-        @Nonnull @Override
+        @Override
         public List<String> getHeaders(String name) {
             return Collections.unmodifiableList(Collections.list(request.getHeaders(name)));
         }

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/SecurityResponseFilterChain.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/filter/SecurityResponseFilterChain.java
@@ -14,8 +14,6 @@ import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.http.HttpRequest;
 import com.yahoo.jdisc.http.HttpResponse;
 
-import javax.annotation.Nonnull;
-
 /**
  * Implementation of TypedFilterChain for DiscFilterResponse
  * @author tejalk
@@ -77,7 +75,7 @@ public class SecurityResponseFilterChain extends AbstractResource implements Res
             return request.context().get(name);
         }
 
-        @Nonnull @Override
+        @Override
         public List<String> getHeaders(String name) {
             List<String> headers = request.headers().get(name);
             return headers == null ? Collections.emptyList() : Collections.unmodifiableList(headers);

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletOutputStreamWriter.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletOutputStreamWriter.java
@@ -3,7 +3,6 @@ package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.handler.CompletionHandler;
 
-import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import java.io.IOException;
@@ -50,14 +49,14 @@ public class ServletOutputStreamWriter {
 
     private final Object monitor = new Object();
 
-    @GuardedBy("monitor")
+    // GuardedBy("monitor")
     private State state = State.NOT_STARTED;
 
-    @GuardedBy("state")
+    // GuardedBy("state")
     private final ServletOutputStream outputStream;
     private final Executor executor;
 
-    @GuardedBy("monitor")
+    // GuardedBy("monitor")
     private final Deque<ResponseContentPart> responseContentQueue = new ArrayDeque<>();
 
     private final MetricReporter metricReporter;

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletRequestReader.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletRequestReader.java
@@ -5,7 +5,6 @@ import com.google.common.base.Preconditions;
 import com.yahoo.jdisc.handler.CompletionHandler;
 import com.yahoo.jdisc.handler.ContentChannel;
 
-import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import java.io.IOException;
@@ -59,7 +58,7 @@ class ServletRequestReader implements ReadListener {
      *    called from a user (request handler) owned thread
      *    (i.e. when being called from user code, don't call back into user code.)
      */
-    @GuardedBy("monitor")
+    // GuardedBy("monitor")
     private State state = State.READING;
 
     /**
@@ -73,7 +72,7 @@ class ServletRequestReader implements ReadListener {
      * - complete the finished future non-exceptionally,
      *   since then we would not be able to report writeCompletionHandler.failed(exception) calls
      */
-    @GuardedBy("monitor")
+    // GuardedBy("monitor")
     private int numberOfOutstandingUserCalls = 0;
 
     /**

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletResponseController.java
@@ -11,7 +11,6 @@ import com.yahoo.jdisc.http.HttpResponse;
 import com.yahoo.jdisc.service.BindingSetNotFoundException;
 import org.eclipse.jetty.http.MimeTypes;
 
-import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -52,7 +51,7 @@ public class ServletResponseController {
     //all calls to the servletOutputStreamWriter must hold the monitor first to ensure visibility of servletResponse changes.
     private final ServletOutputStreamWriter servletOutputStreamWriter;
 
-    @GuardedBy("monitor")
+    // GuardedBy("monitor")
     private boolean responseCommitted = false;
 
     public ServletResponseController(

--- a/orchestrator-restapi/pom.xml
+++ b/orchestrator-restapi/pom.xml
@@ -34,12 +34,6 @@
       <version>${jackson2.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -16,14 +16,6 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/vespa-http-client/pom.xml
+++ b/vespa-http-client/pom.xml
@@ -90,11 +90,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/TestDocument.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/TestDocument.java
@@ -1,13 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.http.client;
 
-import net.jcip.annotations.Immutable;
-
 /**
-* @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
-* @since 5.1.20
+* @author Einar M R Rosenvinge
 */
-@Immutable
 public class TestDocument {
     private final String documentId;
     private final byte[] contents;


### PR DESCRIPTION
- jsr305 is needed by guava, which declares it as optional dep.
- Remaining modules with annotations do not affect the container.

FYI: @hakonhall The findbugs annotations are abandoned, and cause problems with new zookeeper that uses a fork called `spotbugs` that use the same package names.