### PR TITLE
Don't enforce access control for non-default instances

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
@@ -155,6 +155,9 @@ public class FilesApplicationPackage implements ApplicationPackage {
     }
 
     @Override
+    public ApplicationId getApplicationId() { return metaData.getApplicationId(); }
+
+    @Override
     public List<NamedReader> getFiles(Path relativePath, String suffix, boolean recurse) {
         return getFiles(relativePath, "", suffix, recurse);
     }

--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -101,6 +101,7 @@
     ],
     "methods": [
       "public abstract java.lang.String getApplicationName()",
+      "public abstract com.yahoo.config.provision.ApplicationId getApplicationId()",
       "public abstract java.io.Reader getServices()",
       "public abstract java.io.Reader getHosts()",
       "public java.util.List getUserIncludeDirs()",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationPackage.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationPackage.java
@@ -3,6 +3,7 @@ package com.yahoo.config.application.api;
 
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.component.Version;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.io.IOUtils;
 import com.yahoo.io.reader.NamedReader;
@@ -89,6 +90,8 @@ public interface ApplicationPackage {
      */
     @Deprecated // TODO: Remove on Vespa 8
     String getApplicationName();
+
+    ApplicationId getApplicationId();
 
     /**
      * Contents of services.xml. Caller must close reader after use.

--- a/config-model/src/main/java/com/yahoo/config/model/test/MockApplicationPackage.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/MockApplicationPackage.java
@@ -99,6 +99,9 @@ public class MockApplicationPackage implements ApplicationPackage {
     }
 
     @Override
+    public ApplicationId getApplicationId() { return ApplicationId.from("default", getApplicationName(), "default"); }
+
+    @Override
     public Reader getServices() {
         return new StringReader(servicesS);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/first/AccessControlValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/first/AccessControlValidator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation.first;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.model.ConfigModelContext.ApplicationType;
 import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.provision.InstanceName;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validator;
 import com.yahoo.vespa.model.container.Container;
@@ -43,7 +44,8 @@ public class AccessControlValidator extends Validator {
                 if (hasHandlerThatNeedsProtection(cluster) || ! cluster.getAllServlets().isEmpty())
                     offendingClusters.add(cluster.getName());
         }
-        if (! offendingClusters.isEmpty())
+        if (! offendingClusters.isEmpty()
+            && deployState.getApplicationPackage().getApplicationId().instance().equals(InstanceName.defaultName()))
             deployState.validationOverrides().invalid(ValidationId.accessControl,
                                                       "Access-control must be enabled for write operations to container clusters in production zones: " +
                                                               mkString(offendingClusters, "[", ", ", "]."), deployState.now());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationPackage.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationPackage.java
@@ -12,6 +12,7 @@ import com.yahoo.config.application.api.UnparsedConfigDefinition;
 import com.yahoo.config.codegen.DefParser;
 import com.yahoo.config.model.application.provider.PreGeneratedFileRegistry;
 import com.yahoo.config.provision.AllocatedHosts;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.NodeFlavors;
 import com.yahoo.config.provision.serialization.AllocatedHostsSerializer;
 import com.yahoo.io.IOUtils;
@@ -120,6 +121,9 @@ public class ZKApplicationPackage implements ApplicationPackage {
     public String getApplicationName() {
         return metaData.getApplicationId().application().value();
     }
+
+    @Override
+    public ApplicationId getApplicationId() { return metaData.getApplicationId(); }
 
     @Override
     public Reader getServices() {


### PR DESCRIPTION
This makes it easier to create additional instances for testing
other services against it.

@mpolden please review