### PR TITLE
Always assume Athenz credentials when not in public

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -618,7 +618,7 @@ public class InternalStepRunner implements StepRunner {
 
         boolean useTesterCertificate = controller.system().isPublic() && id.type().isTest();
         byte[] servicesXml = servicesXml(controller.zoneRegistry().accessControlDomain(),
-                                         spec.athenzDomain().isPresent(),
+                                         ! controller.system().isPublic(),
                                          useTesterCertificate,
                                          testerFlavorFor(id, spec));
         byte[] testPackage = controller.applications().applicationStore().get(id.tester(), version);


### PR DESCRIPTION
@bjorncs please review.

Some time ago the tests were set to run with Athenz credentials (on our pipeline) only when an Athenz service was configured by the customers. Now, the error message pointing customers to how to configure this is only displayed when Athenz credentials are attempted used, but there aren't any. (Now, instead, the error message is that there is nothing under `$HOME/.athenz/`.

This revert makes sure customers outside the public systems get the relevant error message, while customers in public don't. 

@bjormel FYI. 