### PR TITLE
Point OS Vespa Maven plugins to public API by default

### DIFF
--- a/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/AbstractVespaMojo.java
+++ b/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/AbstractVespaMojo.java
@@ -21,7 +21,7 @@ public abstract class AbstractVespaMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
-    @Parameter(property = "endpoint", defaultValue = "https://api.vespa.corp.yahoo.com:4443") // TODO jvenstad: Change default
+    @Parameter(property = "endpoint", defaultValue = "https://api.vespa-external.aws.oath.cloud:4443")
     protected String endpoint;
 
     @Parameter(property = "tenant")


### PR DESCRIPTION
@oyving please review and merge. These should only be in use in public. This will allow us to not explicitly set the endpoint for the "default" user. 