### PR TITLE
Balder/merge topn instead of append sort trim rebased

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastHit.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastHit.java
@@ -158,6 +158,15 @@ public class FastHit extends Hit {
         this.sortDataSorting = sorting;
     }
 
+    @Override
+    public int compareTo(Hit other) {
+        int cmpRes = 0;
+        if ((sortData != null) && (other instanceof FastHit) && hasSortData(((FastHit) other).sortDataSorting)) {
+            cmpRes =  SortDataHitSorter.getComparator(sortDataSorting, null).compare(this, other);
+        }
+        return (cmpRes != 0) ? cmpRes : super.compareTo(other);
+    }
+
     public boolean hasSortData(Sorting sorting) {
         return sortData != null && sortDataSorting != null && sortDataSorting.equals(sorting);
     }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -6,13 +6,17 @@ import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.vespa.config.search.DispatchConfig;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -56,8 +60,6 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
     private boolean timedOut = false;
     private boolean degradedByMatchPhase = false;
 
-    private boolean trimResult = false;
-
     public InterleavedSearchInvoker(Collection<SearchInvoker> invokers, SearchCluster searchCluster, Set<Integer> alreadyFailedNodes) {
         super(Optional.empty());
         this.invokers = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -82,7 +84,6 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         int originalOffset = query.getOffset();
         query.setHits(query.getHits() + query.getOffset());
         query.setOffset(0);
-        trimResult = originalHits != query.getHits() || originalOffset != query.getOffset();
 
         for (SearchInvoker invoker : invokers) {
             invoker.sendSearchRequest(query);
@@ -95,6 +96,8 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
 
     @Override
     protected Result getSearchResult(Execution execution) throws IOException {
+
+        List<Hit> merged = Collections.emptyList();
         long nextTimeout = query.getTimeLeft();
         try {
             while (!invokers.isEmpty() && nextTimeout >= 0) {
@@ -103,7 +106,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
                     log.fine(() -> "Search timed out with " + askedNodes + " requests made, " + answeredNodes + " responses received");
                     break;
                 } else {
-                    mergeResult(invoker.getSearchResult(execution));
+                    merged = mergeResult(invoker.getSearchResult(execution), merged);
                     ejectInvoker(invoker);
                 }
                 nextTimeout = nextTimeout();
@@ -117,16 +120,13 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         }
         insertNetworkErrors();
         result.setCoverage(createCoverage());
-        trimResult(execution);
+        int needed = query.getOffset() + query.getHits();
+        for (int index = query.getOffset(); (index < merged.size()) && (index < needed); index++) {
+            result.hits().add(merged.get(index));
+        }
         Result ret = result;
         result = null;
         return ret;
-    }
-
-    private void trimResult(Execution execution) {
-        if (trimResult || result.hits().size() > query.getHits()) {
-            result.hits().trim(query.getOffset(), query.getHits());
-        }
     }
 
     private void insertNetworkErrors() {
@@ -195,15 +195,34 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         return nextAdaptive;
     }
 
-    private void mergeResult(Result partialResult) {
+    private List<Hit> mergeResult(Result partialResult, List<Hit> current) {
         collectCoverage(partialResult.getCoverage(true));
 
         if (result == null) {
             result = partialResult;
-            return;
+            return result.hits().asUnorderedHits();
         }
         result.mergeWith(partialResult);
-        result.hits().addAll(partialResult.hits().asUnorderedHits());
+        int needed = query.getOffset() + query.getHits();
+        List<Hit> partial = partialResult.hits().asUnorderedHits();
+        List<Hit> merged = new ArrayList<>(needed);
+        int indexCurrent = 0;
+        int indexPartial = 0;
+        while (indexCurrent < current.size() && indexPartial < partial.size() && merged.size() < needed) {
+            int cmpRes = current.get(indexCurrent).compareTo(partial.get(indexPartial));
+            if (cmpRes <= 0) {
+                merged.add(current.get(indexCurrent++));
+            } else {
+                merged.add(partial.get(indexPartial++));
+            }
+        }
+        while ((indexCurrent < current.size()) && (merged.size() < needed)) {
+            merged.add(current.get(indexCurrent++));
+        }
+        while ((indexPartial < partial.size()) && (merged.size() < needed)) {
+            merged.add(partial.get(indexPartial++));
+        }
+        return merged;
     }
 
     private void collectCoverage(Coverage source) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -7,7 +7,6 @@ import com.yahoo.search.dispatch.searchcluster.SearchCluster;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.result.Hit;
-import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.vespa.config.search.DispatchConfig;
 
@@ -48,8 +47,6 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
     private long adaptiveTimeoutMin = 0;
     private long adaptiveTimeoutMax = 0;
     private long deadline = 0;
-
-    private Result result = null;
 
     private long answeredDocs = 0;
     private long answeredActiveDocs = 0;
@@ -96,7 +93,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
 
     @Override
     protected Result getSearchResult(Execution execution) throws IOException {
-
+        Result result = new Result(query);
         List<Hit> merged = Collections.emptyList();
         long nextTimeout = query.getTimeLeft();
         try {
@@ -106,7 +103,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
                     log.fine(() -> "Search timed out with " + askedNodes + " requests made, " + answeredNodes + " responses received");
                     break;
                 } else {
-                    merged = mergeResult(invoker.getSearchResult(execution), merged);
+                    merged = mergeResult(result, invoker.getSearchResult(execution), merged);
                     ejectInvoker(invoker);
                 }
                 nextTimeout = nextTimeout();
@@ -115,21 +112,16 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
             throw new RuntimeException("Interrupted while waiting for search results", e);
         }
 
-        if (result == null) {
-            result = new Result(query);
-        }
-        insertNetworkErrors();
+        insertNetworkErrors(result);
         result.setCoverage(createCoverage());
         int needed = query.getOffset() + query.getHits();
         for (int index = query.getOffset(); (index < merged.size()) && (index < needed); index++) {
             result.hits().add(merged.get(index));
         }
-        Result ret = result;
-        result = null;
-        return ret;
+        return result;
     }
 
-    private void insertNetworkErrors() {
+    private void insertNetworkErrors(Result result) {
         // Network errors will be reported as errors only when all nodes fail, otherwise they are just traced
         boolean asErrors = answeredNodes == 0;
 
@@ -195,25 +187,31 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         return nextAdaptive;
     }
 
-    private List<Hit> mergeResult(Result partialResult, List<Hit> current) {
+    private List<Hit> mergeResult(Result result, Result partialResult, List<Hit> current) {
         collectCoverage(partialResult.getCoverage(true));
 
-        if (result == null) {
-            result = partialResult;
-            return result.hits().asUnorderedHits();
-        }
         result.mergeWith(partialResult);
-        int needed = query.getOffset() + query.getHits();
         List<Hit> partial = partialResult.hits().asUnorderedHits();
+        if (current.isEmpty() ) {
+            return partial;
+        }
+        if (partial.isEmpty()) {
+            return current;
+        }
+
+        int needed = query.getOffset() + query.getHits();
         List<Hit> merged = new ArrayList<>(needed);
         int indexCurrent = 0;
         int indexPartial = 0;
         while (indexCurrent < current.size() && indexPartial < partial.size() && merged.size() < needed) {
             int cmpRes = current.get(indexCurrent).compareTo(partial.get(indexPartial));
-            if (cmpRes <= 0) {
+            if (cmpRes < 0) {
                 merged.add(current.get(indexCurrent++));
-            } else {
+            } else if (cmpRes > 0) {
                 merged.add(partial.get(indexPartial++));
+            } else { // Duplicates
+                merged.add(current.get(indexCurrent++));
+                indexPartial++;
             }
         }
         while ((indexCurrent < current.size()) && (merged.size() < needed)) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -201,7 +201,7 @@ public class ProtobufSerialization {
 
         int hitItems = protobuf.getHitsCount();
         var haveGrouping = protobuf.getGroupingBlob() != null && !protobuf.getGroupingBlob().isEmpty();
-        if(haveGrouping) {
+        if (haveGrouping) {
             hitItems++;
         }
         result.hits().ensureCapacity(hitItems);
@@ -238,7 +238,7 @@ public class ProtobufSerialization {
 
             result.hits().add(hit);
         }
-        if(sorting != null) {
+        if (sorting != null) {
             result.hits().setSorted(true);
         }
         var slimeTrace = protobuf.getSlimeTrace();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -83,8 +83,7 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
 
         ProtobufResponse protobufResponse = response.response().get();
         CompressionType compression = CompressionType.valueOf(protobufResponse.compression());
-        byte[] payload = resourcePool.compressor().decompress(protobufResponse.compressedPayload(), compression,
-                protobufResponse.uncompressedSize());
+        byte[] payload = resourcePool.compressor().decompress(protobufResponse.compressedPayload(), compression, protobufResponse.uncompressedSize());
         var result = ProtobufSerialization.deserializeToSearchResult(payload, query, searcher, node.pathIndex(), node.key());
 
         return result;


### PR DESCRIPTION
@bratseth and @bjorncs PR
The first commit is the same as in #10551 
The second fixes
- an issue that compareTo and HitGroup.sort uses different compare if you have sort data.
- It also handles duplicates
- And avoid duplicates when starting of with the first result. Just simply start off with a fresh one.
