### PR TITLE
Balder/auxiliary hits are not merged and pruned

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -232,11 +232,21 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
                 indexPartial++;
             }
         }
-        while ((indexCurrent < current.size()) && (merged.size() < needed)) {
-            merged.add(current.get(indexCurrent++));
+        while (indexCurrent < current.size()) {
+            Hit h = current.get(indexCurrent++);
+            if (h.isAuxiliary()) {
+                auxiliaryHits.add(h);
+            } else if (merged.size() < needed) {
+                merged.add(h);
+            }
         }
-        while ((indexPartial < partial.size()) && (merged.size() < needed)) {
-            merged.add(partial.get(indexPartial++));
+        while (indexPartial < partial.size()) {
+            Hit h = partial.get(indexPartial++);
+            if (h.isAuxiliary()) {
+                auxiliaryHits.add(h);
+            } else if (merged.size() < needed) {
+                merged.add(h);
+            }
         }
         return merged;
     }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -195,7 +196,15 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         result.mergeWith(partialResult);
         List<Hit> partial = partialResult.hits().asUnorderedHits();
         if (current.isEmpty() ) {
-            return partial;
+            boolean hasAuxillary = false;
+            for(Hit hit : partial) {
+                if (hit.isAuxiliary()) {
+                    hasAuxillary = true;
+                    break;
+                }
+            }
+            if ( ! hasAuxillary)
+                return partial;
         }
         if (partial.isEmpty()) {
             return current;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockInvoker.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockInvoker.java
@@ -5,14 +5,17 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.Coverage;
+import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 class MockInvoker extends SearchInvoker {
     private final Coverage coverage;
     private Query query;
+    private List<Hit> hits;
 
     protected MockInvoker(int key, Coverage coverage) {
         super(Optional.of(new Node(key, "?", 0, 0)));
@@ -21,6 +24,11 @@ class MockInvoker extends SearchInvoker {
 
     protected MockInvoker(int key) {
         this(key, null);
+    }
+
+    MockInvoker setHits(List<Hit> hits) {
+        this.hits = hits;
+        return this;
     }
 
     @Override
@@ -33,6 +41,9 @@ class MockInvoker extends SearchInvoker {
         Result ret = new Result(query);
         if (coverage != null) {
             ret.setCoverage(coverage);
+        }
+        if (hits != null) {
+            ret.hits().addAll(hits);
         }
         return ret;
     }


### PR DESCRIPTION
We are a bit short on unit tests here. Adding that and also add proper handling of auxiliary hits.
That does not make make merge and offset handling any simpler.
@bratseth PR
I will merge it now as state is incorrect now.
