### PR TITLE
Remove com.google.code.findbugs:annotations from container-dep-versions 

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -81,7 +81,6 @@
                                                 <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:[2.5.4, ${jackson2.version}]:jar:provided</include>
                                                 <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:[2.5.4, ${jackson2.version}]:jar:provided</include>
 
-                                                <include>com.google.code.findbugs:annotations:[${findbugs.version}]:jar:provided</include>
                                                 <include>com.google.code.findbugs:jsr305:[${findbugs.version}]:jar:provided</include>
                                                 <include>com.google.guava:guava:[${guava.version}]:jar:provided</include>
                                                 <include>com.google.inject.extensions:guice-assistedinject:[${guice.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -109,11 +109,8 @@
                 <version>${jackson2.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${findbugs.version}</version>
-            </dependency>
-            <dependency>
+                <!-- Not provided runtime, but necessary to build with guava in many cases.
+                     Guava has an optional dep on this and uses the annotations in some classes. -->
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${findbugs.version}</version>


### PR DESCRIPTION
- The annotations are not used runtime and not provided by the
  container.
- Since recently, they do not leak out from the 'container'
  artifact, so some users may need to add it to their own pom.

