### PR TITLE
Add temporary test of xgboost missing field if-inversion 

### DIFF
--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/xgboost/XGBoostParser.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/xgboost/XGBoostParser.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 class XGBoostParser {
 
     private List<XGBoostTree> xgboostTrees;
+    private boolean doIfInversion = false;
 
     /**
      * Constructor stores parsed JSON trees.
@@ -31,6 +32,7 @@ class XGBoostParser {
         for (JsonNode treeNode : forestNode) {
             this.xgboostTrees.add(mapper.treeToValue(treeNode, XGBoostTree.class));
         }
+        doIfInversion = filePath.endsWith("if_inversion.json");
     }
 
     /**
@@ -69,8 +71,11 @@ class XGBoostParser {
                 trueExp = treeToRankExp(node.getChildren().get(1));
                 falseExp = treeToRankExp(node.getChildren().get(0));
             }
-            return "if (" + node.getSplit() + " < " + Double.toString(node.getSplit_condition()) + ", " + trueExp + ", "
-                    + falseExp + ")";
+            String condition = node.getSplit() + " < " + node.getSplit_condition();
+            if (doIfInversion && node.getMissing() == node.getYes()) {
+                condition = "!(" + node.getSplit() + " >= " + node.getSplit_condition() + ")";
+            }
+            return "if (" + condition + ", " + trueExp + ", " + falseExp + ")";
         }
     }
 

--- a/model-integration/src/test/java/ai/vespa/rankingexpression/importer/xgboost/XGBoostImportTestCase.java
+++ b/model-integration/src/test/java/ai/vespa/rankingexpression/importer/xgboost/XGBoostImportTestCase.java
@@ -25,4 +25,17 @@ public class XGBoostImportTestCase {
         assertEquals(1, model.outputExpressions().size());
     }
 
+    @Test
+    public void testXGBoostWithIfInversion() {
+        ImportedModel model = new XGBoostImporter().importModel("test", "src/test/models/xgboost/xgboost.2.2.if_inversion.json");
+        assertTrue("All inputs are scalar", model.inputs().isEmpty());
+        assertEquals(1, model.expressions().size());
+        RankingExpression expression = model.expressions().get("test");
+        assertNotNull(expression);
+        assertEquals("if (f29 < -0.1234567, if (!(f56 >= -0.242398), 1.71218, -1.70044), if (f109 < 0.8723473, -1.94071, 1.85965)) + if (f60 < -0.482947, if (!(f29 >= -4.2387498), 0.784718, -0.96853), -6.23624)",
+                expression.getRoot().toString());
+        assertEquals(1, model.outputExpressions().size());
+    }
+
+
 }

--- a/model-integration/src/test/models/xgboost/xgboost.2.2.if_inversion.json
+++ b/model-integration/src/test/models/xgboost/xgboost.2.2.if_inversion.json
@@ -1,0 +1,19 @@
+[
+  { "nodeid": 0, "depth": 0, "split": "f29", "split_condition": -0.1234567, "yes": 1, "no": 2, "missing": 2, "children": [
+    { "nodeid": 1, "depth": 1, "split": "f56", "split_condition": -0.242398, "yes": 3, "no": 4, "missing": 3, "children": [
+      { "nodeid": 3, "leaf": 1.71218 },
+      { "nodeid": 4, "leaf": -1.70044 }
+    ]},
+    { "nodeid": 2, "depth": 1, "split": "f109", "split_condition": 0.8723473, "yes": 5, "no": 6, "missing": 6, "children": [
+      { "nodeid": 5, "leaf": -1.94071 },
+      { "nodeid": 6, "leaf": 1.85965 }
+    ]}
+  ]},
+  { "nodeid": 0, "depth": 0, "split": "f60", "split_condition": -0.482947, "yes": 1, "no": 2, "missing": 2, "children": [
+    { "nodeid": 1, "depth": 1, "split": "f29", "split_condition": -4.2387498, "yes": 3, "no": 4, "missing": 3, "children": [
+      { "nodeid": 3, "leaf": 0.784718 },
+      { "nodeid": 4, "leaf": -0.96853 }
+    ]},
+    { "nodeid": 2, "leaf": -6.23624 }
+  ]}
+]


### PR DESCRIPTION
@bratseth Please review. This is temporary (only kicks in for specially named xgboost files) and intended for measuring deviance in the relevant performance test.