### PR TITLE
Remove support for bandwidth in node-repo 

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodePatcher.java
@@ -158,8 +158,6 @@ public class NodePatcher {
                 return node.with(node.flavor().with(node.flavor().resources().withVcpu(value.asDouble())));
             case "fastDisk":
                 return node.with(node.flavor().with(node.flavor().resources().withDiskSpeed(value.asBool() ? fast : slow)));
-            case "bandwidth":
-                return node.with(node.flavor().with(node.flavor().resources().withBandwidthGbps(value.asDouble() / 1000)));
             case "bandwidthGbps":
                 return node.with(node.flavor().with(node.flavor().resources().withBandwidthGbps(value.asDouble())));
             case "modelName":

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesApiHandler.java
@@ -242,9 +242,7 @@ public class NodesApiHandler extends LoggingRequestHandler {
                     requiredField(inspector, "minCpuCores", Inspector::asDouble),
                     requiredField(inspector, "minMainMemoryAvailableGb", Inspector::asDouble),
                     requiredField(inspector, "minDiskAvailableGb", Inspector::asDouble),
-                    inspector.field("bandwidth").valid() ?
-                            requiredField(inspector, "bandwidth", Inspector::asDouble) / 1000 :
-                            requiredField(inspector, "bandwidthGbps", Inspector::asDouble),
+                    requiredField(inspector, "bandwidthGbps", Inspector::asDouble),
                     requiredField(inspector, "fastDisk", Inspector::asBool) ? fast : slow));
         }
 
@@ -255,8 +253,6 @@ public class NodesApiHandler extends LoggingRequestHandler {
             flavor = flavor.with(flavor.resources().withMemoryGb(inspector.field("minMainMemoryAvailableGb").asDouble()));
         if (inspector.field("minDiskAvailableGb").valid())
             flavor = flavor.with(flavor.resources().withDiskGb(inspector.field("minDiskAvailableGb").asDouble()));
-        if (inspector.field("bandwidth").valid())
-            flavor = flavor.with(flavor.resources().withBandwidthGbps(inspector.field("bandwidth").asDouble() / 1000));
         if (inspector.field("bandwidthGbps").valid())
             flavor = flavor.with(flavor.resources().withBandwidthGbps(inspector.field("bandwidthGbps").asDouble()));
         if (inspector.field("fastDisk").valid())

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -152,7 +152,6 @@ class NodesResponse extends HttpResponse {
         if (node.flavor().cost() > 0)
             object.setLong("cost", node.flavor().cost());
         object.setBool("fastDisk", node.flavor().hasFastDisk());
-        object.setDouble("bandwidth", 1000 * node.flavor().getBandwidthGbps()); // TODO: Remove after all clients migrated to bandwidthGbps
         object.setDouble("bandwidthGbps", node.flavor().getBandwidthGbps());
         object.setString("environment", node.flavor().getType().name());
         node.allocation().ifPresent(allocation -> {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/RestApiTest.java
@@ -872,7 +872,7 @@ public class RestApiTest {
                         Request.Method.POST),
                 "{\"message\":\"Added 1 nodes to the provisioned state\"}");
         assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/" + hostname),
-                "\"minDiskAvailableGb\":1234.0,\"minMainMemoryAvailableGb\":128.0,\"minCpuCores\":64.0,\"fastDisk\":true,\"bandwidth\":15000.0,");
+                "\"minDiskAvailableGb\":1234.0,\"minMainMemoryAvailableGb\":128.0,\"minCpuCores\":64.0,\"fastDisk\":true,\"bandwidthGbps\":15.0,");
 
         // Test patching with overrides
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/" + hostname,
@@ -886,7 +886,7 @@ public class RestApiTest {
                         Request.Method.PATCH),
                 "{\"message\":\"Updated " + hostname + "\"}");
         assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/" + hostname),
-                "\"minDiskAvailableGb\":5432.0,\"minMainMemoryAvailableGb\":128.0,\"minCpuCores\":64.0,\"fastDisk\":true,\"bandwidth\":15000.0,");
+                "\"minDiskAvailableGb\":5432.0,\"minMainMemoryAvailableGb\":128.0,\"minCpuCores\":64.0,\"fastDisk\":true,\"bandwidthGbps\":15.0,");
     }
 
     @Test
@@ -895,7 +895,7 @@ public class RestApiTest {
         // Test adding new node with resources
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
                         ("[{\"hostname\":\"" + hostname + "\"," + createIpAddresses("::1") + "\"openStackId\":\"osid-123\"," +
-                                "\"minDiskAvailableGb\":1234,\"minCpuCores\":5,\"fastDisk\":false,\"bandwidth\":300}]").
+                                "\"minDiskAvailableGb\":1234,\"minCpuCores\":5,\"fastDisk\":false,\"bandwidthGbps\":0.3}]").
                                 getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
                 400,
@@ -903,20 +903,20 @@ public class RestApiTest {
 
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
                         ("[{\"hostname\":\"" + hostname + "\"," + createIpAddresses("::1") + "\"openStackId\":\"osid-123\"," +
-                                "\"minDiskAvailableGb\":1234,\"minMainMemoryAvailableGb\":4321,\"minCpuCores\":5,\"fastDisk\":false,\"bandwidth\":300}]")
+                                "\"minDiskAvailableGb\":1234,\"minMainMemoryAvailableGb\":4321,\"minCpuCores\":5,\"fastDisk\":false,\"bandwidthGbps\":0.3}]")
                                 .getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
                 "{\"message\":\"Added 1 nodes to the provisioned state\"}");
         assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/" + hostname),
-                "\"minDiskAvailableGb\":1234.0,\"minMainMemoryAvailableGb\":4321.0,\"minCpuCores\":5.0,\"fastDisk\":false,\"bandwidth\":300.0,");
+                "\"minDiskAvailableGb\":1234.0,\"minMainMemoryAvailableGb\":4321.0,\"minCpuCores\":5.0,\"fastDisk\":false,\"bandwidthGbps\":0.3,");
 
         // Test patching with overrides
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/" + hostname,
-                        "{\"minDiskAvailableGb\":12,\"minMainMemoryAvailableGb\":34,\"minCpuCores\":56,\"fastDisk\":true,\"bandwidth\":78}".getBytes(StandardCharsets.UTF_8),
+                        "{\"minDiskAvailableGb\":12,\"minMainMemoryAvailableGb\":34,\"minCpuCores\":56,\"fastDisk\":true,\"bandwidthGbps\":78.0}".getBytes(StandardCharsets.UTF_8),
                         Request.Method.PATCH),
                 "{\"message\":\"Updated " + hostname + "\"}");
         assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/" + hostname),
-                "\"minDiskAvailableGb\":12.0,\"minMainMemoryAvailableGb\":34.0,\"minCpuCores\":56.0,\"fastDisk\":true,\"bandwidth\":78.0");
+                "\"minDiskAvailableGb\":12.0,\"minMainMemoryAvailableGb\":34.0,\"minCpuCores\":56.0,\"fastDisk\":true,\"bandwidthGbps\":78.0");
     }
 
     private String asDockerNodeJson(String hostname, String parentHostname, String... ipAddress) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg1.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 16.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 10000.0,
   "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/cfg2.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 16.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 10000.0,
   "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/controller1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/controller1.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 16.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 10000.0,
   "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-container1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-container1.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 1.0,
   "minCpuCores": 1.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade-complete.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1-os-upgrade.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node1.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node2.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node3.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node4.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/docker-node5.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/dockerhost1-with-firmware-data.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/dockerhost1-with-firmware-data.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 32.0,
   "minCpuCores": 4.0,
   "fastDisk": true,
-  "bandwidth": 20000.0,
   "bandwidthGbps": 20.0,
   "environment": "BARE_METAL",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node1.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node10.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node11.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 1.0,
   "minCpuCores": 1.0,
   "fastDisk": true,
-  "bandwidth": 300.0,
   "bandwidthGbps": 0.3,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node13.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node13.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 48.0,
   "minCpuCores": 10.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node14.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node14.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 48.0,
   "minCpuCores": 10.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node2.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node3.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 48.0,
   "minCpuCores": 0.5,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4-after-changes.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node4.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 1.0,
   "minCpuCores": 1.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5-after-changes.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 1.0,
   "minCpuCores": 1.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node5.json
@@ -12,7 +12,6 @@
   "minMainMemoryAvailableGb": 1.0,
   "minCpuCores": 1.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node55.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-after-changes.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-2.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports-3.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6-reports.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node6.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "owner": {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node7.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 8.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 1000.0,
   "bandwidthGbps": 1.0,
   "environment": "DOCKER_CONTAINER",
   "rebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node8.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 16.0,
   "minCpuCores": 2.0,
   "fastDisk": true,
-  "bandwidth": 10000.0,
   "bandwidthGbps": 10.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/node9.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 128.0,
   "minCpuCores": 64.0,
   "fastDisk": true,
-  "bandwidth": 15000.0,
   "bandwidthGbps": 15.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent1.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 16.0,
   "minCpuCores": 2.0,
   "fastDisk":true,
-  "bandwidth":0.0,
   "bandwidthGbps": 0.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/v2/responses/parent2.json
@@ -11,7 +11,6 @@
   "minMainMemoryAvailableGb": 128.0,
   "minCpuCores": 64.0,
   "fastDisk":true,
-  "bandwidth": 15000.0,
   "bandwidthGbps": 15.0,
   "environment": "BARE_METAL",
   "rebootGeneration": 0,


### PR DESCRIPTION
All clients have migrated to `bandwidthGbps`