### PR TITLE
- query.setOffset(0) when you conduct a trim

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -414,7 +414,7 @@ public class ClusterSearcher extends Searcher {
         if (queries.size() == 1) {
             return searcher.search(queries.get(0), execution);
         } else {
-            Result mergedResult = new Result(query.clone());
+            Result mergedResult = new Result(query);
             for (Query q : queries) {
                 Result result = searcher.search(q, execution);
                 mergedResult.mergeWith(result);
@@ -427,6 +427,7 @@ public class ClusterSearcher extends Searcher {
                     searcher.fill(mergedResult, Execution.ATTRIBUTEPREFETCH, execution);
                 }
                 mergedResult.hits().trim(query.getOffset(), query.getHits());
+                query.setOffset(0); // Needed when doing a trim
             }
             return mergedResult;
         }

--- a/container-search/src/main/java/com/yahoo/search/searchchain/testutil/DocumentSourceSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/testutil/DocumentSourceSearcher.java
@@ -105,6 +105,7 @@ public class DocumentSourceSearcher extends Searcher {
 
         r.setQuery(query);
         r.hits().trim(query.getOffset(), query.getHits());
+        query.setOffset(0);
         return r;
     }
 

--- a/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
@@ -18,6 +18,7 @@ import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.prelude.fastsearch.test.MockMetric;
 import com.yahoo.search.Query;
+import com.yahoo.search.Result;
 import com.yahoo.search.config.ClusterConfig;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
@@ -354,7 +355,9 @@ public class ClusterSearcherTestCase {
     }
 
     private com.yahoo.search.Result getResult(int offset, int hits, Execution execution) {
-        return getResult(offset, hits, null, execution);
+        Result result = getResult(offset, hits, null, execution);
+        assertEquals(0, result.getQuery().getOffset());
+        return result;
     }
 
     private com.yahoo.search.Result getResult(int offset, int hits, String extra, Execution execution) {


### PR DESCRIPTION
- Remove a clone that is not necessary.

@bratseth PR
There is also trimming in FieldCollapsingSearch and BlendingSearcher, but they are further up the chain and I think you are closer so saying if they do it correctly, so I will leave them alone.
