### PR TITLE
Ensure static `SBEnv` instance is destroyed when exceptions are triggered

### DIFF
--- a/slobrok/src/apps/slobrok/slobrok.cpp
+++ b/slobrok/src/apps/slobrok/slobrok.cpp
@@ -84,16 +84,19 @@ App::Main()
     } catch (const config::ConfigTimeoutException &e) {
         LOG(error, "config timeout during construction : %s", e.what());
         EV_STOPPING("slobrok", "config timeout during construction");
-        return 1;
+        res = 1;
     } catch (const vespalib::PortListenException &e) {
         LOG(error, "Failed listening to network port(%d) with protocol(%s): '%s'",
                    e.get_port(), e.get_protocol().c_str(), e.what());
         EV_STOPPING("slobrok", "could not listen to our network port");
-        return 1;
+        res = 1;
     } catch (const std::exception & e) {
         LOG(error, "unknown exception during construction : %s", e.what());
         EV_STOPPING("slobrok", "unknown exception during construction");
-        return 2;
+        res = 2;
+    }
+    if (mainobj && !mainobj->isShuttingDown()) {
+        mainobj->shutdown();
     }
     mainobj.reset();
     return res;


### PR DESCRIPTION
@arnej27959 please review. I also added an explicit shutdown step to ensure that exceptional destruction won't hang waiting for the underlying transport layer to finish.

Since the instance is declared as `static` it will otherwise be destroyed as part
of the global destructor invocation cycle at exit. Any transitive dependencies
that are also static may or may not be destroyed prior to the `SBEnv` instance
itself, causing undefined behavior.

