### PR TITLE
Add config overrides for simulating processing of large bucket sets

### DIFF
--- a/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
@@ -64,7 +64,7 @@ BucketManager::BucketManager(const config::ConfigUri & configUri,
 
 BucketManager::~BucketManager()
 {
-    if (_thread.get() != 0) {
+    if (_thread) {
         LOG(error, "BucketManager deleted without calling close() first");
         onClose();
     }
@@ -75,9 +75,9 @@ BucketManager::~BucketManager()
 void BucketManager::onClose()
 {
     // Stop internal thread such that we don't send any more messages down.
-    if (_thread.get() != 0) {
+    if (_thread) {
         _thread->interruptAndJoin(_workerLock, _workerCond);
-        _thread.reset(0);
+        _thread.reset();
     }
     StorageLinkQueued::onClose();
 }

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -31,6 +31,8 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _minBucketsPerVisitor(5),
       _maxClusterClockSkew(0),
       _inhibitMergeSendingOnBusyNodeDuration(std::chrono::seconds(60)),
+      _simulated_db_pruning_latency(0),
+      _simulated_db_merging_latency(0),
       _doInlineSplit(true),
       _enableJoinForSiblingLessBuckets(false),
       _enableInconsistentJoin(false),
@@ -159,6 +161,8 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     if (config.inhibitMergeSendingOnBusyNodeDurationSec >= 0) {
         _inhibitMergeSendingOnBusyNodeDuration = std::chrono::seconds(config.inhibitMergeSendingOnBusyNodeDurationSec);
     }
+    _simulated_db_pruning_latency = std::chrono::milliseconds(std::max(0, config.simulatedDbPruningLatencyMsec));
+    _simulated_db_merging_latency = std::chrono::milliseconds(std::max(0, config.simulatedDbMergingLatencyMsec));
     
     LOG(debug,
         "Distributor now using new configuration parameters. Split limits: %d docs/%d bytes. "

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -229,6 +229,13 @@ public:
         return _inhibitMergeSendingOnBusyNodeDuration;
     }
 
+    std::chrono::milliseconds simulated_db_pruning_latency() const noexcept {
+        return _simulated_db_pruning_latency;
+    }
+    std::chrono::milliseconds simulated_db_merging_latency() const noexcept {
+        return _simulated_db_merging_latency;
+    }
+
     bool getSequenceMutatingOperations() const noexcept {
         return _sequenceMutatingOperations;
     }
@@ -276,6 +283,8 @@ private:
     MaintenancePriorities _maintenancePriorities;
     std::chrono::seconds _maxClusterClockSkew;
     std::chrono::seconds _inhibitMergeSendingOnBusyNodeDuration;
+    std::chrono::milliseconds _simulated_db_pruning_latency;
+    std::chrono::milliseconds _simulated_db_merging_latency;
 
     bool _doInlineSplit;
     bool _enableJoinForSiblingLessBuckets;

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -191,3 +191,11 @@ inhibit_merge_sending_on_busy_node_duration_sec int default=10
 ## For this option to take effect, the cluster controller must also have two-phase
 ## states enabled.
 allow_stale_reads_during_cluster_state_transitions bool default=false
+
+## If greater than zero, injects a thread sleep into certain parts of the bucket
+## processing logic. This allows for easier testing of racing edge cases where the
+## main distributor thread is CPU-blocked processing large amounts of buckets, but
+## without actually needing to use a lot of buckets in the test itself.
+## Setting any of these values only makes sense for testing!
+simulated_db_pruning_latency_msec int default=0
+simulated_db_merging_latency_msec int default=0

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.h
@@ -179,6 +179,9 @@ private:
     void enqueueRecheckUntilPendingStateEnabled(uint16_t node, const document::Bucket&);
     void sendAllQueuedBucketRechecks();
 
+    void maybe_inject_simulated_db_pruning_delay();
+    void maybe_inject_simulated_db_merging_delay();
+
     friend class BucketDBUpdater_Test;
     friend class MergeOperation_Test;
 


### PR DESCRIPTION
@geirst please review

Allows injecting artificial thread delays during bucket DB pruning
and merging on the distributor.

By default, of course, will not inject any delays at all.