### PR TITLE
Check target OS version per zone

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
@@ -62,6 +62,9 @@ public interface NodeRepository {
     /** Upgrade OS for all nodes of given type to a new version */
     void upgradeOs(ZoneId zone, NodeType type, Version version);
 
+    /** Get target versions for upgrades in given zone */
+    TargetVersions targetVersionsOf(ZoneId zone);
+
     /** Requests firmware checks on all hosts in the given zone. */
     void requestFirmwareCheck(ZoneId zone);
 

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/TargetVersions.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/TargetVersions.java
@@ -1,0 +1,67 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.configserver;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.NodeType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Target versions for node upgrades in a zone.
+ *
+ * @author mpolden
+ */
+public class TargetVersions {
+
+    public static final TargetVersions EMPTY = new TargetVersions(Map.of(), Map.of());
+
+    private final Map<NodeType, Version> vespaVersions;
+    private final Map<NodeType, Version> osVersions;
+
+    public TargetVersions(Map<NodeType, Version> vespaVersions, Map<NodeType, Version> osVersions) {
+        this.vespaVersions = Map.copyOf(Objects.requireNonNull(vespaVersions, "vespaVersions must be non-null"));
+        this.osVersions = Map.copyOf(Objects.requireNonNull(osVersions, "osVersions must be non-null"));
+    }
+
+    /** Returns a copy of this with Vespa version set for given node type */
+    public TargetVersions withVespaVersion(NodeType nodeType, Version version) {
+        var vespaVersions = new HashMap<>(this.vespaVersions);
+        vespaVersions.put(nodeType, version);
+        return new TargetVersions(vespaVersions, osVersions);
+    }
+
+    /** Returns a copy of this with OS version set for given node type */
+    public TargetVersions withOsVersion(NodeType nodeType, Version version) {
+        var osVersions = new HashMap<>(this.osVersions);
+        osVersions.put(nodeType, version);
+        return new TargetVersions(vespaVersions, osVersions);
+    }
+
+    /** Returns the target OS version of given node type, if any */
+    public Optional<Version> osVersion(NodeType type) {
+        return Optional.ofNullable(osVersions.get(type));
+    }
+
+    /** Returns the target Vespa version of given node type, if any */
+    public Optional<Version> vespaVersion(NodeType type) {
+        return Optional.ofNullable(vespaVersions.get(type));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TargetVersions that = (TargetVersions) o;
+        return vespaVersions.equals(that.vespaVersions) &&
+               osVersions.equals(that.osVersions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vespaVersions, osVersions);
+    }
+
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeTargetVersions.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeTargetVersions.java
@@ -1,0 +1,37 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.noderepository;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * @author mpolden
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NodeTargetVersions {
+
+    @JsonProperty("versions")
+    private final Map<NodeType, String> vespaVersions;
+
+    @JsonProperty("osVersions")
+    private final Map<NodeType, String> osVersions;
+
+    @JsonCreator
+    public NodeTargetVersions(@JsonProperty("versions") Map<NodeType, String> vespaVersions,
+                              @JsonProperty("osVersions") Map<NodeType, String> osVersions) {
+        this.vespaVersions = Map.copyOf(vespaVersions);
+        this.osVersions = Map.copyOf(osVersions);
+    }
+
+    public Map<NodeType, String> vespaVersions() {
+        return vespaVersions;
+    }
+
+    public Map<NodeType, String> osVersions() {
+        return osVersions;
+    }
+
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/ProvisionResource.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/ProvisionResource.java
@@ -82,6 +82,10 @@ public interface ProvisionResource {
     String upgrade(@PathParam("nodeType") NodeType nodeType, NodeUpgrade nodeUpgrade,
                    @HeaderParam("X-HTTP-Method-Override") String patchOverride);
 
+    @GET
+    @Path("/upgrade/")
+    NodeTargetVersions upgrade();
+
     @POST
     @Path("/upgrade/firmware")
     String requestFirmwareChecks();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -9,7 +9,6 @@ import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 
 import java.time.Duration;
-import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -23,7 +22,7 @@ public class SystemUpgrader extends InfrastructureUpgrader {
 
     private static final Logger log = Logger.getLogger(SystemUpgrader.class.getName());
 
-    private static final Set<Node.State> upgradableNodeStates = EnumSet.of(Node.State.active, Node.State.reserved);
+    private static final Set<Node.State> upgradableNodeStates = Set.of(Node.State.active, Node.State.reserved);
 
     public SystemUpgrader(Controller controller, Duration interval, JobControl jobControl) {
         super(controller, interval, jobControl, controller.zoneRegistry().upgradePolicy(), null);
@@ -31,6 +30,7 @@ public class SystemUpgrader extends InfrastructureUpgrader {
 
     @Override
     protected void upgrade(Version target, SystemApplication application, ZoneApi zone) {
+        // TODO(mpolden): Simplify this by comparing with version from NodeRepository#targetVersionsOf instead
         if (minVersion(zone, application, Node::wantedVersion).map(target::isAfter)
                                                               .orElse(true)) {
             log.info(String.format("Deploying %s version %s in %s", application.id(), target, zone.getId()));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -91,7 +91,7 @@ public class OsUpgraderTest {
 
         // zone 2 and 3: begins upgrading
         osUpgrader.maintain();
-        assertWanted(version1, SystemApplication.proxy, zone2.getId(), zone3.getId());
+        assertWanted(version1, SystemApplication.tenantHost, zone2.getId(), zone3.getId());
 
         // zone 4: still on previous version
         assertWanted(Version.emptyVersion, SystemApplication.tenantHost, zone4.getId());
@@ -126,7 +126,10 @@ public class OsUpgraderTest {
     }
 
     private void assertWanted(Version version, SystemApplication application, ZoneId... zones) {
-        assertVersion(application, version, Node::wantedOsVersion, zones);
+        for (var zone : zones) {
+            assertEquals("Target version set for " + application + " in " + zone, version,
+                         nodeRepository().targetVersionsOf(zone).osVersion(application.nodeType()).orElse(Version.emptyVersion));
+        }
     }
 
     private void assertVersion(SystemApplication application, Version version, Function<Node, Version> versionField,
@@ -162,7 +165,7 @@ public class OsUpgraderTest {
             for (Node node : nodesRequiredToUpgrade(zone, application)) {
                 nodeRepository().putByHostname(zone, new Node(
                         node.hostname(), node.state(), node.type(), node.owner(), node.currentVersion(),
-                        node.wantedVersion(), node.wantedOsVersion(), node.wantedOsVersion(), node.serviceState(),
+                        node.wantedVersion(), version, version, node.serviceState(),
                         node.restartGeneration(), node.wantedRestartGeneration(), node.rebootGeneration(),
                         node.wantedRebootGeneration(), node.vcpu(), node.memoryGb(), node.diskGb(),
                         node.bandwidthGbps(), node.fastDisk(), node.cost(), node.canonicalFlavor(),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -143,10 +143,12 @@ public class OsApiTest extends ControllerContainerTest {
     private void completeUpgrade(ZoneId... zones) {
         for (ZoneId zone : zones) {
             for (SystemApplication application : SystemApplication.all()) {
+                var targetVersion = nodeRepository().targetVersionsOf(zone).osVersion(application.nodeType());
                 for (Node node : nodeRepository().list(zone, application.id())) {
+                    var version = targetVersion.orElse(node.wantedOsVersion());
                     nodeRepository().putByHostname(zone, new Node(
                             node.hostname(), node.state(), node.type(), node.owner(), node.currentVersion(),
-                            node.wantedVersion(), node.wantedOsVersion(), node.wantedOsVersion(), node.serviceState(),
+                            node.wantedVersion(), version, version, node.serviceState(),
                             node.restartGeneration(), node.wantedRestartGeneration(), node.rebootGeneration(),
                             node.wantedRebootGeneration(), node.vcpu(), node.memoryGb(), node.diskGb(),
                             node.bandwidthGbps(), node.fastDisk(), node.cost(), node.canonicalFlavor(),


### PR DESCRIPTION
This change makes the controller check the target OS version per zone (retrieved
from `/nodes/v2/upgrade/`) when deciding whether to set a target.

In the node repository, the OS version value in `/nodes/v2/upgrade/` and the value of
each nodes `wantedOsVersion` are backed by the same ZK data.

To implement automatic pausing of OS upgrades we'll eventually start omitting
the `wantedOsVersion` node field when an OS version is deactivated. We therefore
make the controller read target version from `/nodes/v2/upgrade/` instead to
avoid the controller repeatedly setting a target version while upgrades to that
version are paused.