### PR TITLE
Reapply: Update the public metric set after architects review.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicConsumer.java
@@ -22,7 +22,6 @@ public class DefaultPublicConsumer {
     private static final MetricSet publicConsumerMetrics = new MetricSet("public-consumer-metrics",
                                                                          emptyList(),
                                                                          ImmutableList.of(defaultPublicMetricSet,
-                                                                                          defaultVespaMetricSet,
                                                                                           systemMetricSet));
 
     public static MetricsConsumer getDefaultPublicConsumer() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -10,10 +10,13 @@ import com.google.common.collect.ImmutableSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 
 /**
- * TODO: Add content metrics.
+ * Metrics for the 'default' consumer, which is used by default for the generic metrics api and
+ * other user facing apis, e.g. 'prometheus/'.
  *
  * @author gjoranv
  */
@@ -24,13 +27,12 @@ public class DefaultPublicMetrics {
     private static MetricSet createMetricSet() {
         return new MetricSet("public",
                              getAllMetrics(),
-                             emptyList());
+                             singleton(defaultVespaMetricSet));
     }
 
     private static Set<Metric> getAllMetrics() {
         return ImmutableSet.<Metric>builder()
                 .addAll(getContentMetrics())
-                .addAll(getStorageMetrics())
                 .addAll(getContainerMetrics())
                 .addAll(getQrserverMetrics())
                 .build();
@@ -69,48 +71,25 @@ public class DefaultPublicMetrics {
     private static Set<Metric> getContentMetrics() {
         Set<Metric> metrics = new LinkedHashSet<>();
 
-        metrics.add(new Metric("content.proton.docsum.docs.rate"));
-        metrics.add(new Metric("content.proton.docsum.latency.average"));
-
-        metrics.add(new Metric("content.proton.transport.query.count.rate"));
-        metrics.add(new Metric("content.proton.transport.query.latency.average"));
+        metrics.add(new Metric("content.proton.search_protocol.docsum.requested_documents.rate"));
+        metrics.add(new Metric("content.proton.search_protocol.docsum.latency.average"));
+        metrics.add(new Metric("content.proton.search_protocol.query.latency.average"));
 
         metrics.add(new Metric("content.proton.documentdb.documents.total.last"));
         metrics.add(new Metric("content.proton.documentdb.documents.ready.last"));
         metrics.add(new Metric("content.proton.documentdb.documents.active.last"));
-        metrics.add(new Metric("content.proton.documentdb.index.docs_in_memory.last"));
         metrics.add(new Metric("content.proton.documentdb.disk_usage.last"));
-
-        metrics.add(new Metric("content.proton.documentdb.job.total.average"));
-        metrics.add(new Metric("content.proton.documentdb.job.attribute_flush.average"));
-        metrics.add(new Metric("content.proton.documentdb.job.disk_index_fusion.average"));
-        metrics.add(new Metric("content.proton.documentdb.job.document_store_compact.average"));
-        metrics.add(new Metric("content.proton.documentdb.job.memory_index_flush.average"));
+        metrics.add(new Metric("content.proton.documentdb.memory_usage.allocated_bytes.last"));
 
         metrics.add(new Metric("content.proton.resource_usage.disk.average"));
-        metrics.add(new Metric("content.proton.resource_usage.disk_utilization.average"));
         metrics.add(new Metric("content.proton.resource_usage.memory.average"));
-
-        metrics.add(new Metric("content.proton.documentdb.ready.document_store.memory_usage.allocated_bytes.average"));
-        metrics.add(new Metric("content.proton.documentdb.ready.document_store.cache.hit_rate.average"));
-        metrics.add(new Metric("content.proton.documentdb.index.memory_usage.allocated_bytes.average"));
 
         metrics.add(new Metric("content.proton.documentdb.matching.docs_matched.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.docs_reranked.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_latency.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.average"));
 
-        return metrics;
-    }
-
-    private static Set<Metric> getStorageMetrics() {
-        Set<Metric> metrics = new LinkedHashSet<>();
-
-        metrics.add(new Metric("vds.filestor.alldisks.allthreads.put.sum.count.rate"));
-        metrics.add(new Metric("vds.filestor.alldisks.allthreads.remove.sum.count.rate"));
-        metrics.add(new Metric("vds.filestor.alldisks.allthreads.get.sum.count.rate"));
-        metrics.add(new Metric("vds.filestor.alldisks.allthreads.update.sum.count.rate"));
-        metrics.add(new Metric("vds.filestor.alldisks.allthreads.visit.sum.count.rate"));
+        metrics.add(new Metric("content.proton.transactionlog.disk_usage.last"));
 
         return metrics;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultVespaMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultVespaMetrics.java
@@ -8,6 +8,9 @@ import java.util.Set;
 /**
  * Encapsulates a minimal set of Vespa metrics to be used as default for all metrics consumers.
  *
+ * Note: most predefined metric sets use this as a child, so changing this will require updating
+ *       e.g. the list of Vespa metrics in the Datadog integration.
+ *
  * @author leandroalves
  */
 public class DefaultVespaMetrics {

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -117,7 +117,7 @@ public class MetricsProxyContainerClusterTest {
         assertEquals(2, config.consumer().size());
         assertEquals(config.consumer(1).name(), DEFAULT_PUBLIC_CONSUMER_ID);
 
-        int numMetricsForPublicDefaultConsumer = defaultPublicMetricSet.getMetrics().size() + numDefaultVespaMetrics + numSystemMetrics;
+        int numMetricsForPublicDefaultConsumer = defaultPublicMetricSet.getMetrics().size() + numSystemMetrics;
         assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(1).metric().size());
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#10675

The failing system test has been made robust against this change.