### PR TITLE
Allow Get-operations through when content node is in Maintenance mode

### DIFF
--- a/storage/src/vespa/storage/storageserver/bouncer.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer.cpp
@@ -263,6 +263,13 @@ Bouncer::onDown(const std::shared_ptr<api::StorageMessage>& msg)
     {
         return false;
     }
+    // Special case for point lookup Gets while node is in maintenance mode
+    // to allow reads to complete during two-phase cluster state transitions
+    if ((*state == lib::State::MAINTENANCE) && (type.getId() == api::MessageType::GET_ID) && clusterIsUp()) {
+        MBUS_TRACE(msg->getTrace(), 7, "Bouncer: node is in Maintenance mode, but letting Get through");
+        return false;
+    }
+
     const bool externalLoad = isExternalLoad(type);
     if (!isInAvailableState && !(isDistributor() && externalLoad)) {
         abortCommandForUnavailableNode(*msg, *state);


### PR DESCRIPTION
@geirst please review

If Gets are bounced by Maintenance nodes, operations that take place
in a two-phase state transition window Up->Maintenance will be aborted.

Also change naming of some existing tests to make it more obvious what functionality they're actually testing.

