### PR TITLE
Remove default-resources feature flag

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.flags;
 
 import com.yahoo.vespa.defaults.Defaults;
-import com.yahoo.vespa.flags.custom.NodeResources;
 import com.yahoo.vespa.flags.custom.PreprovisionCapacity;
 
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import static com.yahoo.vespa.flags.FetchVector.Dimension.APPLICATION_ID;
-import static com.yahoo.vespa.flags.FetchVector.Dimension.CLUSTER_TYPE;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.NODE_TYPE;
 
@@ -135,12 +133,6 @@ public class Flags {
                     "reservation, and fail with exception unless requested resource match advertised host resources exactly.",
             "Takes effect on next iteration of HostProvisionMaintainer.",
             APPLICATION_ID);
-
-    public static final UnboundJacksonFlag<NodeResources> DEFAULT_RESOURCES = defineJacksonFlag(
-            "default-resources", null, NodeResources.class,
-            "Node resources that will be used when not specified in services.xml",
-            "Takes effect on next deployment",
-            CLUSTER_TYPE);
 
     public static final UnboundBooleanFlag USE_HTTPS_LOAD_BALANCER_UPSTREAM = defineFeatureFlag(
             "use-https-load-balancer-upstream", false,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -58,7 +58,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
     public NodeRepositoryProvisioner(NodeRepository nodeRepository, Zone zone,
                                      ProvisionServiceProvider provisionServiceProvider, FlagSource flagSource) {
         this.nodeRepository = nodeRepository;
-        this.capacityPolicies = new CapacityPolicies(zone, flagSource);
+        this.capacityPolicies = new CapacityPolicies(zone);
         this.zone = zone;
         this.loadBalancerProvisioner = provisionServiceProvider.getLoadBalancerService().map(lbService -> new LoadBalancerProvisioner(nodeRepository, lbService, flagSource));
         this.preparer = new Preparer(nodeRepository,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -91,7 +91,7 @@ public class ProvisioningTester {
         this.orchestrator = orchestrator;
         ProvisionServiceProvider provisionServiceProvider = new MockProvisionServiceProvider(loadBalancerService, hostProvisioner);
         this.provisioner = new NodeRepositoryProvisioner(nodeRepository, zone, provisionServiceProvider, flagSource);
-        this.capacityPolicies = new CapacityPolicies(zone, flagSource);
+        this.capacityPolicies = new CapacityPolicies(zone);
         this.provisionLogger = new NullProvisionLogger();
         this.loadBalancerService = loadBalancerService;
     }


### PR DESCRIPTION
Flag is currently set to:
* 0.5 vCPU, 4 GB memory and 50 GB disk for admin cluster nodes (`t3.medium`)
* 2 vCPU, 8 GB memory and 50 GB disk for the rest (`m5.large`)
in all AWS zones. Unset everywhere else.