### PR TITLE
Bratseth/vip logic

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/cluster/BaseNodeMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/BaseNodeMonitor.java
@@ -26,25 +26,25 @@ public abstract class BaseNodeMonitor<T> {
     /** The object representing the monitored node */
     protected T node;
 
-    protected boolean isWorking=true;
+    protected boolean isWorking = true;
 
     /** Whether this node is quarantined for unstability */
-    protected boolean isQuarantined=false;
+    protected boolean isQuarantined = false;
 
     /** The last time this node failed, in ms */
-    protected long failedAt=0;
+    protected long failedAt = 0;
 
     /** The last time this node responded (failed or succeeded), in ms */
-    protected long respondedAt=0;
+    protected long respondedAt = 0;
 
     /** The last time this node responded successfully */
-    protected long succeededAt=0;
+    protected long succeededAt = 0;
 
     /** The configuration of this monitor */
     protected MonitorConfiguration configuration;
 
     /** Is the node we monitor part of an internal Vespa cluster or not */
-    private boolean internal=false;
+    private boolean internal;
 
     public BaseNodeMonitor(boolean internal) {
         this.internal=internal;

--- a/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
@@ -24,7 +24,7 @@ public class ClusterMonitor<T> {
 
     private MonitorConfiguration configuration = new MonitorConfiguration();
 
-    private static Logger log=Logger.getLogger(ClusterMonitor.class.getName());
+    private static Logger log = Logger.getLogger(ClusterMonitor.class.getName());
 
     private NodeManager<T> nodeManager;
 
@@ -69,6 +69,7 @@ public class ClusterMonitor<T> {
 
     /** Called from ClusterSearcher/NodeManager when a node failed */
     public synchronized void failed(T node, ErrorMessage error) {
+        nodeManager.statusIsKnown(node);
         BaseNodeMonitor<T> monitor = nodeMonitors.get(node);
         boolean wasWorking = monitor.isWorking();
         monitor.failed(error);
@@ -79,6 +80,7 @@ public class ClusterMonitor<T> {
 
     /** Called when a node responded */
     public synchronized void responded(T node) {
+        nodeManager.statusIsKnown(node);
         BaseNodeMonitor<T> monitor = nodeMonitors.get(node);
         boolean wasFailing =! monitor.isWorking();
         monitor.responded();

--- a/container-search/src/main/java/com/yahoo/search/cluster/NodeManager.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/NodeManager.java
@@ -11,6 +11,9 @@ import java.util.concurrent.Executor;
  */
 public interface NodeManager<T> {
 
+    /** Called when we gain evidence about whether or not a node is working */
+    default void statusIsKnown(T node) { }
+
     /** Called when a failed node is working (ready for production) again */
     void working(T node);
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -139,7 +139,7 @@ public class Dispatcher extends AbstractComponent {
         return invoker;
     }
 
-    // build invoker based on searchpath
+    /** Builds an invoker based on searchpath */
     private Optional<SearchInvoker> getSearchPathInvoker(Query query, VespaBackEndSearcher searcher) {
         String searchPath = query.getModel().getSearchPath();
         if (searchPath == null) return Optional.empty();
@@ -156,7 +156,7 @@ public class Dispatcher extends AbstractComponent {
     }
 
     private Optional<SearchInvoker> getInternalInvoker(Query query, VespaBackEndSearcher searcher) {
-        Optional<Node> directNode = searchCluster.directDispatchTarget();
+        Optional<Node> directNode = searchCluster.localCorpusDispatchTarget();
         if (directNode.isPresent()) {
             Node node = directNode.get();
             query.trace(false, 2, "Dispatching directly to ", node);
@@ -202,4 +202,5 @@ public class Dispatcher extends AbstractComponent {
             metric.add(INTERNAL_METRIC, 1, metricContext);
         }
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -77,6 +77,11 @@ public class Group {
         return this.activeDocuments.get();
     }
 
+    public boolean isFullCoverageStatusChanged(boolean hasFullCoverageNow) {
+        boolean previousState = hasFullCoverage.getAndSet(hasFullCoverageNow);
+        return previousState != hasFullCoverageNow;
+    }
+
     @Override
     public String toString() { return "search group " + id; }
 
@@ -90,8 +95,4 @@ public class Group {
         return ((Group) other).id == this.id;
     }
 
-    public boolean isFullCoverageStatusChanged(boolean hasFullCoverageNow) {
-        boolean previousState = hasFullCoverage.getAndSet(hasFullCoverageNow);
-        return previousState != hasFullCoverageNow;
-    }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
@@ -19,6 +19,7 @@ public class Node {
     private final int fs4port;
     final int group;
 
+    private final AtomicBoolean statusIsKnown = new AtomicBoolean(false);
     private final AtomicBoolean working = new AtomicBoolean(true);
     private final AtomicLong activeDocuments = new AtomicLong(0);
 
@@ -45,9 +46,13 @@ public class Node {
     /** Returns the id of this group this node belongs to */
     public int group() { return group; }
 
-    public void setWorking(boolean working) {
-        this.working.lazySet(working);
-    }
+    /** Note that we know the status of this node */
+    public void setStatusIsKnown() { statusIsKnown.lazySet(true); }
+
+    /** Returns whether we know the status of this node */
+    public boolean getStatusIsKnown() { return statusIsKnown.get(); }
+
+    public void setWorking(boolean working) { this.working.lazySet(working); }
 
     /** Returns whether this node is currently responding to requests */
     public boolean isWorking() { return working.get(); }
@@ -77,4 +82,5 @@ public class Node {
 
     @Override
     public String toString() { return "search node " + hostname + ":" + fs4port + " in group " + group; }
+
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/PingFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/PingFactory.java
@@ -6,5 +6,7 @@ import com.yahoo.search.cluster.ClusterMonitor;
 import java.util.concurrent.Callable;
 
 public interface PingFactory {
+
     Callable<Pong> createPinger(Node node, ClusterMonitor<Node> monitor);
+
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -242,7 +242,7 @@ public class SearchCluster implements NodeManager<Node> {
         else {
             if ( ! hasInformationAboutAllNodes()) return;
 
-            if (hasWorkingNodesWithDocumentsOnline())
+            if (hasWorkingNodes())
                 vipStatus.addToRotation(clusterId);
             else
                 vipStatus.removeFromRotation(clusterId);
@@ -267,8 +267,8 @@ public class SearchCluster implements NodeManager<Node> {
         return nodesByHost.values().stream().allMatch(Node::getStatusIsKnown);
     }
 
-    private boolean hasWorkingNodesWithDocumentsOnline() {
-        return nodesByHost.values().stream().anyMatch(node -> node.isWorking() && node.getActiveDocuments() > 0);
+    private boolean hasWorkingNodes() {
+        return nodesByHost.values().stream().anyMatch(Node::isWorking);
     }
 
     private boolean usesLocalCorpusIn(Node node) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
@@ -69,7 +69,7 @@ public class DispatcherTest {
     public void requireThatDispatcherSupportsSingleNodeDirectDispatch() {
         SearchCluster cl = new MockSearchCluster("1", 0, 0) {
             @Override
-            public Optional<Node> directDispatchTarget() {
+            public Optional<Node> localCorpusDispatchTarget() {
                 return Optional.of(new Node(1, "test", 123, 1));
             }
         };

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
@@ -89,7 +89,7 @@ public class MockSearchCluster extends SearchCluster {
     }
 
     @Override
-    public Optional<Node> directDispatchTarget() {
+    public Optional<Node> localCorpusDispatchTarget() {
         return Optional.empty();
     }
 


### PR DESCRIPTION
@baldersheim please review

I collected all vip actions in two updateVipStatus* methods and copied over an adapted version of the prelude monitor code such that
- We take symmetric actions by taking ourselves both in and out of rotation also in the non-local case,
- but (in the non-local case) only when we have full information about all the nodes.

It could be that the version prior to this achieved the same thing since coverage and up/down changes are dependent, but it was not clear to me.

And as you observed we don't have sufficient unit tests on this ...


