### PR TITLE
Split Instance and Application part 4

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Application.java
@@ -1,0 +1,244 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller;
+
+import com.google.common.collect.ImmutableMap;
+import com.yahoo.component.Version;
+import com.yahoo.config.application.api.DeploymentSpec;
+import com.yahoo.config.application.api.ValidationOverrides;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueId;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.User;
+import com.yahoo.vespa.hosted.controller.application.ApplicationActivity;
+import com.yahoo.vespa.hosted.controller.application.AssignedRotation;
+import com.yahoo.vespa.hosted.controller.application.Change;
+import com.yahoo.vespa.hosted.controller.application.Deployment;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
+import com.yahoo.vespa.hosted.controller.application.EndpointId;
+import com.yahoo.vespa.hosted.controller.application.EndpointList;
+import com.yahoo.vespa.hosted.controller.metric.ApplicationMetrics;
+import com.yahoo.vespa.hosted.controller.rotation.RotationStatus;
+import com.yahoo.vespa.hosted.controller.tenant.Tenant;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An application. Belongs to a {@link Tenant}, and may have many {@link Instance}s.
+ *
+ * This is immutable.
+ *
+ * @author jonmv
+ */
+public class Application {
+
+    private final ApplicationId id;
+    private final Instant createdAt;
+    private final DeploymentSpec deploymentSpec;
+    private final ValidationOverrides validationOverrides;
+    private final Map<ZoneId, Deployment> deployments;
+    private final DeploymentJobs deploymentJobs;
+    private final Change change;
+    private final Change outstandingChange;
+    private final Optional<IssueId> ownershipIssueId;
+    private final Optional<User> owner;
+    private final OptionalInt majorVersion;
+    private final ApplicationMetrics metrics;
+    private final Optional<String> pemDeployKey;
+    private final List<AssignedRotation> rotations;
+    private final RotationStatus rotationStatus;
+
+    /** Creates an empty application. */
+    public Application(ApplicationId id, Instant now) {
+        this(id, now, DeploymentSpec.empty, ValidationOverrides.empty, Collections.emptyMap(),
+             new DeploymentJobs(OptionalLong.empty(), Collections.emptyList(), Optional.empty(), false),
+             Change.empty(), Change.empty(), Optional.empty(), Optional.empty(), OptionalInt.empty(),
+             new ApplicationMetrics(0, 0),
+             Optional.empty(), Collections.emptyList(), RotationStatus.EMPTY);
+    }
+
+    /** Used from persistence layer: Do not use */
+    public Application(ApplicationId id, Instant createdAt, DeploymentSpec deploymentSpec, ValidationOverrides validationOverrides,
+                       List<Deployment> deployments, DeploymentJobs deploymentJobs, Change change,
+                       Change outstandingChange, Optional<IssueId> ownershipIssueId, Optional<User> owner,
+                       OptionalInt majorVersion, ApplicationMetrics metrics, Optional<String> pemDeployKey,
+                       List<AssignedRotation> rotations, RotationStatus rotationStatus) {
+        this(id, createdAt, deploymentSpec, validationOverrides,
+             deployments.stream().collect(Collectors.toMap(Deployment::zone, Function.identity())),
+             deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+             metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    Application(ApplicationId id, Instant createdAt, DeploymentSpec deploymentSpec, ValidationOverrides validationOverrides,
+                Map<ZoneId, Deployment> deployments, DeploymentJobs deploymentJobs, Change change,
+                Change outstandingChange, Optional<IssueId> ownershipIssueId, Optional<User> owner,
+                OptionalInt majorVersion, ApplicationMetrics metrics, Optional<String> pemDeployKey,
+                List<AssignedRotation> rotations, RotationStatus rotationStatus) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.createdAt = Objects.requireNonNull(createdAt, "instant of creation cannot be null");
+        this.deploymentSpec = Objects.requireNonNull(deploymentSpec, "deploymentSpec cannot be null");
+        this.validationOverrides = Objects.requireNonNull(validationOverrides, "validationOverrides cannot be null");
+        this.deployments = ImmutableMap.copyOf(Objects.requireNonNull(deployments, "deployments cannot be null"));
+        this.deploymentJobs = Objects.requireNonNull(deploymentJobs, "deploymentJobs cannot be null");
+        this.change = Objects.requireNonNull(change, "change cannot be null");
+        this.outstandingChange = Objects.requireNonNull(outstandingChange, "outstandingChange cannot be null");
+        this.ownershipIssueId = Objects.requireNonNull(ownershipIssueId, "ownershipIssueId cannot be null");
+        this.owner = Objects.requireNonNull(owner, "owner cannot be null");
+        this.majorVersion = Objects.requireNonNull(majorVersion, "majorVersion cannot be null");
+        this.metrics = Objects.requireNonNull(metrics, "metrics cannot be null");
+        this.pemDeployKey = pemDeployKey;
+        this.rotations = List.copyOf(Objects.requireNonNull(rotations, "rotations cannot be null"));
+        this.rotationStatus = Objects.requireNonNull(rotationStatus, "rotationStatus cannot be null");
+    }
+
+    public ApplicationId id() { return id; }
+
+    public Instant createdAt() { return createdAt; }
+
+    /**
+     * Returns the last deployed deployment spec of this application,
+     * or the empty deployment spec if it has never been deployed
+     */
+    public DeploymentSpec deploymentSpec() { return deploymentSpec; }
+
+    /**
+     * Returns the last deployed validation overrides of this application,
+     * or the empty validation overrides if it has never been deployed
+     * (or was deployed with an empty/missing validation overrides)
+     */
+    public ValidationOverrides validationOverrides() { return validationOverrides; }
+
+    /** Returns an immutable map of the current deployments of this */
+    public Map<ZoneId, Deployment> deployments() { return deployments; }
+
+    /**
+     * Returns an immutable map of the current *production* deployments of this
+     * (deployments also includes manually deployed environments)
+     */
+    public Map<ZoneId, Deployment> productionDeployments() {
+        return ImmutableMap.copyOf(deployments.values().stream()
+                                           .filter(deployment -> deployment.zone().environment() == Environment.prod)
+                                           .collect(Collectors.toMap(Deployment::zone, Function.identity())));
+    }
+
+    public DeploymentJobs deploymentJobs() { return deploymentJobs; }
+
+    /**
+     * Returns base change for this application, i.e., the change that is deployed outside block windows.
+     * This is empty when no change is currently under deployment.
+     */
+    public Change change() { return change; }
+
+    /**
+     * Returns whether this has an outstanding change (in the source repository), which
+     * has currently not started deploying (because a deployment is (or was) already in progress
+     */
+    public Change outstandingChange() { return outstandingChange; }
+
+    /** Returns ID of the last ownership issue filed for this */
+    public Optional<IssueId> ownershipIssueId() {
+        return ownershipIssueId;
+    }
+
+    public Optional<User> owner() {
+        return owner;
+    }
+
+    /**
+     * Overrides the system major version for this application. This override takes effect if the deployment
+     * spec does not specify a major version.
+     */
+    public OptionalInt majorVersion() { return majorVersion; }
+
+    /** Returns metrics for this */
+    public ApplicationMetrics metrics() {
+        return metrics;
+    }
+
+    /** Returns activity for this */
+    public ApplicationActivity activity() {
+        return ApplicationActivity.from(deployments.values());
+    }
+
+    /**
+     * Returns the oldest platform version this has deployed in a permanent zone (not test or staging).
+     *
+     * This is unfortunately quite similar to {@link ApplicationController#oldestInstalledPlatform(ApplicationId)},
+     * but this checks only what the controller has deployed to the production zones, while that checks the node repository
+     * to see what's actually installed on each node. Thus, this is the right choice for, e.g., target Vespa versions for
+     * new deployments, while that is the right choice for version to compile against.
+     */
+    public Optional<Version> oldestDeployedPlatform() {
+        return productionDeployments().values().stream()
+                                      .map(Deployment::version)
+                                      .min(Comparator.naturalOrder());
+    }
+
+    /**
+     * Returns the oldest application version this has deployed in a permanent zone (not test or staging).
+     */
+    public Optional<ApplicationVersion> oldestDeployedApplication() {
+        return productionDeployments().values().stream()
+                                      .map(Deployment::applicationVersion)
+                                      .min(Comparator.naturalOrder());
+    }
+
+    /** Returns all rotations assigned to this */
+    public List<AssignedRotation> rotations() {
+        return rotations;
+    }
+
+    /** Returns the default global endpoints for this in given system - for a given endpoint ID */
+    public EndpointList endpointsIn(SystemName system, EndpointId endpointId) {
+        if (rotations.isEmpty()) return EndpointList.EMPTY;
+        return EndpointList.create(id, endpointId, system);
+    }
+
+    /** Returns the default global endpoints for this in given system */
+    public EndpointList endpointsIn(SystemName system) {
+        if (rotations.isEmpty()) return EndpointList.EMPTY;
+        final var endpointStream = rotations.stream()
+                .flatMap(rotation -> EndpointList.create(id, rotation.endpointId(), system).asList().stream());
+        return EndpointList.of(endpointStream);
+    }
+
+    public Optional<String> pemDeployKey() { return pemDeployKey; }
+
+    /** Returns the status of the global rotation(s) assigned to this */
+    public RotationStatus rotationStatus() {
+        return rotationStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (! (o instanceof Application)) return false;
+
+        Application that = (Application) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "application '" + id + "'";
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -161,12 +161,26 @@ public class ApplicationController {
     }
 
     /** Returns the application with the given id, or null if it is not present */
+    public Optional<Application> getApplication(ApplicationId id) {
+        return curator.readApplication(id);
+    }
+
+    /** Returns the application with the given id, or null if it is not present */
     public Optional<Instance> get(ApplicationId id) {
         return curator.readInstance(id);
     }
 
     /**
      * Returns the application with the given id
+     *
+     * @throws IllegalArgumentException if it does not exist
+     */
+    public Application requireApplication(ApplicationId id) {
+        return getApplication(id).orElseThrow(() -> new IllegalArgumentException(id + " not found"));
+    }
+
+    /**
+     * Returns the instance with the given id
      *
      * @throws IllegalArgumentException if it does not exist
      */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedApplication.java
@@ -1,0 +1,287 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.application.api.DeploymentSpec;
+import com.yahoo.config.application.api.ValidationOverrides;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.curator.Lock;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueId;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.User;
+import com.yahoo.vespa.hosted.controller.application.AssignedRotation;
+import com.yahoo.vespa.hosted.controller.application.Change;
+import com.yahoo.vespa.hosted.controller.application.ClusterInfo;
+import com.yahoo.vespa.hosted.controller.application.ClusterUtilization;
+import com.yahoo.vespa.hosted.controller.application.Deployment;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
+import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
+import com.yahoo.vespa.hosted.controller.application.JobStatus;
+import com.yahoo.vespa.hosted.controller.metric.ApplicationMetrics;
+import com.yahoo.vespa.hosted.controller.rotation.RotationStatus;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+/**
+ * An application that has been locked for modification. Provides methods for modifying an application's fields.
+ *
+ * @author jonmv
+ */
+public class LockedApplication {
+
+    private final Lock lock;
+    private final ApplicationId id;
+    private final Instant createdAt;
+    private final DeploymentSpec deploymentSpec;
+    private final ValidationOverrides validationOverrides;
+    private final Map<ZoneId, Deployment> deployments;
+    private final DeploymentJobs deploymentJobs;
+    private final Change change;
+    private final Change outstandingChange;
+    private final Optional<IssueId> ownershipIssueId;
+    private final Optional<User> owner;
+    private final OptionalInt majorVersion;
+    private final ApplicationMetrics metrics;
+    private final Optional<String> pemDeployKey;
+    private final List<AssignedRotation> rotations;
+    private final RotationStatus rotationStatus;
+
+    /**
+     * Used to create a locked application
+     *
+     * @param application The application to lock.
+     * @param lock The lock for the application.
+     */
+    LockedApplication(Application application, Lock lock) {
+        this(Objects.requireNonNull(lock, "lock cannot be null"), application.id(), application.createdAt(),
+             application.deploymentSpec(), application.validationOverrides(),
+             application.deployments(),
+             application.deploymentJobs(), application.change(), application.outstandingChange(),
+             application.ownershipIssueId(), application.owner(), application.majorVersion(), application.metrics(),
+             application.pemDeployKey(), application.rotations(), application.rotationStatus());
+    }
+
+    private LockedApplication(Lock lock, ApplicationId id, Instant createdAt,
+                              DeploymentSpec deploymentSpec, ValidationOverrides validationOverrides,
+                              Map<ZoneId, Deployment> deployments, DeploymentJobs deploymentJobs, Change change,
+                              Change outstandingChange, Optional<IssueId> ownershipIssueId, Optional<User> owner,
+                              OptionalInt majorVersion, ApplicationMetrics metrics, Optional<String> pemDeployKey,
+                              List<AssignedRotation> rotations, RotationStatus rotationStatus) {
+        this.lock = lock;
+        this.id = id;
+        this.createdAt = createdAt;
+        this.deploymentSpec = deploymentSpec;
+        this.validationOverrides = validationOverrides;
+        this.deployments = deployments;
+        this.deploymentJobs = deploymentJobs;
+        this.change = change;
+        this.outstandingChange = outstandingChange;
+        this.ownershipIssueId = ownershipIssueId;
+        this.owner = owner;
+        this.majorVersion = majorVersion;
+        this.metrics = metrics;
+        this.pemDeployKey = pemDeployKey;
+        this.rotations = rotations;
+        this.rotationStatus = rotationStatus;
+    }
+
+    /** Returns a read-only copy of this */
+    public Instance get() {
+        return new Instance(id, createdAt, deploymentSpec, validationOverrides, deployments, deploymentJobs, change,
+                            outstandingChange, ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                            rotations, rotationStatus);
+    }
+
+    public LockedApplication withBuiltInternally(boolean builtInternally) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.withBuiltInternally(builtInternally), change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication withProjectId(OptionalLong projectId) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.withProjectId(projectId), change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication withDeploymentIssueId(IssueId issueId) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.with(issueId), change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication withJobPause(JobType jobType, OptionalLong pausedUntil) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.withPause(jobType, pausedUntil), change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication withJobCompletion(long projectId, JobType jobType, JobStatus.JobRun completion,
+                                               Optional<DeploymentJobs.JobError> jobError) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.withCompletion(projectId, jobType, completion, jobError),
+                                     change, outstandingChange, ownershipIssueId, owner, majorVersion, metrics,
+                                     pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication withJobTriggering(JobType jobType, JobStatus.JobRun job) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.withTriggering(jobType, job), change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication withNewDeployment(ZoneId zone, ApplicationVersion applicationVersion, Version version,
+                                               Instant instant, Map<DeploymentMetrics.Warning, Integer> warnings) {
+        // Use info from previous deployment if available, otherwise create a new one.
+        Deployment previousDeployment = deployments.getOrDefault(zone, new Deployment(zone, applicationVersion,
+                                                                                      version, instant));
+        Deployment newDeployment = new Deployment(zone, applicationVersion, version, instant,
+                                                  previousDeployment.clusterUtils(),
+                                                  previousDeployment.clusterInfo(),
+                                                  previousDeployment.metrics().with(warnings),
+                                                  previousDeployment.activity());
+        return with(newDeployment);
+    }
+
+    public LockedApplication withClusterUtilization(ZoneId zone, Map<ClusterSpec.Id, ClusterUtilization> clusterUtilization) {
+        Deployment deployment = deployments.get(zone);
+        if (deployment == null) return this;    // No longer deployed in this zone.
+        return with(deployment.withClusterUtils(clusterUtilization));
+    }
+
+    public LockedApplication withClusterInfo(ZoneId zone, Map<ClusterSpec.Id, ClusterInfo> clusterInfo) {
+        Deployment deployment = deployments.get(zone);
+        if (deployment == null) return this;    // No longer deployed in this zone.
+        return with(deployment.withClusterInfo(clusterInfo));
+
+    }
+
+    public LockedApplication recordActivityAt(Instant instant, ZoneId zone) {
+        Deployment deployment = deployments.get(zone);
+        if (deployment == null) return this;
+        return with(deployment.recordActivityAt(instant));
+    }
+
+    public LockedApplication with(ZoneId zone, DeploymentMetrics deploymentMetrics) {
+        Deployment deployment = deployments.get(zone);
+        if (deployment == null) return this;    // No longer deployed in this zone.
+        return with(deployment.withMetrics(deploymentMetrics));
+    }
+
+    public LockedApplication withoutDeploymentIn(ZoneId zone) {
+        Map<ZoneId, Deployment> deployments = new LinkedHashMap<>(this.deployments);
+        deployments.remove(zone);
+        return with(deployments);
+    }
+
+    public LockedApplication withoutDeploymentJob(JobType jobType) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs.without(jobType), change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication with(DeploymentSpec deploymentSpec) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange,
+                                     ownershipIssueId, owner, majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    public LockedApplication with(ValidationOverrides validationOverrides) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication withChange(Change change) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication withOutstandingChange(Change outstandingChange) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication withOwnershipIssueId(IssueId issueId) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, Optional.ofNullable(issueId), owner,
+                                     majorVersion, metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication withOwner(User owner) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId,
+                                     Optional.ofNullable(owner), majorVersion, metrics, pemDeployKey,
+                                     rotations, rotationStatus);
+    }
+
+    /** Set a major version for this, or set to null to remove any major version override */
+    public LockedApplication withMajorVersion(Integer majorVersion) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner,
+                                     majorVersion == null ? OptionalInt.empty() : OptionalInt.of(majorVersion),
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication with(ApplicationMetrics metrics) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    public LockedApplication withPemDeployKey(String pemDeployKey) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, Optional.ofNullable(pemDeployKey), rotations, rotationStatus);
+    }
+
+    public LockedApplication with(List<AssignedRotation> assignedRotations) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, assignedRotations, rotationStatus);
+    }
+
+    public LockedApplication with(RotationStatus rotationStatus) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    /** Don't expose non-leaf sub-objects. */
+    private LockedApplication with(Deployment deployment) {
+        Map<ZoneId, Deployment> deployments = new LinkedHashMap<>(this.deployments);
+        deployments.put(deployment.zone(), deployment);
+        return with(deployments);
+    }
+
+    private LockedApplication with(Map<ZoneId, Deployment> deployments) {
+        return new LockedApplication(lock, id, createdAt, deploymentSpec, validationOverrides, deployments,
+                                     deploymentJobs, change, outstandingChange, ownershipIssueId, owner, majorVersion,
+                                     metrics, pemDeployKey, rotations, rotationStatus);
+    }
+
+    @Override
+    public String toString() {
+        return "application '" + id + "'";
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/ApplicationList.java
@@ -1,0 +1,233 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.application;
+
+import com.google.common.collect.ImmutableList;
+import com.yahoo.component.Version;
+import com.yahoo.config.application.api.DeploymentSpec.UpgradePolicy;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.ApplicationController;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A list of applications which can be filtered in various ways.
+ *
+ * @author jonmv
+ */
+public class ApplicationList {
+
+    private final ImmutableList<Application> list;
+
+    private ApplicationList(Iterable<Application> applications) {
+        this.list = ImmutableList.copyOf(applications);
+    }
+
+    // ----------------------------------- Factories
+
+    public static ApplicationList from(Iterable<Application> applications) {
+        return new ApplicationList(applications);
+    }
+
+    public static ApplicationList from(Collection<ApplicationId> ids, ApplicationController applications) {
+        return listOf(ids.stream().map(applications::requireApplication));
+    }
+
+    // ----------------------------------- Accessors
+
+    /** Returns the applications in this as an immutable list */
+    public List<Application> asList() { return list; }
+
+    /** Returns the ids of the applications in this as an immutable list */
+    public List<ApplicationId> idList() { return ImmutableList.copyOf(list.stream().map(Application::id)::iterator); }
+
+    public boolean isEmpty() { return list.isEmpty(); }
+
+    public int size() { return list.size(); }
+
+    // ----------------------------------- Filters
+
+    /** Returns the subset of applications which are upgrading (to any version), not considering block windows. */
+    public ApplicationList upgrading() {
+        return listOf(list.stream().filter(application -> application.change().platform().isPresent()));
+    }
+
+    /** Returns the subset of applications which are currently upgrading to the given version */
+    public ApplicationList upgradingTo(Version version) {
+        return listOf(list.stream().filter(application -> isUpgradingTo(version, application)));
+    }
+
+    /** Returns the subset of applications which are not pinned to a certain Vespa version. */
+    public ApplicationList unpinned() {
+        return listOf(list.stream().filter(application -> ! application.change().isPinned()));
+    }
+
+    /** Returns the subset of applications which are currently not upgrading to the given version */
+    public ApplicationList notUpgradingTo(Version version) {
+        return notUpgradingTo(Collections.singletonList(version));
+    }
+
+    /** Returns the subset of applications which are currently not upgrading to any of the given versions */
+    public ApplicationList notUpgradingTo(Collection<Version> versions) {
+        return listOf(list.stream().filter(application -> versions.stream().noneMatch(version -> isUpgradingTo(version, application))));
+    }
+
+    /**
+     * Returns the subset of applications which are currently not upgrading to the given version,
+     * or returns all if no version is specified
+     */
+    public ApplicationList notUpgradingTo(Optional<Version> version) {
+        if (version.isEmpty()) return this;
+        return notUpgradingTo(version.get());
+    }
+
+    /** Returns the subset of applications which have changes left to deploy; blocked, or deploying */
+    public ApplicationList withChanges() {
+        return listOf(list.stream().filter(application -> application.change().hasTargets() || application.outstandingChange().hasTargets()));
+    }
+
+    /** Returns the subset of applications which are currently not deploying a change */
+    public ApplicationList notDeploying() {
+        return listOf(list.stream().filter(application -> ! application.change().hasTargets()));
+    }
+
+    /** Returns the subset of applications which currently does not have any failing jobs */
+    public ApplicationList notFailing() {
+        return listOf(list.stream().filter(application -> ! application.deploymentJobs().hasFailures()));
+    }
+
+    /** Returns the subset of applications which currently have failing jobs */
+    public ApplicationList failing() {
+        return listOf(list.stream().filter(application -> application.deploymentJobs().hasFailures()));
+    }
+
+    /** Returns the subset of applications which have been failing an upgrade to the given version since the given instant */
+    public ApplicationList failingUpgradeToVersionSince(Version version, Instant threshold) {
+        return listOf(list.stream().filter(application -> failingUpgradeToVersionSince(application, version, threshold)));
+    }
+
+    /** Returns the subset of applications which have been failing an application change since the given instant */
+    public ApplicationList failingApplicationChangeSince(Instant threshold) {
+        return listOf(list.stream().filter(application -> failingApplicationChangeSince(application, threshold)));
+    }
+
+    /** Returns the subset of applications which currently does not have any failing jobs on the given version */
+    public ApplicationList notFailingOn(Version version) {
+        return listOf(list.stream().filter(application -> ! failingOn(version, application)));
+    }
+
+    /** Returns the subset of applications which have at least one production deployment */
+    public ApplicationList hasDeployment() {
+        return listOf(list.stream().filter(a -> !a.productionDeployments().isEmpty()));
+    }
+
+    /** Returns the subset of applications which started failing on the given version */
+    public ApplicationList startedFailingOn(Version version) {
+        return listOf(list.stream().filter(application -> ! JobList.from(application).firstFailing().on(version).isEmpty()));
+    }
+
+    /** Returns the subset of applications which has the given upgrade policy */
+    public ApplicationList with(UpgradePolicy policy) {
+        return listOf(list.stream().filter(a ->  a.deploymentSpec().upgradePolicy() == policy));
+    }
+
+    /** Returns the subset of applications which does not have the given upgrade policy */
+    public ApplicationList without(UpgradePolicy policy) {
+        return listOf(list.stream().filter(a ->  a.deploymentSpec().upgradePolicy() != policy));
+    }
+
+    /** Returns the subset of applications which have at least one deployment on a lower version than the given one */
+    public ApplicationList onLowerVersionThan(Version version) {
+        return listOf(list.stream()
+                          .filter(a -> a.productionDeployments().values().stream()
+                                                                         .anyMatch(d -> d.version().isBefore(version))));
+    }
+
+    /** Returns the subset of applications which have a project ID */
+    public ApplicationList withProjectId() {
+        return listOf(list.stream().filter(a -> a.deploymentJobs().projectId().isPresent()));
+    }
+
+    /** Returns the subset of applications which have at least one production deployment */
+    public ApplicationList hasProductionDeployment() {
+        return listOf(list.stream().filter(a -> ! a.productionDeployments().isEmpty()));
+    }
+
+    /** Returns the subset of applications that are allowed to upgrade at the given time */
+    public ApplicationList canUpgradeAt(Instant instant) {
+        return listOf(list.stream().filter(a -> a.deploymentSpec().canUpgradeAt(instant)));
+    }
+
+    /** Returns the subset of applications that have at least one assigned rotation */
+    public ApplicationList hasRotation() {
+        return listOf(list.stream().filter(a -> !a.rotations().isEmpty()));
+    }
+
+    /**
+     * Returns the subset of applications that hasn't pinned to an an earlier major version than the given one.
+     *
+     * @param targetMajorVersion the target major version which applications returned allows upgrading to
+     * @param defaultMajorVersion the default major version to assume for applications not specifying one
+     */
+    public ApplicationList allowMajorVersion(int targetMajorVersion, int defaultMajorVersion) {
+        return listOf(list.stream().filter(a -> a.deploymentSpec().majorVersion().orElse(a.majorVersion().orElse(defaultMajorVersion))
+                                           >= targetMajorVersion));
+    }
+
+    /** Returns the first n application in this (or all, if there are less than n). */
+    public ApplicationList first(int n) {
+        if (list.size() < n) return this;
+        return new ApplicationList(list.subList(0, n));
+    }
+
+     // ----------------------------------- Sorting
+
+    /**
+     * Returns this list sorted by increasing deployed version.
+     * If multiple versions are deployed the oldest is used.
+     * Applications without any deployments are ordered first.
+     */
+    public ApplicationList byIncreasingDeployedVersion() {
+        return listOf(list.stream().sorted(Comparator.comparing(application -> application.oldestDeployedPlatform().orElse(Version.emptyVersion))));
+    }
+
+    // ----------------------------------- Internal helpers
+
+    private static boolean isUpgradingTo(Version version, Application application) {
+        return application.change().platform().equals(Optional.of(version));
+    }
+
+    private static boolean failingOn(Version version, Application application) {
+        return ! JobList.from(application)
+                .failing()
+                .lastCompleted().on(version)
+                .isEmpty();
+    }
+
+    private static boolean failingUpgradeToVersionSince(Application application, Version version, Instant threshold) {
+        return ! JobList.from(application)
+                .not().failingApplicationChange()
+                .firstFailing().before(threshold)
+                .lastCompleted().on(version)
+                .isEmpty();
+    }
+
+    private static boolean failingApplicationChangeSince(Application application, Instant threshold) {
+        return ! JobList.from(application)
+                .failingApplicationChange()
+                .firstFailing().before(threshold)
+                .isEmpty();
+    }
+
+    /** Convenience converter from a stream to an ApplicationList */
+    private static ApplicationList listOf(Stream<Application> applications) {
+        return from(applications::iterator);
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/JobList.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.controller.application;
 
 import com.google.common.collect.ImmutableList;
 import com.yahoo.component.Version;
+import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
@@ -37,6 +38,10 @@ public class JobList {
 
     public static JobList from(Iterable<JobStatus> jobs) {
         return new JobList(jobs);
+    }
+
+    public static JobList from(Application application) {
+        return from(application.deploymentJobs().jobStatus().values());
     }
 
     public static JobList from(Instance instance) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/TenantAndApplicationId.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/TenantAndApplicationId.java
@@ -1,0 +1,94 @@
+package com.yahoo.vespa.hosted.controller.application;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ApplicationName;
+import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.TenantName;
+
+import java.util.Objects;
+
+/**
+ * Tenant and application name pair.
+ *
+ * TODO jonmv: rename to ApplicationId if ApplicationId is renamed.
+ */
+public class TenantAndApplicationId implements Comparable<TenantAndApplicationId> {
+
+    private final TenantName tenant;
+    private final ApplicationName application;
+
+    private TenantAndApplicationId(TenantName tenant, ApplicationName application) {
+        requireNonBlank(tenant.value(), "Tenant name");
+        requireNonBlank(application.value(), "Application name");
+        this.tenant = tenant;
+        this.application = application;
+    }
+
+    public static TenantAndApplicationId from(TenantName tenant, ApplicationName application) {
+        return new TenantAndApplicationId(tenant, application);
+    }
+
+    public static TenantAndApplicationId from(String tenant, String application) {
+        return from(TenantName.from(tenant), ApplicationName.from(application));
+    }
+
+    public static TenantAndApplicationId fromSerialized(String value) {
+        String[] parts = value.split(":");
+        if (parts.length != 2)
+            throw new IllegalArgumentException("Serialized value should be '<tenant>:<application>', but was '" + value + "'");
+
+        return from(parts[0], parts[1]);
+    }
+
+    public static TenantAndApplicationId from(ApplicationId id) {
+        return from(id.tenant(), id.application());
+    }
+
+    public ApplicationId defaultInstance() {
+        return ApplicationId.from(tenant, application, InstanceName.defaultName());
+    }
+
+    public String serialized() {
+        return tenant.value() + ":" + application.value();
+    }
+
+    public TenantName tenant() {
+        return tenant;
+    }
+
+    public ApplicationName application() {
+        return application;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        TenantAndApplicationId that = (TenantAndApplicationId) other;
+        return tenant.equals(that.tenant) &&
+               application.equals(that.application);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tenant, application);
+    }
+
+    @Override
+    public int compareTo(TenantAndApplicationId other) {
+        int tenantComparison = tenant.compareTo(other.tenant);
+        return tenantComparison != 0 ? tenantComparison : application.compareTo(other.application);
+    }
+
+    @Override
+    public String toString() {
+        return tenant.value() + "." + application.value();
+    }
+
+    private static void requireNonBlank(String value, String name) {
+        Objects.requireNonNull(value, name + " cannot be null");
+        if (name.isBlank())
+            throw new IllegalArgumentException(name + " cannot be blank");
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -1,0 +1,574 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.persistence;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.application.api.DeploymentSpec;
+import com.yahoo.config.application.api.ValidationOverrides;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.slime.ArrayTraverser;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Inspector;
+import com.yahoo.slime.ObjectTraverser;
+import com.yahoo.slime.Slime;
+import com.yahoo.vespa.hosted.controller.Application;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.SourceRevision;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueId;
+import com.yahoo.vespa.hosted.controller.api.integration.organization.User;
+import com.yahoo.vespa.hosted.controller.application.AssignedRotation;
+import com.yahoo.vespa.hosted.controller.application.Change;
+import com.yahoo.vespa.hosted.controller.application.ClusterInfo;
+import com.yahoo.vespa.hosted.controller.application.ClusterUtilization;
+import com.yahoo.vespa.hosted.controller.application.Deployment;
+import com.yahoo.vespa.hosted.controller.application.DeploymentActivity;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs;
+import com.yahoo.vespa.hosted.controller.application.DeploymentJobs.JobError;
+import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
+import com.yahoo.vespa.hosted.controller.application.EndpointId;
+import com.yahoo.vespa.hosted.controller.application.JobStatus;
+import com.yahoo.vespa.hosted.controller.metric.ApplicationMetrics;
+import com.yahoo.vespa.hosted.controller.rotation.RotationId;
+import com.yahoo.vespa.hosted.controller.rotation.RotationState;
+import com.yahoo.vespa.hosted.controller.rotation.RotationStatus;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+
+/**
+ * Serializes {@link Application}s to/from slime.
+ * This class is multithread safe.
+ *
+ * @author jonmv
+ */
+public class ApplicationSerializer {
+
+    // WARNING: Since there are multiple servers in a ZooKeeper cluster and they upgrade one by one
+    //          (and rewrite all nodes on startup), changes to the serialized format must be made
+    //          such that what is serialized on version N+1 can be read by version N:
+    //          - ADDING FIELDS: Always ok
+    //          - REMOVING FIELDS: Stop reading the field first. Stop writing it on a later version.
+    //          - CHANGING THE FORMAT OF A FIELD: Don't do it bro.
+
+    // Application fields
+    private static final String idField = "id";
+    private static final String createdAtField = "createdAt";
+    private static final String deploymentSpecField = "deploymentSpecField";
+    private static final String validationOverridesField = "validationOverrides";
+    private static final String deploymentsField = "deployments";
+    private static final String deploymentJobsField = "deploymentJobs";
+    private static final String deployingField = "deployingField";
+    private static final String pinnedField = "pinned";
+    private static final String outstandingChangeField = "outstandingChangeField";
+    private static final String ownershipIssueIdField = "ownershipIssueId";
+    private static final String ownerField = "confirmedOwner";
+    private static final String majorVersionField = "majorVersion";
+    private static final String writeQualityField = "writeQuality";
+    private static final String queryQualityField = "queryQuality";
+    private static final String pemDeployKeyField = "pemDeployKey";
+    private static final String assignedRotationsField = "assignedRotations";
+    private static final String assignedRotationEndpointField = "endpointId";
+    private static final String assignedRotationClusterField = "clusterId";
+    private static final String assignedRotationRotationField = "rotationId";
+    private static final String applicationCertificateField = "applicationCertificate";
+
+    // Deployment fields
+    private static final String zoneField = "zone";
+    private static final String environmentField = "environment";
+    private static final String regionField = "region";
+    private static final String deployTimeField = "deployTime";
+    private static final String applicationBuildNumberField = "applicationBuildNumber";
+    private static final String applicationPackageRevisionField = "applicationPackageRevision";
+    private static final String sourceRevisionField = "sourceRevision";
+    private static final String repositoryField = "repositoryField";
+    private static final String branchField = "branchField";
+    private static final String commitField = "commitField";
+    private static final String authorEmailField = "authorEmailField";
+    private static final String compileVersionField = "compileVersion";
+    private static final String buildTimeField = "buildTime";
+    private static final String lastQueriedField = "lastQueried";
+    private static final String lastWrittenField = "lastWritten";
+    private static final String lastQueriesPerSecondField = "lastQueriesPerSecond";
+    private static final String lastWritesPerSecondField = "lastWritesPerSecond";
+
+    // DeploymentJobs fields
+    private static final String projectIdField = "projectId";
+    private static final String jobStatusField = "jobStatus";
+    private static final String issueIdField = "jiraIssueId";
+    private static final String builtInternallyField = "builtInternally";
+
+    // JobStatus field
+    private static final String jobTypeField = "jobType";
+    private static final String errorField = "jobError";
+    private static final String lastTriggeredField = "lastTriggered";
+    private static final String lastCompletedField = "lastCompleted";
+    private static final String firstFailingField = "firstFailing";
+    private static final String lastSuccessField = "lastSuccess";
+    private static final String pausedUntilField = "pausedUntil";
+
+    // JobRun fields
+    private static final String jobRunIdField = "id";
+    private static final String versionField = "version";
+    private static final String revisionField = "revision";
+    private static final String sourceVersionField = "sourceVersion";
+    private static final String sourceApplicationField = "sourceRevision";
+    private static final String reasonField = "reason";
+    private static final String atField = "at";
+
+    // ClusterInfo fields
+    private static final String clusterInfoField = "clusterInfo";
+    private static final String clusterInfoFlavorField = "flavor";
+    private static final String clusterInfoCostField = "cost";
+    private static final String clusterInfoCpuField = "flavorCpu";
+    private static final String clusterInfoMemField = "flavorMem";
+    private static final String clusterInfoDiskField = "flavorDisk";
+    private static final String clusterInfoTypeField = "clusterType";
+    private static final String clusterInfoHostnamesField = "hostnames";
+
+    // ClusterUtils fields
+    private static final String clusterUtilsField = "clusterUtils";
+    private static final String clusterUtilsCpuField = "cpu";
+    private static final String clusterUtilsMemField = "mem";
+    private static final String clusterUtilsDiskField = "disk";
+    private static final String clusterUtilsDiskBusyField = "diskbusy";
+
+    // Deployment metrics fields
+    private static final String deploymentMetricsField = "metrics";
+    private static final String deploymentMetricsQPSField = "queriesPerSecond";
+    private static final String deploymentMetricsWPSField = "writesPerSecond";
+    private static final String deploymentMetricsDocsField = "documentCount";
+    private static final String deploymentMetricsQueryLatencyField = "queryLatencyMillis";
+    private static final String deploymentMetricsWriteLatencyField = "writeLatencyMillis";
+    private static final String deploymentMetricsUpdateTime = "lastUpdated";
+    private static final String deploymentMetricsWarningsField = "warnings";
+
+    // RotationStatus fields
+    private static final String rotationStatusField = "rotationStatus2";
+    private static final String rotationIdField = "rotationId";
+    private static final String rotationStateField = "state";
+    private static final String statusField = "status";
+
+    // ------------------ Serialization
+
+    public Slime toSlime(Application instance) {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+        root.setString(idField, instance.id().serializedForm());
+        root.setLong(createdAtField, instance.createdAt().toEpochMilli());
+        root.setString(deploymentSpecField, instance.deploymentSpec().xmlForm());
+        root.setString(validationOverridesField, instance.validationOverrides().xmlForm());
+        deploymentsToSlime(instance.deployments().values(), root.setArray(deploymentsField));
+        toSlime(instance.deploymentJobs(), root.setObject(deploymentJobsField));
+        toSlime(instance.change(), root, deployingField);
+        toSlime(instance.outstandingChange(), root, outstandingChangeField);
+        instance.ownershipIssueId().ifPresent(issueId -> root.setString(ownershipIssueIdField, issueId.value()));
+        instance.owner().ifPresent(owner -> root.setString(ownerField, owner.username()));
+        instance.majorVersion().ifPresent(majorVersion -> root.setLong(majorVersionField, majorVersion));
+        root.setDouble(queryQualityField, instance.metrics().queryServiceQuality());
+        root.setDouble(writeQualityField, instance.metrics().writeServiceQuality());
+        instance.pemDeployKey().ifPresent(pemDeployKey -> root.setString(pemDeployKeyField, pemDeployKey));
+        assignedRotationsToSlime(instance.rotations(), root, assignedRotationsField);
+        toSlime(instance.rotationStatus(), root.setArray(rotationStatusField));
+        return slime;
+    }
+
+    private void deploymentsToSlime(Collection<Deployment> deployments, Cursor array) {
+        for (Deployment deployment : deployments)
+            deploymentToSlime(deployment, array.addObject());
+    }
+
+    private void deploymentToSlime(Deployment deployment, Cursor object) {
+        zoneIdToSlime(deployment.zone(), object.setObject(zoneField));
+        object.setString(versionField, deployment.version().toString());
+        object.setLong(deployTimeField, deployment.at().toEpochMilli());
+        toSlime(deployment.applicationVersion(), object.setObject(applicationPackageRevisionField));
+        clusterInfoToSlime(deployment.clusterInfo(), object);
+        clusterUtilsToSlime(deployment.clusterUtils(), object);
+        deploymentMetricsToSlime(deployment.metrics(), object);
+        deployment.activity().lastQueried().ifPresent(instant -> object.setLong(lastQueriedField, instant.toEpochMilli()));
+        deployment.activity().lastWritten().ifPresent(instant -> object.setLong(lastWrittenField, instant.toEpochMilli()));
+        deployment.activity().lastQueriesPerSecond().ifPresent(value -> object.setDouble(lastQueriesPerSecondField, value));
+        deployment.activity().lastWritesPerSecond().ifPresent(value -> object.setDouble(lastWritesPerSecondField, value));
+    }
+
+    private void deploymentMetricsToSlime(DeploymentMetrics metrics, Cursor object) {
+        Cursor root = object.setObject(deploymentMetricsField);
+        root.setDouble(deploymentMetricsQPSField, metrics.queriesPerSecond());
+        root.setDouble(deploymentMetricsWPSField, metrics.writesPerSecond());
+        root.setDouble(deploymentMetricsDocsField, metrics.documentCount());
+        root.setDouble(deploymentMetricsQueryLatencyField, metrics.queryLatencyMillis());
+        root.setDouble(deploymentMetricsWriteLatencyField, metrics.writeLatencyMillis());
+        metrics.instant().ifPresent(instant -> root.setLong(deploymentMetricsUpdateTime, instant.toEpochMilli()));
+        if (!metrics.warnings().isEmpty()) {
+            Cursor warningsObject = root.setObject(deploymentMetricsWarningsField);
+            metrics.warnings().forEach((warning, count) -> warningsObject.setLong(warning.name(), count));
+        }
+    }
+
+    private void clusterInfoToSlime(Map<ClusterSpec.Id, ClusterInfo> clusters, Cursor object) {
+        Cursor root = object.setObject(clusterInfoField);
+        for (Map.Entry<ClusterSpec.Id, ClusterInfo> entry : clusters.entrySet()) {
+            toSlime(entry.getValue(), root.setObject(entry.getKey().value()));
+        }
+    }
+
+    private void toSlime(ClusterInfo info, Cursor object) {
+        object.setString(clusterInfoFlavorField, info.getFlavor());
+        object.setLong(clusterInfoCostField, info.getFlavorCost());
+        object.setDouble(clusterInfoCpuField, info.getFlavorCPU());
+        object.setDouble(clusterInfoMemField, info.getFlavorMem());
+        object.setDouble(clusterInfoDiskField, info.getFlavorDisk());
+        object.setString(clusterInfoTypeField, info.getClusterType().name());
+        Cursor array = object.setArray(clusterInfoHostnamesField);
+        for (String host : info.getHostnames()) {
+            array.addString(host);
+        }
+    }
+
+    private void clusterUtilsToSlime(Map<ClusterSpec.Id, ClusterUtilization> clusters, Cursor object) {
+        Cursor root = object.setObject(clusterUtilsField);
+        for (Map.Entry<ClusterSpec.Id, ClusterUtilization> entry : clusters.entrySet()) {
+            toSlime(entry.getValue(), root.setObject(entry.getKey().value()));
+        }
+    }
+
+    private void toSlime(ClusterUtilization utils, Cursor object) {
+        object.setDouble(clusterUtilsCpuField, utils.getCpu());
+        object.setDouble(clusterUtilsMemField, utils.getMemory());
+        object.setDouble(clusterUtilsDiskField, utils.getDisk());
+        object.setDouble(clusterUtilsDiskBusyField, utils.getDiskBusy());
+    }
+
+    private void zoneIdToSlime(ZoneId zone, Cursor object) {
+        object.setString(environmentField, zone.environment().value());
+        object.setString(regionField, zone.region().value());
+    }
+
+    private void toSlime(ApplicationVersion applicationVersion, Cursor object) {
+        if (applicationVersion.buildNumber().isPresent() && applicationVersion.source().isPresent()) {
+            object.setLong(applicationBuildNumberField, applicationVersion.buildNumber().getAsLong());
+            toSlime(applicationVersion.source().get(), object.setObject(sourceRevisionField));
+            applicationVersion.authorEmail().ifPresent(email -> object.setString(authorEmailField, email));
+            applicationVersion.compileVersion().ifPresent(version -> object.setString(compileVersionField, version.toString()));
+            applicationVersion.buildTime().ifPresent(time -> object.setLong(buildTimeField, time.toEpochMilli()));
+        }
+    }
+
+    private void toSlime(SourceRevision sourceRevision, Cursor object) {
+        object.setString(repositoryField, sourceRevision.repository());
+        object.setString(branchField, sourceRevision.branch());
+        object.setString(commitField, sourceRevision.commit());
+    }
+
+    private void toSlime(DeploymentJobs deploymentJobs, Cursor cursor) {
+        deploymentJobs.projectId().ifPresent(projectId -> cursor.setLong(projectIdField, projectId));
+        jobStatusToSlime(deploymentJobs.jobStatus().values(), cursor.setArray(jobStatusField));
+        deploymentJobs.issueId().ifPresent(jiraIssueId -> cursor.setString(issueIdField, jiraIssueId.value()));
+        cursor.setBool(builtInternallyField, deploymentJobs.deployedInternally());
+    }
+
+    private void jobStatusToSlime(Collection<JobStatus> jobStatuses, Cursor jobStatusArray) {
+        for (JobStatus jobStatus : jobStatuses)
+            toSlime(jobStatus, jobStatusArray.addObject());
+    }
+
+    private void toSlime(JobStatus jobStatus, Cursor object) {
+        object.setString(jobTypeField, jobStatus.type().jobName());
+        if (jobStatus.jobError().isPresent())
+            object.setString(errorField, jobStatus.jobError().get().name());
+
+        jobStatus.lastTriggered().ifPresent(run -> jobRunToSlime(run, object, lastTriggeredField));
+        jobStatus.lastCompleted().ifPresent(run -> jobRunToSlime(run, object, lastCompletedField));
+        jobStatus.lastSuccess().ifPresent(run -> jobRunToSlime(run, object, lastSuccessField));
+        jobStatus.firstFailing().ifPresent(run -> jobRunToSlime(run, object, firstFailingField));
+        jobStatus.pausedUntil().ifPresent(until -> object.setLong(pausedUntilField, until));
+    }
+
+    private void jobRunToSlime(JobStatus.JobRun jobRun, Cursor parent, String jobRunObjectName) {
+        Cursor object = parent.setObject(jobRunObjectName);
+        object.setLong(jobRunIdField, jobRun.id());
+        object.setString(versionField, jobRun.platform().toString());
+        toSlime(jobRun.application(), object.setObject(revisionField));
+        jobRun.sourcePlatform().ifPresent(version -> object.setString(sourceVersionField, version.toString()));
+        jobRun.sourceApplication().ifPresent(version -> toSlime(version, object.setObject(sourceApplicationField)));
+        object.setString(reasonField, jobRun.reason());
+        object.setLong(atField, jobRun.at().toEpochMilli());
+    }
+
+    private void toSlime(Change deploying, Cursor parentObject, String fieldName) {
+        if (deploying.isEmpty()) return;
+
+        Cursor object = parentObject.setObject(fieldName);
+        if (deploying.platform().isPresent())
+            object.setString(versionField, deploying.platform().get().toString());
+        if (deploying.application().isPresent())
+            toSlime(deploying.application().get(), object);
+        if (deploying.isPinned())
+            object.setBool(pinnedField, true);
+    }
+
+    private void toSlime(RotationStatus status, Cursor array) {
+        status.asMap().forEach((rotationId, zoneStatus) -> {
+            Cursor rotationObject = array.addObject();
+            rotationObject.setString(rotationIdField, rotationId.asString());
+            Cursor statusArray = rotationObject.setArray(statusField);
+            zoneStatus.forEach((zone, state) -> {
+                Cursor statusObject = statusArray.addObject();
+                zoneIdToSlime(zone, statusObject);
+                statusObject.setString(rotationStateField, state.name());
+            });
+        });
+    }
+
+    private void assignedRotationsToSlime(List<AssignedRotation> rotations, Cursor parent, String fieldName) {
+        var rotationsArray = parent.setArray(fieldName);
+        for (var rotation : rotations) {
+            var object = rotationsArray.addObject();
+            object.setString(assignedRotationEndpointField, rotation.endpointId().id());
+            object.setString(assignedRotationRotationField, rotation.rotationId().asString());
+            object.setString(assignedRotationClusterField, rotation.clusterId().value());
+        }
+    }
+
+    // ------------------ Deserialization
+
+    public Application fromSlime(Slime slime) {
+        Inspector root = slime.get();
+
+        ApplicationId id = ApplicationId.fromSerializedForm(root.field(idField).asString());
+        Instant createdAt = Instant.ofEpochMilli(root.field(createdAtField).asLong());
+        DeploymentSpec deploymentSpec = DeploymentSpec.fromXml(root.field(deploymentSpecField).asString(), false);
+        ValidationOverrides validationOverrides = ValidationOverrides.fromXml(root.field(validationOverridesField).asString());
+        List<Deployment> deployments = deploymentsFromSlime(root.field(deploymentsField));
+        DeploymentJobs deploymentJobs = deploymentJobsFromSlime(root.field(deploymentJobsField));
+        Change deploying = changeFromSlime(root.field(deployingField));
+        Change outstandingChange = changeFromSlime(root.field(outstandingChangeField));
+        Optional<IssueId> ownershipIssueId = Serializers.optionalString(root.field(ownershipIssueIdField)).map(IssueId::from);
+        Optional<User> owner = Serializers.optionalString(root.field(ownerField)).map(User::from);
+        OptionalInt majorVersion = Serializers.optionalInteger(root.field(majorVersionField));
+        ApplicationMetrics metrics = new ApplicationMetrics(root.field(queryQualityField).asDouble(),
+                                                            root.field(writeQualityField).asDouble());
+        Optional<String> pemDeployKey = Serializers.optionalString(root.field(pemDeployKeyField));
+        List<AssignedRotation> assignedRotations = assignedRotationsFromSlime(deploymentSpec, root);
+        RotationStatus rotationStatus = rotationStatusFromSlime(root);
+
+        return new Application(id, createdAt, deploymentSpec, validationOverrides, deployments, deploymentJobs,
+                            deploying, outstandingChange, ownershipIssueId, owner, majorVersion, metrics,
+                            pemDeployKey, assignedRotations, rotationStatus);
+    }
+
+    private List<Deployment> deploymentsFromSlime(Inspector array) {
+        List<Deployment> deployments = new ArrayList<>();
+        array.traverse((ArrayTraverser) (int i, Inspector item) -> deployments.add(deploymentFromSlime(item)));
+        return deployments;
+    }
+
+    private Deployment deploymentFromSlime(Inspector deploymentObject) {
+        return new Deployment(zoneIdFromSlime(deploymentObject.field(zoneField)),
+                              applicationVersionFromSlime(deploymentObject.field(applicationPackageRevisionField)),
+                              Version.fromString(deploymentObject.field(versionField).asString()),
+                              Instant.ofEpochMilli(deploymentObject.field(deployTimeField).asLong()),
+                              clusterUtilsMapFromSlime(deploymentObject.field(clusterUtilsField)),
+                              clusterInfoMapFromSlime(deploymentObject.field(clusterInfoField)),
+                              deploymentMetricsFromSlime(deploymentObject.field(deploymentMetricsField)),
+                              DeploymentActivity.create(Serializers.optionalInstant(deploymentObject.field(lastQueriedField)),
+                                                        Serializers.optionalInstant(deploymentObject.field(lastWrittenField)),
+                                                        Serializers.optionalDouble(deploymentObject.field(lastQueriesPerSecondField)),
+                                                        Serializers.optionalDouble(deploymentObject.field(lastWritesPerSecondField))));
+    }
+
+    private DeploymentMetrics deploymentMetricsFromSlime(Inspector object) {
+        Optional<Instant> instant = object.field(deploymentMetricsUpdateTime).valid() ?
+                Optional.of(Instant.ofEpochMilli(object.field(deploymentMetricsUpdateTime).asLong())) :
+                Optional.empty();
+        return new DeploymentMetrics(object.field(deploymentMetricsQPSField).asDouble(),
+                                     object.field(deploymentMetricsWPSField).asDouble(),
+                                     object.field(deploymentMetricsDocsField).asDouble(),
+                                     object.field(deploymentMetricsQueryLatencyField).asDouble(),
+                                     object.field(deploymentMetricsWriteLatencyField).asDouble(),
+                                     instant,
+                                     deploymentWarningsFrom(object.field(deploymentMetricsWarningsField)));
+    }
+
+    private Map<DeploymentMetrics.Warning, Integer> deploymentWarningsFrom(Inspector object) {
+        Map<DeploymentMetrics.Warning, Integer> warnings = new HashMap<>();
+        object.traverse((ObjectTraverser) (name, value) -> warnings.put(DeploymentMetrics.Warning.valueOf(name),
+                                                                        (int) value.asLong()));
+        return Collections.unmodifiableMap(warnings);
+    }
+
+    private RotationStatus rotationStatusFromSlime(Inspector parentObject) {
+        var object = parentObject.field(rotationStatusField);
+        var statusMap = new LinkedHashMap<RotationId, Map<ZoneId, RotationState>>();
+        object.traverse((ArrayTraverser) (idx, statusObject) -> statusMap.put(new RotationId(statusObject.field(rotationIdField).asString()),
+                                                                              singleRotationStatusFromSlime(statusObject.field(statusField))));
+        return RotationStatus.from(statusMap);
+    }
+
+    private Map<ZoneId, RotationState> singleRotationStatusFromSlime(Inspector object) {
+        if (!object.valid()) {
+            return Collections.emptyMap();
+        }
+        Map<ZoneId, RotationState> rotationStatus = new LinkedHashMap<>();
+        object.traverse((ArrayTraverser) (idx, statusObject) -> {
+            var zone = zoneIdFromSlime(statusObject);
+            var status = RotationState.valueOf(statusObject.field(rotationStateField).asString());
+            rotationStatus.put(zone, status);
+        });
+        return Collections.unmodifiableMap(rotationStatus);
+    }
+
+    private Map<ClusterSpec.Id, ClusterInfo> clusterInfoMapFromSlime   (Inspector object) {
+        Map<ClusterSpec.Id, ClusterInfo> map = new HashMap<>();
+        object.traverse((String name, Inspector value) -> map.put(new ClusterSpec.Id(name), clusterInfoFromSlime(value)));
+        return map;
+    }
+
+    private Map<ClusterSpec.Id, ClusterUtilization> clusterUtilsMapFromSlime(Inspector object) {
+        Map<ClusterSpec.Id, ClusterUtilization> map = new HashMap<>();
+        object.traverse((String name, Inspector value) -> map.put(new ClusterSpec.Id(name), clusterUtililzationFromSlime(value)));
+        return map;
+    }
+
+    private ClusterUtilization clusterUtililzationFromSlime(Inspector object) {
+        double cpu = object.field(clusterUtilsCpuField).asDouble();
+        double mem = object.field(clusterUtilsMemField).asDouble();
+        double disk = object.field(clusterUtilsDiskField).asDouble();
+        double diskBusy = object.field(clusterUtilsDiskBusyField).asDouble();
+
+        return new ClusterUtilization(mem, cpu, disk, diskBusy);
+    }
+
+    private ClusterInfo clusterInfoFromSlime(Inspector inspector) {
+        String flavor = inspector.field(clusterInfoFlavorField).asString();
+        int cost = (int)inspector.field(clusterInfoCostField).asLong();
+        String type = inspector.field(clusterInfoTypeField).asString();
+        double flavorCpu = inspector.field(clusterInfoCpuField).asDouble();
+        double flavorMem = inspector.field(clusterInfoMemField).asDouble();
+        double flavorDisk = inspector.field(clusterInfoDiskField).asDouble();
+
+        List<String> hostnames = new ArrayList<>();
+        inspector.field(clusterInfoHostnamesField).traverse((ArrayTraverser)(int index, Inspector value) -> hostnames.add(value.asString()));
+        return new ClusterInfo(flavor, cost, flavorCpu, flavorMem, flavorDisk, ClusterSpec.Type.from(type), hostnames);
+    }
+
+    private ZoneId zoneIdFromSlime(Inspector object) {
+        return ZoneId.from(object.field(environmentField).asString(), object.field(regionField).asString());
+    }
+
+    private ApplicationVersion applicationVersionFromSlime(Inspector object) {
+        if ( ! object.valid()) return ApplicationVersion.unknown;
+        OptionalLong applicationBuildNumber = Serializers.optionalLong(object.field(applicationBuildNumberField));
+        Optional<SourceRevision> sourceRevision = sourceRevisionFromSlime(object.field(sourceRevisionField));
+        if (sourceRevision.isEmpty() || applicationBuildNumber.isEmpty()) {
+            return ApplicationVersion.unknown;
+        }
+        Optional<String> authorEmail = Serializers.optionalString(object.field(authorEmailField));
+        Optional<Version> compileVersion = Serializers.optionalString(object.field(compileVersionField)).map(Version::fromString);
+        Optional<Instant> buildTime = Serializers.optionalInstant(object.field(buildTimeField));
+
+        if (authorEmail.isEmpty())
+            return ApplicationVersion.from(sourceRevision.get(), applicationBuildNumber.getAsLong());
+
+        if (compileVersion.isEmpty() || buildTime.isEmpty())
+            return ApplicationVersion.from(sourceRevision.get(), applicationBuildNumber.getAsLong(), authorEmail.get());
+
+        return ApplicationVersion.from(sourceRevision.get(), applicationBuildNumber.getAsLong(), authorEmail.get(),
+                                       compileVersion.get(), buildTime.get());
+    }
+
+    private Optional<SourceRevision> sourceRevisionFromSlime(Inspector object) {
+        if ( ! object.valid()) return Optional.empty();
+        return Optional.of(new SourceRevision(object.field(repositoryField).asString(),
+                                              object.field(branchField).asString(),
+                                              object.field(commitField).asString()));
+    }
+
+    private DeploymentJobs deploymentJobsFromSlime(Inspector object) {
+        OptionalLong projectId = Serializers.optionalLong(object.field(projectIdField));
+        List<JobStatus> jobStatusList = jobStatusListFromSlime(object.field(jobStatusField));
+        Optional<IssueId> issueId = Serializers.optionalString(object.field(issueIdField)).map(IssueId::from);
+        boolean builtInternally = object.field(builtInternallyField).asBool();
+
+        return new DeploymentJobs(projectId, jobStatusList, issueId, builtInternally);
+    }
+
+    private Change changeFromSlime(Inspector object) {
+        if ( ! object.valid()) return Change.empty();
+        Inspector versionFieldValue = object.field(versionField);
+        Change change = Change.empty();
+        if (versionFieldValue.valid())
+            change = Change.of(Version.fromString(versionFieldValue.asString()));
+        if (object.field(applicationBuildNumberField).valid())
+            change = change.with(applicationVersionFromSlime(object));
+        if (object.field(pinnedField).asBool())
+            change = change.withPin();
+        return change;
+    }
+
+    private List<JobStatus> jobStatusListFromSlime(Inspector array) {
+        List<JobStatus> jobStatusList = new ArrayList<>();
+        array.traverse((ArrayTraverser) (int i, Inspector item) -> jobStatusFromSlime(item).ifPresent(jobStatusList::add));
+        return jobStatusList;
+    }
+
+    private Optional<JobStatus> jobStatusFromSlime(Inspector object) {
+        // if the job type has since been removed, ignore it
+        Optional<JobType> jobType =
+                JobType.fromOptionalJobName(object.field(jobTypeField).asString());
+        if (jobType.isEmpty()) return Optional.empty();
+
+        Optional<JobError> jobError = Optional.empty();
+        if (object.field(errorField).valid())
+            jobError = Optional.of(JobError.valueOf(object.field(errorField).asString()));
+
+        return Optional.of(new JobStatus(jobType.get(),
+                                         jobError,
+                                         jobRunFromSlime(object.field(lastTriggeredField)),
+                                         jobRunFromSlime(object.field(lastCompletedField)),
+                                         jobRunFromSlime(object.field(firstFailingField)),
+                                         jobRunFromSlime(object.field(lastSuccessField)),
+                                         Serializers.optionalLong(object.field(pausedUntilField))));
+    }
+
+    private Optional<JobStatus.JobRun> jobRunFromSlime(Inspector object) {
+        if ( ! object.valid()) return Optional.empty();
+        return Optional.of(new JobStatus.JobRun(object.field(jobRunIdField).asLong(),
+                                                new Version(object.field(versionField).asString()),
+                                                applicationVersionFromSlime(object.field(revisionField)),
+                                                Serializers.optionalString(object.field(sourceVersionField)).map(Version::fromString),
+                                                Optional.of(object.field(sourceApplicationField)).filter(Inspector::valid).map(this::applicationVersionFromSlime),
+                                                object.field(reasonField).asString(),
+                                                Instant.ofEpochMilli(object.field(atField).asLong())));
+    }
+
+    private List<AssignedRotation> assignedRotationsFromSlime(DeploymentSpec deploymentSpec, Inspector root) {
+        var assignedRotations = new LinkedHashMap<EndpointId, AssignedRotation>();
+
+        root.field(assignedRotationsField).traverse((ArrayTraverser) (idx, inspector) -> {
+            var clusterId = new ClusterSpec.Id(inspector.field(assignedRotationClusterField).asString());
+            var endpointId = EndpointId.of(inspector.field(assignedRotationEndpointField).asString());
+            var rotationId = new RotationId(inspector.field(assignedRotationRotationField).asString());
+            var regions = deploymentSpec.endpoints().stream()
+                                        .filter(endpoint -> endpoint.endpointId().equals(endpointId.id()))
+                                        .flatMap(endpoint -> endpoint.regions().stream())
+                                        .collect(Collectors.toSet());
+            assignedRotations.putIfAbsent(endpointId, new AssignedRotation(clusterId, endpointId, rotationId, regions));
+        });
+
+        return List.copyOf(assignedRotations.values());
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -334,7 +334,7 @@ public class CuratorDb {
     // -------------- Instances ---------------------------------------------
 
     public void writeInstance(Instance instance) {
-        curator.set(applicationPath(instance.id()), asJson(instanceSerializer.toSlime(instance)));
+        curator.set(oldApplicationPath(instance.id()), asJson(instanceSerializer.toSlime(instance)));
         curator.set(instancePath(instance.id()), asJson(instanceSerializer.toSlime(instance)));
     }
 
@@ -363,9 +363,29 @@ public class CuratorDb {
 
     public void removeInstance(ApplicationId id) {
         // WARNING: This is part of a multi-step data move operation, so don't touch!!!
-        curator.delete(applicationPath(id));
+        curator.delete(oldApplicationPath(id));
         curator.delete(instancePath(id));
     }
+
+    /**
+     * Migration plan:
+     *
+     * Add filter for reading only Instance from old application path           MERGED
+     * Write instance to Instance and old application path                      MERGED
+     *
+     * Write Instance to instance and application and old application paths     DONE
+     * Read Instance from instance path                                         DONE
+     * Duplicate Application from Instance, with helper classes                 DONE
+     * Write Application to instance and application and old application paths  DONE
+     * Read Application from instance path                                      DONE
+     * Use Application where applicable
+     *
+     * Stop writing Instance to old application path
+     * Read Application from application path
+     *
+     * Stop writing instance part to application path, and vice versa
+     * Remove unused parts of Instance and Application
+     */
 
     // -------------- Job Runs ------------------------------------------------
 
@@ -582,7 +602,7 @@ public class CuratorDb {
         return tenantRoot.append(name.value());
     }
 
-    private static Path applicationPath(ApplicationId application) {
+    private static Path oldApplicationPath(ApplicationId application) {
         return applicationRoot.append(application.serializedForm());
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -331,7 +331,7 @@ public class CuratorDb {
         curator.delete(tenantPath(name));
     }
 
-    // -------------- Application ---------------------------------------------
+    // -------------- Instances ---------------------------------------------
 
     public void writeInstance(Instance instance) {
         curator.set(applicationPath(instance.id()), asJson(instanceSerializer.toSlime(instance)));
@@ -339,7 +339,7 @@ public class CuratorDb {
     }
 
     public Optional<Instance> readInstance(ApplicationId application) {
-        return readSlime(applicationPath(application)).map(instanceSerializer::fromSlime);
+        return readSlime(instancePath(application)).map(instanceSerializer::fromSlime);
     }
 
     public List<Instance> readInstances() {
@@ -351,10 +351,7 @@ public class CuratorDb {
     }
 
     private Stream<ApplicationId> readInstanceIds() {
-        return curator.getChildren(applicationRoot).stream()
-                      .filter(id -> id.split(":").length == 3)
-                      .distinct()
-                      .map(ApplicationId::fromSerializedForm);
+        return curator.getChildren(instanceRoot).stream().map(ApplicationId::fromSerializedForm);
     }
 
     private List<Instance> readInstances(Predicate<ApplicationId> instanceFilter) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/OldCuratorDb.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/OldCuratorDb.java
@@ -337,8 +337,7 @@ public class OldCuratorDb {
     }
 
     public Optional<Instance> readInstance(ApplicationId application) {
-        return readSlime(instancePath(application)).or(() -> readSlime(applicationPath(application)))
-                                                   .map(instanceSerializer::fromSlime);
+        return readSlime(applicationPath(application)).map(instanceSerializer::fromSlime);
     }
 
     public List<Instance> readInstances() {
@@ -350,11 +349,10 @@ public class OldCuratorDb {
     }
 
     private Stream<ApplicationId> readInstanceIds() {
-        return Stream.concat(curator.getChildren(applicationRoot).stream()
-                                    .filter(id -> id.split(":").length == 3),
-                             curator.getChildren(instanceRoot).stream())
-                     .distinct()
-                     .map(ApplicationId::fromSerializedForm);
+        return curator.getChildren(applicationRoot).stream()
+                      .filter(id -> id.split(":").length == 3)
+                      .distinct()
+                      .map(ApplicationId::fromSerializedForm);
     }
 
     private List<Instance> readInstances(Predicate<ApplicationId> instanceFilter) {


### PR DESCRIPTION
@mpolden please review.

This covers

     * Write Instance to instance and application and old application paths     DONE
     * Read Instance from instance path                                         DONE
     * Duplicate Application from Instance, with helper classes                 DONE
     * Write Application to instance and application and old application paths  DONE
     * Read Application from instance path                                      DONE

Next step is to replaces usages of `Instance` with `Application`, and this may or may not be part of this release. 

It is critical this PR is not merged and released before the previous PR is already released to all controllers. 