### PR TITLE
Remove Export-Package's added to support Vespa 6 bundles on 7.

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
@@ -59,18 +59,6 @@ public class ExportPackages {
         for (int i = 1; i < jars.length; ++i) {
             out.append(", ").append(getExportedPackages(jars[i]));
         }
-
-        //TODO: temporary additions for backwards compatibility with Vespa 6. Remove when all apps have been built with 7
-        out.append(", ")
-                .append("javax.annotation, ")
-                .append("javax.activation, ")
-                .append("javax.xml.bind.annotation.adapters, ")
-                .append("javax.xml.bind.annotation, ")
-                .append("javax.xml.bind.attachment, ")
-                .append("javax.xml.bind.helpers, ")
-                .append("javax.xml.bind.util, ")
-                .append("javax.xml.bind");
-
         return out.toString();
     }
 


### PR DESCRIPTION
I have verified that no bundles in my set of (almost) all hosted apps require these version-less imports after building with Vespa 7.

FYI: @bjorncs 