### PR TITLE
added function identifying which elements matched

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -26,6 +26,8 @@ using namespace search::grouping;
 using search::DocumentMetaData;
 using search::LidUsageStats;
 using search::FeatureSet;
+using search::StructFieldMapper;
+using search::MatchingElements;
 using search::attribute::IAttributeContext;
 using search::fef::MatchDataLayout;
 using search::fef::MatchData;
@@ -366,6 +368,19 @@ Matcher::getRankFeatures(const DocsumRequest & req, ISearchContext & searchCtx,
                          IAttributeContext & attrCtx, SessionManager &sessionMgr)
 {
     return getFeatureSet(req, searchCtx, attrCtx, sessionMgr, false);
+}
+
+MatchingElements
+Matcher::get_matching_elements(const DocsumRequest &req, ISearchContext &search_ctx,
+                               IAttributeContext &attr_ctx, SessionManager &session_manager,
+                               const StructFieldMapper &field_mapper)
+{
+    (void) req;
+    (void) search_ctx;
+    (void) attr_ctx;
+    (void) session_manager;
+    (void) field_mapper;
+    return MatchingElements();
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.h
@@ -10,6 +10,8 @@
 #include <vespa/searchcore/proton/matching/querylimiter.h>
 #include <vespa/searchcommon/attribute/i_attribute_functor.h>
 #include <vespa/searchlib/common/featureset.h>
+#include <vespa/searchlib/common/struct_field_mapper.h>
+#include <vespa/searchlib/common/matching_elements.h>
 #include <vespa/searchlib/common/resultset.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/fef/fef.h>
@@ -49,6 +51,8 @@ private:
     using DocsumRequest = search::engine::DocsumRequest;
     using Properties = search::fef::Properties;
     using my_clock = std::chrono::steady_clock;
+    using StructFieldMapper = search::StructFieldMapper;
+    using MatchingElements = search::MatchingElements;
     IndexEnvironment              _indexEnv;
     search::fef::BlueprintFactory _blueprintFactory;
     search::fef::RankSetup::SP    _rankSetup;
@@ -154,6 +158,22 @@ public:
     search::FeatureSet::SP
     getRankFeatures(const DocsumRequest & req, ISearchContext & searchCtx,
                     IAttributeContext & attrCtx, SessionManager &sessionManager);
+
+    /**
+     * Perform partial matching for the documents in the given docsum request
+     * to identify which struct field elements the query matched.
+     *
+     * @param req the docsum request
+     * @param search_ctx abstract view of searchable data
+     * @param attr_ctx abstract view of attribute data
+     * @param session_manager multilevel grouping session and query cache
+     * @param field_mapper knows which fields to collect information
+     *                     about and how they relate to each other
+     * @return matching elements
+     **/
+    MatchingElements get_matching_elements(const DocsumRequest &req, ISearchContext &search_ctx,
+                                           IAttributeContext &attr_ctx, SessionManager &session_manager,
+                                           const StructFieldMapper &field_mapper);
 
     /**
      * @return true if this rankprofile has summary-features enabled

--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -100,9 +100,11 @@ vespa_define_module(
     src/tests/common/bitvector
     src/tests/common/foregroundtaskexecutor
     src/tests/common/location
+    src/tests/common/matching_elements
     src/tests/common/packets
     src/tests/common/resultset
     src/tests/common/sequencedtaskexecutor
+    src/tests/common/struct_field_mapper
     src/tests/common/summaryfeatures
     src/tests/diskindex/bitvector
     src/tests/diskindex/diskindex

--- a/searchlib/src/tests/common/matching_elements/CMakeLists.txt
+++ b/searchlib/src/tests/common/matching_elements/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchlib_common_matching_elements_test_app TEST
+    SOURCES
+    matching_elements_test.cpp
+    DEPENDS
+    searchlib
+    gtest
+)
+vespa_add_test(NAME searchlib_common_matching_elements_test_app COMMAND searchlib_common_matching_elements_test_app)

--- a/searchlib/src/tests/common/matching_elements/matching_elements_test.cpp
+++ b/searchlib/src/tests/common/matching_elements/matching_elements_test.cpp
@@ -1,0 +1,45 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/searchlib/common/matching_elements.h>
+
+using namespace search;
+
+namespace {
+
+std::vector<uint32_t> vec(const std::initializer_list<uint32_t> list) {
+    return std::vector<uint32_t>(list);
+}
+
+}
+
+struct MatchingElementsTest : ::testing::Test {
+    MatchingElements matches;
+    MatchingElementsTest() : matches() {
+        matches.add_matching_elements(1, "foo", vec({1, 3, 5}));
+        matches.add_matching_elements(1, "bar", vec({2, 4, 6}));
+        matches.add_matching_elements(2, "foo", vec({1, 2, 3}));
+        matches.add_matching_elements(2, "bar", vec({4, 5, 6}));
+        matches.add_matching_elements(2, "foo", vec({2, 3, 5}));
+        matches.add_matching_elements(2, "bar", vec({2, 4, 5}));
+    }
+    ~MatchingElementsTest() = default;
+};
+
+
+TEST_F(MatchingElementsTest, require_that_added_matches_can_be_looked_up) {
+    EXPECT_EQ(matches.get_matching_elements(1, "foo"), vec({1, 3, 5}));
+    EXPECT_EQ(matches.get_matching_elements(1, "bar"), vec({2, 4, 6}));
+}
+
+TEST_F(MatchingElementsTest, require_that_added_matches_are_merged) {
+    EXPECT_EQ(matches.get_matching_elements(2, "foo"), vec({1, 2, 3, 5}));
+    EXPECT_EQ(matches.get_matching_elements(2, "bar"), vec({2, 4, 5, 6}));
+}
+
+TEST_F(MatchingElementsTest, require_that_nonexisting_lookup_gives_empty_result) {
+    EXPECT_EQ(matches.get_matching_elements(1, "bogus"), vec({}));
+    EXPECT_EQ(matches.get_matching_elements(7, "foo"), vec({}));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/common/struct_field_mapper/CMakeLists.txt
+++ b/searchlib/src/tests/common/struct_field_mapper/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchlib_common_struct_field_mapper_test_app TEST
+    SOURCES
+    struct_field_mapper_test.cpp
+    DEPENDS
+    searchlib
+    gtest
+)
+vespa_add_test(NAME searchlib_common_struct_field_mapper_test_app COMMAND searchlib_common_struct_field_mapper_test_app)

--- a/searchlib/src/tests/common/struct_field_mapper/struct_field_mapper_test.cpp
+++ b/searchlib/src/tests/common/struct_field_mapper/struct_field_mapper_test.cpp
@@ -1,0 +1,52 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/searchlib/common/struct_field_mapper.h>
+
+using namespace search;
+
+namespace {
+
+std::string str(const vespalib::string &s) { return std::string(s.data(), s.size()); }
+
+}
+
+struct StructFieldMapperTest : ::testing::Test {
+    StructFieldMapper mapper;
+    StructFieldMapperTest() : mapper() {
+        mapper.add_mapping("foo", "foo.a");
+        mapper.add_mapping("foo", "foo.b");
+        mapper.add_mapping("bar", "bar.x");
+        mapper.add_mapping("bar", "bar.y");
+    }
+    ~StructFieldMapperTest() = default;
+};
+
+TEST_F(StructFieldMapperTest, require_that_struct_field_can_be_identified) {
+    EXPECT_TRUE(mapper.is_struct_field("foo"));
+    EXPECT_TRUE(mapper.is_struct_field("bar"));
+    EXPECT_TRUE(!mapper.is_struct_field("foo.a"));
+    EXPECT_TRUE(!mapper.is_struct_field("bar.x"));
+    EXPECT_TRUE(!mapper.is_struct_field("bogus"));
+}
+
+TEST_F(StructFieldMapperTest, require_that_struct_subfield_can_be_identified) {
+    EXPECT_TRUE(!mapper.is_struct_subfield("foo"));
+    EXPECT_TRUE(!mapper.is_struct_subfield("bar"));
+    EXPECT_TRUE(mapper.is_struct_subfield("foo.a"));
+    EXPECT_TRUE(mapper.is_struct_subfield("bar.x"));
+    EXPECT_TRUE(!mapper.is_struct_subfield("bogus"));
+}
+
+TEST_F(StructFieldMapperTest, require_that_struct_subfield_maps_to_enclosing_struct_field_name) {
+    EXPECT_EQ(str(mapper.get_struct_field("foo.a")), str("foo"));
+    EXPECT_EQ(str(mapper.get_struct_field("foo.b")), str("foo"));
+    EXPECT_EQ(str(mapper.get_struct_field("bar.x")), str("bar"));
+    EXPECT_EQ(str(mapper.get_struct_field("bar.y")), str("bar"));
+}
+
+TEST_F(StructFieldMapperTest, require_that_nonexisting_struct_subfield_maps_to_empty_string) {
+    EXPECT_EQ(str(mapper.get_struct_field("bogus")), str(""));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/common/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/common/CMakeLists.txt
@@ -18,6 +18,7 @@ vespa_add_library(searchlib_common OBJECT
     location.cpp
     locationiterators.cpp
     mapnames.cpp
+    matching_elements.cpp
     packets.cpp
     partialbitvector.cpp
     resultset.cpp
@@ -28,6 +29,7 @@ vespa_add_library(searchlib_common OBJECT
     sortdata.cpp
     sortresults.cpp
     sortspec.cpp
+    struct_field_mapper.cpp
     threaded_compactable_lid_space.cpp
     tunefileinfo.cpp
     DEPENDS

--- a/searchlib/src/vespa/searchlib/common/matching_elements.cpp
+++ b/searchlib/src/vespa/searchlib/common/matching_elements.cpp
@@ -1,0 +1,31 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "matching_elements.h"
+#include <algorithm>
+
+namespace search {
+
+MatchingElements::MatchingElements() = default;
+MatchingElements::~MatchingElements() = default;
+
+void
+MatchingElements::add_matching_elements(uint32_t docid, const vespalib::string &struct_field_name, const std::vector<uint32_t> &elements)
+{
+    auto &list = _map[key_t(docid, struct_field_name)];
+    std::vector<uint32_t> new_list;
+    std::set_union(list.begin(), list.end(), elements.begin(), elements.end(), std::back_inserter(new_list));
+    list = std::move(new_list);
+}
+
+const std::vector<uint32_t> &
+MatchingElements::get_matching_elements(uint32_t docid, const vespalib::string &struct_field_name) const
+{
+    static const std::vector<uint32_t> empty;
+    auto res = _map.find(key_t(docid, struct_field_name));
+    if (res == _map.end()) {
+        return empty;
+    }
+    return res->second;
+}
+
+} // namespace search

--- a/searchlib/src/vespa/searchlib/common/matching_elements.h
+++ b/searchlib/src/vespa/searchlib/common/matching_elements.h
@@ -1,0 +1,31 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+#include <utility>
+#include <map>
+#include <vector>
+#include <vespa/vespalib/stllike/string.h>
+
+namespace search {
+
+/**
+ * Keeps track of which elements matched the query for a set of struct
+ * fields across multiple documents.
+ **/
+class MatchingElements
+{
+private:
+    using key_t = std::pair<uint32_t, vespalib::string>;
+    using value_t = std::vector<uint32_t>;
+
+    std::map<key_t, value_t> _map;
+
+public:
+    MatchingElements();
+    ~MatchingElements();
+
+    void add_matching_elements(uint32_t docid, const vespalib::string &struct_field_name, const std::vector<uint32_t> &elements);
+    const std::vector<uint32_t> &get_matching_elements(uint32_t docid, const vespalib::string &struct_field_name) const;
+};
+
+} // namespace search

--- a/searchlib/src/vespa/searchlib/common/struct_field_mapper.cpp
+++ b/searchlib/src/vespa/searchlib/common/struct_field_mapper.cpp
@@ -1,0 +1,10 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "struct_field_mapper.h"
+
+namespace search {
+
+StructFieldMapper::StructFieldMapper() = default;
+StructFieldMapper::~StructFieldMapper() = default;
+
+} // namespace search

--- a/searchlib/src/vespa/searchlib/common/struct_field_mapper.h
+++ b/searchlib/src/vespa/searchlib/common/struct_field_mapper.h
@@ -1,0 +1,47 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/stllike/string.h>
+#include <set>
+#include <map>
+
+namespace search {
+
+/**
+ * Keeps track of a set of struct field names and enables mapping the
+ * full name of struct subfields into the name of the enclosing struct
+ * field.
+ **/
+class StructFieldMapper
+{
+private:
+    std::set<vespalib::string> _struct_fields;
+    std::map<vespalib::string,vespalib::string> _struct_subfields;
+
+public:
+    StructFieldMapper();
+    ~StructFieldMapper();
+    void add_mapping(const vespalib::string &struct_field_name,
+                     const vespalib::string &struct_subfield_name)
+    {
+        _struct_fields.insert(struct_field_name);
+        _struct_subfields[struct_subfield_name] = struct_field_name;
+    }
+    bool is_struct_field(const vespalib::string &field_name) const {
+        return (_struct_fields.count(field_name) > 0);
+    }
+    bool is_struct_subfield(const vespalib::string &field_name) const {
+        return (_struct_subfields.find(field_name) != _struct_subfields.end());
+    }
+    const vespalib::string &get_struct_field(const vespalib::string &struct_subfield_name) const {
+        static const vespalib::string empty;
+        auto res = _struct_subfields.find(struct_subfield_name);
+        if (res == _struct_subfields.end()) {
+            return empty;
+        }
+        return res->second;
+    }
+};
+
+} // namespace search


### PR DESCRIPTION
only a skeleton for now; outlines the interface between the summary
generator and the matcher.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
@toregge FYI