### PR TITLE
Inhibit merges when ideal node is unavailable in pending state

### DIFF
--- a/storage/src/vespa/storage/distributor/statechecker.cpp
+++ b/storage/src/vespa/storage/distributor/statechecker.cpp
@@ -66,6 +66,7 @@ StateChecker::Context::Context(const DistributorComponent& c,
     : bucket(bucket_),
       siblingBucket(c.getSibling(bucket.getBucketId())),
       systemState(distributorBucketSpace.getClusterState()),
+      pending_cluster_state(c.getDistributor().pendingClusterStateOrNull(bucket_.getBucketSpace())),
       distributorConfig(c.getDistributor().getConfig()),
       distribution(distributorBucketSpace.getDistribution()),
       gcTimeCalculator(c.getDistributor().getBucketIdHasher(),
@@ -75,12 +76,11 @@ StateChecker::Context::Context(const DistributorComponent& c,
       db(distributorBucketSpace.getBucketDatabase()),
       stats(statsTracker)
 {
-    idealState =
-        distribution.getIdealStorageNodes(systemState, bucket.getBucketId());
+    idealState = distribution.getIdealStorageNodes(systemState, bucket.getBucketId());
     unorderedIdealState.insert(idealState.begin(), idealState.end());
 }
 
-StateChecker::Context::~Context() {}
+StateChecker::Context::~Context() = default;
 
 std::string
 StateChecker::Context::toString() const
@@ -99,12 +99,7 @@ StateChecker::Context::toString() const
     return ss.str();
 }
 
-StateChecker::StateChecker()
-{
-}
-
-StateChecker::~StateChecker()
-{
-}
+StateChecker::StateChecker()  = default;
+StateChecker::~StateChecker() = default;
 
 }

--- a/storage/src/vespa/storage/distributor/statechecker.h
+++ b/storage/src/vespa/storage/distributor/statechecker.h
@@ -64,6 +64,7 @@ public:
 
         // Common
         const lib::ClusterState& systemState;
+        const lib::ClusterState* pending_cluster_state; // nullptr if no state is pending.
         const DistributorConfiguration& distributorConfig;
         const lib::Distribution& distribution;
 


### PR DESCRIPTION
@geirst please review

Upon entering a cluster state transition edge the distributor will
prune all replicas from its DB that are on nodes that are unavailable
in the _pending_ state. As long as this state is pending, the _current_
state will include these nodes as available. But since replicas for
the unavailable node(s) have been pruned away, started merges that
involve these nodes as part of their chain are doomed to fail. We
therefore inhibit such merges from being started in the first place.
