### PR TITLE
Add config override for simulating bucket info request processing latency

### DIFF
--- a/storage/src/tests/bucketdb/bucketmanagertest.cpp
+++ b/storage/src/tests/bucketdb/bucketmanagertest.cpp
@@ -156,7 +156,7 @@ void BucketManagerTest::setupTestEnvironment(bool fakePersistenceLayer,
     _node->setTypeRepo(repo);
     _node->setupDummyPersistence();
     // Set up the 3 links
-    auto manager = std::make_unique<BucketManager>("", _node->getComponentRegister());
+    auto manager = std::make_unique<BucketManager>(config.getConfigId(), _node->getComponentRegister());
     _manager = manager.get();
     _top->push_back(std::move(manager));
     if (fakePersistenceLayer) {

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -1,13 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 /**
- * @class storage::BucketManager
- * @ingroup bucketdb
+ * Storage link handling requests concerning buckets.
  *
- * @brief Storage link handling requests concerning buckets.
- *
- * @author H�kon Humberset
- * @date 2006-01-16
- * @version $Id$
+ * @author Håkon Humberset
  */
 
 #pragma once
@@ -23,6 +18,7 @@
 #include <vespa/storageframework/generic/metric/metricupdatehook.h>
 #include <vespa/storageframework/generic/status/statusreporter.h>
 
+#include <chrono>
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
@@ -84,6 +80,7 @@ private:
     ServiceLayerComponent _component;
     std::shared_ptr<BucketManagerMetrics> _metrics;
     framework::Thread::UP _thread;
+    std::chrono::milliseconds _simulated_processing_delay;
 
     BucketManager(const BucketManager&);
     BucketManager& operator=(const BucketManager&);

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -80,3 +80,7 @@ switch_new_meta_data_flow bool default=false restart
 ## operations.
 bucket_rechecking_chunk_size int default=100
 
+## If greater than zero, simulates added latency caused by CPU processing during
+## full bucket info requests. The latency is added per batch of operations processed.
+## Only useful for testing!
+simulated_bucket_request_latency_msec int default=0


### PR DESCRIPTION
@geirst please review. This one is needed to complete a realistic testing of two-phase state transitions.

Simulates added request latency caused by the BucketManager computing bucket
ownership for a very large number of buckets.

Fetched at BucketManager init only, so not a dynamic config. This is only
meant for internal testing so should not have any practical consequences.