### PR TITLE
fix test case fail in LogFormatterTestCase

### DIFF
--- a/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFormatter.java
+++ b/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFormatter.java
@@ -22,13 +22,13 @@ public class LogFormatter extends Formatter {
     static SimpleDateFormat yyyyMMdd;
 
     static {
-        ddMMMyyyy = new SimpleDateFormat("[dd/MMM/yyyy:HH:mm:ss Z]");
+        ddMMMyyyy = new SimpleDateFormat("[dd/MMM/yyyy:HH:mm:ss Z]", Locale.US);
         ddMMMyyyy.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        dfMMM = new SimpleDateFormat("MMM");
+        dfMMM = new SimpleDateFormat("MMM", Locale.US);
         dfMMM.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        yyyyMMdd = new SimpleDateFormat("[yyyy-MM-dd HH:mm:ss]");
+        yyyyMMdd = new SimpleDateFormat("[yyyy-MM-dd HH:mm:ss]", Locale.US);
         yyyyMMdd.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
@@ -102,7 +102,7 @@ public class LogFormatter extends Formatter {
      * </ul>
      */
     public static String insertDate(String pattern, long time) {
-        DateFormat df = new SimpleDateFormat("yyyy.MM.dd:HH:mm:ss.SSS Z");
+        DateFormat df = new SimpleDateFormat("yyyy.MM.dd:HH:mm:ss.SSS Z", Locale.US);
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date date = new Date(time);
         String datetime = df.format(date);

--- a/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFormatter.java
+++ b/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFormatter.java
@@ -4,6 +4,7 @@ package com.yahoo.container.logging;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;


### PR DESCRIPTION
better define locale to us avoiding some special locale such as china/france which called sep to 9月/sept
the test case will fail in enviroment using zh_CN.UTF-8
org.junit.ComparisonFailure: expected:<test20030825133035[Aug]> but was:<test20030825133035[8月]>

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
