### PR TITLE
Add new node reboot events

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -141,6 +141,8 @@ public class History {
             rebooted(false),
             // The node upgraded its OS (implies a reboot)
             osUpgraded(false),
+            // The node verified its firmware (whether this resulted in a reboot depends on the node model)
+            firmwareVerified(false),
             // The node was failed
             failed(false);
             

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -139,6 +139,8 @@ public class History {
             requested,
             // The node was rebooted
             rebooted(false),
+            // The node upgraded its OS (implies a reboot)
+            osUpgraded(false),
             // The node was failed
             failed(false);
             

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -341,6 +341,7 @@ public class NodeSerializer {
             case "requested" : return History.Event.Type.requested;
             case "rebooted" : return History.Event.Type.rebooted;
             case "osUpgraded" : return History.Event.Type.osUpgraded;
+            case "firmwareVerified" : return History.Event.Type.firmwareVerified;
         }
         throw new IllegalArgumentException("Unknown node event type '" + eventTypeString + "'");
     }
@@ -360,6 +361,7 @@ public class NodeSerializer {
             case requested: return "requested";
             case rebooted: return "rebooted";
             case osUpgraded: return "osUpgraded";
+            case firmwareVerified: return "firmwareVerified";
         }
         throw new IllegalArgumentException("Serialized form of '" + nodeEventType + "' not defined");
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -340,6 +340,7 @@ public class NodeSerializer {
             case "down" : return History.Event.Type.down;
             case "requested" : return History.Event.Type.requested;
             case "rebooted" : return History.Event.Type.rebooted;
+            case "osUpgraded" : return History.Event.Type.osUpgraded;
         }
         throw new IllegalArgumentException("Unknown node event type '" + eventTypeString + "'");
     }
@@ -358,6 +359,7 @@ public class NodeSerializer {
             case down : return "down";
             case requested: return "requested";
             case rebooted: return "rebooted";
+            case osUpgraded: return "osUpgraded";
         }
         throw new IllegalArgumentException("Serialized form of '" + nodeEventType + "' not defined");
     }


### PR DESCRIPTION
This change adds two new history events that indicate node reboots:

* `osUpgraded`
* `firmwareVerified`

The purpose of these fields is to help operators identify why nodes reboot.
Writing these events will happen in a future PR.