### PR TITLE
avoid blocking accept calls

### DIFF
--- a/vespalib/src/tests/net/socket/socket_test.cpp
+++ b/vespalib/src/tests/net/socket/socket_test.cpp
@@ -324,6 +324,15 @@ TEST("require that sockets can be set blocking and non-blocking") {
     TEST_DO(verifier.verify_blocking(false));
 }
 
+TEST("require that server sockets use non-blocking underlying socket") {
+    ServerSocket tcp_server("tcp/0");
+    ServerSocket ipc_server("ipc/file:my_socket");
+    test::SocketOptionsVerifier tcp_verifier(tcp_server.get_fd());
+    test::SocketOptionsVerifier ipc_verifier(ipc_server.get_fd());
+    TEST_DO(tcp_verifier.verify_blocking(false));
+    TEST_DO(ipc_verifier.verify_blocking(false));
+}
+
 TEST("require that tcp nodelay can be enabled and disabled") {
     SocketHandle handle(socket(my_inet(), SOCK_STREAM, 0));
     test::SocketOptionsVerifier verifier(handle.get());

--- a/vespalib/src/vespa/vespalib/net/server_socket.h
+++ b/vespalib/src/vespa/vespalib/net/server_socket.h
@@ -4,6 +4,7 @@
 
 #include "socket_handle.h"
 #include "socket_address.h"
+#include <atomic>
 
 namespace vespalib {
 
@@ -14,9 +15,9 @@ class ServerSocket
 private:
     SocketHandle _handle;
     vespalib::string _path;
+    bool _blocking;
+    std::atomic<bool> _shutdown;
 
-    explicit ServerSocket(SocketHandle handle);
-    static ServerSocket listen(const SocketSpec &spec);
     void cleanup();
 public:
     ServerSocket() : _handle(), _path() {}
@@ -30,7 +31,10 @@ public:
     int get_fd() const { return _handle.get(); }
     SocketAddress address() const;
     void shutdown();
-    bool set_blocking(bool value) { return _handle.set_blocking(value); }
+    bool set_blocking(bool value) {
+        _blocking = value;
+        return true;
+    }
     SocketHandle accept();
 };
 


### PR DESCRIPTION
this is to increase portability to platforms not implementing the
close-convention for (server) sockets.

also set all accepted sockets to blocking mode to avoid issues related
to maybe inheriting this setting from the server socket.

@toregge please review