### PR TITLE
Add config for trusting empty ZooKeeper snapshots

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -42,3 +42,8 @@ server[].id int
 server[].hostname string
 server[].quorumPort int default=2182
 server[].electionPort int default=2183
+
+# Needed when upgrading from ZooKeeper 3.4 to 3.5, see https://issues.apache.org/jira/browse/ZOOKEEPER-3056,
+# and in general where there is a zookeeper ensemble running that has had few transactions.
+# TODO: Consider setting this to false by default (and override where appropriate)
+trustEmptySnapshot bool default=true

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -651,12 +651,13 @@
                 <version>1.7</version>
             </dependency>
             <dependency>
-                <!-- Explicitly included to get Zookeeper version 3.4.14,
+            <!-- Explicitly force Zookeeper version,
                      can be excluded if you want the Zookeeper version
-                     used by curator by default -->
+                     used by curator by default
+            -->
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.14</version>
+                <version>${zookeeper.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
@@ -787,6 +788,7 @@
         <protobuf.version>3.7.0</protobuf.version>
         <surefire.version>2.22.0</surefire.version>
         <tensorflow.version>1.12.0</tensorflow.version>
+        <zookeeper.version>3.4.14</zookeeper.version>
 
         <doclint>all</doclint>
         <test.hide>true</test.hide>

--- a/zkfacade/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperServer.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperServer.java
@@ -30,7 +30,8 @@ public class ZooKeeperServer extends AbstractComponent implements Runnable {
     ZooKeeperServer(ZookeeperServerConfig zookeeperServerConfig, boolean startServer) {
         this.zookeeperServerConfig = zookeeperServerConfig;
         System.setProperty("zookeeper.jmx.log4j.disable", "true");
-        System.setProperty(ZOOKEEPER_JUTE_MAX_BUFFER, "" + zookeeperServerConfig.juteMaxBuffer());
+        System.setProperty("zookeeper.snapshot.trust.empty", Boolean.valueOf(zookeeperServerConfig.trustEmptySnapshot()).toString());
+        System.setProperty(ZOOKEEPER_JUTE_MAX_BUFFER, Integer.valueOf(zookeeperServerConfig.juteMaxBuffer()).toString());
 
         writeConfigToDisk(zookeeperServerConfig);
         zkServerThread = new Thread(this, "zookeeper server");
@@ -113,7 +114,7 @@ public class ZooKeeperServer extends AbstractComponent implements Runnable {
     public void run() {
         System.setProperty(ZOOKEEPER_JMX_LOG4J_DISABLE, "true");
         String[] args = new String[]{getDefaults().underVespaHome(zookeeperServerConfig.zooKeeperConfigFile())};
-        log.log(LogLevel.DEBUG, "Starting ZooKeeper server with config: " + args[0]);
+        log.log(LogLevel.DEBUG, "Starting ZooKeeper server with config file " + args[0]);
         log.log(LogLevel.INFO, "Trying to establish ZooKeeper quorum (from " + zookeeperServerHostnames(zookeeperServerConfig) + ")");
         org.apache.zookeeper.server.quorum.QuorumPeerMain.main(args);
     }


### PR DESCRIPTION
Needed when upgrading from ZooKeeper 3.4 to 3.5
