### PR TITLE
setup signal catching before loading bundles

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/StandaloneMain.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/StandaloneMain.java
@@ -39,9 +39,9 @@ public class StandaloneMain {
             // We're not logging at this point since the application is responsible
             // for setting up logging.
             System.out.println("debug\tInitializing application without privileges.");
+            setupSignalHandlers();
             loader.init(bundleLocation, false);
             loader.start();
-            setupSignalHandlers();
             waitForShutdown();
             System.out.println("debug\tTrying to shutdown in a controlled manner.");
             log.log(Level.INFO, "JDisc shutting down");


### PR DESCRIPTION
* We have seen many core dumps happening during class initialization
  (in JNI code) - this happens when the container gets a SIGTERM
  while initialization is still happening; the normal shutdown that
  is triggered in this case will unload shared libraries while they
  are still in use.  To counteract this trap SIGTERM early, but don't
  process it until bundle loading is complete.  The downside is that
  early shutdown will be delayed, in some cases for quite a long time.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review and merge
