### PR TITLE
Exit vespa-http-client with non-zero status upon command line option errors

### DIFF
--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/runner/Runner.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/runner/Runner.java
@@ -61,7 +61,7 @@ public class Runner {
     public static void main(String[] args) throws IOException {
         CommandLineArguments commandLineArgs = CommandLineArguments.build(args);
         if (commandLineArgs == null) {
-            System.exit(-1);
+            System.exit(1);
         }
 
         FormatInputStream formatInputStream = new FormatInputStream(

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/runner/Runner.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/runner/Runner.java
@@ -61,7 +61,7 @@ public class Runner {
     public static void main(String[] args) throws IOException {
         CommandLineArguments commandLineArgs = CommandLineArguments.build(args);
         if (commandLineArgs == null) {
-            return;
+            System.exit(-1);
         }
 
         FormatInputStream formatInputStream = new FormatInputStream(


### PR DESCRIPTION
Addressing #10841, this change will explicitly exit with a non-zero return code if argument parsing fails.

```
$ java -jar target/vespa-http-client-jar-with-dependencies.jar --noretry --endpoint https://someendpoint.com --useTls --verbose --useDynamicThrottling --useCompression --retrydelay 1 --timeout 1 --file vespacorpfeed-prod-sample.xml
Now sending data.
(...)
Sent 0.005794525146484375 MB in 0.032 seconds.
Speed: 1.4486312866210938 Mbits/sec, + HTTP overhead (not taking compression into account)
Docs/sec 31.250

Wed Oct 02 14:52:55 CEST 2019 Result received: 1 (1 failed so far, 1 sent, success rate 0.00 docs/sec).

$ echo $?
0

$ java -jar target/vespa-http-client-jar-with-dependencies.jar --noretry --endpoint https://someendpoint.com --useTls --verbose --useDynamicThrottling --useCompression --retrydelay 1 --timeout 1 --file
Required values for option 'fileArg' not provided
Use --help to show usage.

$ echo $?
1
```

@bratseth: Please review.