### PR TITLE
Add distribution state snapshotting

### DIFF
--- a/storage/src/tests/distributor/bucketdbupdatertest.cpp
+++ b/storage/src/tests/distributor/bucketdbupdatertest.cpp
@@ -2,11 +2,10 @@
 
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storage/distributor/bucketdbupdater.h>
+#include <vespa/storage/distributor/cluster_distribution_context.h>
 #include <vespa/storage/distributor/distributormetricsset.h>
 #include <vespa/storage/distributor/pending_bucket_space_db_transition.h>
 #include <vespa/storage/distributor/outdated_nodes_map.h>
-#include <vespa/vespalib/io/fileutil.h>
-#include <vespa/storageframework/defaultimplementation/clock/realclock.h>
 #include <vespa/storage/storageutil/distributorstatecache.h>
 #include <tests/distributor/distributortestutil.h>
 #include <vespa/document/test/make_document_bucket.h>
@@ -124,7 +123,7 @@ public:
         createLinks();
         _bucketSpaces = getBucketSpaces();
         // Disable deferred activation by default (at least for now) to avoid breaking the entire world.
-        getConfig().setAllowStaleReadsDuringClusterStateTransitions(false);
+        getBucketDBUpdater().set_stale_reads_enabled(false);
     };
 
     void TearDown() override {
@@ -2415,7 +2414,7 @@ void for_each_bucket(const DistributorBucketSpaceRepo& repo, Func&& f) {
 }
 
 TEST_F(BucketDBUpdaterTest, non_owned_buckets_moved_to_read_only_db_on_ownership_change) {
-    getConfig().setAllowStaleReadsDuringClusterStateTransitions(true);
+    getBucketDBUpdater().set_stale_reads_enabled(true);
 
     lib::ClusterState initial_state("distributor:1 storage:4"); // All buckets owned by us by definition
     set_cluster_state_bundle(lib::ClusterStateBundle(initial_state, {}, false)); // Skip activation step for simplicity
@@ -2468,7 +2467,7 @@ TEST_F(BucketDBUpdaterTest, buckets_no_longer_available_are_not_moved_to_read_on
 }
 
 TEST_F(BucketDBUpdaterTest, non_owned_buckets_purged_when_read_only_support_is_config_disabled) {
-    getConfig().setAllowStaleReadsDuringClusterStateTransitions(false);
+    getBucketDBUpdater().set_stale_reads_enabled(false);
 
     lib::ClusterState initial_state("distributor:1 storage:4"); // All buckets owned by us by definition
     set_cluster_state_bundle(lib::ClusterStateBundle(initial_state, {}, false)); // Skip activation step for simplicity
@@ -2497,7 +2496,6 @@ void BucketDBUpdaterTest::trigger_completed_but_not_yet_activated_transition(
         uint32_t pending_buckets,
         uint32_t pending_expected_msgs)
 {
-    getConfig().setAllowStaleReadsDuringClusterStateTransitions(true);
     lib::ClusterState initial_state(initial_state_str);
     setSystemState(initial_state);
     ASSERT_EQ(messageCount(initial_expected_msgs), _sender.commands().size());
@@ -2514,6 +2512,7 @@ void BucketDBUpdaterTest::trigger_completed_but_not_yet_activated_transition(
 }
 
 TEST_F(BucketDBUpdaterTest, deferred_activated_state_does_not_enable_state_until_activation_received) {
+    getBucketDBUpdater().set_stale_reads_enabled(true);
     constexpr uint32_t n_buckets = 10;
     ASSERT_NO_FATAL_FAILURE(
         trigger_completed_but_not_yet_activated_transition("version:1 distributor:2 storage:4", 0, 4,
@@ -2533,6 +2532,7 @@ TEST_F(BucketDBUpdaterTest, deferred_activated_state_does_not_enable_state_until
 }
 
 TEST_F(BucketDBUpdaterTest, read_only_db_cleared_once_pending_state_is_activated) {
+    getBucketDBUpdater().set_stale_reads_enabled(true);
     constexpr uint32_t n_buckets = 10;
     ASSERT_NO_FATAL_FAILURE(
         trigger_completed_but_not_yet_activated_transition("version:1 distributor:1 storage:4", n_buckets, 4,
@@ -2544,6 +2544,7 @@ TEST_F(BucketDBUpdaterTest, read_only_db_cleared_once_pending_state_is_activated
 }
 
 TEST_F(BucketDBUpdaterTest, read_only_db_is_populated_even_when_self_is_marked_down) {
+    getBucketDBUpdater().set_stale_reads_enabled(true);
     constexpr uint32_t n_buckets = 10;
     ASSERT_NO_FATAL_FAILURE(
         trigger_completed_but_not_yet_activated_transition("version:1 distributor:1 storage:4", n_buckets, 4,
@@ -2557,6 +2558,7 @@ TEST_F(BucketDBUpdaterTest, read_only_db_is_populated_even_when_self_is_marked_d
 }
 
 TEST_F(BucketDBUpdaterTest, activate_cluster_state_request_with_mismatching_version_returns_actual_version) {
+    getBucketDBUpdater().set_stale_reads_enabled(true);
     constexpr uint32_t n_buckets = 10;
     ASSERT_NO_FATAL_FAILURE(
         trigger_completed_but_not_yet_activated_transition("version:4 distributor:1 storage:4", n_buckets, 4,
@@ -2570,6 +2572,7 @@ TEST_F(BucketDBUpdaterTest, activate_cluster_state_request_with_mismatching_vers
 }
 
 TEST_F(BucketDBUpdaterTest, activate_cluster_state_request_without_pending_transition_passes_message_through) {
+    getBucketDBUpdater().set_stale_reads_enabled(true);
     constexpr uint32_t n_buckets = 10;
     ASSERT_NO_FATAL_FAILURE(
         trigger_completed_but_not_yet_activated_transition("version:1 distributor:2 storage:4", 0, 4,
@@ -2726,5 +2729,145 @@ TEST_F(BucketDBUpdaterTest, pending_cluster_state_getter_is_non_null_only_when_s
     state = getBucketDBUpdater().pendingClusterStateOrNull(FixedBucketSpaces::global_space());
     EXPECT_TRUE(state == nullptr);
 }
+
+struct BucketDBUpdaterSnapshotTest : BucketDBUpdaterTest {
+    lib::ClusterState empty_state;
+    std::shared_ptr<lib::ClusterState> initial_baseline;
+    std::shared_ptr<lib::ClusterState> initial_default;
+    lib::ClusterStateBundle initial_bundle;
+    Bucket default_bucket;
+    Bucket global_bucket;
+
+    BucketDBUpdaterSnapshotTest()
+        : BucketDBUpdaterTest(),
+          empty_state(),
+          initial_baseline(std::make_shared<lib::ClusterState>("distributor:1 storage:2 .0.s:d")),
+          initial_default(std::make_shared<lib::ClusterState>("distributor:1 storage:2 .0.s:m")),
+          initial_bundle(*initial_baseline, {{FixedBucketSpaces::default_space(), initial_default},
+                                             {FixedBucketSpaces::global_space(), initial_baseline}}),
+          default_bucket(FixedBucketSpaces::default_space(), BucketId(16, 1234)),
+          global_bucket(FixedBucketSpaces::global_space(), BucketId(16, 1234))
+    {
+    }
+    ~BucketDBUpdaterSnapshotTest() override;
+
+    void SetUp() override {
+        BucketDBUpdaterTest::SetUp();
+        getBucketDBUpdater().set_stale_reads_enabled(true);
+    };
+
+    // Assumes that the distributor owns all buckets, so it may choose any arbitrary bucket in the bucket space
+    uint32_t buckets_in_snapshot_matching_current_db(DistributorBucketSpaceRepo& repo, BucketSpace bucket_space) {
+        auto def_rs = getBucketDBUpdater().read_snapshot_for_bucket(Bucket(bucket_space, BucketId(16, 1234)));
+        if (!def_rs.is_routable()) {
+            return 0;
+        }
+        auto guard = def_rs.steal_read_guard();
+        uint32_t found_buckets = 0;
+        for_each_bucket(repo, [&](const auto& space, const auto& entry) {
+            if (space == bucket_space) {
+                std::vector<BucketDatabase::Entry> entries;
+                guard->find_parents_and_self(entry.getBucketId(), entries);
+                if (entries.size() == 1) {
+                    ++found_buckets;
+                }
+            }
+        });
+        return found_buckets;
+    }
+};
+
+BucketDBUpdaterSnapshotTest::~BucketDBUpdaterSnapshotTest() = default;
+
+TEST_F(BucketDBUpdaterSnapshotTest, default_space_snapshot_prior_to_activated_state_is_non_routable) {
+    auto rs = getBucketDBUpdater().read_snapshot_for_bucket(default_bucket);
+    EXPECT_FALSE(rs.is_routable());
+}
+
+TEST_F(BucketDBUpdaterSnapshotTest, global_space_snapshot_prior_to_activated_state_is_non_routable) {
+    auto rs = getBucketDBUpdater().read_snapshot_for_bucket(global_bucket);
+    EXPECT_FALSE(rs.is_routable());
+}
+
+TEST_F(BucketDBUpdaterSnapshotTest, read_snapshot_returns_appropriate_cluster_states) {
+    set_cluster_state_bundle(initial_bundle);
+    // State currently pending, empty initial state is active
+
+    auto def_rs = getBucketDBUpdater().read_snapshot_for_bucket(default_bucket);
+    EXPECT_EQ(def_rs.context().active_cluster_state()->toString(), empty_state.toString());
+    EXPECT_EQ(def_rs.context().baseline_active_cluster_state()->toString(), empty_state.toString());
+    ASSERT_TRUE(def_rs.context().has_pending_state_transition());
+    EXPECT_EQ(def_rs.context().pending_cluster_state()->toString(), initial_default->toString());
+
+    auto global_rs = getBucketDBUpdater().read_snapshot_for_bucket(global_bucket);
+    EXPECT_EQ(global_rs.context().active_cluster_state()->toString(), empty_state.toString());
+    EXPECT_EQ(global_rs.context().baseline_active_cluster_state()->toString(), empty_state.toString());
+    ASSERT_TRUE(global_rs.context().has_pending_state_transition());
+    EXPECT_EQ(global_rs.context().pending_cluster_state()->toString(), initial_baseline->toString());
+
+    ASSERT_NO_FATAL_FAILURE(completeBucketInfoGathering(*initial_baseline, messageCount(1), 0));
+    // State now activated, no pending
+
+    def_rs = getBucketDBUpdater().read_snapshot_for_bucket(default_bucket);
+    EXPECT_EQ(def_rs.context().active_cluster_state()->toString(), initial_default->toString());
+    EXPECT_EQ(def_rs.context().baseline_active_cluster_state()->toString(), initial_baseline->toString());
+    EXPECT_FALSE(def_rs.context().has_pending_state_transition());
+
+    global_rs = getBucketDBUpdater().read_snapshot_for_bucket(global_bucket);
+    EXPECT_EQ(global_rs.context().active_cluster_state()->toString(), initial_baseline->toString());
+    EXPECT_EQ(global_rs.context().baseline_active_cluster_state()->toString(), initial_baseline->toString());
+    EXPECT_FALSE(global_rs.context().has_pending_state_transition());
+}
+
+TEST_F(BucketDBUpdaterSnapshotTest, snapshot_with_no_pending_state_transition_returns_mutable_db_guard) {
+    constexpr uint32_t n_buckets = 10;
+    ASSERT_NO_FATAL_FAILURE(
+            trigger_completed_but_not_yet_activated_transition("version:1 distributor:2 storage:4", 0, 4,
+                                                               "version:2 distributor:1 storage:4", n_buckets, 4));
+    EXPECT_FALSE(activate_cluster_state_version(2));
+    EXPECT_EQ(buckets_in_snapshot_matching_current_db(mutable_repo(), FixedBucketSpaces::default_space()),
+              n_buckets);
+    EXPECT_EQ(buckets_in_snapshot_matching_current_db(mutable_repo(), FixedBucketSpaces::global_space()),
+              n_buckets);
+}
+
+TEST_F(BucketDBUpdaterSnapshotTest, snapshot_returns_unroutable_for_non_owned_bucket_in_current_state) {
+    ASSERT_NO_FATAL_FAILURE(
+            trigger_completed_but_not_yet_activated_transition("version:1 distributor:2 storage:4", 0, 4,
+                                                               "version:2 distributor:2 .0.s:d storage:4", 0, 0));
+    EXPECT_FALSE(activate_cluster_state_version(2));
+    // We're down in state 2 and therefore do not own any buckets
+    auto def_rs = getBucketDBUpdater().read_snapshot_for_bucket(default_bucket);
+    EXPECT_FALSE(def_rs.is_routable());
+}
+
+TEST_F(BucketDBUpdaterSnapshotTest, snapshot_with_pending_state_returns_read_only_guard_for_bucket_only_owned_in_current_state) {
+    constexpr uint32_t n_buckets = 10;
+    ASSERT_NO_FATAL_FAILURE(
+            trigger_completed_but_not_yet_activated_transition("version:1 distributor:1 storage:4", n_buckets, 4,
+                                                               "version:2 distributor:2 .0.s:d storage:4", 0, 0));
+    EXPECT_EQ(buckets_in_snapshot_matching_current_db(read_only_repo(), FixedBucketSpaces::default_space()),
+              n_buckets);
+    EXPECT_EQ(buckets_in_snapshot_matching_current_db(read_only_repo(), FixedBucketSpaces::global_space()),
+              n_buckets);
+}
+
+TEST_F(BucketDBUpdaterSnapshotTest, snapshot_is_unroutable_if_stale_reads_disabled_and_bucket_not_owned_in_pending_state) {
+    getBucketDBUpdater().set_stale_reads_enabled(false);
+    constexpr uint32_t n_buckets = 10;
+    ASSERT_NO_FATAL_FAILURE(
+            trigger_completed_but_not_yet_activated_transition("version:1 distributor:1 storage:4", n_buckets, 4,
+                                                               "version:2 distributor:2 .0.s:d storage:4", 0, 0));
+    auto def_rs = getBucketDBUpdater().read_snapshot_for_bucket(default_bucket);
+    EXPECT_FALSE(def_rs.is_routable());
+}
+
+
+/*
+ * TODO test
+ *  - is_routable for pending/no pending
+ *  - explicit guard (how?)
+ *  - snapshots for pending/no pending
+ */
 
 }

--- a/storage/src/tests/distributor/distributortestutil.cpp
+++ b/storage/src/tests/distributor/distributortestutil.cpp
@@ -417,7 +417,8 @@ DistributorTestUtil::getBucketSpaces() const
 void
 DistributorTestUtil::enableDistributorClusterState(vespalib::stringref state)
 {
-    _distributor->enableClusterStateBundle(lib::ClusterStateBundle(lib::ClusterState(state)));
+    getBucketDBUpdater().simulate_cluster_state_bundle_activation(
+            lib::ClusterStateBundle(lib::ClusterState(state)));
 }
 
 }

--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -505,6 +505,7 @@ document::BucketId ExternalOperationHandlerTest::set_up_pending_cluster_state_tr
     std::string current = "version:123 distributor:2 storage:2";
     std::string pending = "version:321 distributor:3 storage:3";
     setupDistributor(1, 3, current);
+    getBucketDBUpdater().set_stale_reads_enabled(read_only_enabled);
     getConfig().setAllowStaleReadsDuringClusterStateTransitions(read_only_enabled);
 
     // Trigger pending cluster state

--- a/storage/src/tests/distributor/getoperationtest.cpp
+++ b/storage/src/tests/distributor/getoperationtest.cpp
@@ -3,6 +3,8 @@
 #include <vespa/config/helper/configgetter.h>
 #include <vespa/document/config/config-documenttypes.h>
 #include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/storage/bucketdb/bucketdatabase.h>
+#include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/externaloperationhandler.h>
 #include <vespa/storage/distributor/distributor.h>
 #include <vespa/storage/distributor/distributormetricsset.h>
@@ -31,7 +33,7 @@ struct GetOperationTest : Test, DistributorTestUtil {
     std::unique_ptr<Operation> op;
 
     GetOperationTest();
-    ~GetOperationTest();
+    ~GetOperationTest() override;
 
     void SetUp() override {
         _repo.reset(
@@ -53,6 +55,7 @@ struct GetOperationTest : Test, DistributorTestUtil {
         auto msg = std::make_shared<api::GetCommand>(makeDocumentBucket(document::BucketId(0)), docId, "[all]");
         op = std::make_unique<GetOperation>(
                 getExternalOperationHandler(), getDistributorBucketSpace(),
+                getDistributorBucketSpace().getBucketDatabase().acquire_read_guard(),
                 msg, getDistributor().getMetrics(). gets[msg->getLoadType()]);
         op->start(_sender, framework::MilliSecTime(0));
     }

--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
@@ -148,7 +148,9 @@ Entry BTreeBucketDatabase::entry_from_iterator(const BTree::ConstIterator& iter)
     if (!iter.valid()) {
         return Entry::createInvalid();
     }
-    return entry_from_value(iter.getKey(), iter.getData());
+    const auto value = iter.getData();
+    std::atomic_thread_fence(std::memory_order_acquire);
+    return entry_from_value(iter.getKey(), value);
 }
 
 ConstEntryRef BTreeBucketDatabase::const_entry_ref_from_iterator(const BTree::ConstIterator& iter) const {
@@ -156,6 +158,7 @@ ConstEntryRef BTreeBucketDatabase::const_entry_ref_from_iterator(const BTree::Co
         return ConstEntryRef::createInvalid();
     }
     const auto value = iter.getData();
+    std::atomic_thread_fence(std::memory_order_acquire);
     const auto replicas_ref = _store.get(entry_ref_from_value(value));
     const auto bucket = BucketId(BucketId::keyToBucketId(iter.getKey()));
     return const_entry_ref_from_replica_array_ref(bucket, gc_timestamp_from_value(value), replicas_ref);

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -7,6 +7,7 @@ vespa_add_library(storage_distributor
     bucket_db_prune_elision.cpp
     bucketgctimecalculator.cpp
     bucketlistmerger.cpp
+    cluster_distribution_context.cpp
     clusterinformation.cpp
     distributor_bucket_space.cpp
     distributor_bucket_space_repo.cpp
@@ -20,6 +21,7 @@ vespa_add_library(storage_distributor
     idealstatemetricsset.cpp
     messagetracker.cpp
     nodeinfo.cpp
+    operation_routing_snapshot.cpp
     operation_sequencer.cpp
     operationowner.cpp
     operationtargetresolver.cpp

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -7,7 +7,7 @@ vespa_add_library(storage_distributor
     bucket_db_prune_elision.cpp
     bucketgctimecalculator.cpp
     bucketlistmerger.cpp
-    cluster_distribution_context.cpp
+    bucket_space_distribution_context.cpp
     clusterinformation.cpp
     distributor_bucket_space.cpp
     distributor_bucket_space_repo.cpp

--- a/storage/src/vespa/storage/distributor/bucket_space_distribution_context.cpp
+++ b/storage/src/vespa/storage/distributor/bucket_space_distribution_context.cpp
@@ -1,50 +1,52 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include "cluster_distribution_context.h"
+#include "bucket_space_distribution_context.h"
 
 namespace storage::distributor {
 
-ClusterDistributionContext::~ClusterDistributionContext() = default;
+BucketSpaceDistributionContext::~BucketSpaceDistributionContext() = default;
 
-ClusterDistributionContext::ClusterDistributionContext(
+BucketSpaceDistributionContext::BucketSpaceDistributionContext(
         std::shared_ptr<const lib::ClusterState> active_cluster_state,
-        std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> default_active_cluster_state,
         std::shared_ptr<const lib::ClusterState> pending_cluster_state,
         std::shared_ptr<const lib::Distribution> distribution,
         uint16_t this_node_index)
     : _active_cluster_state(std::move(active_cluster_state)),
-      _baseline_active_cluster_state(std::move(baseline_active_cluster_state)),
+      _default_active_cluster_state(std::move(default_active_cluster_state)),
       _pending_cluster_state(std::move(pending_cluster_state)),
       _distribution(std::move(distribution)),
       _this_node_index(this_node_index)
 {}
 
-std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_state_transition(
+std::shared_ptr<BucketSpaceDistributionContext> BucketSpaceDistributionContext::make_state_transition(
         std::shared_ptr<const lib::ClusterState> active_cluster_state,
-        std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> default_active_cluster_state,
         std::shared_ptr<const lib::ClusterState> pending_cluster_state,
         std::shared_ptr<const lib::Distribution> distribution,
         uint16_t this_node_index)
 {
-    return std::make_shared<ClusterDistributionContext>(
-            std::move(active_cluster_state), std::move(baseline_active_cluster_state),
+    return std::make_shared<BucketSpaceDistributionContext>(
+            std::move(active_cluster_state), std::move(default_active_cluster_state),
             std::move(pending_cluster_state), std::move(distribution),
             this_node_index);
 }
 
-std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_stable_state(
+std::shared_ptr<BucketSpaceDistributionContext> BucketSpaceDistributionContext::make_stable_state(
         std::shared_ptr<const lib::ClusterState> active_cluster_state,
-        std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> default_active_cluster_state,
         std::shared_ptr<const lib::Distribution> distribution,
         uint16_t this_node_index)
 {
-    return std::make_shared<ClusterDistributionContext>(
-            std::move(active_cluster_state), std::move(baseline_active_cluster_state),
+    return std::make_shared<BucketSpaceDistributionContext>(
+            std::move(active_cluster_state), std::move(default_active_cluster_state),
             std::shared_ptr<const lib::ClusterState>(),
             std::move(distribution), this_node_index);
 }
 
-std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_not_yet_initialized(uint16_t this_node_index) {
-    return std::make_shared<ClusterDistributionContext>(
+std::shared_ptr<BucketSpaceDistributionContext>
+BucketSpaceDistributionContext::make_not_yet_initialized(uint16_t this_node_index)
+{
+    return std::make_shared<BucketSpaceDistributionContext>(
             std::make_shared<const lib::ClusterState>(),
             std::make_shared<const lib::ClusterState>(),
             std::shared_ptr<const lib::ClusterState>(),
@@ -52,8 +54,8 @@ std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_not
             this_node_index);
 }
 
-bool ClusterDistributionContext::bucket_owned_in_state(const lib::ClusterState& state,
-                                                       const document::BucketId& id) const
+bool BucketSpaceDistributionContext::bucket_owned_in_state(const lib::ClusterState& state,
+                                                           const document::BucketId& id) const
 {
     try {
         uint16_t owner_idx = _distribution->getIdealDistributorNode(state, id);
@@ -65,11 +67,11 @@ bool ClusterDistributionContext::bucket_owned_in_state(const lib::ClusterState& 
     }
 }
 
-bool ClusterDistributionContext::bucket_owned_in_active_state(const document::BucketId& id) const {
+bool BucketSpaceDistributionContext::bucket_owned_in_active_state(const document::BucketId& id) const {
     return bucket_owned_in_state(*_active_cluster_state, id);
 }
 
-bool ClusterDistributionContext::bucket_owned_in_pending_state(const document::BucketId& id) const {
+bool BucketSpaceDistributionContext::bucket_owned_in_pending_state(const document::BucketId& id) const {
     if (_pending_cluster_state) {
         return bucket_owned_in_state(*_pending_cluster_state, id);
     }

--- a/storage/src/vespa/storage/distributor/bucket_space_distribution_context.h
+++ b/storage/src/vespa/storage/distributor/bucket_space_distribution_context.h
@@ -9,45 +9,48 @@
 namespace storage::distributor {
 
 /**
- * TODO desc
- * TODO rename to be bucket space specific?
+ * Represents a consistent snapshot of cluster state and distribution config
+ * information at a particular point in time. This is sufficient to compute
+ * bucket ownership and distributions for the bucket space associated with
+ * the context.
+ *
+ * Since this is a snapshot in time, the context is immutable once created.
  */
-class ClusterDistributionContext {
+class BucketSpaceDistributionContext {
     std::shared_ptr<const lib::ClusterState> _active_cluster_state;
-    std::shared_ptr<const lib::ClusterState> _baseline_active_cluster_state;
+    std::shared_ptr<const lib::ClusterState> _default_active_cluster_state;
     std::shared_ptr<const lib::ClusterState> _pending_cluster_state; // May be null if no state is pending
     std::shared_ptr<const lib::Distribution> _distribution; // TODO ideally should have a pending distribution as well
     uint16_t _this_node_index;
 public:
-    // Public due to make_shared, prefer factory functions instead.
-    ClusterDistributionContext(std::shared_ptr<const lib::ClusterState> active_cluster_state,
-                               std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
-                               std::shared_ptr<const lib::ClusterState> pending_cluster_state,
-                               std::shared_ptr<const lib::Distribution> distribution,
-                               uint16_t this_node_index);
+    BucketSpaceDistributionContext() = delete;
+    // Public due to make_shared, prefer factory functions to instantiate instead.
+    BucketSpaceDistributionContext(std::shared_ptr<const lib::ClusterState> active_cluster_state,
+                                   std::shared_ptr<const lib::ClusterState> default_active_cluster_state,
+                                   std::shared_ptr<const lib::ClusterState> pending_cluster_state,
+                                   std::shared_ptr<const lib::Distribution> distribution,
+                                   uint16_t this_node_index);
+    ~BucketSpaceDistributionContext();
 
-    ClusterDistributionContext() = delete;
-    ~ClusterDistributionContext();
-
-    static std::shared_ptr<ClusterDistributionContext> make_state_transition(
+    static std::shared_ptr<BucketSpaceDistributionContext> make_state_transition(
             std::shared_ptr<const lib::ClusterState> active_cluster_state,
-            std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+            std::shared_ptr<const lib::ClusterState> default_active_cluster_state,
             std::shared_ptr<const lib::ClusterState> pending_cluster_state,
             std::shared_ptr<const lib::Distribution> distribution,
             uint16_t this_node_index);
-    static std::shared_ptr<ClusterDistributionContext> make_stable_state(
+    static std::shared_ptr<BucketSpaceDistributionContext> make_stable_state(
             std::shared_ptr<const lib::ClusterState> active_cluster_state,
-            std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+            std::shared_ptr<const lib::ClusterState> default_active_cluster_state,
             std::shared_ptr<const lib::Distribution> distribution,
             uint16_t this_node_index);
-    static std::shared_ptr<ClusterDistributionContext> make_not_yet_initialized(uint16_t this_node_index);
+    static std::shared_ptr<BucketSpaceDistributionContext> make_not_yet_initialized(uint16_t this_node_index);
 
     const std::shared_ptr<const lib::ClusterState>& active_cluster_state() const noexcept {
         return _active_cluster_state;
     }
 
-    const std::shared_ptr<const lib::ClusterState>& baseline_active_cluster_state() const noexcept {
-        return _baseline_active_cluster_state;
+    const std::shared_ptr<const lib::ClusterState>& default_active_cluster_state() const noexcept {
+        return _default_active_cluster_state;
     }
     bool has_pending_state_transition() const noexcept {
         return (_pending_cluster_state.get() != nullptr);

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.h
@@ -28,7 +28,7 @@ class XmlAttribute;
 namespace storage::distributor {
 
 class Distributor;
-class ClusterDistributionContext;
+class BucketSpaceDistributionContext;
 
 class BucketDBUpdater : public framework::StatusReporter,
                         public api::MessageHandler
@@ -140,6 +140,12 @@ private:
         }
     };
 
+    friend class DistributorTestUtil;
+    // Only to be used by tests that want to ensure both the BucketDBUpdater _and_ the Distributor
+    // components agree on the currently active cluster state bundle.
+    // Transitively invokes Distributor::enableClusterStateBundle
+    void simulate_cluster_state_bundle_activation(const lib::ClusterStateBundle& activated_state);
+
     bool shouldDeferStateEnabling() const noexcept;
     bool hasPendingClusterState() const;
     bool pendingClusterStateAccepted(const std::shared_ptr<api::RequestBucketInfoReply>& repl);
@@ -196,9 +202,6 @@ private:
     void maybe_inject_simulated_db_pruning_delay();
     void maybe_inject_simulated_db_merging_delay();
 
-    friend class BucketDBUpdater_Test;
-    friend class MergeOperation_Test;
-
     /**
        Removes all copies of buckets that are on nodes that are down.
     */
@@ -251,7 +254,7 @@ private:
     framework::MilliSecTimer _transitionTimer;
     std::atomic<bool> _stale_reads_enabled;
     using DistributionContexts = std::unordered_map<document::BucketSpace,
-                                                    std::shared_ptr<ClusterDistributionContext>,
+                                                    std::shared_ptr<BucketSpaceDistributionContext>,
                                                     document::BucketSpace::hash>;
     DistributionContexts _active_distribution_contexts;
     using DbGuards = std::unordered_map<document::BucketSpace,

--- a/storage/src/vespa/storage/distributor/cluster_distribution_context.cpp
+++ b/storage/src/vespa/storage/distributor/cluster_distribution_context.cpp
@@ -1,0 +1,79 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "cluster_distribution_context.h"
+
+namespace storage::distributor {
+
+ClusterDistributionContext::~ClusterDistributionContext() = default;
+
+ClusterDistributionContext::ClusterDistributionContext(
+        std::shared_ptr<const lib::ClusterState> active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> pending_cluster_state,
+        std::shared_ptr<const lib::Distribution> distribution,
+        uint16_t this_node_index)
+    : _active_cluster_state(std::move(active_cluster_state)),
+      _baseline_active_cluster_state(std::move(baseline_active_cluster_state)),
+      _pending_cluster_state(std::move(pending_cluster_state)),
+      _distribution(std::move(distribution)),
+      _this_node_index(this_node_index)
+{}
+
+std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_state_transition(
+        std::shared_ptr<const lib::ClusterState> active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> pending_cluster_state,
+        std::shared_ptr<const lib::Distribution> distribution,
+        uint16_t this_node_index)
+{
+    return std::make_shared<ClusterDistributionContext>(
+            std::move(active_cluster_state), std::move(baseline_active_cluster_state),
+            std::move(pending_cluster_state), std::move(distribution),
+            this_node_index);
+}
+
+std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_stable_state(
+        std::shared_ptr<const lib::ClusterState> active_cluster_state,
+        std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+        std::shared_ptr<const lib::Distribution> distribution,
+        uint16_t this_node_index)
+{
+    return std::make_shared<ClusterDistributionContext>(
+            std::move(active_cluster_state), std::move(baseline_active_cluster_state),
+            std::shared_ptr<const lib::ClusterState>(),
+            std::move(distribution), this_node_index);
+}
+
+std::shared_ptr<ClusterDistributionContext> ClusterDistributionContext::make_not_yet_initialized(uint16_t this_node_index) {
+    return std::make_shared<ClusterDistributionContext>(
+            std::make_shared<const lib::ClusterState>(),
+            std::make_shared<const lib::ClusterState>(),
+            std::shared_ptr<const lib::ClusterState>(),
+            std::make_shared<const lib::Distribution>(),
+            this_node_index);
+}
+
+bool ClusterDistributionContext::bucket_owned_in_state(const lib::ClusterState& state,
+                                                       const document::BucketId& id) const
+{
+    try {
+        uint16_t owner_idx = _distribution->getIdealDistributorNode(state, id);
+        return (owner_idx == _this_node_index);
+    } catch (lib::TooFewBucketBitsInUseException&) {
+        return false;
+    } catch (lib::NoDistributorsAvailableException&) {
+        return false;
+    }
+}
+
+bool ClusterDistributionContext::bucket_owned_in_active_state(const document::BucketId& id) const {
+    return bucket_owned_in_state(*_active_cluster_state, id);
+}
+
+bool ClusterDistributionContext::bucket_owned_in_pending_state(const document::BucketId& id) const {
+    if (_pending_cluster_state) {
+        return bucket_owned_in_state(*_pending_cluster_state, id);
+    }
+    return true; // No pending state, owned by default.
+}
+
+}

--- a/storage/src/vespa/storage/distributor/cluster_distribution_context.h
+++ b/storage/src/vespa/storage/distributor/cluster_distribution_context.h
@@ -1,0 +1,67 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vdslib/distribution/distribution.h>
+#include <vespa/vdslib/state/clusterstate.h>
+#include <memory>
+#include <cstdint>
+
+namespace storage::distributor {
+
+/**
+ * TODO desc
+ * TODO rename to be bucket space specific?
+ */
+class ClusterDistributionContext {
+    std::shared_ptr<const lib::ClusterState> _active_cluster_state;
+    std::shared_ptr<const lib::ClusterState> _baseline_active_cluster_state;
+    std::shared_ptr<const lib::ClusterState> _pending_cluster_state; // May be null if no state is pending
+    std::shared_ptr<const lib::Distribution> _distribution; // TODO ideally should have a pending distribution as well
+    uint16_t _this_node_index;
+public:
+    // Public due to make_shared, prefer factory functions instead.
+    ClusterDistributionContext(std::shared_ptr<const lib::ClusterState> active_cluster_state,
+                               std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+                               std::shared_ptr<const lib::ClusterState> pending_cluster_state,
+                               std::shared_ptr<const lib::Distribution> distribution,
+                               uint16_t this_node_index);
+
+    ClusterDistributionContext() = delete;
+    ~ClusterDistributionContext();
+
+    static std::shared_ptr<ClusterDistributionContext> make_state_transition(
+            std::shared_ptr<const lib::ClusterState> active_cluster_state,
+            std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+            std::shared_ptr<const lib::ClusterState> pending_cluster_state,
+            std::shared_ptr<const lib::Distribution> distribution,
+            uint16_t this_node_index);
+    static std::shared_ptr<ClusterDistributionContext> make_stable_state(
+            std::shared_ptr<const lib::ClusterState> active_cluster_state,
+            std::shared_ptr<const lib::ClusterState> baseline_active_cluster_state,
+            std::shared_ptr<const lib::Distribution> distribution,
+            uint16_t this_node_index);
+    static std::shared_ptr<ClusterDistributionContext> make_not_yet_initialized(uint16_t this_node_index);
+
+    const std::shared_ptr<const lib::ClusterState>& active_cluster_state() const noexcept {
+        return _active_cluster_state;
+    }
+
+    const std::shared_ptr<const lib::ClusterState>& baseline_active_cluster_state() const noexcept {
+        return _baseline_active_cluster_state;
+    }
+    bool has_pending_state_transition() const noexcept {
+        return (_pending_cluster_state.get() != nullptr);
+    }
+    // Returned shared_ptr is nullptr iff has_pending_state_transition() == false.
+    const std::shared_ptr<const lib::ClusterState>& pending_cluster_state() const noexcept {
+        return _pending_cluster_state;
+    }
+
+    bool bucket_owned_in_state(const lib::ClusterState& state, const document::BucketId& id) const;
+    bool bucket_owned_in_active_state(const document::BucketId& id) const;
+    bool bucket_owned_in_pending_state(const document::BucketId& id) const;
+
+    uint16_t this_node_index() const noexcept { return _this_node_index; }
+};
+
+}

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -834,6 +834,7 @@ Distributor::enableNextConfig()
     _bucketDBMetricUpdater.setMinimumReplicaCountingMode(getConfig().getMinimumReplicaCountingMode());
     _ownershipSafeTimeCalc->setMaxClusterClockSkew(getConfig().getMaxClusterClockSkew());
     _pendingMessageTracker.setNodeBusyDuration(getConfig().getInhibitMergesOnBusyNodeDuration());
+    _bucketDBUpdater.set_stale_reads_enabled(getConfig().allowStaleReadsDuringClusterStateTransitions());
 }
 
 void

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -170,6 +170,8 @@ public:
         return *_readOnlyBucketSpaceRepo;
     }
 
+    OperationRoutingSnapshot read_snapshot_for_bucket(const document::Bucket&) const override;
+
     class Status;
     class MetricUpdateHook : public framework::MetricUpdateHook
     {

--- a/storage/src/vespa/storage/distributor/distributor_bucket_space.h
+++ b/storage/src/vespa/storage/distributor/distributor_bucket_space.h
@@ -48,12 +48,18 @@ public:
     void setClusterState(std::shared_ptr<const lib::ClusterState> clusterState);
 
     const lib::ClusterState &getClusterState() const noexcept { return *_clusterState; }
+    const std::shared_ptr<const lib::ClusterState>& cluster_state_sp() const noexcept {
+        return _clusterState;
+    }
 
     void setDistribution(std::shared_ptr<const lib::Distribution> distribution);
 
     // Precondition: setDistribution has been called at least once prior.
     const lib::Distribution& getDistribution() const noexcept {
         return *_distribution;
+    }
+    const std::shared_ptr<const lib::Distribution>& distribution_sp() const noexcept {
+        return _distribution;
     }
 
 };

--- a/storage/src/vespa/storage/distributor/distributorinterface.h
+++ b/storage/src/vespa/storage/distributor/distributorinterface.h
@@ -4,6 +4,7 @@
 #include "bucketgctimecalculator.h"
 #include "distributormessagesender.h"
 #include "bucketownership.h"
+#include "operation_routing_snapshot.h"
 #include <vespa/storage/bucketdb/bucketdatabase.h>
 #include <vespa/document/bucket/bucket.h>
 
@@ -48,6 +49,8 @@ public:
      * @return Returns the current cluster state bundle.
      */
     virtual const lib::ClusterStateBundle& getClusterStateBundle() const = 0;
+
+    virtual OperationRoutingSnapshot read_snapshot_for_bucket(const document::Bucket&) const = 0;
 
     /**
      * Returns true if the node is currently initializing.

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "bucket_space_distribution_context.h"
 #include "externaloperationhandler.h"
 #include "distributor.h"
 #include <vespa/document/base/documentid.h>
@@ -12,7 +13,6 @@
 #include <vespa/storage/distributor/operations/external/statbucketlistoperation.h>
 #include <vespa/storage/distributor/operations/external/removelocationoperation.h>
 #include <vespa/storage/distributor/operations/external/visitoroperation.h>
-#include <vespa/document/util/stringutil.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/storageapi/message/stat.h>
@@ -30,11 +30,16 @@ ExternalOperationHandler::ExternalOperationHandler(Distributor& owner,
                                                    DistributorBucketSpaceRepo& bucketSpaceRepo,
                                                    DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
                                                    const MaintenanceOperationGenerator& gen,
-                                                   DistributorComponentRegister& compReg)
+                                                   DistributorComponentRegister& compReg,
+                                                   bool enable_concurrent_gets)
     : DistributorComponent(owner, bucketSpaceRepo, readOnlyBucketSpaceRepo, compReg, "External operation handler"),
       _operationGenerator(gen),
-      _rejectFeedBeforeTimeReached() // At epoch
-{ }
+      _rejectFeedBeforeTimeReached(), // At epoch
+      _non_main_thread_ops_mutex(),
+      _non_main_thread_ops_owner(owner, getClock()),
+      _enable_concurrent_gets(enable_concurrent_gets)
+{
+}
 
 ExternalOperationHandler::~ExternalOperationHandler() = default;
 
@@ -78,22 +83,30 @@ void ExternalOperationHandler::bounce_with_result(api::StorageCommand& cmd, cons
     sendUp(std::shared_ptr<api::StorageMessage>(reply.release()));
 }
 
-void ExternalOperationHandler::bounce_with_wrong_distribution(api::StorageCommand& cmd) {
+void ExternalOperationHandler::bounce_with_wrong_distribution(api::StorageCommand& cmd,
+                                                              const lib::ClusterState& cluster_state)
+{
     // Distributor ownership is equal across bucket spaces, so always send back default space state.
     // This also helps client avoid getting confused by possibly observing different actual
     // (derived) state strings for global/non-global document types for the same state version.
     // Similarly, if we've yet to activate any version at all we send back BUSY instead
     // of a suspiciously empty WrongDistributionReply.
     // TOOD consider NOT_READY instead of BUSY once we're sure this won't cause any other issues.
-    const auto& cluster_state = _bucketSpaceRepo.get(document::FixedBucketSpaces::default_space()).getClusterState();
     if (cluster_state.getVersion() != 0) {
         auto cluster_state_str = cluster_state.toString();
-        LOG(debug, "Got message with wrong distribution, sending back state '%s'", cluster_state_str.c_str());
+        LOG(debug, "Got %s with wrong distribution, sending back state '%s'",
+            cmd.toString().c_str(), cluster_state_str.c_str());
         bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::WRONG_DISTRIBUTION, cluster_state_str));
     } else { // Only valid for empty startup state
-        LOG(debug, "Got message with wrong distribution, but no cluster state activated yet. Sending back BUSY");
+        LOG(debug, "Got %s with wrong distribution, but no cluster state activated yet. Sending back BUSY",
+            cmd.toString().c_str());
         bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::BUSY, "No cluster state activated yet"));
     }
+}
+
+void ExternalOperationHandler::bounce_with_wrong_distribution(api::StorageCommand& cmd) {
+    const auto& cluster_state = _bucketSpaceRepo.get(document::FixedBucketSpaces::default_space()).getClusterState();
+    bounce_with_wrong_distribution(cmd, cluster_state);
 }
 
 void ExternalOperationHandler::bounce_with_busy_during_state_transition(
@@ -283,10 +296,23 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Get)
 {
     document::Bucket bucket(cmd->getBucket().getBucketSpace(), getBucketId(cmd->getDocumentId()));
     auto& metrics = getMetrics().gets[cmd->getLoadType()];
-    bounce_or_invoke_read_only_op(*cmd, bucket, metrics, [&](auto& bucket_space_repo) {
-        auto& space = bucket_space_repo.get(cmd->getBucket().getBucketSpace());
-        _op = std::make_shared<GetOperation>(*this, space, space.getBucketDatabase().acquire_read_guard(), cmd, metrics);
-    });
+    auto snapshot = getDistributor().read_snapshot_for_bucket(bucket);
+    if (!snapshot.is_routable()) {
+        const auto& ctx = snapshot.context();
+        if (ctx.has_pending_state_transition()) {
+            bounce_with_busy_during_state_transition(*cmd, *ctx.default_active_cluster_state(),
+                                                     *ctx.pending_cluster_state());
+        } else {
+            bounce_with_wrong_distribution(*cmd, *snapshot.context().default_active_cluster_state());
+            metrics.failures.wrongdistributor.inc(); // TODO thread safety for updates
+        }
+        return true;
+    }
+    // The snapshot is aware of whether stale reads are enabled, so we don't have to check that here.
+    const auto* space_repo = snapshot.bucket_space_repo();
+    assert(space_repo != nullptr);
+    _op = std::make_shared<GetOperation>(*this, space_repo->get(bucket.getBucketSpace()),
+                                         snapshot.steal_read_guard(), cmd, metrics);
     return true;
 }
 

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -284,8 +284,8 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Get)
     document::Bucket bucket(cmd->getBucket().getBucketSpace(), getBucketId(cmd->getDocumentId()));
     auto& metrics = getMetrics().gets[cmd->getLoadType()];
     bounce_or_invoke_read_only_op(*cmd, bucket, metrics, [&](auto& bucket_space_repo) {
-        _op = std::make_shared<GetOperation>(*this, bucket_space_repo.get(cmd->getBucket().getBucketSpace()),
-                                             cmd, metrics);
+        auto& space = bucket_space_repo.get(cmd->getBucket().getBucketSpace());
+        _op = std::make_shared<GetOperation>(*this, space, space.getBucketDatabase().acquire_read_guard(), cmd, metrics);
     });
     return true;
 }

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -8,6 +8,7 @@
 #include <vespa/storage/distributor/distributorcomponent.h>
 #include <vespa/storageapi/messageapi/messagehandler.h>
 #include <chrono>
+#include <mutex>
 
 namespace storage {
 
@@ -39,7 +40,8 @@ public:
                              DistributorBucketSpaceRepo& bucketSpaceRepo,
                              DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
                              const MaintenanceOperationGenerator&,
-                             DistributorComponentRegister& compReg);
+                             DistributorComponentRegister& compReg,
+                             bool enable_concurrent_gets);
 
     ~ExternalOperationHandler() override;
 
@@ -55,6 +57,9 @@ private:
     OperationSequencer _mutationSequencer;
     Operation::SP _op;
     TimePoint _rejectFeedBeforeTimeReached;
+    mutable std::mutex _non_main_thread_ops_mutex;
+    OperationOwner _non_main_thread_ops_owner;
+    bool _enable_concurrent_gets;
 
     template <typename Func>
     void bounce_or_invoke_read_only_op(api::StorageCommand& cmd,
@@ -62,6 +67,8 @@ private:
                                        PersistenceOperationMetricSet& metrics,
                                        Func f);
 
+    void bounce_with_wrong_distribution(api::StorageCommand& cmd, const lib::ClusterState& cluster_state);
+    // Bounce with the current _default_ space cluster state.
     void bounce_with_wrong_distribution(api::StorageCommand& cmd);
     void bounce_with_busy_during_state_transition(api::StorageCommand& cmd,
                                                   const lib::ClusterState& current_state,

--- a/storage/src/vespa/storage/distributor/operation_routing_snapshot.cpp
+++ b/storage/src/vespa/storage/distributor/operation_routing_snapshot.cpp
@@ -3,25 +3,28 @@
 
 namespace storage::distributor {
 
-OperationRoutingSnapshot::OperationRoutingSnapshot(std::shared_ptr<ClusterDistributionContext> context,
-                                                   std::shared_ptr<BucketDatabase::ReadGuard> read_guard)
+OperationRoutingSnapshot::OperationRoutingSnapshot(std::shared_ptr<const BucketSpaceDistributionContext> context,
+                                                   std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
+                                                   const DistributorBucketSpaceRepo* bucket_space_repo)
     : _context(std::move(context)),
-      _read_guard(std::move(read_guard))
+      _read_guard(std::move(read_guard)),
+      _bucket_space_repo(bucket_space_repo)
 {}
 
 OperationRoutingSnapshot::~OperationRoutingSnapshot() = default;
 
 OperationRoutingSnapshot OperationRoutingSnapshot::make_not_routable_in_state(
-        std::shared_ptr<ClusterDistributionContext> context)
+        std::shared_ptr<const BucketSpaceDistributionContext> context)
 {
-    return OperationRoutingSnapshot(std::move(context), std::shared_ptr<BucketDatabase::ReadGuard>());
+    return OperationRoutingSnapshot(std::move(context), std::shared_ptr<BucketDatabase::ReadGuard>(), nullptr);
 }
 
 OperationRoutingSnapshot OperationRoutingSnapshot::make_routable_with_guard(
-        std::shared_ptr<ClusterDistributionContext> context,
-        std::shared_ptr<BucketDatabase::ReadGuard> read_guard)
+        std::shared_ptr<const BucketSpaceDistributionContext> context,
+        std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
+        const DistributorBucketSpaceRepo& bucket_space_repo)
 {
-    return OperationRoutingSnapshot(std::move(context), std::move(read_guard));
+    return OperationRoutingSnapshot(std::move(context), std::move(read_guard), &bucket_space_repo);
 }
 
 }

--- a/storage/src/vespa/storage/distributor/operation_routing_snapshot.cpp
+++ b/storage/src/vespa/storage/distributor/operation_routing_snapshot.cpp
@@ -1,0 +1,27 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "operation_routing_snapshot.h"
+
+namespace storage::distributor {
+
+OperationRoutingSnapshot::OperationRoutingSnapshot(std::shared_ptr<ClusterDistributionContext> context,
+                                                   std::shared_ptr<BucketDatabase::ReadGuard> read_guard)
+    : _context(std::move(context)),
+      _read_guard(std::move(read_guard))
+{}
+
+OperationRoutingSnapshot::~OperationRoutingSnapshot() = default;
+
+OperationRoutingSnapshot OperationRoutingSnapshot::make_not_routable_in_state(
+        std::shared_ptr<ClusterDistributionContext> context)
+{
+    return OperationRoutingSnapshot(std::move(context), std::shared_ptr<BucketDatabase::ReadGuard>());
+}
+
+OperationRoutingSnapshot OperationRoutingSnapshot::make_routable_with_guard(
+        std::shared_ptr<ClusterDistributionContext> context,
+        std::shared_ptr<BucketDatabase::ReadGuard> read_guard)
+{
+    return OperationRoutingSnapshot(std::move(context), std::move(read_guard));
+}
+
+}

--- a/storage/src/vespa/storage/distributor/operation_routing_snapshot.h
+++ b/storage/src/vespa/storage/distributor/operation_routing_snapshot.h
@@ -6,21 +6,37 @@
 
 namespace storage::distributor {
 
-class ClusterDistributionContext;
+class BucketSpaceDistributionContext;
+class DistributorBucketSpaceRepo;
 
 /**
- * TODO desc
+ * An "operation routing snapshot" is intended to provide a stable means of computing
+ * bucket routing targets and performing database lookups for a particular bucket space
+ * in a potentially multi-threaded setting. When using multiple threads, both the current
+ * cluster/distribution state as well as the underlying bucket database may change
+ * independent of each other when observed from any other thread than the main distributor
+ * thread. Additionally, the bucket management system may operate with separate read-only
+ * databases during state transitions, complicating things further.
+ *
+ * By using an OperationRoutingSnapshot, a caller gets a consistent view of the world
+ * that stays valid throughout the operation's life time.
+ *
+ * Note that holding the DB read guard should be done for as short a time as possible to
+ * avoid elevated memory usage caused by data stores not being able to free on-hold items.
  */
 class OperationRoutingSnapshot {
-    std::shared_ptr<ClusterDistributionContext> _context;
+    std::shared_ptr<const BucketSpaceDistributionContext> _context;
     std::shared_ptr<BucketDatabase::ReadGuard> _read_guard;
+    const DistributorBucketSpaceRepo* _bucket_space_repo;
 public:
-    OperationRoutingSnapshot(std::shared_ptr<ClusterDistributionContext> context,
-                             std::shared_ptr<BucketDatabase::ReadGuard> read_guard);
+    OperationRoutingSnapshot(std::shared_ptr<const BucketSpaceDistributionContext> context,
+                             std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
+                             const DistributorBucketSpaceRepo* bucket_space_repo);
 
-    static OperationRoutingSnapshot make_not_routable_in_state(std::shared_ptr<ClusterDistributionContext> context);
-    static OperationRoutingSnapshot make_routable_with_guard(std::shared_ptr<ClusterDistributionContext> context,
-                                                             std::shared_ptr<BucketDatabase::ReadGuard> read_guard);
+    static OperationRoutingSnapshot make_not_routable_in_state(std::shared_ptr<const BucketSpaceDistributionContext> context);
+    static OperationRoutingSnapshot make_routable_with_guard(std::shared_ptr<const BucketSpaceDistributionContext> context,
+                                                             std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
+                                                             const DistributorBucketSpaceRepo& bucket_space_repo);
 
     OperationRoutingSnapshot(const OperationRoutingSnapshot&) noexcept = default;
     OperationRoutingSnapshot& operator=(const OperationRoutingSnapshot&) noexcept = default;
@@ -29,12 +45,15 @@ public:
 
     ~OperationRoutingSnapshot();
 
-    const ClusterDistributionContext& context() const noexcept { return *_context; }
+    const BucketSpaceDistributionContext& context() const noexcept { return *_context; }
     std::shared_ptr<BucketDatabase::ReadGuard> steal_read_guard() noexcept {
         return std::move(_read_guard);
     }
     bool is_routable() const noexcept {
         return (_read_guard.get() != nullptr);
+    }
+    const DistributorBucketSpaceRepo* bucket_space_repo() const noexcept {
+        return _bucket_space_repo;
     }
 };
 

--- a/storage/src/vespa/storage/distributor/operation_routing_snapshot.h
+++ b/storage/src/vespa/storage/distributor/operation_routing_snapshot.h
@@ -1,0 +1,41 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/storage/bucketdb/bucketdatabase.h>
+#include <memory>
+
+namespace storage::distributor {
+
+class ClusterDistributionContext;
+
+/**
+ * TODO desc
+ */
+class OperationRoutingSnapshot {
+    std::shared_ptr<ClusterDistributionContext> _context;
+    std::shared_ptr<BucketDatabase::ReadGuard> _read_guard;
+public:
+    OperationRoutingSnapshot(std::shared_ptr<ClusterDistributionContext> context,
+                             std::shared_ptr<BucketDatabase::ReadGuard> read_guard);
+
+    static OperationRoutingSnapshot make_not_routable_in_state(std::shared_ptr<ClusterDistributionContext> context);
+    static OperationRoutingSnapshot make_routable_with_guard(std::shared_ptr<ClusterDistributionContext> context,
+                                                             std::shared_ptr<BucketDatabase::ReadGuard> read_guard);
+
+    OperationRoutingSnapshot(const OperationRoutingSnapshot&) noexcept = default;
+    OperationRoutingSnapshot& operator=(const OperationRoutingSnapshot&) noexcept = default;
+    OperationRoutingSnapshot(OperationRoutingSnapshot&&) noexcept = default;
+    OperationRoutingSnapshot& operator=(OperationRoutingSnapshot&&) noexcept = default;
+
+    ~OperationRoutingSnapshot();
+
+    const ClusterDistributionContext& context() const noexcept { return *_context; }
+    std::shared_ptr<BucketDatabase::ReadGuard> steal_read_guard() noexcept {
+        return std::move(_read_guard);
+    }
+    bool is_routable() const noexcept {
+        return (_read_guard.get() != nullptr);
+    }
+};
+
+}

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.cpp
@@ -45,7 +45,7 @@ GetOperation::GroupId::operator==(const GroupId& other) const
 }
 
 GetOperation::GetOperation(DistributorComponent& manager,
-                           DistributorBucketSpace &bucketSpace,
+                           const DistributorBucketSpace &bucketSpace,
                            std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
                            std::shared_ptr<api::GetCommand> msg,
                            PersistenceOperationMetricSet& metric)

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -3,7 +3,7 @@
 
 #include <vespa/storageapi/defs.h>
 #include <vespa/storage/distributor/operations/operation.h>
-#include <vespa/storage/bucketdb/bucketcopy.h>
+#include <vespa/storage/bucketdb/bucketdatabase.h>
 #include <vespa/storageapi/messageapi/storagemessage.h>
 #include <vespa/storageframework/generic/clock/timer.h>
 
@@ -23,8 +23,11 @@ class DistributorBucketSpace;
 class GetOperation  : public Operation
 {
 public:
-    GetOperation(DistributorComponent& manager, DistributorBucketSpace &bucketSpace,
-                 std::shared_ptr<api::GetCommand> msg, PersistenceOperationMetricSet& metric);
+    GetOperation(DistributorComponent& manager,
+                 DistributorBucketSpace &bucketSpace,
+                 std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
+                 std::shared_ptr<api::GetCommand> msg,
+                 PersistenceOperationMetricSet& metric);
 
     void onClose(DistributorMessageSender& sender) override;
     void onStart(DistributorMessageSender& sender) override;
@@ -89,7 +92,7 @@ private:
     void sendReply(DistributorMessageSender& sender);
     bool sendForChecksum(DistributorMessageSender& sender, const document::BucketId& id, GroupVector& res);
 
-    void assignTargetNodeGroups();
+    void assignTargetNodeGroups(const BucketDatabase::ReadGuard& read_guard);
     bool copyIsOnLocalNode(const BucketCopy&) const;
     /**
      * Returns the vector index of the target to send to, or -1 if none

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -24,7 +24,7 @@ class GetOperation  : public Operation
 {
 public:
     GetOperation(DistributorComponent& manager,
-                 DistributorBucketSpace &bucketSpace,
+                 const DistributorBucketSpace &bucketSpace,
                  std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
                  std::shared_ptr<api::GetCommand> msg,
                  PersistenceOperationMetricSet& metric);
@@ -77,7 +77,7 @@ private:
     std::map<GroupId, GroupVector> _responses;
 
     DistributorComponent& _manager;
-    DistributorBucketSpace &_bucketSpace;
+    const DistributorBucketSpace &_bucketSpace;
 
     std::shared_ptr<api::GetCommand> _msg;
 

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -178,7 +178,8 @@ TwoPhaseUpdateOperation::startSafePathUpdate(DistributorMessageSender& sender)
     document::Bucket bucket(_updateCmd->getBucket().getBucketSpace(), document::BucketId(0));
     auto get = std::make_shared<api::GetCommand>(bucket, _updateCmd->getDocumentId(),"[all]");
     copyMessageSettings(*_updateCmd, *get);
-    auto getOperation = std::make_shared<GetOperation>(_manager, _bucketSpace, get, _getMetric);
+    auto getOperation = std::make_shared<GetOperation>(
+            _manager, _bucketSpace, _bucketSpace.getBucketDatabase().acquire_read_guard(), get, _getMetric);
     GetOperation & op = *getOperation;
     IntermediateMessageSender intermediate(_sentMessageMap, std::move(getOperation), sender);
     op.start(intermediate, _manager.getClock().getTimeInMillis());


### PR DESCRIPTION
@geirst please review. This adds the bulk of the functionality required to begin processing Get operations outside the main distributor thread (though things like thread-safe metric updates etc remain).
