### PR TITLE
Upgrade Jetty to 9.4.21

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -451,7 +451,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.20.v20190813</jetty.version>
+        <jetty.version>9.4.21.v20190926</jetty.version>
         <lz4.version>1.3.0</lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
"Jetty 9.4.20.v20190813 includes a significant number of bug fixes and improvements. It is recommended that all users upgrade as soon as they are able."

https://www.eclipse.org/lists/jetty-announce/msg00134.html