### PR TITLE
Stop reading unused clusterUtils field

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -425,7 +425,7 @@ public class ApplicationSerializer {
                               applicationVersionFromSlime(deploymentObject.field(applicationPackageRevisionField)),
                               Version.fromString(deploymentObject.field(versionField).asString()),
                               Instant.ofEpochMilli(deploymentObject.field(deployTimeField).asLong()),
-                              clusterUtilsMapFromSlime(deploymentObject.field(clusterUtilsField)),
+                              Map.of(),
                               clusterInfoMapFromSlime(deploymentObject.field(clusterInfoField)),
                               deploymentMetricsFromSlime(deploymentObject.field(deploymentMetricsField)),
                               DeploymentActivity.create(Serializers.optionalInstant(deploymentObject.field(lastQueriedField)),
@@ -479,21 +479,6 @@ public class ApplicationSerializer {
         Map<ClusterSpec.Id, ClusterInfo> map = new HashMap<>();
         object.traverse((String name, Inspector value) -> map.put(new ClusterSpec.Id(name), clusterInfoFromSlime(value)));
         return map;
-    }
-
-    private Map<ClusterSpec.Id, ClusterUtilization> clusterUtilsMapFromSlime(Inspector object) {
-        Map<ClusterSpec.Id, ClusterUtilization> map = new HashMap<>();
-        object.traverse((String name, Inspector value) -> map.put(new ClusterSpec.Id(name), clusterUtililzationFromSlime(value)));
-        return map;
-    }
-
-    private ClusterUtilization clusterUtililzationFromSlime(Inspector object) {
-        double cpu = object.field(clusterUtilsCpuField).asDouble();
-        double mem = object.field(clusterUtilsMemField).asDouble();
-        double disk = object.field(clusterUtilsDiskField).asDouble();
-        double diskBusy = object.field(clusterUtilsDiskBusyField).asDouble();
-
-        return new ClusterUtilization(mem, cpu, disk, diskBusy);
     }
 
     private ClusterInfo clusterInfoFromSlime(Inspector inspector) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -193,10 +193,7 @@ public class ApplicationSerializerTest {
 
         // Test cluster utilization
         assertEquals(0, serialized.require(id1.instance()).deployments().get(zone1).clusterUtils().size());
-        assertEquals(3, serialized.require(id1.instance()).deployments().get(zone2).clusterUtils().size());
-        assertEquals(0.4, serialized.require(id1.instance()).deployments().get(zone2).clusterUtils().get(ClusterSpec.Id.from("id2")).getCpu(), 0.01);
-        assertEquals(0.2, serialized.require(id1.instance()).deployments().get(zone2).clusterUtils().get(ClusterSpec.Id.from("id1")).getCpu(), 0.01);
-        assertEquals(0.2, serialized.require(id1.instance()).deployments().get(zone2).clusterUtils().get(ClusterSpec.Id.from("id1")).getMemory(), 0.01);
+        assertEquals(0, serialized.require(id1.instance()).deployments().get(zone2).clusterUtils().size());
 
         // Test cluster info
         assertEquals(3, serialized.require(id1.instance()).deployments().get(zone2).clusterInfo().size());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -28,40 +28,10 @@
     "lastWritesPerSecond": 2.0
   },
   "cost": {
-    "tco": 74,
+    "tco": 0,
     "waste": 0,
-    "utilization": 2.9999999999999996,
-    "cluster": {
-      "cluster1": {
-        "count": 2,
-        "resource": "cpu",
-        "utilization": 2.9999999999999996,
-        "tco": 74,
-        "waste": 0,
-        "flavor": "flavor1",
-        "flavorCost":37.0,
-        "flavorCpu":2.0,
-        "flavorMem":4.0,
-        "flavorDisk":50.0,
-        "type": "content",
-        "util": {
-          "cpu": 2.9999999999999996,
-          "mem": 0.4285714285714286,
-          "disk": 0.5714285714285715,
-          "diskBusy": 1.0
-        },
-        "usage": {
-          "cpu": 0.6,
-          "mem": 0.3,
-          "disk": 0.4,
-          "diskBusy": 0.3
-        },
-        "hostnames": [
-          "host1",
-          "host2"
-        ]
-      }
-    }
+    "utilization": 0.0,
+    "cluster": {}
   },
   "metrics": {
     "queriesPerSecond": 1.0,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1.json
@@ -25,40 +25,10 @@
     "lastWritesPerSecond": 2.0
   },
   "cost": {
-    "tco": 74,
+    "tco": 0,
     "waste": 0,
-    "utilization": 2.9999999999999996,
-    "cluster": {
-      "cluster1": {
-        "count": 2,
-        "resource": "cpu",
-        "utilization": 2.9999999999999996,
-        "tco": 74,
-        "waste": 0,
-        "flavor": "flavor1",
-        "flavorCost": 37.0,
-        "flavorCpu": 2.0,
-        "flavorMem": 4.0,
-        "flavorDisk": 50.0,
-        "type": "content",
-        "util": {
-          "cpu": 2.9999999999999996,
-          "mem": 0.4285714285714286,
-          "disk": 0.5714285714285715,
-          "diskBusy": 1.0
-        },
-        "usage": {
-          "cpu": 0.6,
-          "mem": 0.3,
-          "disk": 0.4,
-          "diskBusy": 0.3
-        },
-        "hostnames": [
-          "host1",
-          "host2"
-        ]
-      }
-    }
+    "utilization": 0.0,
+    "cluster": {}
   },
   "metrics": {
     "queriesPerSecond": 1.0,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -37,40 +37,10 @@
     "lastWritesPerSecond": 2.0
   },
   "cost": {
-    "tco": 74,
+    "tco": 0,
     "waste": 0,
-    "utilization": 2.9999999999999996,
-    "cluster": {
-      "cluster1": {
-        "count": 2,
-        "resource": "cpu",
-        "utilization": 2.9999999999999996,
-        "tco": 74,
-        "waste": 0,
-        "flavor": "flavor1",
-        "flavorCost": 37.0,
-        "flavorCpu": 2.0,
-        "flavorMem": 4.0,
-        "flavorDisk": 50.0,
-        "type": "content",
-        "util": {
-          "cpu": 2.9999999999999996,
-          "mem": 0.4285714285714286,
-          "disk": 0.5714285714285715,
-          "diskBusy": 1.0
-        },
-        "usage": {
-          "cpu": 0.6,
-          "mem": 0.3,
-          "disk": 0.4,
-          "diskBusy": 0.3
-        },
-        "hostnames": [
-          "host1",
-          "host2"
-        ]
-      }
-    }
+    "utilization": 0.0,
+    "cluster": {}
   },
   "metrics": {
     "queriesPerSecond": 1.0,


### PR DESCRIPTION
This field is no longer updated after removal of `MetricsService` integration.