### PR TITLE
Remove commons-daemon from all pom files.

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -89,7 +89,6 @@
                                                 <include>com.sun.activation:javax.activation:[1.2.0]:jar:provided</include>
                                                 <include>com.sun.xml.bind:jaxb-core:[${jaxb.version}]:jar:provided</include>
                                                 <include>com.sun.xml.bind:jaxb-impl:[${jaxb.version}]:jar:provided</include>
-                                                <include>commons-daemon:commons-daemon:[${commons-daemon.version}]:jar:provided</include>
                                                 <include>commons-logging:commons-logging:[1.1.1]:jar:provided</include>
                                                 <include>javax.annotation:javax.annotation-api:[${javax.annotation-api.version}]:jar:provided</include>
                                                 <include>javax.inject:javax.inject:[${javax.inject.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -115,11 +115,6 @@
                 <classifier>no_aop</classifier>
             </dependency>
             <dependency>
-                <groupId>commons-daemon</groupId>
-                <artifactId>commons-daemon</artifactId>
-                <version>${commons-daemon.version}</version>
-            </dependency>
-            <dependency>
               <groupId>commons-logging</groupId>
               <artifactId>commons-logging</artifactId>
                 <!-- This version is exported by jdisc via jcl-over-slf4j. -->
@@ -442,7 +437,6 @@
     <properties>
         <aopalliance.version>1.0</aopalliance.version>
         <bouncycastle.version>1.63</bouncycastle.version>
-        <commons-daemon.version>1.0.3</commons-daemon.version>
         <felix.version>6.0.3</felix.version>
         <felix.log.version>1.0.1</felix.log.version>
         <findbugs.version>1.3.9</findbugs.version>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -104,12 +104,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <!-- TODO: Remove, we don't use commons-daemon anymore, and should not provide it.  -->
-            <groupId>commons-daemon</groupId>
-            <artifactId>commons-daemon</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
             <scope>compile</scope>
@@ -244,7 +238,6 @@
                                 <classpath />
                                 <argument>com.yahoo.jdisc.core.ExportPackages</argument>
                                 <argument>${exportPackagesFile}</argument>
-                                <argument>${project.build.directory}/dependency/commons-daemon.jar</argument>
                                 <argument>__REPLACE_VERSION__${project.build.directory}/dependency/guava.jar</argument>
                                 <argument>${project.build.directory}/dependency/guice-no_aop.jar</argument>
                                 <argument>${project.build.directory}/dependency/guice-assistedinject.jar</argument>

--- a/jdisc_core_test/test_bundles/cert-k-pkgs/src/main/java/com/yahoo/jdisc/bundle/k/CertificateK.java
+++ b/jdisc_core_test/test_bundles/cert-k-pkgs/src/main/java/com/yahoo/jdisc/bundle/k/CertificateK.java
@@ -133,8 +133,6 @@ public class CertificateK {
     private final javax.xml.xpath.XPath xPath = null;
     private final org.aopalliance.intercept.Joinpoint jointpoint = null;
     private final org.aopalliance.aop.Advice advice = null;
-    private final org.apache.commons.daemon.Daemon daemon = null;
-    private final org.apache.commons.daemon.support.DaemonLoader daemonLoader = null;
     private final org.apache.commons.logging.LogFactory logFactory = null;
     private final org.apache.commons.logging.impl.SimpleLog simpleLog = null;
     private final org.apache.log4j.Appender appender = null;


### PR DESCRIPTION
I have verified that no hosted bundles import `commons.daemon*` packages, so it should be safe to remove.

- Has not been needed since we stopped using JSVC.
- NOTE: this commit stops providing it from Jdisc.

FYI: @bratseth, @baldersheim, @arnej27959 