### PR TITLE
Remove unused vespa/vespalib/util/regexp.h include in vdslib.

### DIFF
--- a/vdslib/src/tests/distribution/distributiontest.cpp
+++ b/vdslib/src/tests/distribution/distributiontest.cpp
@@ -13,7 +13,6 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/lexical_cast.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
-#include <vespa/vespalib/util/regexp.h>
 #include <chrono>
 #include <thread>
 #include <fstream>


### PR DESCRIPTION
@baldersheim : please review
