### PR TITLE
Add test-and-set failures as own distributor metric

### DIFF
--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
@@ -28,6 +28,7 @@ public:
     metrics::LongCountMetric inconsistent_bucket;
     metrics::LongCountMetric notfound;
     metrics::LongCountMetric concurrent_mutations;
+    metrics::LongCountMetric test_and_set_failed;
 
     MetricSet * clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
                       metrics::MetricSet* owner, bool includeUnused) const override;


### PR DESCRIPTION
@geirst please review

Would otherwise be counted under mysterious "storagefailure" catch-all
category. Currently not tracked under aggregate failure sum metric,
as these are not really "failures" since TaS-failures are expected
to happen and do not indicate problems in the backend.

We should probably add another aggregate metric for client-expected failures
since these also provide useful information.