### PR TITLE
Add REPLACE_EXISTING for atomic moves

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/UnixPath.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/UnixPath.java
@@ -206,7 +206,7 @@ public class UnixPath {
 
     /** This path must be on the same file system as the to-path. Returns UnixPath of 'to'. */
     public UnixPath atomicMove(Path to) {
-        uncheck(() -> Files.move(path, to, StandardCopyOption.ATOMIC_MOVE));
+        uncheck(() -> Files.move(path, to, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING));
         return new UnixPath(to);
     }
 


### PR DESCRIPTION
If the destination file exists for an atomic move, then JimFs throws a
java.nio.file.FileAlreadyExistsException exception. The documentation for
Files.move() says "all other options are ignored" with ATOMIC_MOVE, so this
seems to be a bug with JimFs. UnixFileSystemProvider correctly ignores other
options with ATOMIC_MOVE.