### PR TITLE
Use summary executor for compactLidSpace() on docstore.

### DIFF
--- a/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
@@ -1146,7 +1146,7 @@ TEST_F("require that compactLidSpace() propagates to document meta store and doc
     f.compactLidSpaceAndWait(2);
     // performIndexForceCommit in index thread, then completion callback
     // in master thread.
-    EXPECT_TRUE(assertThreadObserver(7, 5, 3, f.writeServiceObserver()));
+    EXPECT_TRUE(assertThreadObserver(7, 5, 4, f.writeServiceObserver()));
     EXPECT_EQUAL(2u, f.metaStoreObserver()._compactLidSpaceLidLimit);
     EXPECT_EQUAL(2u, f.getDocumentStore()._compactLidSpaceLidLimit);
     EXPECT_EQUAL(1u, f.metaStoreObserver()._holdUnblockShrinkLidSpaceCnt);

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
@@ -786,7 +786,8 @@ StoreOnlyFeedView::handleCompactLidSpace(const CompactLidSpaceOperation &op)
         forceCommit(serialNum, commitContext);
     }
     if (useDocumentStore(serialNum)) {
-        _summaryAdapter->compactLidSpace(op.getLidLimit());
+        _writeService.summary().execute(makeLambdaTask([this, &op]() { _summaryAdapter->compactLidSpace(op.getLidLimit()); }));
+        _writeService.summary().sync();
     }
 }
 


### PR DESCRIPTION
@baldersheim : please review
