### PR TITLE
improve fake searchable attributes

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/fakesearchcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/fakesearchcontext.cpp
@@ -12,7 +12,9 @@ FakeSearchContext::FakeSearchContext(size_t initialNumDocs)
       _indexes(new IndexCollection(_selector)),
       _attrSearchable(),
       _docIdLimit(initialNumDocs)
-{}
+{
+    _attrSearchable.is_attr(true);
+}
 
 FakeSearchContext::~FakeSearchContext() {}
 

--- a/searchlib/src/tests/queryeval/fake_searchable/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/fake_searchable/CMakeLists.txt
@@ -4,5 +4,6 @@ vespa_add_executable(searchlib_fake_searchable_test_app TEST
     fake_searchable_test.cpp
     DEPENDS
     searchlib
+    gtest
 )
 vespa_add_test(NAME searchlib_fake_searchable_test_app COMMAND searchlib_fake_searchable_test_app)

--- a/searchlib/src/vespa/searchlib/queryeval/fake_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_search.h
@@ -19,7 +19,7 @@ private:
     FakeResult                   _result;
     uint32_t                     _offset;
     fef::TermFieldMatchDataArray _tfmda;
-    std::unique_ptr<attribute::ISearchContext> _ctx;
+    const attribute::ISearchContext *_ctx;
 
     bool valid() const { return _offset < _result.inspect().size(); }
     uint32_t currId() const { return _result.inspect()[_offset].docId; }
@@ -32,16 +32,18 @@ public:
                const FakeResult &res,
                const fef::TermFieldMatchDataArray &tfmda)
         : _tag(tag), _field(field), _term(term),
-          _result(res), _offset(0), _tfmda(tfmda)
+          _result(res), _offset(0), _tfmda(tfmda),
+          _ctx(nullptr)
     {
         assert(_tfmda.size() == 1);
     }
-    void is_attr(bool value);
+    void attr_ctx(const attribute::ISearchContext *ctx) { _ctx = ctx; }
+    bool is_attr() const { return (_ctx != nullptr); }
     void doSeek(uint32_t docid) override;
     void doUnpack(uint32_t docid) override;
     const PostingInfo *getPostingInfo() const override { return _result.postingInfo(); }
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
-    const attribute::ISearchContext *getAttributeSearchContext() const override { return _ctx.get(); }
+    const attribute::ISearchContext *getAttributeSearchContext() const override { return _ctx; }
 };
 
 } // namespace queryeval

--- a/searchlib/src/vespa/searchlib/queryeval/fake_searchable.h
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_searchable.h
@@ -17,11 +17,11 @@ class FakeSearchable : public Searchable
 {
 private:
     typedef std::pair<vespalib::string, vespalib::string> Key;
-    typedef FakeResult                          Value;
-    typedef std::map<Key, Value>                Map;
+    typedef std::map<Key, FakeResult> Map;
 
     vespalib::string _tag;
-    Map         _map;
+    Map              _map;
+    bool             _is_attr;
 
 public:
     /**
@@ -38,6 +38,16 @@ public:
      **/
     FakeSearchable &tag(const vespalib::string &t) {
         _tag = t;
+        return *this;
+    }
+
+    /**
+     * Is this searchable searching attributes? Setting this to true
+     * will result in blueprints and search iterators exposing a
+     * mocked attribute search context interface.
+     **/
+    FakeSearchable &is_attr(bool value) {
+        _is_attr = value;
         return *this;
     }
 

--- a/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.h
@@ -51,7 +51,7 @@ private:
     vespalib::string _term;
     FieldSpec   _field;
     FakeResult  _result;
-    bool _is_attr;
+    std::unique_ptr<attribute::ISearchContext> _ctx;
 
 protected:
     SearchIterator::UP
@@ -67,15 +67,16 @@ public:
     }
     const vespalib::string &tag() const { return _tag; }
 
-    FakeBlueprint &is_attr(bool value) {
-        _is_attr = value;
-        return *this;
-    }
-    bool is_attr() const { return _is_attr; }
+    FakeBlueprint &is_attr(bool value);
+    bool is_attr() const { return bool(_ctx); }
 
     FakeBlueprint &term(const vespalib::string &t) {
         _term = t;
         return *this;
+    }
+
+    const attribute::ISearchContext *get_attribute_search_context() const override {
+        return _ctx.get();
     }
 };
 


### PR DESCRIPTION
blueprint/search iterator now exposes a more functional attribute
search context

fake attribute searches will now unpack a single entry containing the
sum of all matched weights

improve matcher test for same element matching by also using the
attribute element iterator

added tests for identifying matching elements in docsum request

@geirst please review