### PR TITLE
auto-compact empty buffers when requesting writable view

### DIFF
--- a/jrt/src/com/yahoo/jrt/Buffer.java
+++ b/jrt/src/com/yahoo/jrt/Buffer.java
@@ -32,7 +32,12 @@ class Buffer {
         }
         readPos = buf.position();
         buf.limit(buf.capacity());
-        buf.position(writePos);
+        if (readPos == writePos) {
+            readPos = 0;
+            buf.position(0);
+        } else {
+            buf.position(writePos);
+        }
         readMode = false;
     }
 

--- a/jrt/src/com/yahoo/jrt/Buffer.java
+++ b/jrt/src/com/yahoo/jrt/Buffer.java
@@ -34,10 +34,9 @@ class Buffer {
         buf.limit(buf.capacity());
         if (readPos == writePos) {
             readPos = 0;
-            buf.position(0);
-        } else {
-            buf.position(writePos);
+            writePos = 0;
         }
+        buf.position(writePos);
         readMode = false;
     }
 

--- a/jrt/tests/com/yahoo/jrt/BufferTest.java
+++ b/jrt/tests/com/yahoo/jrt/BufferTest.java
@@ -11,6 +11,21 @@ import static org.junit.Assert.assertTrue;
 public class BufferTest {
 
     @org.junit.Test
+    public void testEmptyBufferAutoCompact() {
+        Buffer buf = new Buffer(1024);
+        ByteBuffer b = buf.getWritable(10);
+        for (int x = 0; x < 10; x++) {
+            b.put((byte)x);
+        }
+        b = buf.getReadable();
+        while (b.remaining() > 0) {
+            b.get();
+        }
+        b = buf.getWritable(10);
+        assertEquals(1024, b.remaining());
+    }
+
+    @org.junit.Test
     public void testBuffer() {
 
         int        size = Buffer.MAX_IO + (Buffer.MAX_IO / 10);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review