### PR TITLE
Avoid dependency on weighted set ordering in unit tests

### DIFF
--- a/searchcore/src/tests/proton/common/attribute_updater/attribute_updater_test.cpp
+++ b/searchcore/src/tests/proton/common/attribute_updater/attribute_updater_test.cpp
@@ -29,6 +29,7 @@
 #include <vespa/searchlib/attribute/reference_attribute.h>
 #include <vespa/searchlib/tensor/dense_tensor_attribute.h>
 #include <vespa/searchlib/tensor/generic_tensor_attribute.h>
+#include <vespa/searchlib/test/weighted_type_test_utils.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/testkit/testapp.h>
 
@@ -158,9 +159,14 @@ check(const AttributePtr &vec, uint32_t docId, const std::vector<T> &values)
     std::vector<T> buf(sz);
     uint32_t asz = vec->get(docId, &buf[0], sz);
     if (!EXPECT_EQUAL(sz, asz)) return false;
+    std::vector<T> wanted(values.begin(), values.end());
+    if (vec->hasWeightedSetType()) {
+        std::sort(wanted.begin(), wanted.end(), value_then_weight_order());
+        std::sort(buf.begin(), buf.end(), value_then_weight_order());
+    }
     for (uint32_t i = 0; i < values.size(); ++i) {
-        if (!EXPECT_EQUAL(buf[i].getValue(), values[i].getValue())) return false;
-        if (!EXPECT_EQUAL(buf[i].getWeight(), values[i].getWeight())) return false;
+        if (!EXPECT_EQUAL(buf[i].getValue(), wanted[i].getValue())) return false;
+        if (!EXPECT_EQUAL(buf[i].getWeight(), wanted[i].getWeight())) return false;
     }
     return true;
 }

--- a/searchlib/src/tests/attribute/enum_attribute_compaction/enum_attribute_compaction_test.cpp
+++ b/searchlib/src/tests/attribute/enum_attribute_compaction/enum_attribute_compaction_test.cpp
@@ -6,6 +6,7 @@
 #include <vespa/searchlib/attribute/attributevector.hpp>
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/stringbase.h>
+#include <vespa/searchlib/test/weighted_type_test_utils.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("enum_attribute_compaction_test");
@@ -141,8 +142,13 @@ CompactionTest<VectorType>::check_values(uint32_t doc_id)
     buffer.fill(*_v, doc_id);
     if (_v->hasMultiValue()) {
         EXPECT_EQ(2u, buffer.size());
-        EXPECT_EQ(CheckType(buffer[0]), MyTestData::make_value(doc_id, 0));
-        EXPECT_EQ(CheckType(buffer[1]), MyTestData::make_value(doc_id, 1));
+        int i = 0, j = 1;
+        if (_v->hasWeightedSetType() && !(CheckType(buffer[0]) == MyTestData::make_value(doc_id, 0))) {
+            i = 1;
+            j = 0;
+        }
+        EXPECT_EQ(CheckType(buffer[i]), MyTestData::make_value(doc_id, 0));
+        EXPECT_EQ(CheckType(buffer[j]), MyTestData::make_value(doc_id, 1));
     } else {
         EXPECT_EQ(1u, buffer.size());
         EXPECT_EQ(CheckType(buffer[0]), MyTestData::make_value(doc_id, 0));

--- a/searchlib/src/vespa/searchlib/test/weighted_type_test_utils.h
+++ b/searchlib/src/vespa/searchlib/test/weighted_type_test_utils.h
@@ -1,0 +1,38 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/searchcommon/attribute/iattributevector.h>
+#include <type_traits>
+
+template <typename T> struct IsWeightedType : std::false_type {};
+template <typename T> struct IsWeightedType<search::attribute::WeightedType<T>> : std::true_type {};
+
+struct value_then_weight_order {
+    template <typename T>
+    bool operator()(const T& lhs, const T& rhs) const noexcept {
+        if (lhs.getValue() != rhs.getValue()) {
+            return (lhs.getValue() < rhs.getValue());
+        }
+        return (lhs.getWeight() < rhs.getWeight());
+    }
+};
+
+struct order_by_value {
+    template <typename T>
+    bool operator()(const T& lhs, const T& rhs) const noexcept {
+        if constexpr (IsWeightedType<T>::value) {
+            return (lhs.getValue() < rhs.getValue());
+        } else {
+            return (lhs < rhs);
+        }
+    }
+};
+
+
+struct order_by_weight {
+    template <typename T>
+    bool operator()(const search::attribute::WeightedType<T>& lhs,
+                    const search::attribute::WeightedType<T>& rhs) const noexcept {
+        return (lhs.getWeight() < rhs.getWeight());
+    }
+};


### PR DESCRIPTION
@toregge @geirst please review

Weighted sets are not guaranteed to be ordered, but thus far they
have been in practice due to implementation details of the update logic.

`docsummary_test` still fails, but that's because it explicitly checks the Slime encoded array ordering of weighted set element objects, so it's not entirely obvious how to best fix it.