### PR TITLE
Use modified ECMAScript regular expression grammar for filtering tests to run using vespalib testkit.

### DIFF
--- a/vespalib/src/vespa/vespalib/testkit/test_hook.cpp
+++ b/vespalib/src/vespa/vespalib/testkit/test_hook.cpp
@@ -98,7 +98,7 @@ TestHook::runAll()
     FastOSTestThreadFactory threadFactory;
     TestThreadFactory::factory = &threadFactory;
     std::string name = TestMaster::master.getName();
-    std::regex pattern(lookup_subset_pattern(name), std::regex::extended);
+    std::regex pattern(lookup_subset_pattern(name));
     size_t testsPassed = 0;
     size_t testsFailed = 0;
     size_t testsIgnored = 0;


### PR DESCRIPTION
@baldersheim : please review
