### PR TITLE
Rename feed latency field

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterMetricsRetriever.java
@@ -119,8 +119,8 @@ public class ClusterMetricsRetriever {
                         values.field("query_latency.sum").asDouble(),
                         values.field("query_latency.count").asDouble());
                 metricsAggregator.addFeedLatency(
-                        values.field("feed_latency.sum").asDouble(),
-                        values.field("feed_latency.count").asDouble());
+                        values.field("feed.latency.sum").asDouble(),
+                        values.field("feed.latency.count").asDouble());
                 break;
             case "vespa.qrserver":
                 metricsAggregator.addQrLatency(

--- a/configserver/src/test/resources/metrics/container_metrics
+++ b/configserver/src/test/resources/metrics/container_metrics
@@ -21,8 +21,8 @@
              "values": {
                   "query_latency.count": 43.0,
                   "query_latency.sum": 3000,
-                  "feed_latency.count": 43.0,
-                  "feed_latency.sum": 3000
+                  "feed.latency.count": 43.0,
+                  "feed.latency.sum": 3000
 
               },
               "dimensions": {


### PR DESCRIPTION
`feed_latency` was changed to `feed.latency` at some point. Still `query_latency` though...