### PR TITLE
Remove unused method

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -58,7 +58,6 @@ public interface ModelContext {
         boolean useAdaptiveDispatch();
         // TODO: Remove temporary default implementation
         default Optional<TlsSecrets> tlsSecrets() { return Optional.empty(); }
-        default boolean enableGroupingSessionCache() { return true; } // TODO Remove once no longer in use by old config models
         double defaultTermwiseLimit();
     }
 


### PR DESCRIPTION
Looks like this is not in use anymore, last change related seems to have been weeks ago (but no version specified when this was removed, so please verify that this is correct)
