### PR TITLE
Revert "search-nodes config is long gone. Now it is taken over by dispatch co…"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/LocalProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/LocalProvider.java
@@ -7,6 +7,7 @@ import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.component.chain.model.ChainedComponentModel;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.prelude.cluster.QrMonitorConfig;
+import com.yahoo.search.config.dispatchprototype.SearchNodesConfig;
 import com.yahoo.vespa.config.search.DispatchConfig;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
 import com.yahoo.vespa.config.search.AttributesConfig;
@@ -15,11 +16,9 @@ import com.yahoo.search.searchchain.model.federation.FederationOptions;
 import com.yahoo.search.searchchain.model.federation.LocalProviderSpec;
 import com.yahoo.vespa.model.search.AbstractSearchCluster;
 import com.yahoo.vespa.model.search.IndexedSearchCluster;
+import com.yahoo.vespa.model.search.SearchNode;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Config producer for search chain responsible for sending queries to a local cluster.
@@ -32,6 +31,7 @@ public class LocalProvider extends Provider implements
         AttributesConfig.Producer,
         QrMonitorConfig.Producer,
         RankProfilesConfig.Producer,
+        SearchNodesConfig.Producer,
         DispatchConfig.Producer {
 
     private final LocalProviderSpec providerSpec;
@@ -66,6 +66,22 @@ public class LocalProvider extends Provider implements
         int requestTimeout = federationOptions().getTimeoutInMilliseconds();
         if (requestTimeout != -1) {
             builder.requesttimeout(requestTimeout);
+        }
+    }
+
+    @Override
+    public void getConfig(final SearchNodesConfig.Builder builder) {
+        if (!(searchCluster instanceof IndexedSearchCluster)) {
+            log.warning("Could not build SearchNodesConfig: Only supported for IndexedSearchCluster, got "
+                    + searchCluster.getClass().getCanonicalName());
+            return;
+        }
+        final IndexedSearchCluster indexedSearchCluster = (IndexedSearchCluster) searchCluster;
+        for (final SearchNode searchNode : indexedSearchCluster.getSearchNodes()) {
+            builder.search_node(
+                    new SearchNodesConfig.Search_node.Builder()
+                            .host(searchNode.getHostName())
+                            .port(searchNode.getDispatchPort()));
         }
     }
 
@@ -105,7 +121,7 @@ public class LocalProvider extends Provider implements
         return providerSpec.clusterName;
     }
 
-    void setSearchCluster(AbstractSearchCluster searchCluster) {
+    public void setSearchCluster(AbstractSearchCluster searchCluster) {
         assert (this.searchCluster == null);
         this.searchCluster = searchCluster;
     }

--- a/container-search/src/main/resources/configdefinitions/search-nodes.def
+++ b/container-search/src/main/resources/configdefinitions/search-nodes.def
@@ -1,0 +1,5 @@
+# Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+namespace=search.config.dispatchprototype
+
+search_node[].host string
+search_node[].port int


### PR DESCRIPTION
Reverts vespa-engine/vespa#11090

Broke centos-build, probably some reference in CMakeLists.txt somewhere