### PR TITLE
Create one Dispatcher component per search cluster

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -46,8 +46,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         RankProfilesConfig.Producer,
         RankingConstantsConfig.Producer,
         ServletPathsConfig.Producer,
-        ContainerMbusConfig.Producer
-{
+        ContainerMbusConfig.Producer {
 
     private final Set<FileReference> applicationBundles = new LinkedHashSet<>();
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -99,9 +99,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         DocprocConfig.Producer,
         ClusterInfoConfig.Producer,
         RoutingProviderConfig.Producer,
-        ConfigserverConfig.Producer
-
-{
+        ConfigserverConfig.Producer {
 
     /**
      * URI prefix used for internal, usually programmatic, APIs. URIs using this
@@ -268,6 +266,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
      *
      * @return the removed component, or null if it was not present
      */
+    @SuppressWarnings("unused") // Used from other repositories
     public Component removeComponent(ComponentId componentId) {
         return componentGroup.removeComponent(componentId);
     }
@@ -298,7 +297,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public void addContainer(CONTAINER container) {
         container.setClusterName(name);
         container.setProp("clustername", name)
-                .setProp("index", this.containers.size());
+                 .setProp("index", this.containers.size());
         containers.add(container);
     }
 
@@ -330,7 +329,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public SearchChains getSearchChains() {
         if (containerSearch == null)
             throw new IllegalStateException("Search components not found in container cluster '" + getSubId() +
-                                                    "': Add <search/> to the cluster in services.xml");
+                                            "': Add <search/> to the cluster in services.xml");
         return containerSearch.getChains();
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerModel.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerModel.java
@@ -48,9 +48,8 @@ public class ContainerModel extends ConfigModel {
         List<AbstractSearchCluster> searchClusters = Content.getSearchClusters(configModelRepo);
 
         Map<String, AbstractSearchCluster> searchClustersByName = new TreeMap<>();
-        for (AbstractSearchCluster c : searchClusters) {
+        for (AbstractSearchCluster c : searchClusters)
             searchClustersByName.put(c.getClusterName(), c);
-        }
 
         getCluster().initialize(searchClustersByName);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/ConfigProducerGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/ConfigProducerGroup.java
@@ -55,9 +55,7 @@ public class ConfigProducerGroup<CHILD extends AbstractConfigProducer<?>> extend
         return Collections.unmodifiableCollection(result);
     }
 
-    /**
-     * @return A map of all components in this group, with (local) component ID as key.
-     */
+    /** Returns a map of all components in this group, with (local) component ID as key. */
     public Map<ComponentId, CHILD> getComponentMap() {
         return Collections.unmodifiableMap(producerById);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -11,17 +11,13 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * <p>
  * Models a jdisc RequestHandler (including ClientProvider).
  * RequestHandlers always have at least one server binding,
  * while ClientProviders have at least one client binding.
- * </p>
  * <p>
  * Note that this is also used to model vespa handlers (which do not have any bindings)
- * </p>
  *
  * @author gjoranv
- * @since 5.1.6
  */
 public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<CHILD, ComponentModel> {
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/SimpleComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/SimpleComponent.java
@@ -9,7 +9,6 @@ import com.yahoo.config.model.producer.AbstractConfigProducer;
  * A component that only needs a simple ComponentModel.
  *
  * @author gjoranv
- * @since 5.1.9
  */
 public class SimpleComponent extends Component<AbstractConfigProducer<?>, ComponentModel> {
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/Chain.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/Chain.java
@@ -26,7 +26,6 @@ public class Chain<T extends ChainedComponent<?>> extends AbstractConfigProducer
     private final ComponentGroup<T> innerComponentsGroup;
     private static final Type.Enum TYPE = Type.SEARCH;
 
-
     public Chain(ChainSpecification specWithoutInnerComponents) {
         super(specWithoutInnerComponents.componentId.stringValue());
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatcherComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatcherComponent.java
@@ -1,0 +1,37 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.search;
+
+import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.xml.BundleMapper;
+import com.yahoo.vespa.model.search.IndexedSearchCluster;
+
+/**
+ * Represents a dispatcher component - an instance of a dispatcher in a search container cluster
+ * knows how to communicate with one indexed search cluster and owns the connections to it.
+ */
+public class DispatcherComponent extends Component<DispatcherComponent, ComponentModel>
+        implements DispatchConfig.Producer {
+
+    private final IndexedSearchCluster indexedSearchCluster;
+
+    public DispatcherComponent(IndexedSearchCluster indexedSearchCluster) {
+        super(toComponentModel(indexedSearchCluster));
+        this.indexedSearchCluster = indexedSearchCluster;
+    }
+
+    private static ComponentModel toComponentModel(IndexedSearchCluster indexedSearchCluster) {
+        String dispatcherComponentId = "dispatcher." + indexedSearchCluster.getClusterName(); // used by ClusterSearcher
+        return new ComponentModel(dispatcherComponentId,
+                                  "com.yahoo.search.dispatch.Dispatcher",
+                                  BundleMapper.searchAndDocprocBundle,
+                                  null);
+    }
+
+    @Override
+    public void getConfig(DispatchConfig.Builder builder) {
+        indexedSearchCluster.getConfig(builder);
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/GenericTarget.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/GenericTarget.java
@@ -6,6 +6,7 @@ import com.yahoo.search.searchchain.model.federation.FederationOptions;
 
 /**
  * A search chain that is intended to be used for federation (i.e. providers, sources)
+ *
  * @author Tony Vaagenes
  */
 abstract public class GenericTarget extends SearchChain {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/LocalProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/LocalProvider.java
@@ -18,7 +18,11 @@ import com.yahoo.vespa.model.search.AbstractSearchCluster;
 import com.yahoo.vespa.model.search.IndexedSearchCluster;
 import com.yahoo.vespa.model.search.SearchNode;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 
 /**
  * Config producer for search chain responsible for sending queries to a local cluster.
@@ -31,8 +35,7 @@ public class LocalProvider extends Provider implements
         AttributesConfig.Producer,
         QrMonitorConfig.Producer,
         RankProfilesConfig.Producer,
-        SearchNodesConfig.Producer,
-        DispatchConfig.Producer {
+        SearchNodesConfig.Producer {
 
     private final LocalProviderSpec providerSpec;
     private volatile AbstractSearchCluster searchCluster;
@@ -122,7 +125,6 @@ public class LocalProvider extends Provider implements
     }
 
     public void setSearchCluster(AbstractSearchCluster searchCluster) {
-        assert (this.searchCluster == null);
         this.searchCluster = searchCluster;
     }
 
@@ -176,13 +178,4 @@ public class LocalProvider extends Provider implements
         return (visibilityDelay < 1.0d) ? 0.0d : visibilityDelay;
     }
 
-    @Override
-    public void getConfig(DispatchConfig.Builder builder) {
-        if (!(searchCluster instanceof IndexedSearchCluster)) {
-            log.warning("Could not build DispatchConfig: Only supported for IndexedSearchCluster, got "
-                        + searchCluster.getClass().getCanonicalName());
-            return;
-        }
-        ((IndexedSearchCluster) searchCluster).getConfig(builder);
-    }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/SearchChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/SearchChains.java
@@ -29,7 +29,7 @@ public class SearchChains extends Chains<SearchChain> {
         LocalClustersCreator.addDefaultLocalProviders(this, searchClustersByName.keySet());
         VespaSearchChainsCreator.addVespaSearchChains(this);
 
-        validateSourceGroups(); //must be done before initializing searchers since they are used by FederationSearchers.
+        validateSourceGroups(); //must be done before initializing searchers since they are used by FederationSearchers
         initializeComponents(searchClustersByName);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleMapper.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleMapper.java
@@ -28,7 +28,6 @@ public class BundleMapper {
 
     public static final Path LIBRARY_PATH = Paths.get(Defaults.getDefaults().underVespaHome("lib/jars"));
 
-
     public static final String searchAndDocprocBundle = "container-search-and-docproc";
 
     private static final Map<String, String> bundleFromClass;
@@ -110,7 +109,6 @@ public class BundleMapper {
         bundleFromClass.put("com.yahoo.search.pagetemplates.engine.Resolver", searchAndDocprocBundle);
         bundleFromClass.put("com.yahoo.search.pagetemplates.engine.resolvers.DeterministicResolver", searchAndDocprocBundle);
         bundleFromClass.put("com.yahoo.search.pagetemplates.engine.resolvers.RandomResolver", searchAndDocprocBundle);
-        bundleFromClass.put("com.yahoo.search.pagetemplates.model.Renderer", searchAndDocprocBundle);
         bundleFromClass.put("com.yahoo.search.pagetemplates.model.Renderer", searchAndDocprocBundle);
         bundleFromClass.put("com.yahoo.search.query.rewrite.QueryRewriteSearcher", searchAndDocprocBundle);
         bundleFromClass.put("com.yahoo.search.query.rewrite.SearchChainDispatcherSearcher", searchAndDocprocBundle);

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/AbstractSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/AbstractSearchCluster.java
@@ -29,13 +29,62 @@ public abstract class AbstractSearchCluster extends AbstractConfigProducer
     protected int index;
     private Double visibilityDelay = 0.0;
     private List<String> documentNames = new ArrayList<>();
+    private List<SearchDefinitionSpec> localSDS = new LinkedList<>();
 
-    protected List<SearchDefinitionSpec> localSDS = new LinkedList<>();
+    public AbstractSearchCluster(AbstractConfigProducer parent, String clusterName, int index) {
+        super(parent, "cluster." + clusterName);
+        this.clusterName = clusterName;
+        this.index = index;
+    }
 
     public void prepareToDistributeFiles(List<SearchNode> backends) {
         for (SearchDefinitionSpec sds : localSDS)
             sds.getSearchDefinition().getSearch().rankingConstants().sendTo(backends);
     }
+
+    public void addDocumentNames(SearchDefinition searchDefinition) {
+        String dName = searchDefinition.getSearch().getDocument().getDocumentName().getName();
+        documentNames.add(dName);
+    }
+
+    /** Returns a List with document names used in this search cluster */
+    public List<String> getDocumentNames() { return documentNames; }
+
+    public List<SearchDefinitionSpec> getLocalSDS() {
+        return localSDS;
+    }
+
+    public String getClusterName()              { return clusterName; }
+    public final String getIndexingModeName()   { return getIndexingMode().getName(); }
+    public final boolean isRealtime()           { return getIndexingMode() == IndexingMode.REALTIME; }
+    public final boolean isStreaming()          { return getIndexingMode() == IndexingMode.STREAMING; }
+
+    public final AbstractSearchCluster setQueryTimeout(Double to) {
+        this.queryTimeout=to;
+        return this;
+    }
+
+    public final AbstractSearchCluster setVisibilityDelay(double delay) {
+        this.visibilityDelay=delay;
+        return this;
+    }
+
+    protected abstract IndexingMode getIndexingMode();
+    public final Double getVisibilityDelay() { return visibilityDelay; }
+    public final Double getQueryTimeout() { return queryTimeout; }
+    public abstract int getRowBits();
+    public final void setClusterIndex(int index) { this.index = index; }
+    public final int getClusterIndex() { return index; }
+    protected abstract void assureSdConsistent();
+
+    @Override
+    public abstract void getConfig(DocumentdbInfoConfig.Builder builder);
+    @Override
+    public abstract void getConfig(IndexInfoConfig.Builder builder);
+    @Override
+    public abstract void getConfig(IlscriptsConfig.Builder builder);
+    public abstract void getConfig(RankProfilesConfig.Builder builder);
+    public abstract void getConfig(AttributesConfig.Builder builder);
 
     public static final class IndexingMode {
 
@@ -74,52 +123,5 @@ public abstract class AbstractSearchCluster extends AbstractConfigProducer
             return userConfigRepo;
         }
     }
-
-    public AbstractSearchCluster(AbstractConfigProducer parent, String clusterName, int index) {
-        super(parent, "cluster." + clusterName);
-        this.clusterName = clusterName;
-        this.index = index;
-    }
-
-    public void addDocumentNames(SearchDefinition searchDefinition) {
-        String dName = searchDefinition.getSearch().getDocument().getDocumentName().getName();
-        documentNames.add(dName);
-    }
-
-    /** Returns a List with document names used in this search cluster */
-    public List<String> getDocumentNames() { return documentNames; }
-
-    public List<SearchDefinitionSpec> getLocalSDS() {
-        return localSDS;
-    }
-
-    public String getClusterName()              { return clusterName; }
-    public final String getIndexingModeName()   { return getIndexingMode().getName(); }
-    public final boolean isRealtime()           { return getIndexingMode() == IndexingMode.REALTIME; }
-    public final boolean isStreaming()          { return getIndexingMode() == IndexingMode.STREAMING; }
-    public final AbstractSearchCluster setQueryTimeout(Double to) {
-        this.queryTimeout=to;
-        return this;
-    }
-    public final AbstractSearchCluster setVisibilityDelay(double delay) {
-        this.visibilityDelay=delay;
-        return this;
-    }
-    protected abstract IndexingMode getIndexingMode();
-    public final Double getVisibilityDelay() { return visibilityDelay; }
-    public final Double getQueryTimeout() { return queryTimeout; }
-    public abstract int getRowBits();
-    public final void setClusterIndex(int index) { this.index = index; }
-    public final int getClusterIndex() { return index; }
-    protected abstract void assureSdConsistent();
-
-    @Override
-    public abstract void getConfig(DocumentdbInfoConfig.Builder builder);
-    @Override
-    public abstract void getConfig(IndexInfoConfig.Builder builder);
-    @Override
-    public abstract void getConfig(IlscriptsConfig.Builder builder);
-    public abstract void getConfig(RankProfilesConfig.Builder builder);
-    public abstract void getConfig(AttributesConfig.Builder builder);
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -30,53 +30,9 @@ import java.util.List;
 public class IndexedSearchCluster extends SearchCluster
     implements
         DocumentdbInfoConfig.Producer,
-        // TODO consider removing, these only produced by UnionConfiguration and DocumentDatabase?
         IndexInfoConfig.Producer,
         IlscriptsConfig.Producer,
-        DispatchConfig.Producer
-{
-
-    /**
-     * Class used to retrieve combined configuration from multiple document databases.
-     * It is not a {@link com.yahoo.config.ConfigInstance.Producer} of those configs,
-     * that is handled (by delegating to this) by the {@link IndexedSearchCluster}
-     * which is the parent to this. This avoids building the config multiple times.
-     */
-    public static class UnionConfiguration
-        extends AbstractConfigProducer
-        implements AttributesConfig.Producer {
-        private final List<DocumentDatabase> docDbs;
-
-        public void getConfig(IndexInfoConfig.Builder builder) {
-            for (DocumentDatabase docDb : docDbs) {
-                docDb.getConfig(builder);
-            }
-        }
-
-        public void getConfig(IlscriptsConfig.Builder builder) {
-            for (DocumentDatabase docDb : docDbs) {
-                docDb.getConfig(builder);
-            }
-        }
-
-        @Override
-        public void getConfig(AttributesConfig.Builder builder) {
-            for (DocumentDatabase docDb : docDbs) {
-                docDb.getConfig(builder);
-            }
-        }
-
-        public void getConfig(RankProfilesConfig.Builder builder) {
-            for (DocumentDatabase docDb : docDbs) {
-                docDb.getConfig(builder);
-            }
-        }
-
-        private UnionConfiguration(AbstractConfigProducer parent, List<DocumentDatabase> docDbs) {
-            super(parent, "union");
-            this.docDbs = docDbs;
-        }
-    }
+        DispatchConfig.Producer {
 
     private String indexingClusterName = null; // The name of the docproc cluster to run indexing, by config.
     private String indexingChainName = null;
@@ -387,5 +343,47 @@ public class IndexedSearchCluster extends SearchCluster
 
     @Override
     public int getRowBits() { return 8; }
+
+    /**
+     * Class used to retrieve combined configuration from multiple document databases.
+     * It is not a {@link com.yahoo.config.ConfigInstance.Producer} of those configs,
+     * that is handled (by delegating to this) by the {@link IndexedSearchCluster}
+     * which is the parent to this. This avoids building the config multiple times.
+     */
+    public static class UnionConfiguration
+            extends AbstractConfigProducer
+            implements AttributesConfig.Producer {
+        private final List<DocumentDatabase> docDbs;
+
+        public void getConfig(IndexInfoConfig.Builder builder) {
+            for (DocumentDatabase docDb : docDbs) {
+                docDb.getConfig(builder);
+            }
+        }
+
+        public void getConfig(IlscriptsConfig.Builder builder) {
+            for (DocumentDatabase docDb : docDbs) {
+                docDb.getConfig(builder);
+            }
+        }
+
+        @Override
+        public void getConfig(AttributesConfig.Builder builder) {
+            for (DocumentDatabase docDb : docDbs) {
+                docDb.getConfig(builder);
+            }
+        }
+
+        public void getConfig(RankProfilesConfig.Builder builder) {
+            for (DocumentDatabase docDb : docDbs) {
+                docDb.getConfig(builder);
+            }
+        }
+
+        private UnionConfiguration(AbstractConfigProducer parent, List<DocumentDatabase> docDbs) {
+            super(parent, "union");
+            this.docDbs = docDbs;
+        }
+    }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/IndexedTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/IndexedTest.java
@@ -166,8 +166,7 @@ public class IndexedTest extends ContentBaseTest {
     }
 
     @Test
-    public void requireProtonStreamingOnly()
-    {
+    public void requireProtonStreamingOnly() {
         VespaModel model = getStreamingVespaModel();
         // TODO
         // HostResource h = model.getHostSystem().getHosts().get(0);
@@ -185,8 +184,7 @@ public class IndexedTest extends ContentBaseTest {
     }
 
     @Test
-    public void requireCorrectClusterList()
-    {
+    public void requireCorrectClusterList() {
         VespaModel model = getStreamingVespaModel();
         ContentCluster s = model.getContentClusters().get("test");
         assertNotNull(s);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
@@ -24,7 +24,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ClusterTest {
 
-    static final double DELTA = 1E-12;
+    private static final double DELTA = 1E-12;
+
     @Test
     public void requireThatContentSearchIsApplied() {
         ContentCluster cluster = newContentCluster(joinLines("<search>",

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchClusterTest.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.search.test;
 
+import com.yahoo.component.ComponentId;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.document.DataType;
 import com.yahoo.search.config.ClusterConfig;
@@ -9,20 +10,22 @@ import com.yahoo.searchdefinition.SearchBuilder;
 import com.yahoo.searchdefinition.document.Attribute;
 import com.yahoo.searchdefinition.document.SDDocumentType;
 import com.yahoo.searchdefinition.document.SDField;
+import com.yahoo.vespa.config.search.DispatchConfig;
 import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ScriptExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.StatementExpression;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.search.AbstractSearchCluster;
+import com.yahoo.vespa.model.search.SearchCluster;
 import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 /**
- *
  * Unit tests for SearchCluster. Please use this instead of SearchModelTestCase if possible and
  * write _unit_ tests. Thanks.
  *
@@ -30,32 +33,19 @@ import static org.junit.Assert.*;
  */
 public class SearchClusterTest {
 
-    private String vespaHosts = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
-            "<hosts>  " +
-            "<host name=\"foo\">" +
-            "<alias>node0</alias>" +
-            "</host>" +
-            "<host name=\"bar\">" +
-            "<alias>node1</alias>" +
-            "</host>" +
-            "<host name=\"baz\">" +
-            "<alias>node2</alias>" +
-            "</host>" +
-            "</hosts>";
-
     @Test
     public void testSdConfigLogical() {
         // sd1
-        SDDocumentType sdt1=new SDDocumentType("s1");
+        SDDocumentType sdt1 = new SDDocumentType("s1");
         Search search1 = new Search("s1", null);
-        SDField f1=new SDField("f1", DataType.STRING);
+        SDField f1 = new SDField("f1", DataType.STRING);
         f1.addAttribute(new Attribute("f1", DataType.STRING));
         f1.setIndexingScript(new ScriptExpression(new StatementExpression(new AttributeExpression("f1"))));
         sdt1.addField(f1);
         search1.addDocument(sdt1);
 
         // sd2
-        SDDocumentType sdt2=new SDDocumentType("s2");
+        SDDocumentType sdt2 = new SDDocumentType("s2");
         Search search2 = new Search("s2", null);
         SDField f2=new SDField("f2", DataType.STRING);
         f2.addAttribute(new Attribute("f2", DataType.STRING));
@@ -71,7 +61,21 @@ public class SearchClusterTest {
 
     @Test
     public void search_model_is_connected_to_container_clusters_two_content_clusters() {
-        String services = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+        String vespaHosts = "<?xml version='1.0' encoding='utf-8' ?>" +
+                            "<hosts>" +
+                            "  <host name='node0host'>" +
+                            "    <alias>node0</alias>" +
+                            "  </host>" +
+                            "  <host name='node1host'>" +
+                            "    <alias>node1</alias>" +
+                            "  </host>" +
+                            "  <host name='node2host'>" +
+                            "    <alias>node2</alias>" +
+                            "  </host>" +
+                            "</hosts>";
+
+        String services =
+                "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
                 "<services version=\"1.0\">" +
                 "  <admin version='2.0'>" +
                 "    <adminserver hostalias='node0' />" +
@@ -105,50 +109,74 @@ public class SearchClusterTest {
                 "     <documents>" +
                 "       <document mode='index' type=\"music\" />" +
                 "     </documents>" +
-                "         <nodes>" +
-                "            <node hostalias=\"node0\" distribution-key=\"0\" />" +
-                "         </nodes>" +
+                "     <nodes>" +
+                "       <node hostalias=\"node0\" distribution-key=\"0\" />" +
+                "     </nodes>" +
                 "  </content>" +
                 "  <content id=\"normal\" version='1.0'>" +
                 "     <redundancy>2</redundancy>" +
                 "     <documents>" +
                 "       <document mode='index' type=\"music\" />" +
                 "     </documents>" +
-                "         <nodes>" +
-                "            <node hostalias=\"node2\" distribution-key=\"0\" />" +
-                "         </nodes>" +
+                "     <nodes>" +
+                "       <node hostalias=\"node2\" distribution-key=\"0\" />" +
+                "     </nodes>" +
                 "  </content>" +
                 "</services>";
 
         VespaModel model = new VespaModelCreatorWithMockPkg(vespaHosts, services, ApplicationPackageUtils.generateSearchDefinitions("music")).create();
 
-        ContainerCluster cluster1 = (ContainerCluster)model.getConfigProducer("j1").get();
-        assertFalse(cluster1.getSearch().getChains().localProviders().isEmpty());
+        ContainerCluster containerCluster1 = (ContainerCluster)model.getConfigProducer("j1").get();
+        assertFalse(containerCluster1.getSearch().getChains().localProviders().isEmpty());
 
-        ContainerCluster cluster2 = (ContainerCluster)model.getConfigProducer("j2").get();
-        assertFalse(cluster2.getSearch().getChains().localProviders().isEmpty());
+        ContainerCluster containerCluster2 = (ContainerCluster)model.getConfigProducer("j2").get();
+        assertFalse(containerCluster2.getSearch().getChains().localProviders().isEmpty());
 
         QrSearchersConfig.Builder builder = new QrSearchersConfig.Builder();
-        cluster1.getConfig(builder);
+        containerCluster1.getConfig(builder);
         QrSearchersConfig config = new QrSearchersConfig(builder);
 
-        assertThat(config.searchcluster().size(), is(2));
-        int normalId = 0;
-        int bulkId = 1;
-        assertThat(config.searchcluster().get(normalId).name(), is("normal"));
-        assertThat(config.searchcluster().get(bulkId).name(), is("xbulk"));
+        assertEquals(2, config.searchcluster().size());
+        int normalIndex = 0;
+        int xbulkIndex = 1;
+        assertEquals("normal", config.searchcluster().get(normalIndex).name());
+        assertEquals("xbulk", config.searchcluster().get(xbulkIndex).name());
 
         ClusterConfig.Builder clusterConfigBuilder = new ClusterConfig.Builder();
         model.getConfig(clusterConfigBuilder, "j1/searchchains/chain/normal/component/com.yahoo.prelude.cluster.ClusterSearcher");
         ClusterConfig clusterConfig = new ClusterConfig(clusterConfigBuilder);
-        assertThat(clusterConfig.clusterId(), is(normalId));
-        assertThat(clusterConfig.clusterName(), is("normal"));
+        assertEquals(normalIndex, clusterConfig.clusterId());
+        assertEquals("normal", clusterConfig.clusterName());
 
         ClusterConfig.Builder clusterConfigBuilder2 = new ClusterConfig.Builder();
         model.getConfig(clusterConfigBuilder2, "j2/searchchains/chain/xbulk/component/com.yahoo.prelude.cluster.ClusterSearcher");
         ClusterConfig clusterConfig2 = new ClusterConfig(clusterConfigBuilder2);
-        assertThat(clusterConfig2.clusterId(), is(bulkId));
-        assertThat(clusterConfig2.clusterName(), is("xbulk"));
+        assertEquals(xbulkIndex, clusterConfig2.clusterId());
+        assertEquals("xbulk", clusterConfig2.clusterName());
+
+        AbstractSearchCluster searchCluster1 = model.getSearchClusters().get(normalIndex);
+        assertEquals("normal", searchCluster1.getClusterName());
+        assertEquals("normal/search/cluster.normal", searchCluster1.getConfigId());
+        AbstractSearchCluster searchCluster2 = model.getSearchClusters().get(xbulkIndex);
+        assertEquals("xbulk", searchCluster2.getClusterName());
+
+        Component<?,?> normalDispatcher = (Component<?, ?>)containerCluster1.getComponentsMap().get(new ComponentId("dispatcher.normal"));
+        assertNotNull(normalDispatcher);
+        assertEquals("dispatcher.normal", normalDispatcher.getComponentId().stringValue());
+        assertEquals("com.yahoo.search.dispatch.Dispatcher", normalDispatcher.getClassId().stringValue());
+        assertEquals("j1/component/dispatcher.normal", normalDispatcher.getConfigId());
+        DispatchConfig.Builder normalDispatchConfigBuilder = new DispatchConfig.Builder();
+        model.getConfig(normalDispatchConfigBuilder, "j1/component/dispatcher.normal");
+        assertEquals("node2host", normalDispatchConfigBuilder.build().node(0).host());
+
+        Component<?,?> xbulkDispatcher = (Component<?, ?>)containerCluster1.getComponentsMap().get(new ComponentId("dispatcher.xbulk"));
+        assertNotNull(xbulkDispatcher);
+        assertEquals("dispatcher.xbulk", xbulkDispatcher.getComponentId().stringValue());
+        assertEquals("com.yahoo.search.dispatch.Dispatcher", xbulkDispatcher.getClassId().stringValue());
+        assertEquals("j1/component/dispatcher.xbulk", xbulkDispatcher.getConfigId());
+        DispatchConfig.Builder xbulkDispatchConfigBuilder = new DispatchConfig.Builder();
+        model.getConfig(xbulkDispatchConfigBuilder, "j1/component/dispatcher.xbulk");
+        assertEquals("node0host", xbulkDispatchConfigBuilder.build().node(0).host());
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
  * @author ollivir
  */
 public class RpcInvokerFactory extends InvokerFactory implements PingFactory {
+
     /** Unless turned off this will fill summaries by dispatching directly to search nodes over RPC when possible */
     private final static CompoundName dispatchSummaries = new CompoundName("dispatch.summaries");
 

--- a/container-search/src/main/java/com/yahoo/search/federation/sourceref/SourcesTarget.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/sourceref/SourcesTarget.java
@@ -16,8 +16,9 @@ import java.util.TreeSet;
 
 
 public class SourcesTarget extends Target {
-    private ComponentRegistry<ComponentAdaptor<SearchChainInvocationSpec>> providerSources =
-            new ComponentRegistry<ComponentAdaptor<SearchChainInvocationSpec>>() {};
+
+    private ComponentRegistry<ComponentAdaptor<SearchChainInvocationSpec>> providerSources = new ComponentRegistry<>() {};
+
     private SearchChainInvocationSpec defaultProviderSource;
 
     public SourcesTarget(ComponentId sourceId) {

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/MockDispatcher.java
@@ -12,6 +12,7 @@ import com.yahoo.vespa.config.search.DispatchConfig;
 import java.util.List;
 
 class MockDispatcher extends Dispatcher {
+
     public static MockDispatcher create(List<Node> nodes) {
         var rpcResourcePool = new RpcResourcePool(toDispatchConfig(nodes));
 
@@ -30,7 +31,7 @@ class MockDispatcher extends Dispatcher {
     }
 
     private MockDispatcher(SearchCluster searchCluster, DispatchConfig dispatchConfig, RpcInvokerFactory invokerFactory) {
-        super(searchCluster, dispatchConfig, invokerFactory, invokerFactory, new MockMetric());
+        super(searchCluster, dispatchConfig, invokerFactory, new MockMetric());
     }
 
     private static DispatchConfig toDispatchConfig(List<Node> nodes) {
@@ -46,4 +47,5 @@ class MockDispatcher extends Dispatcher {
         }
         return new DispatchConfig(dispatchConfigBuilder);
     }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
@@ -38,14 +38,12 @@ public class DispatcherTest {
 
     @Test
     public void requireDispatcherToIgnoreMultilevelConfigurations() {
-        SearchCluster cl = new MockSearchCluster("1", 2, 2);
-        DispatchConfig.Builder builder = new DispatchConfig.Builder();
-        builder.useMultilevelDispatch(true);
-        DispatchConfig dc = new DispatchConfig(builder);
+        SearchCluster searchCluster = new MockSearchCluster("1", 2, 2);
+        DispatchConfig dispatchConfig = new DispatchConfig.Builder().useMultilevelDispatch(true).build();
 
-        var invokerFactory = new MockInvokerFactory(cl);
+        var invokerFactory = new MockInvokerFactory(searchCluster);
 
-        Dispatcher disp = new Dispatcher(cl, dc, invokerFactory, invokerFactory, new MockMetric());
+        Dispatcher disp = new Dispatcher(searchCluster, dispatchConfig, invokerFactory, invokerFactory, new MockMetric());
         assertThat(disp.getSearchInvoker(query(), null).isPresent(), is(false));
     }
 
@@ -113,6 +111,7 @@ public class DispatcherTest {
     }
 
     private static class MockInvokerFactory extends InvokerFactory implements PingFactory {
+
         private final FactoryStep[] events;
         private int step = 0;
 


### PR DESCRIPTION
This avoids creating an excessive number of connections
to search clusters when the application (incorrectly) creates
many local provider chains to the same search cluster.
