### PR TITLE
Add "safe mode" flag support to vespa-set-node-state tool

### DIFF
--- a/vespaclient/src/perl/lib/Yahoo/Vespa/Bin/SetNodeState.pm
+++ b/vespaclient/src/perl/lib/Yahoo/Vespa/Bin/SetNodeState.pm
@@ -22,6 +22,7 @@ our $wanted_state_description;
 our $nodes_attempted_set;
 our $success;
 our $no_wait;
+our $safe_mode;
 
 return 1;
 
@@ -63,6 +64,12 @@ EOS
     setOptionHeader("Options related to operation visibility:");
     setFlagOption(['n', 'no-wait'], \$no_wait, "Do not wait for node state "
                 . "changes to be visible in the cluster before returning.");
+    setFlagOption(['a', 'safe'], \$safe_mode, "Only carries out state changes "
+                . "if deemed safe by the cluster controller. For maintenance mode, "
+                . "will also set the distributor with the same distribution key "
+                . "to down atomically as part of the same state change. For up "
+                . "mode, transition is only allowed if the content node reports "
+                . "itself as up. Only supported for type storage.");
 
     Yahoo::Vespa::ContentNodeSelection::registerCommandLineArguments();
     Yahoo::Vespa::VespaModel::registerCommandLineArguments();
@@ -115,6 +122,6 @@ sub setNodeStateForNode {
     my ($cluster, $type, $index) = (
             $$info{'cluster'}, $$info{'type'}, $$info{'index'});
     $success &&= setNodeUserState($cluster, $type, $index, $wanted_state,
-                                  $wanted_state_description, $no_wait);
+                                  $wanted_state_description, $no_wait, $safe_mode);
     ++$nodes_attempted_set;
 }

--- a/vespaclient/src/perl/lib/Yahoo/Vespa/ClusterController.pm
+++ b/vespaclient/src/perl/lib/Yahoo/Vespa/ClusterController.pm
@@ -80,8 +80,8 @@ sub detectClusterController { # ()
         enableAutomaticLineBreaks($oldVal);
     }
 }
-sub setNodeUserState { # (ClusterName, NodeType, Index, State, Reason, NoWait)
-    my ($cluster, $service, $index, $state, $reason, $no_wait) = @_;
+sub setNodeUserState { # (ClusterName, NodeType, Index, State, Reason, NoWait, SafeMode)
+    my ($cluster, $service, $index, $state, $reason, $no_wait, $safe_mode) = @_;
     my @params = ();
     my @headers = (
         'Content-Type' => 'application/json'
@@ -102,6 +102,9 @@ sub setNodeUserState { # (ClusterName, NodeType, Index, State, Reason, NoWait)
     };
     if ($no_wait) {
         $request->{'response-wait'} = 'no-wait';
+    }
+    if ($safe_mode) {
+        $request->{'condition'} = 'safe';
     }
     my $content = Json::encode($request);
 


### PR DESCRIPTION
@geirst please review this tiny bit of happy Perl code 🙈 System testing of the flag will come shortly.

Enables the tool to trigger the same state transition checks that are
used by orchestration components. Caveat: due to the REST API currently
returning HTTP 200 OK even for denied transitions (but with a JSON payload
indicating failure instead), the tool will return with status code 0
even if the state change failed.
