### PR TITLE
Fix application handler bindings to work with instance

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -116,20 +116,7 @@
       <binding>http://*/application/v2/tenant/*/application/</binding>
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.ApplicationHandler' bundle='configserver'>
-      <!-- WARNING: THIS LIST *MUST* MATCH THE ONE IN ApplicationHandler::getBindingMatch -->
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/content/*</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/filedistributionstatus</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/suspended</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/restart</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/converge</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/serviceconverge</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/serviceconverge/*</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/clustercontroller/*/status/*</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/metrics</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*/logs</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/environment/*/region/*/instance/*</binding>
       <binding>http://*/application/v2/tenant/*/application/*</binding>
-      <binding>http://*/application/v2/tenant/*/application/*/logs</binding>
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.HttpGetConfigHandler' bundle='configserver'>
       <binding>http://*/config/v2/tenant/*/application/*/*</binding>


### PR DESCRIPTION
Currently the old logs path is matched before the new one (because `logs` is lexicographically before `environment`), likely there is a bug in `GlobPattern::compareTo`, but I don't wanna risk changing that cause that just might break everything.

At least this removes duplication between `ApplicationHandler.java` and `services.xml`.