### PR TITLE
Revert "Store commit details of latest version"

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.controller;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
-import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneApi;
@@ -193,14 +192,7 @@ public final class ControllerTester {
 
     /** Upgrade controller to given version */
     public void upgradeController(Version version, String commitSha, Instant commitDate) {
-        for (var hostname : controller().curator().cluster()) {
-            upgradeController(hostname, version, commitSha, commitDate);
-        }
-    }
-
-    /** Upgrade controller to given version */
-    public void upgradeController(HostName hostname, Version version, String commitSha, Instant commitDate) {
-        controller().curator().writeControllerVersion(hostname, new ControllerVersion(version, commitSha, commitDate));
+        controller().curator().writeControllerVersion(controller().hostname(), new ControllerVersion(version, commitSha, commitDate));
         computeVersionStatus();
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalDeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalDeploymentTester.java
@@ -82,11 +82,7 @@ public class InternalDeploymentTester {
     public Instance instance(ApplicationId id) { return tester.instance(id); }
 
     public InternalDeploymentTester() {
-        this(new ControllerTester());
-    }
-
-    public InternalDeploymentTester(ControllerTester controllerTester) {
-        tester = new DeploymentTester(controllerTester);
+        tester = new DeploymentTester();
         jobs = tester.controller().jobController();
         routing = tester.controllerTester().serviceRegistry().routingGeneratorMock();
         cloud = (MockTesterCloud) tester.controller().jobController().cloud();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
@@ -386,16 +386,9 @@ public class VersionStatusTest {
 
     @Test
     public void testCommitDetailsPreservation() {
-        HostName controller1 = HostName.from("controller-1");
-        HostName controller2 = HostName.from("controller-2");
-        HostName controller3 = HostName.from("controller-3");
-        MockCuratorDb db = new MockCuratorDb(Stream.of(controller1, controller2, controller3)
-                                                   .map(hostName -> hostName.value() + ":2222")
-                                                   .collect(Collectors.joining(",")));
-        InternalDeploymentTester tester = new InternalDeploymentTester(new ControllerTester(db));
-
+        InternalDeploymentTester tester = new InternalDeploymentTester();
         // Commit details are set for initial version
-        var version0 = new Version("7.2");
+        var version0 = new Version("6.2");
         var commitSha0 = "badc0ffee";
         var commitDate0 = Instant.EPOCH;
         tester.controllerTester().upgradeSystem(version0);
@@ -407,7 +400,7 @@ public class VersionStatusTest {
         tester.deploymentContext().submit().deploy();
 
         // Commit details are updated for new version
-        var version1 = new Version("7.3");
+        var version1 = new Version("6.3");
         var commitSha1 = "deadbeef";
         var commitDate1 = Instant.ofEpochMilli(123);
         tester.controllerTester().upgradeController(version1, commitSha1, commitDate1);


### PR DESCRIPTION
Reverts vespa-engine/vespa#11137

Unit test fails with:
`[ERROR] testCommitDetailsPreservation(com.yahoo.vespa.hosted.controller.versions.VersionStatusTest)  Time elapsed: 0.026 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[badc0ffee]> but was:<[ac7f8b21dcdc2be0dd112b75872345db6f308c68]>
	at com.yahoo.vespa.hosted.controller.versions.VersionStatusTest.testCommitDetailsPreservation(VersionStatusTest.java:403)
`