### PR TITLE
Require security/clients.pem in public systems

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -63,6 +63,7 @@ public class TestProperties implements ModelContext.Properties {
         defaultTermwiseLimit = limit;
         return this;
     }
+
     public TestProperties setApplicationId(ApplicationId applicationId) {
         this.applicationId = applicationId;
         return this;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -316,16 +316,14 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
         // If the deployment contains certificate/private key reference, setup TLS port
         if (deployState.tlsSecrets().isPresent()) {
-            addTlsPort(deployState, spec, cluster);
+            addTlsPort(deployState, cluster);
         }
     }
 
-    private void addTlsPort(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {
-        boolean authorizeClient = XML.getChild(spec, "client-authorize") != null;
-        if (authorizeClient) {
-            if (deployState.tlsClientAuthority().isEmpty()) {
-                throw new RuntimeException("client-authorize set, but security/clients.pem is missing");
-            }
+    private void addTlsPort(DeployState deployState, ApplicationContainerCluster cluster) {
+        boolean authorizeClient = deployState.zone().system().isPublic();
+        if (authorizeClient && deployState.tlsClientAuthority().isEmpty()) {
+            throw new RuntimeException("Client certificate authority security/clients.pem is missing - see: https://vespa.ai/documentation/security-model#data-plane");
         }
         if(cluster.getHttp() == null) {
             Http http = new Http(Collections.emptyList());

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -682,7 +682,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     }
 
     @Test
-    public void client_ca_certs_succeeds_with_client_authorize_and_clients_pem() {
+    public void security_clients_pem_is_picked_up() {
         var applicationPackage = new MockApplicationPackage.Builder()
                 .withRoot(applicationFolder.getRoot())
                 .build();


### PR DESCRIPTION
* Require that `security/clients.pem` is present in public.
* Point to documentation in error message.