### PR TITLE
Store commit details of latest version

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionStatus.java
@@ -99,11 +99,6 @@ public class VersionStatus {
         }
         infrastructureVersions.putAll(systemApplicationVersions.asVersionMap());
 
-        // The controller version is the lowest controller version of all controllers
-        ControllerVersion controllerVersion = controllerVersions.keySet().stream()
-                                                                .min(Comparator.naturalOrder())
-                                                                .get();
-
         // The system version is the oldest infrastructure version, if that version is newer than the current system
         // version
         Version newSystemVersion = infrastructureVersions.keySet().stream().min(Comparator.naturalOrder()).get();
@@ -134,7 +129,7 @@ public class VersionStatus {
             try {
                 boolean isReleased = Collections.binarySearch(releasedVersions, statistics.version()) >= 0;
                 VespaVersion vespaVersion = createVersion(statistics,
-                                                          controllerVersion,
+                                                          controllerVersions.keySet(),
                                                           systemVersion,
                                                           isReleased,
                                                           systemApplicationVersions.matching(statistics.version()),
@@ -240,11 +235,13 @@ public class VersionStatus {
     }
 
     private static VespaVersion createVersion(DeploymentStatistics statistics,
-                                              ControllerVersion controllerVersion,
+                                              Set<ControllerVersion> controllerVersions,
                                               Version systemVersion,
                                               boolean isReleased,
                                               NodeVersions nodeVersions,
                                               Controller controller) {
+        var latestVersion = controllerVersions.stream().max(Comparator.naturalOrder()).get();
+        var controllerVersion = controllerVersions.stream().min(Comparator.naturalOrder()).get();
         var isSystemVersion = statistics.version().equals(systemVersion);
         var isControllerVersion = statistics.version().equals(controllerVersion.version());
         var confidence = controller.curator().readConfidenceOverrides().get(statistics.version());
@@ -263,8 +260,8 @@ public class VersionStatus {
         }
 
         // Preserve existing commit details if we've previously computed status for this version
-        var commitSha = controllerVersion.commitSha();
-        var commitDate = controllerVersion.commitDate();
+        var commitSha = latestVersion.commitSha();
+        var commitDate = latestVersion.commitDate();
         if (previousStatus != null) {
             commitSha = previousStatus.releaseCommit();
             commitDate = previousStatus.committedAt();
@@ -275,6 +272,7 @@ public class VersionStatus {
                 confidence = previousStatus.confidence();
             }
         }
+
         return new VespaVersion(statistics,
                                 commitSha,
                                 commitDate,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneApi;
@@ -192,7 +193,14 @@ public final class ControllerTester {
 
     /** Upgrade controller to given version */
     public void upgradeController(Version version, String commitSha, Instant commitDate) {
-        controller().curator().writeControllerVersion(controller().hostname(), new ControllerVersion(version, commitSha, commitDate));
+        for (var hostname : controller().curator().cluster()) {
+            upgradeController(hostname, version, commitSha, commitDate);
+        }
+    }
+
+    /** Upgrade controller to given version */
+    public void upgradeController(HostName hostname, Version version, String commitSha, Instant commitDate) {
+        controller().curator().writeControllerVersion(hostname, new ControllerVersion(version, commitSha, commitDate));
         computeVersionStatus();
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -81,6 +81,7 @@ public final class ControllerTester {
     private final AtomicLong nextPropertyId = new AtomicLong(1000);
     private final AtomicInteger nextProjectId = new AtomicInteger(1000);
     private final AtomicInteger nextDomainId = new AtomicInteger(1000);
+    private final AtomicInteger nextMinorVersion = new AtomicInteger(ControllerVersion.CURRENT.version().getMinor() + 1);
 
     private Controller controller;
 
@@ -162,6 +163,15 @@ public final class ControllerTester {
 
     public Optional<Record> findCname(String name) {
         return serviceRegistry.nameService().findRecords(Record.Type.CNAME, RecordName.from(name)).stream().findFirst();
+    }
+
+    /**
+     * Returns a version suitable as the next system version, i.e. a version that is always higher than the compiled-in
+     * controller version.
+     */
+    public Version nextVersion() {
+        var current = ControllerVersion.CURRENT.version();
+        return new Version(current.getMajor(), nextMinorVersion.getAndIncrement(), current.getMicro());
     }
 
     /** Create a new controller instance. Useful to verify that controller state is rebuilt from persistence */

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalDeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalDeploymentTester.java
@@ -82,7 +82,11 @@ public class InternalDeploymentTester {
     public Instance instance(ApplicationId id) { return tester.instance(id); }
 
     public InternalDeploymentTester() {
-        tester = new DeploymentTester();
+        this(new ControllerTester());
+    }
+
+    public InternalDeploymentTester(ControllerTester controllerTester) {
+        tester = new DeploymentTester(controllerTester);
         jobs = tester.controller().jobController();
         routing = tester.controllerTester().serviceRegistry().routingGeneratorMock();
         cloud = (MockTesterCloud) tester.controller().jobController().cloud();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
@@ -7,7 +7,6 @@ import com.yahoo.component.Vtag;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.zone.ZoneApi;
-import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
@@ -15,7 +14,6 @@ import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentContext;
-import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.deployment.InternalDeploymentTester;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
 import com.yahoo.vespa.hosted.controller.persistence.MockCuratorDb;
@@ -395,7 +393,7 @@ public class VersionStatusTest {
         InternalDeploymentTester tester = new InternalDeploymentTester(new ControllerTester(db));
 
         // Commit details are set for initial version
-        var version0 = new Version("7.2");
+        var version0 = tester.controllerTester().nextVersion();
         var commitSha0 = "badc0ffee";
         var commitDate0 = Instant.EPOCH;
         tester.controllerTester().upgradeSystem(version0);
@@ -407,7 +405,7 @@ public class VersionStatusTest {
         tester.deploymentContext().submit().deploy();
 
         // Commit details are updated for new version
-        var version1 = new Version("7.3");
+        var version1 = tester.controllerTester().nextVersion();
         var commitSha1 = "deadbeef";
         var commitDate1 = Instant.ofEpochMilli(123);
         tester.controllerTester().upgradeController(version1, commitSha1, commitDate1);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
@@ -386,9 +386,16 @@ public class VersionStatusTest {
 
     @Test
     public void testCommitDetailsPreservation() {
-        InternalDeploymentTester tester = new InternalDeploymentTester();
+        HostName controller1 = HostName.from("controller-1");
+        HostName controller2 = HostName.from("controller-2");
+        HostName controller3 = HostName.from("controller-3");
+        MockCuratorDb db = new MockCuratorDb(Stream.of(controller1, controller2, controller3)
+                                                   .map(hostName -> hostName.value() + ":2222")
+                                                   .collect(Collectors.joining(",")));
+        InternalDeploymentTester tester = new InternalDeploymentTester(new ControllerTester(db));
+
         // Commit details are set for initial version
-        var version0 = new Version("6.2");
+        var version0 = new Version("7.2");
         var commitSha0 = "badc0ffee";
         var commitDate0 = Instant.EPOCH;
         tester.controllerTester().upgradeSystem(version0);
@@ -400,7 +407,7 @@ public class VersionStatusTest {
         tester.deploymentContext().submit().deploy();
 
         // Commit details are updated for new version
-        var version1 = new Version("6.3");
+        var version1 = new Version("7.3");
         var commitSha1 = "deadbeef";
         var commitDate1 = Instant.ofEpochMilli(123);
         tester.controllerTester().upgradeController(version1, commitSha1, commitDate1);


### PR DESCRIPTION
Since the controller version defaults to VTAG, we have to use a version that's
always higher.