### PR TITLE
It is better to just lookup a function by name from the hierarchical …

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -541,6 +541,12 @@ public class RankProfile implements Serializable, Cloneable {
         return rankingExpressionFunction;
     }
 
+    public RankingExpressionFunction findFunction(String name) {
+        RankingExpressionFunction function = functions.get(name);
+        return ((function == null) && (getInherited() != null))
+                ? getInherited().findFunction(name)
+                : function;
+    }
     /** Returns an unmodifiable snapshot of the functions in this */
     public Map<String, RankingExpressionFunction> getFunctions() {
         if (functions.isEmpty() && getInherited() == null) return Collections.emptyMap();

--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/FunctionShadower.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/FunctionShadower.java
@@ -43,7 +43,7 @@ public class FunctionShadower extends ExpressionTransformer<RankProfileTransform
 
     private ExpressionNode transformFunctionNode(FunctionNode function, RankProfileTransformContext context) {
         String name = function.getFunction().toString();
-        RankProfile.RankingExpressionFunction rankingExpressionFunction = context.rankProfile().getFunctions().get(name);
+        RankProfile.RankingExpressionFunction rankingExpressionFunction = context.rankProfile().findFunction(name);
         if (rankingExpressionFunction == null) {
             return transformChildren(function, context);
         }


### PR DESCRIPTION
…maps in shadoworder than creating a new joined map for every lookup.

@bratseth or @lesters PR
This improves rankprofile deploy from 30s to 20s for a large application.