### PR TITLE
Simplify ConfigServerRestExecutorImpl

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
@@ -74,12 +74,6 @@ public class ProxyRequest {
         this.scheme = requestUri.getScheme();
     }
 
-    /**
-     * A discovery query lists environments and regions.
-     */
-    public boolean isDiscoveryRequest() {
-        return region.isEmpty();
-    }
 
     public String getRegion() {
         return region;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
@@ -1,15 +1,17 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.proxy;
 
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.net.HostName;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLDecoder;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import static com.yahoo.jdisc.http.HttpRequest.Method;
 
 /**
  * Keeping information about the calls that are being proxied.
@@ -19,95 +21,84 @@ import java.util.Map;
  */
 public class ProxyRequest {
 
-    private final String environment;
-    private final String region;
-    private final String configServerRequest;
-    private final InputStream requestData;
+    private final Method method;
+    private final URI requestUri;
     private final Map<String, List<String>> headers;
-    private final String method;
-    private final String controllerPrefix;
-    private final String scheme;
+    private final InputStream requestData;
+
+    private final ZoneId zoneId;
+    private final String proxyPath;
 
     /**
      * The constructor calls exception if the request is invalid.
      *
      * @param request the request from the jdisc framework.
-     * @param pathPrefix the path prefix of the proxy.
+     * @param zoneId the zone to proxy to.
+     * @param proxyPath the path to proxy to.
      * @throws ProxyException on errors
      */
-    public ProxyRequest(HttpRequest request, String pathPrefix) throws ProxyException, IOException {
-        this(request.getUri(), request.getJDiscRequest().headers(), request.getData(), request.getMethod().name(),
-             pathPrefix);
+    public ProxyRequest(HttpRequest request, ZoneId zoneId, String proxyPath) throws ProxyException {
+        this(request.getMethod(), request.getUri(), request.getJDiscRequest().headers(), request.getData(),
+             zoneId, proxyPath);
     }
 
-    ProxyRequest(URI requestUri, Map<String, List<String>> headers, InputStream body, String method,
-                 String pathPrefix) throws ProxyException, IOException {
-        if (requestUri == null) {
-            throw new ProxyException(ErrorResponse.badRequest("Request not set."));
-        }
-        final String path = URLDecoder.decode(requestUri.getPath(),"UTF-8");
-        if (! path.startsWith(pathPrefix)) {
-            // This has to be caused by wrong mapping of path in services.xml.
-            throw new ProxyException(ErrorResponse.notFoundError("Request not starting with " + pathPrefix));
-        }
-        final String uriNoPrefix = path.replaceFirst(pathPrefix, "")
-                + (requestUri.getRawQuery() == null ? "" : "?" + requestUri.getRawQuery());
+    ProxyRequest(Method method, URI requestUri, Map<String, List<String>> headers, InputStream body,
+                 ZoneId zoneId, String proxyPath) throws ProxyException {
+        Objects.requireNonNull(requestUri, "Request must be non-null");
+        if (!requestUri.getPath().endsWith(proxyPath))
+            throw new ProxyException(ErrorResponse.badRequest(String.format(
+                    "Request path '%s' does not end with proxy path '%s'", requestUri.getPath(), proxyPath)));
 
-        final String[] parts = uriNoPrefix.split("/");
-
-        this.environment = parts.length > 0 ? parts[0] : "";
-        this.region = parts.length > 1 ? parts[1] : "";
-        this.configServerRequest = parts.length > 2 ? uriNoPrefix.replace(environment + "/" + region, "") : "";
+        this.method = Objects.requireNonNull(method);
+        this.requestUri = Objects.requireNonNull(requestUri);
+        this.headers = Objects.requireNonNull(headers);
         this.requestData = body;
-        this.headers = headers;
-        this.method = method;
 
-        String hostPort = headers.containsKey("host")
-                ? headers.get("host").get(0)
-                : HostName.getLocalhost() + ":" + requestUri.getPort();
-        StringBuilder prefix = new StringBuilder(hostPort + pathPrefix);
-        if (! environment.isEmpty()) {
-            prefix.append(environment).append("/").append(region);
-        }
-
-        this.controllerPrefix = prefix.toString();
-        this.scheme = requestUri.getScheme();
+        this.zoneId = Objects.requireNonNull(zoneId);
+        this.proxyPath = proxyPath.startsWith("/") ? proxyPath : "/" + proxyPath;
     }
 
 
-    public String getRegion() {
-        return region;
-    }
-
-    public String getEnvironment() {
-        return environment;
-    }
-
-    public String getConfigServerRequest() {
-        return configServerRequest;
-    }
-
-    public InputStream getData() {
-        return requestData;
-    }
-
-    @Override
-    public String toString() {
-        return "[ region: " + region + " env: " + environment + " request: " + configServerRequest + "]";
+    public Method getMethod() {
+        return method;
     }
 
     public Map<String, List<String>> getHeaders() {
         return headers;
     }
 
-    public String getMethod() {
-        return method;
+    public InputStream getData() {
+        return requestData;
     }
 
-    public String getControllerPrefix() {
-        return controllerPrefix;
+    public ZoneId getZoneId() {
+        return zoneId;
     }
 
-    public String getScheme() { return scheme; }
+    public URI createConfigServerRequestUri(URI baseURI) {
+        try {
+            return new URI(baseURI.getScheme(), baseURI.getUserInfo(), baseURI.getHost(),
+                    baseURI.getPort(), proxyPath, requestUri.getQuery(), requestUri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public URI getControllerPrefixUri() {
+        String prefixPath = proxyPath.equals("/") && !requestUri.getPath().endsWith("/") ?
+                requestUri.getPath() + proxyPath :
+                requestUri.getPath().substring(0, requestUri.getPath().length() - proxyPath.length() + 1);
+        try {
+            return new URI(requestUri.getScheme(), requestUri.getUserInfo(), requestUri.getHost(),
+                    requestUri.getPort(), prefixPath, null, null);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "[zone: " + zoneId + " request: " + proxyPath + "]";
+    }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponse.java
@@ -15,7 +15,7 @@ import java.nio.charset.StandardCharsets;
  *
  * @author Haakon Dybdahl
  */
-public class ProxyResponse  extends HttpResponse {
+public class ProxyResponse extends HttpResponse {
 
     private final String bodyResponseRewritten;
     private final String contentType;
@@ -29,11 +29,6 @@ public class ProxyResponse  extends HttpResponse {
         super(statusResponse);
         this.contentType = contentType;
 
-        if (controllerRequest.getControllerPrefix().isEmpty()) {
-            bodyResponseRewritten = bodyResponse;
-            return;
-        }
-
         final String configServerPrefix;
         final String controllerRequestPrefix;
         try {
@@ -41,12 +36,9 @@ public class ProxyResponse  extends HttpResponse {
                     .setScheme(configServer.getScheme())
                     .setHost(configServer.getHost())
                     .setPort(configServer.getPort())
+                    .setPath("/")
                     .build().toString();
-            controllerRequestPrefix = new URIBuilder()
-                    .setScheme(controllerRequest.getScheme())
-                    // controller prefix is more than host, so it is a bit hackish, but verified by tests.
-                    .setHost(controllerRequest.getControllerPrefix())
-                    .build().toString();
+            controllerRequestPrefix = controllerRequest.getControllerPrefixUri().toString();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponse.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponse.java
@@ -9,7 +9,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 /**
  * Response class that also rewrites URL from config server.
@@ -25,12 +24,12 @@ public class ProxyResponse  extends HttpResponse {
             ProxyRequest controllerRequest,
             String bodyResponse,
             int statusResponse,
-            Optional<URI> configServer,
+            URI configServer,
             String contentType) {
         super(statusResponse);
         this.contentType = contentType;
 
-        if (! configServer.isPresent() || controllerRequest.getControllerPrefix().isEmpty()) {
+        if (controllerRequest.getControllerPrefix().isEmpty()) {
             bodyResponseRewritten = bodyResponse;
             return;
         }
@@ -39,9 +38,9 @@ public class ProxyResponse  extends HttpResponse {
         final String controllerRequestPrefix;
         try {
             configServerPrefix = new URIBuilder()
-                    .setScheme(configServer.get().getScheme())
-                    .setHost(configServer.get().getHost())
-                    .setPort(configServer.get().getPort())
+                    .setScheme(configServer.getScheme())
+                    .setHost(configServer.getHost())
+                    .setPort(configServer.getPort())
                     .build().toString();
             controllerRequestPrefix = new URIBuilder()
                     .setScheme(controllerRequest.getScheme())

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
@@ -1,25 +1,24 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi.zone.v2;
 
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.config.provision.zone.ZoneList;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
+import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
 import com.yahoo.vespa.hosted.controller.Controller;
-import com.yahoo.config.provision.zone.ZoneId;
-import com.yahoo.config.provision.zone.ZoneList;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 import com.yahoo.vespa.hosted.controller.auditlog.AuditLoggingRequestHandler;
 import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
-import com.yahoo.restapi.ErrorResponse;
-import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.yolean.Exceptions;
 
-import java.io.IOException;
 import java.util.logging.Level;
 
 /**
@@ -83,8 +82,8 @@ public class ZoneApiHandler extends AuditLoggingRequestHandler {
             throw new IllegalArgumentException("No such zone: " + zoneId.value());
         }
         try {
-            return proxy.handle(new ProxyRequest(request, "/zone/v2/"));
-        } catch (ProxyException | IOException e) {
+            return proxy.handle(new ProxyRequest(request, zoneId, path.getRest()));
+        } catch (ProxyException e) {
             throw new RuntimeException(e);
         }
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
@@ -13,8 +13,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Haakon Dybdahl
@@ -34,24 +32,6 @@ public class ProxyRequestTest {
     public void testBadUri() throws Exception {
         exception.expectMessage("Request not starting with /zone/v2/");
         testRequest(URI.create("http://foo"), "/zone/v2/");
-    }
-
-    @Test
-    public void testConfigRequestEmpty() throws Exception {
-        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo/bar"), "/zone/v2/");
-        assertEquals("foo", proxyRequest.getEnvironment());
-        assertEquals("bar", proxyRequest.getRegion());
-        assertFalse(proxyRequest.isDiscoveryRequest());
-        assertTrue(proxyRequest.getConfigServerRequest().isEmpty());
-
-    }
-
-    @Test
-    public void testDiscoveryRequest() throws Exception {
-        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo"), "/zone/v2/");
-        assertEquals("foo", proxyRequest.getEnvironment());
-        assertTrue(proxyRequest.isDiscoveryRequest());
-
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
@@ -1,15 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.proxy;
 
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.jdisc.http.HttpRequest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -24,40 +22,53 @@ public class ProxyRequestTest {
 
     @Test
     public void testEmpty() throws Exception {
-        exception.expectMessage("Request not set.");
-        testRequest(null, "/zone/v2/");
+        exception.expectMessage("Request must be non-null");
+        new ProxyRequest(HttpRequest.Method.GET, null, Map.of(), null, ZoneId.from("dev", "us-north-1"), "/zone/v2");
     }
 
     @Test
     public void testBadUri() throws Exception {
-        exception.expectMessage("Request not starting with /zone/v2/");
-        testRequest(URI.create("http://foo"), "/zone/v2/");
+        exception.expectMessage("Request path '/path' does not end with proxy path '/zone/v2/'");
+        testRequest("http://domain.tld/path", "/zone/v2/");
     }
 
     @Test
-    public void testProxyRequest() throws Exception {
-        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo/bar/bla/bla/v1/something"),
-                                                "/zone/v2/");
-        assertEquals("foo", proxyRequest.getEnvironment());
-        assertEquals("/bla/bla/v1/something", proxyRequest.getConfigServerRequest());
+    public void testUris() throws Exception {
+        {
+            // Root request
+            ProxyRequest request = testRequest("http://controller.domain.tld/my/path", "");
+            assertEquals(URI.create("http://controller.domain.tld/my/path/"), request.getControllerPrefixUri());
+            assertEquals(URI.create("https://cfg.prod.us-north-1.domain.tld:1234/"),
+                    request.createConfigServerRequestUri(URI.create("https://cfg.prod.us-north-1.domain.tld:1234/")));
+        }
+
+        {
+            // Root request with trailing /
+            ProxyRequest request = testRequest("http://controller.domain.tld/my/path/", "/");
+            assertEquals(URI.create("http://controller.domain.tld/my/path/"), request.getControllerPrefixUri());
+            assertEquals(URI.create("https://cfg.prod.us-north-1.domain.tld:1234/"),
+                    request.createConfigServerRequestUri(URI.create("https://cfg.prod.us-north-1.domain.tld:1234/")));
+        }
+
+        {
+            // API path test
+            ProxyRequest request = testRequest("http://controller.domain.tld:1234/my/path/nodes/v2", "/nodes/v2");
+            assertEquals(URI.create("http://controller.domain.tld:1234/my/path/"), request.getControllerPrefixUri());
+            assertEquals(URI.create("https://cfg.prod.us-north-1.domain.tld/nodes/v2"),
+                    request.createConfigServerRequestUri(URI.create("https://cfg.prod.us-north-1.domain.tld")));
+        }
+
+        {
+            // API path test with query
+            ProxyRequest request = testRequest("http://controller.domain.tld:1234/my/path/nodes/v2/?some=thing", "/nodes/v2/");
+            assertEquals(URI.create("http://controller.domain.tld:1234/my/path/"), request.getControllerPrefixUri());
+            assertEquals(URI.create("https://cfg.prod.us-north-1.domain.tld/nodes/v2/?some=thing"),
+                    request.createConfigServerRequestUri(URI.create("https://cfg.prod.us-north-1.domain.tld")));
+        }
     }
 
-    @Test
-    public void testProxyRequestWithParameters() throws Exception {
-        ProxyRequest proxyRequest = testRequest(URI.create("http://foo/zone/v2/foo/bar/something?p=v&q=y"),
-                                                "/zone/v2/");
-        assertEquals("foo", proxyRequest.getEnvironment());
-        assertEquals("/something?p=v&q=y", proxyRequest.getConfigServerRequest());
+    private static ProxyRequest testRequest(String url, String pathPrefix) throws ProxyException {
+        return new ProxyRequest(
+                HttpRequest.Method.GET, URI.create(url), Map.of(), null, ZoneId.from("dev", "us-north-1"), pathPrefix);
     }
-
-    private static ProxyRequest testRequest(URI url, String pathPrefix) throws IOException, ProxyException {
-        return new ProxyRequest(url, headers("controller:49152"), null, "GET", pathPrefix);
-    }
-
-    private static Map<String, List<String>> headers(String hostPort) {
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("host", Collections.singletonList(hostPort));
-        return Collections.unmodifiableMap(headers);
-    }
-
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
@@ -1,15 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.proxy;
 
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.jdisc.http.HttpRequest;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -20,50 +19,37 @@ public class ProxyResponseTest {
 
     @Test
     public void testRewriteUrl() throws Exception {
-        String controllerPrefix = "/zone/v2/";
-        URI configServer = URI.create("http://configserver:1234");
-        ProxyRequest request = new ProxyRequest(URI.create("http://foo/zone/v2/env/region/configserver"),
-                                                headers("controller:49152"), null, "GET",
-                                                controllerPrefix);
+        ProxyRequest request = new ProxyRequest(HttpRequest.Method.GET, URI.create("http://domain.tld/zone/v2/dev/us-north-1/configserver"),
+                Map.of(), null, ZoneId.from("dev", "us-north-1"), "configserver");
         ProxyResponse proxyResponse = new ProxyResponse(
                 request,
                 "response link is http://configserver:1234/bla/bla/",
                 200,
-                Optional.of(configServer),
+                URI.create("http://configserver:1234"),
                 "application/json");
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         proxyResponse.render(outputStream);
-        String document = new String(outputStream.toByteArray(),"UTF-8");
-        assertEquals("response link is http://controller:49152/zone/v2/env/region/bla/bla/", document);
+        String document = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        assertEquals("response link is http://domain.tld/zone/v2/dev/us-north-1/bla/bla/", document);
     }
 
     @Test
     public void testRewriteSecureUrl() throws Exception {
-        String controllerPrefix = "/zone/v2/";
-        URI configServer = URI.create("http://configserver:1234");
-        ProxyRequest request = new ProxyRequest(URI.create("https://foo/zone/v2/env/region/configserver"),
-                                                headers("controller:49152"), null, "GET",
-                                                controllerPrefix);
+        ProxyRequest request = new ProxyRequest(HttpRequest.Method.GET, URI.create("https://domain.tld/zone/v2/prod/eu-south-3/configserver"),
+                Map.of(), null, ZoneId.from("prod", "eu-south-3"), "configserver");
         ProxyResponse proxyResponse = new ProxyResponse(
                 request,
                 "response link is http://configserver:1234/bla/bla/",
                 200,
-                Optional.of(configServer),
+                URI.create("http://configserver:1234"),
                 "application/json");
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         proxyResponse.render(outputStream);
-        String document = new String(outputStream.toByteArray(),"UTF-8");
-        assertEquals("response link is https://controller:49152/zone/v2/env/region/bla/bla/", document);
+        String document = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        assertEquals("response link is https://domain.tld/zone/v2/prod/eu-south-3/bla/bla/", document);
     }
-
-    private static Map<String, List<String>> headers(String hostPort) {
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("host", Collections.singletonList(hostPort));
-        return Collections.unmodifiableMap(headers);
-    }
-
 }


### PR DESCRIPTION
This shouldn't have an functional changes, just some cleanup refactoring to make it easier to reuse this for future `/configserver/v1` proxy API.

The discovery API removed in first commit is not used as it is not reachable today since it will be rejected here: https://github.com/vespa-engine/vespa/blob/c154ec58f64daa83c1f3631fa5695144ae46cdaa/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java#L79