### PR TITLE
Precompute the fixed set of feature types once.

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
@@ -42,8 +42,9 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
     /** For invocation loop detection */
     private final Deque<Reference> currentResolutionCallStack;
 
-    MapEvaluationTypeContext(Collection<ExpressionFunction> functions) {
+    MapEvaluationTypeContext(Collection<ExpressionFunction> functions, Map<Reference, TensorType> featureTypes) {
         super(functions);
+        this.featureTypes.putAll(featureTypes);
         this.currentResolutionCallStack =  new ArrayDeque<>();
     }
 

--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/RankProfileTransformContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/RankProfileTransformContext.java
@@ -4,8 +4,10 @@ package com.yahoo.searchdefinition.expressiontransforms;
 import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.searchdefinition.RankProfile;
+import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 import com.yahoo.searchlib.rankingexpression.transform.TransformContext;
+import com.yahoo.tensor.TensorType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,10 +27,11 @@ public class RankProfileTransformContext extends TransformContext {
 
     public RankProfileTransformContext(RankProfile rankProfile,
                                        QueryProfileRegistry queryProfiles,
+                                       Map<Reference, TensorType> featureTypes,
                                        ImportedMlModels importedModels,
                                        Map<String, Value> constants,
                                        Map<String, RankProfile.RankingExpressionFunction> inlineFunctions) {
-        super(constants, rankProfile.typeContext(queryProfiles));
+        super(constants, rankProfile.typeContext(queryProfiles, featureTypes));
         this.rankProfile = rankProfile;
         this.queryProfiles = queryProfiles;
         this.importedModels = importedModels;


### PR DESCRIPTION
@bratseth PR This brings it down from 13s to 10s -> DONE
In total 3x for deploy and 20x for getConfig() for a large application.
