### PR TITLE
Create /configserver/v1

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
@@ -20,7 +20,8 @@ import java.util.Set;
 enum PathGroup {
 
     /** Paths exclusive to operators (including read), used for system management. */
-    classifiedOperator("/configserver/v1/{*}"),
+    classifiedOperator(Optional.of("/api"),
+                       "/configserver/v1/{*}"),
 
     /** Paths used for system management by operators. */
     operator("/controller/v1/{*}",

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
@@ -20,7 +20,8 @@ import java.util.Set;
 enum PathGroup {
 
     /** Paths used for system management by operators. */
-    operator("/controller/v1/{*}",
+    operator("/configserver/v1/{*}",
+             "/controller/v1/{*}",
              "/flags/v1/{*}",
              "/nodes/v2/{*}",
              "/orchestrator/v1/{*}",

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
@@ -19,9 +19,11 @@ import java.util.Set;
  */
 enum PathGroup {
 
+    /** Paths exclusive to operators (including read), used for system management. */
+    classifiedOperator("/configserver/v1/{*}"),
+
     /** Paths used for system management by operators. */
-    operator("/configserver/v1/{*}",
-             "/controller/v1/{*}",
+    operator("/controller/v1/{*}",
              "/flags/v1/{*}",
              "/nodes/v2/{*}",
              "/orchestrator/v1/{*}",
@@ -227,6 +229,10 @@ enum PathGroup {
     /** All known path groups */
     static Set<PathGroup> all() {
         return EnumSet.allOf(PathGroup.class);
+    }
+
+    static Set<PathGroup> allExcept(PathGroup... pathGroups) {
+        return EnumSet.complementOf(EnumSet.copyOf(List.of(pathGroups)));
     }
 
     /** Returns whether this group matches path in given context */

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/Policy.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/Policy.java
@@ -115,7 +115,7 @@ enum Policy {
 
     /** Read access to all information in select systems. */
     classifiedRead(Privilege.grant(Action.read)
-                            .on(PathGroup.all())
+                            .on(PathGroup.allExcept(PathGroup.classifiedOperator))
                             .in(SystemName.main, SystemName.cd, SystemName.dev)),
 
     /** Read access to public info. */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -2,9 +2,13 @@
 package com.yahoo.vespa.hosted.controller.proxy;
 
 import com.google.inject.Inject;
+import com.yahoo.component.AbstractComponent;
 import com.yahoo.jdisc.http.HttpRequest.Method;
 import com.yahoo.log.LogLevel;
+import com.yahoo.vespa.athenz.api.AthenzIdentity;
 import com.yahoo.vespa.athenz.identity.ServiceIdentityProvider;
+import com.yahoo.vespa.athenz.tls.AthenzIdentityVerifier;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 import org.apache.http.Header;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -14,14 +18,17 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -30,7 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static com.yahoo.yolean.Exceptions.uncheck;
 
@@ -40,18 +49,24 @@ import static com.yahoo.yolean.Exceptions.uncheck;
  * @author bjorncs
  */
 @SuppressWarnings("unused") // Injected
-public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
+public class ConfigServerRestExecutorImpl extends AbstractComponent implements ConfigServerRestExecutor {
 
     private static final Logger log = Logger.getLogger(ConfigServerRestExecutorImpl.class.getName());
 
     private static final Duration PROXY_REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private static final Set<String> HEADERS_TO_COPY = Set.of("X-HTTP-Method-Override", "Content-Type");
 
-    private final ServiceIdentityProvider sslContextProvider;
+    private final CloseableHttpClient client;
 
     @Inject
-    public ConfigServerRestExecutorImpl(ServiceIdentityProvider sslContextProvider) {
-        this.sslContextProvider = sslContextProvider;
+    public ConfigServerRestExecutorImpl(ZoneRegistry zoneRegistry, ServiceIdentityProvider sslContextProvider) {
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
+                .setConnectionRequestTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
+                .setSocketTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis()).build();
+
+        this.client = createHttpClient(config, sslContextProvider,
+                new ControllerOrConfigserverHostnameVerifier(zoneRegistry));
     }
 
     @Override
@@ -60,7 +75,7 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
         List<URI> allServers = new ArrayList<>(proxyRequest.getTargets());
 
         StringBuilder errorBuilder = new StringBuilder();
-        if (queueFirstServerIfDown(allServers, proxyRequest.getTargetHostnameVerifier())) {
+        if (queueFirstServerIfDown(allServers)) {
             errorBuilder.append("Change ordering due to failed ping.");
         }
         for (URI uri : allServers) {
@@ -85,11 +100,7 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
                 .setConnectTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
                 .setConnectionRequestTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
                 .setSocketTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis()).build();
-        try (
-                CloseableHttpClient client = createHttpClient(
-                        config, sslContextProvider, proxyRequest.getTargetHostnameVerifier());
-                CloseableHttpResponse response = client.execute(requestBase)
-        ) {
+        try (CloseableHttpResponse response = client.execute(requestBase)) {
             String content = getContent(response);
             int status = response.getStatusLine().getStatusCode();
             if (status / 100 == 5) {
@@ -167,7 +178,7 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
      * if it is not responding, we try the other servers first. False positive/negatives are not critical,
      * but will increase latency to some extent.
      */
-    private boolean queueFirstServerIfDown(List<URI> allServers, HostnameVerifier hostnameVerifier) {
+    private boolean queueFirstServerIfDown(List<URI> allServers) {
         if (allServers.size() < 2) {
             return false;
         }
@@ -179,10 +190,8 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
                 .setConnectTimeout(timeout)
                 .setConnectionRequestTimeout(timeout)
                 .setSocketTimeout(timeout).build();
-        try (
-                CloseableHttpClient client = createHttpClient(config, sslContextProvider, hostnameVerifier);
-                CloseableHttpResponse response = client.execute(httpget)
-        ) {
+        httpget.setConfig(config);
+        try (CloseableHttpResponse response = client.execute(httpget)) {
             if (response.getStatusLine().getStatusCode() == 200) {
                 return false;
             }
@@ -195,6 +204,15 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
         return true;
     }
 
+    @Override
+    public void deconstruct() {
+        try {
+            client.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     private static CloseableHttpClient createHttpClient(RequestConfig config,
                                                         ServiceIdentityProvider sslContextProvider,
                                                         HostnameVerifier hostnameVerifier) {
@@ -203,7 +221,31 @@ public class ConfigServerRestExecutorImpl implements ConfigServerRestExecutor {
                 .setSslcontext(sslContextProvider.getIdentitySslContext())
                 .setSSLHostnameVerifier(hostnameVerifier)
                 .setDefaultRequestConfig(config)
+                .setMaxConnPerRoute(10)
+                .setMaxConnTotal(500)
+                .setConnectionTimeToLive(1, TimeUnit.MINUTES)
                 .build();
     }
 
+    private static class ControllerOrConfigserverHostnameVerifier implements HostnameVerifier {
+
+        private final HostnameVerifier controllerVerifier = new DefaultHostnameVerifier();
+        private final HostnameVerifier configserverVerifier;
+
+        ControllerOrConfigserverHostnameVerifier(ZoneRegistry registry) {
+            this.configserverVerifier = createConfigserverVerifier(registry);
+        }
+
+        private static HostnameVerifier createConfigserverVerifier(ZoneRegistry registry) {
+            Set<AthenzIdentity> configserverIdentities = registry.zones().all().zones().stream()
+                    .map(zone -> registry.getConfigServerHttpsIdentity(zone.getId()))
+                    .collect(Collectors.toSet());
+            return new AthenzIdentityVerifier(configserverIdentities);
+        }
+
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+            return controllerVerifier.verify(hostname, session) || configserverVerifier.verify(hostname, session);
+        }
+    }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -96,10 +96,6 @@ public class ConfigServerRestExecutorImpl extends AbstractComponent implements C
         // Empty list of headers to copy for now, add headers when needed, or rewrite logic.
         copyHeaders(proxyRequest.getHeaders(), requestBase);
 
-        RequestConfig config = RequestConfig.custom()
-                .setConnectTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
-                .setConnectionRequestTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis())
-                .setSocketTimeout((int) PROXY_REQUEST_TIMEOUT.toMillis()).build();
         try (CloseableHttpResponse response = client.execute(requestBase)) {
             String content = getContent(response);
             int status = response.getStatusLine().getStatusCode();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.controller.proxy;
 
 import com.yahoo.container.jdisc.HttpRequest;
 
-import javax.net.ssl.HostnameVerifier;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,7 +26,6 @@ public class ProxyRequest {
     private final InputStream requestData;
 
     private final List<URI> targets;
-    private final HostnameVerifier targetHostnameVerifier;
     private final String targetPath;
 
     /**
@@ -35,17 +33,16 @@ public class ProxyRequest {
      *
      * @param request the request from the jdisc framework.
      * @param targets list of targets this request should be proxied to (targets are tried once in order until a response is returned).
-     * @param targetHostnameVerifier hostname verifier to use when proxying the request.
      * @param targetPath the path to proxy to.
      * @throws ProxyException on errors
      */
-    public ProxyRequest(HttpRequest request, List<URI> targets, HostnameVerifier targetHostnameVerifier, String targetPath) throws ProxyException {
+    public ProxyRequest(HttpRequest request, List<URI> targets, String targetPath) throws ProxyException {
         this(request.getMethod(), request.getUri(), request.getJDiscRequest().headers(), request.getData(),
-             targets, targetHostnameVerifier, targetPath);
+             targets, targetPath);
     }
 
     ProxyRequest(Method method, URI requestUri, Map<String, List<String>> headers, InputStream body,
-                 List<URI> targets, HostnameVerifier targetHostnameVerifier, String targetPath) throws ProxyException {
+                 List<URI> targets, String targetPath) throws ProxyException {
         Objects.requireNonNull(requestUri, "Request must be non-null");
         if (!requestUri.getPath().endsWith(targetPath))
             throw new ProxyException(ErrorResponse.badRequest(String.format(
@@ -58,7 +55,6 @@ public class ProxyRequest {
 
         this.targets = List.copyOf(targets);
         this.targetPath = targetPath.startsWith("/") ? targetPath : "/" + targetPath;
-        this.targetHostnameVerifier = targetHostnameVerifier;
     }
 
 
@@ -76,10 +72,6 @@ public class ProxyRequest {
 
     public List<URI> getTargets() {
         return targets;
-    }
-
-    public HostnameVerifier getTargetHostnameVerifier() {
-        return targetHostnameVerifier;
     }
 
     public URI createConfigServerRequestUri(URI baseURI) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequest.java
@@ -1,9 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.proxy;
 
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.jdisc.HttpRequest;
 
+import javax.net.ssl.HostnameVerifier;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -26,36 +26,39 @@ public class ProxyRequest {
     private final Map<String, List<String>> headers;
     private final InputStream requestData;
 
-    private final ZoneId zoneId;
-    private final String proxyPath;
+    private final List<URI> targets;
+    private final HostnameVerifier targetHostnameVerifier;
+    private final String targetPath;
 
     /**
      * The constructor calls exception if the request is invalid.
      *
      * @param request the request from the jdisc framework.
-     * @param zoneId the zone to proxy to.
-     * @param proxyPath the path to proxy to.
+     * @param targets list of targets this request should be proxied to (targets are tried once in order until a response is returned).
+     * @param targetHostnameVerifier hostname verifier to use when proxying the request.
+     * @param targetPath the path to proxy to.
      * @throws ProxyException on errors
      */
-    public ProxyRequest(HttpRequest request, ZoneId zoneId, String proxyPath) throws ProxyException {
+    public ProxyRequest(HttpRequest request, List<URI> targets, HostnameVerifier targetHostnameVerifier, String targetPath) throws ProxyException {
         this(request.getMethod(), request.getUri(), request.getJDiscRequest().headers(), request.getData(),
-             zoneId, proxyPath);
+             targets, targetHostnameVerifier, targetPath);
     }
 
     ProxyRequest(Method method, URI requestUri, Map<String, List<String>> headers, InputStream body,
-                 ZoneId zoneId, String proxyPath) throws ProxyException {
+                 List<URI> targets, HostnameVerifier targetHostnameVerifier, String targetPath) throws ProxyException {
         Objects.requireNonNull(requestUri, "Request must be non-null");
-        if (!requestUri.getPath().endsWith(proxyPath))
+        if (!requestUri.getPath().endsWith(targetPath))
             throw new ProxyException(ErrorResponse.badRequest(String.format(
-                    "Request path '%s' does not end with proxy path '%s'", requestUri.getPath(), proxyPath)));
+                    "Request path '%s' does not end with proxy path '%s'", requestUri.getPath(), targetPath)));
 
         this.method = Objects.requireNonNull(method);
         this.requestUri = Objects.requireNonNull(requestUri);
         this.headers = Objects.requireNonNull(headers);
         this.requestData = body;
 
-        this.zoneId = Objects.requireNonNull(zoneId);
-        this.proxyPath = proxyPath.startsWith("/") ? proxyPath : "/" + proxyPath;
+        this.targets = List.copyOf(targets);
+        this.targetPath = targetPath.startsWith("/") ? targetPath : "/" + targetPath;
+        this.targetHostnameVerifier = targetHostnameVerifier;
     }
 
 
@@ -71,23 +74,27 @@ public class ProxyRequest {
         return requestData;
     }
 
-    public ZoneId getZoneId() {
-        return zoneId;
+    public List<URI> getTargets() {
+        return targets;
+    }
+
+    public HostnameVerifier getTargetHostnameVerifier() {
+        return targetHostnameVerifier;
     }
 
     public URI createConfigServerRequestUri(URI baseURI) {
         try {
             return new URI(baseURI.getScheme(), baseURI.getUserInfo(), baseURI.getHost(),
-                    baseURI.getPort(), proxyPath, requestUri.getQuery(), requestUri.getFragment());
+                    baseURI.getPort(), targetPath, requestUri.getQuery(), requestUri.getFragment());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }
 
     public URI getControllerPrefixUri() {
-        String prefixPath = proxyPath.equals("/") && !requestUri.getPath().endsWith("/") ?
-                requestUri.getPath() + proxyPath :
-                requestUri.getPath().substring(0, requestUri.getPath().length() - proxyPath.length() + 1);
+        String prefixPath = targetPath.equals("/") && !requestUri.getPath().endsWith("/") ?
+                requestUri.getPath() + targetPath :
+                requestUri.getPath().substring(0, requestUri.getPath().length() - targetPath.length() + 1);
         try {
             return new URI(requestUri.getScheme(), requestUri.getUserInfo(), requestUri.getHost(),
                     requestUri.getPort(), prefixPath, null, null);
@@ -98,7 +105,7 @@ public class ProxyRequest {
 
     @Override
     public String toString() {
-        return "[zone: " + zoneId + " request: " + proxyPath + "]";
+        return "[targets: " + targets + " request: " + targetPath + "]";
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 @SuppressWarnings("unused")
 public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
 
+    private static final String OPTIONAL_PREFIX = "/api";
     private static final ZoneId CONTROLLER_ZONE = ZoneId.from("prod", "controller");
     private static final List<String> WHITELISTED_APIS = List.of("/flags/v1/", "/nodes/v2/", "/orchestrator/v1/");
 
@@ -72,7 +73,7 @@ public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
     }
 
     private HttpResponse get(HttpRequest request) {
-        Path path = new Path(request.getUri());
+        Path path = new Path(request.getUri(), OPTIONAL_PREFIX);
         if (path.matches("/configserver/v1")) {
             return root(request);
         }
@@ -80,7 +81,7 @@ public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
     }
 
     private HttpResponse proxy(HttpRequest request) {
-        Path path = new Path(request.getUri());
+        Path path = new Path(request.getUri(), OPTIONAL_PREFIX);
         if ( ! path.matches("/configserver/v1/{environment}/{region}/{*}")) {
             return ErrorResponse.notFoundError("Nothing at " + path);
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
@@ -18,6 +18,7 @@ import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
 import com.yahoo.yolean.Exceptions;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 
 import javax.net.ssl.HostnameVerifier;
 import java.net.URI;
@@ -129,7 +130,7 @@ public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
     }
 
     private HostnameVerifier createHostnameVerifier(ZoneId zoneId) {
-        if (CONTROLLER_ZONE.equals(zoneId)) return null;
+        if (CONTROLLER_ZONE.equals(zoneId)) return new DefaultHostnameVerifier();
         return new AthenzIdentityVerifier(Set.of(zoneRegistry.getConfigServerHttpsIdentity(zoneId)));
     }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
@@ -1,0 +1,135 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.restapi.configserver;
+
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.config.provision.zone.ZoneList;
+import com.yahoo.container.jdisc.HttpRequest;
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.restapi.ErrorResponse;
+import com.yahoo.restapi.Path;
+import com.yahoo.restapi.SlimeJsonResponse;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Slime;
+import com.yahoo.vespa.athenz.tls.AthenzIdentityVerifier;
+import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
+import com.yahoo.vespa.hosted.controller.auditlog.AuditLoggingRequestHandler;
+import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
+import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
+import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
+import com.yahoo.yolean.Exceptions;
+
+import javax.net.ssl.HostnameVerifier;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Stream;
+
+/**
+ * REST API for proxying operator APIs to config servers in a given zone.
+ *
+ * @author freva
+ */
+@SuppressWarnings("unused")
+public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
+
+    private static final ZoneId CONTROLLER_ZONE = ZoneId.from("prod", "controller");
+    private static final List<String> WHITELISTED_APIS = List.of("/flags/v1/", "/nodes/v2/", "/orchestrator/v1/");
+
+    private final ZoneRegistry zoneRegistry;
+    private final ConfigServerRestExecutor proxy;
+
+    public ConfigServerApiHandler(Context parentCtx, ZoneRegistry zoneRegistry,
+                                  ConfigServerRestExecutor proxy, Controller controller) {
+        super(parentCtx, controller.auditLogger());
+        this.zoneRegistry = zoneRegistry;
+        this.proxy = proxy;
+    }
+
+    @Override
+    public HttpResponse auditAndHandle(HttpRequest request) {
+        try {
+            switch (request.getMethod()) {
+                case GET:
+                    return get(request);
+                case POST:
+                case PUT:
+                case DELETE:
+                case PATCH:
+                    return proxy(request);
+                default:
+                    return ErrorResponse.methodNotAllowed("Method '" + request.getMethod() + "' is unsupported");
+            }
+        } catch (IllegalArgumentException e) {
+            return ErrorResponse.badRequest(Exceptions.toMessageString(e));
+        } catch (RuntimeException e) {
+            log.log(Level.WARNING, "Unexpected error handling '" + request.getUri() + "', "
+                                   + Exceptions.toMessageString(e));
+            return ErrorResponse.internalServerError(Exceptions.toMessageString(e));
+        }
+    }
+
+    private HttpResponse get(HttpRequest request) {
+        Path path = new Path(request.getUri());
+        if (path.matches("/configserver/v1")) {
+            return root(request);
+        }
+        return proxy(request);
+    }
+
+    private HttpResponse proxy(HttpRequest request) {
+        Path path = new Path(request.getUri());
+        if ( ! path.matches("/configserver/v1/{environment}/{region}/{*}")) {
+            return ErrorResponse.notFoundError("Nothing at " + path);
+        }
+
+        ZoneId zoneId = ZoneId.from(path.get("environment"), path.get("region"));
+        if (! zoneRegistry.hasZone(zoneId) && ! CONTROLLER_ZONE.equals(zoneId)) {
+            throw new IllegalArgumentException("No such zone: " + zoneId.value());
+        }
+
+        String cfgPath = "/" + path.getRest();
+        if (WHITELISTED_APIS.stream().noneMatch(cfgPath::startsWith)) {
+            return ErrorResponse.forbidden("Cannot access '" + cfgPath +
+                    "' through /configserver/v1, following APIs are permitted: " + String.join(", ", WHITELISTED_APIS));
+        }
+
+        try {
+            return proxy.handle(new ProxyRequest(
+                    request, List.of(getEndpoint(zoneId)), createHostnameVerifier(zoneId), cfgPath));
+        } catch (ProxyException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpResponse root(HttpRequest request) {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+        ZoneList zoneList = zoneRegistry.zones().reachable();
+
+        Cursor zones = root.setArray("zones");
+        Stream.concat(Stream.of(CONTROLLER_ZONE), zoneRegistry.zones().reachable().ids().stream())
+                .forEach(zone -> {
+            Cursor object = zones.addObject();
+            object.setString("environment", zone.environment().value());
+            object.setString("region", zone.region().value());
+            object.setString("uri", request.getUri().resolve(
+                    "/configserver/v1/" + zone.environment().value() + "/" + zone.region().value()).toString());
+        });
+        return new SlimeJsonResponse(slime);
+    }
+
+    private HttpResponse notFound(Path path) {
+        return ErrorResponse.notFoundError("Nothing at " + path);
+    }
+
+    private URI getEndpoint(ZoneId zoneId) {
+        return CONTROLLER_ZONE.equals(zoneId) ? zoneRegistry.apiUrl() : zoneRegistry.getConfigServerVipUri(zoneId);
+    }
+
+    private HostnameVerifier createHostnameVerifier(ZoneId zoneId) {
+        if (CONTROLLER_ZONE.equals(zoneId)) return null;
+        return new AthenzIdentityVerifier(Set.of(zoneRegistry.getConfigServerHttpsIdentity(zoneId)));
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
@@ -10,7 +10,6 @@ import com.yahoo.restapi.Path;
 import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
-import com.yahoo.vespa.athenz.tls.AthenzIdentityVerifier;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 import com.yahoo.vespa.hosted.controller.auditlog.AuditLoggingRequestHandler;
@@ -18,12 +17,9 @@ import com.yahoo.vespa.hosted.controller.proxy.ConfigServerRestExecutor;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
 import com.yahoo.yolean.Exceptions;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 
-import javax.net.ssl.HostnameVerifier;
 import java.net.URI;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
@@ -98,8 +94,7 @@ public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
         }
 
         try {
-            return proxy.handle(new ProxyRequest(
-                    request, List.of(getEndpoint(zoneId)), createHostnameVerifier(zoneId), cfgPath));
+            return proxy.handle(new ProxyRequest(request, List.of(getEndpoint(zoneId)), cfgPath));
         } catch (ProxyException e) {
             throw new RuntimeException(e);
         }
@@ -128,10 +123,5 @@ public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
 
     private URI getEndpoint(ZoneId zoneId) {
         return CONTROLLER_ZONE.equals(zoneId) ? zoneRegistry.apiUrl() : zoneRegistry.getConfigServerVipUri(zoneId);
-    }
-
-    private HostnameVerifier createHostnameVerifier(ZoneId zoneId) {
-        if (CONTROLLER_ZONE.equals(zoneId)) return new DefaultHostnameVerifier();
-        return new AthenzIdentityVerifier(Set.of(zoneRegistry.getConfigServerHttpsIdentity(zoneId)));
     }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/package-info.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+/**
+ * @author freva
+ */
+package com.yahoo.vespa.hosted.controller.restapi.configserver;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
@@ -11,7 +11,6 @@ import com.yahoo.restapi.Path;
 import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
-import com.yahoo.vespa.athenz.tls.AthenzIdentityVerifier;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 import com.yahoo.vespa.hosted.controller.auditlog.AuditLoggingRequestHandler;
@@ -20,10 +19,8 @@ import com.yahoo.vespa.hosted.controller.proxy.ProxyException;
 import com.yahoo.vespa.hosted.controller.proxy.ProxyRequest;
 import com.yahoo.yolean.Exceptions;
 
-import javax.net.ssl.HostnameVerifier;
 import java.net.URI;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -87,8 +84,7 @@ public class ZoneApiHandler extends AuditLoggingRequestHandler {
             throw new IllegalArgumentException("No such zone: " + zoneId.value());
         }
         try {
-            return proxy.handle(new ProxyRequest(
-                    request, getConfigserverEndpoints(zoneId), createHostnameVerifier(zoneId), path.getRest()));
+            return proxy.handle(new ProxyRequest(request, getConfigserverEndpoints(zoneId), path.getRest()));
         } catch (ProxyException e) {
             throw new RuntimeException(e);
         }
@@ -124,9 +120,5 @@ public class ZoneApiHandler extends AuditLoggingRequestHandler {
         } else {
             return zoneRegistry.getConfigServerUris(zoneId);
         }
-    }
-
-    private HostnameVerifier createHostnameVerifier(ZoneId zoneId) {
-        return new AthenzIdentityVerifier(Set.of(zoneRegistry.getConfigServerHttpsIdentity(zoneId)));
     }
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.integration;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
@@ -24,8 +23,6 @@ import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
 
 import java.net.URI;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +35,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     private final Map<ZoneId, Duration> deploymentTimeToLive = new HashMap<>();
     private final Map<Environment, RegionName> defaultRegionForEnvironment = new HashMap<>();
-    private List<ZoneApi> zones = new ArrayList<>();
+    private List<ZoneApi> zones = List.of();
     private SystemName system;
     private UpgradePolicy upgradePolicy = null;
     private Map<CloudName, UpgradePolicy> osUpgradePolicies = new HashMap<>();
@@ -136,7 +133,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Override
     public List<UpgradePolicy> osUpgradePolicies() {
-        return ImmutableList.copyOf(osUpgradePolicies.values());
+        return List.copyOf(osUpgradePolicies.values());
     }
 
     @Override
@@ -176,7 +173,9 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Override
     public List<URI> getConfigServerUris(ZoneId zoneId) {
-        return Collections.singletonList(URI.create(String.format("https://cfg.%s.test:4443/", zoneId.value())));
+        return List.of(
+                URI.create(String.format("https://cfg1.%s.test:4443/", zoneId.value())),
+                URI.create(String.format("https://cfg2.%s.test:4443/", zoneId.value())));
     }
 
     @Override
@@ -186,11 +185,9 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Override
     public List<URI> getConfigServerApiUris(ZoneId zoneId) {
-        List<URI> uris = new ArrayList<URI>();
-        uris.add(URI.create(String.format("https://cfg.%s.test:4443/", zoneId.value())));
-        uris.add(URI.create(String.format("https://cfg.%s.test.vip:4443/", zoneId.value())));
-
-        return uris;
+        return List.of(
+                URI.create(String.format("https://cfg.%s.test:4443/", zoneId.value())),
+                URI.create(String.format("https://cfg.%s.test.vip:4443/", zoneId.value())));
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
@@ -1,13 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.proxy;
 
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.jdisc.http.HttpRequest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -23,7 +23,7 @@ public class ProxyRequestTest {
     @Test
     public void testEmpty() throws Exception {
         exception.expectMessage("Request must be non-null");
-        new ProxyRequest(HttpRequest.Method.GET, null, Map.of(), null, ZoneId.from("dev", "us-north-1"), "/zone/v2");
+        new ProxyRequest(HttpRequest.Method.GET, null, Map.of(), null, List.of(), null, "/zone/v2");
     }
 
     @Test
@@ -69,6 +69,6 @@ public class ProxyRequestTest {
 
     private static ProxyRequest testRequest(String url, String pathPrefix) throws ProxyException {
         return new ProxyRequest(
-                HttpRequest.Method.GET, URI.create(url), Map.of(), null, ZoneId.from("dev", "us-north-1"), pathPrefix);
+                HttpRequest.Method.GET, URI.create(url), Map.of(), null, List.of(), null, pathPrefix);
     }
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyRequestTest.java
@@ -23,7 +23,7 @@ public class ProxyRequestTest {
     @Test
     public void testEmpty() throws Exception {
         exception.expectMessage("Request must be non-null");
-        new ProxyRequest(HttpRequest.Method.GET, null, Map.of(), null, List.of(), null, "/zone/v2");
+        new ProxyRequest(HttpRequest.Method.GET, null, Map.of(), null, List.of(), "/zone/v2");
     }
 
     @Test
@@ -69,6 +69,6 @@ public class ProxyRequestTest {
 
     private static ProxyRequest testRequest(String url, String pathPrefix) throws ProxyException {
         return new ProxyRequest(
-                HttpRequest.Method.GET, URI.create(url), Map.of(), null, List.of(), null, pathPrefix);
+                HttpRequest.Method.GET, URI.create(url), Map.of(), null, List.of(), pathPrefix);
     }
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
@@ -20,7 +20,7 @@ public class ProxyResponseTest {
     @Test
     public void testRewriteUrl() throws Exception {
         ProxyRequest request = new ProxyRequest(HttpRequest.Method.GET, URI.create("http://domain.tld/zone/v2/dev/us-north-1/configserver"),
-                Map.of(), null, List.of(), null, "configserver");
+                Map.of(), null, List.of(), "configserver");
         ProxyResponse proxyResponse = new ProxyResponse(
                 request,
                 "response link is http://configserver:1234/bla/bla/",
@@ -38,7 +38,7 @@ public class ProxyResponseTest {
     @Test
     public void testRewriteSecureUrl() throws Exception {
         ProxyRequest request = new ProxyRequest(HttpRequest.Method.GET, URI.create("https://domain.tld/zone/v2/prod/eu-south-3/configserver"),
-                Map.of(), null, List.of(), null, "configserver");
+                Map.of(), null, List.of(), "configserver");
         ProxyResponse proxyResponse = new ProxyResponse(
                 request,
                 "response link is http://configserver:1234/bla/bla/",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/proxy/ProxyResponseTest.java
@@ -1,13 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.proxy;
 
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.jdisc.http.HttpRequest;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -20,7 +20,7 @@ public class ProxyResponseTest {
     @Test
     public void testRewriteUrl() throws Exception {
         ProxyRequest request = new ProxyRequest(HttpRequest.Method.GET, URI.create("http://domain.tld/zone/v2/dev/us-north-1/configserver"),
-                Map.of(), null, ZoneId.from("dev", "us-north-1"), "configserver");
+                Map.of(), null, List.of(), null, "configserver");
         ProxyResponse proxyResponse = new ProxyResponse(
                 request,
                 "response link is http://configserver:1234/bla/bla/",
@@ -38,7 +38,7 @@ public class ProxyResponseTest {
     @Test
     public void testRewriteSecureUrl() throws Exception {
         ProxyRequest request = new ProxyRequest(HttpRequest.Method.GET, URI.create("https://domain.tld/zone/v2/prod/eu-south-3/configserver"),
-                Map.of(), null, ZoneId.from("prod", "eu-south-3"), "configserver");
+                Map.of(), null, List.of(), null, "configserver");
         ProxyResponse proxyResponse = new ProxyResponse(
                 request,
                 "response link is http://configserver:1234/bla/bla/",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
@@ -92,6 +92,10 @@ public class ControllerContainerTest {
                "    <binding>http://*/zone/v2</binding>\n" +
                "    <binding>http://*/zone/v2/*</binding>\n" +
                "  </handler>\n" +
+               "  <handler id='com.yahoo.vespa.hosted.controller.restapi.configserver.ConfigServerApiHandler'>\n" +
+               "    <binding>http://*/configserver/v1</binding>\n" +
+               "    <binding>http://*/configserver/v1/*</binding>\n" +
+               "  </handler>\n" +
                "  <handler id='com.yahoo.vespa.hosted.controller.restapi.flags.AuditedFlagsHandler'>\n" +
                "    <binding>http://*/flags/v1</binding>\n" +
                "    <binding>http://*/flags/v1/*</binding>\n" +

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
@@ -34,12 +34,16 @@ import static org.junit.Assert.assertEquals;
  */
 public class ControllerContainerTest {
 
+    private static final AthenzUser hostedOperator = AthenzUser.fromUserId("alice");
     private static final AthenzUser defaultUser = AthenzUser.fromUserId("bob");
 
     protected JDisc container;
 
     @Before
-    public void startContainer() { container = JDisc.fromServicesXml(controllerServicesXml(), Networking.disable); }
+    public void startContainer() {
+        container = JDisc.fromServicesXml(controllerServicesXml(), Networking.disable);
+        addUserToHostedOperatorRole(hostedOperator);
+    }
 
     @After
     public void stopContainer() { container.close(); }
@@ -151,8 +155,16 @@ public class ControllerContainerTest {
         return addIdentityToRequest(new Request(uri), defaultUser);
     }
 
-    protected static Request authenticatedRequest(String uri, byte[] body, Request.Method method) {
+    protected static Request authenticatedRequest(String uri, String body, Request.Method method) {
         return addIdentityToRequest(new Request(uri, body, method), defaultUser);
+    }
+
+    protected static Request operatorRequest(String uri) {
+        return addIdentityToRequest(new Request(uri), hostedOperator);
+    }
+
+    protected static Request operatorRequest(String uri, String body, Request.Method method) {
+        return addIdentityToRequest(new Request(uri, body, method), hostedOperator);
     }
 
     protected static Request addIdentityToRequest(Request request, AthenzIdentity identity) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/ControllerContainerTest.java
@@ -99,6 +99,8 @@ public class ControllerContainerTest {
                "  <handler id='com.yahoo.vespa.hosted.controller.restapi.configserver.ConfigServerApiHandler'>\n" +
                "    <binding>http://*/configserver/v1</binding>\n" +
                "    <binding>http://*/configserver/v1/*</binding>\n" +
+               "    <binding>http://*/api/configserver/v1</binding>\n" +
+               "    <binding>http://*/api/configserver/v1/*</binding>\n" +
                "  </handler>\n" +
                "  <handler id='com.yahoo.vespa.hosted.controller.restapi.flags.AuditedFlagsHandler'>\n" +
                "    <binding>http://*/flags/v1</binding>\n" +

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandlerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandlerTest.java
@@ -68,7 +68,7 @@ public class ConfigServerApiHandlerTest extends ControllerContainerTest {
         assertLastRequest("https://cfg.prod.us-north-1.test.vip:4443/", "PUT");
 
         // DELETE /configserver/v1/prod/us-north-1/nodes/v2/node/node1
-        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/configserver/v1/prod/controller/nodes/v2/node/node1",
+        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/api/configserver/v1/prod/controller/nodes/v2/node/node1",
                 "", Request.Method.DELETE), "ok");
         assertLastRequest("https://api.tld:4443/", "DELETE");
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/configserver/responses/root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/configserver/responses/root.json
@@ -1,0 +1,29 @@
+{
+  "zones": [
+    {
+      "environment": "prod",
+      "region": "controller",
+      "uri": "http://localhost:8080/configserver/v1/prod/controller"
+    },
+    {
+      "environment": "prod",
+      "region": "us-north-1",
+      "uri": "http://localhost:8080/configserver/v1/prod/us-north-1"
+    },
+    {
+      "environment": "dev",
+      "region": "aws-us-north-2",
+      "uri": "http://localhost:8080/configserver/v1/dev/aws-us-north-2"
+    },
+    {
+      "environment": "test",
+      "region": "us-north-3",
+      "uri": "http://localhost:8080/configserver/v1/test/us-north-3"
+    },
+    {
+      "environment": "staging",
+      "region": "us-north-4",
+      "uri": "http://localhost:8080/configserver/v1/staging/us-north-4"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiTest.java
@@ -1,15 +1,11 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.restapi.zone.v2;
 
-import com.yahoo.application.container.handler.Request;
 import com.yahoo.application.container.handler.Request.Method;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneId;
-import com.yahoo.text.Utf8;
-import com.yahoo.vespa.athenz.api.AthenzIdentity;
-import com.yahoo.vespa.athenz.api.AthenzUser;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerProxyMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneApiMock;
 import com.yahoo.vespa.hosted.controller.integration.ZoneRegistryMock;
@@ -31,7 +27,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class ZoneApiTest extends ControllerContainerTest {
 
-    private static final AthenzIdentity HOSTED_VESPA_OPERATOR = AthenzUser.fromUserId("johnoperator");
     private static final String responseFiles = "src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/";
     private static final List<ZoneApi> zones = List.of(
             ZoneApiMock.fromId("prod.us-north-1"),
@@ -50,7 +45,6 @@ public class ZoneApiTest extends ControllerContainerTest {
                     .setZones(zones);
         this.tester = new ContainerControllerTester(container, responseFiles);
         this.proxy = (ConfigServerProxyMock) container.components().getComponent(ConfigServerProxyMock.class.getName());
-        addUserToHostedOperatorRole(HOSTED_VESPA_OPERATOR);
     }
 
     @Test
@@ -71,23 +65,23 @@ public class ZoneApiTest extends ControllerContainerTest {
         assertLastRequest(ZoneId.from("prod", "us-north-1"), 2, "GET");
 
         // POST /zone/v2/dev/us-north-2/nodes/v2/command/restart?hostname=node1
-        tester.containerTester().assertResponse(hostedOperatorRequest("http://localhost:8080/zone/v2/dev/aws-us-north-2/nodes/v2/command/restart?hostname=node1",
-                                                            new byte[0], Method.POST),
+        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/zone/v2/dev/aws-us-north-2/nodes/v2/command/restart?hostname=node1",
+                                                            "", Method.POST),
                                                 "ok");
 
         // PUT /zone/v2/prod/us-north-1/nodes/v2/state/dirty/node1
-        tester.containerTester().assertResponse(hostedOperatorRequest("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/state/dirty/node1",
-                                                            new byte[0], Method.PUT), "ok");
+        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/state/dirty/node1",
+                                                            "", Method.PUT), "ok");
         assertLastRequest(ZoneId.from("prod", "us-north-1"), 2, "PUT");
 
         // DELETE /zone/v2/prod/us-north-1/nodes/v2/node/node1
-        tester.containerTester().assertResponse(hostedOperatorRequest("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/node/node1",
-                                                            new byte[0], Method.DELETE), "ok");
+        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/zone/v2/prod/us-north-1/nodes/v2/node/node1",
+                                                            "", Method.DELETE), "ok");
         assertLastRequest(ZoneId.from("prod", "us-north-1"), 2, "DELETE");
 
         // PATCH /zone/v2/prod/us-north-1/nodes/v2/node/node1
-        tester.containerTester().assertResponse(hostedOperatorRequest("http://localhost:8080/zone/v2/dev/aws-us-north-2/nodes/v2/node/node1",
-                                                            Utf8.toBytes("{\"currentRestartGeneration\": 1}"),
+        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/zone/v2/dev/aws-us-north-2/nodes/v2/node/node1",
+                                                            "{\"currentRestartGeneration\": 1}",
                                                             Method.PATCH), "ok");
         assertLastRequest(ZoneId.from("dev", "aws-us-north-2"), 1, "PATCH");
         assertEquals("{\"currentRestartGeneration\": 1}", proxy.lastRequestBody().get());
@@ -98,8 +92,8 @@ public class ZoneApiTest extends ControllerContainerTest {
     @Test
     public void test_invalid_requests() {
         // POST /zone/v2/prod/us-north-34/nodes/v2
-        tester.containerTester().assertResponse(hostedOperatorRequest("http://localhost:8080/zone/v2/prod/us-north-42/nodes/v2",
-                                                            new byte[0], Method.POST),
+        tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/zone/v2/prod/us-north-42/nodes/v2",
+                                                            "", Method.POST),
                                                 new File("unknown-zone.json"), 400);
         assertFalse(proxy.lastReceived().isPresent());
     }
@@ -109,10 +103,6 @@ public class ZoneApiTest extends ControllerContainerTest {
         assertEquals(targets, last.getTargets().size());
         assertTrue(last.getTargets().get(0).toString().contains(zoneId.value()));
         assertEquals(com.yahoo.jdisc.http.HttpRequest.Method.valueOf(method), last.getMethod());
-    }
-
-    private static Request hostedOperatorRequest(String uri, byte[] body, Request.Method method) {
-        return addIdentityToRequest(new Request(uri, body, method), HOSTED_VESPA_OPERATOR);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/responses/root.json
@@ -1,7 +1,7 @@
 {
   "uris": [
     "http://localhost:8080/zone/v2/prod/us-north-1",
-    "http://localhost:8080/zone/v2/dev/us-north-2",
+    "http://localhost:8080/zone/v2/dev/aws-us-north-2",
     "http://localhost:8080/zone/v2/test/us-north-3",
     "http://localhost:8080/zone/v2/staging/us-north-4"
   ],
@@ -12,7 +12,7 @@
     },
     {
       "environment": "dev",
-      "region": "us-north-2"
+      "region": "aws-us-north-2"
     },
     {
       "environment": "test",


### PR DESCRIPTION
`/configserver/v1` is a new proxy API on controller to configservers. Differences from `/zone/v2`:
* `/configserver/v1` proxies only select APIs, currently `/flags/v1`, `/nodes/v2/`, `/orchestrator/v1`.
* `/configserver/v1` is limited to operators only.
* `/configserver/v1` supports the controller "zone".
* `/configserver/v1` only proxies through VIP (`/zone/v2` uses VIP for AWS zones, iterates through config servers on-prem due to VESPA-11845)

This API will be used for the console operator dashboard, but we cloud also start using it in `hv`, this will simplify the code that deals with the controller zone for `node` and `flag` commands, while the `orchestrator` command does not even support it yet.