### PR TITLE
Print error message if deployment fails, not getting compile version

### DIFF
--- a/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/DeployMojo.java
+++ b/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/DeployMojo.java
@@ -37,25 +37,22 @@ public class DeployMojo extends AbstractVespaDeploymentMojo {
 
     @Override
     protected void doExecute() throws MojoFailureException, MojoExecutionException {
-        try {
-            controller.compileVersion(id);
-        }
-        catch (IllegalArgumentException e) {
-            throw new MojoFailureException( "The application " + id.tenant() + "." + id.application() + " does not exist, "
-                                          + "or you do not have the required privileges to access it; "
-                                          + "please visit the Vespa cloud web UI and make sure the application exists and you have access!");
-        }
-
         loggable = DeploymentLog.Level.valueOf(vespaLogLevel);
         Deployment deployment = Deployment.ofPackage(Paths.get(firstNonBlank(applicationZip,
                                                                              projectPathOf("target", "application.zip"))));
         if (vespaVersion != null) deployment = deployment.atVersion(vespaVersion);
 
         ZoneId zone = zoneOf(environment, region);
-        DeploymentResult result = controller.deploy(deployment, id, zone);
-        getLog().info(result.message());
-
-        if (follow) tailLogs(id, zone, result.run());
+        try {
+            DeploymentResult result = controller.deploy(deployment, id, zone);
+            getLog().info(result.message());
+            if (follow) tailLogs(id, zone, result.run());
+        }
+        catch (IllegalArgumentException e) {
+            throw new MojoFailureException( "The application " + id.tenant() + "." + id.application() + " does not exist, "
+                                            + "or you do not have the required privileges to access it; "
+                                            + "please visit the Vespa cloud web UI and make sure the application exists and you have access!");
+        }
     }
 
     private void tailLogs(ApplicationId id, ZoneId zone, long run) throws MojoFailureException, MojoExecutionException {


### PR DESCRIPTION
@hmusum please review.

This would make it impossible to deploy under user tenants to a new application. I don't really want people to do this, as we'd like them to stop using the user tenants, but we said it should continue to work.