### PR TITLE
Use localhost when talking to controller

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/proxy/ConfigServerRestExecutorImpl.java
@@ -18,7 +18,6 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -225,7 +224,6 @@ public class ConfigServerRestExecutorImpl extends AbstractComponent implements C
 
     private static class ControllerOrConfigserverHostnameVerifier implements HostnameVerifier {
 
-        private final HostnameVerifier controllerVerifier = new DefaultHostnameVerifier();
         private final HostnameVerifier configserverVerifier;
 
         ControllerOrConfigserverHostnameVerifier(ZoneRegistry registry) {
@@ -241,7 +239,7 @@ public class ConfigServerRestExecutorImpl extends AbstractComponent implements C
 
         @Override
         public boolean verify(String hostname, SSLSession session) {
-            return controllerVerifier.verify(hostname, session) || configserverVerifier.verify(hostname, session);
+            return "localhost".equals(hostname) || configserverVerifier.verify(hostname, session);
         }
     }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
@@ -31,8 +31,9 @@ import java.util.stream.Stream;
 @SuppressWarnings("unused")
 public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
 
-    private static final String OPTIONAL_PREFIX = "/api";
     private static final ZoneId CONTROLLER_ZONE = ZoneId.from("prod", "controller");
+    private static final URI CONTROLLER_URI = URI.create("https://localhost:4443");
+    private static final String OPTIONAL_PREFIX = "/api";
     private static final List<String> WHITELISTED_APIS = List.of("/flags/v1/", "/nodes/v2/", "/orchestrator/v1/");
 
     private final ZoneRegistry zoneRegistry;
@@ -122,6 +123,6 @@ public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
     }
 
     private URI getEndpoint(ZoneId zoneId) {
-        return CONTROLLER_ZONE.equals(zoneId) ? zoneRegistry.apiUrl() : zoneRegistry.getConfigServerVipUri(zoneId);
+        return CONTROLLER_ZONE.equals(zoneId) ? CONTROLLER_URI : zoneRegistry.getConfigServerVipUri(zoneId);
     }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandler.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 public class ConfigServerApiHandler extends AuditLoggingRequestHandler {
 
     private static final ZoneId CONTROLLER_ZONE = ZoneId.from("prod", "controller");
-    private static final URI CONTROLLER_URI = URI.create("https://localhost:4443");
+    private static final URI CONTROLLER_URI = URI.create("https://localhost:4443/");
     private static final String OPTIONAL_PREFIX = "/api";
     private static final List<String> WHITELISTED_APIS = List.of("/flags/v1/", "/nodes/v2/", "/orchestrator/v1/");
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandlerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/configserver/ConfigServerApiHandlerTest.java
@@ -70,7 +70,7 @@ public class ConfigServerApiHandlerTest extends ControllerContainerTest {
         // DELETE /configserver/v1/prod/us-north-1/nodes/v2/node/node1
         tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/api/configserver/v1/prod/controller/nodes/v2/node/node1",
                 "", Request.Method.DELETE), "ok");
-        assertLastRequest("https://api.tld:4443/", "DELETE");
+        assertLastRequest("https://localhost:4443/", "DELETE");
 
         // PATCH /configserver/v1/prod/us-north-1/nodes/v2/node/node1
         tester.containerTester().assertResponse(operatorRequest("http://localhost:8080/configserver/v1/dev/aws-us-north-2/nodes/v2/node/node1",


### PR DESCRIPTION
Short summary for future reference:
In public systems the certificate is signed to hostname starting with `console.`, which means we cant use `apiUrl()`, additionally all CNAME records to controller VIP are in the public zone in Route 53 and are not resolveable on the controller itself.

Finally, the console handlers are explicitly set up only on the hostname starting with `console.`, which means that we would either have to override port to 4443 or prefix paths with `/api` if the request came to port 443, otherwise we will get `index.html` from `DashboardHandler`.