### PR TITLE
FastSearcher must not call shutdown on the dispatcher, as it does not…

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastSearcher.java
@@ -172,10 +172,4 @@ public class FastSearcher extends VespaBackEndSearcher {
     protected boolean isLoggingFine() {
         return getLogger().isLoggable(Level.FINE);
     }
-
-    @Override
-    public void shutDown() {
-        super.shutDown();
-        dispatcher.shutDown();
-    }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -101,6 +101,7 @@ public class Dispatcher extends AbstractComponent {
              metric);
     }
 
+    /* Protected for simple mocking in tests. Beware that searchCluster is shutdown on in deconstruct() */
     protected Dispatcher(SearchCluster searchCluster,
                          DispatchConfig dispatchConfig,
                          RpcInvokerFactory rcpInvokerFactory,
@@ -108,6 +109,7 @@ public class Dispatcher extends AbstractComponent {
         this(searchCluster, dispatchConfig, rcpInvokerFactory, rcpInvokerFactory, metric);
     }
 
+    /* Protected for simple mocking in tests. Beware that searchCluster is shutdown on in deconstruct() */
     protected Dispatcher(SearchCluster searchCluster,
                          DispatchConfig dispatchConfig,
                          InvokerFactory invokerFactory,
@@ -132,6 +134,7 @@ public class Dispatcher extends AbstractComponent {
     @Override
     public void deconstruct() {
         invokerFactory.release();
+        searchCluster.shutDown();
     }
 
     public Optional<FillInvoker> getFillInvoker(Result result, VespaBackEndSearcher searcher) {
@@ -212,10 +215,6 @@ public class Dispatcher extends AbstractComponent {
         }
 
         return Optional.empty();
-    }
-
-    public void shutDown() {
-        searchCluster.shutDown();
     }
 
     private void emitDispatchMetric(Optional<SearchInvoker> invoker) {


### PR DESCRIPTION
… own it.

The dispatcher has a life independant og the BackendSearchers and should properly self destruct.

@bratseth and @geirst PR
