### PR TITLE
Add non-converged nodes to task deadline exceeded messages

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -126,6 +126,8 @@ public class FleetControllerOptions implements Cloneable {
     // TODO: Choose a default value
     public double minMergeCompletionRatio = 1.0;
 
+    public int maxDivergentNodesPrintedInTaskErrorMessages = 10;
+
     // TODO: Replace usage of this by usage where the nodes are explicitly passed (below)
     public FleetControllerOptions(String clusterName) {
         this.clusterName = clusterName;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RemoteClusterControllerTask.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RemoteClusterControllerTask.java
@@ -48,6 +48,30 @@ public abstract class RemoteClusterControllerTask {
         DEADLINE_EXCEEDED
     }
 
+    public static class Failure {
+        private final FailureCondition condition;
+        private final String message;
+
+        private Failure(FailureCondition condition, String message) {
+            this.condition = condition;
+            this.message = message;
+        }
+        public static Failure of(FailureCondition condition, String message) {
+            return new Failure(condition, message);
+        }
+        public static Failure of(FailureCondition condition) {
+            return new Failure(condition, "");
+        }
+
+        public FailureCondition getCondition() {
+            return condition;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
     /**
      *  If the task completion has been deferred due to hasVersionAckDependency(),
      *  this method will be invoked if a failure occurs before the version has
@@ -64,9 +88,10 @@ public abstract class RemoteClusterControllerTask {
      *  before the dependent cluster version has been published.
      *
      *  The task implementation is responsible for communicating the appropriate
-     *  error semantics to the caller who initially scheduled the task.
+     *  error semantics to the caller who initially scheduled the task. If additional
+     *  details are available, Failure.getMessage() will return a non-empty string.
      */
-    public void handleFailure(FailureCondition condition) {}
+    public void handleFailure(Failure failure) {}
 
     public Optional<Instant> getDeadline() {
         return Optional.empty();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Request.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Request.java
@@ -61,12 +61,21 @@ public abstract class Request<Result> extends RemoteClusterControllerTask {
         }
     }
 
+    private static String failureStringWithPossibleMessage(String prefix, String message) {
+        if (message != null && !message.isEmpty()) {
+            return String.format("%s: %s", prefix, message);
+        }
+        return prefix;
+    }
+
     @Override
-    public void handleFailure(FailureCondition condition) {
-        if (condition == FailureCondition.LEADERSHIP_LOST) {
-            failure = new UnknownMasterException("Leadership lost before request could complete");
-        } else if (condition == FailureCondition.DEADLINE_EXCEEDED) {
-            failure = new DeadlineExceededException("Task exceeded its version wait deadline");
+    public void handleFailure(Failure failure) {
+        if (failure.getCondition() == FailureCondition.LEADERSHIP_LOST) {
+            this.failure = new UnknownMasterException(failureStringWithPossibleMessage(
+                    "Leadership lost before request could complete", failure.getMessage()));
+        } else if (failure.getCondition() == FailureCondition.DEADLINE_EXCEEDED) {
+            this.failure = new DeadlineExceededException(failureStringWithPossibleMessage(
+                    "Task exceeded its version wait deadline", failure.getMessage()));
         }
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -428,24 +428,25 @@ public class SetNodeStateTest extends StateRestApiTest {
         expectedException.expect(UnknownMasterException.class);
 
         SetNodeStateRequest request = createDummySetNodeStateRequest();
-        request.handleFailure(RemoteClusterControllerTask.FailureCondition.LEADERSHIP_LOST);
+        request.handleFailure(RemoteClusterControllerTask.Failure.of(RemoteClusterControllerTask.FailureCondition.LEADERSHIP_LOST));
         request.getResult();
     }
 
     @Test
     public void leadership_loss_marks_request_as_failed_for_early_out_response() {
         SetNodeStateRequest request = createDummySetNodeStateRequest();
-        request.handleFailure(RemoteClusterControllerTask.FailureCondition.LEADERSHIP_LOST);
+        request.handleFailure(RemoteClusterControllerTask.Failure.of(RemoteClusterControllerTask.FailureCondition.LEADERSHIP_LOST));
         assertTrue(request.isFailed());
     }
 
     @Test
     public void deadline_exceeded_fails_set_node_state_request() throws Exception {
-        expectedException.expectMessage("Task exceeded its version wait deadline");
+        expectedException.expectMessage("Task exceeded its version wait deadline: gremlins in the computer");
         expectedException.expect(DeadlineExceededException.class);
 
         SetNodeStateRequest request = createDummySetNodeStateRequest();
-        request.handleFailure(RemoteClusterControllerTask.FailureCondition.DEADLINE_EXCEEDED);
+        request.handleFailure(RemoteClusterControllerTask.Failure.of(
+                RemoteClusterControllerTask.FailureCondition.DEADLINE_EXCEEDED, "gremlins in the computer"));
         request.getResult();
     }
 


### PR DESCRIPTION
@geirst please review

Makes it easier for an external observer to understand what set of nodes
is causing the cluster state to not converge.

