### PR TITLE
Gjoranv/reapply allow duplicate bundles

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/config/BundleLoader.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/BundleLoader.java
@@ -10,7 +10,6 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.wiring.BundleRevision;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,11 +25,18 @@ import static com.yahoo.container.core.BundleLoaderProperties.DISK_BUNDLE_PREFIX
  * Manages the set of installed 3rd-party component bundles.
  *
  * @author Tony Vaagenes
+ * @author gjoranv
  */
 public class BundleLoader {
 
-    private final List<Bundle> initialBundles;
-
+    /* Map of file refs of active bundles (not scheduled for uninstall) to a list of all bundles that were installed
+     * (pre-install directive) by the bundle pointed to by the file ref (including itself).
+     *
+     * Used to:
+     * 1. Avoid installing already installed bundles. Just an optimization, installing the same bundle location is a NOP
+     * 2. Start bundles (all are started every time)
+     * 3. Calculate the set of bundles to uninstall
+     */
     private final Map<FileReference, List<Bundle>> reference2Bundles = new LinkedHashMap<>();
 
     private final Logger log = Logger.getLogger(BundleLoader.class.getName());
@@ -38,7 +44,6 @@ public class BundleLoader {
 
     public BundleLoader(Osgi osgi) {
         this.osgi = osgi;
-        initialBundles = Arrays.asList(osgi.getBundles());
     }
 
     private List<Bundle> obtainBundles(FileReference reference, FileAcquirer fileAcquirer) throws InterruptedException {
@@ -46,17 +51,19 @@ public class BundleLoader {
         return osgi.install(file.getAbsolutePath());
     }
 
-    /** Returns the number of bundles installed by this call. */
-    private int install(List<FileReference> references) {
+    private void install(List<FileReference> references) {
         Set<FileReference> bundlesToInstall = new HashSet<>(references);
+
+        // This is just an optimization, as installing a bundle with the same location id returns the already installed bundle.
+        // It's ok that fileRefs pending uninstall are removed from the map, because they are never in the new set of bundles..
         bundlesToInstall.removeAll(reference2Bundles.keySet());
 
         PredicateSplit<FileReference> bundlesToInstall_isDisk = partition(bundlesToInstall, BundleLoader::isDiskBundle);
         installBundlesFromDisk(bundlesToInstall_isDisk.trueValues);
         installBundlesFromFileDistribution(bundlesToInstall_isDisk.falseValues);
 
+        // TODO: Remove. Bundles are also started in use()
         startBundles();
-        return bundlesToInstall.size();
     }
 
     private static boolean isDiskBundle(FileReference fileReference) {
@@ -97,6 +104,7 @@ public class BundleLoader {
         }
 
         List<Bundle> bundles = osgi.install(file.getAbsolutePath());
+
         reference2Bundles.put(reference, bundles);
     }
 
@@ -113,13 +121,16 @@ public class BundleLoader {
         }
     }
 
-    // All bundles must have been started first to ensure correct package resolution.
+    /**
+     * Resolves and starts (calls the Bundles BundleActivator) all bundles. Bundle resolution must take place
+     * after all bundles are installed to ensure that the framework can resolve dependencies between bundles.
+     */
     private void startBundles() {
         for (List<Bundle> bundles : reference2Bundles.values()) {
             for (Bundle bundle : bundles) {
                 try {
                     if ( ! isFragment(bundle))
-                        bundle.start();
+                        bundle.start();  // NOP for already ACTIVE bundles
                 } catch(Exception e) {
                     throw new RuntimeException("Could not start bundle '" + bundle.getSymbolicName() + "'", e);
                 }
@@ -135,38 +146,44 @@ public class BundleLoader {
         return (bundleRevision.getTypes() & BundleRevision.TYPE_FRAGMENT) != 0;
     }
 
-    /** Returns the number of uninstalled bundles */
-    private int retainOnly(List<FileReference> newReferences) {
-        Set<Bundle> bundlesToRemove = new HashSet<>(Arrays.asList(osgi.getBundles()));
+    /**
+     * Returns the bundles to schedule for uninstall after their components have been deconstructed
+     * and removes the same bundles from the map of active bundles.
+     */
+    private Set<Bundle> getBundlesToUninstall(List<FileReference> newReferences) {
+        Set<Bundle> bundlesToRemove = new HashSet<>(osgi.getCurrentBundles());
 
         for (FileReference fileReferenceToKeep: newReferences) {
             if (reference2Bundles.containsKey(fileReferenceToKeep))
                 bundlesToRemove.removeAll(reference2Bundles.get(fileReferenceToKeep));
         }
 
-        bundlesToRemove.removeAll(initialBundles);
-        for (Bundle bundle : bundlesToRemove) {
-            log.info("Removing bundle '" + bundle.toString() + "'");
-            osgi.uninstall(bundle);
-        }
+        bundlesToRemove.removeAll(osgi.getInitialBundles());
+        removeInactiveFileReferences(newReferences);
 
-        Set<FileReference> fileReferencesToRemove = new HashSet<>(reference2Bundles.keySet());
-        fileReferencesToRemove.removeAll(newReferences);
-
-        for (FileReference fileReferenceToRemove : fileReferencesToRemove) {
-            reference2Bundles.remove(fileReferenceToRemove);
-        }
-        return bundlesToRemove.size();
+        return bundlesToRemove;
     }
 
-    public synchronized int use(List<FileReference> bundles) {
-        int removedBundles = retainOnly(bundles);
-        int installedBundles = install(bundles);
+    private void removeInactiveFileReferences(List<FileReference> newReferences) {
+        // Clean up the map of active bundles
+        Set<FileReference> fileReferencesToRemove = new HashSet<>(reference2Bundles.keySet());
+        fileReferencesToRemove.removeAll(newReferences);
+        fileReferencesToRemove.forEach(reference2Bundles::remove);
+    }
+
+    /**
+     * Installs the given set of bundles and returns the set of bundles that is no longer used
+     * by the application, and should therefore be scheduled for uninstall.
+     */
+    public synchronized Set<Bundle> use(List<FileReference> newBundles) {
+        Set<Bundle> bundlesToUninstall = getBundlesToUninstall(newBundles);
+        osgi.allowDuplicateBundles(bundlesToUninstall);
+        log.info(() -> bundlesToUninstall.isEmpty() ? "Adding bundles to allowed duplicates: " + bundlesToUninstall : "");
+        install(newBundles);
         startBundles();
 
-        log.info(removedBundles + " bundles were removed, and " + installedBundles + " bundles were installed.");
         log.info(installedBundlesMessage());
-        return removedBundles + installedBundles;
+        return bundlesToUninstall;
     }
 
     private String installedBundlesMessage() {

--- a/container-core/src/main/java/com/yahoo/container/core/config/BundleLoader.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/BundleLoader.java
@@ -46,11 +46,6 @@ public class BundleLoader {
         this.osgi = osgi;
     }
 
-    private List<Bundle> obtainBundles(FileReference reference, FileAcquirer fileAcquirer) throws InterruptedException {
-        File file = fileAcquirer.waitFor(reference, 7, TimeUnit.DAYS);
-        return osgi.install(file.getAbsolutePath());
-    }
-
     private void install(List<FileReference> references) {
         Set<FileReference> bundlesToInstall = new HashSet<>(references);
 
@@ -119,6 +114,11 @@ public class BundleLoader {
                 throw new RuntimeException("Could not install bundle '" + reference + "'", e);
             }
         }
+    }
+
+    private List<Bundle> obtainBundles(FileReference reference, FileAcquirer fileAcquirer) throws InterruptedException {
+        File file = fileAcquirer.waitFor(reference, 7, TimeUnit.DAYS);
+        return osgi.install(file.getAbsolutePath());
     }
 
     /**

--- a/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
@@ -19,7 +19,6 @@ import com.yahoo.osgi.MockOsgi;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Random;
 import java.util.Set;
@@ -90,7 +89,7 @@ public class HandlersConfigurerTestWrapper {
 
     public HandlersConfigurerTestWrapper(Container container, String configId) {
         createFiles(configId);
-        MockOsgi mockOsgi = new MockOsgi();
+        MockOsgiWrapper mockOsgiWrapper = new MockOsgiWrapper();
         ComponentDeconstructor testDeconstructor = getTestDeconstructor();
         configurer = new HandlersConfigurerDi(
                 new CloudSubscriberFactory(configSources),
@@ -98,16 +97,17 @@ public class HandlersConfigurerTestWrapper {
                 configId,
                 testDeconstructor,
                 guiceInjector(),
-                mockOsgi);
+                mockOsgiWrapper);
         this.container = container;
     }
 
     private ComponentDeconstructor getTestDeconstructor() {
-        return components -> components.forEach(component -> {
+        return (components, bundles) -> components.forEach(component -> {
             if (component instanceof AbstractComponent) {
                 AbstractComponent abstractComponent = (AbstractComponent) component;
                 if (abstractComponent.isDeconstructable()) abstractComponent.deconstruct();
             }
+            if (! bundles.isEmpty()) throw new IllegalArgumentException("This test should not use bundles");
         });
     }
 

--- a/container-core/src/main/java/com/yahoo/container/core/config/testutil/MockOsgiWrapper.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/testutil/MockOsgiWrapper.java
@@ -1,0 +1,44 @@
+package com.yahoo.container.core.config.testutil;
+
+import com.yahoo.component.ComponentSpecification;
+import com.yahoo.osgi.OsgiWrapper;
+import org.osgi.framework.Bundle;
+
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * @author gjoranv
+ */
+public class MockOsgiWrapper implements OsgiWrapper {
+
+    @Override
+    public List<Bundle> getInitialBundles() {
+        return emptyList();
+    }
+
+    @Override
+    public Bundle[] getBundles() {
+        return new Bundle[0];
+    }
+
+    @Override
+    public List<Bundle> getCurrentBundles() {
+        return emptyList();
+    }
+
+    @Override
+    public Bundle getBundle(ComponentSpecification bundleId) {
+        return null;
+    }
+
+    @Override
+    public List<Bundle> install(String absolutePath) {
+        return emptyList();
+    }
+
+    @Override
+    public void allowDuplicateBundles(Collection<Bundle> bundles) {  }
+}

--- a/container-core/src/main/java/com/yahoo/osgi/MockOsgi.java
+++ b/container-core/src/main/java/com/yahoo/osgi/MockOsgi.java
@@ -16,8 +16,18 @@ import java.util.List;
 public class MockOsgi extends NonWorkingOsgiFramework implements Osgi {
 
     @Override
+    public List<Bundle> getInitialBundles() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public Bundle[] getBundles() {
         return new Bundle[0];
+    }
+
+    @Override
+    public List<Bundle> getCurrentBundles() {
+        return Collections.emptyList();
     }
 
     @Override
@@ -28,14 +38,6 @@ public class MockOsgi extends NonWorkingOsgiFramework implements Osgi {
     @Override
     public List<Bundle> install(String absolutePath) {
         return Collections.emptyList();
-    }
-
-    @Override
-    public void uninstall(Bundle bundle) {
-    }
-
-    @Override
-    public void refreshPackages() {
     }
 
 }

--- a/container-core/src/main/java/com/yahoo/osgi/Osgi.java
+++ b/container-core/src/main/java/com/yahoo/osgi/Osgi.java
@@ -4,6 +4,7 @@ package com.yahoo.osgi;
 import com.yahoo.component.ComponentSpecification;
 import org.osgi.framework.Bundle;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -11,14 +12,17 @@ import java.util.List;
  */
 public interface Osgi {
 
+    List<Bundle> getInitialBundles();
+
     Bundle[] getBundles();
+
+    /** Returns all bundles that have not been scheduled for uninstall. */
+    List<Bundle> getCurrentBundles();
 
     Bundle getBundle(ComponentSpecification bundleId);
 
     List<Bundle> install(String absolutePath);
 
-    void uninstall(Bundle bundle);
-
-    void refreshPackages();
+    void allowDuplicateBundles(Collection<Bundle> bundles);
 
 }

--- a/container-core/src/main/java/com/yahoo/osgi/OsgiWrapper.java
+++ b/container-core/src/main/java/com/yahoo/osgi/OsgiWrapper.java
@@ -1,0 +1,16 @@
+package com.yahoo.osgi;
+
+import com.yahoo.component.ComponentSpecification;
+import org.osgi.framework.Bundle;
+
+/**
+ * @author gjoranv
+ */
+public interface OsgiWrapper extends Osgi, com.yahoo.container.di.Osgi {
+
+    @Override
+    default Bundle getBundle(ComponentSpecification bundleId) {
+        return null;
+    }
+
+}

--- a/container-di/src/main/java/com/yahoo/container/di/ComponentDeconstructor.java
+++ b/container-di/src/main/java/com/yahoo/container/di/ComponentDeconstructor.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.di;
 
+import org.osgi.framework.Bundle;
+
 import java.util.Collection;
 
 /**
@@ -8,5 +10,7 @@ import java.util.Collection;
  * @author Tony Vaagenes
  */
 public interface ComponentDeconstructor {
-    void deconstruct(Collection<Object> components);
+
+    void deconstruct(Collection<Object> components, Collection<Bundle> bundles);
+
 }

--- a/container-di/src/main/java/com/yahoo/container/di/Osgi.java
+++ b/container-di/src/main/java/com/yahoo/container/di/Osgi.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptySet;
+
 /**
  * @author gjoranv
  * @author Tony Vaagenes
@@ -23,8 +25,13 @@ public interface Osgi {
         return new BundleClasses(new MockBundle(), Collections.emptySet());
     }
 
-    default void useBundles(Collection<FileReference> bundles) {
+    /**
+     * Returns the set of bundles that is not used by the current application generation,
+     * and therefore should be scheduled for uninstalling.
+     */
+    default Set<Bundle> useBundles(Collection<FileReference> bundles) {
         System.out.println("useBundles " + bundles.stream().map(Object::toString).collect(Collectors.joining(", ")));
+        return emptySet();
     }
 
     default Class<?> resolveClass(BundleInstantiationSpecification spec) {

--- a/container-di/src/test/java/com/yahoo/container/di/ContainerTestBase.java
+++ b/container-di/src/test/java/com/yahoo/container/di/ContainerTestBase.java
@@ -5,7 +5,6 @@ import com.google.inject.Guice;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.config.FileReference;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
-import com.yahoo.container.di.CloudSubscriberFactory;
 import com.yahoo.container.di.ContainerTest.ComponentTakingConfig;
 import com.yahoo.container.di.componentgraph.core.ComponentGraph;
 import com.yahoo.container.di.osgi.BundleClasses;
@@ -15,6 +14,8 @@ import org.osgi.framework.Bundle;
 
 import java.util.Collection;
 import java.util.Set;
+
+import static java.util.Collections.emptySet;
 
 /**
  * @author Tony Vaagenes
@@ -60,7 +61,8 @@ public class ContainerTestBase {
                         }
 
                         @Override
-                        public void useBundles(Collection<FileReference> bundles) {
+                        public Set<Bundle> useBundles(Collection<FileReference> bundles) {
+                            return emptySet();
                         }
 
                         @Override

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/DisableOsgiFramework.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/DisableOsgiFramework.java
@@ -6,6 +6,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -48,6 +49,16 @@ public final class DisableOsgiFramework implements OsgiFramework {
 
     @Override
     public List<Bundle> bundles() {
+        throw newException();
+    }
+
+    @Override
+    public List<Bundle> getBundles(Bundle requestingBundle) {
+        throw newException();
+    }
+
+    @Override
+    public void allowDuplicateBundles(Collection<Bundle> bundles) {
         throw newException();
     }
 

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertTrue;
 
@@ -28,7 +29,7 @@ public class DeconstructorTest {
     public void require_abstract_component_destructed() throws InterruptedException {
         TestAbstractComponent abstractComponent = new TestAbstractComponent();
         // Done by executor, so it takes some time even with a 0 delay.
-        deconstructor.deconstruct(singleton(abstractComponent));
+        deconstructor.deconstruct(singleton(abstractComponent), emptyList());
         int cnt = 0;
         while (! abstractComponent.destructed && (cnt++ < 12000)) {
             Thread.sleep(10);
@@ -39,14 +40,14 @@ public class DeconstructorTest {
     @Test
     public void require_provider_destructed() {
         TestProvider provider = new TestProvider();
-        deconstructor.deconstruct(singleton(provider));
+        deconstructor.deconstruct(singleton(provider), emptyList());
         assertTrue(provider.destructed);
     }
 
     @Test
     public void require_shared_resource_released() {
         TestSharedResource sharedResource = new TestSharedResource();
-        deconstructor.deconstruct(singleton(sharedResource));
+        deconstructor.deconstruct(singleton(sharedResource), emptyList());
         assertTrue(sharedResource.released);
     }
 

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/application/OsgiFramework.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/application/OsgiFramework.java
@@ -5,6 +5,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -13,6 +14,7 @@ import java.util.List;
  * {@link BundleInstaller} since that provides common convenience methods.
  *
  * @author Simon Thoresen Hult
+ * @author gjoranv
  */
 public interface OsgiFramework {
 
@@ -58,6 +60,8 @@ public interface OsgiFramework {
     /**
      * Synchronously refresh all bundles currently loaded. Once this method returns, the
      * class loaders of all bundles will reflect on the current set of loaded bundles.
+     *
+     * NOTE: This method is no longer used by the Jdisc container framework, but kept for completeness.
      */
     void refreshPackages();
 
@@ -79,6 +83,20 @@ public interface OsgiFramework {
      * @return an iterable collection of Bundle objects, one object per installed bundle
      */
     List<Bundle> bundles();
+
+    /**
+     * Returns all installed bundles that are visible to the requesting bundle. Bundle visibility
+     * is controlled via implementations of {@link org.osgi.framework.hooks.bundle.FindHook};
+     */
+    List<Bundle> getBundles(Bundle requestingBundle);
+
+    /**
+     * Allows this framework to install duplicates of the given collection of bundles. Duplicate detection
+     * is handled by the {@link com.yahoo.jdisc.core.BundleCollisionHook}.
+     *
+     * @param bundles The bundles to allow duplicates of
+     */
+    void allowDuplicateBundles(Collection<Bundle> bundles);
 
     /**
      * This method starts the framework instance. Before this method is called, any call to {@link

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/BundleCollisionHook.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/BundleCollisionHook.java
@@ -121,7 +121,7 @@ public class BundleCollisionHook implements CollisionHook, EventHook, FindHook {
             if (requestingContext.getBundle() instanceof Framework) {
                 log.fine(() -> "Requesting bundle is the Framework, so hidden bundles will be visible: " + hiddenBundles);
             } else {
-                log.info("Hiding bundles from bundle '" + requestingContext.getBundle() + "': " + hiddenBundles);
+                log.fine(() -> "Hiding bundles from bundle '" + requestingContext.getBundle() + "': " + hiddenBundles);
             }
         }
     }

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/BundleCollisionHook.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/BundleCollisionHook.java
@@ -8,6 +8,7 @@ import org.osgi.framework.Version;
 import org.osgi.framework.hooks.bundle.CollisionHook;
 import org.osgi.framework.hooks.bundle.EventHook;
 import org.osgi.framework.hooks.bundle.FindHook;
+import org.osgi.framework.launch.Framework;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -18,9 +19,10 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 /**
- * A bundle {@link CollisionHook} that contains a set of bundles that are allowed to collide with
- * bundles that are about to be installed. In order to clean up when bundles are uninstalled, this
- * is also a bundle {@link EventHook}.
+ * A bundle {@link CollisionHook} that contains a set of bundles that are allowed to collide with bundles
+ * that are about to be installed. This class also implements a {@link FindHook} to provide a consistent
+ * view of bundles such that the two sets of duplicate bundles are invisible to each other.
+ * In order to clean up when bundles are uninstalled, this is also a bundle {@link EventHook}.
  *
  * Thread safe
  *
@@ -86,9 +88,6 @@ public class BundleCollisionHook implements CollisionHook, EventHook, FindHook {
      * If the given context represents one of the allowed duplicates, this method filters out all bundles
      * that are duplicates of the allowed duplicates. Otherwise this method filters out the allowed duplicates,
      * so they are not visible to other bundles.
-     *
-     * NOTE:  This hook method is added for a consistent view of the installed bundles, but is not actively
-     *        used by jdisc. The OSGi framework does not use FindHooks when calculating bundle wiring.
      */
     @Override
     public synchronized void find(BundleContext context, Collection<Bundle> bundles) {
@@ -107,12 +106,24 @@ public class BundleCollisionHook implements CollisionHook, EventHook, FindHook {
                 }
             }
         }
-        log.info("Hiding bundles from bundle '" + context.getBundle() + "': " + bundlesToHide);
+        logHiddenBundles(context, bundlesToHide);
         bundles.removeAll(bundlesToHide);
     }
 
     private boolean isDuplicateOfAllowedDuplicates(Bundle bundle) {
         return ! allowedDuplicates.containsKey(bundle) && allowedDuplicates.containsValue(new BsnVersion(bundle));
+    }
+
+    private void logHiddenBundles(BundleContext requestingContext, Set<Bundle> hiddenBundles) {
+        if (hiddenBundles.isEmpty()) {
+            log.fine(() -> "No bundles to hide from bundle " + requestingContext.getBundle());
+        } else {
+            if (requestingContext.getBundle() instanceof Framework) {
+                log.fine(() -> "Requesting bundle is the Framework, so hidden bundles will be visible: " + hiddenBundles);
+            } else {
+                log.info("Hiding bundles from bundle '" + requestingContext.getBundle() + "': " + hiddenBundles);
+            }
+        }
     }
 
 

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/BundleCollisionHook.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/BundleCollisionHook.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * A bundle {@link CollisionHook} that contains a set of bundles that are allowed to collide with
@@ -26,6 +27,7 @@ import java.util.Set;
  * @author gjoranv
  */
 public class BundleCollisionHook implements CollisionHook, EventHook, FindHook {
+    private static Logger log = Logger.getLogger(BundleCollisionHook.class.getName());
 
     private ServiceRegistration<?> registration;
     private Map<Bundle, BsnVersion> allowedDuplicates = new HashMap<>(5);
@@ -105,6 +107,7 @@ public class BundleCollisionHook implements CollisionHook, EventHook, FindHook {
                 }
             }
         }
+        log.info("Hiding bundles from bundle '" + context.getBundle() + "': " + bundlesToHide);
         bundles.removeAll(bundlesToHide);
     }
 

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/FelixFramework.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/FelixFramework.java
@@ -117,6 +117,9 @@ public class FelixFramework implements OsgiFramework {
         return sb.toString();
     }
 
+    /**
+     * NOTE: This method is no longer used by the Jdisc container framework, but kept for completeness.
+     */
     @Override
     public void refreshPackages() {
         FrameworkWiring wiring = felix.adapt(FrameworkWiring.class);
@@ -153,8 +156,13 @@ public class FelixFramework implements OsgiFramework {
         return Arrays.asList(felix.getBundleContext().getBundles());
     }
 
+    @Override
     public List<Bundle> getBundles(Bundle requestingBundle) {
-        return Arrays.asList(requestingBundle.getBundleContext().getBundles());
+        log.fine(() -> "All bundles: " + bundles());
+        log.fine(() -> "Getting visible bundles for bundle " + requestingBundle);
+        List<Bundle> visibleBundles = Arrays.asList(requestingBundle.getBundleContext().getBundles());
+        log.fine(() -> "Visible bundles: " + visibleBundles);
+        return visibleBundles;
     }
 
     public void allowDuplicateBundles(Collection<Bundle> bundles) {

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/test/NonWorkingOsgiFramework.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/test/NonWorkingOsgiFramework.java
@@ -5,6 +5,7 @@ import com.yahoo.jdisc.application.OsgiFramework;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,6 +38,14 @@ public class NonWorkingOsgiFramework implements OsgiFramework {
     public List<Bundle> bundles() {
         return Collections.emptyList();
     }
+
+    @Override
+    public List<Bundle> getBundles(Bundle requestingBundle) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void allowDuplicateBundles(Collection<Bundle> bundles) { }
 
     @Override
     public void start() {

--- a/standalone-container/src/main/java/com/yahoo/application/container/impl/ClassLoaderOsgiFramework.java
+++ b/standalone-container/src/main/java/com/yahoo/application/container/impl/ClassLoaderOsgiFramework.java
@@ -63,7 +63,7 @@ public final class ClassLoaderOsgiFramework implements OsgiFramework {
 
     @Override
     public List<Bundle> installBundle(String bundleLocation) {
-        if (bundleLocation != null && bundleLocation.isEmpty() == false) {
+        if (bundleLocation != null && ! bundleLocation.isEmpty()) {
             try {
                 URL url = new URL(bundleLocation);
                 bundleLocations.add(url);
@@ -104,6 +104,14 @@ public final class ClassLoaderOsgiFramework implements OsgiFramework {
     public List<Bundle> bundles() {
         return bundleList;
     }
+
+    @Override
+    public List<Bundle> getBundles(Bundle requestingBundle) {
+        return bundleList;
+    }
+
+    @Override
+    public void allowDuplicateBundles(Collection<Bundle> bundles) { }
 
     @Override
     public void start() {

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerActivator.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerActivator.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
@@ -140,6 +141,14 @@ public class StandaloneContainerActivator implements BundleActivator {
         public List<Bundle> bundles() {
             return Collections.emptyList();
         }
+
+        @Override
+        public List<Bundle> getBundles(Bundle requestingBundle) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void allowDuplicateBundles(Collection<Bundle> bundles) { }
 
         @Override
         public void start() {


### PR DESCRIPTION
Only the second last commit is significant, except for the two re-apply commits.
* Avoid making the pre-installed bundles (X-JDisc-Preinstall-Bundle) invisible for component construction. 
* Avoid uninstalling above bundles when they have been added back by another bundle.

FYI: @kkraune 