### PR TITLE
Add '-bundle.jar' to file suffixes to copy to the application.

### DIFF
--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -107,6 +107,7 @@ public class ApplicationMojo extends AbstractMojo {
         File moduleTargetDir = new File(moduleDir, "target");
         if (moduleTargetDir.exists()) {
             File[] bundles = moduleTargetDir.listFiles((dir, name) -> name.endsWith("-deploy.jar") ||
+                                                                      name.endsWith("-bundle.jar") ||
                                                                       name.endsWith("-jar-with-dependencies.jar"));
             if (bundles == null) return;
             for (File bundle : bundles) {


### PR DESCRIPTION
This is the default classifier name when using the 'AttachBundle' config setting.