### PR TITLE
Revert "Add '-bundle.jar' to file suffixes to copy to the application."

### DIFF
--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -107,7 +107,6 @@ public class ApplicationMojo extends AbstractMojo {
         File moduleTargetDir = new File(moduleDir, "target");
         if (moduleTargetDir.exists()) {
             File[] bundles = moduleTargetDir.listFiles((dir, name) -> name.endsWith("-deploy.jar") ||
-                                                                      name.endsWith("-bundle.jar") ||
                                                                       name.endsWith("-jar-with-dependencies.jar"));
             if (bundles == null) return;
             for (File bundle : bundles) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#11231

sample-apps module fails to build with:
`[ERROR] Failed to execute goal on project multiple-bundles: Could not resolve dependencies for project com.yahoo.demo.multibundle:multiple-bundles:container-plugin:7.137.2: Could not find artifact com.yahoo.demo.multibundle:multiple-bundles-lib:jar:1.0.1 in artifactory-maven-remote-repos (https://edge.artifactory.yahoo.com:4443/artifactory/maven-remote-repos) -> [Help 1]`