### PR TITLE
Remove unused mounts

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -272,10 +272,7 @@ public class DockerOperationsImpl implements DockerOperations {
                 Paths.get("/opt/splunkforwarder/var/log"),  // VESPA-14917, thin pool leakage
                 Paths.get("/var/log"),                      // VESPA-14917, thin pool leakage
                 Paths.get("/var/spool/postfix/maildrop"),   // VESPA-14917, thin pool leakage
-                context.pathInNodeUnderVespaHome("logs/daemontools_y"), // TODO: related to ykeykey?
                 context.pathInNodeUnderVespaHome("logs/vespa"),
-                context.pathInNodeUnderVespaHome("logs/yca"),
-                context.pathInNodeUnderVespaHome("logs/ykeykeyd"), // TODO: should only be needed for proxy?
                 context.pathInNodeUnderVespaHome("logs/ysar"),
                 context.pathInNodeUnderVespaHome("tmp"),
                 context.pathInNodeUnderVespaHome("var/crash"), // core dumps


### PR DESCRIPTION
* `logs/daemontools_y` Logs ~2 kB once on around container start. Not sure where this even comes from, this package is not referenced anywhere in our code base.
* `logs/ykeykeyd`: Not used anymore, last logs around Oct. 22.
* `logs/yca`: Logs ~2 lines per day, each line is ~2 kB