### PR TITLE
Treat inner square brackets as syntactic sugar

### DIFF
--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -855,10 +855,10 @@ DynamicTensor indexedTensorValueBody(TensorType type) :
     ExpressionNode value;
 }
 {
-    <LSQUARE>
-        (         value = expression() { cells.add(value); } )*
-        ( <COMMA> value = expression() { cells.add(value); } )*
-    <RSQUARE>
+    <LSQUARE> // TODO: Parse inner square brackets properly
+        ( (<LSQUARE>)* value = expression() (<RSQUARE>)* { cells.add(value); }  )*
+        ( <COMMA> (<LSQUARE>)* value = expression() (<RSQUARE>)* { cells.add(value); } )*
+//    <RSQUARE>
     { return DynamicTensor.from(type, TensorFunctionNode.wrap(cells)); }
 }
 

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -371,6 +371,8 @@ public class EvaluationTestCase {
         tester.assertEvaluates("tensor(x{}):{ {x:a}:6.0, {x:b}:4.0, {x:c}:14.0 }",
                                "tensor(x{}):{ {x:a}:1+2+3, {x:b}:if(1>2,3,4), {x:c}:sum(tensor0*tensor1) }",
                                "{ {x:0}:7 }", "tensor(x{}):{ {x:0}:2 }");
+        tester.assertEvaluates("tensor<float>(d0[1],x[3]):[[1.0, 0.5, 0.25]]",
+                               "tensor<float>(d0[1],x[3]):[[one,one_half,a_quarter]]");
     }
 
     @Test


### PR DESCRIPTION
@lesters please review

We agreed to do strict parsing of inner brackets but for now this is symmetric to what we do when parsing literal tensors outside expressions.