### PR TITLE
Let Z-curve attribute be authoritative for position field existence

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
@@ -85,6 +85,8 @@ void fillInPositionFields(Document &doc, DocumentIdT lid, const DocumentRetrieve
         if (!(*attr)->isUndefined(lid)) {
             int64_t zcurve = (*attr)->getInt(lid);
             doc.setValue(*it.first, *positionFromZcurve(zcurve));
+        } else {
+            doc.remove(*it.first); // Don't resurrect old values from the docstore.
         }
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
@@ -81,8 +81,8 @@ FieldValue::UP positionFromZcurve(int64_t zcurve) {
 void fillInPositionFields(Document &doc, DocumentIdT lid, const DocumentRetriever::PositionFields & possiblePositionFields, const IAttributeManager & attr_manager)
 {
     for (const auto & it : possiblePositionFields) {
-        if (doc.hasValue(*it.first)) {
-            AttributeGuard::UP attr = attr_manager.getAttribute(it.second);
+        AttributeGuard::UP attr = attr_manager.getAttribute(it.second);
+        if (!(*attr)->isUndefined(lid)) {
             int64_t zcurve = (*attr)->getInt(lid);
             doc.setValue(*it.first, *positionFromZcurve(zcurve));
         }


### PR DESCRIPTION
@geirst @toregge please review

Avoids inconsistencies caused by concrete position struct fields not
being created or cleared by partial updates, only the Z-curve attribute
fields.

This fixes #11208

