### PR TITLE
Always try to build config model for old versions

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -66,14 +66,20 @@ public class VespaModelFactory implements ModelFactory {
 
         this.clock = Clock.systemUTC();
     }
-    
+
+    // For testing only
     public VespaModelFactory(ConfigModelRegistry configModelRegistry) {
         this(configModelRegistry, Clock.systemUTC());
     }
+
+    // For testing only
     public VespaModelFactory(ConfigModelRegistry configModelRegistry, Clock clock) {
-        this(new Version(VespaVersion.major, VespaVersion.minor, VespaVersion.micro), configModelRegistry, clock);
+        this(new Version(VespaVersion.major, VespaVersion.minor, VespaVersion.micro), configModelRegistry,
+             clock, Zone.defaultZone());
     }
-    public VespaModelFactory(Version version, ConfigModelRegistry configModelRegistry, Clock clock) {
+
+    // For testing only
+    public VespaModelFactory(Version version, ConfigModelRegistry configModelRegistry, Clock clock, Zone zone) {
         this.version = version;
         if (configModelRegistry == null) {
             this.configModelRegistry = new NullConfigModelRegistry();
@@ -82,7 +88,7 @@ public class VespaModelFactory implements ModelFactory {
             this.configModelRegistry = configModelRegistry;
         }
         this.modelImporters = Collections.emptyList();
-        this.zone = Zone.defaultZone();
+        this.zone = zone;
         this.clock = clock;
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -143,12 +143,17 @@ public class DeployTester {
 
     /** Create a model factory for a particular version */
     public static CountingModelFactory createModelFactory(Version version) {
-        return new CountingModelFactory(version, Clock.systemUTC());
+        return createModelFactory(version, Clock.systemUTC());
     }
 
     /** Create a model factory for a particular version */
     public static CountingModelFactory createModelFactory(Version version, Clock clock) {
-        return new CountingModelFactory(version, clock);
+        return createModelFactory(version, clock, Zone.defaultZone());
+    }
+
+    /** Create a model factory for a particular version */
+    public static CountingModelFactory createModelFactory(Version version, Clock clock, Zone zone) {
+        return new CountingModelFactory(version, clock, zone);
     }
 
     /** Create a model factory which always fails validation */
@@ -299,8 +304,8 @@ public class DeployTester {
             this.wrapped = new VespaModelFactory(new NullConfigModelRegistry(), clock);
         }
 
-        public CountingModelFactory(Version version, Clock clock) {
-            this.wrapped = new VespaModelFactory(version, new NullConfigModelRegistry(), clock);
+        public CountingModelFactory(Version version, Clock clock, Zone zone) {
+            this.wrapped = new VespaModelFactory(version, new NullConfigModelRegistry(), clock, zone);
         }
 
         /** Returns the number of models created successfully by this instance */


### PR DESCRIPTION
Try to build old config models, but do not fail deployment if skip-old-config-models validation override is true and building an old model fails. In manually deployed zones we previously did not build old config models, since skip-old-config-models was always true. With this change we will try to build those old models, but not fail if building one or more old models fails.
