### PR TITLE
Filter out unwanted log messages from Jersey client.

### DIFF
--- a/jaxrs_client_utils/src/main/java/ai/vespa/util/http/VespaClientBuilderFactory.java
+++ b/jaxrs_client_utils/src/main/java/ai/vespa/util/http/VespaClientBuilderFactory.java
@@ -4,14 +4,20 @@ package ai.vespa.util.http;
 import com.yahoo.security.tls.MixedMode;
 import com.yahoo.security.tls.TlsContext;
 import com.yahoo.security.tls.TransportSecurityUtils;
+import org.glassfish.jersey.client.internal.HttpUrlConnector;
+import org.glassfish.jersey.process.internal.ExecutorProviders;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.Optional;
+import java.util.logging.Filter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.CONFIG;
 
 /**
  * Factory for JAX-RS http client builder for internal Vespa communications over http/https.
@@ -25,6 +31,26 @@ import java.util.logging.Logger;
 public class VespaClientBuilderFactory implements AutoCloseable {
 
     private static final Logger log = Logger.getLogger(VespaClientBuilderFactory.class.getName());
+
+    static {
+        // CONFIG log message are logged repeatedly from these classes.
+        disableConfigLogging(HttpUrlConnector.class);
+        disableConfigLogging(ExecutorProviders.class);
+    }
+
+    // This method will hook a filter into the Jersey logger removing unwanted messages.
+    private static void disableConfigLogging(Class<?> klass) {
+        @SuppressWarnings("LoggerInitializedWithForeignClass")
+        Logger logger = Logger.getLogger(klass.getName());
+        Optional<Filter> currentFilter = Optional.ofNullable(logger.getFilter());
+        Filter filter = logRecord ->
+                !logRecord.getMessage().startsWith("Restricted headers are not enabled")
+                        && !logRecord.getMessage().startsWith("Selected ExecutorServiceProvider implementation")
+                        && !logRecord.getLevel().equals(CONFIG)
+                        && currentFilter.map(f -> f.isLoggable(logRecord)).orElse(true); // Honour existing filter if exists
+        logger.setFilter(filter);
+    }
+
 
     private final TlsContext tlsContext = TransportSecurityUtils.createTlsContext().orElse(null);
     private final MixedMode mixedMode = TransportSecurityUtils.getInsecureMixedMode();


### PR DESCRIPTION
@hakonhall You seem to be the owner of this module. I decided to add the log filter in the client builder instead of adding it everywhere the client is used.

The filter itself has been proven to work as it was used in the old vespa-yahoo/metricsproxy.

FYI: @mpolden 