### PR TITLE
Revert "Filter out unwanted log messages from Jersey client."

### DIFF
--- a/jaxrs_client_utils/src/main/java/ai/vespa/util/http/VespaClientBuilderFactory.java
+++ b/jaxrs_client_utils/src/main/java/ai/vespa/util/http/VespaClientBuilderFactory.java
@@ -4,20 +4,14 @@ package ai.vespa.util.http;
 import com.yahoo.security.tls.MixedMode;
 import com.yahoo.security.tls.TlsContext;
 import com.yahoo.security.tls.TransportSecurityUtils;
-import org.glassfish.jersey.client.internal.HttpUrlConnector;
-import org.glassfish.jersey.process.internal.ExecutorProviders;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
-import java.util.Optional;
-import java.util.logging.Filter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.util.logging.Level.CONFIG;
 
 /**
  * Factory for JAX-RS http client builder for internal Vespa communications over http/https.
@@ -31,26 +25,6 @@ import static java.util.logging.Level.CONFIG;
 public class VespaClientBuilderFactory implements AutoCloseable {
 
     private static final Logger log = Logger.getLogger(VespaClientBuilderFactory.class.getName());
-
-    static {
-        // CONFIG log message are logged repeatedly from these classes.
-        disableConfigLogging(HttpUrlConnector.class);
-        disableConfigLogging(ExecutorProviders.class);
-    }
-
-    // This method will hook a filter into the Jersey logger removing unwanted messages.
-    private static void disableConfigLogging(Class<?> klass) {
-        @SuppressWarnings("LoggerInitializedWithForeignClass")
-        Logger logger = Logger.getLogger(klass.getName());
-        Optional<Filter> currentFilter = Optional.ofNullable(logger.getFilter());
-        Filter filter = logRecord ->
-                !logRecord.getMessage().startsWith("Restricted headers are not enabled")
-                        && !logRecord.getMessage().startsWith("Selected ExecutorServiceProvider implementation")
-                        && !logRecord.getLevel().equals(CONFIG)
-                        && currentFilter.map(f -> f.isLoggable(logRecord)).orElse(true); // Honour existing filter if exists
-        logger.setFilter(filter);
-    }
-
 
     private final TlsContext tlsContext = TransportSecurityUtils.createTlsContext().orElse(null);
     private final MixedMode mixedMode = TransportSecurityUtils.getInsecureMixedMode();


### PR DESCRIPTION
Reverts vespa-engine/vespa#11277

FYI: @mpolden, @hmusum 

controller-cd failed with

```
[2019-11-12 13:53:34.193] ERROR   : configserver     Container.com.yahoo.jdisc.core.StandaloneMain
    JDisc exiting: Throwable caught:
    exception=
    com.yahoo.container.di.componentgraph.core.ComponentNode$ComponentConstructorException: Error constructing 'com.yahoo.vespa.orchestrator.controller.RetryingClusterControllerClientFactory'
    Caused by: java.lang.NoClassDefFoundError: org/glassfish/jersey/client/internal/HttpUrlConnector
    at ai.vespa.util.http.VespaClientBuilderFactory.<clinit>(VespaClientBuilderFactory.java:37)
    at com.yahoo.vespa.jaxrs.client.VespaJerseyJaxRsClientFactory.<init>(VespaJerseyJaxRsClientFactory.java:24)
    Caused by: java.lang.ClassNotFoundException: org.glassfish.jersey.client.internal.HttpUrlConnector not found by orchestrator [102]
    at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1597)
    at org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)
    at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1982)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
    ... 2 more
```
