### PR TITLE
Commit at regular interval when clearing docs.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -663,8 +663,13 @@ AttributeVector::clearDocs(DocId lidLow, DocId lidLimit)
 {
     assert(lidLow <= lidLimit);
     assert(lidLimit <= getNumDocs());
+    uint32_t count = 0;
+    constexpr uint32_t commit_interval = 1000;
     for (DocId lid = lidLow; lid < lidLimit; ++lid) {
         clearDoc(lid);
+        if ((++count % commit_interval) == 0) {
+            commit();
+        }
     }
 }
 


### PR DESCRIPTION
This avoids allocating too much memory in the change vector if compacting
lid space with a huge reduction.

@toregge please review