### PR TITLE
Write TLS config to zookeeper config file based on Vespa config

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -17,10 +17,6 @@ dataDir string default="var/zookeeper"
 
 clientPort int default=2181
 
-# In the hosted Vespa prod.us-east-3 zone, a snapshotCount of 50000 corresponds
-# to about 5 transaction log snapshots per hour. Assuming this is a fairly
-# normal zone, a snapRetainCount of 15 gives 3-4 hours of logs before they're
-# purged.
 snapshotCount int default=50000
 # Purge interval in hours
 autopurge.purgeInterval int default=1
@@ -41,3 +37,6 @@ server[].electionPort int default=2183
 # and in general where there is a zookeeper ensemble running that has had few transactions.
 # TODO: Consider setting this to false by default (and override where appropriate)
 trustEmptySnapshot bool default=true
+
+# TLS options
+tlsForQuorumCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF

--- a/zookeeper-server/zookeeper-server-3.5/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
@@ -91,7 +91,7 @@ public class VespaZooKeeperServerImpl extends AbstractComponent implements Runna
         sb.append("ssl.quorum.clientAuth=NEED\n");
         sb.append("ssl.quorum.ciphersuites=").append(String.join(",", new TreeSet<>(TlsContext.ALLOWED_CIPHER_SUITES))).append("\n");
         sb.append("ssl.quorum.enabledProtocols=").append(String.join(",", new TreeSet<>(TlsContext.ALLOWED_PROTOCOLS))).append("\n");
-        sb.append("ssl.quorum.protocol=TLSv1.2\n");
+        sb.append("ssl.quorum.protocol=TLS\n");
 
         String tlsSetting = config.tlsForQuorumCommunication().name();
         switch (tlsSetting) {

--- a/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
@@ -26,11 +26,7 @@ public class VespaZooKeeperServerImplTest {
     public void config_is_written_correctly_when_one_server() throws IOException {
         File cfgFile = folder.newFile();
         File idFile = folder.newFile();
-        ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
-        builder.zooKeeperConfigFile(cfgFile.getAbsolutePath());
-        builder.myidFile(idFile.getAbsolutePath());
-        builder.server(newServer(0, "foo", 123, 321));
-        builder.myid(0);
+        ZookeeperServerConfig.Builder builder = createConfigBuilderForSingleHost(cfgFile, idFile);
         createServer(builder);
         validateConfigFileSingleHost(cfgFile);
         validateIdFile(idFile, "");
@@ -50,6 +46,45 @@ public class VespaZooKeeperServerImplTest {
         createServer(builder);
         validateConfigFileMultipleHosts(cfgFile);
         validateIdFile(idFile, "1\n");
+    }
+
+    @Test
+    public void config_is_written_correctly_with_tls_for_quorum_communication_port_unification() throws IOException {
+        File cfgFile = folder.newFile();
+        File idFile = folder.newFile();
+        ZookeeperServerConfig.Builder builder = createConfigBuilderForSingleHost(cfgFile, idFile);
+        builder.tlsForQuorumCommunication(ZookeeperServerConfig.TlsForQuorumCommunication.Enum.PORT_UNIFICATION);
+        createServer(builder);
+        validateConfigFilePortUnification(cfgFile);
+    }
+
+    @Test
+    public void config_is_written_correctly_with_tls_for_quorum_communication_tls_with_port_unification() throws IOException {
+        File cfgFile = folder.newFile();
+        File idFile = folder.newFile();
+        ZookeeperServerConfig.Builder builder = createConfigBuilderForSingleHost(cfgFile, idFile);
+        builder.tlsForQuorumCommunication(ZookeeperServerConfig.TlsForQuorumCommunication.Enum.TLS_WITH_PORT_UNIFICATION);
+        createServer(builder);
+        validateConfigFileTlsWithPortUnification(cfgFile);
+    }
+
+    @Test
+    public void config_is_written_correctly_with_tls_for_quorum_communication_tls_only() throws IOException {
+        File cfgFile = folder.newFile();
+        File idFile = folder.newFile();
+        ZookeeperServerConfig.Builder builder = createConfigBuilderForSingleHost(cfgFile, idFile);
+        builder.tlsForQuorumCommunication(ZookeeperServerConfig.TlsForQuorumCommunication.Enum.TLS_ONLY);
+        createServer(builder);
+        validateConfigFileTlsOnly(cfgFile);
+    }
+
+    private ZookeeperServerConfig.Builder createConfigBuilderForSingleHost(File cfgFile, File idFile) {
+        ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
+        builder.zooKeeperConfigFile(cfgFile.getAbsolutePath());
+        builder.myidFile(idFile.getAbsolutePath());
+        builder.server(newServer(0, "foo", 123, 321));
+        builder.myid(0);
+        return builder;
     }
 
     private void createServer(ZookeeperServerConfig.Builder builder) {
@@ -99,41 +134,78 @@ public class VespaZooKeeperServerImplTest {
         assertThat(actual, is(expected));
     }
 
+    private String commonConfig() {
+       return "tickTime=2000\n" +
+              "initLimit=20\n" +
+              "syncLimit=15\n" +
+              "maxClientCnxns=0\n" +
+              "snapCount=50000\n" +
+              "dataDir=" + getDefaults().underVespaHome("var/zookeeper") + "\n" +
+              "clientPort=2181\n" +
+              "autopurge.purgeInterval=1\n" +
+              "autopurge.snapRetainCount=15\n" +
+              "4lw.commands.whitelist=conf,cons,crst,dirs,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n" +
+              "admin.enableServer=false\n" +
+              "serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory\n";
+    }
+
     private void validateConfigFileSingleHost(File cfgFile) throws IOException {
         String expected =
-            "tickTime=2000\n" +
-            "initLimit=20\n" +
-            "syncLimit=15\n" +
-            "maxClientCnxns=0\n" +
-            "snapCount=50000\n" +
-            "dataDir=" + getDefaults().underVespaHome("var/zookeeper") + "\n" +
-            "clientPort=2181\n" +
-            "autopurge.purgeInterval=1\n" +
-            "autopurge.snapRetainCount=15\n" +
-            "4lw.commands.whitelist=conf,cons,crst,dirs,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n" +
-            "admin.enableServer=false\n" +
-            "serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory\n" +
-            "server.0=foo:321:123\n";
+                commonConfig() +
+                "server.0=foo:321:123\n" +
+                commonTlsConfig() +
+                "sslQuorum=false\n" +
+                "portUnification=false\n";
         validateConfigFile(cfgFile, expected);
+    }
+
+    private String commonTlsConfig() {
+        return "ssl.quorum.hostnameVerification=false\n" +
+               "ssl.quorum.clientAuth=NEED\n" +
+               "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n" +
+               "ssl.quorum.enabledProtocols=TLSv1.2\n" +
+               "ssl.quorum.protocol=TLSv1.2\n";
     }
 
     private void validateConfigFileMultipleHosts(File cfgFile) throws IOException {
         String expected =
-                "tickTime=2000\n" +
-                        "initLimit=20\n" +
-                        "syncLimit=15\n" +
-                        "maxClientCnxns=0\n" +
-                        "snapCount=50000\n" +
-                        "dataDir=" + getDefaults().underVespaHome("var/zookeeper") + "\n" +
-                        "clientPort=2181\n" +
-                        "autopurge.purgeInterval=1\n" +
-                        "autopurge.snapRetainCount=15\n" +
-                        "4lw.commands.whitelist=conf,cons,crst,dirs,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n" +
-                        "admin.enableServer=false\n" +
-                        "serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory\n" +
-                        "server.0=foo:321:123\n" +
-                        "server.1=bar:432:234\n" +
-                        "server.2=baz:543:345\n";
+                commonConfig() +
+                "server.0=foo:321:123\n" +
+                "server.1=bar:432:234\n" +
+                "server.2=baz:543:345\n" +
+                commonTlsConfig() +
+                "sslQuorum=false\n" +
+                "portUnification=false\n";
+        validateConfigFile(cfgFile, expected);
+    }
+
+    private void validateConfigFilePortUnification(File cfgFile) throws IOException {
+        String expected =
+                commonConfig() +
+                "server.0=foo:321:123\n" +
+                commonTlsConfig() +
+                "sslQuorum=false\n" +
+                "portUnification=true\n";
+        validateConfigFile(cfgFile, expected);
+    }
+
+    private void validateConfigFileTlsWithPortUnification(File cfgFile) throws IOException {
+        String expected =
+                commonConfig() +
+                "server.0=foo:321:123\n" +
+                commonTlsConfig() +
+                "sslQuorum=true\n" +
+                "portUnification=true\n";
+        validateConfigFile(cfgFile, expected);
+    }
+
+    private void validateConfigFileTlsOnly(File cfgFile) throws IOException {
+        String expected =
+                commonConfig() +
+                "server.0=foo:321:123\n" +
+                commonTlsConfig() +
+                "sslQuorum=true\n" +
+                "portUnification=false\n";
         validateConfigFile(cfgFile, expected);
     }
 

--- a/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
@@ -164,7 +164,7 @@ public class VespaZooKeeperServerImplTest {
                "ssl.quorum.clientAuth=NEED\n" +
                "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n" +
                "ssl.quorum.enabledProtocols=TLSv1.2\n" +
-               "ssl.quorum.protocol=TLSv1.2\n";
+               "ssl.quorum.protocol=TLS\n";
     }
 
     private void validateConfigFileMultipleHosts(File cfgFile) throws IOException {


### PR DESCRIPTION
tlsForQuorumCommunication will always be off for now, next step is to wire in use of feature flag to control setting in Vespa config zookeeper-server config