### PR TITLE
Use fast updates when replica metadata is out of sync but document itself is in sync

### DIFF
--- a/storage/src/tests/distributor/distributortest.cpp
+++ b/storage/src/tests/distributor/distributortest.cpp
@@ -174,6 +174,12 @@ struct DistributorTest : Test, DistributorTestUtil {
         configureDistributor(builder);
     }
 
+    void configure_update_fast_path_restart_enabled(bool enabled) {
+        ConfigBuilder builder;
+        builder.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent = enabled;
+        configureDistributor(builder);
+    }
+
     void configureMaxClusterClockSkew(int seconds);
     void sendDownClusterStateCommand();
     void replyToSingleRequestBucketInfoCommandWith1Bucket();
@@ -999,6 +1005,17 @@ TEST_F(DistributorTest, stale_reads_config_is_propagated_to_external_operation_h
 
     configure_stale_reads_enabled(false);
     EXPECT_FALSE(getExternalOperationHandler().concurrent_gets_enabled());
+}
+
+TEST_F(DistributorTest, fast_path_on_consistent_gets_config_is_propagated_to_internal_config) {
+    createLinks(true);
+    setupDistributor(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
+
+    configure_update_fast_path_restart_enabled(true);
+    EXPECT_TRUE(getConfig().update_fast_path_restart_enabled());
+
+    configure_update_fast_path_restart_enabled(false);
+    EXPECT_FALSE(getConfig().update_fast_path_restart_enabled());
 }
 
 TEST_F(DistributorTest, concurrent_reads_not_enabled_if_btree_db_is_not_enabled) {

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -40,6 +40,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _disableBucketActivation(false),
       _sequenceMutatingOperations(true),
       _allowStaleReadsDuringClusterStateTransitions(false),
+      _update_fast_path_restart_enabled(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 { }
 
@@ -150,6 +151,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _disableBucketActivation = config.disableBucketActivation;
     _sequenceMutatingOperations = config.sequenceMutatingOperations;
     _allowStaleReadsDuringClusterStateTransitions = config.allowStaleReadsDuringClusterStateTransitions;
+    _update_fast_path_restart_enabled = config.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent;
 
     _minimumReplicaCountingMode = config.minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -250,6 +250,13 @@ public:
         _allowStaleReadsDuringClusterStateTransitions = allow;
     }
 
+    bool update_fast_path_restart_enabled() const noexcept {
+        return _update_fast_path_restart_enabled;
+    }
+    void set_update_fast_path_restart_enabled(bool enabled) noexcept {
+        _update_fast_path_restart_enabled = enabled;
+    }
+
     bool containsTimeStatement(const std::string& documentSelection) const;
     
 private:
@@ -293,6 +300,7 @@ private:
     bool _disableBucketActivation;
     bool _sequenceMutatingOperations;
     bool _allowStaleReadsDuringClusterStateTransitions;
+    bool _update_fast_path_restart_enabled;
 
     DistrConfig::MinimumReplicaCountingMode _minimumReplicaCountingMode;
     

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -205,3 +205,12 @@ simulated_db_merging_latency_msec int default=0
 ## read only operations, as the B-tree database is thread safe for concurrent reads.
 use_btree_database bool default=false restart
 
+## If a bucket is inconsistent and an Update operation is received, a two-phase
+## write-repair path is triggered in which a Get is sent to all diverging replicas.
+## Once received, the update is applied on the distributor and pushed out to the
+## content nodes as Puts.
+## Iff this config is set to true AND all Gets return the same timestamp from all
+## content nodes, the two-phase update path reverts back to the regular fast path.
+## Since all replicas of the document were in sync, applying the update in-place
+## shall be considered safe.
+restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=true

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -35,7 +35,7 @@ public:
     const char* getName() const override { return "get"; }
     std::string getStatus() const override { return ""; }
 
-    bool hasConsistentCopies() const;
+    bool all_bucket_metadata_initially_consistent() const;
 
     // Exposed for unit testing. TODO feels a bit dirty :I
     const DistributorBucketSpace& bucketSpace() const noexcept { return _bucketSpace; }
@@ -88,6 +88,7 @@ private:
 
     PersistenceOperationMetricSet& _metric;
     framework::MilliSecTimer _operationTimer;
+    bool _has_replica_inconsistency;
 
     void sendReply(DistributorMessageSender& sender);
     bool sendForChecksum(DistributorMessageSender& sender, const document::BucketId& id, GroupVector& res);

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -121,6 +121,8 @@ private:
     bool hasTasCondition() const noexcept;
     void replyWithTasFailure(DistributorMessageSender& sender,
                              vespalib::stringref message);
+    bool may_restart_with_fast_path(const api::GetReply& reply);
+    void restart_with_fast_path_due_to_consistent_get_timestamps(DistributorMessageSender& sender);
 
     UpdateMetricSet& _updateMetric;
     PersistenceOperationMetricSet& _putMetric;

--- a/storage/src/vespa/storage/distributor/update_metric_set.cpp
+++ b/storage/src/vespa/storage/distributor/update_metric_set.cpp
@@ -12,7 +12,10 @@ UpdateMetricSet::UpdateMetricSet(MetricSet* owner)
     : PersistenceOperationMetricSet("updates", owner),
       diverging_timestamp_updates("diverging_timestamp_updates", {},
                                   "Number of updates that report they were performed against "
-                                  "divergent version timestamps on different replicas", this)
+                                  "divergent version timestamps on different replicas", this),
+      fast_path_restarts("fast_path_restarts", {}, "Number of safe path (write repair) updates "
+                         "that were restarted as fast path updates because all replicas returned "
+                         "documents with the same timestamp in the initial read phase", this)
 {
 }
 

--- a/storage/src/vespa/storage/distributor/update_metric_set.h
+++ b/storage/src/vespa/storage/distributor/update_metric_set.h
@@ -10,6 +10,7 @@ namespace storage {
 class UpdateMetricSet : public PersistenceOperationMetricSet {
 public:
     metrics::LongCountMetric diverging_timestamp_updates;
+    metrics::LongCountMetric fast_path_restarts;
 
     explicit UpdateMetricSet(MetricSet* owner = nullptr);
     ~UpdateMetricSet() override;

--- a/storageapi/src/vespa/storageapi/message/persistence.cpp
+++ b/storageapi/src/vespa/storageapi/message/persistence.cpp
@@ -207,13 +207,17 @@ GetCommand::print(std::ostream& out, bool verbose, const std::string& indent) co
     }
 }
 
-GetReply::GetReply(const GetCommand& cmd, const DocumentSP& doc, Timestamp lastModified)
+GetReply::GetReply(const GetCommand& cmd,
+                   const DocumentSP& doc,
+                   Timestamp lastModified,
+                   bool had_consistent_replicas)
     : BucketInfoReply(cmd),
       _docId(cmd.getDocumentId()),
       _fieldSet(cmd.getFieldSet()),
       _doc(doc),
       _beforeTimestamp(cmd.getBeforeTimestamp()),
-      _lastModifiedTime(lastModified)
+      _lastModifiedTime(lastModified),
+      _had_consistent_replicas(had_consistent_replicas)
 {
 }
 

--- a/storageapi/src/vespa/storageapi/message/persistence.h
+++ b/storageapi/src/vespa/storageapi/message/persistence.h
@@ -217,11 +217,13 @@ class GetReply : public BucketInfoReply {
     DocumentSP _doc; // Null pointer if not found
     Timestamp _beforeTimestamp;
     Timestamp _lastModifiedTime;
+    bool _had_consistent_replicas;
 
 public:
     GetReply(const GetCommand& cmd,
              const DocumentSP& doc = DocumentSP(),
-             Timestamp lastModified = 0);
+             Timestamp lastModified = 0,
+             bool had_consistent_replicas = false);
     ~GetReply() override;
 
     const DocumentSP& getDocument() const { return _doc; }
@@ -230,6 +232,8 @@ public:
 
     Timestamp getLastModifiedTimestamp() const { return _lastModifiedTime; }
     Timestamp getBeforeTimestamp() const { return _beforeTimestamp; }
+
+    bool had_consistent_replicas() const noexcept { return _had_consistent_replicas; }
 
     bool wasFound() const { return (_doc.get() != 0); }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;


### PR DESCRIPTION
@toregge please review
@geirst FYI

When a bucket has replicas with mismatching metadata (i.e. they are out of sync),
the distributor will initiate a write-repair for updates to avoid divergence of
replica content. This is done by first sending a Get to all diverging replica
sets, picking the highest timestamp and applying the update locally. The updated
document is then sent out as a Put. This can be very expensive if document Put
operations are disproportionally more expensive than partial updates, and also
makes the distributor thread part of a contended critical path.

This commit lets `TwoPhaseUpdateOperation` restart an update as a "fast path"
update (partial updates sent directly to the nodes) if the initial read phase
returns the same timestamp for the document across all replicas.

It also removes an old (but now presumed unsafe) optimization where Get
operations are only sent to replicas marked "trusted" even if others are
out of sync with it. Since trustedness is a transient state that does not
persist across restarts or bucket handoffs, it's not robust enough to be
used for such purposes. Gets will now be sent to all out of sync replica
groups regardless of trusted status.
