### PR TITLE
add skeleton for NearestNeighborItem

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -696,6 +696,7 @@
       "public static final enum com.yahoo.prelude.query.Item$ItemType PREDICATE_QUERY",
       "public static final enum com.yahoo.prelude.query.Item$ItemType REGEXP",
       "public static final enum com.yahoo.prelude.query.Item$ItemType WORD_ALTERNATIVES",
+      "public static final enum com.yahoo.prelude.query.Item$ItemType NEAREST_NEIGHBOR",
       "public final int code"
     ]
   },
@@ -846,6 +847,27 @@
       "protected int distance",
       "public static final int defaultDistance"
     ]
+  },
+  "com.yahoo.prelude.query.NearestNeighborItem": {
+    "superClass": "com.yahoo.prelude.query.SimpleTaggableItem",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public int getTargetNumHits()",
+      "public void setTargetNumHits(int)",
+      "public java.lang.String getQueryProperty()",
+      "public void <init>(java.lang.String, java.lang.String)",
+      "public java.lang.String getIndexName()",
+      "public void setIndexName(java.lang.String)",
+      "public com.yahoo.prelude.query.Item$ItemType getItemType()",
+      "public java.lang.String getName()",
+      "public int getTermCount()",
+      "public int encode(java.nio.ByteBuffer)",
+      "protected void appendBodyString(java.lang.StringBuilder)"
+    ],
+    "fields": []
   },
   "com.yahoo.prelude.query.NonReducibleCompositeItem": {
     "superClass": "com.yahoo.prelude.query.CompositeItem",

--- a/container-search/src/main/java/com/yahoo/prelude/query/Item.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Item.java
@@ -59,7 +59,8 @@ public abstract class Item implements Cloneable {
         WAND(22),
         PREDICATE_QUERY(23),
         REGEXP(24),
-        WORD_ALTERNATIVES(25);
+        WORD_ALTERNATIVES(25),
+        NEAREST_NEIGHBOR(26);
 
         public final int code;
 

--- a/container-search/src/main/java/com/yahoo/prelude/query/NearestNeighborItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/NearestNeighborItem.java
@@ -1,0 +1,56 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.prelude.query;
+
+import java.nio.ByteBuffer;
+
+/**
+ *
+ * @author arnej
+ */
+public class NearestNeighborItem extends SimpleTaggableItem {
+
+    private int targetNumber = 1000;
+    private String field;
+    private String property;
+
+    public int getTargetNumHits() { return targetNumber; }
+    public void setTargetNumHits(int target) { this.targetNumber = target; }
+
+    public String getQueryProperty() { return property; }
+
+    public NearestNeighborItem(String fieldName, String queryProperty) {
+        this.field = fieldName;
+        this.property = queryProperty;
+    }
+
+    public String getIndexName() { return field; }
+
+    @Override
+    public void setIndexName(String index) { this.field = index; }
+
+    @Override
+    public ItemType getItemType() { return ItemType.NEAREST_NEIGHBOR; }
+
+    @Override
+    public String getName() { return "NEAREST_NEIGHBOR"; }
+
+    @Override
+    public int getTermCount() { return 1; }
+
+    @Override
+    public int encode(ByteBuffer buffer) {
+        super.encodeThis(buffer);
+        putString(field, buffer);
+        putString(property, buffer);
+        buffer.putInt(targetNumber);
+        return 1;  // number of encoded stack dump items
+    }
+
+    @Override
+    protected void appendBodyString(StringBuilder buffer) {
+        buffer.append("{field=").append(field);
+        buffer.append(",property=").append(property);
+        buffer.append(",targetnumhits=").append(targetNumber).append("}");
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -20,6 +20,7 @@ import static com.yahoo.search.yql.YqlParser.HIT_LIMIT;
 import static com.yahoo.search.yql.YqlParser.IMPLICIT_TRANSFORMS;
 import static com.yahoo.search.yql.YqlParser.LABEL;
 import static com.yahoo.search.yql.YqlParser.NEAR;
+import static com.yahoo.search.yql.YqlParser.NEAREST_NEIGHBOR;
 import static com.yahoo.search.yql.YqlParser.NORMALIZE_CASE;
 import static com.yahoo.search.yql.YqlParser.ONEAR;
 import static com.yahoo.search.yql.YqlParser.ORIGIN;
@@ -73,6 +74,7 @@ import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.MarkerWordItem;
 import com.yahoo.prelude.query.NearItem;
+import com.yahoo.prelude.query.NearestNeighborItem;
 import com.yahoo.prelude.query.NotItem;
 import com.yahoo.prelude.query.NullItem;
 import com.yahoo.prelude.query.ONearItem;
@@ -687,6 +689,28 @@ public class VespaSerializer {
 
     }
 
+    private static class NearestNeighborSerializer extends Serializer<NearestNeighborItem> {
+
+        @Override
+        void onExit(StringBuilder destination, NearestNeighborItem item) { }
+
+        @Override
+        boolean serialize(StringBuilder destination, NearestNeighborItem item) {
+            destination.append("[{");
+            int initLen = destination.length();
+            destination.append(leafAnnotations(item));
+            comma(destination, initLen);
+            int targetNumHits = item.getTargetNumHits();
+            destination.append("\"targetNumHits\": ").append(targetNumHits);
+            destination.append("}]");
+            destination.append(NEAREST_NEIGHBOR).append('(');
+            destination.append(item.getIndexName()).append(", ");
+            destination.append(item.getQueryProperty()).append(')');
+            return false;
+        }
+
+    }
+
     private static class PredicateQuerySerializer extends Serializer<PredicateQueryItem> {
 
         @Override
@@ -1131,6 +1155,7 @@ public class VespaSerializer {
         dispatchBuilder.put(BoolItem.class, new BoolSerializer());
         dispatchBuilder.put(MarkerWordItem.class, new WordSerializer()); // gotcha
         dispatchBuilder.put(NearItem.class, new NearSerializer());
+        dispatchBuilder.put(NearestNeighborItem.class, new NearestNeighborSerializer());
         dispatchBuilder.put(NotItem.class, new NotSerializer());
         dispatchBuilder.put(NullItem.class, new NullSerializer());
         dispatchBuilder.put(ONearItem.class, new ONearSerializer());

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -125,6 +125,12 @@ public class VespaSerializerTestCase {
     }
 
     @Test
+    public void testNearestNeighbor() {
+        parseAndConfirm("[{\"label\": \"foo\", \"targetNumHits\": 1000}]nearestNeighbor(semantic_embedding, my_property)");
+        parseAndConfirm("[{\"targetNumHits\": 42}]nearestNeighbor(semantic_embedding, my_property)");
+    }
+
+    @Test
     public void testNumbers() {
         parseAndConfirm("title = 500");
         parseAndConfirm("title > 500");

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -548,6 +548,14 @@ public class YqlParserTestCase {
     }
 
     @Test
+    public void testNearestNeighbor() {
+        assertParse("select foo from bar where nearestNeighbor(semantic_embedding, my_vector);",
+                    "NEAREST_NEIGHBOR {field=semantic_embedding,property=my_vector,targetnumhits=1000}");
+        assertParse("select foo from bar where [{\"targetNumHits\": 37}]nearestNeighbor(semantic_embedding, my_vector);",
+                    "NEAREST_NEIGHBOR {field=semantic_embedding,property=my_vector,targetnumhits=37}");
+    }
+
+    @Test
     public void testPredicate() {
         assertParse("select foo from bar where predicate(predicate_field, " +
                 "{\"gender\":\"male\", \"hobby\":[\"music\", \"hiking\"]}, {\"age\":23L});",


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

this is a preview with unfinished code.  some questions I have are:
 - if targetNumHits should have no default, it should probably be a 3rd argument to the YQL function, instead of an annotation.  For now it has a default to avoid making the annotation mandatory.
- how should buildNearestNeighbor get the arguments from the AST? I used the "fetchFieldRead" method but I'm not sure why that works, and if we want an integer 3rd argument I have no idea how to do that
- when serializing to binary format, should we use IntegerCompressor for targetNumHits instead of just buffer.putInt()?
- missing: validating that the "query property" string actually refers to a property containing a tensor of the correct type
- missing: how to actually pass the query property to the backend?

@bratseth please review
@geirst FYI
@baldersheim feel free to take a look