### PR TITLE
Include qualifier in isAfter/isBefore comparison 

### DIFF
--- a/component/src/main/java/com/yahoo/component/Version.java
+++ b/component/src/main/java/com/yahoo/component/Version.java
@@ -347,17 +347,21 @@ public final class Version implements Comparable<Version> {
 
         return getQualifier().compareTo(other.getQualifier());
     }
-    
-    /** Returns whether this version number (ignoring qualifier) is strictly lower than the given version */
+
+    /**
+     * Returns whether this version number is strictly lower than the given version. This has the same semantics as
+     * {@link this#compareTo}.
+     */
     public boolean isBefore(Version other) {
-        if (this.major == other.major && this.minor == other.minor) return this.micro < other.micro;
-        if (this.major == other.major) return this.minor < other.minor;
-        return this.major < other.major;
+        return compareTo(other) < 0;
     }
 
-    /** Returns whether this version number (ignoring qualifier) is strictly higher than the given version */
+    /**
+     * Returns whether this version number is strictly higher than the given version. This has the same semantics as
+     * {@link this#compareTo}.
+     */
     public boolean isAfter(Version other) {
-        return ! this.isBefore(other) && ! this.equals(other);
+        return compareTo(other) > 0;
     }
 
     /** Creates a version specification that only matches this version */

--- a/component/src/main/java/com/yahoo/component/Version.java
+++ b/component/src/main/java/com/yahoo/component/Version.java
@@ -350,7 +350,7 @@ public final class Version implements Comparable<Version> {
 
     /**
      * Returns whether this version number is strictly lower than the given version. This has the same semantics as
-     * {@link this#compareTo}.
+     * {@link Version#compareTo}.
      */
     public boolean isBefore(Version other) {
         return compareTo(other) < 0;
@@ -358,7 +358,7 @@ public final class Version implements Comparable<Version> {
 
     /**
      * Returns whether this version number is strictly higher than the given version. This has the same semantics as
-     * {@link this#compareTo}.
+     * {@link Version#compareTo}.
      */
     public boolean isAfter(Version other) {
         return compareTo(other) > 0;

--- a/component/src/test/java/com/yahoo/component/VersionTestCase.java
+++ b/component/src/test/java/com/yahoo/component/VersionTestCase.java
@@ -93,11 +93,11 @@ public class VersionTestCase {
     public void testOrder() {
         assertTrue(new Version("1.2.3").compareTo(new Version("1.2.3"))==0);
         assertTrue(new Version("1.2.3").compareTo(new Version("1.2.4"))<0);
+        assertTrue(new Version("1.2.3").compareTo(new Version("1.2.3.foo"))<0);
         assertTrue(new Version("1.2.3").compareTo(new Version("1.2.2"))>0);
-
+        assertTrue(new Version("1.2.3.foo").compareTo(new Version("1.2.3"))>0);
         assertTrue(new Version("1.2.3").compareTo(new Version("2"))<0);
         assertTrue(new Version("1.2.3").compareTo(new Version("1.3"))<0);
-
         assertTrue(new Version("1.0.0").compareTo(new Version("1"))==0);
     }
     
@@ -107,9 +107,11 @@ public class VersionTestCase {
         assertFalse(new Version("1.2.3").isBefore(new Version("1.1.3")));
         assertFalse(new Version("1.2.3").isBefore(new Version("1.2.2")));
         assertFalse(new Version("1.2.3").isBefore(new Version("1.2.3")));
+        assertFalse(new Version("1.2.3.foo").isBefore(new Version("1.2.3")));
         assertTrue( new Version("1.2.3").isBefore(new Version("1.2.4")));
         assertTrue( new Version("1.2.3").isBefore(new Version("1.3.3")));
         assertTrue( new Version("1.2.3").isBefore(new Version("2.2.3")));
+        assertTrue( new Version("1.2.3").isBefore(new Version("1.2.3.foo")));
     }
 
     @Test
@@ -117,10 +119,12 @@ public class VersionTestCase {
         assertTrue( new Version("1.2.3").isAfter(new Version("0.2.3")));
         assertTrue( new Version("1.2.3").isAfter(new Version("1.1.3")));
         assertTrue( new Version("1.2.3").isAfter(new Version("1.2.2")));
+        assertTrue( new Version("1.2.3.foo").isAfter(new Version("1.2.3")));
         assertFalse(new Version("1.2.3").isAfter(new Version("1.2.3")));
         assertFalse(new Version("1.2.3").isAfter(new Version("1.2.4")));
         assertFalse(new Version("1.2.3").isAfter(new Version("1.3.3")));
         assertFalse(new Version("1.2.3").isAfter(new Version("2.2.3")));
+        assertFalse(new Version("1.2.3").isAfter(new Version("1.2.3.foo")));
     }
 
 }


### PR DESCRIPTION
In dev system we will version local changes using the format
`X.Y.Z.yyyyMMddTHHmm` and we want such versions to be considered higher than
`X.Y.Z`.

Example:

- Developer bootstraps dev system on `7.142.13`.
- Developer adds code changes and creates a new Docker image. This image is
given the version `7.142.13.20191118T1415`.
- Developer tells system to upgrade to `7.142.13.20191118T1415`

FYI @tokle