### PR TITLE
Revert "Skip tester owned nodes when considering best moves"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Rebalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Rebalancer.java
@@ -99,7 +99,6 @@ public class Rebalancer extends Maintainer {
         Move bestMove = Move.none;
         for (Node node : allNodes.nodeType(NodeType.tenant).state(Node.State.active)) {
             if (node.parentHostname().isEmpty()) continue;
-            if (node.allocation().get().owner().instance().isTester())) continue;
             for (Node toHost : allNodes.nodeType(NodeType.host).state(NodePrioritizer.ALLOCATABLE_HOST_STATES)) {
                 if (toHost.hostname().equals(node.parentHostname().get())) continue;
                 if ( ! capacity.freeCapacityOf(toHost).satisfies(node.flavor().resources())) continue;


### PR DESCRIPTION
Reverts vespa-engine/vespa#11347

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project node-repository: Compilation failure
[ERROR] /Users/musum/git/github/vespa-engine/vespa/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Rebalancer.java:[102,71] illegal start of expression