### PR TITLE
Remove more cipher suites not supported by Java 11 from set configure…

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
@@ -13,7 +13,16 @@ import java.util.Set;
  */
 public interface TlsContext extends AutoCloseable {
 
-    // TODO: Where does this set come from?
+    /**
+     * Handpicked subset of supported ciphers from https://www.openssl.org/docs/manmaster/man1/ciphers.html
+     * based on Modern spec from https://wiki.mozilla.org/Security/Server_Side_TLS
+     * For TLSv1.2 we only allow RSA and ECDSA with ephemeral key exchange and GCM.
+     * For TLSv1.3 we allow the DEFAULT group ciphers.
+     * Note that we _only_ allow AEAD ciphers for either TLS version.
+     */
+    // TODO: Remove TLS_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    // TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 and TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256?
+    // These cipher suites are not supported in Java 11, see https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
     Set<String> ALLOWED_CIPHER_SUITES = Set.of(
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",

--- a/zookeeper-server/zookeeper-server-3.5/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
@@ -165,8 +165,11 @@ public class VespaZooKeeperServerImpl extends AbstractComponent implements Runna
 
     private TreeSet<String> getCipherSuites() {
         Set<String> cipherSuites = new HashSet<>(TlsContext.ALLOWED_CIPHER_SUITES);
-        // Remove cipher suite not supported by Java
+        // Remove cipher suites not supported by Java 11
         cipherSuites.remove("TLS_CHACHA20_POLY1305_SHA256");
+        cipherSuites.remove("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+        cipherSuites.remove("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256");
+        cipherSuites.remove("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
         return new TreeSet<>(cipherSuites);
     }
 

--- a/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
@@ -204,7 +204,7 @@ public class VespaZooKeeperServerImplTest {
     private String commonTlsConfig() {
         return "ssl.quorum.hostnameVerification=false\n" +
                "ssl.quorum.clientAuth=NEED\n" +
-               "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n" +
+               "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n" +
                "ssl.quorum.enabledProtocols=TLSv1.2\n" +
                "ssl.quorum.protocol=TLS\n";
     }


### PR DESCRIPTION
…d for use by ZooKeeper

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bjorncs @vekterli FYI regarding the TODO I added in TlsContext, I am not sure if what I wrote there makes sense
