### PR TITLE
remove "termindex" which is always -1

### DIFF
--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -191,8 +191,7 @@ Node::UP buildQueryTree(const ViewResolver &resolver,
     query_builder.addNumberTerm(int_term, field, 1, Weight(0));
     query_builder.addPrefixTerm(prefix_term, field, 2, Weight(0));
     query_builder.addRangeTerm(range_term, field, 3, Weight(0));
-    query_builder.addStringTerm(string_term, field, string_id, string_weight)
-        .setTermIndex(term_index);
+    query_builder.addStringTerm(string_term, field, string_id, string_weight);
     query_builder.addSubstringTerm(substring_term, field, 5, Weight(0));
     query_builder.addSuffixTerm(suffix_term, field, 6, Weight(0));
     query_builder.addPhrase(2, field, 7, Weight(0));
@@ -402,7 +401,6 @@ public:
         EXPECT_EQUAL(string_weight.percent(),
                    term_data.getWeight().percent());
         EXPECT_EQUAL(1u, term_data.getPhraseLength());
-        EXPECT_EQUAL(-1u, term_data.getTermIndex());
         EXPECT_EQUAL(string_id, term_data.getUniqueId());
         EXPECT_EQUAL(term_data.numFields(), n.numFields());
         for (size_t i = 0; i < term_data.numFields(); ++i) {

--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
@@ -93,7 +93,6 @@ struct ProtonTermBase : public Base,
 
     // ITermData interface
     uint32_t getPhraseLength() const override final { return numTerms<Base>(*this); }
-    uint32_t getTermIndex() const override final { return -1; }
     search::query::Weight getWeight() const override final { return Base::getWeight(); }
     uint32_t getUniqueId() const override final { return Base::getId(); }
 };

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -463,30 +463,6 @@ TEST("require that Invalid Trees Cannot Be Built") {
                  builder.error());
 }
 
-TEST("require that Term Index Can Be Added") {
-    const int term_index0 = 14;
-    const int term_index1 = 65;
-
-    QueryBuilder<SimpleQueryNodeTypes> builder;
-    builder.addAnd(2);
-    builder.addStringTerm(str[0], view[0], id[0], weight[0])
-        .setTermIndex(term_index0);
-    builder.addSubstringTerm(str[1], view[1], id[1], weight[1])
-        .setTermIndex(term_index1);
-
-    Node::UP node = builder.build();
-    ASSERT_TRUE(!builder.hasError());
-    Intermediate *intermediate = dynamic_cast<Intermediate *>(node.get());
-    ASSERT_TRUE(intermediate);
-    ASSERT_TRUE(intermediate->getChildren().size() == 2);
-    Term *term = dynamic_cast<Term *>(intermediate->getChildren()[0]);
-    ASSERT_TRUE(term);
-    EXPECT_EQUAL(term_index0, term->getTermIndex());
-    term = dynamic_cast<Term *>(intermediate->getChildren()[1]);
-    ASSERT_TRUE(term);
-    EXPECT_EQUAL(term_index1, term->getTermIndex());
-}
-
 TEST("require that Rank Can Be Turned Off") {
     QueryBuilder<SimpleQueryNodeTypes> builder;
     builder.addAnd(3);

--- a/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
@@ -86,10 +86,9 @@ struct VectorizedQueryTerms {
     struct Term {
         fef::TermFieldHandle handle;
         int weight;
-        int index;
 
-        Term(fef::TermFieldHandle handle_in, int weight_in, int index_in)
-            : handle(handle_in), weight(weight_in), index(index_in)
+        Term(fef::TermFieldHandle handle_in, int weight_in)
+            : handle(handle_in), weight(weight_in)
         {}
     };
 
@@ -117,12 +116,11 @@ struct VectorizedQueryTerms {
                     if (tfd.getFieldId() == field_id) {
                         int term_weight = termData->getWeight().percent();
                         total_weight += term_weight;
-                        terms.push_back(Term(tfd.getHandle(), term_weight, termData->getTermIndex()));
+                        terms.push_back(Term(tfd.getHandle(), term_weight));
                     }
                 }
             }
         }
-        std::sort(terms.begin(), terms.end(), [](const Term &a, const Term &b) { return (a.index < b.index); });
         handles.reserve(terms.size());
         weights.reserve(terms.size());
         for (size_t i = 0; i < terms.size(); ++i) {

--- a/searchlib/src/vespa/searchlib/features/text_similarity_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/text_similarity_feature.cpp
@@ -13,9 +13,8 @@ namespace {
 struct Term {
     fef::TermFieldHandle handle;
     int                          weight;
-    int                          index;
-    Term(fef::TermFieldHandle handle_in, int weight_in, int index_in)
-        : handle(handle_in), weight(weight_in), index(index_in) {}
+    Term(fef::TermFieldHandle handle_in, int weight_in)
+        : handle(handle_in), weight(weight_in) {}
 };
 
 struct State {
@@ -92,13 +91,11 @@ TextSimilarityExecutor::TextSimilarityExecutor(const fef::IQueryEnvironment &env
                 if (tfd.getFieldId() == field_id) {
                     int term_weight = termData->getWeight().percent();
                     _total_term_weight += term_weight;
-                    terms.push_back(Term(tfd.getHandle(), term_weight,
-                                    termData->getTermIndex()));
+                    terms.push_back(Term(tfd.getHandle(), term_weight));
                 }
             }
         }
     }
-    std::sort(terms.begin(), terms.end(), [](const Term &a, const Term &b){ return (a.index < b.index); });
     _handles.reserve(terms.size());
     _weights.reserve(terms.size());
     for (size_t i = 0; i < terms.size(); ++i) {

--- a/searchlib/src/vespa/searchlib/fef/itermdata.h
+++ b/searchlib/src/vespa/searchlib/fef/itermdata.h
@@ -28,13 +28,6 @@ public:
     virtual uint32_t getPhraseLength() const = 0;
 
     /**
-     * Obtain the location of this term in the original user query.
-     *
-     * @return term index
-     **/
-    virtual uint32_t getTermIndex() const = 0;
-
-    /**
      * Obtain the unique id of this term. 0 means not set.
      *
      * @return unique id or 0

--- a/searchlib/src/vespa/searchlib/fef/phrasesplitter.cpp
+++ b/searchlib/src/vespa/searchlib/fef/phrasesplitter.cpp
@@ -18,7 +18,6 @@ PhraseSplitter::considerTerm(uint32_t termIdx, const ITermData &term, std::vecto
                 SimpleTermData prototype;
                 prototype.setWeight(term.getWeight());
                 prototype.setPhraseLength(1);
-                prototype.setTermIndex(term.getTermIndex());
                 prototype.setUniqueId(term.getUniqueId());
                 prototype.addField(fieldId);
                 phraseTerms.push_back(PhraseTerm(term, _terms.size(), h));

--- a/searchlib/src/vespa/searchlib/fef/simpletermdata.cpp
+++ b/searchlib/src/vespa/searchlib/fef/simpletermdata.cpp
@@ -17,7 +17,6 @@ SimpleTermData::SimpleTermData()
 SimpleTermData::SimpleTermData(const ITermData &rhs)
     : _weight(rhs.getWeight()),
       _numTerms(rhs.getPhraseLength()),
-      _termIndex(rhs.getTermIndex()),
       _uniqueId(rhs.getUniqueId()),
       _fields()
 {

--- a/searchlib/src/vespa/searchlib/fef/simpletermdata.h
+++ b/searchlib/src/vespa/searchlib/fef/simpletermdata.h
@@ -49,13 +49,6 @@ public:
     uint32_t getPhraseLength() const override { return _numTerms; }
 
     /**
-     * Obtain the location of this term in the original user query.
-     *
-     * @return term index
-     **/
-    uint32_t getTermIndex() const override { return _termIndex; }
-
-    /**
      * Obtain the unique id of this term. 0 means not set.
      *
      * @return unique id or 0

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -110,13 +110,6 @@ public:
     uint32_t getUniqueId() const { return _currUniqueId; }
 
     /**
-     * Get the term index of the current item.
-     *
-     * @return term index of current item
-     **/
-    uint32_t getTermIndex() const { return -1; }
-
-    /**
      * Get the flags of the current item.
      *
      * @return flags of current item

--- a/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
@@ -47,18 +47,15 @@ class Equiv : public QueryNodeMixin<Equiv, Intermediate> {
 private:
     int32_t _id;
     Weight  _weight;
-    int32_t _term_index;
 public:
     virtual ~Equiv() = 0;
 
     Equiv(int32_t id, Weight weight)
-        : _id(id), _weight(weight), _term_index(-1)
+        : _id(id), _weight(weight)
     {}
-    void setTermIndex(int32_t term_index) { _term_index = term_index; }
 
     Weight getWeight() const { return _weight; }
     int32_t getId() const { return _id; }
-    int32_t getTermIndex() const { return _term_index; }
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -48,8 +48,7 @@ private:
     }
 
     void visit(Equiv &node) override {
-        _builder.addEquiv(node.getChildren().size(), node.getId(), node.getWeight())
-            .setTermIndex(node.getTermIndex());
+        _builder.addEquiv(node.getChildren().size(), node.getId(), node.getWeight());
         visitNodes(node.getChildren());
     }
 

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -28,7 +28,6 @@ public:
         while (!builder.hasError() && queryStack.next()) {
             Term *t = createQueryTerm(queryStack, builder, pureTermView);
             if (!builder.hasError() && t) {
-                t->setTermIndex(queryStack.getTermIndex());
                 if (queryStack.getFlags() & ParseItem::IFLAG_NORANK) {
                     t->setRanked(false);
                 }

--- a/searchlib/src/vespa/searchlib/query/tree/term.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/term.cpp
@@ -11,13 +11,11 @@ Term::Term(vespalib::stringref view, int32_t id, Weight weight) :
     _view(view),
     _id(id),
     _weight(weight),
-    _term_index(-1),
     _ranked(true),
     _position_data(true)
 { }
 
 void Term::setStateFrom(const Term& other) {
-    setTermIndex(other.getTermIndex());
     setRanked(other.isRanked());
     setPositionData(other.usePositionData());
     // too late to copy this state:

--- a/searchlib/src/vespa/searchlib/query/tree/term.h
+++ b/searchlib/src/vespa/searchlib/query/tree/term.h
@@ -16,14 +16,12 @@ class Term
     vespalib::string _view;
     int32_t          _id;
     Weight           _weight;
-    int32_t          _term_index;
     bool             _ranked;
     bool             _position_data;
 
 public:
     virtual ~Term() = 0;
 
-    void setTermIndex(int32_t term_index) { _term_index = term_index; }
     void setView(const vespalib::string & view) { _view = view; }
     void setRanked(bool ranked) { _ranked = ranked; }
     void setPositionData(bool position_data) { _position_data = position_data; }
@@ -33,7 +31,6 @@ public:
     const vespalib::string & getView() const { return _view; }
     Weight getWeight() const { return _weight; }
     int32_t getId() const { return _id; }
-    int32_t getTermIndex() const { return _term_index; }
     bool isRanked() const { return _ranked; }
     bool usePositionData() const { return _position_data; }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

termindex was only sent when using the "bigramweight" feature, which was removed from the query serialization in 2012.

@baldersheim please review and merge
@havardpe @geirst FYI