### PR TITLE
don't deploy to us-east-1 when user specifies aws-us-west-2a

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/JobType.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/JobType.java
@@ -70,7 +70,7 @@ public enum JobType {
                             Map.of(main, ZoneId.from("dev"    , "us-east-1"))),
 
     devAwsUsEast2a         ("dev-aws-us-east-2a",
-                            Map.of(main, ZoneId.from("dev"    , "us-east-1"))),
+                            Map.of(main, ZoneId.from("dev"    , "aws-us-east-2a"))),
 
     productionCdAwsUsEast1a("production-cd-aws-us-east-1a",
                             Map.of(cd  , ZoneId.from("prod"   , "cd-aws-us-east-1a"))),


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
