### PR TITLE
Revert "Let "required" on nodes apply to node resources"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.Zone;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Defines the policies for assigning cluster capacity in various environments
@@ -26,24 +27,23 @@ public class CapacityPolicies {
         this.isUsingAdvertisedResources = zone.region().value().contains("aws-");
     }
 
-    public int decideSize(Capacity capacity, ClusterSpec.Type clusterType) {
-        int requestedNodes = ensureRedundancy(capacity.nodeCount(), clusterType, capacity.canFail());
-        if (capacity.isRequired()) return requestedNodes;
+    public int decideSize(Capacity requestedCapacity, ClusterSpec.Type clusterType) {
+        int requestedNodes = ensureRedundancy(requestedCapacity.nodeCount(), clusterType, requestedCapacity.canFail());
+        if (requestedCapacity.isRequired()) return requestedNodes;
 
         switch(zone.environment()) {
             case dev : case test : return 1;
-            case perf : return Math.min(capacity.nodeCount(), 3);
+            case perf : return Math.min(requestedCapacity.nodeCount(), 3);
             case staging: return requestedNodes <= 1 ? requestedNodes : Math.max(2, requestedNodes / 10);
             case prod : return requestedNodes;
             default : throw new IllegalArgumentException("Unsupported environment " + zone.environment());
         }
     }
 
-    public NodeResources decideNodeResources(Capacity capacity, ClusterSpec cluster) {
-        NodeResources resources = capacity.nodeResources().orElse(defaultNodeResources(cluster.type()));
-        ensureSufficientResources(resources, cluster);
+    public NodeResources decideNodeResources(Optional<NodeResources> requestedResources, ClusterSpec cluster) {
+        if (requestedResources.isPresent()) assertMinimumResources(requestedResources.get(), cluster);
 
-        if (capacity.isRequired()) return resources;
+        NodeResources resources = requestedResources.orElse(defaultNodeResources(cluster.type()));
 
         // Allow slow storage in zones which are not performance sensitive
         if (zone.system().isCd() || zone.environment() == Environment.dev || zone.environment() == Environment.test)
@@ -57,7 +57,7 @@ public class CapacityPolicies {
         return resources;
     }
 
-    private void ensureSufficientResources(NodeResources resources, ClusterSpec cluster) {
+    private void assertMinimumResources(NodeResources resources, ClusterSpec cluster) {
         double minMemoryGb = cluster.type() == ClusterSpec.Type.admin ? 2 : 4;
         if (resources.memoryGb() >= minMemoryGb) return;
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -94,7 +94,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
             if (zone.environment().isManuallyDeployed() && nodeCount < requestedCapacity.nodeCount())
                 logger.log(Level.INFO, "Requested " + requestedCapacity.nodeCount() + " nodes for " + cluster +
                                        ", downscaling to " + nodeCount + " nodes in " + zone.environment());
-            resources = Optional.of(capacityPolicies.decideNodeResources(requestedCapacity, cluster));
+            resources = Optional.of(capacityPolicies.decideNodeResources(requestedCapacity.nodeResources(), cluster));
             boolean exclusive = capacityPolicies.decideExclusivity(cluster.isExclusive());
             effectiveGroups = wantedGroups > nodeCount ? nodeCount : wantedGroups; // cannot have more groups than nodes
             requestedNodes = NodeSpec.from(nodeCount, resources.get(), exclusive, requestedCapacity.canFail());


### PR DESCRIPTION
Reverts vespa-engine/vespa#11387

2 integrations tests which have `<nodes count="2" required="true"/>` (that seems to be all integration tests that use `required="true"`) started failing after this was merged (with `OUT_OF_CAPACITY`). Links to the 2 apps: 

- https://git.ouroath.com/vespa/integration-test-application/blob/master/src/main/application/services.xml#L26
- https://git.ouroath.com/vespa/vespa-yahoo/blob/master/hosted/integration-tests/src/test/resources/applications/music-restart-on-deploy/src/main/application/services.xml#L35
