### PR TITLE
Remove code for generating unused score-board config

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -10,7 +10,6 @@ import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.StatisticsConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
-import com.yahoo.jdisc.metrics.yamasconsumer.cloud.ScoreBoardConfig;
 import com.yahoo.net.HostName;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.container.ContainerCluster;
@@ -29,7 +28,6 @@ public class ConfigserverCluster extends AbstractConfigProducer
         implements
         ZookeeperServerConfig.Producer,
         ConfigserverConfig.Producer,
-        ScoreBoardConfig.Producer,
         StatisticsConfig.Producer,
         HealthMonitorConfig.Producer {
     private final CloudConfigOptions options;
@@ -173,13 +171,6 @@ public class ConfigserverCluster extends AbstractConfigProducer
         builder.hostname(server.hostName);
         builder.id(id);
         return builder;
-    }
-
-    @Override
-    public void getConfig(ScoreBoardConfig.Builder builder) {
-        builder.applicationName("configserver");
-        builder.flushTime(60);
-        builder.step(60);
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/ConfigserverClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/ConfigserverClusterTest.java
@@ -9,7 +9,6 @@ import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.container.StatisticsConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
-import com.yahoo.jdisc.metrics.yamasconsumer.cloud.ScoreBoardConfig;
 import com.yahoo.net.HostName;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.defaults.Defaults;
@@ -88,14 +87,6 @@ public class ConfigserverClusterTest {
         StatisticsConfig config = getConfig(StatisticsConfig.class);
         assertThat((int) config.collectionintervalsec(), is(60));
         assertThat((int) config.loggingintervalsec(), is(60));
-    }
-
-    @Test
-    public void testScoreBoardConfig() {
-        ScoreBoardConfig config = getConfig(ScoreBoardConfig.class);
-        assertThat(config.applicationName(), is("configserver"));
-        assertThat(config.flushTime(), is(60));
-        assertThat(config.step(), is(60));
     }
 
     @Test


### PR DESCRIPTION
Config definition can be removed when no config models generate this config
anymore
