### PR TITLE
Base64 support for fbench

### DIFF
--- a/fbench/CMakeLists.txt
+++ b/fbench/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_define_module(
     DEPENDS
     fastos
     vespalib
+    staging_vespalib
 
     APPS
     src/fbench

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -226,7 +226,7 @@ Client::run()
             int cLen = _args->_usePostMode ? urlSource.nextContent() : 0;
             auto content = urlSource.content();
             if (_args->_usePostMode && _args->_base64Decode) {
-                auto base64_decoded = Base64::decode(std::string(urlSource.content(), cLen));
+                auto base64_decoded = Base64::decode(std::string(content, cLen));
                 content = base64_decoded.c_str();
                 cLen = base64_decoded.size();
             }

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -273,7 +273,7 @@ Client::run()
                 auto base64_content = std::string(urlSource.content(), cLen);
                 auto decoded = base64_decode(base64_content);
                 content = decoded.c_str();
-                cLen = content.size();
+                cLen = decoded.size();
             }
                         
             _reqTimer->Start();

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -8,53 +8,9 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <vespa/vespalib/encoding/base64.h>
 
-static const std::string base64_chars =
-             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-             "abcdefghijklmnopqrstuvwxyz"
-             "0123456789+/";
-
-
-static inline bool is_base64(unsigned char c) {
-  return (isalnum(c) || (c == '+') || (c == '/'));
-}
-
-std::string base64_decode(std::string const& encoded_string) {
-  int in_len = encoded_string.size();
-  int i = 0;
-  int j = 0;
-  int in_ = 0;
-  unsigned char char_array_4[4], char_array_3[3];
-  std::string ret;
-
-  while (in_len-- && ( encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
-    char_array_4[i++] = encoded_string[in_]; in_++;
-    if (i ==4) {
-      for (i = 0; i <4; i++)
-        char_array_4[i] = base64_chars.find(char_array_4[i]);
-
-      char_array_3[0] = ( char_array_4[0] << 2       ) + ((char_array_4[1] & 0x30) >> 4);
-      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) +   char_array_4[3];
-
-      for (i = 0; (i < 3); i++)
-        ret += char_array_3[i];
-      i = 0;
-    }
-  }
-
-  if (i) {
-    for (j = 0; j < i; j++)
-      char_array_4[j] = base64_chars.find(char_array_4[j]);
-
-    char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-    char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-
-    for (j = 0; (j < i - 1); j++) ret += char_array_3[j];
-  }
-
-  return ret;
-}
+using namespace vespalib;
 
 Client::Client(vespalib::CryptoEngine::SP engine, ClientArguments *args)
     : _args(args),
@@ -270,10 +226,9 @@ Client::run()
             int cLen = _args->_usePostMode ? urlSource.nextContent() : 0;
             auto content = urlSource.content();
             if (_args->_usePostMode && _args->_base64Decode) {
-                auto base64_content = std::string(urlSource.content(), cLen);
-                auto decoded = base64_decode(base64_content);
-                content = decoded.c_str();
-                cLen = decoded.size();
+                auto base64_decoded = Base64::decode(std::string(urlSource.content(), cLen));
+                content = base64_decoded.c_str();
+                cLen = base64_decoded.size();
             }
                         
             _reqTimer->Start();

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -224,9 +224,11 @@ Client::run()
                 strcat(_linebuf, _args->_queryStringToAppend.c_str());
             }
             int cLen = _args->_usePostMode ? urlSource.nextContent() : 0;
-            auto content = urlSource.content();
+            
+            const char* content = urlSource.content();
+            std::string base64_decoded;
             if (_args->_usePostMode && _args->_base64Decode) {
-                auto base64_decoded = Base64::decode(std::string(content, cLen));
+                base64_decoded = Base64::decode(content, cLen);
                 content = base64_decoded.c_str();
                 cLen = base64_decoded.size();
             }

--- a/fbench/src/fbench/client.h
+++ b/fbench/src/fbench/client.h
@@ -96,7 +96,8 @@ struct ClientArguments
     bool        _keepAlive;
     
     /**
-     * Indicate wether to base64 decode the request before sending it
+     * Indicate wether POST content should be Base64 decoded before
+     * sending it
      **/
     bool        _base64Decode;
 

--- a/fbench/src/fbench/client.h
+++ b/fbench/src/fbench/client.h
@@ -94,6 +94,11 @@ struct ClientArguments
      * client.
      **/
     bool        _keepAlive;
+    
+    /**
+     * Indicate wether to base64 decode the request before sending it
+     **/
+    bool        _base64Decode;
 
     /** Whether we should use POST in requests */
     bool        _usePostMode;
@@ -117,7 +122,8 @@ struct ClientArguments
                     long cycle, long delay,
                     int ignoreCount, int byteLimit,
                     int restartLimit, int maxLineSize,
-                    bool keepAlive, bool headerBenchmarkdataCoverage,
+                    bool keepAlive, bool base64Decode,
+                    bool headerBenchmarkdataCoverage,
                     uint64_t queryfileOffset, uint64_t queryfileEndOffset, bool singleQueryFile,
                     const std::string & queryStringToAppend, const std::string & extraHeaders,
                     const std::string &authority, bool postMode)
@@ -134,6 +140,7 @@ struct ClientArguments
           _restartLimit(restartLimit),
           _maxLineSize(maxLineSize),
           _keepAlive(keepAlive),
+          _base64Decode(base64Decode),
           _usePostMode(postMode),
           _headerBenchmarkdataCoverage(headerBenchmarkdataCoverage),
           _queryfileOffset(queryfileOffset),

--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -363,7 +363,7 @@ FBench::Main(int argc, char *argv[])
 
     idx = 1;
     optError = false;
-    while((opt = GetOpt(argc, argv, "H:A:T:C:K:Da:n:c:l:i:s:q:o:r:m:p:kxyzP", arg, idx)) != -1) {
+    while((opt = GetOpt(argc, argv, "H:A:T:C:K:Da:n:c:l:i:s:q:o:r:m:p:kdxyzP", arg, idx)) != -1) {
         switch(opt) {
         case 'A':
             authority = arg;

--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -107,7 +107,8 @@ void
 FBench::InitBenchmark(int numClients, int ignoreCount, int cycle,
                       const char *filenamePattern, const char *outputPattern,
                       int byteLimit, int restartLimit, int maxLineSize,
-                      bool keepAlive, bool headerBenchmarkdataCoverage, int seconds,
+                      bool keepAlive, bool base64Decode,
+                      bool headerBenchmarkdataCoverage, int seconds,
                       bool singleQueryFile, const std::string & queryStringToAppend, const std::string & extraHeaders,
                       const std::string &authority, bool postMode)
 {
@@ -127,6 +128,7 @@ FBench::InitBenchmark(int numClients, int ignoreCount, int cycle,
     _restartLimit    = restartLimit;
     _maxLineSize     = maxLineSize;
     _keepAlive       = keepAlive;
+    _base64Decode    = base64Decode;
     _usePostMode     = postMode;
     _headerBenchmarkdataCoverage = headerBenchmarkdataCoverage;
     _seconds = seconds;
@@ -152,7 +154,8 @@ FBench::CreateClients()
                                 _ports[i % _ports.size()], _cycle,
                                 random() % spread, _ignoreCount,
                                 _byteLimit, _restartLimit, _maxLineSize,
-                                _keepAlive, _headerBenchmarkdataCoverage,
+                                _keepAlive, _base64Decode,
+                                _headerBenchmarkdataCoverage,
                                 off_beg, off_end,
                                 _singleQueryFile, _queryStringToAppend, _extraHeaders, _authority, _usePostMode));
         ++i;
@@ -298,6 +301,7 @@ FBench::Usage()
     printf("            Can not be less than the minimum [1024].\n");
     printf(" -p <num> : print summary every <num> seconds.\n");
     printf(" -k       : disable HTTP keep-alive.\n");
+    printf(" -d       : Base64 decode POST request content.\n");
     printf(" -y       : write data on coverage to output file.\n");
     printf(" -z       : use single query file to be distributed between clients.\n");
     printf(" -T <str> : CA certificate file to verify peer against.\n");
@@ -342,6 +346,7 @@ FBench::Main(int argc, char *argv[])
 
     int  restartLimit = -1;
     bool keepAlive    = true;
+    bool base64Decode = false;
     bool headerBenchmarkdataCoverage = false;
     bool usePostMode = false;
 
@@ -425,6 +430,9 @@ FBench::Main(int argc, char *argv[])
             break;
         case 'k':
             keepAlive = false;
+            break;
+        case 'd':
+            base64Decode = false;
             break;
         case 'x': 
             // consuming x for backwards compability. This turned on header benchmark data
@@ -513,7 +521,7 @@ FBench::Main(int argc, char *argv[])
     InitBenchmark(numClients, ignoreCount, cycleTime,
                   queryFilePattern, outputFilePattern,
                   byteLimit, restartLimit, maxLineSize,
-                  keepAlive,
+                  keepAlive, base64Decode,
                   headerBenchmarkdataCoverage, seconds,
                   singleQueryFile, queryStringToAppend, extraHeaders,
                   authority, usePostMode);

--- a/fbench/src/fbench/fbench.h
+++ b/fbench/src/fbench/fbench.h
@@ -23,6 +23,7 @@ private:
     int                 _restartLimit;
     int                 _maxLineSize;
     bool                _keepAlive;
+    bool                _base64Decode;
     bool                _usePostMode;
     bool                _headerBenchmarkdataCoverage;
     int                 _seconds;
@@ -41,7 +42,8 @@ private:
     void InitBenchmark(int numClients, int ignoreCount, int cycle,
                        const char *filenamePattern, const char *outputPattern,
                        int byteLimit, int restartLimit, int maxLineSize,
-                       bool keepAlive, bool headerBenchmarkdataCoverage, int seconds,
+                       bool keepAlive, bool base64Decode,
+                       bool headerBenchmarkdataCoverage, int seconds,
                        bool singleQueryFile, const std::string & queryStringToAppend, const std::string & extraHeaders,
                        const std::string &authority, bool postMode);
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Added a -d option to fbench to allow base64 decode before sending the request body. This is useful for cases where the POST body is binary e.g protobuf and we want to avoid the base64 decode on the client