### PR TITLE
Allow adding node with resources

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodeSerializer.java
@@ -70,12 +70,30 @@ public class NodeSerializer {
         }
     }
 
+    public NodeResources.DiskSpeed diskSpeedFrom(String diskSpeed) {
+        switch (diskSpeed) {
+            case "fast": return NodeResources.DiskSpeed.fast;
+            case "slow": return NodeResources.DiskSpeed.slow;
+            case "any" : return NodeResources.DiskSpeed.any;
+            default: throw new IllegalArgumentException("Unknown disk speed '" + diskSpeed + "'");
+        }
+    }
+
     public String toString(NodeResources.DiskSpeed diskSpeed) {
         switch (diskSpeed) {
             case fast : return "fast";
             case slow : return "slow";
             case any  : return "any";
             default: throw new IllegalArgumentException("Unknown disk speed '" + diskSpeed.name() + "'");
+        }
+    }
+
+    public NodeResources.StorageType storageTypeFrom(String storageType) {
+        switch (storageType) {
+            case "local" : return NodeResources.StorageType.local;
+            case "remote": return NodeResources.StorageType.remote;
+            case "any"   : return NodeResources.StorageType.any;
+            default: throw new IllegalArgumentException("Unknown storage type '" + storageType + "'");
         }
     }
 


### PR DESCRIPTION
In #11391 we added all `resources` object to node output which is intended to replace `minCpuCores`, `minMainMemoryAvailableGb`, etc. I'm in process of updating our clients to use the new format, this PR makes it possible to add new nodes with a `resources` object, the point of this is to be able to reuse `NodeRepositoryNode` binding in `controller-api` and `node-admin` for gets and adds.