### PR TITLE
Use resources in node response

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
@@ -5,7 +5,6 @@ import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeType;
-import org.jetbrains.annotations.TestOnly;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -65,18 +64,11 @@ public class Node {
         this.diskGb = diskGb;
         this.bandwidthGbps = bandwidthGbps;
         this.fastDisk = fastDisk;
+        this.remoteStorage = remoteStorage;
         this.cost = cost;
         this.canonicalFlavor = canonicalFlavor;
         this.clusterId = clusterId;
         this.clusterType = clusterType;
-    }
-
-    @TestOnly
-    public Node(HostName hostname, Optional<HostName> parentHostname, State state, NodeType type, Optional<ApplicationId> owner,
-                Version currentVersion, Version wantedVersion) {
-        this(hostname, parentHostname, state, type, owner, currentVersion, wantedVersion,
-             Version.emptyVersion, Version.emptyVersion, ServiceState.unorchestrated, 0, 0, 0, 0,
-             2, 8, 50, 1, true, 0, "d-2-8-50", "cluster", ClusterType.container);
     }
 
     public HostName hostname() {
@@ -210,4 +202,178 @@ public class Node {
         unknown
     }
 
+    public static class Builder {
+        private HostName hostname;
+        private Optional<HostName> parentHostname = Optional.empty();
+        private State state;
+        private NodeType type;
+        private Optional<ApplicationId> owner = Optional.empty();
+        private Version currentVersion;
+        private Version wantedVersion;
+        private Version currentOsVersion;
+        private Version wantedOsVersion;
+        private ServiceState serviceState;
+        private long restartGeneration;
+        private long wantedRestartGeneration;
+        private long rebootGeneration;
+        private long wantedRebootGeneration;
+        private double vcpu;
+        private double memoryGb;
+        private double diskGb;
+        private double bandwidthGbps;
+        private boolean fastDisk;
+        private int cost;
+        private String canonicalFlavor;
+        private String clusterId;
+        private ClusterType clusterType;
+        
+        public Builder() { }
+
+        public Builder(Node node) {
+            this.hostname = node.hostname;
+            this.parentHostname = node.parentHostname;
+            this.state = node.state;
+            this.type = node.type;
+            this.owner = node.owner;
+            this.currentVersion = node.currentVersion;
+            this.wantedVersion = node.wantedVersion;
+            this.currentOsVersion = node.currentOsVersion;
+            this.wantedOsVersion = node.wantedOsVersion;
+            this.serviceState = node.serviceState;
+            this.restartGeneration = node.restartGeneration;
+            this.wantedRestartGeneration = node.wantedRestartGeneration;
+            this.rebootGeneration = node.rebootGeneration;
+            this.wantedRebootGeneration = node.wantedRebootGeneration;
+            this.vcpu = node.vcpu;
+            this.memoryGb = node.memoryGb;
+            this.diskGb = node.diskGb;
+            this.bandwidthGbps = node.bandwidthGbps;
+            this.fastDisk = node.fastDisk;
+            this.cost = node.cost;
+            this.canonicalFlavor = node.canonicalFlavor;
+            this.clusterId = node.clusterId;
+            this.clusterType = node.clusterType;
+        }
+
+        public Builder hostname(HostName hostname) {
+            this.hostname = hostname;
+            return this;
+        }
+
+        public Builder parentHostname(HostName parentHostname) {
+            this.parentHostname = Optional.ofNullable(parentHostname);
+            return this;
+        }
+
+        public Builder state(State state) {
+            this.state = state;
+            return this;
+        }
+
+        public Builder type(NodeType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder owner(ApplicationId owner) {
+            this.owner = Optional.ofNullable(owner);
+            return this;
+        }
+
+        public Builder currentVersion(Version currentVersion) {
+            this.currentVersion = currentVersion;
+            return this;
+        }
+
+        public Builder wantedVersion(Version wantedVersion) {
+            this.wantedVersion = wantedVersion;
+            return this;
+        }
+
+        public Builder currentOsVersion(Version currentOsVersion) {
+            this.currentOsVersion = currentOsVersion;
+            return this;
+        }
+
+        public Builder wantedOsVersion(Version wantedOsVersion) {
+            this.wantedOsVersion = wantedOsVersion;
+            return this;
+        }
+
+        public Builder serviceState(ServiceState serviceState) {
+            this.serviceState = serviceState;
+            return this;
+        }
+
+        public Builder restartGeneration(long restartGeneration) {
+            this.restartGeneration = restartGeneration;
+            return this;
+        }
+
+        public Builder wantedRestartGeneration(long wantedRestartGeneration) {
+            this.wantedRestartGeneration = wantedRestartGeneration;
+            return this;
+        }
+
+        public Builder rebootGeneration(long rebootGeneration) {
+            this.rebootGeneration = rebootGeneration;
+            return this;
+        }
+
+        public Builder wantedRebootGeneration(long wantedRebootGeneration) {
+            this.wantedRebootGeneration = wantedRebootGeneration;
+            return this;
+        }
+
+        public Builder vcpu(double vcpu) {
+            this.vcpu = vcpu;
+            return this;
+        }
+
+        public Builder memoryGb(double memoryGb) {
+            this.memoryGb = memoryGb;
+            return this;
+        }
+
+        public Builder diskGb(double diskGb) {
+            this.diskGb = diskGb;
+            return this;
+        }
+
+        public Builder bandwidthGbps(double bandwidthGbps) {
+            this.bandwidthGbps = bandwidthGbps;
+            return this;
+        }
+
+        public Builder fastDisk(boolean fastDisk) {
+            this.fastDisk = fastDisk;
+            return this;
+        }
+
+        public Builder cost(int cost) {
+            this.cost = cost;
+            return this;
+        }
+
+        public Builder canonicalFlavor(String canonicalFlavor) {
+            this.canonicalFlavor = canonicalFlavor;
+            return this;
+        }
+
+        public Builder clusterId(String clusterId) {
+            this.clusterId = clusterId;
+            return this;
+        }
+
+        public Builder clusterType(ClusterType clusterType) {
+            this.clusterType = clusterType;
+            return this;
+        }
+
+        public Node build() {
+            return new Node(hostname, parentHostname, state, type, owner, currentVersion, wantedVersion, currentOsVersion,
+                    wantedOsVersion, serviceState, restartGeneration, wantedRestartGeneration, rebootGeneration, wantedRebootGeneration,
+                    vcpu, memoryGb, diskGb, bandwidthGbps, fastDisk, cost, canonicalFlavor, clusterId, clusterType);
+        }
+    }
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
@@ -34,14 +34,14 @@ public class Node {
     private final long rebootGeneration;
     private final long wantedRebootGeneration;
     private final int cost;
-    private final String canonicalFlavor;
+    private final String flavor;
     private final String clusterId;
     private final ClusterType clusterType;
 
     public Node(HostName hostname, Optional<HostName> parentHostname, State state, NodeType type, NodeResources resources, Optional<ApplicationId> owner,
                 Version currentVersion, Version wantedVersion, Version currentOsVersion, Version wantedOsVersion, ServiceState serviceState,
                 long restartGeneration, long wantedRestartGeneration, long rebootGeneration, long wantedRebootGeneration,
-                int cost, String canonicalFlavor, String clusterId, ClusterType clusterType) {
+                int cost, String flavor, String clusterId, ClusterType clusterType) {
         this.hostname = hostname;
         this.parentHostname = parentHostname;
         this.state = state;
@@ -58,7 +58,7 @@ public class Node {
         this.rebootGeneration = rebootGeneration;
         this.wantedRebootGeneration = wantedRebootGeneration;
         this.cost = cost;
-        this.canonicalFlavor = canonicalFlavor;
+        this.flavor = flavor;
         this.clusterId = clusterId;
         this.clusterType = clusterType;
     }
@@ -125,8 +125,8 @@ public class Node {
         return cost;
     }
 
-    public String canonicalFlavor() {
-        return canonicalFlavor;
+    public String flavor() {
+        return flavor;
     }
 
     public String clusterId() {
@@ -195,7 +195,7 @@ public class Node {
         private long rebootGeneration;
         private long wantedRebootGeneration;
         private int cost;
-        private String canonicalFlavor;
+        private String flavor;
         private String clusterId;
         private ClusterType clusterType;
         
@@ -218,7 +218,7 @@ public class Node {
             this.rebootGeneration = node.rebootGeneration;
             this.wantedRebootGeneration = node.wantedRebootGeneration;
             this.cost = node.cost;
-            this.canonicalFlavor = node.canonicalFlavor;
+            this.flavor = node.flavor;
             this.clusterId = node.clusterId;
             this.clusterType = node.clusterType;
         }
@@ -303,8 +303,8 @@ public class Node {
             return this;
         }
 
-        public Builder canonicalFlavor(String canonicalFlavor) {
-            this.canonicalFlavor = canonicalFlavor;
+        public Builder flavor(String flavor) {
+            this.flavor = flavor;
             return this;
         }
 
@@ -321,7 +321,7 @@ public class Node {
         public Node build() {
             return new Node(hostname, parentHostname, state, type, resources, owner, currentVersion, wantedVersion, currentOsVersion,
                     wantedOsVersion, serviceState, restartGeneration, wantedRestartGeneration, rebootGeneration, wantedRebootGeneration,
-                    cost, canonicalFlavor, clusterId, clusterType);
+                    cost, flavor, clusterId, clusterType);
         }
     }
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.api.integration.configserver;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 
 import java.util.Objects;
@@ -21,6 +22,7 @@ public class Node {
     private final Optional<HostName> parentHostname;
     private final State state;
     private final NodeType type;
+    private final NodeResources resources;
     private final Optional<ApplicationId> owner;
     private final Version currentVersion;
     private final Version wantedVersion;
@@ -31,24 +33,20 @@ public class Node {
     private final long wantedRestartGeneration;
     private final long rebootGeneration;
     private final long wantedRebootGeneration;
-    private final double vcpu;
-    private final double memoryGb;
-    private final double diskGb;
-    private final double bandwidthGbps;
-    private final boolean fastDisk;
     private final int cost;
     private final String canonicalFlavor;
     private final String clusterId;
     private final ClusterType clusterType;
 
-    public Node(HostName hostname, Optional<HostName> parentHostname, State state, NodeType type, Optional<ApplicationId> owner,
+    public Node(HostName hostname, Optional<HostName> parentHostname, State state, NodeType type, NodeResources resources, Optional<ApplicationId> owner,
                 Version currentVersion, Version wantedVersion, Version currentOsVersion, Version wantedOsVersion, ServiceState serviceState,
                 long restartGeneration, long wantedRestartGeneration, long rebootGeneration, long wantedRebootGeneration,
-                double vcpu, double memoryGb, double diskGb, double bandwidthGbps, boolean fastDisk, int cost, String canonicalFlavor, String clusterId, ClusterType clusterType) {
+                int cost, String canonicalFlavor, String clusterId, ClusterType clusterType) {
         this.hostname = hostname;
         this.parentHostname = parentHostname;
         this.state = state;
         this.type = type;
+        this.resources = resources;
         this.owner = owner;
         this.currentVersion = currentVersion;
         this.wantedVersion = wantedVersion;
@@ -59,12 +57,6 @@ public class Node {
         this.wantedRestartGeneration = wantedRestartGeneration;
         this.rebootGeneration = rebootGeneration;
         this.wantedRebootGeneration = wantedRebootGeneration;
-        this.vcpu = vcpu;
-        this.memoryGb = memoryGb;
-        this.diskGb = diskGb;
-        this.bandwidthGbps = bandwidthGbps;
-        this.fastDisk = fastDisk;
-        this.remoteStorage = remoteStorage;
         this.cost = cost;
         this.canonicalFlavor = canonicalFlavor;
         this.clusterId = clusterId;
@@ -83,6 +75,10 @@ public class Node {
 
     public NodeType type() {
         return type;
+    }
+
+    public NodeResources resources() {
+        return resources;
     }
 
     public Optional<ApplicationId> owner() {
@@ -123,26 +119,6 @@ public class Node {
 
     public long wantedRebootGeneration() {
         return wantedRebootGeneration;
-    }
-
-    public double vcpu() {
-        return vcpu;
-    }
-
-    public double memoryGb() {
-        return memoryGb;
-    }
-
-    public double diskGb() {
-        return diskGb;
-    }
-
-    public double bandwidthGbps() {
-        return bandwidthGbps;
-    }
-
-    public boolean fastDisk() {
-        return fastDisk;
     }
 
     public int cost() {
@@ -207,6 +183,7 @@ public class Node {
         private Optional<HostName> parentHostname = Optional.empty();
         private State state;
         private NodeType type;
+        private NodeResources resources;
         private Optional<ApplicationId> owner = Optional.empty();
         private Version currentVersion;
         private Version wantedVersion;
@@ -217,11 +194,6 @@ public class Node {
         private long wantedRestartGeneration;
         private long rebootGeneration;
         private long wantedRebootGeneration;
-        private double vcpu;
-        private double memoryGb;
-        private double diskGb;
-        private double bandwidthGbps;
-        private boolean fastDisk;
         private int cost;
         private String canonicalFlavor;
         private String clusterId;
@@ -234,6 +206,7 @@ public class Node {
             this.parentHostname = node.parentHostname;
             this.state = node.state;
             this.type = node.type;
+            this.resources = node.resources;
             this.owner = node.owner;
             this.currentVersion = node.currentVersion;
             this.wantedVersion = node.wantedVersion;
@@ -244,11 +217,6 @@ public class Node {
             this.wantedRestartGeneration = node.wantedRestartGeneration;
             this.rebootGeneration = node.rebootGeneration;
             this.wantedRebootGeneration = node.wantedRebootGeneration;
-            this.vcpu = node.vcpu;
-            this.memoryGb = node.memoryGb;
-            this.diskGb = node.diskGb;
-            this.bandwidthGbps = node.bandwidthGbps;
-            this.fastDisk = node.fastDisk;
             this.cost = node.cost;
             this.canonicalFlavor = node.canonicalFlavor;
             this.clusterId = node.clusterId;
@@ -272,6 +240,11 @@ public class Node {
 
         public Builder type(NodeType type) {
             this.type = type;
+            return this;
+        }
+
+        public Builder resources(NodeResources resources) {
+            this.resources = resources;
             return this;
         }
 
@@ -325,31 +298,6 @@ public class Node {
             return this;
         }
 
-        public Builder vcpu(double vcpu) {
-            this.vcpu = vcpu;
-            return this;
-        }
-
-        public Builder memoryGb(double memoryGb) {
-            this.memoryGb = memoryGb;
-            return this;
-        }
-
-        public Builder diskGb(double diskGb) {
-            this.diskGb = diskGb;
-            return this;
-        }
-
-        public Builder bandwidthGbps(double bandwidthGbps) {
-            this.bandwidthGbps = bandwidthGbps;
-            return this;
-        }
-
-        public Builder fastDisk(boolean fastDisk) {
-            this.fastDisk = fastDisk;
-            return this;
-        }
-
         public Builder cost(int cost) {
             this.cost = cost;
             return this;
@@ -371,9 +319,9 @@ public class Node {
         }
 
         public Node build() {
-            return new Node(hostname, parentHostname, state, type, owner, currentVersion, wantedVersion, currentOsVersion,
+            return new Node(hostname, parentHostname, state, type, resources, owner, currentVersion, wantedVersion, currentOsVersion,
                     wantedOsVersion, serviceState, restartGeneration, wantedRestartGeneration, rebootGeneration, wantedRebootGeneration,
-                    vcpu, memoryGb, diskGb, bandwidthGbps, fastDisk, cost, canonicalFlavor, clusterId, clusterType);
+                    cost, canonicalFlavor, clusterId, clusterType);
         }
     }
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
@@ -101,7 +101,7 @@ public interface NodeRepository {
                         toInt(node.getCurrentRebootGeneration()),
                         toInt(node.getRebootGeneration()),
                         toInt(node.getCost()),
-                        node.getCanonicalFlavor(),
+                        node.getFlavor(),
                         clusterIdOf(node.getMembership()),
                         clusterTypeOf(node.getMembership()));
     }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -32,6 +32,10 @@ public class NodeRepositoryNode {
     private String flavor;
     @JsonProperty("canonicalFlavor")
     private String canonicalFlavor;
+    @JsonProperty("resources")
+    private NodeResources resources;
+    @JsonProperty("requestedResources")
+    private NodeResources requestedResources;
     @JsonProperty("membership")
     private NodeMembership membership;
     @JsonProperty("owner")
@@ -68,18 +72,8 @@ public class NodeRepositoryNode {
     private Boolean wantToRetire;
     @JsonProperty("wantToDeprovision")
     private Boolean wantToDeprovision;
-    @JsonProperty("minDiskAvailableGb")
-    private Double minDiskAvailableGb;
-    @JsonProperty("minMainMemoryAvailableGb")
-    private Double minMainMemoryAvailableGb;
     @JsonProperty("cost")
     private Integer cost;
-    @JsonProperty("minCpuCores")
-    private Double minCpuCores;
-    @JsonProperty("bandwidthGbps")
-    private Double bandwidthGbps;
-    @JsonProperty("fastDisk")
-    private Boolean fastDisk;
     @JsonProperty("description")
     private String description;
     @JsonProperty("history")
@@ -161,6 +155,22 @@ public class NodeRepositoryNode {
 
     public void setCanonicalFlavor(String canonicalFlavor) {
         this.canonicalFlavor = canonicalFlavor;
+    }
+
+    public NodeResources getResources() {
+        return resources;
+    }
+
+    public void setResources(NodeResources resources) {
+        this.resources = resources;
+    }
+
+    public NodeResources getRequestedResources() {
+        return requestedResources;
+    }
+
+    public void setRequestedResources(NodeResources requestedResources) {
+        this.requestedResources = requestedResources;
     }
 
     public NodeMembership getMembership() {
@@ -289,52 +299,12 @@ public class NodeRepositoryNode {
         this.wantToDeprovision = wantToDeprovision;
     }
 
-    public Double getMinDiskAvailableGb() {
-        return minDiskAvailableGb;
-    }
-
-    public void setMinDiskAvailableGb(Double minDiskAvailableGb) {
-        this.minDiskAvailableGb = minDiskAvailableGb;
-    }
-
-    public Double getMinMainMemoryAvailableGb() {
-        return minMainMemoryAvailableGb;
-    }
-
-    public void setMinMainMemoryAvailableGb(Double minMainMemoryAvailableGb) {
-        this.minMainMemoryAvailableGb = minMainMemoryAvailableGb;
-    }
-
     public Integer getCost() {
         return cost;
     }
 
     public void setCost(Integer cost) {
         this.cost = cost;
-    }
-
-    public Double getMinCpuCores() {
-        return minCpuCores;
-    }
-
-    public void setMinCpuCores(Double minCpuCores) {
-        this.minCpuCores = minCpuCores;
-    }
-
-    public Double getBandwidthGbps() {
-        return bandwidthGbps;
-    }
-
-    public void setBandwidthGbps(Double bandwidthGbps) {
-        this.bandwidthGbps = bandwidthGbps;
-    }
-
-    public Boolean getFastDisk() {
-        return fastDisk;
-    }
-
-    public void setFastDisk(Boolean fastDisk) {
-        this.fastDisk = fastDisk;
     }
 
     public String getDescription() {
@@ -401,6 +371,8 @@ public class NodeRepositoryNode {
                ", openStackId='" + openStackId + '\'' +
                ", flavor='" + flavor + '\'' +
                ", canonicalFlavor='" + canonicalFlavor + '\'' +
+               ", resources=" + resources +
+               ", requestedResources=" + requestedResources +
                ", membership=" + membership +
                ", owner=" + owner +
                ", restartGeneration=" + restartGeneration +
@@ -419,12 +391,7 @@ public class NodeRepositoryNode {
                ", parentHostname='" + parentHostname + '\'' +
                ", wantToRetire=" + wantToRetire +
                ", wantToDeprovision=" + wantToDeprovision +
-               ", minDiskAvailableGb=" + minDiskAvailableGb +
-               ", minMainMemoryAvailableGb=" + minMainMemoryAvailableGb +
                ", cost=" + cost +
-               ", minCpuCores=" + minCpuCores +
-               ", bandwidthGbps=" + bandwidthGbps +
-               ", fastDisk=" + fastDisk +
                ", description='" + description + '\'' +
                ", history=" + Arrays.toString(history) +
                ", allowedToBeDown=" + allowedToBeDown +

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -30,8 +30,6 @@ public class NodeRepositoryNode {
     private String openStackId;
     @JsonProperty("flavor")
     private String flavor;
-    @JsonProperty("canonicalFlavor")
-    private String canonicalFlavor;
     @JsonProperty("resources")
     private NodeResources resources;
     @JsonProperty("requestedResources")
@@ -74,8 +72,6 @@ public class NodeRepositoryNode {
     private Boolean wantToDeprovision;
     @JsonProperty("cost")
     private Integer cost;
-    @JsonProperty("description")
-    private String description;
     @JsonProperty("history")
     private NodeHistory[] history;
     @JsonProperty("allowedToBeDown")
@@ -147,14 +143,6 @@ public class NodeRepositoryNode {
 
     public void setFlavor(String flavor) {
         this.flavor = flavor;
-    }
-
-    public String getCanonicalFlavor() {
-        return canonicalFlavor;
-    }
-
-    public void setCanonicalFlavor(String canonicalFlavor) {
-        this.canonicalFlavor = canonicalFlavor;
     }
 
     public NodeResources getResources() {
@@ -307,14 +295,6 @@ public class NodeRepositoryNode {
         this.cost = cost;
     }
 
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public NodeHistory[] getHistory() {
         return history;
     }
@@ -370,7 +350,6 @@ public class NodeRepositoryNode {
                ", additionalIpAddresses=" + additionalIpAddresses +
                ", openStackId='" + openStackId + '\'' +
                ", flavor='" + flavor + '\'' +
-               ", canonicalFlavor='" + canonicalFlavor + '\'' +
                ", resources=" + resources +
                ", requestedResources=" + requestedResources +
                ", membership=" + membership +
@@ -392,7 +371,6 @@ public class NodeRepositoryNode {
                ", wantToRetire=" + wantToRetire +
                ", wantToDeprovision=" + wantToDeprovision +
                ", cost=" + cost +
-               ", description='" + description + '\'' +
                ", history=" + Arrays.toString(history) +
                ", allowedToBeDown=" + allowedToBeDown +
                ", reports=" + reports +

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeResources.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeResources.java
@@ -1,0 +1,87 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.noderepository;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author freva
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NodeResources {
+
+    @JsonProperty
+    private Double vcpu;
+    @JsonProperty
+    private Double memoryGb;
+    @JsonProperty
+    private Double diskGb;
+    @JsonProperty
+    private Double bandwidthGbps;
+    @JsonProperty
+    private String diskSpeed;
+    @JsonProperty
+    private String storageType;
+
+    public Double getVcpu() {
+        return vcpu;
+    }
+
+    public void setVcpu(Double vcpu) {
+        this.vcpu = vcpu;
+    }
+
+    public Double getMemoryGb() {
+        return memoryGb;
+    }
+
+    public void setMemoryGb(Double memoryGb) {
+        this.memoryGb = memoryGb;
+    }
+
+    public Double getDiskGb() {
+        return diskGb;
+    }
+
+    public void setDiskGb(Double diskGb) {
+        this.diskGb = diskGb;
+    }
+
+    public Double getBandwidthGbps() {
+        return bandwidthGbps;
+    }
+
+    public void setBandwidthGbps(Double bandwidthGbps) {
+        this.bandwidthGbps = bandwidthGbps;
+    }
+
+    public String getDiskSpeed() {
+        return diskSpeed;
+    }
+
+    public void setDiskSpeed(String diskSpeed) {
+        this.diskSpeed = diskSpeed;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public void setStorageType(String storageType) {
+        this.storageType = storageType;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeResources{" +
+                "vcpu=" + vcpu +
+                ", memoryGb=" + memoryGb +
+                ", diskGb=" + diskGb +
+                ", bandwidthGbps=" + bandwidthGbps +
+                ", diskSpeed='" + diskSpeed + '\'' +
+                ", storageType='" + storageType + '\'' +
+                '}';
+    }
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/resource/ResourceSnapshot.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/resource/ResourceSnapshot.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.controller.api.integration.resource;
 
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 
@@ -37,9 +38,9 @@ public class ResourceSnapshot {
 
         return new ResourceSnapshot(
                 applicationIds.iterator().next(),
-                nodes.stream().mapToDouble(Node::vcpu).sum(),
-                nodes.stream().mapToDouble(Node::memoryGb).sum(),
-                nodes.stream().mapToDouble(Node::diskGb).sum(),
+                nodes.stream().map(Node::resources).mapToDouble(NodeResources::vcpu).sum(),
+                nodes.stream().map(Node::resources).mapToDouble(NodeResources::memoryGb).sum(),
+                nodes.stream().map(Node::resources).mapToDouble(NodeResources::diskGb).sum(),
                 timestamp,
                 zoneId
         );

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainer.java
@@ -63,7 +63,8 @@ public class ClusterInfoMaintainer extends Maintainer {
                                                  .map(Node::hostname)
                                                  .map(HostName::value)
                                                  .collect(Collectors.toList());
-            ClusterInfo info = new ClusterInfo(node.canonicalFlavor(), node.cost(), node.vcpu(), node.memoryGb(), node.diskGb(),
+            ClusterInfo info = new ClusterInfo(node.canonicalFlavor(), node.cost(),
+                                               node.resources().vcpu(), node.resources().memoryGb(), node.resources().diskGb(),
                                                ClusterSpec.Type.from(node.clusterType().name()), hostnames);
             infoMap.put(new ClusterSpec.Id(id), info);
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainer.java
@@ -63,7 +63,7 @@ public class ClusterInfoMaintainer extends Maintainer {
                                                  .map(Node::hostname)
                                                  .map(HostName::value)
                                                  .collect(Collectors.toList());
-            ClusterInfo info = new ClusterInfo(node.canonicalFlavor(), node.cost(),
+            ClusterInfo info = new ClusterInfo(node.flavor(), node.cost(),
                                                node.resources().vcpu(), node.resources().memoryGb(), node.resources().diskGb(),
                                                ClusterSpec.Type.from(node.clusterType().name()), hostnames);
             infoMap.put(new ClusterSpec.Id(id), info);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -601,7 +601,9 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
             nodeObject.setDouble("memoryGb", node.resources().memoryGb());
             nodeObject.setDouble("diskGb", node.resources().diskGb());
             nodeObject.setDouble("bandwidthGbps", node.resources().bandwidthGbps());
-            nodeObject.setBool("fastDisk", node.resources().diskSpeed() == NodeResources.DiskSpeed.fast);
+            nodeObject.setString("diskSpeed", valueOf(node.resources().diskSpeed()));
+            nodeObject.setString("storageType", valueOf(node.resources().storageType()));
+            nodeObject.setBool("fastDisk", node.resources().diskSpeed() == NodeResources.DiskSpeed.fast); // TODO: Remove
             nodeObject.setString("clusterId", node.clusterId());
             nodeObject.setString("clusterType", valueOf(node.clusterType()));
         }
@@ -637,6 +639,24 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
             case content: return "content";
             case container: return "container";
             default: throw new IllegalArgumentException("Unexpected node cluster type '" + type + "'.");
+        }
+    }
+
+    private static String valueOf(NodeResources.DiskSpeed diskSpeed) {
+        switch (diskSpeed) {
+            case fast : return "fast";
+            case slow : return "slow";
+            case any  : return "any";
+            default: throw new IllegalArgumentException("Unknown disk speed '" + diskSpeed.name() + "'");
+        }
+    }
+
+    private static String valueOf(NodeResources.StorageType storageType) {
+        switch (storageType) {
+            case remote : return "remote";
+            case local  : return "local";
+            case any    : return "any";
+            default: throw new IllegalArgumentException("Unknown storage type '" + storageType.name() + "'");
         }
     }
 
@@ -1992,3 +2012,4 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
     }
 
 }
+

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -596,7 +596,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
             nodeObject.setString("state", valueOf(node.state()));
             nodeObject.setString("orchestration", valueOf(node.serviceState()));
             nodeObject.setString("version", node.currentVersion().toString());
-            nodeObject.setString("flavor", node.canonicalFlavor());
+            nodeObject.setString("flavor", node.flavor());
             nodeObject.setDouble("vcpu", node.resources().vcpu());
             nodeObject.setDouble("memoryGb", node.resources().memoryGb());
             nodeObject.setDouble("diskGb", node.resources().diskGb());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.jdisc.HttpRequest;
@@ -596,11 +597,11 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
             nodeObject.setString("orchestration", valueOf(node.serviceState()));
             nodeObject.setString("version", node.currentVersion().toString());
             nodeObject.setString("flavor", node.canonicalFlavor());
-            nodeObject.setDouble("vcpu", node.vcpu());
-            nodeObject.setDouble("memoryGb", node.memoryGb());
-            nodeObject.setDouble("diskGb", node.diskGb());
-            nodeObject.setDouble("bandwidthGbps", node.bandwidthGbps());
-            nodeObject.setBool("fastDisk", node.fastDisk());
+            nodeObject.setDouble("vcpu", node.resources().vcpu());
+            nodeObject.setDouble("memoryGb", node.resources().memoryGb());
+            nodeObject.setDouble("diskGb", node.resources().diskGb());
+            nodeObject.setDouble("bandwidthGbps", node.resources().bandwidthGbps());
+            nodeObject.setBool("fastDisk", node.resources().diskSpeed() == NodeResources.DiskSpeed.fast);
             nodeObject.setString("clusterId", node.clusterId());
             nodeObject.setString("clusterType", valueOf(node.clusterType()));
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/cost/CostCalculator.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/cost/CostCalculator.java
@@ -54,7 +54,7 @@ public class CostCalculator {
             Property property = propertyByTenantName.get(node.owner().get().tenant());
             if (property == null) continue;
             var allocation = allocationByProperty.getOrDefault(property, ResourceAllocation.ZERO);
-            var nodeAllocation = new ResourceAllocation(node.vcpu(), node.memoryGb(), node.diskGb());
+            var nodeAllocation = new ResourceAllocation(node.resources().vcpu(), node.resources().memoryGb(), node.resources().diskGb());
             allocationByProperty.put(property, allocation.plus(nodeAllocation));
             totalAllocation = totalAllocation.plus(nodeAllocation);
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -6,6 +6,7 @@ import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.flags.json.FlagData;
@@ -90,8 +91,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
                                                                .owner(application)
                                                                .currentVersion(initialVersion)
                                                                .wantedVersion(initialVersion)
-                                                               .vcpu(2).memoryGb(8).diskGb(50).bandwidthGbps(1)
-                                                               .fastDisk(true)
+                                                               .resources(new NodeResources(2, 8, 50, 1))
                                                                .serviceState(Node.ServiceState.unorchestrated)
                                                                .canonicalFlavor("d-2-8-50")
                                                                .clusterId("cluster")

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -50,6 +50,9 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.yahoo.config.provision.NodeResources.DiskSpeed.slow;
+import static com.yahoo.config.provision.NodeResources.StorageType.remote;
+
 /**
  * @author mortent
  * @author jonmv
@@ -91,7 +94,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
                                                                .owner(application)
                                                                .currentVersion(initialVersion)
                                                                .wantedVersion(initialVersion)
-                                                               .resources(new NodeResources(2, 8, 50, 1))
+                                                               .resources(new NodeResources(2, 8, 50, 1, slow, remote))
                                                                .serviceState(Node.ServiceState.unorchestrated)
                                                                .flavor("d-2-8-50")
                                                                .clusterId("cluster")

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -93,7 +93,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
                                                                .wantedVersion(initialVersion)
                                                                .resources(new NodeResources(2, 8, 50, 1))
                                                                .serviceState(Node.ServiceState.unorchestrated)
-                                                               .canonicalFlavor("d-2-8-50")
+                                                               .flavor("d-2-8-50")
                                                                .clusterId("cluster")
                                                                .clusterType(Node.ClusterType.container)
                                                                .build());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -84,13 +84,19 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
 
     /** Assigns a reserved tenant node to the given deployment, with initial versions. */
     public void provision(ZoneId zone, ApplicationId application) {
-        nodeRepository().putByHostname(zone, new Node(hostFor(application, zone),
-                                                      Optional.empty(),
-                                                      Node.State.reserved,
-                                                      NodeType.tenant,
-                                                      Optional.of(application),
-                                                      initialVersion,
-                                                      initialVersion));
+        nodeRepository().putByHostname(zone, new Node.Builder().hostname(hostFor(application, zone))
+                                                               .state(Node.State.reserved)
+                                                               .type(NodeType.tenant)
+                                                               .owner(application)
+                                                               .currentVersion(initialVersion)
+                                                               .wantedVersion(initialVersion)
+                                                               .vcpu(2).memoryGb(8).diskGb(50).bandwidthGbps(1)
+                                                               .fastDisk(true)
+                                                               .serviceState(Node.ServiceState.unorchestrated)
+                                                               .canonicalFlavor("d-2-8-50")
+                                                               .clusterId("cluster")
+                                                               .clusterType(Node.ClusterType.container)
+                                                               .build());
     }
 
     public HostName hostFor(ApplicationId application, ZoneId zone) {
@@ -110,16 +116,15 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
         for (ZoneId zone : zones) {
             for (SystemApplication application : applications) {
                 List<Node> nodes = IntStream.rangeClosed(1, 3)
-                                            .mapToObj(i -> new Node(
-                                                    HostName.from("node-" + i + "-" + application.id().application()
-                                                                                                 .value()
-                                                                  + "-" + zone.value()),
-                                                    Optional.empty(),
-                                                    Node.State.active, application.nodeType(),
-                                                    Optional.of(application.id()),
-                                                    initialVersion,
-                                                    initialVersion
-                                            ))
+                                            .mapToObj(i -> new Node.Builder()
+                                                    .hostname(HostName.from("node-" + i + "-" + application.id().application()
+                                                            .value() + "-" + zone.value()))
+                                                    .state(Node.State.active)
+                                                    .type(application.nodeType())
+                                                    .owner(application.id())
+                                                    .currentVersion(initialVersion).wantedVersion(initialVersion)
+                                                    .currentOsVersion(Version.emptyVersion).wantedOsVersion(Version.emptyVersion)
+                                                    .build())
                                             .collect(Collectors.toList());
                 nodeRepository().putByHostname(zone, nodes);
                 convergeServices(application.id(), zone);
@@ -177,19 +182,9 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
         for (Node node : nodeRepository().list(zone, application)) {
             Node newNode;
             if (osVersion) {
-                newNode = new Node(node.hostname(), Optional.empty(), node.state(), node.type(), node.owner(), node.currentVersion(),
-                                   node.wantedVersion(), version, version, node.serviceState(),
-                                   node.restartGeneration(), node.wantedRestartGeneration(), node.rebootGeneration(),
-                                   node.wantedRebootGeneration(), node.vcpu(), node.memoryGb(), node.diskGb(),
-                                   node.bandwidthGbps(), node.fastDisk(), node.cost(), node.canonicalFlavor(),
-                                   node.clusterId(), node.clusterType());
+                newNode = new Node.Builder(node).currentOsVersion(version).wantedOsVersion(version).build();
             } else {
-                newNode = new Node(node.hostname(), Optional.empty(), node.state(), node.type(), node.owner(), version,
-                                   version, node.currentOsVersion(), node.wantedOsVersion(), node.serviceState(),
-                                   node.restartGeneration(), node.wantedRestartGeneration(), node.rebootGeneration(),
-                                   node.wantedRebootGeneration(), node.vcpu(), node.memoryGb(), node.diskGb(),
-                                   node.bandwidthGbps(), node.fastDisk(), node.cost(), node.canonicalFlavor(),
-                                   node.clusterId(), node.clusterType());
+                newNode = new Node.Builder(node).currentVersion(version).wantedVersion(version).build();
             }
             nodeRepository().putByHostname(zone, newNode);
             if (++n == nodeCount) break;
@@ -307,13 +302,10 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
             application.activate();
             List<Node> nodes = nodeRepository.list(deployment.zoneId(), deployment.applicationId());
             for (Node node : nodes) {
-                nodeRepository.putByHostname(deployment.zoneId(), new Node(node.hostname(),
-                                                                           Optional.empty(),
-                                                                           Node.State.active,
-                                                                           node.type(),
-                                                                           node.owner(),
-                                                                           node.currentVersion(),
-                                                                           application.version().get()));
+                nodeRepository.putByHostname(deployment.zoneId(), new Node.Builder(node)
+                        .state(Node.State.active)
+                        .wantedVersion(application.version().get())
+                        .build());
             }
             serviceStatus.put(deployment, new ServiceConvergence(deployment.applicationId(),
                                                                  deployment.zoneId(),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
@@ -66,52 +66,38 @@ public class NodeRepositoryMock implements NodeRepository {
     }
 
     public void addFixedNodes(ZoneId zone) {
-        var nodeA = new Node(HostName.from("hostA"),
-                             Optional.of(HostName.from("parentHostA")),
-                             Node.State.active,
-                             NodeType.tenant,
-                             Optional.of(ApplicationId.from("tenant1", "app1", "default")),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.6"),
-                             Version.fromString("7.6"),
-                             Node.ServiceState.expectedUp,
-                             0,
-                             0,
-                             0,
-                             0,
-                             24,
-                             24,
-                             500,
-                             1000,
-                             false,
-                             10,
-                             "C-2B/24/500",
-                             "clusterA",
-                             Node.ClusterType.container);
-        var nodeB = new Node(HostName.from("hostB"),
-                             Optional.of(HostName.from("parentHostB")),
-                             Node.State.active,
-                             NodeType.tenant,
-                             Optional.of(ApplicationId.from("tenant2", "app2", "default")),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.6"),
-                             Version.fromString("7.6"),
-                             Node.ServiceState.expectedUp,
-                             0,
-                             0,
-                             0,
-                             0,
-                             40,
-                             24,
-                             500,
-                             1000,
-                             false,
-                             20,
-                             "C-2C/24/500",
-                             "clusterB",
-                             Node.ClusterType.container);
+        var nodeA = new Node.Builder()
+                .hostname(HostName.from("hostA"))
+                .parentHostname(HostName.from("parentHostA"))
+                .state(Node.State.active)
+                .type(NodeType.tenant)
+                .owner(ApplicationId.from("tenant1", "app1", "default"))
+                .currentVersion(Version.fromString("7.42"))
+                .wantedVersion(Version.fromString("7.42"))
+                .currentOsVersion(Version.fromString("7.6"))
+                .wantedOsVersion(Version.fromString("7.6"))
+                .serviceState(Node.ServiceState.expectedUp)
+                .vcpu(24).memoryGb(24).diskGb(500)
+                .cost(10)
+                .clusterId("clusterA")
+                .clusterType(Node.ClusterType.container)
+                .build();
+        var nodeB = new Node.Builder()
+                .hostname(HostName.from("hostB"))
+                .parentHostname(HostName.from("parentHostB"))
+                .state(Node.State.active)
+                .type(NodeType.tenant)
+                .owner(ApplicationId.from("tenant2", "app2", "default"))
+                .currentVersion(Version.fromString("7.42"))
+                .wantedVersion(Version.fromString("7.42"))
+                .currentOsVersion(Version.fromString("7.6"))
+                .wantedOsVersion(Version.fromString("7.6"))
+                .serviceState(Node.ServiceState.expectedUp)
+                .vcpu(40).memoryGb(24).diskGb(500)
+                .cost(20)
+                .clusterId("clusterB")
+                .clusterType(Node.ClusterType.container)
+                .build();
         addNodes(zone, List.of(nodeA, nodeB));
     }
 
@@ -162,8 +148,7 @@ public class NodeRepositoryMock implements NodeRepository {
         nodeRepository.getOrDefault(zone, Collections.emptyMap()).values()
                       .stream()
                       .filter(node -> node.type() == type)
-                      .map(node -> new Node(node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(),
-                                            node.currentVersion(), version))
+                      .map(node -> new Node.Builder(node).wantedVersion(version).build())
                       .forEach(node -> putByHostname(zone, node));
     }
 
@@ -193,7 +178,7 @@ public class NodeRepositoryMock implements NodeRepository {
     public void doUpgrade(DeploymentId deployment, Optional<HostName> hostName, Version version) {
         modifyNodes(deployment, hostName, node -> {
             assert node.wantedVersion().equals(version);
-            return new Node(node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(), version, version);
+            return new Node.Builder(node).currentVersion(version).build();
         });
     }
 
@@ -206,107 +191,19 @@ public class NodeRepositoryMock implements NodeRepository {
     }
 
     public void requestRestart(DeploymentId deployment, Optional<HostName> hostname) {
-        modifyNodes(deployment, hostname, node -> new Node(node.hostname(),
-                                                           node.parentHostname(),
-                                                           node.state(),
-                                                           node.type(),
-                                                           node.owner(),
-                                                           node.currentVersion(),
-                                                           node.wantedVersion(),
-                                                           node.currentOsVersion(),
-                                                           node.wantedOsVersion(),
-                                                           node.serviceState(),
-                                                           node.restartGeneration(),
-                                                           node.wantedRestartGeneration() + 1,
-                                                           node.rebootGeneration(),
-                                                           node.wantedRebootGeneration(),
-                                                           node.vcpu(),
-                                                           node.memoryGb(),
-                                                           node.diskGb(),
-                                                           node.bandwidthGbps(),
-                                                           node.fastDisk(),
-                                                           node.cost(),
-                                                           node.canonicalFlavor(),
-                                                           node.clusterId(),
-                                                           node.clusterType()));
+        modifyNodes(deployment, hostname, node -> new Node.Builder(node).wantedRestartGeneration(node.wantedRestartGeneration() + 1).build());
     }
 
     public void doRestart(DeploymentId deployment, Optional<HostName> hostname) {
-        modifyNodes(deployment, hostname, node -> new Node(node.hostname(),
-                                                           node.parentHostname(),
-                                                           node.state(),
-                                                           node.type(),
-                                                           node.owner(),
-                                                           node.currentVersion(),
-                                                           node.wantedVersion(),
-                                                           node.currentOsVersion(),
-                                                           node.wantedOsVersion(),
-                                                           node.serviceState(),
-                                                           node.restartGeneration() + 1,
-                                                           node.wantedRestartGeneration(),
-                                                           node.rebootGeneration(),
-                                                           node.wantedRebootGeneration(),
-                                                           node.vcpu(),
-                                                           node.memoryGb(),
-                                                           node.diskGb(),
-                                                           node.bandwidthGbps(),
-                                                           node.fastDisk(),
-                                                           node.cost(),
-                                                           node.canonicalFlavor(),
-                                                           node.clusterId(),
-                                                           node.clusterType()));
+        modifyNodes(deployment, hostname, node -> new Node.Builder(node).restartGeneration(node.restartGeneration() + 1).build());
     }
 
     public void requestReboot(DeploymentId deployment, Optional<HostName> hostname) {
-        modifyNodes(deployment, hostname, node -> new Node(node.hostname(),
-                                                           node.parentHostname(),
-                                                           node.state(),
-                                                           node.type(),
-                                                           node.owner(),
-                                                           node.currentVersion(),
-                                                           node.wantedVersion(),
-                                                           node.currentOsVersion(),
-                                                           node.wantedOsVersion(),
-                                                           node.serviceState(),
-                                                           node.restartGeneration(),
-                                                           node.wantedRestartGeneration(),
-                                                           node.rebootGeneration(),
-                                                           node.wantedRebootGeneration() + 1,
-                                                           node.vcpu(),
-                                                           node.memoryGb(),
-                                                           node.diskGb(),
-                                                           node.bandwidthGbps(),
-                                                           node.fastDisk(),
-                                                           node.cost(),
-                                                           node.canonicalFlavor(),
-                                                           node.clusterId(),
-                                                           node.clusterType()));
+        modifyNodes(deployment, hostname, node -> new Node.Builder(node).wantedRebootGeneration(node.wantedRebootGeneration() + 1).build());
     }
 
     public void doReboot(DeploymentId deployment, Optional<HostName> hostname) {
-        modifyNodes(deployment, hostname, node -> new Node(node.hostname(),
-                                                           node.parentHostname(),
-                                                           node.state(),
-                                                           node.type(),
-                                                           node.owner(),
-                                                           node.currentVersion(),
-                                                           node.wantedVersion(),
-                                                           node.currentOsVersion(),
-                                                           node.wantedOsVersion(),
-                                                           node.serviceState(),
-                                                           node.restartGeneration(),
-                                                           node.wantedRestartGeneration(),
-                                                           node.rebootGeneration() + 1,
-                                                           node.wantedRebootGeneration(),
-                                                           node.vcpu(),
-                                                           node.memoryGb(),
-                                                           node.diskGb(),
-                                                           node.bandwidthGbps(),
-                                                           node.fastDisk(),
-                                                           node.cost(),
-                                                           node.canonicalFlavor(),
-                                                           node.clusterId(),
-                                                           node.clusterType()));
+        modifyNodes(deployment, hostname, node -> new Node.Builder(node).rebootGeneration(node.rebootGeneration() + 1).build());
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.integration;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
@@ -77,8 +78,7 @@ public class NodeRepositoryMock implements NodeRepository {
                 .currentOsVersion(Version.fromString("7.6"))
                 .wantedOsVersion(Version.fromString("7.6"))
                 .serviceState(Node.ServiceState.expectedUp)
-                .vcpu(24).memoryGb(24).diskGb(500)
-                .cost(10)
+                .resources(new NodeResources(24, 24, 500, 1))
                 .clusterId("clusterA")
                 .clusterType(Node.ClusterType.container)
                 .build();
@@ -93,7 +93,7 @@ public class NodeRepositoryMock implements NodeRepository {
                 .currentOsVersion(Version.fromString("7.6"))
                 .wantedOsVersion(Version.fromString("7.6"))
                 .serviceState(Node.ServiceState.expectedUp)
-                .vcpu(40).memoryGb(24).diskGb(500)
+                .resources(new NodeResources(40, 24, 500, 1))
                 .cost(20)
                 .clusterId("clusterB")
                 .clusterType(Node.ClusterType.container)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainerTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -53,52 +52,36 @@ public class ClusterInfoMaintainerTest {
     }
 
     private void addNodes(ZoneId zone) {
-        var nodeA = new Node(HostName.from("hostA"),
-                             Optional.empty(),
-                             Node.State.active,
-                             NodeType.tenant,
-                             Optional.of(ApplicationId.from("tenant1", "app1", "default")),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.6"),
-                             Version.fromString("7.6"),
-                             Node.ServiceState.expectedUp,
-                             0,
-                             0,
-                             0,
-                             0,
-                             24,
-                             24,
-                             500,
-                             1000,
-                             false,
-                             10,
-                             "C-2B/24/500",
-                             "clusterA",
-                             Node.ClusterType.container);
-        var nodeB = new Node(HostName.from("hostB"),
-                             Optional.empty(),
-                             Node.State.active,
-                             NodeType.tenant,
-                             Optional.of(ApplicationId.from("tenant1", "app1", "default")),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.42"),
-                             Version.fromString("7.6"),
-                             Version.fromString("7.6"),
-                             Node.ServiceState.expectedUp,
-                             0,
-                             0,
-                             0,
-                             0,
-                             40,
-                             24,
-                             500,
-                             1000,
-                             false,
-                             20,
-                             "C-2C/24/500",
-                             "clusterB",
-                             Node.ClusterType.container);
+        var nodeA = new Node.Builder()
+                .hostname(HostName.from("hostA"))
+                .parentHostname(HostName.from("parentHostA"))
+                .state(Node.State.active)
+                .type(NodeType.tenant)
+                .owner(ApplicationId.from("tenant1", "app1", "default"))
+                .currentVersion(Version.fromString("7.42"))
+                .wantedVersion(Version.fromString("7.42"))
+                .currentOsVersion(Version.fromString("7.6"))
+                .wantedOsVersion(Version.fromString("7.6"))
+                .serviceState(Node.ServiceState.expectedUp)
+                .cost(10)
+                .clusterId("clusterA")
+                .clusterType(Node.ClusterType.container)
+                .build();
+        var nodeB = new Node.Builder()
+                .hostname(HostName.from("hostB"))
+                .parentHostname(HostName.from("parentHostB"))
+                .state(Node.State.active)
+                .type(NodeType.tenant)
+                .owner(ApplicationId.from("tenant1", "app1", "default"))
+                .currentVersion(Version.fromString("7.42"))
+                .wantedVersion(Version.fromString("7.42"))
+                .currentOsVersion(Version.fromString("7.6"))
+                .wantedOsVersion(Version.fromString("7.6"))
+                .serviceState(Node.ServiceState.expectedUp)
+                .cost(20)
+                .clusterId("clusterB")
+                .clusterType(Node.ClusterType.container)
+                .build();
         tester.configServer().nodeRepository().addNodes(zone, List.of(nodeA, nodeB));
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ClusterInfoMaintainerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -63,6 +64,7 @@ public class ClusterInfoMaintainerTest {
                 .currentOsVersion(Version.fromString("7.6"))
                 .wantedOsVersion(Version.fromString("7.6"))
                 .serviceState(Node.ServiceState.expectedUp)
+                .resources(new NodeResources(1, 1, 1, 1))
                 .cost(10)
                 .clusterId("clusterA")
                 .clusterType(Node.ClusterType.container)
@@ -78,6 +80,7 @@ public class ClusterInfoMaintainerTest {
                 .currentOsVersion(Version.fromString("7.6"))
                 .wantedOsVersion(Version.fromString("7.6"))
                 .serviceState(Node.ServiceState.expectedUp)
+                .resources(new NodeResources(1, 1, 1, 1))
                 .cost(20)
                 .clusterId("clusterB")
                 .clusterType(Node.ClusterType.container)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -154,8 +154,7 @@ public class OsUpgraderTest {
             throw new IllegalArgumentException("No nodes allocated to " + application.id());
         }
         Node node = nodes.get(0);
-        nodeRepository().putByHostname(zone, new Node(node.hostname(), node.parentHostname(), Node.State.failed, node.type(), node.owner(),
-                                                      node.currentVersion(), node.wantedVersion()));
+        nodeRepository().putByHostname(zone, new Node.Builder(node).state(Node.State.failed).build());
     }
 
     /** Simulate OS upgrade of nodes allocated to application. In a real system this is done by the node itself */
@@ -163,13 +162,7 @@ public class OsUpgraderTest {
         assertWanted(version, application, zones);
         for (ZoneId zone : zones) {
             for (Node node : nodesRequiredToUpgrade(zone, application)) {
-                nodeRepository().putByHostname(zone, new Node(
-                        node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(), node.currentVersion(),
-                        node.wantedVersion(), version, version, node.serviceState(),
-                        node.restartGeneration(), node.wantedRestartGeneration(), node.rebootGeneration(),
-                        node.wantedRebootGeneration(), node.vcpu(), node.memoryGb(), node.diskGb(),
-                        node.bandwidthGbps(), node.fastDisk(), node.cost(), node.canonicalFlavor(),
-                        node.clusterId(), node.clusterType()));
+                nodeRepository().putByHostname(zone, new Node.Builder(node).wantedOsVersion(version).currentOsVersion(version).build());
             }
             assertCurrent(version, application, zone);
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgraderTest.java
@@ -301,7 +301,7 @@ public class SystemUpgraderTest {
             for (Node node : listNodes(zone, application)) {
                 nodeRepository().putByHostname(
                         zone.getId(),
-                        new Node(node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(), node.wantedVersion(), node.wantedVersion()));
+                        new Node.Builder(node).currentVersion(node.wantedVersion()).build());
             }
 
             assertCurrentVersion(application, version, zone);
@@ -326,7 +326,7 @@ public class SystemUpgraderTest {
         Node node = nodes.get(0);
         nodeRepository().putByHostname(
                 zone.getId(),
-                new Node(node.hostname(), node.parentHostname(), Node.State.failed, node.type(), node.owner(), node.currentVersion(), node.wantedVersion()));
+                new Node.Builder(node).state(Node.State.failed).build());
     }
 
     private void assertSystemVersion(Version version) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-nodes.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application-nodes.json
@@ -10,7 +10,9 @@
       "memoryGb": 8.0,
       "diskGb": 50.0,
       "bandwidthGbps": 1.0,
-      "fastDisk": true,
+      "diskSpeed": "slow",
+      "storageType": "remote",
+      "fastDisk": false,
       "clusterId": "cluster",
       "clusterType": "container"
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -144,13 +144,7 @@ public class OsApiTest extends ControllerContainerTest {
                 var targetVersion = nodeRepository().targetVersionsOf(zone).osVersion(application.nodeType());
                 for (Node node : nodeRepository().list(zone, application.id())) {
                     var version = targetVersion.orElse(node.wantedOsVersion());
-                    nodeRepository().putByHostname(zone, new Node(
-                            node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(), node.currentVersion(),
-                            node.wantedVersion(), version, version, node.serviceState(),
-                            node.restartGeneration(), node.wantedRestartGeneration(), node.rebootGeneration(),
-                            node.wantedRebootGeneration(), node.vcpu(), node.memoryGb(), node.diskGb(),
-                            node.bandwidthGbps(), node.fastDisk(), node.cost(), node.canonicalFlavor(),
-                            node.clusterId(), node.clusterType()));
+                    nodeRepository().putByHostname(zone, new Node.Builder(node).currentOsVersion(version).wantedOsVersion(version).build());
                 }
             }
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/versions/VersionStatusTest.java
@@ -66,7 +66,7 @@ public class VersionStatusTest {
         // Upgrade some config servers
         for (ZoneApi zone : tester.zoneRegistry().zones().all().zones()) {
             for (Node node : tester.configServer().nodeRepository().list(zone.getId(), SystemApplication.configServer.id())) {
-                Node upgradedNode = new Node(node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(), version1, node.wantedVersion());
+                Node upgradedNode = new Node.Builder(node).currentVersion(version1).build();
                 tester.configServer().nodeRepository().putByHostname(zone.getId(), upgradedNode);
                 break;
             }
@@ -110,7 +110,7 @@ public class VersionStatusTest {
         Version ancientVersion = Version.fromString("5.1");
         for (ZoneApi zone : tester.controller().zoneRegistry().zones().all().zones()) {
             for (Node node : tester.configServer().nodeRepository().list(zone.getId(), SystemApplication.configServer.id())) {
-                Node downgradedNode = new Node(node.hostname(), node.parentHostname(), node.state(), node.type(), node.owner(), ancientVersion, node.wantedVersion());
+                Node downgradedNode = new Node.Builder(node).currentVersion(ancientVersion).build();
                 tester.configServer().nodeRepository().putByHostname(zone.getId(), downgradedNode);
                 break;
             }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
@@ -28,6 +28,8 @@ public class NodeRepositoryNode {
     public String openStackId;
     @JsonProperty("flavor")
     public String flavor;
+    @JsonProperty("resources")
+    public NodeResources resources;
     @JsonProperty("membership")
     public Membership membership;
     @JsonProperty("owner")
@@ -56,12 +58,6 @@ public class NodeRepositoryNode {
     public String modelName;
     @JsonProperty("failCount")
     public Integer failCount;
-    @JsonProperty("fastDisk")
-    public Boolean fastDisk;
-    @JsonProperty("remoteStorage")
-    public Boolean remoteStorage;
-    @JsonProperty("bandwidthGbps")
-    public Double bandwidthGbps;
     @JsonProperty("environment")
     public String environment;
     @JsonProperty("type")
@@ -76,12 +72,6 @@ public class NodeRepositoryNode {
     public Boolean wantToRetire;
     @JsonProperty("wantToDeprovision")
     public Boolean wantToDeprovision;
-    @JsonProperty("minDiskAvailableGb")
-    public Double minDiskAvailableGb;
-    @JsonProperty("minMainMemoryAvailableGb")
-    public Double minMainMemoryAvailableGb;
-    @JsonProperty("minCpuCores")
-    public Double minCpuCores;
     @JsonProperty("allowedToBeDown")
     public Boolean allowedToBeDown;
 
@@ -98,6 +88,7 @@ public class NodeRepositoryNode {
                 ", openStackId='" + openStackId + '\'' +
                 ", modelName='" + modelName + '\'' +
                 ", flavor='" + flavor + '\'' +
+                ", resources=" + resources +
                 ", membership=" + membership +
                 ", owner=" + owner +
                 ", restartGeneration=" + restartGeneration +
@@ -111,9 +102,6 @@ public class NodeRepositoryNode {
                 ", currentFirmwareCheck=" + currentFirmwareCheck +
                 ", wantedFirmwareCheck=" + wantedFirmwareCheck +
                 ", failCount=" + failCount +
-                ", fastDisk=" + fastDisk +
-                ", remoteStorage=" + remoteStorage +
-                ", bandwidthGbps=" + bandwidthGbps +
                 ", environment='" + environment + '\'' +
                 ", type='" + type + '\'' +
                 ", wantedDockerImage='" + wantedDockerImage + '\'' +
@@ -121,9 +109,6 @@ public class NodeRepositoryNode {
                 ", parentHostname='" + parentHostname + '\'' +
                 ", wantToRetire=" + wantToRetire +
                 ", wantToDeprovision=" + wantToDeprovision +
-                ", minDiskAvailableGb=" + minDiskAvailableGb +
-                ", minMainMemoryAvailableGb=" + minMainMemoryAvailableGb +
-                ", minCpuCores=" + minCpuCores +
                 ", allowedToBeDown=" + allowedToBeDown +
                 ", reports=" + reports +
                 '}';
@@ -169,6 +154,35 @@ public class NodeRepositoryNode {
                     " index = " + index +
                     " retired = " + retired +
                     " }";
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class NodeResources {
+        @JsonProperty
+        public Double vcpu;
+        @JsonProperty
+        public Double memoryGb;
+        @JsonProperty
+        public Double diskGb;
+        @JsonProperty
+        public Double bandwidthGbps;
+        @JsonProperty
+        public String diskSpeed;
+        @JsonProperty
+        public String storageType;
+
+        @Override
+        public String toString() {
+            return "NodeResources{" +
+                    "vcpu=" + vcpu +
+                    ", memoryGb=" + memoryGb +
+                    ", diskGb=" + diskGb +
+                    ", bandwidthGbps=" + bandwidthGbps +
+                    ", diskSpeed='" + diskSpeed + '\'' +
+                    ", storageType='" + storageType + '\'' +
+                    '}';
         }
     }
 }


### PR DESCRIPTION
* Updates controller's and node-admin's node-repository clients to use `resources` object.
* Removes usage of `canonicalFlavor` (is equal to `flavor`) and `description` (removed a while ago) from controller's node-repository client.
* Adds `diskSpeed` and `storageType` to `/application/v4/` nodes response.

Must be merged with the corresponding PR in internal repo.