### PR TITLE
Bjorncs/tls utils

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/SslContextBuilder.java
+++ b/security-utils/src/main/java/com/yahoo/security/SslContextBuilder.java
@@ -2,6 +2,7 @@
 package com.yahoo.security;
 
 import com.yahoo.security.tls.KeyManagerUtils;
+import com.yahoo.security.tls.TlsContext;
 import com.yahoo.security.tls.TrustManagerUtils;
 
 import javax.net.ssl.KeyManager;
@@ -122,7 +123,7 @@ public class SslContextBuilder {
 
     public SSLContext build() {
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            SSLContext sslContext = SSLContext.getInstance(TlsContext.SSL_CONTEXT_VERSION);
             TrustManager[] trustManagers = new TrustManager[] { trustManagerFactory.createTrustManager(trustStoreSupplier.get()) };
             X509ExtendedKeyManager keyManager = this.keyManager != null
                     ? this.keyManager

--- a/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
@@ -35,6 +35,7 @@ public interface TlsContext extends AutoCloseable {
             "TLS_CHACHA20_POLY1305_SHA256"); // TLSv1.3, Java 12
 
     Set<String> ALLOWED_PROTOCOLS = Set.of("TLSv1.2"); // TODO Enable TLSv1.3
+    String SSL_CONTEXT_VERSION = "TLSv1.2"; // TODO Enable TLSv1.3
 
     /**
      * @return the allowed cipher suites supported by the provided context instance

--- a/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
@@ -204,9 +204,9 @@ public class VespaZooKeeperServerImplTest {
     private String commonTlsConfig() {
         return "ssl.quorum.hostnameVerification=false\n" +
                "ssl.quorum.clientAuth=NEED\n" +
-               "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n" +
+               "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n" +
                "ssl.quorum.enabledProtocols=TLSv1.2\n" +
-               "ssl.quorum.protocol=TLS\n";
+               "ssl.quorum.protocol=TLSv1.2\n";
     }
 
     private void validateConfigFileMultipleHosts(File cfgFile) throws IOException {


### PR DESCRIPTION
Note: This will reintroduce `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` as allowed cipher for Zookeeper.