### PR TITLE
Fix ever-growing message tracker for concurrent Get operations

### DIFF
--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -532,7 +532,6 @@ TEST_F(ExternalOperationHandlerTest, gets_are_busy_bounced_during_transition_per
             makeGetCommandForUser(non_owned_bucket.withoutCountBits())));
     EXPECT_EQ("ReturnCode(BUSY, Currently pending cluster state transition from version 123 to 321)",
               _sender.reply(0)->getResult().toString());
-
 }
 
 // TODO support sequencing of RemoveLocation? It's a mutating operation, but supporting it with

--- a/storage/src/vespa/storage/common/messagesender.h
+++ b/storage/src/vespa/storage/common/messagesender.h
@@ -27,7 +27,7 @@ namespace storage::api {
 namespace storage {
 
 struct MessageSender {
-    virtual ~MessageSender() {}
+    virtual ~MessageSender() = default;
 
     virtual void sendCommand(const std::shared_ptr<api::StorageCommand>&) = 0;
     virtual void sendReply(const std::shared_ptr<api::StorageReply>&) = 0;
@@ -36,7 +36,7 @@ struct MessageSender {
 };
 
 struct ChainedMessageSender {
-    virtual ~ChainedMessageSender() {}
+    virtual ~ChainedMessageSender() = default;
     virtual void sendUp(const std::shared_ptr<api::StorageMessage>&) = 0;
     virtual void sendDown(const std::shared_ptr<api::StorageMessage>&) = 0;
 };

--- a/storage/src/vespa/storage/common/storagelink.cpp
+++ b/storage/src/vespa/storage/common/storagelink.cpp
@@ -173,7 +173,7 @@ void StorageLink::sendUp(const shared_ptr<StorageMessage> & msg)
         ost << vespalib::getStackTrace(0);
         if (!msg->getType().isReply()) {
             LOGBP(warning, "%s", ost.str().c_str());
-            StorageCommand& cmd = static_cast<StorageCommand&>(*msg);
+            auto& cmd = static_cast<StorageCommand&>(*msg);
             shared_ptr<StorageReply> reply(cmd.makeReply().release());
 
             if (reply.get()) {

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -55,13 +55,15 @@ public:
                 HostInfo& hostInfoReporterRegistrar,
                 ChainedMessageSender* = nullptr);
 
-    ~Distributor();
+    ~Distributor() override;
 
     void onOpen() override;
     void onClose() override;
     bool onDown(const std::shared_ptr<api::StorageMessage>&) override;
     void sendUp(const std::shared_ptr<api::StorageMessage>&) override;
     void sendDown(const std::shared_ptr<api::StorageMessage>&) override;
+    // Bypasses message tracker component. Thread safe.
+    void send_up_without_tracking(const std::shared_ptr<api::StorageMessage>&);
 
     ChainedMessageSender& getMessageSender() override {
         return (_messageSender == 0 ? *this : *_messageSender);

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -20,6 +20,7 @@ namespace distributor {
 
 class Distributor;
 class MaintenanceOperationGenerator;
+class DirectDispatchSender;
 
 class ExternalOperationHandler : public DistributorComponent,
                                  public api::MessageHandler
@@ -55,6 +56,8 @@ public:
     // Returns true iff message was handled and should not be processed further by the caller.
     bool try_handle_message_outside_main_thread(const std::shared_ptr<api::StorageMessage>& msg);
 
+    void close_pending();
+
     void set_concurrent_gets_enabled(bool enabled) noexcept {
         _concurrent_gets_enabled.store(enabled, std::memory_order_relaxed);
     }
@@ -64,6 +67,7 @@ public:
     }
 
 private:
+    std::unique_ptr<DirectDispatchSender> _direct_dispatch_sender;
     const MaintenanceOperationGenerator& _operationGenerator;
     OperationSequencer _mutationSequencer;
     Operation::SP _op;


### PR DESCRIPTION
@geirst please review.

When Get requests initiated outside the main distributor thread were sent
via the `MessageSender` that is implemented by the main `Distributor` instance,
they would be implicitly registered with the pending message tracker.
Not only was this thread unsafe, the registrations would never be cleared
away since the reply pipeline bypassed it entirely. This would cause a silent
memory leak that would build up many small allocations over time.

We now dispatch Get requests directly through the storage link chain, bypassing
the message tracking component. This both fixes the leak and avoids extra
overhead for the Get requests.

Note: the concurrent Get feature is _not_ enabled by default.

Also fixes an issue where concurrent Get operations weren't correctly
gracefully aborted when the node shuts down.
