### PR TITLE
Preserve DNS records for inactive load balancers

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/RoutingPolicy.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/RoutingPolicy.java
@@ -27,16 +27,18 @@ public class RoutingPolicy {
     private final HostName canonicalName;
     private final Optional<String> dnsZone;
     private final Set<EndpointId> endpoints;
+    private final boolean active;
 
     /** DO NOT USE. Public for serialization purposes */
     public RoutingPolicy(ApplicationId owner, ClusterSpec.Id cluster, ZoneId zone, HostName canonicalName,
-                         Optional<String> dnsZone, Set<EndpointId> endpoints) {
+                         Optional<String> dnsZone, Set<EndpointId> endpoints, boolean active) {
         this.owner = Objects.requireNonNull(owner, "owner must be non-null");
         this.cluster = Objects.requireNonNull(cluster, "cluster must be non-null");
         this.zone = Objects.requireNonNull(zone, "zone must be non-null");
         this.canonicalName = Objects.requireNonNull(canonicalName, "canonicalName must be non-null");
         this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
         this.endpoints = ImmutableSortedSet.copyOf(Objects.requireNonNull(endpoints, "endpoints must be non-null"));
+        this.active = active;
     }
 
     /** The application owning this */
@@ -67,6 +69,11 @@ public class RoutingPolicy {
     /** The endpoints of this policy */
     public Set<EndpointId> endpoints() {
         return endpoints;
+    }
+
+    /** Returns whether this is active (the underlying load balancer is in an active state) */
+    public boolean active() {
+        return active;
     }
 
     /** Returns the endpoint of this */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -909,6 +909,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         // Per-cluster rotations
         Set<RoutingPolicy> routingPolicies = controller.applications().routingPolicies().get(instance.id());
         for (RoutingPolicy policy : routingPolicies) {
+            if (!policy.active()) continue;
             policy.rotationEndpointsIn(controller.system()).asList().stream()
                   .map(Endpoint::url)
                   .map(URI::toString)
@@ -1009,6 +1010,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         // Add endpoint(s) defined by routing policies
         var endpointArray = response.setArray("endpoints");
         for (var policy : controller.applications().routingPolicies().get(deploymentId)) {
+            if (!policy.active()) continue;
             Cursor endpointObject = endpointArray.addObject();
             Endpoint endpoint = policy.endpointIn(controller.system());
             endpointObject.setString("cluster", policy.cluster().value());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunnerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunnerTest.java
@@ -221,13 +221,13 @@ public class InternalStepRunnerTest {
                                                                                                       JobType.systemTest.zone(system()),
                                                                                                       HostName.from("host"),
                                                                                                       Optional.empty(),
-                                                                                                      emptySet())));
+                                                                                                      emptySet(), true)));
         tester.controller().curator().writeRoutingPolicies(app.testerId().id(), Set.of(new RoutingPolicy(app.testerId().id(),
                                                                                                          ClusterSpec.Id.from("default"),
                                                                                                          JobType.systemTest.zone(system()),
                                                                                                          HostName.from("host"),
                                                                                                          Optional.empty(),
-                                                                                                         emptySet())));
+                                                                                                         emptySet(), true)));
         tester.runner().run();;
         assertEquals(succeeded, tester.jobs().last(app.instanceId(), JobType.systemTest).get().steps().get(Step.installReal));
         assertEquals(succeeded, tester.jobs().last(app.instanceId(), JobType.systemTest).get().steps().get(Step.installTester));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/RoutingPoliciesTest.java
@@ -320,14 +320,6 @@ public class RoutingPoliciesTest {
                                      LoadBalancer.State.active,
                                      Optional.of("dns-zone-1")));
         }
-        // Add an inactive load balancers that should be ignored
-        loadBalancers.add(new LoadBalancer("inactive-LB-0-Z-" + zone.value(),
-                                           application,
-                                           ClusterSpec.Id.from("c0"),
-                                           HostName.from("lb-0--" + application.serializedForm() +
-                                                         "--" + zone.value()),
-                                           LoadBalancer.State.inactive,
-                                           Optional.of("dns-zone-1")));
         return loadBalancers;
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializerTest.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.config.SlimeUtils;
 import com.yahoo.vespa.hosted.controller.application.EndpointId;
 import com.yahoo.vespa.hosted.controller.application.RoutingPolicy;
 import org.junit.Test;
@@ -15,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mortent
@@ -24,7 +26,7 @@ public class RoutingPolicySerializerTest {
     private final RoutingPolicySerializer serializer = new RoutingPolicySerializer();
 
     @Test
-    public void test_serialization() {
+    public void serialization() {
         var owner = ApplicationId.defaultId();
         var endpoints = Set.of(EndpointId.of("r1"), EndpointId.of("r2"));
         var policies = ImmutableSet.of(new RoutingPolicy(owner,
@@ -32,13 +34,13 @@ public class RoutingPolicySerializerTest {
                                                          ZoneId.from("prod", "us-north-1"),
                                                          HostName.from("long-and-ugly-name"),
                                                          Optional.of("zone1"),
-                                                         endpoints),
+                                                         endpoints, true),
                                        new RoutingPolicy(owner,
                                                          ClusterSpec.Id.from("my-cluster2"),
                                                          ZoneId.from("prod", "us-north-2"),
                                                          HostName.from("long-and-ugly-name-2"),
                                                          Optional.empty(),
-                                                         endpoints));
+                                                         endpoints, false));
         var serialized = serializer.fromSlime(owner, serializer.toSlime(policies));
         assertEquals(policies.size(), serialized.size());
         for (Iterator<RoutingPolicy> it1 = policies.iterator(), it2 = serialized.iterator(); it1.hasNext();) {
@@ -50,7 +52,18 @@ public class RoutingPolicySerializerTest {
             assertEquals(expected.canonicalName(), actual.canonicalName());
             assertEquals(expected.dnsZone(), actual.dnsZone());
             assertEquals(expected.endpoints(), actual.endpoints());
+            assertEquals(expected.active(), actual.active());
         }
+    }
+
+    @Test
+    public void legacy_serialization() {
+        var json = "{\"routingPolicies\":[{\"cluster\":\"default\",\"zone\":\"prod.us-north-1\"," +
+                   "\"canonicalName\":\"lb-0\"," +
+                   "\"dnsZone\":\"dns-zone-id\",\"rotations\":[]}]}";
+        var serialized = serializer.fromSlime(ApplicationId.defaultId(), SlimeUtils.jsonToSlime(json));
+        assertTrue(serialized.iterator().next().active());
+
     }
 
 }


### PR DESCRIPTION
This change ensures that we preserve DNS records, as long as the underlying load
balancer exists, even if it's inactive.

Inactive routing policies are excluded in the application API so that endpoints
for deleted clusters are not shown in console.