### PR TITLE
tensor peek

### DIFF
--- a/eval/src/tests/eval/compiled_function/compiled_function_test.cpp
+++ b/eval/src/tests/eval/compiled_function/compiled_function_test.cpp
@@ -58,6 +58,9 @@ std::vector<vespalib::string> unsupported = {
 };
 
 bool is_unsupported(const vespalib::string &expression) {
+    if (expression.find("{") != vespalib::string::npos) {
+        return true;
+    }
     for (const auto &prefix: unsupported) {
         if (starts_with(expression, prefix)) {
             return true;

--- a/eval/src/tests/eval/node_types/node_types_test.cpp
+++ b/eval/src/tests/eval/node_types/node_types_test.cpp
@@ -214,6 +214,31 @@ TEST("require that tensor create resolves correct type") {
     TEST_DO(verify("tensor(x[3]):{{x:0}:double,{x:1}:error,{x:2}:double}", "error"));
 }
 
+TEST("require that tensor peek resolves correct type") {
+    TEST_DO(verify("tensor(x[3]){x:1}", "double"));
+    TEST_DO(verify("tensor(x[3]){x:double}", "error"));
+    TEST_DO(verify("tensor(x[3]){x:(double)}", "double"));
+    TEST_DO(verify("tensor(x[3]){x:3}", "error"));
+    TEST_DO(verify("tensor(x{}){x:1}", "double"));
+    TEST_DO(verify("tensor(x{}){x:foo}", "double"));
+    TEST_DO(verify("tensor(x{}){x:(double)}", "double"));
+    TEST_DO(verify("tensor(x{}){x:tensor(x[3])}", "error"));
+    TEST_DO(verify("tensor(x{},y[3]){x:foo,y:2}", "double"));
+    TEST_DO(verify("tensor(x{},y[3]){x:foo}", "tensor(y[3])"));
+    TEST_DO(verify("tensor(x{},y[3]){y:2}", "tensor(x{})"));
+    TEST_DO(verify("tensor<float>(x[3]){x:1}", "double"));
+    TEST_DO(verify("tensor<float>(x[3]){x:double}", "error"));
+    TEST_DO(verify("tensor<float>(x[3]){x:(double)}", "double"));
+    TEST_DO(verify("tensor<float>(x[3]){x:3}", "error"));
+    TEST_DO(verify("tensor<float>(x{}){x:1}", "double"));
+    TEST_DO(verify("tensor<float>(x{}){x:foo}", "double"));
+    TEST_DO(verify("tensor<float>(x{}){x:(double)}", "double"));
+    TEST_DO(verify("tensor<float>(x{}){x:tensor(x[3])}", "error"));
+    TEST_DO(verify("tensor<float>(x{},y[3]){x:foo,y:2}", "double"));
+    TEST_DO(verify("tensor<float>(x{},y[3]){x:foo}", "tensor<float>(y[3])"));
+    TEST_DO(verify("tensor<float>(x{},y[3]){y:2}", "tensor<float>(x{})"));
+}
+
 TEST("require that tensor concat resolves correct type") {
     TEST_DO(verify("concat(double,double,x)", "tensor(x[2])"));
     TEST_DO(verify("concat(tensor(x[2]),tensor(x[3]),x)", "tensor(x[5])"));

--- a/eval/src/vespa/eval/eval/interpreted_function.cpp
+++ b/eval/src/vespa/eval/eval/interpreted_function.cpp
@@ -6,6 +6,7 @@
 #include "check_type.h"
 #include "tensor_spec.h"
 #include "operation.h"
+#include "tensor_nodes.h"
 #include "tensor_engine.h"
 #include <vespa/vespalib/util/classname.h>
 #include <vespa/eval/eval/llvm/compile_cache.h>
@@ -21,13 +22,13 @@ namespace eval {
 namespace {
 
 const Function *get_lambda(const nodes::Node &node) {
-    if (auto ptr = as<nodes::TensorMap>(node)) {
+    if (auto ptr = nodes::as<nodes::TensorMap>(node)) {
         return &ptr->lambda();
     }
-    if (auto ptr = as<nodes::TensorJoin>(node)) {
+    if (auto ptr = nodes::as<nodes::TensorJoin>(node)) {
         return &ptr->lambda();
     }
-    if (auto ptr = as<nodes::TensorLambda>(node)) {
+    if (auto ptr = nodes::as<nodes::TensorLambda>(node)) {
         return &ptr->lambda();
     }
     return nullptr;

--- a/eval/src/vespa/eval/eval/key_gen.cpp
+++ b/eval/src/vespa/eval/eval/key_gen.cpp
@@ -42,6 +42,7 @@ struct KeyGen : public NodeVisitor, public NodeTraverser {
     void visit(const TensorLambda &) override { add_byte(15); } // type/lambda should be part of key
     void visit(const TensorConcat &) override { add_byte(16); } // dimension should be part of key
     void visit(const TensorCreate &) override { add_byte(17); } // type should be part of key
+    void visit(const TensorPeek   &) override { add_byte(18); } // addr should be part of key
     void visit(const Add          &) override { add_byte(20); }
     void visit(const Sub          &) override { add_byte(21); }
     void visit(const Mul          &) override { add_byte(22); }

--- a/eval/src/vespa/eval/eval/llvm/compiled_function.cpp
+++ b/eval/src/vespa/eval/eval/llvm/compiled_function.cpp
@@ -132,7 +132,8 @@ CompiledFunction::detect_issues(const Function &function)
                                   nodes::TensorRename,
                                   nodes::TensorLambda,
                                   nodes::TensorConcat,
-                                  nodes::TensorCreate>(node))
+                                  nodes::TensorCreate,
+                                  nodes::TensorPeek>(node))
             {
                 issues.push_back(make_string("unsupported node type: %s",
                                 getClassName(node).c_str()));

--- a/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
+++ b/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
@@ -482,6 +482,9 @@ struct FunctionBuilder : public NodeVisitor, public NodeTraverser {
     void visit(const TensorCreate &node) override {
         make_error(node.num_children());
     }
+    void visit(const TensorPeek &node) override {
+        make_error(node.num_children());
+    }
 
     // operator nodes
 

--- a/eval/src/vespa/eval/eval/node_visitor.h
+++ b/eval/src/vespa/eval/eval/node_visitor.h
@@ -36,6 +36,7 @@ struct NodeVisitor {
     virtual void visit(const nodes::TensorLambda &) = 0;
     virtual void visit(const nodes::TensorConcat &) = 0;
     virtual void visit(const nodes::TensorCreate &) = 0;
+    virtual void visit(const nodes::TensorPeek   &) = 0;
 
     // operator nodes
     virtual void visit(const nodes::Add          &) = 0;
@@ -105,6 +106,7 @@ struct EmptyNodeVisitor : NodeVisitor {
     void visit(const nodes::TensorLambda &) override {}
     void visit(const nodes::TensorConcat &) override {}
     void visit(const nodes::TensorCreate &) override {}
+    void visit(const nodes::TensorPeek   &) override {}
     void visit(const nodes::Add          &) override {}
     void visit(const nodes::Sub          &) override {}
     void visit(const nodes::Mul          &) override {}

--- a/eval/src/vespa/eval/eval/simple_tensor_engine.h
+++ b/eval/src/vespa/eval/eval/simple_tensor_engine.h
@@ -20,10 +20,10 @@ public:
     static const TensorEngine &ref() { return _engine; };
 
     TensorSpec to_spec(const Value &value) const override;
-    Value::UP from_spec(const TensorSpec &spec) const override;
+    std::unique_ptr<Value> from_spec(const TensorSpec &spec) const override;
 
     void encode(const Value &value, nbostream &output) const override;
-    Value::UP decode(nbostream &input) const override;
+    std::unique_ptr<Value> decode(nbostream &input) const override;
 
     const Value &map(const Value &a, map_fun_t function, Stash &stash) const override;
     const Value &join(const Value &a, const Value &b, join_fun_t function, Stash &stash) const override;

--- a/eval/src/vespa/eval/eval/string_stuff.cpp
+++ b/eval/src/vespa/eval/eval/string_stuff.cpp
@@ -5,6 +5,19 @@
 
 namespace vespalib::eval {
 
+bool is_number(const vespalib::string &str) {
+    for (char c: str) {
+        if (!isdigit(c)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+size_t as_number(const vespalib::string &str) {
+    return atoi(str.c_str());
+}
+
 vespalib::string as_string(const TensorSpec::Address &address) {
     CommaTracker label_list;
     vespalib::string str = "{";

--- a/eval/src/vespa/eval/eval/string_stuff.h
+++ b/eval/src/vespa/eval/eval/string_stuff.h
@@ -38,6 +38,16 @@ struct CommaTracker {
 };
 
 /**
+ * Is this string a positive integer (dimension index)
+ **/
+bool is_number(const vespalib::string &str);
+
+/**
+ * Convert this string to a positive integer (dimension index)
+ **/
+size_t as_number(const vespalib::string &str);
+
+/**
  * Convert a tensor spec address into a string on the form:
  * '{dim1:label,dim2:index, ...}'
  **/

--- a/eval/src/vespa/eval/eval/tensor_engine.h
+++ b/eval/src/vespa/eval/eval/tensor_engine.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "value_type.h"
-#include "tensor_function.h"
 #include "aggr.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <memory>
@@ -18,8 +16,9 @@ class nbostream;
 namespace eval {
 
 struct Value;
-class Tensor;
+class ValueType;
 class TensorSpec;
+class TensorFunction;
 
 /**
  * Top-level API for a tensor implementation. All Tensor operations
@@ -33,7 +32,6 @@ class TensorSpec;
 struct TensorEngine
 {
     using Aggr = eval::Aggr;
-    using Tensor = eval::Tensor;
     using TensorFunction = eval::TensorFunction;
     using TensorSpec = eval::TensorSpec;
     using Value = eval::Value;
@@ -42,10 +40,10 @@ struct TensorEngine
     using map_fun_t = double (*)(double);
 
     virtual TensorSpec to_spec(const Value &value) const = 0;
-    virtual Value::UP from_spec(const TensorSpec &spec) const = 0;
+    virtual std::unique_ptr<Value> from_spec(const TensorSpec &spec) const = 0;
 
     virtual void encode(const Value &value, nbostream &output) const = 0;
-    virtual Value::UP decode(nbostream &input) const = 0;
+    virtual std::unique_ptr<Value> decode(nbostream &input) const = 0;
 
     virtual const TensorFunction &optimize(const TensorFunction &expr, Stash &) const { return expr; }
 

--- a/eval/src/vespa/eval/eval/tensor_nodes.cpp
+++ b/eval/src/vespa/eval/eval/tensor_nodes.cpp
@@ -14,6 +14,7 @@ void TensorRename::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 void TensorLambda::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 void TensorConcat::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 void TensorCreate::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
+void TensorPeek  ::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 
 } // namespace vespalib::eval::nodes
 } // namespace vespalib::eval

--- a/eval/src/vespa/eval/eval/test/eval_spec.cpp
+++ b/eval/src/vespa/eval/eval/test/eval_spec.cpp
@@ -178,6 +178,7 @@ EvalSpec::add_tensor_operation_cases() {
     add_expression({"a","b"}, "concat(a,b,x)");
     add_expression({"a","b"}, "concat(a,b,y)");
     add_expression({}, "tensor(x[3]):{{x:0}:0,{x:1}:1,{x:2}:2}");
+    add_expression({"a"}, "a{x:3}");
 }
 
 void

--- a/eval/src/vespa/eval/eval/test/tensor_conformance.cpp
+++ b/eval/src/vespa/eval/eval/test/tensor_conformance.cpp
@@ -810,6 +810,25 @@ struct TestContext {
 
     //-------------------------------------------------------------------------
 
+    void test_tensor_peek(const vespalib::string &expr, const TensorSpec &param, const TensorSpec &expect) {
+        TEST_DO(verify_result(Expr_TT(expr).eval(engine, param, spec(1.0)), expect));
+    }
+
+    void test_tensor_peek() {
+        auto param_double = spec({x({"0", "1"}),y(2)}, Seq({1.0, 2.0, 3.0, 4.0}));
+        auto param_float = spec(float_cells({x({"0", "1"}),y(2)}), Seq({1.0, 2.0, 3.0, 4.0}));
+        TEST_DO(test_tensor_peek("tensor(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_double, spec(x(2), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_float, spec(x(2), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor<float>(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_double, spec(float_cells({x(2)}), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor<float>(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_float, spec(float_cells({x(2)}), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("a{x:(b)}", param_double, spec(y(2), Seq({3.0, 4.0}))));
+        TEST_DO(test_tensor_peek("a{x:(b)}", param_float, spec(float_cells({y(2)}), Seq({3.0, 4.0}))));
+        TEST_DO(test_tensor_peek("a{y:(b)}", param_double, spec(x({"0", "1"}), Seq({2.0, 4.0}))));
+        TEST_DO(test_tensor_peek("a{y:(b)}", param_float, spec(float_cells({x({"0", "1"})}), Seq({2.0, 4.0}))));
+    }
+
+    //-------------------------------------------------------------------------
+
     void verify_encode_decode(const TensorSpec &spec,
                               const TensorEngine &encode_engine,
                               const TensorEngine &decode_engine)
@@ -893,6 +912,7 @@ struct TestContext {
         TEST_DO(test_rename());
         TEST_DO(test_tensor_lambda());
         TEST_DO(test_tensor_create());
+        TEST_DO(test_tensor_peek());
         TEST_DO(test_binary_format());
     }
 };

--- a/eval/src/vespa/eval/eval/visit_stuff.h
+++ b/eval/src/vespa/eval/eval/visit_stuff.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/vespalib/objects/visit.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <vector>
 

--- a/eval/src/vespa/eval/tensor/default_tensor_engine.h
+++ b/eval/src/vespa/eval/tensor/default_tensor_engine.h
@@ -19,10 +19,10 @@ public:
     static const TensorEngine &ref() { return _engine; };
 
     TensorSpec to_spec(const Value &value) const override;
-    Value::UP from_spec(const TensorSpec &spec) const override;
+    std::unique_ptr<Value> from_spec(const TensorSpec &spec) const override;
 
     void encode(const Value &value, nbostream &output) const override;
-    Value::UP decode(nbostream &input) const override;
+    std::unique_ptr<Value> decode(nbostream &input) const override;
 
     const TensorFunction &optimize(const TensorFunction &expr, Stash &stash) const override;
 

--- a/searchlib/src/vespa/searchlib/expression/resultvector.h
+++ b/searchlib/src/vespa/searchlib/expression/resultvector.h
@@ -97,7 +97,7 @@ public:
     void reserve(size_t sz) override { _result.reserve(sz); }
     void negate() override;
 private:
-    void visitMembers(vespalib::ObjectVisitor &visitor) const override { visit(visitor, "Vector", _result); }
+    void visitMembers(vespalib::ObjectVisitor &visitor) const override { ::visit(visitor, "Vector", _result); }
     size_t onSize() const override { return _result.size(); }
     const vespalib::Identifiable::RuntimeClass & getBaseClass() const override { return B::_RTClass; }
     int64_t onGetInteger(size_t index) const override { return _result[index].getInteger(index); }

--- a/staging_vespalib/src/vespa/vespalib/objects/visit.hpp
+++ b/staging_vespalib/src/vespa/vespalib/objects/visit.hpp
@@ -48,7 +48,7 @@ template<typename T>
 void visit(vespalib::ObjectVisitor &self, const vespalib::string &name, const std::vector<T> &list) {
     self.openStruct(name, "std::vector");
     for (uint32_t i = 0; i < list.size(); ++i) {
-        visit(self, vespalib::make_string("[%u]", i), list[i]);
+        ::visit(self, vespalib::make_string("[%u]", i), list[i]);
     }
     self.closeStruct();
 }
@@ -57,7 +57,7 @@ template<typename T>
 void visit(vespalib::ObjectVisitor &self, const vespalib::string &name, const vespalib::Array<T> &list) {
     self.openStruct(name, "vespalib::Array");
     for (uint32_t i = 0; i < list.size(); ++i) {
-        visit(self, vespalib::make_string("[%u]", i), list[i]);
+        ::visit(self, vespalib::make_string("[%u]", i), list[i]);
     }
     self.closeStruct();
 }


### PR DESCRIPTION
initial implementation of tensor peek (very slow). Supports peeking tensor sub-spaces in addition to peeking individual cell values. Also supports auto-conversion from numeric expression result to string label for mapped dimensions. Access outside tensors detected compile-time will result in type resolution failure. Run-time out-of-bounds access results in the value 0.0

@arnej27959 please review
@bratseth FYI