### PR TITLE
Preserve AssignValueUpdates to struct fields in indexing docproc

### DIFF
--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -19,6 +19,7 @@ import com.yahoo.document.datatypes.Struct;
 import com.yahoo.document.datatypes.WeightedSet;
 import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
+import com.yahoo.document.update.AssignValueUpdate;
 import com.yahoo.document.update.FieldUpdate;
 import com.yahoo.document.update.MapValueUpdate;
 import com.yahoo.document.update.ValueUpdate;
@@ -154,10 +155,8 @@ public class DocumentScriptTestCase {
         Struct out = (Struct)processDocument(in);
         assertSpanTrees(out.getFieldValue("myString"), "mySpanTree");
 
-        StringFieldValue str = (StringFieldValue)((MapValueUpdate)processFieldUpdate(in)).getUpdate().getValue();
-        assertSpanTrees(str, "mySpanTree");
-
-        str = (StringFieldValue)((MapValueUpdate)processFieldUpdate(in)).getUpdate().getValue();
+        var updStruct = (Struct)((AssignValueUpdate)processFieldUpdate(in)).getValue();
+        var str = (StringFieldValue)updStruct.getFieldValue(updStruct.getField("myString"));
         assertSpanTrees(str, "mySpanTree");
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldUpdateAdapter.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldUpdateAdapter.java
@@ -242,7 +242,6 @@ public class FieldUpdateAdapter implements UpdateAdapter {
 
     private static class CompleteBuilder extends PartialBuilder {
 
-        static final ValueUpdate nullMap = new MapValueUpdate(null, null);
         static final ValueUpdate nullAssign = new AssignValueUpdate(null);
 
         CompleteBuilder() {
@@ -251,11 +250,7 @@ public class FieldUpdateAdapter implements UpdateAdapter {
 
         @Override
         List<ValueUpdate> createValueUpdates(FieldValue val, ValueUpdate upd) {
-            if (val instanceof StructuredFieldValue) {
-                return super.createValueUpdates(val, nullMap);
-            } else {
-                return super.createValueUpdates(val, nullAssign);
-            }
+            return super.createValueUpdates(val, nullAssign);
         }
     }
 }


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Would previously be rewritten as `MapValueUpdates` for unknown reasons.
This wouldn't actually work, as an exception would be thrown during
serialization when sanity checking code figured out that the MapValue
update was attempted used for a non-array/wset field data type.
