### PR TITLE
Only include node states that are meterable in metering

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainer.java
@@ -100,7 +100,7 @@ public class ResourceMeterMaintainer extends Maintainer {
     private static final Set<Node.State> METERABLE_NODE_STATES = Set.of(
             Node.State.reserved,   // an application will soon use this node
             Node.State.active,     // an application is currently using this node
-            Node.State.inactive    // an application owner might set a node inactive
+            Node.State.inactive    // an application is not using it, but it is reserved for being re-introduced or decommissioned
     );
 
     private boolean isNodeStateMeterable(Node node) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
@@ -63,10 +63,7 @@ public class NodeRepositoryMock implements NodeRepository {
     }
 
     public void addNodes(ZoneId zone, List<Node> nodes) {
-        var existingNodes = nodeRepository.getOrDefault(zone, new HashMap<>());
-        var newNodes = nodes.stream().collect(Collectors.toMap(Node::hostname, Function.identity()));
-        newNodes.forEach(existingNodes::put);
-        nodeRepository.put(zone, existingNodes);
+        nodeRepository.put(zone, nodes.stream().collect(Collectors.toMap(Node::hostname, Function.identity())));
     }
 
     public void addFixedNodes(ZoneId zone) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
@@ -63,7 +63,10 @@ public class NodeRepositoryMock implements NodeRepository {
     }
 
     public void addNodes(ZoneId zone, List<Node> nodes) {
-        nodeRepository.put(zone, nodes.stream().collect(Collectors.toMap(Node::hostname, Function.identity())));
+        var existingNodes = nodeRepository.getOrDefault(zone, new HashMap<>());
+        var newNodes = nodes.stream().collect(Collectors.toMap(Node::hostname, Function.identity()));
+        newNodes.forEach(existingNodes::put);
+        nodeRepository.put(zone, existingNodes);
     }
 
     public void addFixedNodes(ZoneId zone) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceMeterMaintainerTest.java
@@ -68,7 +68,7 @@ public class ResourceMeterMaintainerTest {
         tester.configServer().nodeRepository().addFixedNodes(nonAwsZone.getId());
         tester.configServer().nodeRepository().addFixedNodes(awsZone1.getId());
         tester.configServer().nodeRepository().addFixedNodes(awsZone2.getId());
-        tester.configServer().nodeRepository().addNodes(
+        tester.configServer().nodeRepository().putByHostname(
                 awsZone1.getId(),
                 createNodesInState(
                         Node.State.provisioned,


### PR DESCRIPTION
Maintain a list of node states that are meterable, and make sure we include only these in our metering snapshots. Unfortunately, we maintain this list inside the Metering maintainer and not on the node state class itself. The reason for this is that we have _many_ different `Node.State` and `NodeState` classes that do exactly the same.