### PR TITLE
Preserve array updates with element index matching in indexing docproc

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldUpdateAdapter.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldUpdateAdapter.java
@@ -207,7 +207,9 @@ public class FieldUpdateAdapter implements UpdateAdapter {
             for (Iterator<FieldValue> it = arr.fieldValueIterator(); it.hasNext();) {
                 FieldValue childVal = it.next();
                 for (ValueUpdate childUpd : createValueUpdates(childVal, upd.getUpdate())) {
-                    ret.add(new MapValueUpdate(childVal, childUpd));
+                    // The array update is always directed towards a particular array index, which is
+                    // kept as the _value_ in the original update.
+                    ret.add(new MapValueUpdate(upd.getValue(), childUpd));
                 }
             }
             return ret;

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldUpdateHelper.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldUpdateHelper.java
@@ -88,7 +88,15 @@ public abstract class FieldUpdateHelper {
             return val;
         } else if (upd instanceof MapValueUpdate) {
             if (val instanceof Array) {
-                return createFieldValue(val, ((MapValueUpdate)upd).getUpdate());
+                var nestedUpdate = ((MapValueUpdate)upd).getUpdate();
+                if (nestedUpdate instanceof AssignValueUpdate) {
+                    // Can't assign an array's value type directly to the array, so we have to add it as a
+                    // singular element to the partial document.
+                    ((Array)val).add(nestedUpdate.getValue());
+                    return val;
+                } else {
+                    return createFieldValue(val, nestedUpdate);
+                }
             } else if (val instanceof MapFieldValue) {
                 throw new UnsupportedOperationException("Can not map into a " + val.getClass().getName() + ".");
             } else if (val instanceof StructuredFieldValue) {


### PR DESCRIPTION
@geirst please review. More fun from the indexing docproc land discovered as I'm working to extend system test coverage of this stuff.
@baldersheim FYI

The resulting `MapValueUpdate` would previously be constructed with the
wrong type for the index, causing an exception to be thrown and for the
update to fail entirely.
