### PR TITLE
FastOS_THread::Sleep -> std::chrono::sleep_for

### DIFF
--- a/config/src/tests/api/api.cpp
+++ b/config/src/tests/api/api.cpp
@@ -32,7 +32,7 @@ TEST_MT_FFF("require that source may be unable to serve config temporarily", 2, 
         ASSERT_TRUE(cfg.get() != NULL);
         ASSERT_EQUAL("myfoo", cfg->myField);
     } else {
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
         f3.myField = "myfoo";
         f2.addBuilder("myid", &f3);
         f1->reload();

--- a/config/src/tests/configfetcher/configfetcher.cpp
+++ b/config/src/tests/configfetcher/configfetcher.cpp
@@ -69,7 +69,7 @@ TEST("requireThatConfigUpdatesArePerformed") {
         while (!cb._configured && timer.elapsed().ms() < 20000.0) {
             if (cb._configured)
                 break;
-            FastOS_Thread::Sleep(1000);
+            std::this_thread::sleep_for(1s);
         }
         ASSERT_TRUE(cb._configured);
         ASSERT_TRUE(cb._config);

--- a/config/src/tests/configretriever/configretriever.cpp
+++ b/config/src/tests/configretriever/configretriever.cpp
@@ -251,7 +251,7 @@ public:
             if (configured) {
                 return true;
             }
-            FastOS_Thread::Sleep(200);
+            std::this_thread::sleep_for(200ms);
         }
         return configured;
     }

--- a/config/src/tests/frt/frt.cpp
+++ b/config/src/tests/frt/frt.cpp
@@ -49,7 +49,7 @@ namespace {
             while (timer.elapsed().ms() < timeoutInMillis) {
                 if (notified)
                     break;
-                FastOS_Thread::Sleep(100);
+                std::this_thread::sleep_for(100ms);
             }
             return notified;
         }
@@ -260,7 +260,7 @@ TEST_FF("require that request is config task is scheduled", SourceFixture(), FRT
         f1.conn.scheduler.CheckTasks();
         if (f2.result.notified)
             break;
-        FastOS_Thread::Sleep(500);
+        std::this_thread::sleep_for(500ms);
     }
     ASSERT_TRUE(f2.result.notified);
     f2.src.close();

--- a/documentapi/src/tests/policies/policies_test.cpp
+++ b/documentapi/src/tests/policies/policies_test.cpp
@@ -284,7 +284,7 @@ Test::assertMirrorReady(const slobrok::api::IMirrorAPI &mirror)
         if (mirror.ready()) {
             return;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     ASSERT_TRUE(false);
 }
@@ -297,7 +297,7 @@ Test::assertMirrorContains(const slobrok::api::IMirrorAPI &mirror, const string 
         if (mirror.lookup(pattern).size() == numEntries) {
             return;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     ASSERT_TRUE(false);
 }

--- a/documentapi/src/tests/policies/testframe.cpp
+++ b/documentapi/src/tests/policies/testframe.cpp
@@ -8,6 +8,8 @@
 #include <vespa/messagebus/testlib/simpleprotocol.h>
 #include <vespa/messagebus/testlib/simplereply.h>
 #include <vespa/messagebus/network/rpcnetworkparams.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".testframe");
@@ -297,7 +299,7 @@ TestFrame::waitSlobrok(const string &pattern, uint32_t cnt)
         if (res.size() == cnt) {
             return true;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     LOG(error, "Slobrok failed to resolve '%s' to %d recipients in time.", pattern.c_str(), cnt);
     return false;

--- a/documentapi/src/vespa/documentapi/messagebus/policies/externslobrokpolicy.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/policies/externslobrokpolicy.cpp
@@ -1,12 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "externslobrokpolicy.h"
-#include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/messagebus/routing/routingcontext.h>
+#include <vespa/vespalib/text/stringtokenizer.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/fnet/frt/frt.h>
 #include <vespa/slobrok/sbmirror.h>
 #include <vespa/fnet/transport.h>
-#include <vespa/fastos/thread.h>
+#include <thread>
 
 using slobrok::api::IMirrorAPI;
 using slobrok::api::MirrorAPI;
@@ -82,7 +83,7 @@ ExternSlobrokPolicy::lookup(mbus::RoutingContext& context, const string& pattern
     if (_firstTry) {
         int count = 0;
         while (entries.empty() && count < 100) {
-            FastOS_Thread::Sleep(50);
+            std::this_thread::sleep_for(50ms);
             entries = mirror.lookup(pattern);
             count++;
         }

--- a/fastos/src/tests/processtest.cpp
+++ b/fastos/src/tests/processtest.cpp
@@ -3,6 +3,8 @@
 #include <vespa/fastos/process.h>
 #include <vespa/fastos/timestamp.h>
 
+using namespace std::chrono_literals;
+
 class MyListener : public FastOS_ProcessRedirectListener
 {
 private:
@@ -119,7 +121,7 @@ public:
                xproc->WriteStdin(nullptr, 0);
             }
 
-            FastOS_Thread::Sleep(1000);
+            std::this_thread::sleep_for(1s);
          }
 
          if(i == 10)

--- a/fastos/src/tests/thread_bounce_test.cpp
+++ b/fastos/src/tests/thread_bounce_test.cpp
@@ -43,7 +43,7 @@ class Thread_Bounce_Test : public ThreadTestBase
 
        int left = static_cast<int>(checkTime.elapsed().ms());
        while (left < 1000) {
-         FastOS_Thread::Sleep(1000 - left);
+         std::this_thread::sleep_for(std::chrono::milliseconds(1000 - left));
          left = static_cast<int>(checkTime.elapsed().ms());
        }
 

--- a/fastos/src/tests/thread_mutex_test.cpp
+++ b/fastos/src/tests/thread_mutex_test.cpp
@@ -132,7 +132,7 @@ class Thread_Mutex_Test : public ThreadTestBase
       {
          bool lockrc;
 
-         FastOS_Thread::Sleep(1000);
+         std::this_thread::sleep_for(1s);
 
          for(int i=0; i<5; i++)
          {
@@ -145,7 +145,7 @@ class Thread_Mutex_Test : public ThreadTestBase
             }
          }
 
-         FastOS_Thread::Sleep(2000);
+         std::this_thread::sleep_for(2s);
 
          lockrc = mtx.try_lock();
          Progress(lockrc, "We should get the mutex lock now (%s)",

--- a/fastos/src/tests/thread_sleep_test.cpp
+++ b/fastos/src/tests/thread_sleep_test.cpp
@@ -20,7 +20,7 @@ class Thread_Sleep_Test : public ThreadTestBase
          Progress(rc, "Creating Thread");
 
          Progress(true, "Sleeping 3 seconds");
-         FastOS_Thread::Sleep(3000);
+         std::this_thread::sleep_for(3s);
       }
 
       Progress(true, "Closing threadpool...");

--- a/fastos/src/tests/thread_stats_test.cpp
+++ b/fastos/src/tests/thread_stats_test.cpp
@@ -31,7 +31,7 @@ class Thread_Stats_Test : public ThreadTestBase
       job[0].ownThread = pool.NewThread(this,
                                         static_cast<void *>(&job[0]));
 
-      FastOS_Thread::Sleep(1000);
+      std::this_thread::sleep_for(1s);
 
       inactiveThreads = pool.GetNumInactiveThreads();
       Progress(inactiveThreads == 0, "Inactive threads = %d", inactiveThreads);
@@ -44,7 +44,7 @@ class Thread_Stats_Test : public ThreadTestBase
       job[1].ownThread = pool.NewThread(this,
                                         static_cast<void *>(&job[1]));
 
-      FastOS_Thread::Sleep(1000);
+      std::this_thread::sleep_for(1s);
 
       inactiveThreads = pool.GetNumInactiveThreads();
       Progress(inactiveThreads == 0, "Inactive threads = %d", inactiveThreads);
@@ -57,7 +57,7 @@ class Thread_Stats_Test : public ThreadTestBase
       job[0].ownThread->SetBreakFlag();
       job[1].ownThread->SetBreakFlag();
 
-      FastOS_Thread::Sleep(3000);
+      std::this_thread::sleep_for(3s);
 
       inactiveThreads = pool.GetNumInactiveThreads();
       Progress(inactiveThreads == 2, "Inactive threads = %d", inactiveThreads);
@@ -72,7 +72,7 @@ class Thread_Stats_Test : public ThreadTestBase
       job[0].code = WAIT_FOR_BREAK_FLAG;
       job[0].ownThread = pool.NewThread(this, static_cast<void *>(&job[0]));
 
-      FastOS_Thread::Sleep(1000);
+      std::this_thread::sleep_for(1s);
 
       inactiveThreads = pool.GetNumInactiveThreads();
       Progress(inactiveThreads == 1, "Inactive threads = %d", inactiveThreads);
@@ -84,7 +84,7 @@ class Thread_Stats_Test : public ThreadTestBase
       job[1].code = WAIT_FOR_BREAK_FLAG;
       job[1].ownThread = pool.NewThread(this, static_cast<void *>(&job[1]));
 
-      FastOS_Thread::Sleep(1000);
+      std::this_thread::sleep_for(1s);
 
       inactiveThreads = pool.GetNumInactiveThreads();
       Progress(inactiveThreads == 0, "Inactive threads = %d", inactiveThreads);
@@ -97,7 +97,7 @@ class Thread_Stats_Test : public ThreadTestBase
       job[0].ownThread->SetBreakFlag();
       job[1].ownThread->SetBreakFlag();
 
-      FastOS_Thread::Sleep(3000);
+      std::this_thread::sleep_for(3s);
 
       inactiveThreads = pool.GetNumInactiveThreads();
       Progress(inactiveThreads == 2, "Inactive threads = %d", inactiveThreads);

--- a/fastos/src/tests/thread_test_base.hpp
+++ b/fastos/src/tests/thread_test_base.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <chrono>
+#include <thread>
 
 static volatile int64_t number;
 #define INCREASE_NUMBER_AMOUNT 10000
@@ -47,7 +48,7 @@ public:
             }
          }
 
-         FastOS_Thread::Sleep(500);
+         std::this_thread::sleep_for(500ms);
 
          if(threadsFinished)
             break;
@@ -88,7 +89,7 @@ void ThreadTestBase::Run (FastOS_ThreadInterface *thread, void *arg)
          Progress(true, "Thread printing message: [%s]", job->message);
          job->result = strlen(job->message);
 
-         FastOS_Thread::Sleep(3000);
+          std::this_thread::sleep_for(3s);
          break;
       }
 
@@ -109,7 +110,7 @@ void ThreadTestBase::Run (FastOS_ThreadInterface *thread, void *arg)
             number = number + 2;
 
             if(i == sleepOn)
-               FastOS_Thread::Sleep(1000);
+                std::this_thread::sleep_for(1s);
          }
 
          guard = std::unique_lock<std::mutex>();
@@ -123,7 +124,7 @@ void ThreadTestBase::Run (FastOS_ThreadInterface *thread, void *arg)
       {
          for(;;)
          {
-            FastOS_Thread::Sleep(1000);
+             std::this_thread::sleep_for(1s);
 
             if(thread->GetBreakFlag())
             {
@@ -192,7 +193,7 @@ void ThreadTestBase::Run (FastOS_ThreadInterface *thread, void *arg)
 
       case WAIT2SEC_AND_SIGNALCOND:
       {
-         FastOS_Thread::Sleep(2000);
+          std::this_thread::sleep_for(2s);
          job->condition->notify_one();
          job->result = 1;
          break;
@@ -202,7 +203,7 @@ void ThreadTestBase::Run (FastOS_ThreadInterface *thread, void *arg)
       {
           {
               std::lock_guard<std::mutex> guard(*job->mutex);
-              FastOS_Thread::Sleep(2000);
+              std::this_thread::sleep_for(2s);
           }
           job->result = 1;
           break;
@@ -210,7 +211,7 @@ void ThreadTestBase::Run (FastOS_ThreadInterface *thread, void *arg)
 
       case WAIT_2_SEC:
       {
-         FastOS_Thread::Sleep(2000);
+          std::this_thread::sleep_for(2s);
          job->result = 1;
          break;
       }

--- a/fastos/src/tests/threadtest.cpp
+++ b/fastos/src/tests/threadtest.cpp
@@ -43,7 +43,7 @@ class ThreadTest : public ThreadTestBase
          if(waitingThreads == numWait)
             break;
 
-         FastOS_Thread::Sleep(100);
+         std::this_thread::sleep_for(100ms);
       }
    }
 
@@ -336,7 +336,7 @@ class ThreadTest : public ThreadTestBase
       // Threads are not guaranteed to have entered sleep yet,
       // as this test only tests for result code
       // Wait another second to be sure.
-      FastOS_Thread::Sleep(1000);
+      std::this_thread::sleep_for(1s);
    }
 
    void SignalTest ()

--- a/fastos/src/vespa/fastos/thread.h
+++ b/fastos/src/vespa/fastos/thread.h
@@ -347,15 +347,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~FastOS_ThreadInterface (){}
-
-    /**
-     * Sleep for x milliseconds. Attempting to sleep for <1 milliseconds
-     * will result in failure.
-     * @param ms   Number of milliseconds to sleep.
-     * @return     Boolean success/failure
-     */
-    static bool Sleep(int ms);
+    virtual ~FastOS_ThreadInterface () {}
 
     /**
      * Instruct a thread to exit. This could be used in conjunction with

--- a/fastos/src/vespa/fastos/unix_process.cpp
+++ b/fastos/src/vespa/fastos/unix_process.cpp
@@ -40,6 +40,8 @@ extern char **environ;
 
 #endif
 
+using namespace std::chrono_literals;
+
 static pid_t safe_fork ()
 {
     pid_t pid;
@@ -1629,7 +1631,7 @@ FastOS_UNIX_ProcessStarter::Wait(FastOS_UNIX_Process *process,
             }
         }
 
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
     }
 
     return rc;

--- a/fastos/src/vespa/fastos/unix_thread.cpp
+++ b/fastos/src/vespa/fastos/unix_thread.cpp
@@ -83,18 +83,6 @@ FastOS_UNIX_Thread::~FastOS_UNIX_Thread()
     }
 }
 
-bool FastOS_UNIX_Thread::Sleep (int ms)
-{
-    bool rc=false;
-
-    if (ms > 0) {
-        usleep(ms*1000);
-        rc = true;
-    }
-
-    return rc;
-}
-
 FastOS_ThreadId FastOS_UNIX_Thread::GetThreadId ()
 {
     return _handle;

--- a/fastos/src/vespa/fastos/unix_thread.h
+++ b/fastos/src/vespa/fastos/unix_thread.h
@@ -36,7 +36,6 @@ public:
 
     ~FastOS_UNIX_Thread();
 
-    static bool Sleep (int ms);
     FastOS_ThreadId GetThreadId () override;
     static bool CompareThreadIds (FastOS_ThreadId a, FastOS_ThreadId b);
     static FastOS_ThreadId GetCurrentThreadId ();

--- a/fnet/src/examples/timeout/timeout.cpp
+++ b/fnet/src/examples/timeout/timeout.cpp
@@ -2,7 +2,8 @@
 
 #include <vespa/fnet/fnet.h>
 #include <vespa/fastos/app.h>
-#include <chrono>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP("timeout");
@@ -55,7 +56,7 @@ MyApp::Main()
   transport.Start(&pool);
 
   // stable-state operation
-  FastOS_Thread::Sleep(500);
+  std::this_thread::sleep_for(500ms);
 
   FNET_Packet  *packet;
   FNET_Context  context;
@@ -64,7 +65,7 @@ MyApp::Main()
   t = clock::now();
   timeout.Schedule(2.0); // timeout in 2 seconds
 
-  FastOS_Thread::Sleep(1000);
+  std::this_thread::sleep_for(1s);
 
   timeout.Unschedule(); // cancel timeout
   ms = (clock::now() - t);

--- a/fnet/src/tests/frt/rpc/detach_return_invoke.cpp
+++ b/fnet/src/tests/frt/rpc/detach_return_invoke.cpp
@@ -54,7 +54,7 @@ TEST("detach return invoke") {
         if (receptor.req != 0) {
             break;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     req->SubRef();
     target->SubRef();

--- a/fnet/src/vespa/fnet/frt/invoker.h
+++ b/fnet/src/vespa/fnet/frt/invoker.h
@@ -5,7 +5,6 @@
 #include "rpcrequest.h"
 #include <vespa/fnet/task.h>
 #include <vespa/fnet/ipackethandler.h>
-#include <vespa/fastos/thread.h>
 #include <mutex>
 #include <condition_variable>
 

--- a/jrt_test/src/tests/mandatory-methods/extract-reflection.cpp
+++ b/jrt_test/src/tests/mandatory-methods/extract-reflection.cpp
@@ -2,6 +2,8 @@
 
 #include <vespa/fastos/app.h>
 #include <vespa/fnet/frt/frt.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 class RPCInfo : public FastOS_Application
 {
@@ -85,7 +87,7 @@ public:
         if (info->GetErrorCode() != FRTE_RPC_CONNECTION) {
             break;
         }
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
         target->SubRef();
         target = supervisor.GetTarget(_argv[1]);
     }

--- a/messagebus/src/tests/context/context.cpp
+++ b/messagebus/src/tests/context/context.cpp
@@ -77,7 +77,7 @@ Test::Main()
         if (queue.size() == 3) {
             break;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     EXPECT_EQUAL(queue.size(), 3u);
     {

--- a/messagebus/src/tests/loadbalance/loadbalance.cpp
+++ b/messagebus/src/tests/loadbalance/loadbalance.cpp
@@ -78,7 +78,7 @@ Test::Main()
         if (queue.size() == msgCnt) {
             break;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     EXPECT_TRUE(queue.size() == msgCnt);
     EXPECT_TRUE(h1.cnt == msgCnt / 3);

--- a/messagebus/src/tests/messagebus/messagebus.cpp
+++ b/messagebus/src/tests/messagebus/messagebus.cpp
@@ -43,7 +43,7 @@ struct Base {
             if (queue.size() == size) {
                 return true;
             }
-            FastOS_Thread::Sleep(10);
+            std::this_thread::sleep_for(10ms);
         }
         return false;
     }
@@ -270,7 +270,7 @@ Test::testSendToCol()
         }
     }
     client->waitQueueSize(300);
-    FastOS_Thread::Sleep(100);
+    std::this_thread::sleep_for(100ms);
     client->waitQueueSize(300);
     while (client->queue.size() > 0) {
         Routable::UP reply = client->queue.dequeue(0);
@@ -347,7 +347,7 @@ Test::testSendToAnyThenCol()
         }
     }
     client->waitQueueSize(300);
-    FastOS_Thread::Sleep(100);
+    std::this_thread::sleep_for(100ms);
     client->waitQueueSize(300);
     while (client->queue.size() > 0) {
         Routable::UP reply = client->queue.dequeue(0);

--- a/messagebus/src/tests/messageordering/messageordering.cpp
+++ b/messagebus/src/tests/messageordering/messageordering.cpp
@@ -167,7 +167,7 @@ Test::Main()
     const int messageCount = 5000;
     for (int i = 0; i < messageCount; ++i) {
         vespalib::string str(vespalib::make_string("%d", i));
-        //FastOS_Thread::Sleep(1);
+        //std::this_thread::sleep_for(1ms);
         auto msg = std::make_unique<SimpleMessage>(str, true, commonMessageId);
         msg->getTrace().setLevel(9);
         //LOG(debug, "Sending message %p for %d", msg.get(), i);

--- a/messagebus/src/tests/serviceaddress/serviceaddress.cpp
+++ b/messagebus/src/tests/serviceaddress/serviceaddress.cpp
@@ -82,7 +82,7 @@ Test::waitSlobrok(RPCNetwork &network, const string &pattern, size_t num)
         if (res.size() == num) {
             return true;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     return false;
 }

--- a/messagebus/src/tests/slobrok/slobrok.cpp
+++ b/messagebus/src/tests/slobrok/slobrok.cpp
@@ -51,7 +51,7 @@ compare(const IMirrorAPI &api, const string &pattern, SpecList expect)
         if (actual == expect) {
             return true;
         }
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
     }
     return false;
 }

--- a/messagebus/src/tests/sourcesession/sourcesession.cpp
+++ b/messagebus/src/tests/sourcesession/sourcesession.cpp
@@ -35,7 +35,7 @@ struct DelayedHandler : public IMessageHandler
         // this will block the transport thread in the server messagebus,
         // but that should be ok, as we only want to test the timing in the
         // client messagebus...
-        FastOS_Thread::Sleep(delay);
+        std::this_thread::sleep_for(std::chrono::milliseconds(delay));
         session->acknowledge(std::move(msg));
     }
 };
@@ -59,7 +59,7 @@ bool waitQueueSize(RoutableQueue &queue, uint32_t size) {
         if (queue.size() == size) {
             return true;
         }
-        FastOS_Thread::Sleep(1);
+        std::this_thread::sleep_for(1ms);
     }
     return false;
 }
@@ -99,7 +99,7 @@ Test::testSequencing()
     EXPECT_TRUE(ss->send(Message::UP(new SimpleMessage("foo", true, 2)), "dst").isAccepted());
     EXPECT_TRUE(ss->send(Message::UP(new SimpleMessage("foo", true, 1)), "dst").isAccepted());
     EXPECT_TRUE(waitQueueSize(dstQ, 2));
-    FastOS_Thread::Sleep(250);
+    std::this_thread::sleep_for(250ms);
     EXPECT_TRUE(waitQueueSize(dstQ, 2));
     EXPECT_TRUE(waitQueueSize(srcQ, 0));
     ds->acknowledge(Message::UP((Message*)dstQ.dequeue(0).release()));

--- a/messagebus/src/tests/throttling/throttling.cpp
+++ b/messagebus/src/tests/throttling/throttling.cpp
@@ -51,7 +51,7 @@ bool waitQueueSize(RoutableQueue &queue, uint32_t size)
         if (queue.size() == size) {
             return true;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     return false;
 }
@@ -62,7 +62,7 @@ bool waitPending(SourceSession& session, uint32_t size)
         if (session.getPendingCount() == size) {
             return true;
         }
-        FastOS_Thread::Sleep(1);
+        std::this_thread::sleep_for(1ms);
     }
     return false;
 }

--- a/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
@@ -17,6 +17,7 @@
 #include <vespa/fnet/scheduler.h>
 #include <vespa/fnet/transport.h>
 #include <vespa/fnet/frt/supervisor.h>
+#include <vespa/fastos/thread.h>
 #include <thread>
 
 #include <vespa/log/log.h>

--- a/messagebus/src/vespa/messagebus/testlib/testserver.cpp
+++ b/messagebus/src/vespa/messagebus/testlib/testserver.cpp
@@ -4,6 +4,8 @@
 #include "slobrok.h"
 #include "slobrokstate.h"
 #include <vespa/vespalib/component/vtag.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 namespace mbus {
 
@@ -59,7 +61,7 @@ TestServer::waitState(const SlobrokState &slobrokState)
         if (done) {
             return true;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     return false;
 }

--- a/messagebus_test/src/tests/error/cpp-client.cpp
+++ b/messagebus_test/src/tests/error/cpp-client.cpp
@@ -7,6 +7,8 @@
 #include <vespa/messagebus/rpcmessagebus.h>
 #include <vespa/messagebus/network/rpcnetworkparams.h>
 #include <vespa/messagebus/testlib/receptor.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/fastos/app.h>
 
 using namespace mbus;
@@ -45,7 +47,7 @@ App::Main()
                 break;
             }
         }
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
     if (reply.get() == 0) {
         fprintf(stderr, "CPP-CLIENT: no reply\n");

--- a/messagebus_test/src/tests/error/cpp-server.cpp
+++ b/messagebus_test/src/tests/error/cpp-server.cpp
@@ -6,6 +6,8 @@
 #include <vespa/messagebus/network/rpcnetworkparams.h>
 #include <vespa/messagebus/emptyreply.h>
 #include <vespa/messagebus/errorcode.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/fastos/app.h>
 
 using namespace mbus;
@@ -55,7 +57,7 @@ App::Main()
                      "file:routing.cfg");
     Server server(mb.getMessageBus());
     while (true) {
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
     return 0;
 }

--- a/messagebus_test/src/tests/speed/cpp-client.cpp
+++ b/messagebus_test/src/tests/speed/cpp-client.cpp
@@ -7,6 +7,8 @@
 #include <vespa/messagebus/testlib/simplemessage.h>
 #include <vespa/messagebus/testlib/simpleprotocol.h>
 #include <vespa/messagebus/testlib/simplereply.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/fastos/timestamp.h>
 #include <vespa/fastos/app.h>
 
@@ -100,7 +102,7 @@ App::Main()
     Client client(mb.getMessageBus(), SourceSessionParams().setTimeout(30s));
 
     // let the system 'warm up'
-    FastOS_Thread::Sleep(5000);
+    std::this_thread::sleep_for(5s);
 
     // inject messages into the feedback loop
     for (uint32_t i = 0; i < 1024; ++i) {
@@ -108,7 +110,7 @@ App::Main()
     }
 
     // let the system 'warm up'
-    FastOS_Thread::Sleep(5000);
+    std::this_thread::sleep_for(5s);
 
     fastos::StopWatch stopWatch;
     uint32_t okBefore   = 0;
@@ -117,7 +119,7 @@ App::Main()
     uint32_t failAfter  = 0;
 
     client.sample(okBefore, failBefore);
-    FastOS_Thread::Sleep(10000); // Benchmark time
+    std::this_thread::sleep_for(10s); // Benchmark time
     fastos::TimeStamp elapsed = stopWatch.elapsed();
     client.sample(okAfter, failAfter);
     double time = elapsed.ms();

--- a/messagebus_test/src/tests/speed/cpp-server.cpp
+++ b/messagebus_test/src/tests/speed/cpp-server.cpp
@@ -6,6 +6,8 @@
 #include <vespa/messagebus/testlib/simpleprotocol.h>
 #include <vespa/messagebus/rpcmessagebus.h>
 #include <vespa/messagebus/network/rpcnetworkparams.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/fastos/app.h>
 
 using namespace mbus;
@@ -62,7 +64,7 @@ App::Main()
                      "file:routing.cfg");
     Server server(mb.getMessageBus());
     while (true) {
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
     return 0;
 }

--- a/messagebus_test/src/tests/trace/cpp-server.cpp
+++ b/messagebus_test/src/tests/trace/cpp-server.cpp
@@ -5,6 +5,8 @@
 #include <vespa/messagebus/rpcmessagebus.h>
 #include <vespa/messagebus/network/rpcnetworkparams.h>
 #include <vespa/messagebus/emptyreply.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/fastos/app.h>
 
 using namespace mbus;
@@ -73,7 +75,7 @@ App::Main()
                      "file:routing.cfg");
     Server server(mb.getMessageBus(), _argv[1]);
     while (true) {
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
     return 0;
 }

--- a/messagebus_test/src/tests/trace/trace.cpp
+++ b/messagebus_test/src/tests/trace/trace.cpp
@@ -36,7 +36,7 @@ waitSlobrok(RPCMessageBus &mbus, const std::string &pattern)
         if (res.size() > 0) {
             return true;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     return false;
 }
@@ -112,7 +112,7 @@ Test::Main()
             }
         }
         std::cout << "Attempt " << i << " got errors, retrying in 1 second.." << std::endl;
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
 
     EXPECT_TRUE(!reply->hasErrors());

--- a/metrics/src/tests/metricmanagertest.cpp
+++ b/metrics/src/tests/metricmanagertest.cpp
@@ -10,8 +10,10 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/xmlstream.h>
-#include <vespa/log/log.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".test.metricmanager");
 
 namespace metrics {
@@ -386,7 +388,7 @@ bool waitForTimeProcessed(const MetricManager& mm,
     while (time(0) < lastchance) {
         if (mm.getLastProcessedTime() >= processtime) return true;
         mm.timeChangedNotification();
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     return false;
 }

--- a/metrics/src/tests/stresstest.cpp
+++ b/metrics/src/tests/stresstest.cpp
@@ -4,6 +4,7 @@
 #include <vespa/metrics/metricmanager.h>
 #include <vespa/metrics/metrics.h>
 #include <vespa/metrics/summetric.hpp>
+#include <vespa/vespalib/util/time.h>
 #include <thread>
 #include <vespa/vespalib/gtest/gtest.h>
 
@@ -40,7 +41,7 @@ InnerMetricSet::InnerMetricSet(const char* name, const LoadTypeSet& lt, MetricSe
     _valueSum.addMetricToSum(_value1);
     _valueSum.addMetricToSum(_value2);
 }
-InnerMetricSet::~InnerMetricSet() { }
+InnerMetricSet::~InnerMetricSet() = default;
 
     MetricSet*
     InnerMetricSet::clone(std::vector<Metric::UP> &ownerList, CopyType copyType,
@@ -134,11 +135,10 @@ TEST(StressTest, test_stress)
     FastOS_ThreadPool threadPool(256 * 1024);
     std::vector<Hammer::UP> hammers;
     for (uint32_t i=0; i<10; ++i) {
-        hammers.push_back(Hammer::UP(
-            new Hammer(metrics, loadTypes, threadPool)));
+        hammers.push_back(std::make_unique<Hammer>(metrics, loadTypes, threadPool));
     }
     LOG(info, "Waiting to let loadgivers hammer a while");
-    std::this_thread::sleep_for(std::chrono::milliseconds(5 * 1000));
+    std::this_thread::sleep_for(5s);
 
     LOG(info, "Removing loadgivers");
     hammers.clear();

--- a/metrics/src/tests/stresstest.cpp
+++ b/metrics/src/tests/stresstest.cpp
@@ -4,6 +4,7 @@
 #include <vespa/metrics/metricmanager.h>
 #include <vespa/metrics/metrics.h>
 #include <vespa/metrics/summetric.hpp>
+#include <thread>
 #include <vespa/vespalib/gtest/gtest.h>
 
 #include <vespa/log/log.h>
@@ -137,7 +138,7 @@ TEST(StressTest, test_stress)
             new Hammer(metrics, loadTypes, threadPool)));
     }
     LOG(info, "Waiting to let loadgivers hammer a while");
-    FastOS_Thread::Sleep(5 * 1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5 * 1000));
 
     LOG(info, "Removing loadgivers");
     hammers.clear();

--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -8,6 +8,7 @@
 #include <vespa/metrics/metricmanager.h>
 #include <vespa/vespalib/util/signalhandler.h>
 #include <vespa/vespalib/util/programoptions.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/config/common/exceptions.h>
 #include <vespa/fastos/app.h>
@@ -198,7 +199,7 @@ App::Main()
                         LOG(info, "Sleeping 900 seconds due to proton state");
                         int sleepLeft = 900;
                         while (!(SIG::INT.check() || SIG::TERM.check()) && sleepLeft > 0) {
-                            FastOS_Thread::Sleep(1000);
+                            std::this_thread::sleep_for(1000ms);
                             --sleepLeft;
                         }
                         EV_STOPPING("proton", "shutdown after stop on io errors");
@@ -226,7 +227,7 @@ App::Main()
             }
             EV_STARTED("proton");
             while (!(SIG::INT.check() || SIG::TERM.check() || (spiProton && spiProton->getNode().attemptedStopped()))) {
-                FastOS_Thread::Sleep(1000);
+                std::this_thread::sleep_for(1000ms);
                 if (spiProton && spiProton->configUpdated()) {
                     storage::ResumeGuard guard(spiProton->getNode().pause());
                     spiProton->updateConfig();
@@ -240,7 +241,7 @@ App::Main()
                             if (spiProton) {
                                 // report down state to cluster controller.
                                 spiProton->getNode().notifyPartitionDown(0, "proton state string is " + stateString);
-                                FastOS_Thread::Sleep(1000);
+                                std::this_thread::sleep_for(1000ms);
                             }
                             EV_STOPPING("proton", "shutdown after new stop on io errors");
                             return 1;

--- a/searchcore/src/apps/vespa-proton-cmd/vespa-proton-cmd.cpp
+++ b/searchcore/src/apps/vespa-proton-cmd/vespa-proton-cmd.cpp
@@ -6,8 +6,10 @@
 #include <vespa/fnet/frt/frt.h>
 #include <vespa/vespalib/util/host_name.h>
 #include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/fastos/app.h>
 #include <sys/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP("vespa-proton-cmd");
@@ -115,7 +117,7 @@ public:
             slobrok::api::MirrorAPI sbmirror(_frt->supervisor(), sbcfg);
             for (int timeout = 1; timeout < 20; timeout++) {
                 if (!sbmirror.ready()) {
-                    FastOS_Thread::Sleep(50*timeout);
+                    std::this_thread::sleep_for(50ms*timeout);
                 }
             }
             if (!sbmirror.ready()) {
@@ -123,12 +125,9 @@ public:
                         "ERROR: no data from service location broker\n");
                 exit(1);
             }
-            slobrok::api::MirrorAPI::SpecList specs =
-                sbmirror.lookup(rtcPattern);
-            slobrok::api::MirrorAPI::SpecList specs2 =
-                sbmirror.lookup(rtcPattern2);
-            slobrok::api::MirrorAPI::SpecList specs3 =
-                sbmirror.lookup(rtcPattern3);
+            slobrok::api::MirrorAPI::SpecList specs = sbmirror.lookup(rtcPattern);
+            slobrok::api::MirrorAPI::SpecList specs2 = sbmirror.lookup(rtcPattern2);
+            slobrok::api::MirrorAPI::SpecList specs3 = sbmirror.lookup(rtcPattern3);
 
             int found = 0;
             std::string service;
@@ -167,7 +166,7 @@ public:
             slobrok::api::MirrorAPI sbmirror(_frt->supervisor(), sbcfg);
             for (int timeout = 1; timeout < 20; timeout++) {
                 if (!sbmirror.ready()) {
-                    FastOS_Thread::Sleep(50*timeout);
+                    std::this_thread::sleep_for(50ms*timeout);
                 }
             }
             if (!sbmirror.ready()) {

--- a/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
+++ b/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/vespalib/util/programoptions.h>
 #include <vespa/vespalib/util/xmlstream.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/document/config/config-documenttypes.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/fieldvalue/document.h>
@@ -14,6 +15,7 @@
 #include <vespa/config/helper/configgetter.hpp>
 #include <vespa/fastos/app.h>
 #include <iostream>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP("vespa-transactionlog-inspect");
@@ -491,7 +493,7 @@ protected:
             return 1;
         }
         for (size_t i = 0; !callback.isEof() && (i < 60 * 60); i++ ) {
-            FastOS_Thread::Sleep(1000);
+            std::this_thread::sleep_for(1s);
         }
         return 0;
     }

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -1064,7 +1064,7 @@ TEST_F("require that document pruner is active",
     MyFrozenBucket::UP frozen3(new MyFrozenBucket(f._mc, bucketId3));
     f.setPruneConfig(DocumentDBPruneRemovedDocumentsConfig(0.2, 900.0));
     for (uint32_t i = 0; i < 6; ++i) {
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
         ASSERT_TRUE(f._executor.waitIdle(TIMEOUT_SEC));
         if (f._removed.getNumUsedLids() != 10u)
             break;
@@ -1073,7 +1073,7 @@ TEST_F("require that document pruner is active",
     EXPECT_EQUAL(10u, f._removed.getDocumentCount());
     frozen3.reset();
     for (uint32_t i = 0; i < 600; ++i) {
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
         ASSERT_TRUE(f._executor.waitIdle(TIMEOUT_SEC));
         if (f._removed.getNumUsedLids() != 10u)
             break;
@@ -1089,7 +1089,7 @@ TEST_F("require that heartbeats are scheduled",
     f.startMaintenance();
     f.setHeartBeatConfig(DocumentDBHeartBeatConfig(0.2));
     for (uint32_t i = 0; i < 600; ++i) {
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
         if (f._fh.getHeartBeats() != 0u)
             break;
     }
@@ -1104,7 +1104,7 @@ TEST_F("require that periodic session prunings are scheduled",
     f.startMaintenance();
     f.setGroupingSessionPruneInterval(0.2);
     for (uint32_t i = 0; i < 600; ++i) {
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
         if (f._gsp.isInvoked) {
             break;
         }
@@ -1233,7 +1233,7 @@ TEST_F("require that a blocked job is unblocked and executed after thaw bucket",
     EXPECT_FALSE(myJob2.isBlocked());
     bool done1 = myJob1._latch.await(TIMEOUT_MS);
     EXPECT_TRUE(done1);
-    FastOS_Thread::Sleep(2000);
+    std::this_thread::sleep_for(2s);
     EXPECT_EQUAL(0u, myJob2._runCnt);
 }
 
@@ -1245,7 +1245,7 @@ TEST_F("require that blocked jobs are not executed", MaintenanceControllerFixtur
     f._mc.registerJobInMasterThread(std::move(job));
     f._injectDefaultJobs = false;
     f.startMaintenance();
-    FastOS_Thread::Sleep(2000);
+    std::this_thread::sleep_for(2s);
     EXPECT_EQUAL(0u, myJob._runCnt);
 }
 

--- a/searchcore/src/tests/proton/flushengine/flushengine_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/flushengine_test.cpp
@@ -685,7 +685,7 @@ assertThatHandlersInCurrentSet(FlushEngine & engine, const std::vector<const cha
 {
     FlushEngine::FlushMetaSet current1 = engine.getCurrentlyFlushingSet();
     while ((current1.size() < targets.size()) || !asserCorrectHandlers(current1, targets)) {
-        FastOS_Thread::Sleep(1);
+        std::this_thread::sleep_for(1ms);
         current1 = engine.getCurrentlyFlushingSet();
     }
 }

--- a/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
+++ b/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
@@ -175,7 +175,7 @@ struct ProtonConfigOwner : public proton::IProtonConfigurer
         while (timer.elapsed().ms() < timeout) {
             if (getConfigured())
                 return true;
-            FastOS_Thread::Sleep(100);
+            std::this_thread::sleep_for(100ms);
         }
         return getConfigured();
     }

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -1,10 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "disk_mem_usage_sampler.h"
-#include <vespa/vespalib/util/timer.h>
+#include <vespa/vespalib/util/scheduledexecutor.h>
 #include <vespa/vespalib/util/lambdatask.h>
 #include <filesystem>
-#include <unistd.h>
 
 using vespalib::makeLambdaTask;
 
@@ -32,7 +31,7 @@ DiskMemUsageSampler::setConfig(const Config &config)
     _filter.setConfig(config.filterConfig);
     _sampleInterval = config.sampleInterval;
     sampleUsage();
-    _periodicTimer = std::make_unique<vespalib::Timer>();
+    _periodicTimer = std::make_unique<vespalib::ScheduledExecutor>();
     _periodicTimer->scheduleAtFixedRate(makeLambdaTask([this]()
                                                        { sampleUsage(); }),
                                         _sampleInterval, _sampleInterval);

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -4,7 +4,7 @@
 
 #include "disk_mem_usage_filter.h"
 
-namespace vespalib { class Timer; }
+namespace vespalib { class ScheduledExecutor; }
 
 namespace proton {
 
@@ -15,7 +15,7 @@ class DiskMemUsageSampler {
     DiskMemUsageFilter _filter;
     std::filesystem::path _path;
     double _sampleInterval;
-    std::unique_ptr<vespalib::Timer> _periodicTimer;
+    std::unique_ptr<vespalib::ScheduledExecutor> _periodicTimer;
 
     void sampleUsage();
     void sampleDiskUsage();

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.cpp
@@ -6,7 +6,7 @@
 #include "i_blockable_maintenance_job.h"
 #include <vespa/searchcorespi/index/i_thread_service.h>
 #include <vespa/vespalib/util/closuretask.h>
-#include <vespa/vespalib/util/timer.h>
+#include <vespa/vespalib/util/scheduledexecutor.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.server.maintenancecontroller");
@@ -167,7 +167,7 @@ MaintenanceController::restart()
     if (!_started || _stopping || !_readySubDB.valid()) {
         return;
     }
-    _periodicTimer.reset(new vespalib::Timer());
+    _periodicTimer = std::make_unique<vespalib::ScheduledExecutor>();
 
     addJobsToPeriodicTimer();
 }

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
@@ -8,6 +8,7 @@
 #include "ibucketfreezelistener.h"
 #include <vespa/searchcore/proton/common/doctypename.h>
 #include <mutex>
+#include <vespa/vespalib/util/scheduledexecutor.h>
 
 namespace vespalib {
     class Timer;
@@ -77,7 +78,7 @@ private:
     MaintenanceDocumentSubDB          _readySubDB;
     MaintenanceDocumentSubDB          _remSubDB;
     MaintenanceDocumentSubDB          _notReadySubDB;
-    std::unique_ptr<vespalib::Timer>  _periodicTimer;
+    std::unique_ptr<vespalib::ScheduledExecutor>  _periodicTimer;
     DocumentDBMaintenanceConfigSP     _config;
     FrozenBuckets                     _frozenBuckets;
     bool                              _started;

--- a/searchlib/src/tests/postinglistbm/stress_runner.cpp
+++ b/searchlib/src/tests/postinglistbm/stress_runner.cpp
@@ -8,9 +8,11 @@
 #include <vespa/searchlib/test/fakedata/fakeword.h>
 #include <vespa/searchlib/test/fakedata/fakewordset.h>
 #include <vespa/searchlib/test/fakedata/fpfactory.h>
+#include <vespa/vespalib/util/time.h>
 #include <condition_variable>
 #include <mutex>
 #include <vector>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".stress_runner");
@@ -306,7 +308,7 @@ StressMaster::run()
             totalTime / _loops, type.c_str());
         dropPostings();
     }
-    FastOS_Thread::Sleep(250);
+    std::this_thread::sleep_for(250ms);
 }
 
 double

--- a/searchlib/src/tests/transactionlog/translogclient_test.cpp
+++ b/searchlib/src/tests/transactionlog/translogclient_test.cpp
@@ -248,7 +248,7 @@ bool Test::partialUpdateTest()
     TransLogClient::Visitor::UP visitor = tls.createVisitor("test1", ca);
     ASSERT_TRUE(visitor.get());
     ASSERT_TRUE( visitor->visit(5, 7) );
-    for (size_t i(0); ! ca._eof && (i < 1000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca._eof && (i < 1000); i++ ) { std::this_thread::sleep_for(10ms); }
     ASSERT_TRUE( ca._eof );
     ASSERT_TRUE( ca.map().size() == 1);
     ASSERT_TRUE( ca.hasSerial(7) );
@@ -257,7 +257,7 @@ bool Test::partialUpdateTest()
     TransLogClient::Visitor::UP visitor1 = tls.createVisitor("test1", ca1);
     ASSERT_TRUE(visitor1.get());
     ASSERT_TRUE( visitor1->visit(4, 5) );
-    for (size_t i(0); ! ca1._eof && (i < 1000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca1._eof && (i < 1000); i++ ) { std::this_thread::sleep_for(10ms); }
     ASSERT_TRUE( ca1._eof );
     ASSERT_TRUE( ca1.map().size() == 0);
 
@@ -265,7 +265,7 @@ bool Test::partialUpdateTest()
     TransLogClient::Visitor::UP visitor2 = tls.createVisitor("test1", ca2);
     ASSERT_TRUE(visitor2.get());
     ASSERT_TRUE( visitor2->visit(5, 6) );
-    for (size_t i(0); ! ca2._eof && (i < 1000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca2._eof && (i < 1000); i++ ) { std::this_thread::sleep_for(10ms); }
     ASSERT_TRUE( ca2._eof );
     ASSERT_TRUE( ca2.map().size() == 0);
 
@@ -273,7 +273,7 @@ bool Test::partialUpdateTest()
     TransLogClient::Visitor::UP visitor3 = tls.createVisitor("test1", ca3);
     ASSERT_TRUE(visitor3.get());
     ASSERT_TRUE( visitor3->visit(5, 1000) );
-    for (size_t i(0); ! ca3._eof && (i < 1000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca3._eof && (i < 1000); i++ ) { std::this_thread::sleep_for(10ms); }
     ASSERT_TRUE( ca3._eof );
     ASSERT_TRUE( ca3.map().size() == 1);
     ASSERT_TRUE( ca3.hasSerial(7) );
@@ -437,7 +437,7 @@ bool Test::visitDomainTest(TransLogClient & tls, TransLogClient::Session * s1, c
     TransLogClient::Visitor::UP visitor = tls.createVisitor(name, ca);
     ASSERT_TRUE(visitor.get());
     EXPECT_TRUE( visitor->visit(0, 1) );
-    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { std::this_thread::sleep_for(10ms); }
     EXPECT_TRUE( ca._eof );
     EXPECT_TRUE( ! ca.hasSerial(0) );
     EXPECT_TRUE( ca.hasSerial(1) );
@@ -447,7 +447,7 @@ bool Test::visitDomainTest(TransLogClient & tls, TransLogClient::Session * s1, c
     visitor = tls.createVisitor(name, ca);
     ASSERT_TRUE(visitor.get());
     EXPECT_TRUE( visitor->visit(1, 2) );
-    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { std::this_thread::sleep_for(10ms); }
     EXPECT_TRUE( ca._eof );
     EXPECT_TRUE( ! ca.hasSerial(0) );
     EXPECT_TRUE( ! ca.hasSerial(1) );
@@ -458,7 +458,7 @@ bool Test::visitDomainTest(TransLogClient & tls, TransLogClient::Session * s1, c
     visitor = tls.createVisitor(name, ca);
     EXPECT_TRUE(visitor.get());
     EXPECT_TRUE( visitor->visit(0, 3) );
-    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { std::this_thread::sleep_for(10ms); }
     EXPECT_TRUE( ca._eof );
     EXPECT_TRUE( ! ca.hasSerial(0) );
     EXPECT_TRUE( ca.hasSerial(1) );
@@ -469,7 +469,7 @@ bool Test::visitDomainTest(TransLogClient & tls, TransLogClient::Session * s1, c
     visitor = tls.createVisitor(name, ca);
     ASSERT_TRUE(visitor.get());
     EXPECT_TRUE( visitor->visit(2, 3) );
-    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { FastOS_Thread::Sleep(10); }
+    for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { std::this_thread::sleep_for(10ms); }
     EXPECT_TRUE( ca._eof );
     EXPECT_TRUE( ! ca.hasSerial(0) );
     EXPECT_TRUE( !ca.hasSerial(1) );
@@ -575,7 +575,7 @@ assertVisitStats(TransLogClient &tls, const vespalib::string &domain,
     ASSERT_TRUE(visitor.get());
     ASSERT_TRUE( visitor->visit(visitStart, visitEnd) );
     for (size_t i(0); ! ca._eof && (i < 60000); i++ ) {
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
     }
     ASSERT_TRUE(ca._eof);
     EXPECT_EQUAL(expFirstSerial, ca._firstSerial);
@@ -623,7 +623,7 @@ void Test::testMany()
         TransLogClient::Visitor::UP visitor = tls.createVisitor("many", ca);
         ASSERT_TRUE(visitor.get());
         ASSERT_TRUE( visitor->visit(2, TOTAL_NUM_ENTRIES) );
-        for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { FastOS_Thread::Sleep(10); }
+        for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { std::this_thread::sleep_for(10ms); }
         ASSERT_TRUE( ca._eof );
         EXPECT_EQUAL(ca._count, TOTAL_NUM_ENTRIES);
         EXPECT_EQUAL(ca._value, TOTAL_NUM_ENTRIES);
@@ -644,7 +644,7 @@ void Test::testMany()
         TransLogClient::Visitor::UP visitor = tls.createVisitor("many", ca);
         ASSERT_TRUE(visitor.get());
         ASSERT_TRUE( visitor->visit(2, TOTAL_NUM_ENTRIES) );
-        for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { FastOS_Thread::Sleep(10); }
+        for (size_t i(0); ! ca._eof && (i < 60000); i++ ) { std::this_thread::sleep_for(10ms); }
         ASSERT_TRUE( ca._eof );
         EXPECT_EQUAL(ca._count, TOTAL_NUM_ENTRIES);
         EXPECT_EQUAL(ca._value, TOTAL_NUM_ENTRIES);

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
@@ -2,12 +2,14 @@
 #include "translogserver.h"
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/frt/rpcrequest.h>
 #include <vespa/fnet/task.h>
 #include <vespa/fnet/transport.h>
 #include <fstream>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".transactionlog.server");
@@ -125,7 +127,7 @@ TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, con
                     listenOk = true;
                 } else {
                     LOG(warning, "Failed listening at port %s trying for %d seconds more.", listenSpec, i);
-                    FastOS_Thread::Sleep(1000);
+                    std::this_thread::sleep_for(1s);
                 }
             }
             if ( ! listenOk ) {

--- a/slobrok/src/tests/configure/configure.cpp
+++ b/slobrok/src/tests/configure/configure.cpp
@@ -85,7 +85,7 @@ compare(MirrorAPI &api, const char *pattern, SpecList expect)
         if (actual == expect) {
             return true;
         }
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
     }
     SpecList actual(api.lookup(pattern));
     std::cerr << "Actual: " << actual.strVal() << std::endl;
@@ -176,7 +176,7 @@ Test::Main()
     srv2Builder.slobrok[0].connectionspec = createSpec(18525);
     cfgCtx->reload();
 
-    FastOS_Thread::Sleep(6000); // reconfiguration time
+    std::this_thread::sleep_for(6s); // reconfiguration time
 
     reg1.registerName("A");
     reg2.registerName("B");

--- a/slobrok/src/tests/mirrorapi/mirrorapi.cpp
+++ b/slobrok/src/tests/mirrorapi/mirrorapi.cpp
@@ -112,7 +112,7 @@ compare(MirrorAPI &api, const char *pattern, SpecList expect)
         if (actual == expect) {
             return true;
         }
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
     }
     return false;
 }
@@ -124,7 +124,7 @@ Test::Main()
     TEST_INIT("mirrorapi_test");
 
     SlobrokServer mock(18501);
-    FastOS_Thread::Sleep(300);
+    std::this_thread::sleep_for(300ms);
 
     Server a("A/x/w", 18502, "tcp/localhost:18501");
     Server b("B/x",   18503, "tcp/localhost:18501");
@@ -143,7 +143,7 @@ Test::Main()
     MirrorAPI mirror(supervisor, config::ConfigUri::createFromInstance(specBuilder));
     EXPECT_TRUE(!mirror.ready());
     transport.Start(&threadPool);
-    FastOS_Thread::Sleep(1000);
+    std::this_thread::sleep_for(1s);
 
     a.reg();
     EXPECT_TRUE(compare(mirror, "A/x/w", SpecList().add("A/x/w", "tcp/localhost:18502")));

--- a/slobrok/src/tests/registerapi/registerapi.cpp
+++ b/slobrok/src/tests/registerapi/registerapi.cpp
@@ -64,7 +64,7 @@ compare(MirrorAPI &api, const char *pattern, SpecList expect)
         if (actual == expect) {
             return true;
         }
-        FastOS_Thread::Sleep(100);
+        std::this_thread::sleep_for(100ms);
     }
     return false;
 }
@@ -75,7 +75,7 @@ Test::Main()
     TEST_INIT("registerapi_test");
 
     SlobrokServer mock(18548);
-    FastOS_Thread::Sleep(300);
+    std::this_thread::sleep_for(300ms);
 
     cloud::config::SlobroksConfigBuilder slobrokSpecs;
     cloud::config::SlobroksConfig::Slobrok sb;
@@ -97,7 +97,7 @@ Test::Main()
     EXPECT_TRUE(compare(mirror, "*/*/*", SpecList().add("A/x/w", myspec.c_str())));
 
     for (int i = 0; i < 30; i++) {
-        if (reg.busy()) FastOS_Thread::Sleep(100);
+        if (reg.busy()) std::this_thread::sleep_for(100ms);
     }
     EXPECT_TRUE(!reg.busy());
 

--- a/slobrok/src/tests/standalone/standalone.cpp
+++ b/slobrok/src/tests/standalone/standalone.cpp
@@ -132,7 +132,7 @@ TEST("standalone") {
             break;
         }
         fprintf(stderr, "ping failed [retry %d]\n", retry);
-        FastOS_Thread::Sleep(200);
+        std::this_thread::sleep_for(200ms);
         sb->SubRef();
         sb = orb.GetTarget(18541);
     }
@@ -268,7 +268,7 @@ TEST("standalone") {
         }
     }
 
-    FastOS_Thread::Sleep(2000);
+    std::this_thread::sleep_for(2s);
 
     // lookup 'B' should give ''
     req = orb.AllocRPCRequest(req);

--- a/staging_vespalib/src/tests/clock/clock_test.cpp
+++ b/staging_vespalib/src/tests/clock/clock_test.cpp
@@ -2,36 +2,27 @@
 
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/clock.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/fastos/thread.h>
 
 using vespalib::Clock;
 using fastos::TimeStamp;
 
-class Test : public vespalib::TestApp
-{
-public:
-    int Main() override;
-};
 
-
-int
-Test::Main()
-{
-    TEST_INIT("clock_test");
+TEST("Test that clock is ticking forward") {
 
     Clock clock(0.050);
     FastOS_ThreadPool pool(0x10000);
     ASSERT_TRUE(pool.NewThread(clock.getRunnable(), nullptr) != nullptr);
     fastos::SteadyTimeStamp start = clock.getTimeNS();
-    FastOS_Thread::Sleep(5000);
+    std::this_thread::sleep_for(5s);
     fastos::SteadyTimeStamp stop = clock.getTimeNS();
     EXPECT_TRUE(stop > start);
-    FastOS_Thread::Sleep(6000);
+    std::this_thread::sleep_for(6s);
     clock.stop();
     fastos::SteadyTimeStamp stop2 = clock.getTimeNS();
     EXPECT_TRUE(stop2 > stop);
     EXPECT_TRUE((stop2 - stop)/TimeStamp::MICRO > 1000);
-    TEST_DONE();
 }
 
-TEST_APPHOOK(Test)
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/staging_vespalib/src/tests/shutdownguard/shutdownguard_test.cpp
+++ b/staging_vespalib/src/tests/shutdownguard/shutdownguard_test.cpp
@@ -13,20 +13,20 @@ Test::Main()
 {
     TEST_INIT("shutdownguard_test");
     {
-        ShutdownGuard farFuture(123456789);
-        FastOS_Thread::Sleep(20);
+        ShutdownGuard farFuture(1000000s);
+        std::this_thread::sleep_for(20ms);
     }
     EXPECT_TRUE(true);
     pid_t child = fork();
     if (child == 0) {
-        ShutdownGuard soon(30);
+        ShutdownGuard soon(30ms);
         for (int i = 0; i < 1000; ++i) {
-            FastOS_Thread::Sleep(20);
+            std::this_thread::sleep_for(20ms);
         }
         exit(0);
     }
     for (int i = 0; i < 1000; ++i) {
-        FastOS_Thread::Sleep(20);
+        std::this_thread::sleep_for(20ms);
         int stat = 0;
         if (waitpid(child, &stat, WNOHANG) == child) {
             EXPECT_TRUE(WIFEXITED(stat));

--- a/staging_vespalib/src/tests/timer/timer_test.cpp
+++ b/staging_vespalib/src/tests/timer/timer_test.cpp
@@ -1,8 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/testkit/testapp.h>
-#include <vespa/vespalib/util/timer.h>
-#include <vespa/vespalib/util/executor.h>
+#include <vespa/vespalib/util/scheduledexecutor.h>
 
 using namespace vespalib;
 using vespalib::Executor;
@@ -37,7 +36,7 @@ void Test::testScheduling()
 {
     vespalib::CountDownLatch latch1(3);
     vespalib::CountDownLatch latch2(2);
-    Timer timer;
+    ScheduledExecutor timer;
     timer.scheduleAtFixedRate(Task::UP(new TestTask(latch1)), 0.1, 0.2);
     timer.scheduleAtFixedRate(Task::UP(new TestTask(latch2)), 0.5, 0.5);
     EXPECT_TRUE(latch1.await(60000));
@@ -47,7 +46,7 @@ void Test::testScheduling()
 void Test::testReset()
 {
     vespalib::CountDownLatch latch1(2);
-    Timer timer;
+    ScheduledExecutor timer;
     timer.scheduleAtFixedRate(Task::UP(new TestTask(latch1)), 2.0, 3.0);
     timer.reset();
     EXPECT_TRUE(!latch1.await(3000));

--- a/staging_vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/staging_vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -16,7 +16,7 @@ vespa_add_library(staging_vespalib_vespalib_util OBJECT
     document_runnable.cpp
     rusage.cpp
     shutdownguard.cpp
-    timer.cpp
+    scheduledexecutor.cpp
     xmlserializable.cpp
     xmlstream.cpp
     DEPENDS

--- a/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.cpp
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include "timer.h"
+#include "scheduledexecutor.h"
 #include <vespa/fnet/scheduler.h>
 #include <vespa/fnet/task.h>
 #include <vespa/fnet/transport.h>
@@ -34,7 +34,7 @@ public:
     }
 };
 
-Timer::Timer()
+ScheduledExecutor::ScheduledExecutor()
     : _threadPool(128 * 1024),
       _transport(new FNET_Transport()),
       _lock(),
@@ -43,7 +43,7 @@ Timer::Timer()
     _transport->Start(&_threadPool);
 }
 
-Timer::~Timer()
+ScheduledExecutor::~ScheduledExecutor()
 {
     vespalib::LockGuard guard(_lock);
     _transport->ShutDown(true);
@@ -53,7 +53,7 @@ Timer::~Timer()
 
 
 void
-Timer::scheduleAtFixedRate(vespalib::Executor::Task::UP task, double delay, double interval)
+ScheduledExecutor::scheduleAtFixedRate(vespalib::Executor::Task::UP task, double delay, double interval)
 {
     vespalib::LockGuard guard(_lock);
     TimerTaskPtr tTask(new TimerTask(_transport->GetScheduler(), std::move(task), interval));
@@ -62,7 +62,7 @@ Timer::scheduleAtFixedRate(vespalib::Executor::Task::UP task, double delay, doub
 }
 
 void
-Timer::reset()
+ScheduledExecutor::reset()
 {
     vespalib::LockGuard guard(_lock);
     _transport->ShutDown(true);

--- a/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.h
@@ -13,7 +13,7 @@ namespace vespalib {
 class TimerTask;
 
 /**
- * Timer is a class capable of running Tasks at a regular
+ * ScheduledExecutor is a class capable of running Tasks at a regular
  * interval. The timer can be reset to clear all tasks currently being
  * scheduled.
  */

--- a/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.h
@@ -17,7 +17,7 @@ class TimerTask;
  * interval. The timer can be reset to clear all tasks currently being
  * scheduled.
  */
-class Timer
+class ScheduledExecutor
 {
 private:
     typedef std::unique_ptr<TimerTask> TimerTaskPtr;
@@ -31,13 +31,13 @@ public:
     /**
      * Create a new timer, capable of scheduling tasks at fixed intervals.
      */
-    Timer();
+    ScheduledExecutor();
 
     /**
      * Destroys this timer, finishing the current task executing and then
      * finishing.
      */
-    ~Timer();
+    ~ScheduledExecutor();
 
     /**
      * Schedule new task to be executed at specified intervals.

--- a/staging_vespalib/src/vespa/vespalib/util/shutdownguard.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/shutdownguard.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "shutdownguard.h"
 #include <unistd.h>
-#include <sys/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".vespalib.shutdownguard");
@@ -10,36 +10,30 @@ namespace vespalib {
 
 namespace {
 enum { STACK_SIZE = (1u << 16) };
-
-uint64_t getTimeInMillis() {
-    struct timeval mytime;
-    gettimeofday(&mytime, 0);
-    uint64_t mult = 1000;
-    return (mytime.tv_sec * mult) + (mytime.tv_usec / mult);
-}
 }
 void ShutdownGuard::Run(FastOS_ThreadInterface *, void *)
 {
-    while (_dieAtTime > getTimeInMillis()) {
-        FastOS_Thread::Sleep(5);
+    while (_dieAtTime > steady_clock::now() && ! GetThread()->GetBreakFlag()) {
+        std::this_thread::sleep_for(5ms);
     }
-    if (_dieAtTime != 0) {
+    if (_dieAtTime < steady_clock::now()) {
         LOG(warning, "ShutdownGuard is now forcing an exit of the process.");
         _exit(EXIT_FAILURE);
     }
 }
 
-ShutdownGuard::ShutdownGuard(uint64_t millis) :
+ShutdownGuard::ShutdownGuard(duration millis) :
     FastOS_Runnable(),
     _pool(STACK_SIZE, 1),
-    _dieAtTime(getTimeInMillis() + millis)
+    _dieAtTime(steady_clock::now() + millis)
 {
     _pool.NewThread(this);
 }
 
 ShutdownGuard::~ShutdownGuard()
 {
-    _dieAtTime = 0;
+    GetThread()->SetBreakFlag();
+    GetThread()->Join();
     _pool.Close();
 }
 

--- a/staging_vespalib/src/vespa/vespalib/util/shutdownguard.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/shutdownguard.cpp
@@ -16,7 +16,7 @@ void ShutdownGuard::Run(FastOS_ThreadInterface *, void *)
     while (_dieAtTime > steady_clock::now() && ! GetThread()->GetBreakFlag()) {
         std::this_thread::sleep_for(5ms);
     }
-    if (_dieAtTime < steady_clock::now()) {
+    if (_dieAtTime <= steady_clock::now()) {
         LOG(warning, "ShutdownGuard is now forcing an exit of the process.");
         _exit(EXIT_FAILURE);
     }

--- a/staging_vespalib/src/vespa/vespalib/util/shutdownguard.h
+++ b/staging_vespalib/src/vespa/vespalib/util/shutdownguard.h
@@ -1,8 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <vespa/vespalib/util/time.h>
 #include <vespa/fastos/thread.h>
-#include <cstdint>
 
 namespace vespalib {
 
@@ -16,7 +16,7 @@ namespace vespalib {
 class ShutdownGuard : public FastOS_Runnable
 {
     FastOS_ThreadPool _pool;
-    volatile uint64_t _dieAtTime;
+    steady_time       _dieAtTime;
 
     void Run(FastOS_ThreadInterface *, void *) override;
 
@@ -25,7 +25,7 @@ public:
      * Construct a shutdown guard with a given lifetime.
      * @arg millis the number of milliseconds before process automatically exits
      **/
-    ShutdownGuard(uint64_t millis);
+    ShutdownGuard(duration millis);
 
     /**
      * Destructor that dismisses the guard and collects the shutdown thread.

--- a/storage/src/tests/common/metricstest.cpp
+++ b/storage/src/tests/common/metricstest.cpp
@@ -1,6 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/document/fieldvalue/document.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageframework/defaultimplementation/clock/fakeclock.h>
 #include <vespa/storage/bucketdb/bucketmanager.h>
@@ -14,6 +13,7 @@
 #include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/time.h>
 #include <gmock/gmock.h>
 #include <thread>
 
@@ -202,7 +202,7 @@ void MetricsTest::createFakeLoad()
     while (uint64_t(_metricManager->getLastProcessedTime())
                 < _clock->getTimeInSeconds().getTime())
     {
-        FastOS_Thread::Sleep(5);
+        std::this_thread::sleep_for(5ms);
         _metricManager->timeChangedNotification();
     }
 }
@@ -257,7 +257,7 @@ TEST_F(MetricsTest, snapshot_presenting) {
             uint64_t(_metricManager->getLastProcessedTime())
                     < _clock->getTimeInSeconds().getTime())
         {
-            FastOS_Thread::Sleep(1);
+            std::this_thread::sleep_for(1ms);
         }
     }
     LOG(debug, "5 minute snapshot should have been taken. Adding put count");

--- a/storage/src/tests/common/teststorageapp.cpp
+++ b/storage/src/tests/common/teststorageapp.cpp
@@ -7,10 +7,11 @@
 #include <vespa/config-load-type.h>
 #include <vespa/config-fleetcontroller.h>
 #include <vespa/persistence/dummyimpl/dummypersistence.h>
-#include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/config/config.h>
 #include <vespa/config/helper/configgetter.hpp>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".test.servicelayerapp");
@@ -111,7 +112,7 @@ TestStorageApp::waitUntilInitialized(
     framework::MilliSecTime endTime(
             clock.getTimeInMillis() + timeout.getMillis());
     while (!isInitialized()) {
-        FastOS_Thread::Sleep(1);
+        std::this_thread::sleep_for(1ms);
         framework::MilliSecTime currentTime(clock.getTimeInMillis());
         if (currentTime > endTime) {
             std::ostringstream error;

--- a/storage/src/tests/distributor/distributortest.cpp
+++ b/storage/src/tests/distributor/distributortest.cpp
@@ -11,9 +11,10 @@
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/document/test/make_bucket_space.h>
 #include <vespa/storage/config/config-stor-distributormanager.h>
-#include <tests/common/dummystoragelink.h>
 #include <vespa/storage/distributor/distributor.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -383,7 +384,7 @@ TEST_F(DistributorTest, tick_processes_status_requests) {
         thread, "statustest", tickWaitMs, tickMaxProcessTime, ticksBeforeWait));
 
     while (true) {
-        FastOS_Thread::Sleep(1);
+        std::this_thread::sleep_for(1ms);
         framework::TickingLockGuard guard(
             distributor_thread_pool().freezeCriticalTicks());
         if (!distributor_status_todos().empty()) {

--- a/storage/src/tests/persistence/filestorage/operationabortingtest.cpp
+++ b/storage/src/tests/persistence/filestorage/operationabortingtest.cpp
@@ -9,6 +9,8 @@
 #include <vespa/vespalib/util/thread.h>
 #include <vespa/vespalib/stllike/hash_set_insert.hpp>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".operationabortingtest");
@@ -53,7 +55,7 @@ public:
         (void) context;
         _queueBarrier.await();
         // message abort stage with active opertion in disk queue
-        FastOS_Thread::Sleep(75);
+        std::this_thread::sleep_for(75ms);
         _completionBarrier.await();
         // test finished
         return spi::Result();

--- a/storage/src/tests/storageserver/communicationmanagertest.cpp
+++ b/storage/src/tests/storageserver/communicationmanagertest.cpp
@@ -15,6 +15,8 @@
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/documentapi/messagebus/messages/removedocumentmessage.h>
 #include <vespa/documentapi/messagebus/messages/getdocumentreply.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using document::test::makeDocumentBucket;
@@ -65,7 +67,7 @@ TEST_F(CommunicationManagerTest, simple) {
     distributor.open();
     storage.open();
 
-    FastOS_Thread::Sleep(1000);
+    std::this_thread::sleep_for(1s);
 
     // Send a message through from distributor to storage
     auto cmd = std::make_shared<api::GetCommand>(

--- a/storage/src/tests/storageserver/statereportertest.cpp
+++ b/storage/src/tests/storageserver/statereportertest.cpp
@@ -11,6 +11,8 @@
 #include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".test.statereporter");
@@ -233,7 +235,7 @@ TEST_F(StateReporterTest, report_metrics) {
             uint64_t(_metricManager->getLastProcessedTime())
                     < _clock->getTimeInSeconds().getTime())
         {
-            FastOS_Thread::Sleep(1);
+            std::this_thread::sleep_for(1ms);
         }
     }
     LOG(debug, "5 minute snapshot should have been taken. Adding put count");

--- a/storage/src/vespa/storage/storageserver/fnetlistener.cpp
+++ b/storage/src/vespa/storage/storageserver/fnetlistener.cpp
@@ -6,9 +6,11 @@
 #include <vespa/storageapi/message/state.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/host_name.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/transport.h>
 #include <sstream>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".rpc.listener");
@@ -50,7 +52,7 @@ FNetListener::registerHandle(vespalib::stringref handle) {
     _slobrokRegister.registerName(handle);
     while (_slobrokRegister.busy()) {
         LOG(debug, "Waiting to register in slobrok");
-        FastOS_Thread::Sleep(50);
+        std::this_thread::sleep_for(50ms);
     }
     _handle = handle;
 }

--- a/storage/src/vespa/storage/storageserver/fnetlistener.h
+++ b/storage/src/vespa/storage/storageserver/fnetlistener.h
@@ -5,6 +5,7 @@
 #include <atomic>
 
 class FNET_Transport;
+class FastOS_ThreadPool;
 
 namespace storage {
 

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -14,6 +14,7 @@
 #include <vespa/storage/common/statusmetricconsumer.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/metrics/metricmanager.h>
 #include <fcntl.h>
 
@@ -568,7 +569,7 @@ StorageNode::waitUntilInitialized(uint32_t timeout) {
             lib::NodeState nodeState(*_component->getStateUpdater().getReportedNodeState());
             if (nodeState.getState() == lib::State::UP) break;
         }
-        FastOS_Thread::Sleep(10);
+        std::this_thread::sleep_for(10ms);
         if (clock.getTimeInMillis() >= endTime) {
             std::ostringstream ost;
             ost << "Storage server not initialized after waiting timeout of "

--- a/storage/src/vespa/storage/tools/storage-cmd.cpp
+++ b/storage/src/vespa/storage/tools/storage-cmd.cpp
@@ -3,6 +3,8 @@
 #include <vespa/slobrok/sbmirror.h>
 #include <vespa/fastos/app.h>
 #include <vespa/vespalib/locale/c.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP("vespa-storage-cmd");
@@ -61,7 +63,7 @@ public:
         slobrok::api::MirrorAPI mirror(supervisor.supervisor(), sbcfg);
 
         while (!mirror.ready()) {
-            FastOS_Thread::Sleep(10);
+            std::this_thread::sleep_for(10ms);
         }
 
         slobrok::api::MirrorAPI::SpecList list = mirror.lookup(_argv[1]);

--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -198,7 +198,7 @@ int StorageApp::Main()
     LOG(debug, "Server was attempted stopped, shutting down");
     // Create guard that will forcifully kill storage if destruction takes longer
     // time than given timeout.
-    vespalib::ShutdownGuard shutdownGuard(_maxShutdownTime);
+    vespalib::ShutdownGuard shutdownGuard(std::chrono::milliseconds(_maxShutdownTime));
     LOG(debug, "Attempting proper shutdown");
     _process.reset();
     LOG(debug, "Completed controlled shutdown.");

--- a/vdslib/src/tests/thread/taskschedulertest.cpp
+++ b/vdslib/src/tests/thread/taskschedulertest.cpp
@@ -2,6 +2,8 @@
 
 #include <vespa/vdslib/thread/taskscheduler.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/time.h>
+#include <thread>
 
 namespace vdslib {
 
@@ -141,13 +143,13 @@ TEST(TaskSchedulerTest, test_simple)
         task->registerCallsWithName("", calls);
         scheduler.addAbsolute(TestTask::UP(task), 50);
         watch.increment(49); // Not yet time to run
-        FastOS_Thread::Sleep(5);
+        std::this_thread::sleep_for(5ms);
             // Check that it has not run yet..
         EXPECT_EQ(counter, scheduler.getTaskCounter());
         watch.increment(10); // Now time is enough for it to run
         scheduler.waitForTaskCounterOfAtLeast(counter + 1);
         watch.increment(10);
-        FastOS_Thread::Sleep(5);
+        std::this_thread::sleep_for(5ms);
             // Check that it has not run yet..
         EXPECT_EQ(counter + 1, scheduler.getTaskCounter());
         watch.increment(50);

--- a/vespaclient/src/vespa/vespaclient/vdsstates/statesapp.cpp
+++ b/vespaclient/src/vespa/vespaclient/vdsstates/statesapp.cpp
@@ -1,19 +1,20 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/defaults.h>
-#include <vespa/document/util/stringutil.h>
 #include <vespa/fnet/frt/frt.h>
 #include <vespa/slobrok/sbmirror.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>
 #include <vespa/vespalib/util/programoptions.h>
 #include <vespa/vespaclient/clusterlist/clusterlist.h>
+#include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/text/lowercase.h>
 #include <vespa/config-stor-distribution.h>
 #include <vespa/config/helper/configgetter.hpp>
 #include <vespa/fastos/app.h>
 #include <sstream>
 #include <iostream>
+#include <thread>
 #include <sys/time.h>
 
 #include <vespa/log/log.h>
@@ -282,7 +283,7 @@ struct StateApp : public FastOS_Application {
                 }
                 warnTime *= 4;
             }
-            FastOS_Thread::Sleep(10);
+            std::this_thread::sleep_for(10ms);
         }
         if (!slobrok->ready()) {
             std::cerr << "Slobrok not ready.\n";

--- a/vespalib/src/tests/delegatelist/delegatelist.cpp
+++ b/vespalib/src/tests/delegatelist/delegatelist.cpp
@@ -780,11 +780,11 @@ Test::testWaitSnapshots()
     ASSERT_TRUE(pool.NewThread(&a1, 0) != 0);
     s1.reset(new DL::Snapshot(dl));                 // create snap 1
     a1.doIt(cmd_wait_snap(&dl));                    // wait for snaps
-    FastOS_Thread::Sleep(1000);
+    std::this_thread::sleep_for(1s);
     EXPECT_TRUE(a1.getState() == Actor::STATE_BUSY); // still waiting...
     s2.reset(new DL::Snapshot(dl));                 // create snap 2
     s1.reset();                                     // destroy snap 1
-    FastOS_Thread::Sleep(1000);
+    std::this_thread::sleep_for(1s);
     EXPECT_TRUE(a1.getState() == Actor::STATE_IDLE); // wait done!
     a1.doIt(cmd_exit());
     a1.waitState(Actor::STATE_DONE);

--- a/vespalib/src/tests/left_right_heap/left_right_heap_bench.cpp
+++ b/vespalib/src/tests/left_right_heap/left_right_heap_bench.cpp
@@ -5,7 +5,12 @@
 #include <vespa/vespalib/util/inline.h>
 #include <vespa/fastos/timestamp.h>
 
-using namespace vespalib;
+using vespalib::RightArrayHeap;
+using vespalib::RightHeap;
+using vespalib::LeftArrayHeap;
+using vespalib::LeftHeap;
+using vespalib::LeftStdHeap;
+using vespalib::make_string;
 
 template <typename H> struct IsRight { enum { VALUE = 0 }; };
 template <> struct IsRight<RightHeap> { enum { VALUE = 1 }; };

--- a/vespalib/src/tests/simple_thread_bundle/simple_thread_bundle_test.cpp
+++ b/vespalib/src/tests/simple_thread_bundle/simple_thread_bundle_test.cpp
@@ -47,7 +47,7 @@ TEST_MT_FF("require that signals can be counted and cancelled", 2, Signal, size_
     if (thread_id == 0) {
         for (size_t i = 0; i < f2; ++i) {
             f1.send();
-            if (i % 128 == 0) { FastOS_Thread::Sleep(1); }
+            if (i % 128 == 0) { std::this_thread::sleep_for(1ms); }
         }
         TEST_BARRIER();
         f1.cancel();

--- a/vespalib/src/tests/simple_thread_bundle/threading_speed_test.cpp
+++ b/vespalib/src/tests/simple_thread_bundle/threading_speed_test.cpp
@@ -65,7 +65,7 @@ TEST("estimate cost of thread bundle fork/join") {
                     if (time < minTime) {
                         minTime = time;
                     }
-                    FastOS_Thread::Sleep(10);
+                    std::this_thread::sleep_for(10ms);
                 }
                 fprintf(stderr, "strategy: %s, threads: %zu, fork: %zu, iter: %zu, time: %g, unit: %g\n",
                         strategy_name[strategy].c_str(), threads, fork, iter, minTime,

--- a/vespalib/src/tests/thread/thread_test.cpp
+++ b/vespalib/src/tests/thread/thread_test.cpp
@@ -32,7 +32,7 @@ TEST("normal operation") {
     {
         Thread thread(agent);
         thread.start();
-        FastOS_Thread::Sleep(20);
+        std::this_thread::sleep_for(20ms);
         thread.stop().join();
     }
     EXPECT_TRUE(agent.started);

--- a/vespalib/src/vespa/vespalib/testkit/test_kit.h
+++ b/vespalib/src/vespa/vespalib/testkit/test_kit.h
@@ -10,3 +10,4 @@
 #include "test_hook.h"
 #include "test_state_guard.h"
 #include "time_bomb.h"
+#include <vespa/vespalib/util/time.h>

--- a/vespalib/src/vespa/vespalib/util/thread.cpp
+++ b/vespalib/src/vespa/vespalib/util/thread.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "thread.h"
+#include <thread>
 
 namespace vespalib {
 
@@ -87,7 +88,7 @@ Thread::currentThread()
 void
 Thread::sleep(size_t ms)
 {
-    FastOS_Thread::Sleep(ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
 
 } // namespace vespalib

--- a/vespamalloc/src/tests/allocfree/allocfree.cpp
+++ b/vespamalloc/src/tests/allocfree/allocfree.cpp
@@ -89,7 +89,7 @@ int Test::Main() {
 
     for (; duration > 0; --duration) {
         LOG(info, "%d seconds left...", duration);
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
     pool.Close();
     size_t numFreeOperations(0);

--- a/vespamalloc/src/tests/allocfree/linklist.cpp
+++ b/vespamalloc/src/tests/allocfree/linklist.cpp
@@ -163,7 +163,7 @@ int Test::Main() {
 
     for (; duration > 0; --duration) {
         LOG(info, "%d seconds left...", duration);
-        FastOS_Thread::Sleep(1000);
+        std::this_thread::sleep_for(1s);
     }
     pool.Close();
     fprintf(stderr, "Did (%lu + %lu) = %lu linkIn operations\n",


### PR DESCRIPTION
Renamed Timer -> ScheduledExecutor.
Do not include thread.h when not needed in header files.

@vekterli PR
Here are no semantic changes.
