### PR TITLE
improve label parsing in ranking expressions.

### DIFF
--- a/eval/src/tests/eval/function/function_test.cpp
+++ b/eval/src/tests/eval/function/function_test.cpp
@@ -828,11 +828,15 @@ TEST("require that tensor lambda can use non-dimension symbols") {
 
 TEST("require that verbose tensor create can be parsed") {
     auto dense = Function::parse("tensor(x[3]):{{x:0}:1,{x:1}:2,{x:2}:3}");
-    auto sparse = Function::parse("tensor(x{}):{{x:a}:1,{x:b}:2,{x:c}:3}");
-    auto mixed = Function::parse("tensor(x{},y[2]):{{x:a,y:0}:1,{x:a,y:1}:2}");
+    auto sparse1 = Function::parse("tensor(x{}):{{x:a}:1,{x:b}:2,{x:c}:3}");
+    auto sparse2 = Function::parse("tensor(x{}):{{x:\"a\"}:1,{x:\"b\"}:2,{x:\"c\"}:3}");
+    auto mixed1 = Function::parse("tensor(x{},y[2]):{{x:a,y:0}:1,{x:a,y:1}:2}");
+    auto mixed2 = Function::parse("tensor(x{},y[2]):{{x:\"a\",y:0}:1,{x:\"a\",y:1}:2}");
     EXPECT_EQUAL("tensor(x[3]):{{x:0}:1,{x:1}:2,{x:2}:3}", dense.dump());
-    EXPECT_EQUAL("tensor(x{}):{{x:a}:1,{x:b}:2,{x:c}:3}", sparse.dump());
-    EXPECT_EQUAL("tensor(x{},y[2]):{{x:a,y:0}:1,{x:a,y:1}:2}", mixed.dump());
+    EXPECT_EQUAL("tensor(x{}):{{x:\"a\"}:1,{x:\"b\"}:2,{x:\"c\"}:3}", sparse1.dump());
+    EXPECT_EQUAL("tensor(x{}):{{x:\"a\"}:1,{x:\"b\"}:2,{x:\"c\"}:3}", sparse2.dump());
+    EXPECT_EQUAL("tensor(x{},y[2]):{{x:\"a\",y:0}:1,{x:\"a\",y:1}:2}", mixed1.dump());
+    EXPECT_EQUAL("tensor(x{},y[2]):{{x:\"a\",y:0}:1,{x:\"a\",y:1}:2}", mixed2.dump());
 }
 
 TEST("require that verbose tensor create can contain expressions") {
@@ -873,15 +877,24 @@ TEST("require that verbose tensor create detects non-numeric indexes for indexed
                          "[tensor(x[1]):{{x:]...[expected number]...[foo}:1}]"));
 }
 
+TEST("require that verbose tensor create indexes cannot be quoted") {
+    TEST_DO(verify_error("tensor(x[1]):{{x:\"1\"}:1}",
+                         "[tensor(x[1]):{{x:]...[expected number]...[\"1\"}:1}]"));
+}
+
 //-----------------------------------------------------------------------------
 
 TEST("require that convenient tensor create can be parsed") {
     auto dense = Function::parse("tensor(x[3]):[1,2,3]");
-    auto sparse = Function::parse("tensor(x{}):{a:1,b:2,c:3}");
-    auto mixed = Function::parse("tensor(x{},y[2]):{a:[1,2]}");
+    auto sparse1 = Function::parse("tensor(x{}):{a:1,b:2,c:3}");
+    auto sparse2 = Function::parse("tensor(x{}):{\"a\":1,\"b\":2,\"c\":3}");
+    auto mixed1 = Function::parse("tensor(x{},y[2]):{a:[1,2]}");
+    auto mixed2 = Function::parse("tensor(x{},y[2]):{\"a\":[1,2]}");
     EXPECT_EQUAL("tensor(x[3]):{{x:0}:1,{x:1}:2,{x:2}:3}", dense.dump());
-    EXPECT_EQUAL("tensor(x{}):{{x:a}:1,{x:b}:2,{x:c}:3}", sparse.dump());
-    EXPECT_EQUAL("tensor(x{},y[2]):{{x:a,y:0}:1,{x:a,y:1}:2}", mixed.dump());
+    EXPECT_EQUAL("tensor(x{}):{{x:\"a\"}:1,{x:\"b\"}:2,{x:\"c\"}:3}", sparse1.dump());
+    EXPECT_EQUAL("tensor(x{}):{{x:\"a\"}:1,{x:\"b\"}:2,{x:\"c\"}:3}", sparse2.dump());
+    EXPECT_EQUAL("tensor(x{},y[2]):{{x:\"a\",y:0}:1,{x:\"a\",y:1}:2}", mixed1.dump());
+    EXPECT_EQUAL("tensor(x{},y[2]):{{x:\"a\",y:0}:1,{x:\"a\",y:1}:2}", mixed2.dump());
 }
 
 TEST("require that convenient tensor create can contain expressions") {
@@ -893,11 +906,11 @@ TEST("require that convenient tensor create can contain expressions") {
 
 TEST("require that convenient tensor create handles dimension order") {
     auto mixed = Function::parse("tensor(y{},x[2]):{a:[1,2]}");
-    EXPECT_EQUAL("tensor(x[2],y{}):{{x:0,y:a}:1,{x:1,y:a}:2}", mixed.dump());
+    EXPECT_EQUAL("tensor(x[2],y{}):{{x:0,y:\"a\"}:1,{x:1,y:\"a\"}:2}", mixed.dump());
 }
 
 TEST("require that convenient tensor create can be highly nested") {
-    vespalib::string expect("tensor(a{},b{},c[1],d[1]):{{a:x,b:y,c:0,d:0}:5}");
+    vespalib::string expect("tensor(a{},b{},c[1],d[1]):{{a:\"x\",b:\"y\",c:0,d:0}:5}");
     auto nested1 = Function::parse("tensor(a{},b{},c[1],d[1]):{x:{y:[[5]]}}");
     auto nested2 = Function::parse("tensor(c[1],d[1],a{},b{}):[[{x:{y:5}}]]");
     auto nested3 = Function::parse("tensor(a{},c[1],b{},d[1]): { x : [ { y : [ 5 ] } ] } ");
@@ -907,7 +920,7 @@ TEST("require that convenient tensor create can be highly nested") {
 }
 
 TEST("require that convenient tensor create can have multiple values on multiple levels") {
-    vespalib::string expect("tensor(x{},y[2]):{{x:a,y:0}:1,{x:a,y:1}:2,{x:b,y:0}:3,{x:b,y:1}:4}");
+    vespalib::string expect("tensor(x{},y[2]):{{x:\"a\",y:0}:1,{x:\"a\",y:1}:2,{x:\"b\",y:0}:3,{x:\"b\",y:1}:4}");
     auto fun1 = Function::parse("tensor(x{},y[2]):{a:[1,2],b:[3,4]}");
     auto fun2 = Function::parse("tensor(y[2],x{}):[{a:1,b:3},{a:2,b:4}]");
     auto fun3 = Function::parse("tensor(x{},y[2]): { a : [ 1 , 2 ] , b : [ 3 , 4 ] } ");
@@ -941,41 +954,44 @@ TEST("require that convenient tensor create detects under-specified cells") {
 //-----------------------------------------------------------------------------
 
 TEST("require that tensor peek can be parsed") {
-    TEST_DO(verify_parse("t{x:1,y:foo}", "f(t)(t{x:1,y:foo})"));
+    TEST_DO(verify_parse("t{x:\"1\",y:\"foo\"}", "f(t)(t{x:\"1\",y:\"foo\"})"));
+    TEST_DO(verify_parse("t{x:1,y:foo}", "f(t)(t{x:\"1\",y:\"foo\"})"));
 }
 
 TEST("require that tensor peek can contain expressions") {
-    TEST_DO(verify_parse("t{x:1+2,y:foo}", "f(t)(t{x:(1+2),y:foo})"));
-    TEST_DO(verify_parse("t{x:1+bar,y:foo}", "f(t,bar)(t{x:(1+bar),y:foo})"));
-    TEST_DO(verify_parse("t{x:1,y:foo+2}", "f(t,foo)(t{x:1,y:(foo+2)})"));
-    TEST_DO(verify_parse("t{x:1,y:(foo)}", "f(t,foo)(t{x:1,y:(foo)})"));
+    TEST_DO(verify_parse("t{x:(1+2),y:1+2}", "f(t)(t{x:(1+2),y:\"1+2\"})"));
+    TEST_DO(verify_parse("t{x:(foo),y:foo}", "f(t,foo)(t{x:(foo),y:\"foo\"})"));
+    TEST_DO(verify_parse("t{x:(foo+2),y:foo+2}", "f(t,foo)(t{x:(foo+2),y:\"foo+2\"})"));
 }
 
-TEST("require that trivial tensor peek string/number expressions are converted to verbatim labels") {
-    TEST_DO(verify_parse("t{x:\"foo\"}", "f(t)(t{x:foo})"));
-    TEST_DO(verify_parse("t{x:(\"foo\")}", "f(t)(t{x:foo})"));
-    TEST_DO(verify_parse("t{x:5.5}", "f(t)(t{x:5})"));
-    TEST_DO(verify_parse("t{x:(5.5)}", "f(t)(t{x:5})"));
+TEST("require that trivial tensor peek number expressions are converted to verbatim labels") {
+    TEST_DO(verify_parse("t{x:(5.7)}", "f(t)(t{x:\"6\"})"));
+    TEST_DO(verify_parse("t{x:(5.3)}", "f(t)(t{x:\"5\"})"));
+    TEST_DO(verify_parse("t{x:(-5.7)}", "f(t)(t{x:\"-6\"})"));
+    TEST_DO(verify_parse("t{x:(-5.3)}", "f(t)(t{x:\"-5\"})"));
 }
 
 TEST("require that tensor peek can contain extra whitespace") {
-    TEST_DO(verify_parse(" t { x : 1 + bar , y : foo + 2 } ",
+    TEST_DO(verify_parse(" t { x : ( 1 + bar ) , y : ( foo + 2 ) } ",
                          "f(t,bar,foo)(t{x:(1+bar),y:(foo+2)})"));
-}
-
-TEST("require that converted tensor peek string expression must be valid identifier") {
-    TEST_DO(verify_error("x{a:\"5.5\"}", "[x{a:\"5.5\"]...[invalid identifier: '5.5']...[}]"));
+    TEST_DO(verify_parse(" t { x : \"1 + bar\" , y : \"foo + 2\" } ",
+                         "f(t)(t{x:\"1 + bar\",y:\"foo + 2\"})"));
 }
 
 TEST("require that empty tensor peek is not allowed") {
     TEST_DO(verify_error("x{}", "[x{}]...[empty peek spec]...[]"));
 }
 
+TEST("require that tensor peek empty label is not allowed") {
+    TEST_DO(verify_error("x{a:}", "[x{a:]...[missing label]...[}]"));
+    TEST_DO(verify_error("x{a:\"\"}", "[x{a:\"\"]...[missing label]...[}]"));
+}
+
 //-----------------------------------------------------------------------------
 
 TEST("require that nested tensor lambda using tensor peek can be parsed") {
-    vespalib::string expect("tensor(x[2]):{{x:0}:tensor(y[2]):{{y:0}:((0+0)+a),{y:1}:((0+1)+a)}{y:0},"
-                            "{x:1}:tensor(y[2]):{{y:0}:((1+0)+a),{y:1}:((1+1)+a)}{y:1}}");
+    vespalib::string expect("tensor(x[2]):{{x:0}:tensor(y[2]):{{y:0}:((0+0)+a),{y:1}:((0+1)+a)}{y:\"0\"},"
+                            "{x:1}:tensor(y[2]):{{y:0}:((1+0)+a),{y:1}:((1+1)+a)}{y:\"1\"}}");
     EXPECT_EQUAL(Function::parse(expect).dump(), expect);
     auto fun = Function::parse("tensor(x[2])(tensor(y[2])(x+y+a){y:(x)})");
     EXPECT_EQUAL(fun.dump(), expect);

--- a/eval/src/tests/eval/node_types/node_types_test.cpp
+++ b/eval/src/tests/eval/node_types/node_types_test.cpp
@@ -222,7 +222,7 @@ TEST("require that tensor peek resolves correct type") {
     TEST_DO(verify("tensor(x{}){x:1}", "double"));
     TEST_DO(verify("tensor(x{}){x:foo}", "double"));
     TEST_DO(verify("tensor(x{}){x:(double)}", "double"));
-    TEST_DO(verify("tensor(x{}){x:tensor(x[3])}", "error"));
+    TEST_DO(verify("tensor(x{}){x:(tensor(x[3]))}", "error"));
     TEST_DO(verify("tensor(x{},y[3]){x:foo,y:2}", "double"));
     TEST_DO(verify("tensor(x{},y[3]){x:foo}", "tensor(y[3])"));
     TEST_DO(verify("tensor(x{},y[3]){y:2}", "tensor(x{})"));
@@ -233,7 +233,7 @@ TEST("require that tensor peek resolves correct type") {
     TEST_DO(verify("tensor<float>(x{}){x:1}", "double"));
     TEST_DO(verify("tensor<float>(x{}){x:foo}", "double"));
     TEST_DO(verify("tensor<float>(x{}){x:(double)}", "double"));
-    TEST_DO(verify("tensor<float>(x{}){x:tensor(x[3])}", "error"));
+    TEST_DO(verify("tensor<float>(x{}){x:(tensor(x[3]))}", "error"));
     TEST_DO(verify("tensor<float>(x{},y[3]){x:foo,y:2}", "double"));
     TEST_DO(verify("tensor<float>(x{},y[3]){x:foo}", "tensor<float>(y[3])"));
     TEST_DO(verify("tensor<float>(x{},y[3]){y:2}", "tensor<float>(x{})"));

--- a/eval/src/vespa/eval/eval/basic_nodes.cpp
+++ b/eval/src/vespa/eval/eval/basic_nodes.cpp
@@ -66,49 +66,6 @@ void Not   ::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 void If    ::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 void Error ::accept(NodeVisitor &visitor) const { visitor.visit(*this); }
 
-vespalib::string
-String::dump(DumpContext &) const
-{
-    vespalib::string str;
-    str.push_back('"');
-    for (uint32_t i = 0; i < _value.size(); ++i) {
-        char c = _value[i];
-        switch (c) {
-        case '\\':
-            str.append("\\\\");
-            break;
-        case '"':
-            str.append("\\\"");
-            break;
-        case '\t':
-            str.append("\\t");
-            break;
-        case '\n':
-            str.append("\\n");
-            break;
-        case '\r':
-            str.append("\\r");
-            break;
-        case '\f':
-            str.append("\\f");
-            break;
-        default:
-            if (static_cast<unsigned char>(c) >= 32 &&
-                static_cast<unsigned char>(c) <= 126)
-            {
-                str.push_back(c);
-            } else {
-                const char *lookup = "0123456789abcdef";
-                str.append("\\x");
-                str.push_back(lookup[(c >> 4) & 0xf]);
-                str.push_back(lookup[c & 0xf]);
-            }
-        }
-    }
-    str.push_back('"');
-    return str;
-}
-
 If::If(Node_UP cond_in, Node_UP true_expr_in, Node_UP false_expr_in, double p_true_in)
     : _cond(std::move(cond_in)),
       _true_expr(std::move(true_expr_in)),

--- a/eval/src/vespa/eval/eval/basic_nodes.h
+++ b/eval/src/vespa/eval/eval/basic_nodes.h
@@ -124,7 +124,9 @@ public:
     double get_const_value() const override { return hash(); }
     const vespalib::string &value() const { return _value; }
     uint32_t hash() const { return hash_code(_value.data(), _value.size()); }
-    vespalib::string dump(DumpContext &ctx) const override;
+    vespalib::string dump(DumpContext &) const override {
+        return as_quoted_string(_value);
+    }
     void accept(NodeVisitor &visitor) const override;
 };
 

--- a/eval/src/vespa/eval/eval/string_stuff.cpp
+++ b/eval/src/vespa/eval/eval/string_stuff.cpp
@@ -5,6 +5,46 @@
 
 namespace vespalib::eval {
 
+vespalib::string as_quoted_string(const vespalib::string &str) {
+    vespalib::string res;
+    res.push_back('"');
+    for (char c: str) {
+        switch (c) {
+        case '\\':
+            res.append("\\\\");
+            break;
+        case '"':
+            res.append("\\\"");
+            break;
+        case '\t':
+            res.append("\\t");
+            break;
+        case '\n':
+            res.append("\\n");
+            break;
+        case '\r':
+            res.append("\\r");
+            break;
+        case '\f':
+            res.append("\\f");
+            break;
+        default:
+            if (static_cast<unsigned char>(c) >= 32 &&
+                static_cast<unsigned char>(c) <= 126)
+            {
+                res.push_back(c);
+            } else {
+                const char *lookup = "0123456789abcdef";
+                res.append("\\x");
+                res.push_back(lookup[(c >> 4) & 0xf]);
+                res.push_back(lookup[c & 0xf]);
+            }
+        }
+    }
+    res.push_back('"');
+    return res;
+}
+
 bool is_number(const vespalib::string &str) {
     for (char c: str) {
         if (!isdigit(c)) {
@@ -24,7 +64,7 @@ vespalib::string as_string(const TensorSpec::Address &address) {
     for (const auto &label: address) {
         label_list.maybe_add_comma(str);
         if (label.second.is_mapped()) {
-            str += make_string("%s:%s", label.first.c_str(), label.second.name.c_str());
+            str += make_string("%s:%s", label.first.c_str(), as_quoted_string(label.second.name).c_str());
         } else {
             str += make_string("%s:%zu", label.first.c_str(), label.second.index);
         }

--- a/eval/src/vespa/eval/eval/string_stuff.h
+++ b/eval/src/vespa/eval/eval/string_stuff.h
@@ -38,6 +38,11 @@ struct CommaTracker {
 };
 
 /**
+ * Convert the given string to a quoted string with escaped special characters.
+ **/
+vespalib::string as_quoted_string(const vespalib::string &str);
+
+/**
  * Is this string a positive integer (dimension index)
  **/
 bool is_number(const vespalib::string &str);

--- a/eval/src/vespa/eval/eval/tensor_function.cpp
+++ b/eval/src/vespa/eval/eval/tensor_function.cpp
@@ -168,14 +168,14 @@ void op_tensor_peek(State &state, uint64_t param) {
             addr.emplace(pos->first, std::get<TensorSpec::Label>(pos->second));
         } else {
             assert(std::holds_alternative<TensorFunction::Child>(pos->second));
-            size_t index(state.peek(child_cnt++).as_double());
+            double index = round(state.peek(child_cnt++).as_double());
             size_t dim_idx = self.param_type().dimension_index(pos->first);
             assert(dim_idx != ValueType::Dimension::npos);
             const auto &param_dim = self.param_type().dimensions()[dim_idx];
             if (param_dim.is_mapped()) {
-                addr.emplace(pos->first, vespalib::make_string("%zu", index));
+                addr.emplace(pos->first, vespalib::make_string("%ld", int64_t(index)));
             } else {
-                addr.emplace(pos->first, index);
+                addr.emplace(pos->first, size_t(index));
             }
         }
     }

--- a/eval/src/vespa/eval/eval/tensor_nodes.h
+++ b/eval/src/vespa/eval/eval/tensor_nodes.h
@@ -285,7 +285,7 @@ public:
                     str += ")";
                 }
             } else {
-                str += dim.second.label;
+                str += as_quoted_string(dim.second.label);
             }
         }
         str += "}";

--- a/eval/src/vespa/eval/eval/test/tensor_conformance.cpp
+++ b/eval/src/vespa/eval/eval/test/tensor_conformance.cpp
@@ -817,10 +817,10 @@ struct TestContext {
     void test_tensor_peek() {
         auto param_double = spec({x({"0", "1"}),y(2)}, Seq({1.0, 2.0, 3.0, 4.0}));
         auto param_float = spec(float_cells({x({"0", "1"}),y(2)}), Seq({1.0, 2.0, 3.0, 4.0}));
-        TEST_DO(test_tensor_peek("tensor(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_double, spec(x(2), Seq({4.0, 1.0}))));
-        TEST_DO(test_tensor_peek("tensor(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_float, spec(x(2), Seq({4.0, 1.0}))));
-        TEST_DO(test_tensor_peek("tensor<float>(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_double, spec(float_cells({x(2)}), Seq({4.0, 1.0}))));
-        TEST_DO(test_tensor_peek("tensor<float>(x[2]):[a{x:1,y:1},a{x:b-1,y:b-1}]", param_float, spec(float_cells({x(2)}), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor(x[2]):[a{x:1,y:1},a{x:(b-1),y:(b-1)}]", param_double, spec(x(2), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor(x[2]):[a{x:1,y:1},a{x:(b-1),y:(b-1)}]", param_float, spec(x(2), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor<float>(x[2]):[a{x:1,y:1},a{x:(b-1),y:(b-1)}]", param_double, spec(float_cells({x(2)}), Seq({4.0, 1.0}))));
+        TEST_DO(test_tensor_peek("tensor<float>(x[2]):[a{x:1,y:1},a{x:(b-1),y:(b-1)}]", param_float, spec(float_cells({x(2)}), Seq({4.0, 1.0}))));
         TEST_DO(test_tensor_peek("a{x:(b)}", param_double, spec(y(2), Seq({3.0, 4.0}))));
         TEST_DO(test_tensor_peek("a{x:(b)}", param_float, spec(float_cells({y(2)}), Seq({3.0, 4.0}))));
         TEST_DO(test_tensor_peek("a{y:(b)}", param_double, spec(x({"0", "1"}), Seq({2.0, 4.0}))));


### PR DESCRIPTION
unquoted labels can now contain almost anything
labels can now also be quoted (in tensor create/peek)
NB: indexes in verbose tensor create cannot be quoted
expressions in tensor peek must have () around them
expression results are rounded before conversion
the sign is kept when expression results are converted to labels
trivial number expressions in tensor peek are converted to labels
... by the parser, to better inline bindings created by tensor lambdas
verbatim tensor peek for indexed dimensions will fail type resolution
... when the label cannot be converted to a valid index

@arnej27959 please review
@bratseth @lesters FYI