### PR TITLE
Jvenstad/remove old job status

### DIFF
--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -77,9 +77,8 @@ public class DeploymentSpecTest {
         );
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
-        assertEquals(2, spec.steps().size());
+        assertEquals(1, spec.steps().size());
         assertEquals(1, spec.requireInstance("default").steps().size());
-        assertTrue(spec.steps().get(0).concerns(Environment.test));
         assertTrue(spec.requireInstance("default").steps().get(0).concerns(Environment.staging));
         assertFalse(spec.requireInstance("default").deploysTo(Environment.test, Optional.empty()));
         assertTrue(spec.requireInstance("default").deploysTo(Environment.staging, Optional.empty()));
@@ -101,12 +100,8 @@ public class DeploymentSpecTest {
         );
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
-        assertEquals(3, spec.steps().size());
+        assertEquals(1, spec.steps().size());
         assertEquals(2, spec.requireInstance("default").steps().size());
-
-        assertTrue(spec.steps().get(0).concerns(Environment.test));
-
-        assertTrue(spec.steps().get(1).concerns(Environment.staging));
 
         assertTrue(spec.requireInstance("default").steps().get(0).concerns(Environment.prod, Optional.of(RegionName.from("us-east1"))));
         assertFalse(((DeploymentSpec.DeclaredZone)spec.requireInstance("default").steps().get(0)).active());
@@ -500,6 +495,7 @@ public class DeploymentSpecTest {
     public void testNestedParallelAndSteps() {
         StringReader r = new StringReader(
                 "<deployment athenz-domain='domain'>" +
+                "   <staging />" +
                 "   <instance id='instance' athenz-service='in-service'>" +
                 "      <prod>" +
                 "         <parallel>" +
@@ -529,13 +525,12 @@ public class DeploymentSpecTest {
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         List<DeploymentSpec.Step> steps = spec.steps();
-        assertEquals(3, steps.size());
-        assertEquals("test", steps.get(0).toString());
-        assertEquals("staging", steps.get(1).toString());
-        assertEquals("instance 'instance'", steps.get(2).toString());
-        assertEquals(Duration.ofHours(4), steps.get(2).delay());
+        assertEquals(2, steps.size());
+        assertEquals("staging", steps.get(0).toString());
+        assertEquals("instance 'instance'", steps.get(1).toString());
+        assertEquals(Duration.ofHours(4), steps.get(1).delay());
 
-        List<DeploymentSpec.Step> instanceSteps = steps.get(2).steps();
+        List<DeploymentSpec.Step> instanceSteps = steps.get(1).steps();
         assertEquals(2, instanceSteps.size());
         assertEquals("4 parallel steps", instanceSteps.get(0).toString());
         assertEquals("prod.us-north-7", instanceSteps.get(1).toString());
@@ -590,12 +585,10 @@ public class DeploymentSpecTest {
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         List<DeploymentSpec.Step> steps = spec.steps();
-        assertEquals(3, steps.size());
-        assertEquals("test", steps.get(0).toString());
-        assertEquals("staging", steps.get(1).toString());
-        assertEquals("2 parallel steps", steps.get(2).toString());
+        assertEquals(1, steps.size());
+        assertEquals("2 parallel steps", steps.get(0).toString());
 
-        List<DeploymentSpec.Step> parallelSteps = steps.get(2).steps();
+        List<DeploymentSpec.Step> parallelSteps = steps.get(0).steps();
         assertEquals("instance 'instance0'", parallelSteps.get(0).toString());
         assertEquals("instance 'instance1'", parallelSteps.get(1).toString());
     }
@@ -620,12 +613,10 @@ public class DeploymentSpecTest {
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         List<DeploymentSpec.Step> steps = spec.steps();
-        assertEquals(5, steps.size());
-        assertEquals("test", steps.get(0).toString());
-        assertEquals("staging", steps.get(1).toString());
-        assertEquals("instance 'instance0'", steps.get(2).toString());
-        assertEquals("delay PT12H", steps.get(3).toString());
-        assertEquals("instance 'instance1'", steps.get(4).toString());
+        assertEquals(3, steps.size());
+        assertEquals("instance 'instance0'", steps.get(0).toString());
+        assertEquals("delay PT12H", steps.get(1).toString());
+        assertEquals("instance 'instance1'", steps.get(2).toString());
     }
 
     @Test

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -516,6 +516,7 @@ public class DeploymentSpecTest {
                 "               <parallel>" +
                 "                  <region active='true' athenz-service='no-service'>ap-northeast-1</region>" +
                 "                  <region active='true'>ap-southeast-2</region>" +
+                "                  <test>aws-us-east-1a</test>" +
                 "               </parallel>" +
                 "            </steps>" +
                 "            <delay hours='3' minutes='30' />" +
@@ -557,14 +558,15 @@ public class DeploymentSpecTest {
         assertEquals(3, secondSerialSteps.size());
         assertEquals("delay PT3H", secondSerialSteps.get(0).toString());
         assertEquals("prod.aws-us-east-1a", secondSerialSteps.get(1).toString());
-        assertEquals("2 parallel steps", secondSerialSteps.get(2).toString());
+        assertEquals("3 parallel steps", secondSerialSteps.get(2).toString());
 
         List<DeploymentSpec.Step> innerParallelSteps = secondSerialSteps.get(2).steps();
-        assertEquals(2, innerParallelSteps.size());
+        assertEquals(3, innerParallelSteps.size());
         assertEquals("prod.ap-northeast-1", innerParallelSteps.get(0).toString());
         assertEquals("no-service", spec.requireInstance("instance").athenzService(Environment.prod, RegionName.from("ap-northeast-1")).get().value());
         assertEquals("prod.ap-southeast-2", innerParallelSteps.get(1).toString());
         assertEquals("in-service", spec.requireInstance("instance").athenzService(Environment.prod, RegionName.from("ap-southeast-2")).get().value());
+        assertEquals("tests for prod.aws-us-east-1a", innerParallelSteps.get(2).toString());
     }
 
     @Test

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
@@ -71,9 +71,8 @@ public class DeploymentSpecWithoutInstanceTest {
         );
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
-        assertEquals(2, spec.steps().size());
+        assertEquals(1, spec.steps().size());
         assertEquals(1, spec.requireInstance("default").steps().size());
-        assertTrue(spec.steps().get(0).concerns(Environment.test));
         assertTrue(spec.requireInstance("default").steps().get(0).concerns(Environment.staging));
         assertFalse(spec.requireInstance("default").deploysTo(Environment.test, Optional.empty()));
         assertTrue(spec.requireInstance("default").deploysTo(Environment.staging, Optional.empty()));
@@ -93,12 +92,8 @@ public class DeploymentSpecWithoutInstanceTest {
         );
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
-        assertEquals(3, spec.steps().size());
+        assertEquals(1, spec.steps().size());
         assertEquals(2, spec.requireInstance("default").steps().size());
-
-        assertTrue(spec.steps().get(0).concerns(Environment.test));
-
-        assertTrue(spec.steps().get(1).concerns(Environment.staging));
 
         assertTrue(spec.requireInstance("default").steps().get(0).concerns(Environment.prod, Optional.of(RegionName.from("us-east1"))));
         assertFalse(((DeploymentSpec.DeclaredZone)spec.requireInstance("default").steps().get(0)).active());
@@ -352,6 +347,7 @@ public class DeploymentSpecWithoutInstanceTest {
     public void testNestedParallelAndSteps() {
         StringReader r = new StringReader(
                 "<deployment athenz-domain='domain' athenz-service='service'>" +
+                "   <staging />" +
                 "   <prod>" +
                 "      <parallel>" +
                 "         <region active='true'>us-west-1</region>" +
@@ -379,18 +375,17 @@ public class DeploymentSpecWithoutInstanceTest {
 
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         List<DeploymentSpec.Step> steps = spec.steps();
-        assertEquals(3, steps.size());
-        assertEquals("test", steps.get(0).toString());
-        assertEquals("staging", steps.get(1).toString());
-        assertEquals("instance 'default'", steps.get(2).toString());
-        assertEquals(Duration.ofHours(4), steps.get(2).delay());
+        assertEquals(1, steps.size());
+        assertEquals("instance 'default'", steps.get(0).toString());
+        assertEquals(Duration.ofHours(4), steps.get(0).delay());
 
-        List<DeploymentSpec.Step> instanceSteps = steps.get(2).steps();
-        assertEquals(2, instanceSteps.size());
-        assertEquals("4 parallel steps", instanceSteps.get(0).toString());
-        assertEquals("prod.us-north-7", instanceSteps.get(1).toString());
+        List<DeploymentSpec.Step> instanceSteps = steps.get(0).steps();
+        assertEquals(3, instanceSteps.size());
+        assertEquals("staging", instanceSteps.get(0).toString());
+        assertEquals("4 parallel steps", instanceSteps.get(1).toString());
+        assertEquals("prod.us-north-7", instanceSteps.get(2).toString());
 
-        List<DeploymentSpec.Step> parallelSteps = instanceSteps.get(0).steps();
+        List<DeploymentSpec.Step> parallelSteps = instanceSteps.get(1).steps();
         assertEquals(4, parallelSteps.size());
         assertEquals("prod.us-west-1", parallelSteps.get(0).toString());
         assertEquals("4 steps", parallelSteps.get(1).toString());

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
@@ -367,6 +367,7 @@ public class DeploymentSpecWithoutInstanceTest {
                 "            <parallel>" +
                 "               <region active='true' athenz-service='no-service'>ap-northeast-1</region>" +
                 "               <region active='true'>ap-southeast-2</region>" +
+                "               <test>aws-us-east-1a</test>" +
                 "            </parallel>" +
                 "         </steps>" +
                 "         <delay hours='3' minutes='30' />" +
@@ -407,14 +408,15 @@ public class DeploymentSpecWithoutInstanceTest {
         assertEquals(3, secondSerialSteps.size());
         assertEquals("delay PT3H", secondSerialSteps.get(0).toString());
         assertEquals("prod.aws-us-east-1a", secondSerialSteps.get(1).toString());
-        assertEquals("2 parallel steps", secondSerialSteps.get(2).toString());
+        assertEquals("3 parallel steps", secondSerialSteps.get(2).toString());
 
         List<DeploymentSpec.Step> innerParallelSteps = secondSerialSteps.get(2).steps();
-        assertEquals(2, innerParallelSteps.size());
+        assertEquals(3, innerParallelSteps.size());
         assertEquals("prod.ap-northeast-1", innerParallelSteps.get(0).toString());
         assertEquals("no-service", spec.requireInstance("default").athenzService(Environment.prod, RegionName.from("ap-northeast-1")).get().value());
         assertEquals("prod.ap-southeast-2", innerParallelSteps.get(1).toString());
         assertEquals("service", spec.requireInstance("default").athenzService(Environment.prod, RegionName.from("ap-southeast-2")).get().value());
+        assertEquals("tests for prod.aws-us-east-1a", innerParallelSteps.get(2).toString());
     }
 
     @Test

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/JobType.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/JobType.java
@@ -35,36 +35,70 @@ public enum JobType {
     productionUsEast3      ("production-us-east-3",
                             Map.of(main, ZoneId.from("prod"   , "us-east-3"))),
 
+    testUsEast3            ("test-us-east-3",
+                            Map.of(main, ZoneId.from("prod"   , "us-east-3")), true),
+
     productionUsWest1      ("production-us-west-1",
                             Map.of(main, ZoneId.from("prod"   , "us-west-1"))),
+
+    testUsWest1            ("test-us-west-1",
+                            Map.of(main, ZoneId.from("prod"   , "us-west-1")), true),
 
     productionUsCentral1   ("production-us-central-1",
                             Map.of(main, ZoneId.from("prod"   , "us-central-1"))),
 
+    testUsCentral1         ("test-us-central-1",
+                            Map.of(main, ZoneId.from("prod"   , "us-central-1")), true),
+
     productionApNortheast1 ("production-ap-northeast-1",
                             Map.of(main, ZoneId.from("prod"   , "ap-northeast-1"))),
+
+    testApNortheast1       ("test-ap-northeast-1",
+                            Map.of(main, ZoneId.from("prod"   , "ap-northeast-1")), true),
 
     productionApNortheast2 ("production-ap-northeast-2",
                             Map.of(main, ZoneId.from("prod"   , "ap-northeast-2"))),
 
+    testApNortheast2       ("test-ap-northeast-2",
+                            Map.of(main, ZoneId.from("prod"   , "ap-northeast-2")), true),
+
     productionApSoutheast1 ("production-ap-southeast-1",
                             Map.of(main, ZoneId.from("prod"   , "ap-southeast-1"))),
+
+    testApSoutheast1       ("test-ap-southeast-1",
+                            Map.of(main, ZoneId.from("prod"   , "ap-southeast-1")), true),
 
     productionEuWest1      ("production-eu-west-1",
                             Map.of(main, ZoneId.from("prod"   , "eu-west-1"))),
 
+    testEuWest1            ("test-eu-west-1",
+                            Map.of(main, ZoneId.from("prod"   , "eu-west-1")), true),
+
     productionAwsUsEast1a  ("production-aws-us-east-1a",
                             Map.of(main, ZoneId.from("prod"   , "aws-us-east-1a"))),
+
+    testAwsUsEast1a        ("test-aws-us-east-1a",
+                            Map.of(main, ZoneId.from("prod"   , "aws-us-east-1a")), true),
 
     productionAwsUsEast1c  ("production-aws-us-east-1c",
                             Map.of(PublicCd, ZoneId.from("prod", "aws-us-east-1c"),
                                    Public,   ZoneId.from("prod", "aws-us-east-1c"))),
 
+    testAwsUsEast1c        ("test-aws-us-east-1c",
+                            Map.of(PublicCd, ZoneId.from("prod", "aws-us-east-1c"),
+                                   Public,   ZoneId.from("prod", "aws-us-east-1c")), true),
+
     productionAwsUsWest2a  ("production-aws-us-west-2a",
                             Map.of(main, ZoneId.from("prod"   , "aws-us-west-2a"))),
 
+    testAwsUsWest2a        ("test-aws-us-west-2a",
+                            Map.of(main, ZoneId.from("prod"   , "aws-us-west-2a")), true),
+
     productionAwsUsEast1b  ("production-aws-us-east-1b",
                             Map.of(main, ZoneId.from("prod"   , "aws-us-east-1b"))),
+
+    testAwsUsEast1b        ("test-aws-us-east-1b",
+                            Map.of(main, ZoneId.from("prod"   , "aws-us-east-1b")), true),
 
     devUsEast1             ("dev-us-east-1",
                             Map.of(main, ZoneId.from("dev"    , "us-east-1"))),
@@ -75,8 +109,14 @@ public enum JobType {
     productionCdAwsUsEast1a("production-cd-aws-us-east-1a",
                             Map.of(cd  , ZoneId.from("prod"   , "cd-aws-us-east-1a"))),
 
+    testCdAwsUsEast1a      ("test-cd-aws-us-east-1a",
+                            Map.of(cd  , ZoneId.from("prod"   , "cd-aws-us-east-1a")), true),
+
     productionCdUsCentral1 ("production-cd-us-central-1",
                             Map.of(cd  , ZoneId.from("prod"   , "cd-us-central-1"))),
+
+    testCdUsCentral1       ("test-cd-us-central-1",
+                            Map.of(cd  , ZoneId.from("prod"   , "cd-us-central-1")), true),
 
     // TODO: Cannot remove production-cd-us-central-2 until we know there are no serialized data in controller referencing it
     productionCdUsCentral2 ("production-cd-us-central-2",
@@ -84,6 +124,9 @@ public enum JobType {
 
     productionCdUsWest1    ("production-cd-us-west-1",
                             Map.of(cd  , ZoneId.from("prod"   , "cd-us-west-1"))),
+
+    testCdUsWest1          ("test-cd-us-west-1",
+                            Map.of(cd  , ZoneId.from("prod"   , "cd-us-west-1")), true),
 
     devCdUsCentral1        ("dev-cd-us-central-1",
                             Map.of(cd  , ZoneId.from("dev"    , "cd-us-central-1"))),
@@ -164,7 +207,7 @@ public enum JobType {
     }
 
     /** Returns the production test job type for the given environment and region or null if none */
-    public static Optional<JobType> from(SystemName system, RegionName region) {
+    public static Optional<JobType> testFrom(SystemName system, RegionName region) {
         return from(system, ZoneId.from(Environment.prod, region), true);
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
@@ -1,18 +1,40 @@
 package com.yahoo.vespa.hosted.controller.deployment;
 
+import com.google.common.collect.ImmutableMap;
+import com.yahoo.component.Version;
+import com.yahoo.config.application.api.DeploymentInstanceSpec;
+import com.yahoo.config.application.api.DeploymentSpec;
+import com.yahoo.config.application.api.DeploymentSpec.DeclaredTest;
+import com.yahoo.config.application.api.DeploymentSpec.DeclaredZone;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
+import com.yahoo.vespa.hosted.controller.application.Change;
+import com.yahoo.vespa.hosted.controller.application.Deployment;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.yahoo.config.provision.Environment.prod;
+import static com.yahoo.config.provision.Environment.staging;
+import static com.yahoo.config.provision.Environment.test;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toUnmodifiableList;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 /**
  * Status of the deployment jobs of an {@link Application}.
@@ -23,10 +45,14 @@ public class DeploymentStatus {
 
     private final Application application;
     private final JobList jobs;
+    private final Map<JobId, List<StepStatus>> steps;
+    private final SystemName system = null; // TODO jonmv: Fix.
+    private final Version systemVersion = null; // TODO jonmv: Fix.
 
     public DeploymentStatus(Application application, Map<JobId, JobStatus> jobs) {
-        this.application = Objects.requireNonNull(application);
+        this.application = requireNonNull(application);
         this.jobs = JobList.from(jobs.values());
+        this.steps = null;//jobDependencies(application.deploymentSpec());
     }
 
     public Application application() {
@@ -55,5 +81,276 @@ public class DeploymentStatus {
                    .collect(groupingBy(job -> job.id().application(),
                                        collectingAndThen(toUnmodifiableList(), JobList::from)));
     }
+
+    Optional<JobId> jobId(DeploymentSpec.Step step, InstanceName instance) {
+        if ( ! step.steps().isEmpty())
+            throw new IllegalArgumentException(step + " is not a primitive");
+
+        if ( ! step.delay().isZero())
+            return Optional.empty();
+
+        Optional<JobType> job;
+        if (step.concerns(prod) && step.isTest())
+            job = JobType.from(system, ((DeclaredTest) step).region());
+        else {
+            DeclaredZone zone = (DeclaredZone) step;
+            job = JobType.from(system, zone.environment(), zone.region().orElse(null));
+        }
+        if (job.isEmpty())
+            throw new IllegalArgumentException("No job is known for " + step + " in " + system);
+
+        return job.map(type -> new JobId(application.id().instance(instance), type));
+    }
+
+    /** Returns a DAG of the dependencies between the primitive steps in the spec, with iteration order equal to declaration order. */
+    Map<JobId, List<StepStatus>> jobDependencies(DeploymentSpec spec) {
+        Map<JobId, List<StepStatus>> dependencies = new LinkedHashMap<>();
+        List<StepStatus> previous = List.of();
+        for (DeploymentSpec.Step step : spec.steps())
+            previous = fillStep(dependencies, step, previous, spec.instanceNames().get(0));
+
+        return ImmutableMap.copyOf(dependencies);
+    }
+
+    /** Adds the primitive steps contained in the given step, which depend on the given previous primitives, to the dependency graph. */
+    List<StepStatus> fillStep(Map<JobId, List<StepStatus>> dependencies, DeploymentSpec.Step step,
+                              List<StepStatus> previous, InstanceName instance) {
+        if (step.steps().isEmpty()) {
+            if ( ! step.delay().isZero())
+                return List.of(new DelayStatus((DeploymentSpec.Delay) step, previous));
+
+            JobType jobType;
+            StepStatus stepStatus;
+            if (step.concerns(test) || step.concerns(staging)) { // SKIP?
+                jobType = JobType.from(system, ((DeclaredZone) step).environment(), ((DeclaredZone) step).region().get())
+                                         .orElseThrow(() -> new IllegalStateException("No job is known for " + step + " in " + system));
+                previous = new ArrayList<>(previous);
+                stepStatus = JobStepStatus.ofTestDeployment((DeclaredZone) step, List.of(), this, instance, jobType);
+                previous.add(stepStatus);
+                return previous;
+            }
+            else if (step.isTest()) {
+                jobType = JobType.from(system, ((DeclaredTest) step).region())
+                                          .orElseThrow(() -> new IllegalStateException("No job is known for " + step + " in " + system));
+                JobType preType = JobType.from(system, prod, ((DeclaredTest) step).region())
+                                         .orElseThrow(() -> new IllegalStateException("No job is known for " + step + " in " + system));
+                stepStatus = JobStepStatus.ofProductionTest((DeclaredTest) step, previous, this, instance, jobType, preType);
+                return List.of(stepStatus);
+            }
+            else {
+                jobType = JobType.from(system, ((DeclaredZone) step).environment(), ((DeclaredZone) step).region().get())
+                                         .orElseThrow(() -> new IllegalStateException("No job is known for " + step + " in " + system));
+                stepStatus = JobStepStatus.ofProductionDeployment((DeclaredZone) step, previous, this, instance, jobType);
+                return List.of(stepStatus);
+            }
+
+        }
+
+        Optional<InstanceName> stepInstance = Optional.of(step)
+                                                      .filter(DeploymentInstanceSpec.class::isInstance)
+                                                      .map(DeploymentInstanceSpec.class::cast)
+                                                      .map(DeploymentInstanceSpec::name);
+        if (step.isOrdered()) {
+            for (DeploymentSpec.Step nested : step.steps())
+                previous = fillStep(dependencies, nested, previous, stepInstance.orElse(instance));
+
+            return previous;
+        }
+
+        List<StepStatus> parallel = new ArrayList<>();
+        for (DeploymentSpec.Step nested : step.steps())
+            parallel.addAll(fillStep(dependencies, nested, previous, stepInstance.orElse(instance)));
+
+        return List.copyOf(parallel);
+    }
+
+    // Used to represent the system and staging tests that are implicitly required when no explicit tests are listed.
+    private static final DeploymentSpec.Step implicitTests = new DeploymentSpec.Step() {
+        @Override public boolean concerns(Environment environment, Optional<RegionName> region) { return false; }
+    };
+
+
+    /**
+     * Used to represent all steps — explicit and implicit — that may run in order to complete deployment of a change.
+     *
+     * Each node contains a step describing the node,
+     * a list of steps which need to be complete before the step may start,
+     * a list of jobs from which completion of the step is computed, and
+     * optionally, an instance name used to identify a job type for the step,
+     *
+     * The completion criterion for each type of step is implemented in subclasses of this.
+     */
+    public static abstract class StepStatus {
+
+        private final DeploymentSpec.Step step;
+        private final List<StepStatus> dependencies;
+        private final Optional<InstanceName> instance;
+
+        protected StepStatus(DeploymentSpec.Step step, List<StepStatus> dependencies) {
+            this(step, dependencies, null);
+        }
+
+        protected StepStatus(DeploymentSpec.Step step, List<StepStatus> dependencies, InstanceName instance) {
+            this.step = requireNonNull(step);
+            this.dependencies = List.copyOf(dependencies);
+            this.instance = Optional.ofNullable(instance);
+        }
+
+        /** The step defining this. */
+        public final DeploymentSpec.Step step() { return step; }
+
+        /** The list of steps that need to be complete before this may start. */
+        public final List<StepStatus> dependencies() { return dependencies; }
+
+        /** The instance of this, if any. */
+        public final Optional<InstanceName> instance() { return instance; }
+
+        /** The time at which this is complete on the given versions. */
+        public abstract Optional<Instant> completedAt(Change change);
+
+        /** The time at which all dependencies completed on the given version. */
+        public final Optional<Instant> readyAt(Change change) {
+            return dependencies.stream().allMatch(step -> step.completedAt(change).isPresent())
+                   ? dependencies.stream().map(step -> step.completedAt(change).get())
+                                 .max(naturalOrder())
+                                 .or(() -> Optional.of(Instant.EPOCH))
+                   : Optional.empty();
+        }
+
+    }
+
+
+    public static class DelayStatus extends StepStatus {
+
+        public DelayStatus(DeploymentSpec.Delay step, List<StepStatus> dependencies) {
+            super(step, dependencies);
+        }
+
+        @Override
+        public Optional<Instant> completedAt(Change change) {
+            return readyAt(change).map(completion -> completion.plus(step().delay()));
+        }
+
+    }
+
+
+    public static abstract class JobStepStatus extends StepStatus {
+
+        private final JobStatus job;
+
+        protected JobStepStatus(DeploymentSpec.Step step, List<StepStatus> dependencies, JobStatus job) {
+            super(step, dependencies, job.id().application().instance());
+            this.job = requireNonNull(job);
+        }
+
+        public static JobStepStatus ofProductionDeployment(DeclaredZone step, List<StepStatus> dependencies,
+                                                           DeploymentStatus status, InstanceName instance, JobType jobType) {
+            ZoneId zone = ZoneId.from(step.environment(), step.region().get());
+            JobStatus job = status.instanceJobs(instance).get(jobType);
+            Optional<Deployment> existingDeployment = Optional.ofNullable(status.application().require(instance)
+                                                                                .deployments().get(zone));
+
+            return new JobStepStatus(step, dependencies, job) {
+                /** Complete if deployment is on pinned version, and last successful deployment, or if given versions is strictly a downgrade, and this isn't forced by a pin. */
+                @Override
+                public Optional<Instant> completedAt(Change change) {
+                    if (     change.isPinned()
+                        &&   change.platform().isPresent()
+                        && ! existingDeployment.map(Deployment::version).equals(change.platform()))
+                        return Optional.empty();
+
+                    Change fullChange = status.application().change();
+                    if (existingDeployment.map(deployment ->    ! (change.upgrades(deployment.version()) || change.upgrades(deployment.applicationVersion()))
+                                                             &&   (fullChange.downgrades(deployment.version()) || fullChange.downgrades(deployment.applicationVersion())))
+                                          .orElse(false))
+                        return job.lastCompleted().flatMap(Run::end);
+
+                    return job.lastSuccess()
+                              .filter(run ->    change.platform().map(run.versions().targetPlatform()::equals).orElse(true)
+                                             && change.application().map(run.versions().targetApplication()::equals).orElse(true))
+                              .flatMap(Run::end);
+                }
+            };
+        }
+
+        public static JobStepStatus ofProductionTest(DeclaredTest step, List<StepStatus> dependencies,
+                                                     DeploymentStatus status, InstanceName instance, JobType testType, JobType jobType) {
+            JobStatus job = status.instanceJobs(instance).get(testType);
+            return new JobStepStatus(step, dependencies, job) {
+                @Override
+                public Optional<Instant> completedAt(Change change) {
+                    Versions toVerify = Versions.from(change, status.application.require(instance).deployments().get(ZoneId.from(prod, step.region())));
+                    return job.lastSuccess()
+                              .filter(run -> toVerify.targetsMatch(run.versions()))
+                              .filter(run -> status.instanceJobs(instance).get(jobType).lastCompleted()
+                                                   .map(last -> last.end().get().isBefore(run.start())).orElse(false))
+                              .map(run -> run.end().get());
+                }
+            };
+        }
+
+        public static JobStepStatus ofTestDeployment(DeclaredZone step, List<StepStatus> dependencies,
+                                                     DeploymentStatus status, InstanceName instance, JobType jobType) {
+            Versions versions = Versions.from(status.application, status.systemVersion);
+            JobStatus job = status.instanceJobs(instance).get(jobType);
+            return new JobStepStatus(step, dependencies, job) {
+                @Override
+                public Optional<Instant> completedAt(Change change) {
+                    return RunList.from(job)
+                                  .on(versions)
+                                  .status(RunStatus.success)
+                                  .asList().stream()
+                                  .map(run -> run.end().get())
+                                  .max(naturalOrder());
+                }
+            };
+        }
+
+    }
+
+    /*
+     *  Compute all JobIds to run: test and staging for first instance, unless declared in a parallel instance.
+     *  Create StepStatus for the first two, then
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     * Prod:        completedAt: change, fullChange
+     * Test:        completedAt: versions?
+     * Delay:       completedAt: change, fullChange
+     * Any:         readyAt: change -> versions
+     * Any:         testedAt: versions
+     *
+     * Start with system and staging for first instance as dependencies.
+     * Declared test jobs replace these for intra-instance dependents.
+     * Test and staging are implicitly parallel. (Well, they already are, if they don't depend on each other.)
+     *
+     * Map JobId to StepStatus:
+     * For each prod JobId: Compute Optional<Versions> to run for current change to be done.
+     * Prod jobs may wait for other prod jobs' to-do runs, but ignores their versions.
+     * Prod jobs may wait for test jobs, considering their versions.
+     * For each prod job, if job already triggered on desired versions, ignore the below.
+     * For each prod job, add other prod job dependencies.
+     * For each prod job, add explicit tests in same instance.
+     * For each prod versions to run, find all prod jobs for which those versions aren't tested (before the job), then
+     *      for each such set of jobs, find the last common dependency instance, and add the test for that, or
+     *      for each such set of jobs, add tests for those versions with the first declared instance; in any case
+     *      add all implicit tests to some structure for tracking.
+     *
+     * Eliminate already running jobs.
+     * Keep set of JobId x Versions for each StepStatus, in topological order, for starting jobs and for display.
+     * DepTri: Needs all jobs to run that are also ready. Test jobs are always ready.
+     * API: Needs all jobs to run, and what they are waiting for, like, delay (until), or other jobs, or pause.
+     *      To find dependency jobs, DFS and sort by topological order.
+     *
+     * anySysTest && anyStaTest || triggeredProd
+     *
+     */
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
@@ -138,7 +138,8 @@ public class DeploymentStatus {
                     testJobs.merge(test,
                                    versions.stream()
                                            .filter(version -> ! steps.get(test).isRunning(version))
-                                           .filter(version -> allJobs.successOn(version).get(test).isEmpty() && allJobs.triggeredOn(version).get(job).isEmpty())
+                                           .filter(version ->    allJobs.successOn(version).get(test).isEmpty()
+                                                              && allJobs.triggeredOn(version).get(job).isEmpty())
                                            .collect(toUnmodifiableList()),
                                    DeploymentStatus::union);
                 });
@@ -146,7 +147,8 @@ public class DeploymentStatus {
                     testJobs.merge(test,
                                    versions.stream()
                                            .filter(version -> ! steps.get(test).isRunning(version))
-                                           .filter(version -> allJobs.successOn(version).get(test).isEmpty() && allJobs.triggeredOn(version).get(job).isEmpty())
+                                           .filter(version ->    allJobs.successOn(version).get(test).isEmpty()
+                                                              && allJobs.triggeredOn(version).get(job).isEmpty())
                                            .collect(toUnmodifiableList()),
                                    DeploymentStatus::union);
                 });
@@ -157,14 +159,16 @@ public class DeploymentStatus {
                 testJobs.merge(new JobId(job.application(), systemTest),
                                versions.stream()
                                        .filter(version -> steps.keySet().stream().noneMatch(id -> id.type() == systemTest && steps.get(id).isRunning(version)))
-                                       .filter(version -> allJobs.successOn(version).type(systemTest).isEmpty() && allJobs.triggeredOn(version).get(job).isEmpty())
+                                       .filter(version ->    allJobs.successOn(version).type(systemTest).isEmpty()
+                                                          && allJobs.triggeredOn(version).get(job).isEmpty())
                                        .collect(toUnmodifiableList()),
                                DeploymentStatus::union);
             if ( ! job.type().isTest() && ! testedOn(versions, stagingTest, testJobs))
                 testJobs.merge(new JobId(job.application(), stagingTest),
                                versions.stream()
                                        .filter(version -> steps.keySet().stream().noneMatch(id -> id.type() == stagingTest && steps.get(id).isRunning(version)))
-                                       .filter(version -> allJobs.successOn(version).type(stagingTest).isEmpty() && allJobs.triggeredOn(version).get(job).isEmpty())
+                                       .filter(version ->    allJobs.successOn(version).type(stagingTest).isEmpty()
+                                                          && allJobs.triggeredOn(version).get(job).isEmpty())
                                        .collect(toUnmodifiableList()),
                                DeploymentStatus::union);
         });

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentSteps.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentSteps.java
@@ -73,7 +73,7 @@ public class DeploymentSteps {
 
     /** Returns test jobs to run for this spec */
     public List<JobType> testJobs() {
-        return jobs().stream().filter(JobType::isTest).collect(Collectors.toUnmodifiableList());
+        return jobs().stream().filter(type -> type.environment().isTest()).collect(Collectors.toUnmodifiableList());
     }
 
     /** Returns declared production jobs in this */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.yahoo.config.application.api.DeploymentInstanceSpec;
 import com.yahoo.config.application.api.DeploymentSpec;
-import com.yahoo.config.application.api.DeploymentSpec.Step;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -14,7 +13,6 @@ import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
-import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 import com.yahoo.vespa.hosted.controller.application.ApplicationList;
 import com.yahoo.vespa.hosted.controller.application.Change;
@@ -35,15 +33,12 @@ import java.util.OptionalLong;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.stagingTest;
 import static com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType.systemTest;
 import static java.util.Comparator.comparing;
-import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 
@@ -136,7 +131,7 @@ public class DeploymentTrigger {
                                                 .collect(groupingBy(Job::applicationId)))
                                          .values().stream()
                                          .map(jobs -> (Supplier<Long>) jobs.stream()
-                                                                           .filter(this::trigger)
+                                                                           .peek(this::trigger)
                                                                            .limit(entry.getKey() ? 1 : Long.MAX_VALUE)::count))
                                  .parallel().map(Supplier::get).reduce(0L, Long::sum);
     }
@@ -147,24 +142,13 @@ public class DeploymentTrigger {
      * If the build service can not find the given job, or claims it is illegal to trigger it,
      * the project id is removed from the application owning the job, to prevent further trigger attempts.
      */
-    public boolean trigger(Job job) {
+    public void trigger(Job job) {
         log.log(LogLevel.DEBUG, "Triggering " + job);
-        try {
-            applications().lockApplicationOrThrow(TenantAndApplicationId.from(job.applicationId()), application -> {
-                    jobs.start(job.applicationId(), job.jobType, job.versions);
-                    applications().store(application.with(job.applicationId().instance(), instance ->
-                            instance.withJobPause(job.jobType, OptionalLong.empty())));
-            });
-
-            return true;
-        }
-        catch (RuntimeException e) {
-            log.log(LogLevel.WARNING, "Exception triggering " + job + ": " + e);
-            if (e instanceof NoSuchElementException || e instanceof IllegalArgumentException)
-                applications().lockApplicationOrThrow(TenantAndApplicationId.from(job.applicationId()), application ->
-                        applications().store(application.withProjectId(OptionalLong.empty())));
-            return false;
-        }
+        applications().lockApplicationOrThrow(TenantAndApplicationId.from(job.applicationId()), application -> {
+            jobs.start(job.applicationId(), job.jobType, job.versions);
+            applications().store(application.with(job.applicationId().instance(), instance ->
+                    instance.withJobPause(job.jobType, OptionalLong.empty())));
+        });
     }
 
     /** Force triggering of a job for given instance. */
@@ -177,6 +161,7 @@ public class DeploymentTrigger {
         var jobStatus = jobs.deploymentStatus(application).instanceJobs(instance.name());
         var jobList = JobList.from(jobStatus.values());
         return (jobType.isProduction() && requireTests && ! isTested(jobList, versions)
+                // TODO jonmv: Expose adding test jobs from DeploymentStatus, and use this here.
                 ? testJobs(application.deploymentSpec(), application.change(), instance, jobList, versions, reason, clock.instant(), __ -> true).stream()
                 : Stream.of(deploymentJob(instance, versions, application.change(), jobType, jobStatus.get(jobType), reason, clock.instant())))
                 .peek(this::trigger)
@@ -238,10 +223,6 @@ public class DeploymentTrigger {
         return Optional.ofNullable(instance.deployments().get(jobType.zone(controller.system())));
     }
 
-    private static <T extends Comparable<T>> Optional<T> max(Optional<T> o1, Optional<T> o2) {
-        return o1.isEmpty() ? o2 : o2.isEmpty() ? o1 : o1.get().compareTo(o2.get()) >= 0 ? o1 : o2;
-    }
-
     // ---------- Ready job computation ----------
 
     /** Returns the set of all jobs which have changes to propagate from the upstream steps. */
@@ -280,94 +261,10 @@ public class DeploymentTrigger {
                 });
             });
         });
-
-        /*
-        applications().getApplication(id).ifPresent(application -> {
-            Collection<Instance> instances = application.deploymentSpec().instances().stream()
-                                                        .flatMap(instance -> application.get(instance.name()).stream())
-                                                        .collect(Collectors.toUnmodifiableList());
-            DeploymentStatus deploymentStatus = this.jobs.deploymentStatus(application);
-            for (Instance instance : instances) {
-                var jobStatus = deploymentStatus.instanceJobs(instance.name());
-                var jobList = JobList.from(jobStatus.values());
-                Change change = application.change();
-                Optional<Instant> completedAt = max(jobList.type(systemTest).first()
-                                                            .<Instant>flatMap(job -> job.lastSuccess().map(run -> run.end().get())),
-                                                    jobList.type(stagingTest).first()
-                                                            .<Instant>flatMap(job -> job.lastSuccess().map(run -> run.end().get())));
-                String reason = "New change available";
-                List<Job> testJobs = null; // null means "uninitialised", while empty means "don't run any jobs".
-                DeploymentSteps steps = steps(application.deploymentSpec().requireInstance(instance.name()));
-
-                if (change.hasTargets()) {
-                    for (Step step : steps.production()) {
-                        List<JobType> stepJobs = steps.toJobs(step);
-                        List<JobType> remainingJobs = stepJobs.stream().filter(job -> ! isComplete(change, change, instance, job, jobStatus.get(job))).collect(toList());
-                        if ( ! remainingJobs.isEmpty()) { // Change is incomplete; trigger remaining jobs if ready, or their test jobs if untested.
-                            for (JobType job : remainingJobs) {
-                                Versions versions = Versions.from(change, application, deploymentFor(instance, job),
-                                                                  controller.systemVersion());
-                                if (isTested(jobList, versions)) {
-                                    if (completedAt.isPresent() && canTrigger(job, jobList, versions, instance, application.deploymentSpec(), stepJobs)) {
-                                        jobs.add(deploymentJob(instance, versions, change, job, jobStatus.get(job), reason, completedAt.get()));
-                                    }
-                                }
-                                else if (testJobs == null) {
-                                    testJobs = testJobs(application.deploymentSpec(),
-                                                        change, instance, jobList, versions,
-                                                        String.format("Testing deployment for %s (%s)",
-                                                                      job.jobName(), versions.toString()),
-                                                        completedAt.orElseGet(clock::instant));
-                                }
-                            }
-                            completedAt = Optional.empty();
-                        }
-                        else { // All jobs are complete; find the time of completion of this step.
-                            if (stepJobs.isEmpty()) { // No jobs means this is a delay step.
-                                completedAt = completedAt.map(at -> at.plus(step.delay())).filter(at -> ! at.isAfter(clock.instant()));
-                                reason += " after a delay of " + step.delay();
-                            }
-                            else {
-                                completedAt = stepJobs.stream().map(job -> jobStatus.get(job).lastCompleted().get().end().get()).max(naturalOrder());
-                                reason = "Available change in " + stepJobs.stream().map(JobType::jobName).collect(joining(", "));
-                            }
-                        }
-                    }
-                }
-                if (testJobs == null) { // If nothing to test, but outstanding commits, test those.
-                    testJobs = testJobs(application.deploymentSpec(), change, instance, jobList,
-                                        Versions.from(application.outstandingChange().onTopOf(change),
-                                                      application,
-                                                      steps.sortedDeployments(instance.productionDeployments().values()).stream().findFirst(),
-                                                      controller.systemVersion()),
-                                        "Testing last changes outside prod", clock.instant());
-                }
-                jobs.addAll(testJobs);
-            }
-        });
-         */
         return Collections.unmodifiableList(jobs);
     }
 
     /** Returns whether given job should be triggered */
-    private boolean canTrigger(JobType type, JobList jobList, Versions versions, Instance instance, DeploymentSpec deploymentSpec, List<JobType> parallelJobs) {
-        if ( ! jobList.type(type).running().isEmpty()) return false;
-
-        // Are we already running jobs which are not in the set which can run in parallel with this?
-        if (     parallelJobs != null
-            && ! parallelJobs.containsAll(jobList.running().production().mapToList(job -> job.id().type()))) return false;
-
-        // Are there another suspended deployment such that we shouldn't simultaneously change this?
-        if (type.isProduction() && isSuspendedInAnotherZone(instance, type.zone(controller.system()))) return false;
-
-        return triggerAt(clock.instant(), type, jobList.type(type).first().get(), versions, instance, deploymentSpec);
-    }
-
-    /** Returns whether given job should be triggered */
-    private boolean canTrigger(JobType job, JobList jobList, Versions versions, Instance instance, DeploymentSpec deploymentSpec) {
-        return canTrigger(job, jobList, versions, instance, deploymentSpec, null);
-    }
-
     private boolean isSuspendedInAnotherZone(Instance instance, ZoneId zone) {
         for (Deployment deployment : instance.productionDeployments().values()) {
             if (   ! deployment.zone().equals(zone)
@@ -471,15 +368,6 @@ public class DeploymentTrigger {
     }
 
     // ---------- Version and job helpers ----------
-
-    /**
-     * Returns the list of test jobs that should run now, and that need to succeed on the given versions for it to be considered tested.
-     */
-    private List<Job> testJobs(DeploymentSpec deploymentSpec, Change change, Instance instance, JobList jobList, Versions versions,
-                               String reason, Instant availableSince) {
-        return testJobs(deploymentSpec, change, instance, jobList, versions, reason, availableSince,
-                        jobType -> canTrigger(jobType, jobList, versions, instance, deploymentSpec));
-    }
 
     /**
      * Returns the list of test jobs that need to succeed on the given versions for it to be considered tested, filtered by the given condition.

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -5,6 +5,7 @@ import com.yahoo.config.application.api.DeploymentInstanceSpec;
 import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.application.api.DeploymentSpec.Step;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.controller.Application;
@@ -264,8 +265,9 @@ public class DeploymentTrigger {
             status.jobsToRun().forEach((job, versionsList) -> {
                 status.stepStatus().get(job).readyAt(status.application().change()).ifPresent(readyAt -> {
                     for (Versions versions : versionsList)
-                        if ( ! isSuspendedInAnotherZone(status.application().require(job.application().instance()),
-                                                        job.type().zone(controller.system())))
+                        if ( ! (   isSuspendedInAnotherZone(status.application().require(job.application().instance()),
+                                                            job.type().zone(controller.system()))
+                                && job.type().environment() != Environment.prod))
                             jobs.add(deploymentJob(status.application().require(job.application().instance()),
                                                    versions,
                                                    status.application().change(),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -248,9 +248,10 @@ public class DeploymentTrigger {
                         status.stepStatus().get(job).readyAt(status.application().change(), versions)
                               .filter(readyAt -> ! clock.instant().isBefore(readyAt))
                               .ifPresent(readyAt -> {
-                        if ( ! (   isSuspendedInAnotherZone(status.application().require(job.application().instance()),
-                                                            job.type().zone(controller.system()))
-                                && job.type().environment() == Environment.prod))
+                        if (   ! (   isSuspendedInAnotherZone(status.application().require(job.application().instance()),
+                                                              job.type().zone(controller.system()))
+                                  && job.type().environment() == Environment.prod)
+                            && ! status.jobs().get(job).get().isRunning())
                             jobs.add(deploymentJob(status.application().require(job.application().instance()),
                                                    versions,
                                                    status.application().change(),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -654,7 +654,7 @@ public class InternalStepRunner implements StepRunner {
         DeploymentSpec spec = controller.applications().requireApplication(TenantAndApplicationId.from(id.application())).deploymentSpec();
 
         ZoneId zone = id.type().zone(controller.system());
-        boolean useTesterCertificate = controller.system().isPublic() && id.type().isTest();
+        boolean useTesterCertificate = controller.system().isPublic() && id.type().environment().isTest();
 
         byte[] servicesXml = servicesXml(controller.zoneRegistry().accessControlDomain(),
                                          ! controller.system().isPublic(),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -700,7 +700,7 @@ public class InternalStepRunner implements StepRunner {
             if (step.concerns(id.type().environment()))
                 return step.zones().get(0).testerFlavor();
 
-        throw new IllegalStateException("No step deploys to the zone this run is for!");
+        return Optional.empty();
     }
 
     /** Returns the generated services.xml content for the tester application. */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -289,15 +289,12 @@ public class JobController {
         return new JobStatus(id, runs(id));
     }
 
-    /** Returns the job status of all declared jobs for the given instance id, indexed by job type. */
+    /** Returns the deployment status of the given application. */
     public DeploymentStatus deploymentStatus(Application application) {
         return new DeploymentStatus(application,
-                                    application.deploymentSpec().instances().stream()
-                                               .flatMap(spec -> new DeploymentSteps(spec, controller::system)
-                                                       .jobs().stream()
-                                                       .map(type -> jobStatus(new JobId(application.id().instance(spec.name()), type))))
-                                               .collect(toUnmodifiableMap(status -> status.id(),
-                                                                          status -> status)),
+                                    DeploymentStatus.jobsFor(application, controller.system()).stream()
+                                                    .collect(toUnmodifiableMap(job -> job,
+                                                                               job -> jobStatus(job))),
                                     controller.system(),
                                     controller.systemVersion());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -297,7 +297,9 @@ public class JobController {
                                                        .jobs().stream()
                                                        .map(type -> jobStatus(new JobId(application.id().instance(spec.name()), type))))
                                                .collect(toUnmodifiableMap(status -> status.id(),
-                                                                          status -> status)));
+                                                                          status -> status)),
+                                    controller.system(),
+                                    controller.systemVersion());
     }
 
     /** Adds deployment status to each of the given applications. */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.deployment;
 import com.yahoo.collections.AbstractFilteringList;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.InstanceName;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 
@@ -56,22 +57,22 @@ public class JobList extends AbstractFilteringList<JobStatus, JobList> {
         return matching(JobList::failingApplicationChange);
     }
 
-    /** Returns the subset of jobs which are failing with the given run status */
+    /** Returns the subset of jobs which are failing with the given run status. */
     public JobList withStatus(RunStatus status) {
         return matching(job -> job.lastStatus().map(status::equals).orElse(false));
     }
 
-    /** Returns the subset of jobs of the given type -- most useful when negated */
+    /** Returns the subset of jobs of the given type -- most useful when negated. */
     public JobList type(Collection<? extends JobType> types) {
         return matching(job -> types.contains(job.id().type()));
     }
 
-    /** Returns the subset of jobs of the given type -- most useful when negated */
+    /** Returns the subset of jobs of the given type -- most useful when negated. */
     public JobList type(JobType... types) {
         return type(List.of(types));
     }
 
-    /** Returns the subset of jobs of which are production jobs */
+    /** Returns the subset of jobs of which are production jobs. */
     public JobList production() {
         return matching(job -> job.id().type().isProduction());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
@@ -6,6 +6,7 @@ import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 
 import java.time.Instant;
@@ -35,6 +36,11 @@ public class JobList extends AbstractFilteringList<JobStatus, JobList> {
     }
 
     // ----------------------------------- Basic filters
+
+    /** Returns the status of the job of the given type, if it is contained in this. */
+    public Optional<JobStatus> get(JobId id) {
+        return asList().stream().filter(job -> job.id().equals(id)).findAny();
+    }
 
     /** Returns the subset of jobs which are currently upgrading */
     public JobList upgrading() {
@@ -70,6 +76,11 @@ public class JobList extends AbstractFilteringList<JobStatus, JobList> {
     /** Returns the subset of jobs of the given type -- most useful when negated. */
     public JobList type(JobType... types) {
         return type(List.of(types));
+    }
+
+    /** Returns the subset of jobs run for the given instance. */
+    public JobList instance(InstanceName instance) {
+        return matching(job -> job.id().application().instance().equals(instance));
     }
 
     /** Returns the subset of jobs of which are production jobs. */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobProfile.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobProfile.java
@@ -49,6 +49,13 @@ public enum JobProfile {
                EnumSet.of(deactivateTester,
                           report)),
 
+    productionTest(EnumSet.of(deployTester,
+                              installTester,
+                              startTests,
+                              endTests),
+                   EnumSet.of(deactivateTester,
+                              report)),
+
     development(EnumSet.of(deployReal,
                            installReal),
                 EnumSet.of(copyVespaLogs));
@@ -67,7 +74,7 @@ public enum JobProfile {
         switch (type.environment()) {
             case test: return systemTest;
             case staging: return stagingTest;
-            case prod: return production;
+            case prod: return type.isTest() ? productionTest : production;
             case perf:
             case dev: return development;
             default: throw new AssertionError("Unexpected environment '" + type.environment() + "'!");

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Versions.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Versions.java
@@ -110,6 +110,15 @@ public class Versions {
                             deployment.map(Deployment::applicationVersion));
     }
 
+    public static Versions from(Change change, Deployment deployment) {
+        return new Versions(change.platform().filter(version -> change.isPinned() || deployment.version().isBefore(version))
+                                  .orElse(deployment.version()),
+                            change.application().filter(version -> deployment.applicationVersion().compareTo(version) < 0)
+                                  .orElse(deployment.applicationVersion()),
+                            Optional.of(deployment.version()),
+                            Optional.of(deployment.applicationVersion()));
+    }
+
     private static Version targetPlatform(Application application, Change change, Optional<Deployment> deployment,
                                           Version defaultVersion) {
         if (change.isPinned() && change.platform().isPresent())

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -744,13 +744,13 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
 
         if (deploymentSpec.instance(instance.name()).isPresent()) {
             // Jobs sorted according to deployment spec
-            List<com.yahoo.vespa.hosted.controller.deployment.JobStatus> jobStatus = controller.applications().deploymentTrigger()
+            List<JobStatus> jobStatus = controller.applications().deploymentTrigger()
                                                   .steps(deploymentSpec.requireInstance(instance.name()))
                                                   .sortedJobs(status.instanceJobs(instance.name()).values());
 
 
             Cursor deploymentJobsArray = object.setArray("deploymentJobs");
-            for (com.yahoo.vespa.hosted.controller.deployment.JobStatus job : jobStatus) {
+            for (JobStatus job : jobStatus) {
                 Cursor jobObject = deploymentJobsArray.addObject();
                 jobObject.setString("type", job.id().type().jobName());
                 jobObject.setBool("success", job.isSuccess());
@@ -860,9 +860,9 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
 
         if (application.deploymentSpec().instance(instance.name()).isPresent()) {
             // Jobs sorted according to deployment spec
-            List<com.yahoo.vespa.hosted.controller.deployment.JobStatus> jobStatus = controller.applications().deploymentTrigger()
-                                                                                               .steps(application.deploymentSpec().requireInstance(instance.name()))
-                                                                                               .sortedJobs(status.instanceJobs(instance.name()).values());
+            List<JobStatus> jobStatus = controller.applications().deploymentTrigger()
+                                                  .steps(application.deploymentSpec().requireInstance(instance.name()))
+                                                  .sortedJobs(status.instanceJobs(instance.name()).values());
 
             Cursor deploymentsArray = object.setArray("deploymentJobs");
             for (JobStatus job : jobStatus) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -24,6 +24,7 @@ import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.Change;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
+import com.yahoo.vespa.hosted.controller.deployment.DeploymentStatus;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentSteps;
 import com.yahoo.vespa.hosted.controller.deployment.JobController;
 import com.yahoo.vespa.hosted.controller.deployment.JobList;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -248,7 +248,7 @@ class JobControllerApiHandlerHelper {
         int runs = 0;
         Cursor runArray = jobObject.setArray("runs");
         JobList jobList = JobList.from(status.values());
-        if (type.isTest()) {
+        if (type.environment().isTest()) {
             Deque<List<JobType>> pending = new ArrayDeque<>();
             pendingProduction.entrySet().stream()
                              .filter(typeVersions -> jobList.type(type).successOn(typeVersions.getValue()).isEmpty())

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -72,6 +72,12 @@ import static java.util.stream.Collectors.toMap;
  */
 class JobControllerApiHandlerHelper {
 
+    static HttpResponse applicationJobs(Controller controller, TenantAndApplicationId id, URI baseUriForJobs) {
+        DeploymentStatus status = controller.jobController().deploymentStatus(controller.applications().requireApplication(id));
+
+        return null;
+    }
+
     /**
      * @return Response with all job types that have recorded runs for the application _and_ the status for the last run of that type
      */

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -103,7 +103,6 @@ public class ControllerTest {
 
         // system and staging test job - succeeding
         context.submit(applicationPackage);
-        applicationVersion = context.application().change().application().get();
         context.runJob(systemTest);
         context.runJob(stagingTest);
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
@@ -99,6 +99,13 @@ public class ApplicationPackageBuilder {
         return this;
     }
 
+    public ApplicationPackageBuilder test(String regionName) {
+        environmentBody.append("      <test>");
+        environmentBody.append(regionName);
+        environmentBody.append("</test>\n");
+        return this;
+    }
+
     public ApplicationPackageBuilder parallel(String... regionName) {
         environmentBody.append("    <parallel>\n");
         Arrays.stream(regionName).forEach(this::region);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
@@ -231,7 +231,7 @@ public class ApplicationPackageBuilder {
         return searchDefinition.getBytes(UTF_8);
     }
 
-    private byte[] buildMeta() {
+    private static byte[] buildMeta() {
         return "{\"compileVersion\":\"6.1\",\"buildTime\":1000}".getBytes(UTF_8);
     }
 
@@ -269,6 +269,21 @@ public class ApplicationPackageBuilder {
 
     private static String asIso8601Date(Instant instant) {
         return new SimpleDateFormat("yyyy-MM-dd").format(Date.from(instant));
+    }
+
+    public static ApplicationPackage fromDeploymentXml(String deploymentXml) {
+        ByteArrayOutputStream zip = new ByteArrayOutputStream();
+        try (ZipOutputStream out = new ZipOutputStream(zip)) {
+            out.putNextEntry(new ZipEntry("deployment.xml"));
+            out.write(deploymentXml.getBytes(UTF_8));
+            out.closeEntry();
+            out.putNextEntry(new ZipEntry("build-meta.json"));
+            out.write(buildMeta());
+            out.closeEntry();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return new ApplicationPackage(zip.toByteArray());
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
@@ -50,6 +50,8 @@ public class ApplicationPackageBuilder {
     private String globalServiceId = null;
     private String athenzIdentityAttributes = null;
     private String searchDefinition = "search test { }";
+    private boolean explicitSystemTest = false;
+    private boolean explicitStagingTest = false;
 
     public ApplicationPackageBuilder majorVersion(int majorVersion) {
         this.majorVersion = OptionalInt.of(majorVersion);
@@ -85,6 +87,16 @@ public class ApplicationPackageBuilder {
             endpointsBody.append("        <region>").append(region).append("</region>\n");
         }
         endpointsBody.append("      </endpoint>\n");
+        return this;
+    }
+
+    public ApplicationPackageBuilder systemTest() {
+        explicitSystemTest = true;
+        return this;
+    }
+
+    public ApplicationPackageBuilder stagingTest() {
+        explicitStagingTest = true;
         return this;
     }
 
@@ -176,6 +188,10 @@ public class ApplicationPackageBuilder {
             xml.append(athenzIdentityAttributes);
         }
         xml.append(">\n");
+        if (explicitSystemTest)
+            xml.append("  <test />\n");
+        if (explicitStagingTest)
+            xml.append("  <staging />\n");
         xml.append("  <instance id='").append(instances).append("'>\n");
         if (upgradePolicy != null) {
             xml.append("    <upgrade policy='");

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
@@ -302,10 +302,12 @@ public class DeploymentContext {
         var job = jobId(type);
         triggerJobs();
         doDeploy(job);
-        doUpgrade(job);
-        doConverge(job);
-        if (job.type().environment().isManuallyDeployed())
-            return this;
+        if ( ! job.type().isTest()) {
+            doUpgrade(job);
+            doConverge(job);
+            if (job.type().environment().isManuallyDeployed())
+                return this;
+        }
         doInstallTester(job);
         doTests(job);
         doTeardown(job);
@@ -514,7 +516,8 @@ public class DeploymentContext {
         ZoneId zone = zone(job);
 
         // All installation is complete and endpoints are ready, so tests may begin.
-        assertEquals(Step.Status.succeeded, jobs.run(id).get().steps().get(Step.installReal));
+        if ( ! job.type().isTest())
+            assertEquals(Step.Status.succeeded, jobs.run(id).get().steps().get(Step.installReal));
         assertEquals(Step.Status.succeeded, jobs.run(id).get().steps().get(Step.installTester));
         assertEquals(Step.Status.succeeded, jobs.run(id).get().steps().get(Step.startTests));
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -47,6 +47,10 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
     public ZoneRegistryMock(SystemName system) {
         this.system = system;
         setZones(List.of(
+                ZoneApiMock.fromId("prod.aws-us-east-1a"),
+                ZoneApiMock.fromId("prod.ap-northeast-1"),
+                ZoneApiMock.fromId("prod.ap-northeast-2"),
+                ZoneApiMock.fromId("prod.ap-southeast-1"),
                 ZoneApiMock.fromId("prod.us-east-3"),
                 ZoneApiMock.fromId("prod.us-west-1"),
                 ZoneApiMock.fromId("prod.us-central-1"),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunnerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunnerTest.java
@@ -9,6 +9,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.deployment.RunId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.SourceRevision;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
+import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.deployment.JobController;
 import com.yahoo.vespa.hosted.controller.deployment.Run;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/UpgraderTest.java
@@ -875,7 +875,7 @@ public class UpgraderTest {
         tester.triggerJobs();
         assertEquals(3, tester.jobs().active().size()); // Just the running upgrade, and tests for the new revision.
 
-        app.runJob(systemTest).runJob(stagingTest).runJob(productionUsCentral1).runJob(productionUsEast3);
+        app.runJob(productionUsCentral1).runJob(productionUsEast3).runJob(systemTest).runJob(stagingTest);
         assertEquals(List.of(), tester.jobs().active()); // No jobs left.
 
         tester.outstandingChangeDeployer().run();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview.json
@@ -239,6 +239,48 @@
           "reason": "Testing for productionUsEast3"
         },
         {
+          "id": 5,
+          "status": "installationFailed",
+          "start": 102000,
+          "end": 102000,
+          "wantedPlatform": "6.1",
+          "wantedApplication": {
+            "hash": "1.0.3-commit1",
+            "build": 3,
+            "source": {
+              "gitRepository": "repository1",
+              "gitBranch": "master",
+              "gitCommit": "commit1"
+            }
+          },
+          "currentPlatform": "6.1",
+          "currentApplication": {
+            "hash": "1.0.1-commit1",
+            "build": 1,
+            "source": {
+              "gitRepository": "repository1",
+              "gitBranch": "master",
+              "gitCommit": "commit1"
+            }
+          },
+          "steps": {
+            "deployTester": "succeeded",
+            "deployInitialReal": "succeeded",
+            "installInitialReal": "failed",
+            "deployReal": "unfinished",
+            "installTester": "unfinished",
+            "installReal": "unfinished",
+            "startTests": "unfinished",
+            "endTests": "unfinished",
+            "copyVespaLogs": "succeeded",
+            "deactivateReal": "succeeded",
+            "deactivateTester": "succeeded",
+            "report": "succeeded"
+          },
+          "tasks": {},
+          "log": "https://some.url:43/root/staging-test/run/5"
+        },
+        {
           "id": 4,
           "status": "installationFailed",
           "start": 2000,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-runs.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-runs.json
@@ -168,5 +168,47 @@
     },
     "tasks": {},
     "log": "https://some.url:43/root/run/4"
+  },
+  "5": {
+    "id": 5,
+    "status": "installationFailed",
+    "start": 102000,
+    "end": 102000,
+    "wantedPlatform": "6.1",
+    "wantedApplication": {
+      "hash": "1.0.3-commit1",
+      "build": 3,
+      "source": {
+        "gitRepository": "repository1",
+        "gitBranch": "master",
+        "gitCommit": "commit1"
+      }
+    },
+    "currentPlatform": "6.1",
+    "currentApplication": {
+      "hash": "1.0.1-commit1",
+      "build": 1,
+      "source": {
+        "gitRepository": "repository1",
+        "gitBranch": "master",
+        "gitCommit": "commit1"
+      }
+    },
+    "steps": {
+      "deployInitialReal": "succeeded",
+      "installInitialReal": "failed",
+      "deployReal": "unfinished",
+      "installReal": "unfinished",
+      "deployTester": "succeeded",
+      "installTester": "unfinished",
+      "startTests": "unfinished",
+      "endTests": "unfinished",
+      "copyVespaLogs": "succeeded",
+      "deactivateReal": "succeeded",
+      "deactivateTester": "succeeded",
+      "report": "succeeded"
+    },
+    "tasks": {},
+    "log": "https://some.url:43/root/run/5"
   }
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiTest.java
@@ -50,7 +50,7 @@ public class DeploymentApiTest extends ControllerContainerTest {
         var appWithoutDeployments = deploymentTester.newDeploymentContext("tenant3", "application3", "default");
         failingApp.submit(applicationPackage).deploy();
         productionApp.submit(multiInstancePackage).runJob(JobType.systemTest).runJob(JobType.stagingTest).runJob(JobType.productionUsWest1);
-        otherProductionApp.runJob(JobType.systemTest).runJob(JobType.stagingTest).runJob(JobType.productionUsWest1);
+        otherProductionApp.runJob(JobType.productionUsWest1);
 
         // Deploy once so that job information is stored, then remove the deployment
         appWithoutDeployments.submit(applicationPackage).deploy();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/responses/root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/responses/root.json
@@ -82,7 +82,7 @@
           "instance": "i2",
           "url": "http://localhost:8080/application/v4/tenant/tenant2/application/application2",
           "upgradePolicy": "default",
-          "running": "staging-test"
+          "running": "production-us-west-1"
         }
       ]
     }


### PR DESCRIPTION
@mpolden please review.

This is WIP, and there is quite some cleanup to do. Nevertheless, I think this all works now, i.e., the new deployment spec syntax, with nested parallel and serial blocks of steps, and with declared production tests. 

Some APIs need to remain until replacements have been available for a while, and some cleanup will have to wait for this as well. 

@bratseth FYI. 