### PR TITLE
Support documented VESPA_CONFIGSERVER_RPC_PORT environment variable

### DIFF
--- a/standalone-container/src/main/java/com/yahoo/container/standalone/CloudConfigInstallVariables.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/CloudConfigInstallVariables.java
@@ -15,7 +15,9 @@ public class CloudConfigInstallVariables implements CloudConfigOptions {
 
     @Override
     public Optional<Integer> rpcPort() {
-        return getInstallVariable("port_configserver_rpc", "services", Integer::parseInt);
+        return Optional.ofNullable(System.getenv("VESPA_CONFIGSERVER_RPC_PORT"))
+                .or(() -> getRawInstallVariable("services.port_configserver_rpc"))
+                .map(Integer::parseInt);
     }
 
     @Override


### PR DESCRIPTION
See https://docs.vespa.ai/documentation/cloudconfig/configuration-server.html#ports