### PR TITLE
Revert "Allow minus sign at the start of a label."

### DIFF
--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -795,7 +795,6 @@ String tag() :
 }
 {
     name = identifier() { return name; } |
-    <SUB> <INTEGER> { return "-" + token.image; } |
     <INTEGER> { return token.image; }
 }
 

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -387,8 +387,6 @@ public class EvaluationTestCase {
         EvaluationTester tester = new EvaluationTester();
         tester.assertEvaluates("tensor(x{}):{ {x:a}:1.0, {x:b}:2.0, {x:c}:3.0 }",
                                "tensor(x{}):{ {x:a}:1.0, {x:b}:2.0, {x:c}:3.0 }");
-        tester.assertEvaluates("tensor(x{}):{ {x:1}:1.0, {x:-2}:2.0 }",
-                               "tensor(x{}):{ {x:1}:1.0, {x:-2}:2.0 }");
         tester.assertEvaluates("tensor(x[3]):[1.0, 2, 3.0]",
                                "tensor(x[3]):[1.0, 2.0, 3]");
         tester.assertEvaluates("tensor(x{},y{}):{ {x:a,y:0}:1.0, {x:b,y:0}:2.0, {x:c,y:0}:3.0 }",

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorAddress.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorAddress.java
@@ -1,7 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.tensor;
 
+import com.google.common.base.Joiner;
+
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -160,7 +163,7 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
     /** Supports building of a tensor address */
     public static class Builder {
 
-        private Pattern labelPattern = Pattern.compile("[-,A-Za-z0-9_@]([A-Z,a-z0-9_@$])*");
+        private Pattern identifierPattern = Pattern.compile("[A-Za-z0-9_]+");
 
         private final TensorType type;
         private final String[] labels;
@@ -205,7 +208,7 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
         private void requireIdentifier(String s, String parameterName) {
             if (s == null)
                 throw new IllegalArgumentException(parameterName + " can not be null");
-            if ( ! labelPattern.matcher(s).matches())
+            if ( ! identifierPattern.matcher(s).matches())
                 throw new IllegalArgumentException(parameterName + " must be an identifier or integer, not '" + s + "'");
         }
 


### PR DESCRIPTION
@bratseth PR We need to revert this one to see if it was the cause for the tensor update perfomance degradation. There are other candidates too, but this is the first one. I suggest we merge it tonight after Thursday release has been made.
@geirst FYI
