### PR TITLE
Simplify HttpHandlerBase to make it more generic and reusable.

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/HttpHandlerBase.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/HttpHandlerBase.java
@@ -32,14 +32,8 @@ import static java.util.logging.Level.WARNING;
  */
 public abstract class HttpHandlerBase extends ThreadedHttpRequestHandler {
 
-    protected final ValuesFetcher valuesFetcher;
-
-    protected HttpHandlerBase(Executor executor,
-                              MetricsManager metricsManager,
-                              VespaServices vespaServices,
-                              MetricsConsumers metricsConsumers) {
+    protected HttpHandlerBase(Executor executor) {
         super(executor);
-        valuesFetcher = new ValuesFetcher(metricsManager, vespaServices, metricsConsumers);
     }
 
     protected abstract Optional<HttpResponse> doHandle(URI requestUri, Path apiPath, String consumer);

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/HttpHandlerBase.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/HttpHandlerBase.java
@@ -4,9 +4,6 @@
 
 package ai.vespa.metricsproxy.http;
 
-import ai.vespa.metricsproxy.core.MetricsConsumers;
-import ai.vespa.metricsproxy.core.MetricsManager;
-import ai.vespa.metricsproxy.service.VespaServices;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/MetricsHandler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/MetricsHandler.java
@@ -32,12 +32,15 @@ public class MetricsHandler extends HttpHandlerBase {
     public static final String V1_PATH = "/metrics/v1";
     static final String VALUES_PATH = V1_PATH + "/values";
 
+    private final ValuesFetcher valuesFetcher;
+
     @Inject
     public MetricsHandler(Executor executor,
                           MetricsManager metricsManager,
                           VespaServices vespaServices,
                           MetricsConsumers metricsConsumers) {
-        super(executor, metricsManager, vespaServices, metricsConsumers);
+        super(executor);
+        valuesFetcher = new ValuesFetcher(metricsManager, vespaServices, metricsConsumers);
     }
 
     @Override

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/prometheus/PrometheusHandler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/prometheus/PrometheusHandler.java
@@ -8,6 +8,7 @@ import ai.vespa.metricsproxy.core.MetricsConsumers;
 import ai.vespa.metricsproxy.core.MetricsManager;
 import ai.vespa.metricsproxy.http.HttpHandlerBase;
 import ai.vespa.metricsproxy.http.TextResponse;
+import ai.vespa.metricsproxy.http.ValuesFetcher;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
 import ai.vespa.metricsproxy.service.VespaServices;
 import com.google.inject.Inject;
@@ -32,12 +33,15 @@ public class PrometheusHandler extends HttpHandlerBase {
     public static final String V1_PATH = "/prometheus/v1";
     static final String VALUES_PATH = V1_PATH + "/values";
 
+    private final ValuesFetcher valuesFetcher;
+
     @Inject
     public PrometheusHandler(Executor executor,
                              MetricsManager metricsManager,
                              VespaServices vespaServices,
                              MetricsConsumers metricsConsumers) {
-        super(executor, metricsManager, vespaServices, metricsConsumers);
+        super(executor);
+        valuesFetcher = new ValuesFetcher(metricsManager, vespaServices, metricsConsumers);
     }
 
     @Override

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/yamas/YamasHandler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/yamas/YamasHandler.java
@@ -3,6 +3,7 @@ package ai.vespa.metricsproxy.http.yamas;
 
 import ai.vespa.metricsproxy.core.MetricsConsumers;
 import ai.vespa.metricsproxy.core.MetricsManager;
+import ai.vespa.metricsproxy.http.ValuesFetcher;
 import ai.vespa.metricsproxy.node.NodeMetricGatherer;
 import ai.vespa.metricsproxy.http.ErrorResponse;
 import ai.vespa.metricsproxy.http.HttpHandlerBase;
@@ -34,6 +35,7 @@ public class YamasHandler extends HttpHandlerBase {
     public static final String V1_PATH = "/yamas/v1";
     private static final String VALUES_PATH = V1_PATH + "/values";
 
+    private final ValuesFetcher valuesFetcher;
     private final NodeMetricGatherer nodeMetricGatherer;
 
     @Inject
@@ -43,7 +45,8 @@ public class YamasHandler extends HttpHandlerBase {
                         MetricsConsumers metricsConsumers,
                         ApplicationDimensions applicationDimensions,
                         NodeDimensions nodeDimensions) {
-        super(executor, metricsManager, vespaServices, metricsConsumers);
+        super(executor);
+        valuesFetcher = new ValuesFetcher(metricsManager, vespaServices, metricsConsumers);
         this.nodeMetricGatherer = new NodeMetricGatherer(metricsManager, vespaServices, applicationDimensions, nodeDimensions);
     }
 


### PR DESCRIPTION
The new ApplicationMetricsHandler will not have a ValuesFetcher.