### PR TITLE
Disable fast update path restarts by default

### DIFF
--- a/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
+++ b/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
@@ -1048,28 +1048,28 @@ TEST_F(TwoPhaseUpdateOperationTest, safe_path_consistent_get_reply_timestamps_do
 }
 
 TEST_F(TwoPhaseUpdateOperationTest, fast_path_not_restarted_if_replica_set_altered_between_get_send_and_receive) {
-        setupDistributor(3, 3, "storage:3 distributor:1");
-        getConfig().set_update_fast_path_restart_enabled(true);
+    setupDistributor(3, 3, "storage:3 distributor:1");
+    getConfig().set_update_fast_path_restart_enabled(true);
 
-        std::shared_ptr<TwoPhaseUpdateOperation> cb(sendUpdate("0=1/2/3,1=2/3/4")); // Inconsistent replicas.
-        DistributorMessageSenderStub sender;
-        cb->start(sender, framework::MilliSecTime(0));
+    std::shared_ptr<TwoPhaseUpdateOperation> cb(sendUpdate("0=1/2/3,1=2/3/4")); // Inconsistent replicas.
+    DistributorMessageSenderStub sender;
+    cb->start(sender, framework::MilliSecTime(0));
 
-        // Replica set changes between time of Get requests sent and
-        // responses received. This may happen e.g. if concurrent mutations
-        // to the same bucket create a new replica. If this happens, we
-        // must not send the Update operations verbatim, as they will
-        // be started with the _current_ replica set, not the one that
-        // was present during the Get request.
-        BucketId bucket(0x400000000000cac4); // Always the same in the test.
-        addNodesToBucketDB(bucket, "0=1/2/3,1=2/3/4,2=3/3/3");
+    // Replica set changes between time of Get requests sent and
+    // responses received. This may happen e.g. if concurrent mutations
+    // to the same bucket create a new replica. If this happens, we
+    // must not send the Update operations verbatim, as they will
+    // be started with the _current_ replica set, not the one that
+    // was present during the Get request.
+    BucketId bucket(0x400000000000cac4); // Always the same in the test.
+    addNodesToBucketDB(bucket, "0=1/2/3,1=2/3/4,2=3/3/3");
 
-        Timestamp old_timestamp = 500;
-        ASSERT_EQ("Get => 0,Get => 1", sender.getCommands(true));
-        replyToGet(*cb, sender, 0, old_timestamp);
-        replyToGet(*cb, sender, 1, old_timestamp);
+    Timestamp old_timestamp = 500;
+    ASSERT_EQ("Get => 0,Get => 1", sender.getCommands(true));
+    replyToGet(*cb, sender, 0, old_timestamp);
+    replyToGet(*cb, sender, 1, old_timestamp);
 
-        ASSERT_EQ("Put => 1,Put => 2,Put => 0", sender.getCommands(true, false, 2));
+    ASSERT_EQ("Put => 1,Put => 2,Put => 0", sender.getCommands(true, false, 2));
 }
 
 // XXX currently differs in behavior from content nodes in that updates for

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -213,4 +213,4 @@ use_btree_database bool default=false restart
 ## content nodes, the two-phase update path reverts back to the regular fast path.
 ## Since all replicas of the document were in sync, applying the update in-place
 ## shall be considered safe.
-restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=true
+restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=false

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -138,6 +138,7 @@ private:
     mbus::TraceNode _trace;
     document::BucketId _updateDocBucketId;
     std::vector<std::pair<document::BucketId, uint16_t>> _replicas_at_get_send_time;
+    uint16_t _fast_path_repair_source_node;
     bool _replySent;
 };
 


### PR DESCRIPTION
@baldersheim please review

Even with the fix in #11561 we are still observing replica
divergence warnings in the logs. Disabling this feature entirely
until the issue has been fully investigated and a complete fix
has been implemented.

Also emit a log message when the distributor has forced convergence
of a detected inconsistent update.
