### PR TITLE
Ensure missing documents on replicas are not erroneously considered consistent

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -6,6 +6,7 @@
 #include <vespa/storage/bucketdb/bucketdatabase.h>
 #include <vespa/storageapi/messageapi/storagemessage.h>
 #include <vespa/storageframework/generic/clock/timer.h>
+#include <optional>
 
 namespace document { class Document; }
 
@@ -88,7 +89,7 @@ private:
     api::ReturnCode _returnCode;
     std::shared_ptr<document::Document> _doc;
 
-    api::Timestamp _lastModified;
+    std::optional<api::Timestamp> _lastModified;
 
     PersistenceOperationMetricSet& _metric;
     framework::MilliSecTimer _operationTimer;


### PR DESCRIPTION
Introducing a new member in the category "stupid bugs that I should have
added explicit tests for when adding the feature initially".

There was ambiguity in the GetOperation code where a timestamp sentinel
value of zero was used to denote not having received any replies yet,
but where a timestamp of zero also means "document not found on replica".
This means that if the first reply was from a replica _without_ a document
and the second reply was from a replica _with_ a document, the code
would act as if the first reply effectively did not exist. Consequently
the Get operation would be tagged as consistent. This had very bad
consequences for the two-phase update operation logic that relied on
this information to be correct.

This change ensures there is no ambiguity between not having received
a reply and having a received a reply with a missing document.

I believe this completes the fix already present in #11561, but until this
has proven itself on a smaller scale it remains config disabled by default.