### PR TITLE
Vespa doc op feature add

### DIFF
--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/pig/VespaStorage.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/pig/VespaStorage.java
@@ -11,6 +11,7 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.pig.ResourceSchema;
 import org.apache.pig.StoreFunc;
 import org.apache.pig.data.Tuple;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.impl.util.UDFContext;
 
 import java.io.*;
@@ -160,7 +161,8 @@ public class VespaStorage extends StoreFunc {
         Map<String, Object> fields = TupleTools.tupleMap(resourceSchema, tuple);
         String docId = TupleTools.toString(fields, template);
 
-        return VespaDocumentOperation.create(operation, docId, fields, properties);
+        Schema schema = Schema.getPigSchema(resourceSchema);
+        return VespaDocumentOperation.create(operation, docId, fields, properties, schema);
     }
 
 


### PR DESCRIPTION
### There are three features added in this PR:
* create-if-non-existent
* treat bag as map // bag-as-map-fields
* treat tuple as map // simple-object-fields

### create-if-non-existent
To create a new doc when the operation is update and the doc is non-existent

### treat bag as map
We cannot just use Map when the value is a Struct. e.g. field matchTerm type map<long, Term> where Term is a Struct.
The schema of Term cannot be preserved if we store the data to disk.
To preserve the schema, use Bag instead of Map.
The first element of Tuple is key. The second element of Tuple is value.

### treat tuple as map
When the type of values are different in a Map, the schema cannot be correctly stores as well.
To preserve it, use Tuple instead of Map.
The alias of Tuple field is key. The corresponding element in Tuple is value. 