### PR TITLE
Gjoranv/cluster membership as host id

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsNodesConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsNodesConfigGenerator.java
@@ -22,7 +22,7 @@ public class MetricsNodesConfigGenerator {
 
     private static MetricsNodesConfig.Node.Builder toNodeBuilder(MetricsProxyContainer container) {
         var builder = new MetricsNodesConfig.Node.Builder()
-                .configId(container.getHost().getConfigId())
+                .nodeId(container.getHost().getConfigId())
                 .hostname(container.getHostName())
                 .metricsPort(MetricsProxyContainer.BASEPORT)
                 .metricsPath(MetricsHandler.VALUES_PATH);
@@ -30,7 +30,7 @@ public class MetricsNodesConfigGenerator {
         if (container.isHostedVespa)
             container.getHostResource().spec().membership()
                     .map(ClusterMembership::stringValue)
-                    .ifPresent(builder::configId);
+                    .ifPresent(builder::nodeId);
 
         return builder;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsNodesConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsNodesConfigGenerator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.admin.metricsproxy;
 
 import ai.vespa.metricsproxy.http.MetricsHandler;
 import ai.vespa.metricsproxy.http.application.MetricsNodesConfig;
+import com.yahoo.config.provision.ClusterMembership;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,11 +21,18 @@ public class MetricsNodesConfigGenerator {
     }
 
     private static MetricsNodesConfig.Node.Builder toNodeBuilder(MetricsProxyContainer container) {
-        return new MetricsNodesConfig.Node.Builder()
+        var builder = new MetricsNodesConfig.Node.Builder()
                 .configId(container.getHost().getConfigId())
                 .hostname(container.getHostName())
                 .metricsPort(MetricsProxyContainer.BASEPORT)
                 .metricsPath(MetricsHandler.VALUES_PATH);
+
+        if (container.isHostedVespa)
+            container.getHostResource().spec().membership()
+                    .map(ClusterMembership::stringValue)
+                    .ifPresent(builder::configId);
+
+        return builder;
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -38,7 +38,7 @@ public class MetricsProxyContainer extends Container implements
         static final String CLUSTER_ID = "clusterid";
     }
 
-    private final boolean isHostedVespa;
+    final boolean isHostedVespa;
 
     public MetricsProxyContainer(AbstractConfigProducer parent, String hostname, int index, boolean isHostedVespa) {
         super(parent, hostname, index);

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -307,8 +307,8 @@ public class MetricsProxyContainerClusterTest {
     }
 
     private void assertNodeConfig(MetricsNodesConfig.Node node) {
-        assertFalse(node.configId().isEmpty());
-        assertFalse(node.hostname().isEmpty());
+        assertTrue(node.configId().startsWith("container/foo/0/"));
+        assertTrue(node.hostname().startsWith("node-1-3-9-"));
         assertEquals(MetricsProxyContainer.BASEPORT, node.metricsPort());
         assertEquals(MetricsHandler.VALUES_PATH, node.metricsPath());
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -307,7 +307,7 @@ public class MetricsProxyContainerClusterTest {
     }
 
     private void assertNodeConfig(MetricsNodesConfig.Node node) {
-        assertTrue(node.configId().startsWith("container/foo/0/"));
+        assertTrue(node.nodeId().startsWith("container/foo/0/"));
         assertTrue(node.hostname().startsWith("node-1-3-9-"));
         assertEquals(MetricsProxyContainer.BASEPORT, node.metricsPort());
         assertEquals(MetricsHandler.VALUES_PATH, node.metricsPath());

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/Node.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/Node.java
@@ -21,7 +21,7 @@ public class Node {
     private final String metricsUriBase;
 
     public Node(MetricsNodesConfig.Node nodeConfig) {
-        this(nodeConfig.configId(), nodeConfig.hostname(), nodeConfig.metricsPort() , nodeConfig.metricsPath());
+        this(nodeConfig.nodeId(), nodeConfig.hostname(), nodeConfig.metricsPort() , nodeConfig.metricsPath());
     }
 
     public Node(String configId, String host, int port, String path) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/Node.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/Node.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  */
 public class Node {
 
-    final String configId;
+    final String nodeId;
     final String host;
     final int port;
     final String path;
@@ -24,12 +24,12 @@ public class Node {
         this(nodeConfig.nodeId(), nodeConfig.hostname(), nodeConfig.metricsPort() , nodeConfig.metricsPath());
     }
 
-    public Node(String configId, String host, int port, String path) {
-        Objects.requireNonNull(configId, "Null configId is not allowed");
+    public Node(String nodeId, String host, int port, String path) {
+        Objects.requireNonNull(nodeId, "Null configId is not allowed");
         Objects.requireNonNull(host, "Null host is not allowed");
         Objects.requireNonNull(path, "Null path is not allowed");
 
-        this.configId = configId;
+        this.nodeId = nodeId;
         this.host = host;
         this.port = port;
         this.path = path;
@@ -37,7 +37,7 @@ public class Node {
     }
 
     public String getName() {
-        return configId;
+        return nodeId;
     }
 
     URI metricsUri(ConsumerId consumer) {
@@ -50,12 +50,12 @@ public class Node {
         if (o == null || getClass() != o.getClass()) return false;
         Node node = (Node) o;
         return port == node.port &&
-                configId.equals(node.configId) &&
+                nodeId.equals(node.nodeId) &&
                 host.equals(node.host);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(configId, host, port);
+        return Objects.hash(nodeId, host, port);
     }
 }

--- a/metrics-proxy/src/main/resources/configdefinitions/metrics-nodes.def
+++ b/metrics-proxy/src/main/resources/configdefinitions/metrics-nodes.def
@@ -1,7 +1,7 @@
 # Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package=ai.vespa.metricsproxy.http.application
 
-node[].configId string
+node[].nodeId string
 node[].hostname string
 node[].metricsPort int
 node[].metricsPath string

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
@@ -171,7 +171,7 @@ public class ApplicationMetricsHandlerTest {
 
     private MetricsNodesConfig.Node.Builder nodeConfig(String path) {
         return new MetricsNodesConfig.Node.Builder()
-                .configId(path)
+                .nodeId(path)
                 .hostname("localhost")
                 .metricsPath(path)
                 .metricsPort(port);

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsRetrieverTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsRetrieverTest.java
@@ -157,7 +157,7 @@ public class ApplicationMetricsRetrieverTest {
 
     private MetricsNodesConfig.Node.Builder nodeConfig(String path) {
         return new MetricsNodesConfig.Node.Builder()
-                .configId(path)
+                .nodeId(path)
                 .hostname(HOST)
                 .metricsPath(path)
                 .metricsPort(port);


### PR DESCRIPTION
This is an attempt to avoid exposing the hostname of a node, while at the same time having a unique identifier for a node, to be used as a metric dimension.