### PR TITLE
Return internal server error if internal delete fails

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.config.server.application;
 
 import com.yahoo.concurrent.StripedExecutor;
-import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.log.LogLevel;
@@ -24,12 +23,10 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -66,9 +66,10 @@ public class ApplicationHandler extends HttpHandler {
     @Override
     public HttpResponse handleDELETE(HttpRequest request) {
         ApplicationId applicationId = getApplicationIdFromRequest(request);
-        boolean deleted = applicationRepository.delete(applicationId);
+        // TODO: Add support for timeout in request
+        boolean deleted = applicationRepository.delete(applicationId, Duration.ofSeconds(60));
         if ( ! deleted)
-            return HttpErrorResponse.notFoundError("Unable to delete " + applicationId + ": Not found");
+            return HttpErrorResponse.notFoundError("Unable to delete " + applicationId.toFullString() + ": Not found");
         return new DeleteApplicationResponse(Response.Status.OK, applicationId);
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -17,7 +17,7 @@ import com.yahoo.test.ManualClock;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.config.server.application.OrchestratorMock;
 import com.yahoo.vespa.config.server.deploy.DeployTester;
-import com.yahoo.vespa.config.server.http.LogRetriever;
+import com.yahoo.vespa.config.server.http.InternalServerException;
 import com.yahoo.vespa.config.server.http.SessionHandlerTest;
 import com.yahoo.vespa.config.server.http.v2.PrepareResult;
 import com.yahoo.vespa.config.server.session.LocalSession;
@@ -34,8 +34,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -51,6 +49,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author hmusum
@@ -276,6 +275,16 @@ public class ApplicationRepositoryTest {
             assertNotNull(applicationRepository.getActiveSession(applicationId()));
 
             assertTrue(applicationRepository.delete(applicationId()));
+        }
+
+        {
+            try {
+                deployApp(testApp);
+                applicationRepository.delete(applicationId(), Duration.ZERO);
+                fail("Should have gotten an exception");
+            } catch (InternalServerException e) {
+                assertEquals("Session 5 was not deleted (waited PT0S)", e.getMessage());
+            }
         }
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -123,6 +123,15 @@ public class ApplicationHandlerTest {
     }
 
     @Test
+    public void testDeleteNonExistent() throws Exception {
+        deleteAndAssertResponse(applicationId,
+                                Zone.defaultZone(),
+                                Response.Status.NOT_FOUND,
+                                HttpErrorResponse.errorCodes.NOT_FOUND,
+                                "Unable to delete mytenant.default.default: Not found");
+    }
+
+    @Test
     public void testGet() throws Exception {
         long sessionId = applicationRepository.deploy(testApp, prepareParams(applicationId)).sessionId();
         assertApplicationGeneration(applicationId, Zone.defaultZone(), sessionId, true);
@@ -232,6 +241,10 @@ public class ApplicationHandlerTest {
     private void deleteAndAssertResponse(ApplicationId applicationId, Zone zone, int expectedStatus, HttpErrorResponse.errorCodes errorCode, boolean fullAppIdInUrl) throws IOException {
         String expectedResponse = "{\"message\":\"Application '" + applicationId + "' deleted\"}";
         deleteAndAssertResponse(toUrlPath(applicationId, zone, fullAppIdInUrl), expectedStatus, errorCode, expectedResponse, com.yahoo.jdisc.http.HttpRequest.Method.DELETE);
+    }
+
+    private void deleteAndAssertResponse(ApplicationId applicationId, Zone zone, int expectedStatus, HttpErrorResponse.errorCodes errorCode, String expectedResponse) throws IOException {
+        deleteAndAssertResponse(toUrlPath(applicationId, zone, true), expectedStatus, errorCode, expectedResponse, com.yahoo.jdisc.http.HttpRequest.Method.DELETE);
     }
 
     private void deleteAndAssertResponse(String url, int expectedStatus, HttpErrorResponse.errorCodes errorCode, String expectedResponse, com.yahoo.jdisc.http.HttpRequest.Method method) throws IOException {


### PR DESCRIPTION
Note that we know return false early if no active session was found. This changes behavior, but seems to me to be the correct thing to do. Review only, do not merge