### PR TITLE
Revert back to using system_clock in MetricManager

### DIFF
--- a/metrics/src/vespa/metrics/metricmanager.cpp
+++ b/metrics/src/vespa/metrics/metricmanager.cpp
@@ -26,7 +26,7 @@ MetricManager::ConsumerSpec::~ConsumerSpec() = default;
 
 time_t
 MetricManager::Timer::getTime() const {
-    return vespalib::count_s(vespalib::steady_clock::now().time_since_epoch());
+    return vespalib::count_s(vespalib::system_clock::now().time_since_epoch());
 }
 
 void


### PR DESCRIPTION
@baldersheim please review

We have to selectively use steady time here, since it will mess with the
metric snapshot timestamps if we use the steady clock for everything.
For now, just revert back to system time.

