### PR TITLE
Double slash breaks RPM debug info extraction.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
@@ -6,7 +6,7 @@
 #include <vespa/fastos/file.h>
 #include <vespa/searchcore/config/config-hwinfo.h>
 #include <vespa/vespalib/io/fileutil.h>
-#include <vespa/vespalib//util/time.h>
+#include <vespa/vespalib/util/time.h>
 #include <filesystem>
 #include <thread>
 #include <vespa/log/log.h>


### PR DESCRIPTION
Found another one of these.
