### PR TITLE
Revert "Bjorncs/apache commons libraries cleanup"

### DIFF
--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>airline</artifactId>
       <exclusions>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -45,6 +45,10 @@
           <groupId>io.airlift</groupId>
           <artifactId>airline</artifactId>
         </exclusion>
+         <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/ZipBuilder.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/ZipBuilder.java
@@ -1,6 +1,8 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +31,7 @@ public class ZipBuilder implements AutoCloseable {
         try (ZipInputStream zin = new ZipInputStream(new ByteArrayInputStream(zippedContent))) {
             for (ZipEntry entry = zin.getNextEntry(); entry != null; entry = zin.getNextEntry()) {
                 zipOutputStream.putNextEntry(entry);
-                zin.transferTo(zipOutputStream);
+                IOUtils.copy(zin, zipOutputStream);
                 zipOutputStream.closeEntry();
             }
         } catch (IOException e) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ZipBuilderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ZipBuilderTest.java
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -52,7 +53,7 @@ public class ZipBuilderTest {
         try (ZipInputStream zin = new ZipInputStream(new ByteArrayInputStream(zippedContent))) {
             for (ZipEntry entry = zin.getNextEntry(); entry != null; entry = zin.getNextEntry()) {
                 if (entry.isDirectory()) continue;
-                contents.put(entry.getName(), new String(zin.readAllBytes(), StandardCharsets.UTF_8));
+                contents.put(entry.getName(), IOUtils.toString(zin, StandardCharsets.UTF_8));
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read zipped content", e);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -32,10 +32,9 @@ import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.serviceview.bindings.ApplicationView;
 import com.yahoo.vespa.serviceview.bindings.ClusterView;
 import com.yahoo.vespa.serviceview.bindings.ServiceView;
+import org.apache.commons.io.IOUtils;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -413,7 +412,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
 
     @Override
     public InputStream getLogs(DeploymentId deployment, Map<String, String> queryParameters) {
-        return new ByteArrayInputStream(log.getBytes(StandardCharsets.UTF_8));
+        return IOUtils.toInputStream(log);
     }
 
     public void setLogStream(String log) {

--- a/fat-model-dependencies/pom.xml
+++ b/fat-model-dependencies/pom.xml
@@ -35,6 +35,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>configdefinitions</artifactId>
       <version>${project.version}</version>

--- a/orchestrator/pom.xml
+++ b/orchestrator/pom.xml
@@ -75,6 +75,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-provisioning</artifactId>
       <version>${project.version}</version>

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/status/ZookeeperStatusServiceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/status/ZookeeperStatusServiceTest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.status;
 
-import com.yahoo.exception.ExceptionUtils;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.Timer;
 import com.yahoo.jdisc.test.TestTimer;
@@ -10,7 +9,7 @@ import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.orchestrator.OrchestratorContext;
 import com.yahoo.vespa.orchestrator.TestIds;
-import com.yahoo.yolean.Exceptions;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.KillSession;
 import org.apache.curator.test.TestingServer;
@@ -220,8 +219,8 @@ public class ZookeeperStatusServiceTest {
                 getException(item).ifPresent( throwable ->
                         mismatchDescription
                                 .appendText("Got exception: ")
-                                .appendText(Exceptions.toMessageString(throwable))
-                                .appendText(ExceptionUtils.getStackTraceRecursivelyAsString(throwable)));
+                                .appendText(ExceptionUtils.getMessage(throwable))
+                                .appendText(ExceptionUtils.getFullStackTrace(throwable)));
             }
         };
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -493,6 +493,16 @@
                 <version>1.6</version>
             </dependency>
             <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.4</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-net</groupId>
                 <artifactId>commons-net</artifactId>
                 <version>2.0</version>
@@ -551,6 +561,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-exec</artifactId>
                 <version>1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>
@@ -756,6 +771,7 @@
         <!-- Athenz dependencies. Make sure these dependencies match those in Vespa's internal repositories -->
         <athenz.version>1.8.29</athenz.version>
         <aws.sdk.version>1.11.542</aws.sdk.version>
+        <commons-lang.version>2.6</commons-lang.version>
         <!-- WARNING: If you change curator version, you also need to update
                  zkfacade/src/main/java/org/apache/curator/**/package-info.java
              using something like

--- a/vespa-application-maven-plugin/pom.xml
+++ b/vespa-application-maven-plugin/pom.xml
@@ -42,6 +42,10 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-jar-plugin</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.plugin.mojo;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,13 +13,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * @author Tony Vaagenes
@@ -98,24 +96,10 @@ public class ApplicationMojo extends AbstractMojo {
     private void copyApplicationPackage(File applicationPackage, File applicationDestination) throws MojoExecutionException {
         if (applicationPackage.exists()) {
             try {
-                copyDirectory(applicationPackage.toPath(), applicationDestination.toPath());
-            } catch (Exception e) {
+                FileUtils.copyDirectory(applicationPackage, applicationDestination);
+            } catch (IOException e) {
                 throw new MojoExecutionException("Failed copying applicationPackage", e);
             }
-        }
-    }
-
-    private static void copyDirectory(Path source, Path destination) {
-        try (Stream<Path> fileStreams = Files.walk(source)) {
-            fileStreams.forEachOrdered(sourcePath -> {
-                try {
-                    Files.copy(sourcePath, source.resolve(destination.relativize(sourcePath)));
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 

--- a/vespa-http-client/pom.xml
+++ b/vespa-http-client/pom.xml
@@ -66,6 +66,12 @@
 
     <!-- Test dependencies -->
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>

--- a/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/XmlFeedReaderTest.java
+++ b/vespa-http-client/src/test/java/com/yahoo/vespa/http/client/core/XmlFeedReaderTest.java
@@ -1,9 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.http.client.core;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.yahoo.vespa.http.client.FeedClient;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -18,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,8 +31,6 @@ public class XmlFeedReaderTest {
     private final static String feedResource2 = "/xml-challenge.xml";
     private final static String feedResource3 = "/xml-challenge2.xml";
     private final static String feedResource4 = "/xml-challenge3.xml";
-
-    private static final XmlMapper xmlMapper = new XmlMapper();
 
     private final String updateDocUpdate =
             "<?xml version=\"1.0\"?>\n" +
@@ -234,9 +232,13 @@ public class XmlFeedReaderTest {
         InputStream inputStream2 = XmlFeedReaderTest.class.getResourceAsStream(filename);
         String rawXML = new java.util.Scanner(inputStream2, "UTF-8").useDelimiter("\\A").next();
 
-        JsonNode decodedDocument = xmlMapper.readTree(document);
-        JsonNode rawDocuments = xmlMapper.readTree(rawXML);
-        assertThat(decodedDocument, is(rawDocuments.get("document")));
+        String rawDoc = rawXML.toString().split("<document")[1].split("</document>")[0];
+        assertThat(rawDoc.length() > 30, is(true));
+
+        String decodedRawXml = StringEscapeUtils.unescapeXml(rawDoc);
+        String decodedDoc = StringEscapeUtils.unescapeXml(document);
+
+        assertThat(decodedDoc, containsString(decodedRawXml));
     }
 
     @Test public void testCData() throws Exception {

--- a/vespa-testrunner-components/pom.xml
+++ b/vespa-testrunner-components/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/vespa-testrunner-components/src/test/java/com/yahoo/vespa/hosted/testrunner/PomXmlGeneratorTest.java
+++ b/vespa-testrunner-components/src/test/java/com/yahoo/vespa/hosted/testrunner/PomXmlGeneratorTest.java
@@ -1,6 +1,7 @@
 // Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.testrunner;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ public class PomXmlGeneratorTest {
     }
 
     private void assertFile(String resourceFile, String actual) throws IOException {
-        String expected = new String(this.getClass().getResourceAsStream(resourceFile).readAllBytes());
+        String expected = IOUtils.toString(this.getClass().getResourceAsStream(resourceFile));
         assertEquals(resourceFile, expected, actual);
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#11681

Breaks building sample-apps module with:
`[ERROR] Failed to execute goal com.yahoo.vespa:vespa-application-maven-plugin:7.157.1:packageApplication (default) on project basic-search-hosted: Failed copying applicationPackage: java.nio.file.NoSuchFileException: /wd/repositories/vespa/sample-apps/basic-search-hosted/src/main/application/../../src/main/application -> [Help 1]`