### PR TITLE
Delete destination dir before moving files

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReceiver.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReceiver.java
@@ -111,6 +111,9 @@ public class FileReceiver {
             }
             File file = new File(fileReferenceDir, fileName);
             try {
+                // Delete destination dir, in case a previous attempt at writing to disk failed and the directory
+                // exists, but has no or incomplete content
+                deleteFileOrDirectory(fileReferenceDir);
                 // Unpack if necessary
                 if (fileType == FileReferenceData.Type.compressed) {
                     File decompressedDir = Files.createTempDirectory(tmpDir.toPath(), "archive").toFile();


### PR DESCRIPTION
Destination dir is either created and files moved into it or a directory
itself is moved, so deleting the directory should always be safe and
might fix an issue in case of full disk, interrupted process or some
other issue leaving the file system in a bad state.
