### PR TITLE
Warn on missing query feature type declarations

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
@@ -13,17 +13,14 @@ import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
 
-import java.sql.Ref;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
@@ -13,14 +13,19 @@ import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
 
+import java.sql.Ref;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -42,19 +47,28 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
     /** For invocation loop detection */
     private final Deque<Reference> currentResolutionCallStack;
 
+    private final SortedSet<Reference> queryFeaturesNotDeclared;
+    private boolean tensorsAreUsed;
+
     MapEvaluationTypeContext(Collection<ExpressionFunction> functions, Map<Reference, TensorType> featureTypes) {
         super(functions);
         this.featureTypes.putAll(featureTypes);
         this.currentResolutionCallStack =  new ArrayDeque<>();
+        this.queryFeaturesNotDeclared = new TreeSet<>();
+        tensorsAreUsed = false;
     }
 
     private MapEvaluationTypeContext(Map<String, ExpressionFunction> functions,
                                      Map<String, String> bindings,
                                      Map<Reference, TensorType> featureTypes,
-                                     Deque<Reference> currentResolutionCallStack) {
+                                     Deque<Reference> currentResolutionCallStack,
+                                     SortedSet<Reference> queryFeaturesNotDeclared,
+                                     boolean tensorsAreUsed) {
         super(functions, bindings);
         this.featureTypes.putAll(featureTypes);
         this.currentResolutionCallStack = currentResolutionCallStack;
+        this.queryFeaturesNotDeclared = queryFeaturesNotDeclared;
+        this.tensorsAreUsed = tensorsAreUsed;
     }
 
     public void setType(Reference reference, TensorType type) {
@@ -63,7 +77,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
 
     @Override
     public TensorType getType(String reference) {
-        throw new UnsupportedOperationException("Not able to parse gereral references from string form");
+        throw new UnsupportedOperationException("Not able to parse general references from string form");
     }
 
     public void forgetResolvedTypes() {
@@ -80,6 +94,8 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
         if (resolvedType == null)
             return defaultTypeOf(reference); // Don't store fallback to default as we may know more later
         resolvedTypes.put(reference, resolvedType);
+        if (resolvedType.rank() > 0)
+            tensorsAreUsed = true;
         return resolvedType;
     }
 
@@ -142,8 +158,10 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
     public TensorType defaultTypeOf(Reference reference) {
         if ( ! FeatureNames.isSimpleFeature(reference))
             throw new IllegalArgumentException("This can only be called for simple references, not " + reference);
-        if (reference.name().equals("query")) // we do not require all query features to be declared, only non-doubles
+        if (reference.name().equals("query")) { // we do not require all query features to be declared, only non-doubles
+            queryFeaturesNotDeclared.add(reference);
             return TensorType.empty;
+        }
         return null;
     }
 
@@ -215,9 +233,26 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
         return Collections.unmodifiableMap(featureTypes);
     }
 
+    /**
+     * Returns an unmodifiable view of the query features which was requested but for which we have no type info
+     * (such that they default to TensorType.empty), shared between all instances of this
+     * involved in resolving a particular rank profile.
+     */
+    public SortedSet<Reference> queryFeaturesNotDeclared() {
+        return Collections.unmodifiableSortedSet(queryFeaturesNotDeclared);
+    }
+
+    /** Returns true if any feature across all instances involved in resolving this rank profile resolves to a tensor */
+    public boolean tensorsAreUsed() { return tensorsAreUsed; }
+
     @Override
     public MapEvaluationTypeContext withBindings(Map<String, String> bindings) {
-        return new MapEvaluationTypeContext(functions(), bindings, featureTypes, currentResolutionCallStack);
+        return new MapEvaluationTypeContext(functions(),
+                                            bindings,
+                                            featureTypes,
+                                            currentResolutionCallStack,
+                                            queryFeaturesNotDeclared,
+                                            tensorsAreUsed);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -755,7 +755,6 @@ public class RankProfile implements Cloneable {
      * referable from this rank profile.
      */
     public MapEvaluationTypeContext typeContext(QueryProfileRegistry queryProfiles) {
-
         return typeContext(queryProfiles, collectFeatureTypes());
     }
 

--- a/config-model/src/main/java/com/yahoo/searchdefinition/SearchBuilder.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/SearchBuilder.java
@@ -187,9 +187,8 @@ public class SearchBuilder {
      * @throws IllegalArgumentException if the given search object has already been processed.
      */
     public String importRawSearch(Search rawSearch) {
-        if (rawSearch.getName() == null) {
+        if (rawSearch.getName() == null)
             throw new IllegalArgumentException("Search has no name.");
-        }
         String rawName = rawSearch.getName();
         for (Search search : searchList) {
             if (rawName.equals(search.getName())) {

--- a/searchlib/abi-spec.json
+++ b/searchlib/abi-spec.json
@@ -343,7 +343,9 @@
   },
   "com.yahoo.searchlib.rankingexpression.Reference": {
     "superClass": "com.yahoo.tensor.evaluation.Name",
-    "interfaces": [],
+    "interfaces": [
+      "java.lang.Comparable"
+    ],
     "attributes": [
       "public"
     ],
@@ -362,7 +364,9 @@
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",
       "public java.lang.String toString()",
-      "public java.lang.StringBuilder toString(java.lang.StringBuilder, com.yahoo.searchlib.rankingexpression.rule.SerializationContext, java.util.Deque, com.yahoo.searchlib.rankingexpression.rule.CompositeNode)"
+      "public java.lang.StringBuilder toString(java.lang.StringBuilder, com.yahoo.searchlib.rankingexpression.rule.SerializationContext, java.util.Deque, com.yahoo.searchlib.rankingexpression.rule.CompositeNode)",
+      "public int compareTo(com.yahoo.searchlib.rankingexpression.Reference)",
+      "public bridge synthetic int compareTo(java.lang.Object)"
     ],
     "fields": []
   },

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/Reference.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/Reference.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  *
  * @author bratseth
  */
-public class Reference extends Name {
+public class Reference extends Name implements Comparable<Reference> {
 
     private final int hashCode;
 
@@ -161,6 +161,11 @@ public class Reference extends Name {
         if (output != null)
             b.append(".").append(output);
         return b;
+    }
+
+    @Override
+    public int compareTo(Reference o) {
+        return this.toString().compareTo(o.toString());
     }
 
 }


### PR DESCRIPTION
Warn on	missing	query feature type declarations in rank profiles
which use tensors. This may help users to remember to declare them
to avoid running into confuson as tensors are interpreted as
string which are hashed to scalars.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
