### PR TITLE
Avoid re-reading version status for every application

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -296,19 +296,24 @@ public class JobController {
 
     /** Returns the deployment status of the given application. */
     public DeploymentStatus deploymentStatus(Application application) {
+        return deploymentStatus(application, controller.systemVersion());
+    }
+
+    private DeploymentStatus deploymentStatus(Application application, Version systemVersion) {
         return new DeploymentStatus(application,
                                     DeploymentStatus.jobsFor(application, controller.system()).stream()
                                                     .collect(toUnmodifiableMap(job -> job,
                                                                                job -> jobStatus(job))),
                                     controller.system(),
-                                    controller.systemVersion(),
+                                    systemVersion,
                                     controller.clock().instant());
     }
 
     /** Adds deployment status to each of the given applications. */
     public DeploymentStatusList deploymentStatuses(ApplicationList applications) {
+        var systemVersion = controller.systemVersion();
         return DeploymentStatusList.from(applications.asList().stream()
-                                                     .map(this::deploymentStatus)
+                                                     .map(application -> deploymentStatus(application, systemVersion))
                                                      .collect(toUnmodifiableList()));
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/VersionStatusSerializer.java
@@ -44,7 +44,6 @@ public class VersionStatusSerializer {
     private static final String isReleasedField = "isReleased";
     private static final String deploymentStatisticsField = "deploymentStatistics";
     private static final String confidenceField = "confidence";
-    private static final String configServersField = "configServerHostnames";
 
     // NodeVersions fields
     private static final String nodeVersionsField = "nodeVersions";


### PR DESCRIPTION
Calling `systemVersion()` implies reading complete version status from
ZooKeeper, and doing this for every single app is naturally expensive.