### PR TITLE
Treat rank features as tensors (or doubles)

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -316,11 +316,23 @@ public class QueryProperties extends Properties {
         return properties;
     }
 
+    @SuppressWarnings("deprecation")
     private void setRankingFeature(Query query, String key, Object value) {
-        if (value instanceof Tensor)
-            query.getRanking().getFeatures().put(key, (Tensor)value);
-        else
-            query.getRanking().getFeatures().put(key, asString(value, ""));
+        if (value instanceof Tensor) {
+            query.getRanking().getFeatures().put(key, (Tensor) value);
+        }
+        else if (value instanceof Double) {
+            query.getRanking().getFeatures().put(key, (Double) value);
+        }
+        else {
+            String valueString = asString(value, "");
+            try {
+                query.getRanking().getFeatures().put(key, Double.parseDouble(valueString));
+            }
+            catch (IllegalArgumentException e) { // TODO: Throw instead on Vespa 8
+                query.getRanking().getFeatures().put(key, valueString);
+            }
+        }
     }
 
     private Object toSpecifiedType(String key, Object value, QueryProfileType type) {

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/RankFeatures.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/RankFeatures.java
@@ -40,19 +40,29 @@ public class RankFeatures implements Cloneable {
         features.put(name, value);
     }
 
-    /** Sets a rank feature to a value represented as a string */
+    /**
+     * Sets a rank feature to a value represented as a string.
+     *
+     * @deprecated set either a double or a tensor
+     */
+    @Deprecated // TODO: Remove on Vespa 8
     public void put(String name, String value) {
         features.put(name, value);
     }
 
-    /** Returns a rank feature as a string by full name or null if not set */
+    /**
+     * Returns a rank feature as a string by full name or null if not set
+     *
+     * @deprecated use getTensor (or getDouble) instead
+     */
+    @Deprecated // TODO: Remove on Vespa 8
     public String get(String name) {
         Object value = features.get(name);
         if (value == null) return null;
         return value.toString();
     }
 
-    /** Returns this value as whatever type it was stored as. Returns null if the value is not set. */
+    /** Returns this value as either a Double, Tensor or String. Returns null if the value is not set. */
     public Object getObject(String name) {
         return features.get(name);
     }
@@ -70,14 +80,15 @@ public class RankFeatures implements Cloneable {
     }
 
     /**
-     * Returns a tensor rank feature, or empty if there is no value with this name.
+     * Returns a rank feature as a tensor, or empty if there is no value with this name.
      *
-     * @throws IllegalArgumentException if the value is set but is not a tensor
+     * @throws IllegalArgumentException if the value is a string, not a tensor or double
      */
     public Optional<Tensor> getTensor(String name) {
         Object feature = features.get(name);
         if (feature == null) return Optional.empty();
         if (feature instanceof Tensor) return Optional.of((Tensor)feature);
+        if (feature instanceof Double) return Optional.of(Tensor.from((Double)feature));
         throw new IllegalArgumentException("Expected a tensor value of '" + name + "' but has " + feature);
     }
 

--- a/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
@@ -39,16 +39,16 @@ public class QueryTestCase {
     public void testSimpleQueryParsing () {
         Query q = newQuery("/search?query=foobar&offset=10&hits=20");
         assertEquals("foobar",((WordItem) q.getModel().getQueryTree().getRoot()).getWord());
-        assertEquals(10,q.getOffset());
-        assertEquals(20,q.getHits());
+        assertEquals(10, q.getOffset());
+        assertEquals(20, q.getHits());
     }
 
     @Test
     public void testAdvancedQueryParsing () {
         Query q = newQuery("/search?query=fOObar and kanoo&offset=10&hits=20&filter=-foo +bar&type=adv&suggestonly=true");
         assertEquals("AND (+(AND fOObar kanoo) -|foo) |bar", q.getModel().getQueryTree().getRoot().toString());
-        assertEquals(10,q.getOffset());
-        assertEquals(20,q.getHits());
+        assertEquals(10, q.getOffset());
+        assertEquals(20, q.getHits());
         assertEquals(true, q.properties().getBoolean("suggestonly", false));
     }
 
@@ -56,10 +56,10 @@ public class QueryTestCase {
     public void testAnyQueryParsing () {
         Query q = newQuery("/search?query=foobar and kanoo&offset=10&hits=10&type=any&suggestonly=true&filter=-fast.type:offensive&encoding=latin1");
         assertEquals("+(OR foobar and kanoo) -|fast.type:offensive", q.getModel().getQueryTree().getRoot().toString());
-        assertEquals(10,q.getOffset());
-        assertEquals(10,q.getHits());
+        assertEquals(10, q.getOffset());
+        assertEquals(10, q.getHits());
         assertEquals(true, q.properties().getBoolean("suggestonly", false));
-        assertEquals("latin1",q.getModel().getEncoding());
+        assertEquals("latin1", q.getModel().getEncoding());
     }
 
     @Test
@@ -71,8 +71,8 @@ public class QueryTestCase {
                             +"interest:www+yahoo+com!136"
                             +"&hits=20&offset=0&vectorranking=queryrank");
         assertEquals("/p13n", q.getHttpRequest().getUri().getPath());
-        assertEquals(0,q.getOffset());
-        assertEquals(20,q.getHits());
+        assertEquals(0, q.getOffset());
+        assertEquals(20, q.getHits());
         assertEquals("queryrank", q.properties().get("vectorranking"));
     }
 
@@ -84,7 +84,7 @@ public class QueryTestCase {
     @Test
     public void testGetParamInt() {
         Query q = newQuery("/search?query=foo%20bar&someint=10&notint=hello");
-        assertEquals(10,(int)q.properties().getInteger("someint"));
+        assertEquals(10, (int)q.properties().getInteger("someint"));
 
         // provoke an exception.  if exception is not triggered
         // we fail the test.
@@ -99,7 +99,7 @@ public class QueryTestCase {
     @Test
     public void testUtf8Decoding() {
         Query q = new Query("/?query=beyonc%C3%A9");
-        assertEquals("beyonc\u00e9",((WordItem) q.getModel().getQueryTree().getRoot()).getWord());
+        assertEquals("beyonc\u00e9", ((WordItem) q.getModel().getQueryTree().getRoot()).getWord());
     }
 
     @Test
@@ -226,14 +226,14 @@ public class QueryTestCase {
     public void testNaNHitValue() {
         assertQueryError(
                 "?query=test&hits=NaN",
-                containsString("Could not set 'hits' to 'NaN': Not a valid integer"));
+                containsString("Could not set 'hits' to 'NaN': 'NaN' is not a valid integer"));
     }
 
     @Test
     public void testNoneHitValue() {
         assertQueryError(
                 "?query=test&hits=(none)",
-                containsString("Could not set 'hits' to '(none)': Not a valid integer"));
+                containsString("Could not set 'hits' to '(none)': '(none)' is not a valid integer"));
     }
 
     @Test
@@ -247,14 +247,14 @@ public class QueryTestCase {
     public void testNaNOffsetValue() {
         assertQueryError(
                 "?query=test&offset=NaN",
-                containsString("Could not set 'offset' to 'NaN': Not a valid integer"));
+                containsString("Could not set 'offset' to 'NaN': 'NaN' is not a valid integer"));
     }
 
     @Test
     public void testNoneOffsetValue() {
         assertQueryError(
                 "?query=test&offset=(none)",
-                containsString("Could not set 'offset' to '(none)': Not a valid integer"));
+                containsString("Could not set 'offset' to '(none)': '(none)' is not a valid integer"));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class QueryTestCase {
                 "?query=test&hits=(none)&offset=-10",
                 anyOf(
                         containsString("Could not set 'offset' to '-10': Must be a positive number"),
-                        containsString("Could not set 'hits' to '(none)': Not a valid integer")));
+                        containsString("Could not set 'hits' to '(none)': '(none)' is not a valid integer")));
     }
 
     @Test
@@ -271,7 +271,7 @@ public class QueryTestCase {
         assertQueryError(
                 "?query=test&hits=(none)&offset=-10",
                 anyOf(
-                        containsString("Could not set 'hits' to '(none)': Not a valid integer"),
+                        containsString("Could not set 'hits' to '(none)': '(none)' is not a valid integer"),
                         containsString("Could not set 'offset' to '-10': Must be a positive number")));
     }
 
@@ -325,7 +325,7 @@ public class QueryTestCase {
         query.getRanking().setFreshness("now");
 
         assertTrue(query.getRanking().getFreshness().getSystemTimeInSecondsSinceEpoch() >= query.getRanking().getFreshness().getRefTime());
-        int presize= query.errors().size();
+        int presize = query.errors().size();
         query.getRanking().setFreshness("sometimeslater");
 
         int postsize = query.errors().size();
@@ -335,12 +335,12 @@ public class QueryTestCase {
     @Test
     public void testCopy() {
         Query qs = newQuery("?query=test&rankfeature.something=2");
-        assertEquals("test",qs.getModel().getQueryTree().toString());
+        assertEquals("test", qs.getModel().getQueryTree().toString());
         assertEquals((int)qs.properties().getInteger("rankfeature.something"),2);
         Query qp = new Query(qs);
         assertEquals("test", qp.getModel().getQueryTree().getRoot().toString());
         assertFalse(qp.getRanking().getFeatures().isEmpty());
-        assertEquals("2", qp.getRanking().getFeatures().get("something"));
+        assertEquals(2.0, qp.getRanking().getFeatures().getDouble("something").getAsDouble(), 0.000001);
     }
 
     private Query newQuery(String queryString) {

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/GroupingExecutorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/GroupingExecutorTestCase.java
@@ -489,6 +489,7 @@ public class GroupingExecutorTestCase {
      */
     @Test
     public void testRankProperties() {
+        final double delta = 0.000000001;
         Execution exc = newExecution(new GroupingExecutor());
         {
             Query query = new Query("?query=foo");
@@ -496,21 +497,21 @@ public class GroupingExecutorTestCase {
         }
         {
             Query query = new Query("?query=foo&rankfeature.fieldMatch(foo)=2");
-            assertEquals("2", query.getRanking().getFeatures().get("fieldMatch(foo)"));
+            assertEquals(2, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
             exc.search(query);
-            assertEquals("2", query.getRanking().getFeatures().get("fieldMatch(foo)"));
+            assertEquals(2.0, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
         }
         {
             Query query = new Query("?query=foo&rankfeature.query(now)=4");
-            assertEquals("4", query.getRanking().getFeatures().get("query(now)"));
+            assertEquals(4, query.getRanking().getFeatures().getDouble("query(now)").getAsDouble(), delta);
             exc.search(query);
-            assertEquals("4", query.getRanking().getProperties().get("now").get(0));
+            assertEquals("4.0", query.getRanking().getProperties().get("now").get(0));
         }
         {
             Query query = new Query("?query=foo&rankfeature.$bar=8");
-            assertEquals("8", query.getRanking().getFeatures().get("$bar"));
+            assertEquals(8, query.getRanking().getFeatures().getDouble("$bar").getAsDouble(), delta);
             exc.search(query);
-            assertEquals("8", query.getRanking().getProperties().get("bar").get(0));
+            assertEquals("8.0", query.getRanking().getProperties().get("bar").get(0));
         }
         {
             Query query = new Query("?query=foo&rankproperty.bar=8");
@@ -520,12 +521,12 @@ public class GroupingExecutorTestCase {
         }
         {
             Query query = new Query("?query=foo&rankfeature.fieldMatch(foo)=2&rankfeature.query(now)=4&rankproperty.bar=8");
-            assertEquals("2", query.getRanking().getFeatures().get("fieldMatch(foo)"));
-            assertEquals("4", query.getRanking().getFeatures().get("query(now)"));
+            assertEquals(2, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
+            assertEquals(4, query.getRanking().getFeatures().getDouble("query(now)").getAsDouble(), delta);
             assertEquals("8", query.getRanking().getProperties().get("bar").get(0));
             exc.search(query);
-            assertEquals("2", query.getRanking().getFeatures().get("fieldMatch(foo)"));
-            assertEquals("4", query.getRanking().getProperties().get("now").get(0));
+            assertEquals(2, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
+            assertEquals("4.0", query.getRanking().getProperties().get("now").get(0));
             assertEquals("8", query.getRanking().getProperties().get("bar").get(0));
         }
     }

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/QueryProfileConfigurationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/QueryProfileConfigurationTestCase.java
@@ -138,20 +138,22 @@ public class QueryProfileConfigurationTestCase {
 
     @Test
     public void testVariant2ConfigurationThroughQueryLookup() {
+        final double delta = 0.0000001;
+
         QueryProfileConfigurer configurer=
                 new QueryProfileConfigurer("file:" + CONFIG_DIR + "query-profile-variants2.cfg");
 
         CompiledQueryProfileRegistry registry = configurer.getCurrentRegistry().compile();
         Query query = new Query(QueryTestCase.httpEncode("?query=heh&queryProfile=multi&myindex=default&myquery=lo ve&tracelevel=5"),
                                 registry.findQueryProfile("multi"));
-        assertEquals("love",query.properties().get("model.queryString"));
-        assertEquals("default",query.properties().get("model.defaultIndex"));
+        assertEquals("love", query.properties().get("model.queryString"));
+        assertEquals("default", query.properties().get("model.defaultIndex"));
 
-        assertEquals("-20",query.properties().get("ranking.features.query(scorelimit)"));
-        assertEquals("-20",query.getRanking().getFeatures().get("query(scorelimit)"));
+        assertEquals(-20.0, query.properties().get("ranking.features.query(scorelimit)"));
+        assertEquals(-20.0, query.getRanking().getFeatures().getDouble("query(scorelimit)").getAsDouble(), delta);
         query.properties().set("rankfeature.query(scorelimit)", -30);
-        assertEquals("-30",query.properties().get("ranking.features.query(scorelimit)"));
-        assertEquals("-30",query.getRanking().getFeatures().get("query(scorelimit)"));
+        assertEquals(-30.0, query.properties().get("ranking.features.query(scorelimit)"));
+        assertEquals(-30, query.getRanking().getFeatures().getDouble("query(scorelimit)").getAsDouble(), delta);
     }
 
     private void assertGet(String expectedValue,String parameter,String[] dimensionValues,QueryProfile profile) {

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
@@ -310,12 +310,12 @@ public class XmlReadingTestCase {
         CompiledQueryProfileRegistry registry=new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase1").compile();
 
         Query query;
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),registry.getComponent("default"));
-        assertEquals("0.0",query.properties().get("ranking.features.b"));
-        assertEquals("0.0",query.properties().listProperties().get("ranking.features.b"));
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),registry.getComponent("default"));
-        assertEquals("0.1",query.properties().get("ranking.features.b"));
-        assertEquals("0.1",query.properties().listProperties().get("ranking.features.b"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),registry.getComponent("default"));
+        assertEquals(0.0, query.properties().get("ranking.features.b"));
+        assertEquals("0.0", query.properties().listProperties().get("ranking.features.b"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),registry.getComponent("default"));
+        assertEquals(0.1, query.properties().get("ranking.features.b"));
+        assertEquals("0.1", query.properties().listProperties().get("ranking.features.b"));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/query/test/ParametersTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/test/ParametersTestCase.java
@@ -16,52 +16,54 @@ import static org.junit.Assert.assertEquals;
  */
 public class ParametersTestCase {
 
+    private final double delta = 0.000001;
+
     @Test
     public void testSettingRankProperty() {
-        Query query=new Query("?query=test&ranking.properties.dotProduct.X=(a:1,b:2)");
-        assertEquals("[(a:1,b:2)]",query.getRanking().getProperties().get("dotProduct.X").toString());
+        Query query = new Query("?query=test&ranking.properties.dotProduct.X=(a:1,b:2)");
+        assertEquals("[(a:1,b:2)]", query.getRanking().getProperties().get("dotProduct.X").toString());
     }
 
     @Test
     public void testSettingRankPropertyAsAlias() {
-        Query query=new Query("?query=test&rankproperty.dotProduct.X=(a:1,b:2)");
-        assertEquals("[(a:1,b:2)]",query.getRanking().getProperties().get("dotProduct.X").toString());
+        Query query = new Query("?query=test&rankproperty.dotProduct.X=(a:1,b:2)");
+        assertEquals("[(a:1,b:2)]", query.getRanking().getProperties().get("dotProduct.X").toString());
     }
 
     @Test
     public void testSettingRankFeature() {
-        Query query=new Query("?query=test&ranking.features.matches=3");
-        assertEquals("3",query.getRanking().getFeatures().get("matches").toString());
+        Query query = new Query("?query=test&ranking.features.matches=3");
+        assertEquals(3, query.getRanking().getFeatures().getDouble("matches").getAsDouble(), delta);
     }
 
     @Test
     public void testSettingRankFeatureAsAlias() {
-        Query query=new Query("?query=test&rankfeature.matches=3");
-        assertEquals("3",query.getRanking().getFeatures().get("matches").toString());
+        Query query = new Query("?query=test&rankfeature.matches=3");
+        assertEquals(3, query.getRanking().getFeatures().getDouble("matches").getAsDouble(), delta);
     }
 
     @Test
     public void testSettingRankPropertyWithQueryProfile() {
-        Query query=new Query(HttpRequest.createTestRequest("?query=test&ranking.properties.dotProduct.X=(a:1,b:2)", Method.GET), createProfile());
-        assertEquals("[(a:1,b:2)]",query.getRanking().getProperties().get("dotProduct.X").toString());
+        Query query = new Query(HttpRequest.createTestRequest("?query=test&ranking.properties.dotProduct.X=(a:1,b:2)", Method.GET), createProfile());
+        assertEquals("[(a:1,b:2)]", query.getRanking().getProperties().get("dotProduct.X").toString());
     }
 
     @Test
     public void testSettingRankPropertyAsAliasWithQueryProfile() {
-        Query query=new Query(HttpRequest.createTestRequest("?query=test&rankproperty.dotProduct.X=(a:1,b:2)", Method.GET), createProfile());
-        assertEquals("[(a:1,b:2)]",query.getRanking().getProperties().get("dotProduct.X").toString());
+        Query query = new Query(HttpRequest.createTestRequest("?query=test&rankproperty.dotProduct.X=(a:1,b:2)", Method.GET), createProfile());
+        assertEquals("[(a:1,b:2)]", query.getRanking().getProperties().get("dotProduct.X").toString());
     }
 
     @Test
     public void testSettingRankFeatureWithQueryProfile() {
-        Query query=new Query(HttpRequest.createTestRequest("?query=test&ranking.features.matches=3", Method.GET), createProfile());
-        assertEquals("3",query.getRanking().getFeatures().get("matches").toString());
+        Query query = new Query(HttpRequest.createTestRequest("?query=test&ranking.features.matches=3", Method.GET), createProfile());
+        assertEquals(3, query.getRanking().getFeatures().getDouble("matches").getAsDouble(), delta);
     }
 
     @Test
     public void testSettingRankFeatureAsAliasWithQueryProfile() {
-        Query query=new Query(HttpRequest.createTestRequest("?query=test&rankfeature.matches=3", Method.GET), createProfile());
-        assertEquals("3",query.getRanking().getFeatures().get("matches").toString());
+        Query query = new Query(HttpRequest.createTestRequest("?query=test&rankfeature.matches=3", Method.GET), createProfile());
+        assertEquals(3, query.getRanking().getFeatures().getDouble("matches").getAsDouble(), delta);
     }
 
     public CompiledQueryProfile createProfile() {

--- a/container-search/src/test/java/com/yahoo/search/query/test/RankFeaturesTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/test/RankFeaturesTestCase.java
@@ -34,6 +34,7 @@ public class RankFeaturesTestCase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void requireThatRankFeaturesUsingDoubleAndDoubleToStringEncodeTheSameWay() {
         RankFeatures withDouble = new RankFeatures();
         withDouble.put("query(myDouble)", 3.8);

--- a/container-search/src/test/java/com/yahoo/search/query/test/RankingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/test/RankingTestCase.java
@@ -13,37 +13,39 @@ import static org.junit.Assert.assertFalse;
  */
 public class RankingTestCase {
 
-    /** tests setting rank feature values */
+    private static final double delta = 0.00000001;
+
+    /** Tests setting rank feature values */
     @Test
     public void testRankFeatures() {
         // Check initializing from query
         Query query = new Query("?query=test&ranking.features.query(name)=0.1&ranking.features.fieldMatch(foo)=0.2");
-        assertEquals("0.1", query.getRanking().getFeatures().get("query(name)"));
-        assertEquals("0.2", query.getRanking().getFeatures().get("fieldMatch(foo)"));
-        assertEquals("{\"query(name)\":\"0.1\",\"fieldMatch(foo)\":\"0.2\"}", query.getRanking().getFeatures().toString());
+        assertEquals(0.1, query.getRanking().getFeatures().getDouble("query(name)").getAsDouble(), delta);
+        assertEquals(0.2, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
+        assertEquals("{\"query(name)\":0.1,\"fieldMatch(foo)\":0.2}", query.getRanking().getFeatures().toString());
 
         // Test cloning
         Query clone = query.clone();
-        assertEquals("0.1", query.getRanking().getFeatures().get("query(name)"));
-        assertEquals("0.2", query.getRanking().getFeatures().get("fieldMatch(foo)"));
+        assertEquals(0.1, query.getRanking().getFeatures().getDouble("query(name)").getAsDouble(), delta);
+        assertEquals(0.2, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
 
         // Check programmatic setting + that the clone really has a separate object
         assertFalse(clone.getRanking().getFeatures() == query.getRanking().getFeatures());
         clone.properties().set("ranking.features.query(name)","0.3");
-        assertEquals("0.3", clone.getRanking().getFeatures().get("query(name)"));
-        assertEquals("0.1", query.getRanking().getFeatures().get("query(name)"));
+        assertEquals(0.3, clone.getRanking().getFeatures().getDouble("query(name)").getAsDouble(), delta);
+        assertEquals(0.1, query.getRanking().getFeatures().getDouble("query(name)").getAsDouble(), delta);
 
         // Check getting
-        assertEquals("0.3",clone.properties().get("ranking.features.query(name)"));
+        assertEquals(0.3, clone.properties().getDouble("ranking.features.query(name)"), 0.0000001);
 
         // Check map access
         assertEquals(2, query.getRanking().getFeatures().asMap().size());
-        assertEquals("0.2", query.getRanking().getFeatures().asMap().get("fieldMatch(foo)"));
-        query.getRanking().getFeatures().asMap().put("fieldMatch(foo)", "0.3");
-        assertEquals("0.3", query.getRanking().getFeatures().get("fieldMatch(foo)"));
+        assertEquals(0.2, query.getRanking().getFeatures().asMap().get("fieldMatch(foo)"));
+        query.getRanking().getFeatures().asMap().put("fieldMatch(foo)", 0.3);
+        assertEquals(0.3, query.getRanking().getFeatures().getDouble("fieldMatch(foo)").getAsDouble(), delta);
     }
 
-    //This test is order dependent. Fix this!!
+    // This test is order dependent. Fix this!!
     @Test
     public void test_setting_rank_feature_values() {
         // Check initializing from query
@@ -73,7 +75,7 @@ public class RankingTestCase {
     /** Test setting sorting to null does not cause an exception. */
     @Test
     public void testResetSorting() {
-        Query q=new Query();
+        Query q = new Query();
         q.getRanking().setSorting((Sorting)null);
         q.getRanking().setSorting((String)null);
     }
@@ -82,13 +84,13 @@ public class RankingTestCase {
     @Test
     public void testFeatureOverride() {
         Query query = new Query("?query=abc&featureoverride.something=2");
-        assertEquals("2", query.getRanking().getFeatures().get("something"));
+        assertEquals(2, query.getRanking().getFeatures().getDouble("something").getAsDouble(), 0.0000001);
     }
 
     @Test
     public void testStructuredRankProperty() {
         Query query = new Query("?query=abc&rankproperty.distanceToPath(gps_position).path=(0,0,10,0,10,5,20,5)");
-        assertEquals("(0,0,10,0,10,5,20,5)", query.getRanking().getProperties().get("distanceToPath(gps_position).path").get(0).toString());
+        assertEquals("(0,0,10,0,10,5,20,5)", query.getRanking().getProperties().get("distanceToPath(gps_position).path").get(0));
     }
 
 }

--- a/processing/src/main/java/com/yahoo/processing/request/Properties.java
+++ b/processing/src/main/java/com/yahoo/processing/request/Properties.java
@@ -411,8 +411,8 @@ public class Properties implements Cloneable {
             if (value == null)
                 return defaultValue;
 
-            if (value instanceof Integer)
-                return (Integer) value;
+            if (value instanceof Number)
+                return ((Number)value).intValue();
 
             String stringValue = value.toString();
             if (stringValue.isEmpty())
@@ -420,7 +420,7 @@ public class Properties implements Cloneable {
 
             return Integer.valueOf(stringValue);
         } catch (IllegalArgumentException e) {
-            throw new NumberFormatException("Not a valid integer");
+            throw new NumberFormatException("'" + value + "' is not a valid integer");
         }
     }
 


### PR DESCRIPTION
The purpose of this is to prepare to disallow rank feature
strings (which can't be parsed to doubles or tensors)
on Vespa 8. Currently, such strings will be converted to
numbers by hashing them during evaluation, but this is not
useful (as the hash can be computed before setting if desired),
and leads to confusion when a feature is intended set from
a tensor string but ends up as a hash due to missing type
information in the configuration.

Changes:
- Parse numeric rank features into doubles as soon as possible
- Deprecate the methods accessing rank features as strings
- Allow double features to be accessible as tensors
