### PR TITLE
Move node name out of the 'node' object.

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/GenericJsonModel.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/GenericJsonModel.java
@@ -19,9 +19,11 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_ABSENT)
-@JsonPropertyOrder({ "node", "services" })
+@JsonPropertyOrder({ "name", "node", "services" })
 public class GenericJsonModel {
-    private static Logger log = Logger.getLogger(GenericJsonModel.class.getName());
+
+    @JsonProperty("name")
+    public String name;
 
     @JsonProperty("node")
     public GenericNode node;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/GenericJsonUtil.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/GenericJsonUtil.java
@@ -72,7 +72,7 @@ public class GenericJsonUtil {
                     .get();
             if (VESPA_NODE_SERVICE_ID.equals(serviceId)) {
                 jsonModel.node = new GenericNode(genericService.timestamp, genericService.metrics);
-                jsonModel.node.name = nodeName;
+                jsonModel.name = nodeName;
             } else {
                 genericServices.add(genericService);
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/GenericNode.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/GenericNode.java
@@ -18,9 +18,6 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
 @JsonPropertyOrder({ "name", "timestamp", "metrics" })
 public class GenericNode {
 
-    @JsonProperty("name")
-    public String name;
-
     @JsonProperty("timestamp")
     public Long timestamp;
 

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
@@ -117,7 +117,7 @@ public class ApplicationMetricsHandlerTest {
 
         assertEquals(1, jsonModel.nodes.size());
         GenericJsonModel nodeModel = jsonModel.nodes.get(0);
-        assertEquals(MOCK_METRICS_PATH, nodeModel.node.name);
+        assertEquals(MOCK_METRICS_PATH, nodeModel.name);
         assertEquals(2, nodeModel.node.metrics.size());
         assertEquals(16.222, nodeModel.node.metrics.get(0).values.get(CPU_METRIC), 0.0001d);
     }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/model/json/GenericApplicationModelTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/model/json/GenericApplicationModelTest.java
@@ -33,7 +33,7 @@ public class GenericApplicationModelTest {
         // Do some sanity checking
         assertEquals(2, model.nodes.size());
         GenericJsonModel node0Model = model.nodes.get(0);
-        assertEquals("node0", node0Model.node.name);
+        assertEquals("node0", node0Model.name);
         assertEquals(1, node0Model.services.size());
         GenericService service = node0Model.services.get(0);
         assertEquals(1, service.metrics.size());
@@ -41,7 +41,7 @@ public class GenericApplicationModelTest {
 
         GenericJsonModel node1Model = model.nodes.get(1);
         GenericNode node1 = node1Model.node;
-        assertEquals("node1", node1.name);
+        assertEquals("node1", node1Model.name);
         assertEquals(32.444, node1.metrics.get(0).values.get("cpu.util"), 0.001d);
 
         assertThatSerializedModelEqualsTestFile(model);
@@ -69,7 +69,7 @@ public class GenericApplicationModelTest {
 
         GenericJsonModel nodeModel = model.nodes.get(0);
         assertNotNull(nodeModel.node);
-        assertEquals("node0", nodeModel.node.name);
+        assertEquals("node0", nodeModel.name);
         assertEquals(1, nodeModel.node.metrics.size());
         GenericMetrics nodeMetrics = nodeModel.node.metrics.get(0);
         assertEquals(1.234, nodeMetrics.values.get("node-metric"), 0.001d);

--- a/metrics-proxy/src/test/resources/generic-application.json
+++ b/metrics-proxy/src/test/resources/generic-application.json
@@ -1,8 +1,8 @@
 {
   "nodes": [
     {
+      "name": "node0",
       "node": {
-        "name": "node0",
         "timestamp": 1234,
         "metrics": [
           {
@@ -36,8 +36,8 @@
       ]
     },
     {
+      "name": "node1",
       "node": {
-        "name": "node1",
         "timestamp": 1234,
         "metrics": [
           {


### PR DESCRIPTION
- The 'node' object is for node metrics, so it makes more sense
  to have the node name as a sibling to 'node' and 'services'.

FYI: @oyving 