### PR TITLE
Optimize handling of "matched-elements-only" when the input field as …

### DIFF
--- a/document/src/vespa/document/fieldvalue/mapfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/mapfieldvalue.h
@@ -72,8 +72,8 @@ public:
         mutable pair   _current;
     };
     class const_iterator {
-        typedef std::pair<const FieldValue *, const FieldValue *> pair;
     public:
+        typedef std::pair<const FieldValue *, const FieldValue *> pair;
         const_iterator(const MapFieldValue & map, size_t index) : _map(&map), _index(index) { }
         bool operator == (const const_iterator & rhs) const { return _map == rhs._map && _index == rhs._index; }
         bool operator != (const const_iterator & rhs) const { return _map != rhs._map || _index != rhs._index; }
@@ -146,6 +146,20 @@ public:
 
     const_iterator find(const FieldValue& fv) const;
     iterator find(const FieldValue& fv);
+
+    bool has_no_erased_keys() const {
+        return (_keys->size() == _count) && (_values->size() == _count);
+    }
+
+    /**
+     * Returns the key-value pair at the given position in the underlying arrays.
+     *
+     * Note: Should only be used when has_no_erased_keys() returns true.
+     * Otherwise you might access elements that are conceptually removed.
+     */
+    const_iterator::pair operator[](size_t idx) const {
+        return const_iterator::pair(&(*_keys)[idx], &(*_values)[idx]);
+    }
 
     FieldValue::UP createValue() const;
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.h
@@ -18,6 +18,8 @@ private:
     uint32_t _input_field_enum;
     std::shared_ptr<StructFieldMapper> _struct_field_mapper;
 
+    const std::vector<uint32_t>& get_matching_elements(uint32_t docid, GetDocsumsState& state) const;
+
 public:
     MatchedElementsFilterDFW(const std::string& input_field_name, uint32_t input_field_enum,
                              std::shared_ptr<StructFieldMapper> struct_field_mapper);

--- a/searchsummary/src/vespa/searchsummary/docsummary/summaryfieldconverter.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/summaryfieldconverter.h
@@ -12,8 +12,16 @@ namespace search::docsummary {
 class SummaryFieldConverter
 {
 public:
-    static document::FieldValue::UP
-    convertSummaryField(bool markup, const document::FieldValue &value);
+    static document::FieldValue::UP convertSummaryField(bool markup, const document::FieldValue &value);
+
+    /**
+     * Converts the given field value to slime, only keeping the elements that are contained in the matching elements vector.
+     *
+     * Filtering occurs when the field value is an ArrayFieldValue or MapFieldValue.
+     */
+    static document::FieldValue::UP convert_field_with_filter(bool markup,
+                                                              const document::FieldValue& value,
+                                                              const std::vector<uint32_t>& matching_elems);
 };
 
 }


### PR DESCRIPTION
…retrieved from the document instance.

In this case we now filter on matching elements while converting to slime,
instead of converting to slime and then filter as done before.

@baldersheim please review
@toregge FYI