### PR TITLE
Lesters/resolve input types for stateless model evaluation 2

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
@@ -11,6 +11,7 @@ import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
 import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.rule.ExpressionNode;
+import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
@@ -63,10 +64,19 @@ public class RankingExpressionTypeResolver extends Processor {
     private void resolveTypesIn(RankProfile profile, boolean validate) {
         MapEvaluationTypeContext context = profile.typeContext(queryProfiles);
         for (Map.Entry<String, RankProfile.RankingExpressionFunction> function : profile.getFunctions().entrySet()) {
-            if (hasUntypedArguments(function.getValue().function())) continue;
-            TensorType type = resolveType(function.getValue().function().getBody(),
-                                          "function '" + function.getKey() + "'",
-                                          context);
+            ExpressionFunction expressionFunction = function.getValue().function();
+            if (hasUntypedArguments(expressionFunction)) continue;
+
+            // Add any missing inputs for type resolution
+            for (String argument : expressionFunction.arguments()) {
+                Reference ref = Reference.fromIdentifier(argument);
+                if (context.getType(ref).equals(TensorType.empty)) {
+                    context.setType(ref, expressionFunction.argumentTypes().get(argument));
+                }
+            }
+            context.forgetResolvedTypes();
+
+            TensorType type = resolveType(expressionFunction.getBody(), "function '" + function.getKey() + "'", context);
             function.getValue().setReturnType(type);
         }
 

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
@@ -11,7 +11,6 @@ import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
 import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.rule.ExpressionNode;
-import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
 import com.yahoo.vespa.model.container.search.QueryProfiles;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
@@ -51,7 +51,7 @@ public class RankingExpressionTypeResolver extends Processor {
                 resolveTypesIn(profile, validate);
             }
             catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("In " + search + ", " + profile, e);
+                throw new IllegalArgumentException("In " + (search != null ? search + ", " : "") + profile, e);
             }
         }
     }


### PR DESCRIPTION
@bratseth Should fix https://github.com/vespa-engine/vespa/pull/11750, unless there are even more type checks I'm not aware of. This at least has been tested successfully in  `ModelEvaluationTest.testMl_serving` with the blog post model available in `src/test/cfg/application/ml_serving`.