### PR TITLE
Avoid inconsistent auto-created document versions taking precedence 

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
@@ -43,6 +43,8 @@ private:
     PersistenceMessageTrackerImpl _trackerInstance;
     PersistenceMessageTracker& _tracker;
     std::shared_ptr<api::UpdateCommand> _msg;
+    const api::Timestamp _new_timestamp;
+    const bool _is_auto_create_update;
 
     DistributorComponent& _manager;
     DistributorBucketSpace &_bucketSpace;
@@ -64,6 +66,8 @@ private:
 
     std::vector<PreviousDocumentVersion> _results;
     UpdateMetricSet& _metrics;
+
+    api::Timestamp adjusted_received_old_timestamp(api::Timestamp old_ts_from_node) const;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
@@ -85,7 +85,7 @@ PersistenceMessageTrackerImpl::receiveReply(
 void
 PersistenceMessageTrackerImpl::revert(
         MessageSender& sender,
-        const std::vector<BucketNodePair> revertNodes)
+        const std::vector<BucketNodePair>& revertNodes)
 {
     if (_revertTimestamp != 0) {
         // Since we're reverting, all received bucket info is voided.

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -54,7 +54,7 @@ public:
 
     typedef std::pair<document::Bucket, uint16_t> BucketNodePair;
 
-    void revert(MessageSender& sender, const std::vector<BucketNodePair> revertNodes);
+    void revert(MessageSender& sender, const std::vector<BucketNodePair>& revertNodes);
 
     /**
        Sends a set of messages that are permissible for early return.


### PR DESCRIPTION
@geirst please review

Create-if-missing updates have a rather finicky behavior in the backend,
wherein they'll set the timestamp of the previous document to that of the
_new_ document timestamp if the update ended up creating a document from
scratch. This particular behavior confuses the "after the fact" timestamp
consistency checks, since it will seem like the document that was created
from scratch is a better candidate to force convergence towards rather
than the ones that actually updated an existing document.

With this change we therefore detect this case specially and treat the
received timestamps as if the document updated had a timestamp of zero.
This matches the behavior of regular (non auto-create) updates.

Note that another venue for solving this would be to alter the returned
timestamp in the backend to be zero instead, but this would cause issues
during rolling upgrades since some of the content nodes would be returning
zero timestamps while others would be returning non-zero. This would in
turn trigger false positives for the inconsistency sanity checks.

Also note that this is a fallback path that should not be hit unless
the a-priori inconsistency checks in the two-phase update operation
somehow fails to recognize that the document versions may be out of
sync.

This relates to issue #11686 