### PR TITLE
Revert "Lesters/resolve input types for stateless model evaluation 2"

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/RankingExpressionTypeResolver.java
@@ -50,7 +50,7 @@ public class RankingExpressionTypeResolver extends Processor {
                 resolveTypesIn(profile, validate);
             }
             catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("In " + (search != null ? search + ", " : "") + profile, e);
+                throw new IllegalArgumentException("In " + search + ", " + profile, e);
             }
         }
     }
@@ -63,19 +63,10 @@ public class RankingExpressionTypeResolver extends Processor {
     private void resolveTypesIn(RankProfile profile, boolean validate) {
         MapEvaluationTypeContext context = profile.typeContext(queryProfiles);
         for (Map.Entry<String, RankProfile.RankingExpressionFunction> function : profile.getFunctions().entrySet()) {
-            ExpressionFunction expressionFunction = function.getValue().function();
-            if (hasUntypedArguments(expressionFunction)) continue;
-
-            // Add any missing inputs for type resolution
-            for (String argument : expressionFunction.arguments()) {
-                Reference ref = Reference.fromIdentifier(argument);
-                if (context.getType(ref).equals(TensorType.empty)) {
-                    context.setType(ref, expressionFunction.argumentTypes().get(argument));
-                }
-            }
-            context.forgetResolvedTypes();
-
-            TensorType type = resolveType(expressionFunction.getBody(), "function '" + function.getKey() + "'", context);
+            if (hasUntypedArguments(function.getValue().function())) continue;
+            TensorType type = resolveType(function.getValue().function().getBody(),
+                                          "function '" + function.getKey() + "'",
+                                          context);
             function.getValue().setReturnType(type);
         }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#11759

Broke unit test in config-model:
`[ERROR] testMl_serving(com.yahoo.vespa.model.ml.ModelEvaluationTest)  Time elapsed: 1.408 s  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...lt.y).type: tensor(d[]1[10])
> but was:<...lt.y).type: tensor(d[0[],d]1[10])
>
	at com.yahoo.vespa.model.ml.ModelEvaluationTest.assertHasMlModels(ModelEvaluationTest.java:110)
	at com.yahoo.vespa.model.ml.ModelEvaluationTest.testMl_serving(ModelEvaluationTest.java:66)`