### PR TITLE
Enable the default public metrics consumer in hosted Vespa.  

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -148,7 +148,7 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         var amendedVespaConsumer = addMetrics(getVespaMetricsConsumer(), getAdditionalDefaultMetrics().getMetrics());
         builder.consumer.addAll(generateConsumers(amendedVespaConsumer, getUserMetricsConsumers()));
 
-        if (! isHostedVespa()) builder.consumer.add(toConsumerBuilder(getDefaultPublicConsumer()));
+        builder.consumer.add(toConsumerBuilder(getDefaultPublicConsumer()));
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -139,10 +139,11 @@ public class MetricsProxyContainerClusterTest {
     }
 
     @Test
-    public void default_public_consumer_is_not_set_up_for_hosted() {
+    public void vespa_consumer_and_default_public_consumer_is_set_up_for_hosted() {
         ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), hosted);
-        assertEquals(1, config.consumer().size());
+        assertEquals(2, config.consumer().size());
         assertEquals(config.consumer(0).name(), VESPA_CONSUMER_ID);
+        assertEquals(config.consumer(1).name(), DEFAULT_PUBLIC_CONSUMER_ID);
     }
 
     @Test
@@ -207,7 +208,7 @@ public class MetricsProxyContainerClusterTest {
         );
         VespaModel hostedModel = getModel(services, hosted);
         ConsumersConfig config = consumersConfigFromModel(hostedModel);
-        assertEquals(1, config.consumer().size());
+        assertEquals(2, config.consumer().size());
 
         // All default metrics are retained
         ConsumersConfig.Consumer vespaConsumer = config.consumer(0);

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/YamasJsonUtil.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/json/YamasJsonUtil.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static ai.vespa.metricsproxy.http.ValuesFetcher.DEFAULT_PUBLIC_CONSUMER_ID;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static com.yahoo.stream.CustomCollectors.toLinkedMap;
 import static java.util.Collections.emptyList;
@@ -112,15 +113,19 @@ public class YamasJsonUtil {
                                 Map.Entry::getValue));
         }
 
-        if (packet.consumers().isEmpty()) model.routing = null;
-        else model.routing = ImmutableMap.of(YAMAS_ROUTING, toYamasJsonNamespaces(packet.consumers()));
+        YamasJsonModel.YamasJsonNamespace namespaces = toYamasJsonNamespaces(packet.consumers());
+        if (namespaces.namespaces.isEmpty()) model.routing = null;
+        else model.routing = ImmutableMap.of(YAMAS_ROUTING, namespaces);
 
         return model;
     }
 
     private static YamasJsonModel.YamasJsonNamespace toYamasJsonNamespaces(Collection<ConsumerId> consumers) {
         YamasJsonModel.YamasJsonNamespace namespaces =  new YamasJsonModel.YamasJsonNamespace();
-        namespaces.namespaces = consumers.stream().map(consumer -> consumer.id).collect(Collectors.toList());
+        namespaces.namespaces = consumers.stream()
+                .filter(consumerId -> consumerId != DEFAULT_PUBLIC_CONSUMER_ID)
+                .map(consumer -> consumer.id)
+                .collect(Collectors.toList());
         return namespaces;
     }
 

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/model/json/YamasJsonUtilTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/model/json/YamasJsonUtilTest.java
@@ -5,10 +5,15 @@ import ai.vespa.metricsproxy.metric.model.MetricsPacket;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Set;
 
+import static ai.vespa.metricsproxy.core.VespaMetrics.VESPA_CONSUMER_ID;
+import static ai.vespa.metricsproxy.http.ValuesFetcher.DEFAULT_PUBLIC_CONSUMER_ID;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
+import static ai.vespa.metricsproxy.metric.model.json.YamasJsonUtil.YAMAS_ROUTING;
 import static ai.vespa.metricsproxy.metric.model.json.YamasJsonUtil.toMetricsPackets;
 import static java.util.Collections.singleton;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -47,6 +52,26 @@ public class YamasJsonUtilTest {
     @Test
     public void empty_consumers_is_translated_to_null_routing_in_json_model() {
         MetricsPacket packet = new MetricsPacket.Builder(toServiceId("foo"))
+                .build();
+        YamasJsonModel jsonModel = YamasJsonUtil.toYamasArray(singleton(packet)).metrics.get(0);
+        assertNull(jsonModel.routing);
+    }
+
+    @Test
+    public void default_public_consumer_is_filtered_from_yamas_routing() {
+        MetricsPacket packet = new MetricsPacket.Builder(toServiceId("foo"))
+                .addConsumers(Set.of(VESPA_CONSUMER_ID, DEFAULT_PUBLIC_CONSUMER_ID))
+                .build();
+        YamasJsonModel jsonModel = YamasJsonUtil.toYamasArray(singleton(packet)).metrics.get(0);
+        List<String> namespaces = jsonModel.routing.get(YAMAS_ROUTING).namespaces;
+        assertEquals(1, namespaces.size());
+        assertEquals(VESPA_CONSUMER_ID.id, namespaces.get(0));
+    }
+
+    @Test
+    public void only_default_public_consumer_yields_null_routing_in_json_model() {
+        MetricsPacket packet = new MetricsPacket.Builder(toServiceId("foo"))
+                .addConsumers(Set.of(DEFAULT_PUBLIC_CONSUMER_ID))
                 .build();
         YamasJsonModel jsonModel = YamasJsonUtil.toYamasArray(singleton(packet)).metrics.get(0);
         assertNull(jsonModel.routing);


### PR DESCRIPTION
- Always filter this consumer from yamas routing, as the effect
  of including it is uncertain.

FYI: @oyving, @ldalves 