### PR TITLE
Update cluster spec for reserved nodes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -115,9 +115,6 @@ public class GroupPreparer {
                                                      " in " + application.toShortString() +
                                                      outOfCapacityDetails(allocation));
 
-                // Extend reservation for already reserved nodes
-                nodeRepository.reserve(nodeRepository.getNodes(application, Node.State.reserved));
-
                 // Carry out and return allocation
                 nodeRepository.reserve(allocation.reservableNodes());
                 nodeRepository.addDockerNodes(new LockedNodeList(allocation.newNodes(), allocationLock));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -339,7 +340,9 @@ class NodeAllocation {
     }
 
     List<Node> reservableNodes() {
-        return nodesFilter(n -> n.node.state() == Node.State.inactive || n.node.state() == Node.State.ready);
+        // Include already reserved nodes to extend reservation period and to potentially update their cluster spec.
+        EnumSet<Node.State> reservableStates = EnumSet.of(Node.State.inactive, Node.State.ready, Node.State.reserved);
+        return nodesFilter(n -> !n.isNewNode && reservableStates.contains(n.node.state()));
     }
 
     List<Node> surplusNodes() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -625,6 +625,23 @@ public class ProvisioningTest {
         tester.activate(application, state.allHosts);
     }
 
+    @Test
+    public void cluster_spec_update_for_already_reserved_nodes() {
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.dev, RegionName.from("us-east"))).build();
+        ApplicationId application = tester.makeApplicationId();
+        Version version1 = Version.fromString("6.42");
+        Version version2 = Version.fromString("6.43");
+        tester.makeReadyNodes(2, defaultResources);
+
+        prepare(application, 1, 0, 1, 0, true, defaultResources, version1, tester);
+        tester.getNodes(application, Node.State.reserved).forEach(node ->
+                assertEquals(version1, node.allocation().get().membership().cluster().vespaVersion()));
+
+        prepare(application, 1, 0, 1, 0, true, defaultResources, version2, tester);
+        tester.getNodes(application, Node.State.reserved).forEach(node ->
+                assertEquals(version2, node.allocation().get().membership().cluster().vespaVersion()));
+    }
+
     private SystemState prepare(ApplicationId application, int container0Size, int container1Size, int content0Size,
                                 int content1Size, NodeResources flavor, ProvisioningTester tester) {
         return prepare(application, container0Size, container1Size, content0Size, content1Size, flavor,


### PR DESCRIPTION
Previously we would re-reserve `reserved` nodes from node-repo which would only update the reserved history time to extend the reservation period. This however didn't include potential updates done to these nodes in `NodeAllocation`, such as updating the `ClusterSpec` if it has changed: https://github.com/vespa-engine/vespa/blob/e42294b01c863ca4ba0986f3e52f568dd746f797/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java#L250