### PR TITLE
Revert "Fail deployment if the wrong web service port is configured"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/Binding.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/Binding.java
@@ -10,7 +10,6 @@ import java.util.logging.Level;
  * @author bjorncs
  */
 public class Binding {
-
     private final ComponentSpecification filterId;
     private final String binding;
 
@@ -21,9 +20,10 @@ public class Binding {
 
     public static Binding create(ComponentSpecification filterId, String binding, DeployLogger logger) {
         if (binding.startsWith("https://")) {
-            logger.log(Level.WARNING, String.format("For binding '%s' on '%s': 'https' bindings are deprecated, " +
-                                                    "use 'http' instead to bind to both http and https traffic.",
-                                                    binding, filterId));
+            logger.log(Level.WARNING, String.format(
+                    "For binding '%s' on '%s': 'https' bindings are deprecated, " +
+                            "use 'http' instead to bind to both http and https traffic.",
+                    binding, filterId));
         }
         return new Binding(filterId, binding);
     }
@@ -35,5 +35,4 @@ public class Binding {
     public String binding() {
         return binding;
     }
-
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/Http.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/Http.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Represents the http servers and filters of a container cluster.
+ * Represents the http servers and filters of a Jdisc cluster.
  *
  * @author Tony Vaagenes
  */
@@ -81,10 +81,11 @@ public class Http extends AbstractConfigProducer<AbstractConfigProducer<?>> impl
 
     @Override
     public void getConfig(ServerConfig.Builder builder) {
-        for (Binding binding : bindings) {
-            builder.filter(new ServerConfig.Filter.Builder()
-                                   .id(binding.filterId().stringValue())
-                                   .binding(binding.binding()));
+        for (final Binding binding : bindings) {
+            builder.filter(
+                    new ServerConfig.Filter.Builder()
+                            .id(binding.filterId().stringValue())
+                            .binding(binding.binding()));
         }
     }
 
@@ -94,17 +95,17 @@ public class Http extends AbstractConfigProducer<AbstractConfigProducer<?>> impl
     }
 
     void validate(Collection<Binding> bindings) {
-        if (bindings.isEmpty()) return;
+        if (!bindings.isEmpty()) {
+            if (filterChains == null)
+                throw new IllegalArgumentException("Null FilterChains is not allowed when there are filter bindings!");
 
-        if (filterChains == null)
-            throw new IllegalArgumentException("Null FilterChains is not allowed when there are filter bindings!");
+            ComponentRegistry<ChainedComponent<?>> filters = filterChains.componentsRegistry();
+            ComponentRegistry<Chain<Filter>> chains = filterChains.allChains();
 
-        ComponentRegistry<ChainedComponent<?>> filters = filterChains.componentsRegistry();
-        ComponentRegistry<Chain<Filter>> chains = filterChains.allChains();
-
-        for (Binding binding: bindings) {
-            if (filters.getComponent(binding.filterId()) == null && chains.getComponent(binding.filterId()) == null)
-                throw new RuntimeException("Can't find filter " + binding.filterId() + " for binding " + binding.binding());
+            for (Binding binding: bindings) {
+                if (filters.getComponent(binding.filterId()) == null && chains.getComponent(binding.filterId()) == null)
+                    throw new RuntimeException("Can't find filter " + binding.filterId() + " for binding " + binding.binding());
+            }
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/HttpBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/HttpBuilder.java
@@ -8,8 +8,8 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
+import com.yahoo.log.LogLevel;
 import com.yahoo.text.XML;
-import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
@@ -127,20 +127,20 @@ public class HttpBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Http> 
         http.setHttpServer(new JettyHttpServerBuilder().build(deployState, ancestor, spec));
     }
 
-    static int readPort(Element spec, boolean isHosted) {
+    static int readPort(Element spec, boolean isHosted, DeployLogger deployLogger) {
         String portString = spec.getAttribute("port");
-        if (portString == null || portString.isEmpty())
-            return Defaults.getDefaults().vespaWebServicePort();
 
         int port = Integer.parseInt(portString);
         if (port < 0)
             throw new IllegalArgumentException(String.format("Invalid port %d.", port));
 
         int legalPortInHostedVespa = Container.BASEPORT;
-        if (isHosted && port != legalPortInHostedVespa)
-            throw new IllegalArgumentException("Illegal port " + port + " in http server '" +
-                                               spec.getAttribute("id") + "'" +
-                                               ": Port must be set to " + legalPortInHostedVespa);
+        if (isHosted && port != legalPortInHostedVespa) {
+            deployLogger.log(LogLevel.WARNING,
+                    String.format("Trying to set port to %d for http server with id %s. You cannot set port to anything else than %s",
+                            port, spec.getAttribute("id"), legalPortInHostedVespa));
+        }
+
         return port;
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyConnectorBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyConnectorBuilder.java
@@ -24,7 +24,7 @@ public class JettyConnectorBuilder extends VespaDomBuilder.DomConfigProducerBuil
     @Override
     protected ConnectorFactory doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element serverSpec) {
         String name = XmlHelper.getIdString(serverSpec);
-        int port = HttpBuilder.readPort(serverSpec, deployState.isHosted());
+        int port = HttpBuilder.readPort(serverSpec, deployState.isHosted(), deployState.getDeployLogger());
 
         SimpleComponent sslProviderComponent = getSslConfigComponents(name, serverSpec);
         return new ConnectorFactory(name, port, sslProviderComponent);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyHttpServerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyHttpServerBuilder.java
@@ -11,10 +11,10 @@ import com.yahoo.vespa.model.container.http.JettyHttpServer;
 import org.w3c.dom.Element;
 
 /**
- * @author Einar M R Rosenvinge
+ * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
+ * @since 5.17.0
  */
 public class JettyHttpServerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<JettyHttpServer> {
-
     @Override
     protected JettyHttpServer doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element http) {
         JettyHttpServer jettyHttpServer = new JettyHttpServer(new ComponentId("jdisc-jetty"));
@@ -25,5 +25,4 @@ public class JettyHttpServerBuilder extends VespaDomBuilder.DomConfigProducerBui
 
         return jettyHttpServer;
     }
-
 }

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -64,7 +64,7 @@ Filtering = element filtering {
 }
 
 HttpServer =  element server {
-    attribute port { xsd:nonNegativeInteger }? &
+    attribute port { xsd:nonNegativeInteger } &
     ComponentId &
     (Ssl | SslProvider)? &
     GenericConfig*

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1297,7 +1297,6 @@ public class ModelProvisioningTest {
         assertEquals(1, model.getRoot().hostSystem().getHosts().size());
         assertEquals(1, model.getAdmin().getSlobroks().size());
     }
-
     @Test
     public void testThatStandaloneSyntaxWorksOnHostedVespa() {
         String services =
@@ -1312,28 +1311,6 @@ public class ModelProvisioningTest {
         VespaModel model = tester.createModel(services, true);
         assertEquals(1, model.getHosts().size());
         assertEquals(1, model.getContainerClusters().size());
-    }
-
-    @Test
-    public void testThatStandaloneSyntaxOnHostedVespaRequiresDefaultPort() {
-        try {
-            String services =
-                    "<?xml version='1.0' encoding='utf-8' ?>" +
-                    "<container id='foo' version='1.0'>" +
-                    "  <http>" +
-                    "    <server id='server1' port='8095' />" +
-                    "  </http>" +
-                    "</container>";
-            VespaModelTester tester = new VespaModelTester();
-            tester.addHosts(1);
-            VespaModel model = tester.createModel(services, true);
-            fail("Expected exception");
-        }
-        catch (IllegalArgumentException e) {
-            // Success
-            assertEquals("Illegal port 8095 in http server 'server1': Port must be set to " +
-                         getDefaults().vespaWebServicePort(), e.getMessage());
-        }
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/search/ImplicitIndexingClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/search/ImplicitIndexingClusterTest.java
@@ -6,7 +6,6 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.model.test.MockApplicationPackage;
-import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
@@ -19,7 +18,6 @@ import static org.junit.Assert.assertNotNull;
  * @author ollivir
  */
 public class ImplicitIndexingClusterTest {
-
     @Test
     public void existing_jdisc_is_used_as_indexing_cluster_when_multitenant() {
         final String servicesXml = "<services version=\"1.0\">\n" + //
@@ -27,7 +25,7 @@ public class ImplicitIndexingClusterTest {
                 "    <search />\n" + //
                 "    <nodes count=\"1\" />\n" + //
                 "    <http>\n" + //
-                "      <server id=\"bar\" port=\"" + Defaults.getDefaults().vespaWebServicePort() + "\" />\n" + //
+                "      <server id=\"bar\" port=\"4080\" />\n" + //
                 "    </http>\n" + //
                 "  </container>\n" + //
                 "  <content id=\"music\" version=\"1.0\">\n" + //

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -35,7 +35,6 @@ import com.yahoo.net.HostName;
 import com.yahoo.path.Path;
 import com.yahoo.prelude.cluster.QrMonitorConfig;
 import com.yahoo.search.config.QrStartConfig;
-import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ApplicationContainer;
@@ -134,49 +133,29 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     }
 
     @Test
-    public void omitting_http_server_port_gives_default() {
-        Element clusterElem = DomBuilderTest.parse(
-                "<container version='1.0'>",
-                "  <http>",
-                "    <server id='foo'/>",
-                "  </http>",
-                nodesXml,
-                "</container>" );
-        createModel(root, clusterElem);
-        AbstractService container = (AbstractService)root.getProducer("container/container.0");
-        assertEquals(Defaults.getDefaults().vespaWebServicePort(), container.getRelativePort(0));
-    }
-
-    @Test
-    public void fail_if_http_port_is_not_default_in_hosted_vespa() throws Exception {
-        try {
-            String servicesXml =
-                    "<services>" +
-                    "<admin version='3.0'>" +
-                    "    <nodes count='1'/>" +
-                    "</admin>" +
-                    "<container version='1.0'>" +
-                    "  <http>" +
-                    "    <server port='9000' id='foo' />" +
-                    "  </http>" +
-                    nodesXml +
-                    "</container>" +
-                    "</services>";
-            ApplicationPackage applicationPackage = new MockApplicationPackage.Builder().withServices(servicesXml).build();
-            // Need to create VespaModel to make deploy properties have effect
-            TestLogger logger = new TestLogger();
-            new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
-                                                                  .applicationPackage(applicationPackage)
-                                                                  .deployLogger(logger)
-                                                                  .properties(new TestProperties().setHostedVespa(true))
-                                                                  .build());
-            fail("Expected exception");
-        }
-        catch (IllegalArgumentException e) {
-            // Success
-            assertEquals("Illegal port 9000 in http server 'foo': Port must be set to " + Defaults.getDefaults().vespaWebServicePort(),
-                         e.getMessage());
-        }
+    public void fail_if_http_port_is_not_4080_in_hosted_vespa() throws Exception {
+        String servicesXml =
+                "<services>" +
+                "<admin version='3.0'>" +
+                "    <nodes count='1'/>" +
+                "</admin>" +
+                "<container version='1.0'>" +
+                "  <http>" +
+                "    <server port='9000' id='foo' />" +
+                "  </http>" +
+                nodesXml +
+                "</container>" +
+                "</services>";
+        ApplicationPackage applicationPackage = new MockApplicationPackage.Builder().withServices(servicesXml).build();
+        // Need to create VespaModel to make deploy properties have effect
+        final TestLogger logger = new TestLogger();
+        new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
+                .applicationPackage(applicationPackage)
+                .deployLogger(logger)
+                .properties(new TestProperties().setHostedVespa(true))
+                .build());
+        assertFalse(logger.msgs.isEmpty());
+        assertThat(logger.msgs.get(0).getSecond(), containsString(String.format("You cannot set port to anything else than %d", Container.BASEPORT)));
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/JettyContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/JettyContainerModelBuilderTest.java
@@ -234,7 +234,7 @@ public class JettyContainerModelBuilderTest extends ContainerModelBuilderTestBas
         Element clusterElem = DomBuilderTest.parse(
                 "<container id='default' version='1.0' jetty='true'>",
                 "    <http>",
-                "        <server port='8080' id='ssl'>",
+                "        <server port='9000' id='ssl'>",
                 "            <ssl>",
                 "                <private-key-file>/foo/key</private-key-file>",
                 "                <certificate-file>/foo/cert</certificate-file>",

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/ModelAmendingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/ModelAmendingTestCase.java
@@ -11,7 +11,6 @@ import com.yahoo.config.model.admin.AdminModel;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
-import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.PortAllocBridge;
@@ -47,32 +46,32 @@ public class ModelAmendingTestCase {
                                                                                       new ContainerModelAmenderBuilder(),
                                                                                       new ContentModelAmenderBuilder());
         String services =
-                "<services version='1.0'>" +
-                "    <admin version='4.0'/>" +
-                "    <container id='test1' version='1.0'>" +
-                "        <search/>" +
-                "        <nodes count='2'/>" +
-                "    </container>" +
-                "    <container id='test2' version='1.0'>" +
-                "        <http><server id='server1' port='" + Defaults.getDefaults().vespaWebServicePort() + "'/></http>" +
-                "        <document-api/>" +
-                "        <nodes count='2'/>" +
-                "    </container>" +
-                "    <content id='test3' version='1.0'>" +
-                "        <redundancy>1</redundancy>" +
-                "        <documents>" +
-                "            <document mode='index' type='type1'/>" +
-                "        </documents>" +
-                "        <nodes count='2'/>" +
-                "    </content>" +
-                "    <content id='test4' version='1.0'>" +
-                "        <redundancy>1</redundancy>" +
-                "        <documents>" +
-                "            <document mode='index' type='type1'/>" +
-                "        </documents>" +
-                "        <nodes count='3'/>" +
-                "    </content>" +
-                "</services>";
+                                             "<services version='1.0'>" +
+                                             "    <admin version='4.0'/>" +
+                                             "    <container id='test1' version='1.0'>" +
+                                             "        <search/>" +
+                                             "        <nodes count='2'/>" +
+                                             "    </container>" +
+                                             "    <container id='test2' version='1.0'>" +
+                                             "        <http><server id='server1' port='19110'/></http>" +
+                                             "        <document-api/>" +
+                                             "        <nodes count='2'/>" +
+                                             "    </container>" +
+                                             "    <content id='test3' version='1.0'>" +
+                                             "        <redundancy>1</redundancy>" +
+                                             "        <documents>" +
+                                             "            <document mode='index' type='type1'/>" +
+                                             "        </documents>" +
+                                             "        <nodes count='2'/>" +
+                                             "    </content>" +
+                                             "    <content id='test4' version='1.0'>" +
+                                             "        <redundancy>1</redundancy>" +
+                                             "        <documents>" +
+                                             "            <document mode='index' type='type1'/>" +
+                                             "        </documents>" +
+                                             "        <nodes count='3'/>" +
+                                             "    </content>" +
+                                             "</services>";
         VespaModelTester tester = new VespaModelTester(amendingModelRepo);
         tester.addHosts(10);
         VespaModel model = tester.createModel(services);

--- a/configserver/src/test/apps/hosted-no-write-access-control/services.xml
+++ b/configserver/src/test/apps/hosted-no-write-access-control/services.xml
@@ -8,7 +8,7 @@
 
   <container version="1.0">
     <http>
-      <server id="foo"/>
+      <server id="foo" port="4080" />
     </http>
     <search/>
     <nodes count='1'/>

--- a/configserver/src/test/apps/hosted-routing-app/services.xml
+++ b/configserver/src/test/apps/hosted-routing-app/services.xml
@@ -11,7 +11,7 @@
       <filtering>
         <access-control domain="foo" write="true" />
       </filtering>
-      <server id="foo"/>
+      <server id="foo" port="4080" />
     </http>
     <search/>
     <nodes type='host'/>

--- a/configserver/src/test/apps/hosted/services.xml
+++ b/configserver/src/test/apps/hosted/services.xml
@@ -11,7 +11,7 @@
       <filtering>
         <access-control domain="foo" write="true" />
       </filtering>
-      <server id="foo"/>
+      <server id="foo" port="4080" />
     </http>
     <search/>
     <nodes count='1'/>

--- a/configserver/src/test/apps/validationOverride/services.xml
+++ b/configserver/src/test/apps/validationOverride/services.xml
@@ -4,7 +4,7 @@
         <filtering>
             <access-control domain="foo" write="true" />
         </filtering>
-        <server id="foo"/>
+        <server id="foo" port="4080" />
     </http>
     <search/>
     <nodes count="2"/>

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooter.java
@@ -41,7 +41,7 @@ public class NodeRebooter extends Maintainer {
 
     @Override
     protected void maintain() {
-        // Reboot candidates: Nodes in long-term states, where we know we can safely orchestrate a reboot
+        // Reboot candidates: Nodes in long-term states, which we know can safely orchestrate a reboot
         List<Node> nodesToReboot = nodeRepository().getNodes(Node.State.active, Node.State.ready).stream()
                 .filter(node -> node.flavor().getType() != Flavor.Type.DOCKER_CONTAINER)
                 .filter(this::shouldReboot)
@@ -66,11 +66,13 @@ public class NodeRebooter extends Maintainer {
         if (overdue.isEmpty()) // should never happen as all !docker-container should have provisioned timestamp
             return random.nextDouble() < interval().getSeconds() / (double) rebootInterval.getSeconds();
 
-        if (overdue.get().isNegative()) return false;
+        if (overdue.get().isNegative())
+            return false;
 
         // Use a probability such that each maintain() schedules the same number of reboots,
         // as long as 0 <= overdue <= rebootInterval, with the last maintain() in that interval
         // naturally scheduling the remaining with probability 1.
+
         int configServers = nodeRepository().database().cluster().size();
         long secondsRemaining = Math.max(0, rebootInterval.getSeconds() - overdue.get().getSeconds());
         double runsRemaining = configServers * secondsRemaining / (double) interval().getSeconds();


### PR DESCRIPTION
Reverts vespa-engine/vespa#11792

Routing app in hosted uses port 4088 so config servers in CD fail to start with:
`	Caused by: java.lang.IllegalArgumentException: Illegal port 4088 in http server 'ats': Port must be set to 4080
	at com.yahoo.vespa.model.container.http.xml.HttpBuilder.readPort(HttpBuilder.java:142)`