### PR TITLE
Improve deploy messages

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServerException.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServerException.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.controller.api.integration.configserver;
 
 import java.net.URI;
+import java.util.Objects;
 
 /**
  * @author Tony Vaagenes
@@ -10,11 +11,13 @@ public class ConfigServerException extends RuntimeException {
 
     private final URI serverUri;
     private final ErrorCode errorCode;
+    private final String serverMessage;
 
-    public ConfigServerException(URI serverUri, String message, ErrorCode errorCode, Throwable cause) {
-        super(message, cause);
-        this.serverUri = serverUri;
-        this.errorCode = errorCode;
+    public ConfigServerException(URI serverUri, String context, String serverMessage, ErrorCode errorCode, Throwable cause) {
+        super(context + ": " + serverMessage, cause);
+        this.serverUri = Objects.requireNonNull(serverUri);
+        this.errorCode = Objects.requireNonNull(errorCode);
+        this.serverMessage = Objects.requireNonNull(serverMessage);
     }
 
     public ErrorCode getErrorCode() {
@@ -23,6 +26,10 @@ public class ConfigServerException extends RuntimeException {
 
     public URI getServerUri() {
         return serverUri;
+    }
+
+    public String getServerMessage() {
+        return serverMessage;
     }
 
     // TODO: Copied from Vespa. Expose these in Vespa and use them here

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -244,18 +244,19 @@ public class InternalStepRunner implements StepRunner {
                 case ACTIVATION_CONFLICT:
                 case APPLICATION_LOCK_FAILURE:
                 case CERTIFICATE_NOT_READY:
-                case LOAD_BALANCER_NOT_READY:
-                    logger.log("Deployment failed with transient error " + e.getErrorCode() + ", will retry: " + e.getMessage());
+                    logger.log("Deployment failed with possibly transient error " + e.getErrorCode() +
+                            ", will retry: " + e.getMessage());
                     return Optional.empty();
+                case LOAD_BALANCER_NOT_READY:
                 case PARENT_HOST_NOT_READY:
-                    logger.log(e.getMessage());
+                    logger.log(e.getServerMessage());
                     return Optional.empty();
                 case OUT_OF_CAPACITY:
-                    logger.log("Deployment failed: Out of capacity: " + e.getMessage());
+                    logger.log(e.getServerMessage());
                     return Optional.of(outOfCapacity);
                 case INVALID_APPLICATION_PACKAGE:
                 case BAD_REQUEST:
-                    logger.log("Deployment failed: " + e.getMessage());
+                    logger.log(e.getMessage());
                     return Optional.of(deploymentFailed);
             }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
@@ -24,14 +24,11 @@ import com.yahoo.vespa.hosted.controller.api.integration.deployment.TesterCloud;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.TesterId;
 import com.yahoo.vespa.hosted.controller.api.integration.routing.RoutingEndpoint;
 import com.yahoo.vespa.hosted.controller.api.integration.routing.RoutingGeneratorMock;
-import com.yahoo.vespa.hosted.controller.api.integration.stubs.MockTesterCloud;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
 import com.yahoo.vespa.hosted.controller.integration.ConfigServerMock;
 import com.yahoo.vespa.hosted.controller.maintenance.JobRunner;
-import com.yahoo.vespa.hosted.controller.maintenance.NameServiceDispatcher;
-import com.yahoo.vespa.hosted.controller.maintenance.ReadyJobsTrigger;
 
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
@@ -49,7 +46,6 @@ import java.util.Set;
 import static com.yahoo.vespa.hosted.controller.deployment.Step.Status.unfinished;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -231,6 +227,7 @@ public class DeploymentContext {
     public DeploymentContext outOfCapacity(JobType type) {
         return failDeployment(type,
                               new ConfigServerException(URI.create("https://config.server"),
+                                                        "Failed to deploy application",
                                                         "Out of capacity",
                                                         ConfigServerException.ErrorCode.OUT_OF_CAPACITY,
                                                         new RuntimeException("Out of capacity from test code")));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -1062,7 +1062,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               400);
 
         ConfigServerMock configServer = tester.serviceRegistry().configServerMock();
-        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to prepare application", "invalid application package", ConfigServerException.ErrorCode.INVALID_APPLICATION_PACKAGE, null));
+        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to prepare application", "Invalid application package", ConfigServerException.ErrorCode.INVALID_APPLICATION_PACKAGE, null));
 
         // GET non-existent application package
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/package", GET).userIdentity(HOSTED_VESPA_OPERATOR),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -1062,7 +1062,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               400);
 
         ConfigServerMock configServer = tester.serviceRegistry().configServerMock();
-        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to prepare application", ConfigServerException.ErrorCode.INVALID_APPLICATION_PACKAGE, null));
+        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to prepare application", "invalid application package", ConfigServerException.ErrorCode.INVALID_APPLICATION_PACKAGE, null));
 
         // GET non-existent application package
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/package", GET).userIdentity(HOSTED_VESPA_OPERATOR),
@@ -1087,21 +1087,21 @@ public class ApplicationApiTest extends ControllerContainerTest {
                               new File("deploy-failure.json"), 400);
 
         // POST (deploy) an application without available capacity
-        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to prepare application", ConfigServerException.ErrorCode.OUT_OF_CAPACITY, null));
+        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to prepare application", "Out of capacity", ConfigServerException.ErrorCode.OUT_OF_CAPACITY, null));
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/dev/region/us-west-1/instance/instance1/deploy", POST)
                                       .data(entity)
                                       .userIdentity(USER_ID),
                               new File("deploy-out-of-capacity.json"), 400);
 
         // POST (deploy) an application where activation fails
-        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to activate application", ConfigServerException.ErrorCode.ACTIVATION_CONFLICT, null));
+        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to activate application", "Activation conflict", ConfigServerException.ErrorCode.ACTIVATION_CONFLICT, null));
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/dev/region/us-west-1/instance/instance1/deploy", POST)
                                       .data(entity)
                                       .userIdentity(USER_ID),
                               new File("deploy-activation-conflict.json"), 409);
 
         // POST (deploy) an application where we get an internal server error
-        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Internal server error", ConfigServerException.ErrorCode.INTERNAL_SERVER_ERROR, null));
+        configServer.throwOnNextPrepare(new ConfigServerException(new URI("server-url"), "Failed to deploy application", "Internal server error", ConfigServerException.ErrorCode.INTERNAL_SERVER_ERROR, null));
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/dev/region/us-west-1/instance/instance1/deploy", POST)
                                       .data(entity)
                                       .userIdentity(USER_ID),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelperTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelperTest.java
@@ -76,7 +76,7 @@ public class JobControllerApiHandlerHelperTest {
         tester.triggerJobs();
 
         // us-east-3 eats the deployment failure and fails before deployment, while us-west-1 fails after.
-        tester.configServer().throwOnNextPrepare(new ConfigServerException(URI.create("url"), "ERROR!", INVALID_APPLICATION_PACKAGE, null));
+        tester.configServer().throwOnNextPrepare(new ConfigServerException(URI.create("url"), "Failed to deploy application", "ERROR!", INVALID_APPLICATION_PACKAGE, null));
         tester.runner().run();
         assertEquals(deploymentFailed, tester.jobs().last(app.instanceId(), productionUsEast3).get().status());
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-activation-conflict.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-activation-conflict.json
@@ -1,4 +1,4 @@
 {
   "error-code":"ACTIVATION_CONFLICT",
-  "message":"Failed to activate application"
+  "message":"Failed to activate application: Activation conflict"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-failure.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-failure.json
@@ -1,4 +1,4 @@
 {
   "error-code":"INVALID_APPLICATION_PACKAGE",
-  "message":"Failed to prepare application"
+  "message":"Failed to prepare application: invalid application package"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-failure.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-failure.json
@@ -1,4 +1,4 @@
 {
   "error-code":"INVALID_APPLICATION_PACKAGE",
-  "message":"Failed to prepare application: invalid application package"
+  "message":"Failed to prepare application: Invalid application package"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-internal-server-error.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-internal-server-error.json
@@ -1,4 +1,4 @@
 {
   "error-code":"INTERNAL_SERVER_ERROR",
-  "message":"Internal server error"
+  "message":"Failed to deploy application: Internal server error"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-out-of-capacity.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deploy-out-of-capacity.json
@@ -1,4 +1,4 @@
 {
   "error-code":"OUT_OF_CAPACITY",
-  "message":"Failed to prepare application"
+  "message":"Failed to prepare application: Out of capacity"
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/us-east-3-log-without-first.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/us-east-3-log-without-first.json
@@ -4,7 +4,7 @@
       {
         "at": 1000,
         "type": "info",
-        "message": "Deployment failed: ERROR!"
+        "message": "Failed to deploy application: ERROR!"
       }
     ],
     "deactivateTester": [


### PR DESCRIPTION
Remove misleading prefix of some deploy messages

parent-host-not-ready:
  0/1 hosts for vespa.album-recommendation.default-t have completed
  provisioning and bootstrapping, still waiting for
  h33908.staging.aws-us-east-1c.vespa-external-cd.aws.oath.cloud

load-balancer-not-ready:
  Failed to (re)configure load balancer for CLUSTER in APPLICATION,
  targeting: REALS. The operation will be retried on next deployment

out-of-capacity one of:
  Could not satisfy request for 3 nodes with...
  Not enough capacity to start 3 r4.xlarge instances...
  No host flavor matches [vcpu: 2, memory: ...], nearest matching host flavor...