### PR TITLE
Vekterli/support weak internal read consistency for client gets

### DIFF
--- a/storage/src/tests/distributor/distributortest.cpp
+++ b/storage/src/tests/distributor/distributortest.cpp
@@ -187,6 +187,12 @@ struct DistributorTest : Test, DistributorTestUtil {
         configureDistributor(builder);
     }
 
+    void configure_use_weak_internal_read_consistency(bool use_weak) {
+        ConfigBuilder builder;
+        builder.useWeakInternalReadConsistencyForClientGets = use_weak;
+        configureDistributor(builder);
+    }
+
     void configureMaxClusterClockSkew(int seconds);
     void sendDownClusterStateCommand();
     void replyToSingleRequestBucketInfoCommandWith1Bucket();
@@ -1036,6 +1042,19 @@ TEST_F(DistributorTest, merge_disabling_config_is_propagated_to_internal_config)
 
     configure_merge_operations_disabled(false);
     EXPECT_FALSE(getConfig().merge_operations_disabled());
+}
+
+TEST_F(DistributorTest, weak_internal_read_consistency_config_is_propagated_to_internal_configs) {
+    createLinks(true);
+    setupDistributor(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
+
+    configure_use_weak_internal_read_consistency(true);
+    EXPECT_TRUE(getConfig().use_weak_internal_read_consistency_for_client_gets());
+    EXPECT_TRUE(getExternalOperationHandler().use_weak_internal_read_consistency_for_gets());
+
+    configure_use_weak_internal_read_consistency(false);
+    EXPECT_FALSE(getConfig().use_weak_internal_read_consistency_for_client_gets());
+    EXPECT_FALSE(getExternalOperationHandler().use_weak_internal_read_consistency_for_gets());
 }
 
 TEST_F(DistributorTest, concurrent_reads_not_enabled_if_btree_db_is_not_enabled) {

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -41,6 +41,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _allowStaleReadsDuringClusterStateTransitions(false),
       _update_fast_path_restart_enabled(false),
       _merge_operations_disabled(false),
+      _use_weak_internal_read_consistency_for_client_gets(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 { }
 
@@ -153,6 +154,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _allowStaleReadsDuringClusterStateTransitions = config.allowStaleReadsDuringClusterStateTransitions;
     _update_fast_path_restart_enabled = config.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent;
     _merge_operations_disabled = config.mergeOperationsDisabled;
+    _use_weak_internal_read_consistency_for_client_gets = config.useWeakInternalReadConsistencyForClientGets;
 
     _minimumReplicaCountingMode = config.minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -228,6 +228,13 @@ public:
         _merge_operations_disabled = disabled;
     }
 
+    void set_use_weak_internal_read_consistency_for_client_gets(bool use_weak) noexcept {
+        _use_weak_internal_read_consistency_for_client_gets = use_weak;
+    }
+    bool use_weak_internal_read_consistency_for_client_gets() const noexcept {
+        return _use_weak_internal_read_consistency_for_client_gets;
+    }
+
     bool containsTimeStatement(const std::string& documentSelection) const;
     
 private:
@@ -273,6 +280,7 @@ private:
     bool _allowStaleReadsDuringClusterStateTransitions;
     bool _update_fast_path_restart_enabled;
     bool _merge_operations_disabled;
+    bool _use_weak_internal_read_consistency_for_client_gets;
 
     DistrConfig::MinimumReplicaCountingMode _minimumReplicaCountingMode;
     

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -219,3 +219,12 @@ restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=
 ## This is ONLY intended for system testing of certain transient edge cases and
 ## MUST NOT be set to true in a production environment.
 merge_operations_disabled bool default=false
+
+## If set, Get operations that are initiated by the client (i.e. _not_ Get operations
+## that are initiated by the distributor) will be forwarded to the backend with
+## a flag signalling that weak read consistency may be used. This allows the
+## backend to minimize internal locking. The downside is that it's not guaranteed
+## to observe the most recent writes to the document, nor to observe an atomically
+## consistent view of fields across document versions.
+## This is mostly useful in a system that is effectively read-only.
+use_weak_internal_read_consistency_for_client_gets bool default=false

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -849,6 +849,8 @@ Distributor::enableNextConfig()
     // Concurrent reads are only safe if the B-tree DB implementation is used.
     _externalOperationHandler.set_concurrent_gets_enabled(
             _use_btree_database && getConfig().allowStaleReadsDuringClusterStateTransitions());
+    _externalOperationHandler.set_use_weak_internal_read_consistency_for_gets(
+            getConfig().use_weak_internal_read_consistency_for_client_gets());
 }
 
 void

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -66,6 +66,14 @@ public:
         return _concurrent_gets_enabled.load(std::memory_order_relaxed);
     }
 
+    void set_use_weak_internal_read_consistency_for_gets(bool use_weak) noexcept {
+        _use_weak_internal_read_consistency_for_gets.store(use_weak, std::memory_order_relaxed);
+    }
+
+    bool use_weak_internal_read_consistency_for_gets() const noexcept {
+        return _use_weak_internal_read_consistency_for_gets.load(std::memory_order_relaxed);
+    }
+
 private:
     std::unique_ptr<DirectDispatchSender> _direct_dispatch_sender;
     const MaintenanceOperationGenerator& _operationGenerator;
@@ -75,6 +83,7 @@ private:
     mutable std::mutex _non_main_thread_ops_mutex;
     OperationOwner _non_main_thread_ops_owner;
     std::atomic<bool> _concurrent_gets_enabled;
+    std::atomic<bool> _use_weak_internal_read_consistency_for_gets;
 
     template <typename Func>
     void bounce_or_invoke_read_only_op(api::StorageCommand& cmd,
@@ -102,6 +111,8 @@ private:
             const document::DocumentId& docId,
             PersistenceOperationMetricSet& persistenceMetrics) const;
     bool allowMutation(const SequencingHandle& handle) const;
+
+    api::InternalReadConsistency desired_get_read_consistency() const noexcept;
 
     DistributorMetricSet& getMetrics() { return getDistributor().getMetrics(); }
 };

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -28,7 +28,8 @@ public:
                  const DistributorBucketSpace &bucketSpace,
                  std::shared_ptr<BucketDatabase::ReadGuard> read_guard,
                  std::shared_ptr<api::GetCommand> msg,
-                 PersistenceOperationMetricSet& metric);
+                 PersistenceOperationMetricSet& metric,
+                 api::InternalReadConsistency desired_read_consistency = api::InternalReadConsistency::Strong);
 
     void onClose(DistributorMessageSender& sender) override;
     void onStart(DistributorMessageSender& sender) override;
@@ -43,6 +44,10 @@ public:
 
     const std::vector<std::pair<document::BucketId, uint16_t>>& replicas_in_db() const noexcept {
         return _replicas_in_db;
+    }
+
+    api::InternalReadConsistency desired_read_consistency() const noexcept {
+        return _desired_read_consistency;
     }
 
 private:
@@ -94,6 +99,7 @@ private:
     PersistenceOperationMetricSet& _metric;
     framework::MilliSecTimer _operationTimer;
     std::vector<std::pair<document::BucketId, uint16_t>> _replicas_in_db;
+    api::InternalReadConsistency _desired_read_consistency;
     bool _has_replica_inconsistency;
 
     void sendReply(DistributorMessageSender& sender);

--- a/storage/src/vespa/storage/persistence/messages.h
+++ b/storage/src/vespa/storage/persistence/messages.h
@@ -25,7 +25,7 @@ public:
     GetIterCommand(const document::Bucket &bucket,
                    const spi::IteratorId iteratorId,
                    uint32_t maxByteSize);
-    ~GetIterCommand();
+    ~GetIterCommand() override;
 
     std::unique_ptr<api::StorageReply> makeReply() override;
 

--- a/storageapi/src/vespa/storageapi/mbusprot/protobuf/feed.proto
+++ b/storageapi/src/vespa/storageapi/mbusprot/protobuf/feed.proto
@@ -61,6 +61,11 @@ message GetRequest {
     bytes  document_id      = 2;
     bytes  field_set        = 3;
     uint64 before_timestamp = 4;
+    enum InternalReadConsistency {
+        Strong = 0; // Default for a good reason.
+        Weak = 1;
+    }
+    InternalReadConsistency internal_read_consistency = 5;
 }
 
 message GetResponse {

--- a/storageapi/src/vespa/storageapi/message/persistence.cpp
+++ b/storageapi/src/vespa/storageapi/message/persistence.cpp
@@ -180,7 +180,8 @@ GetCommand::GetCommand(const document::Bucket &bucket, const document::DocumentI
     : BucketInfoCommand(MessageType::GET, bucket),
       _docId(docId),
       _beforeTimestamp(before),
-      _fieldSet(fieldSet)
+      _fieldSet(fieldSet),
+      _internal_read_consistency(InternalReadConsistency::Strong)
 {
 }
 

--- a/storageapi/src/vespa/storageapi/message/persistence.h
+++ b/storageapi/src/vespa/storageapi/message/persistence.h
@@ -184,7 +184,7 @@ class GetCommand : public BucketInfoCommand {
     document::DocumentId _docId;
     Timestamp _beforeTimestamp;
     vespalib::string _fieldSet;
-
+    InternalReadConsistency _internal_read_consistency;
 public:
     GetCommand(const document::Bucket &bucket, const document::DocumentId&,
                vespalib::stringref fieldSet, Timestamp before = MAX_TIMESTAMP);
@@ -194,6 +194,12 @@ public:
     Timestamp getBeforeTimestamp() const { return _beforeTimestamp; }
     const vespalib::string& getFieldSet() const { return _fieldSet; }
     void setFieldSet(vespalib::stringref fieldSet) { _fieldSet = fieldSet; }
+    InternalReadConsistency internal_read_consistency() const noexcept {
+        return _internal_read_consistency;
+    }
+    void set_internal_read_consistency(InternalReadConsistency consistency) noexcept {
+        _internal_read_consistency = consistency;
+    }
 
     vespalib::string getSummary() const override;
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;

--- a/storageapi/src/vespa/storageapi/messageapi/storagemessage.cpp
+++ b/storageapi/src/vespa/storageapi/messageapi/storagemessage.cpp
@@ -302,16 +302,27 @@ StorageMessage::getSummary() const {
 
 const char* to_string(LockingRequirements req) noexcept {
     switch (req) {
-    case LockingRequirements::Exclusive:
-        return "Exclusive";
-    case LockingRequirements::Shared:
-        return "Shared";
+    case LockingRequirements::Exclusive: return "Exclusive";
+    case LockingRequirements::Shared:    return "Shared";
+    default: abort();
     }
-    assert(false);
 }
 
 std::ostream& operator<<(std::ostream& os, LockingRequirements req) {
     os << to_string(req);
+    return os;
+}
+
+const char* to_string(InternalReadConsistency consistency) noexcept {
+    switch (consistency) {
+    case InternalReadConsistency::Strong: return "Strong";
+    case InternalReadConsistency::Weak:   return "Weak";
+    default: abort();
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, InternalReadConsistency consistency) {
+    os << to_string(consistency);
     return os;
 }
 

--- a/storageapi/src/vespa/storageapi/messageapi/storagemessage.h
+++ b/storageapi/src/vespa/storageapi/messageapi/storagemessage.h
@@ -316,8 +316,20 @@ enum class LockingRequirements : uint8_t {
 };
 
 const char* to_string(LockingRequirements req) noexcept;
-
 std::ostream& operator<<(std::ostream&, LockingRequirements);
+
+// This mirrors spi::ReadConsistency and has the same semantics, but is
+// decoupled to avoid extra cross-module dependencies.
+// Note that the name _internal_ read consistency is intentional to lessen
+// any ambiguities on whether this is consistency in a distributed systems
+// setting (i.e. linearizability) on internally in the persistence provider.
+enum class InternalReadConsistency : uint8_t {
+    Strong = 0,
+    Weak
+};
+
+const char* to_string(InternalReadConsistency consistency) noexcept;
+std::ostream& operator<<(std::ostream&, InternalReadConsistency);
 
 class StorageMessage : public vespalib::Printable
 {


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

If configured, Get operations initiated by the client are flagged
with weak internal consistency. This allows the backend to bypass
certain internal synchronization mechanisms, which minimizes latency
at the cost of possibly not observing a consistent view of the
document. This config should only be used in a very restricted set
of cases where the document set is effectively read-only, or cross-
field consistency or freshness does not matter.

To enable the weak consistency, use an explicit config override:

```
<config name="vespa.config.content.core.stor-distributormanager">
  <use_weak_internal_read_consistency_for_client_gets>
    true
  </use_weak_internal_read_consistency_for_client_gets>
</config>
```