### PR TITLE
Use bucket_space metric in retirement

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
@@ -76,6 +76,7 @@ public class ClusterControllerClusterConfigurer {
         options.clusterHasGlobalDocumentTypes = config.cluster_has_global_document_types();
         options.minMergeCompletionRatio = config.min_merge_completion_ratio();
         options.enableTwoPhaseClusterStateActivation = config.enable_two_phase_cluster_state_transitions();
+        options.determineBucketsFromBucketSpaceMetric = config.determine_buckets_from_bucket_space_metric();
     }
 
     private void configure(SlobroksConfig config) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -22,6 +22,7 @@ public class ContentCluster {
     private final ClusterInfo clusterInfo = new ClusterInfo();
 
     private final Map<Node, Long> nodeStartTimestamps = new TreeMap<>();
+    private final boolean determineBucketsFromBucketSpaceMetric;
 
     private int slobrokGenerationCount = 0;
 
@@ -32,7 +33,9 @@ public class ContentCluster {
     private double minRatioOfStorageNodesUp;
 
     public ContentCluster(String clusterName, Collection<ConfiguredNode> configuredNodes, Distribution distribution,
-                          int minStorageNodesUp, double minRatioOfStorageNodesUp) {
+                          int minStorageNodesUp, double minRatioOfStorageNodesUp,
+                          boolean determineBucketsFromBucketSpaceMetric) {
+        this.determineBucketsFromBucketSpaceMetric = determineBucketsFromBucketSpaceMetric;
         if (configuredNodes == null) throw new IllegalArgumentException("Nodes must be set");
         this.clusterName = clusterName;
         this.distribution = distribution;
@@ -183,7 +186,8 @@ public class ContentCluster {
                 minStorageNodesUp,
                 minRatioOfStorageNodesUp,
                 distribution.getRedundancy(),
-                clusterInfo);
+                clusterInfo,
+                determineBucketsFromBucketSpaceMetric);
         return nodeStateChangeChecker.evaluateTransition(node, clusterState, condition, oldState, newState);
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -193,7 +193,7 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
                 options.nodes,
                 options.storageDistribution,
                 options.minStorageNodesUp,
-                options.minRatioOfStorageNodesUp);
+                options.minRatioOfStorageNodesUp, true);
         NodeStateGatherer stateGatherer = new NodeStateGatherer(timer, timer, log);
         Communicator communicator = new RPCCommunicator(
                 RPCCommunicator.createRealSupervisor(),

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -128,6 +128,9 @@ public class FleetControllerOptions implements Cloneable {
 
     public int maxDivergentNodesPrintedInTaskErrorMessages = 10;
 
+    // TODO: May be removed once rolled out everywhere.
+    public boolean determineBucketsFromBucketSpaceMetric = true;
+
     // TODO: Replace usage of this by usage where the nodes are explicitly passed (below)
     public FleetControllerOptions(String clusterName) {
         this.clusterName = clusterName;

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
@@ -198,7 +198,7 @@ public class ClusterFixture {
         Collection<ConfiguredNode> nodes = DistributionBuilder.buildConfiguredNodes(nodeCount);
 
         Distribution distribution = DistributionBuilder.forFlatCluster(nodeCount);
-        ContentCluster cluster = new ContentCluster("foo", nodes, distribution, 0, 0.0);
+        ContentCluster cluster = new ContentCluster("foo", nodes, distribution, 0, 0.0, true);
 
         return new ClusterFixture(cluster, distribution);
     }
@@ -206,7 +206,7 @@ public class ClusterFixture {
     static ClusterFixture forHierarchicCluster(DistributionBuilder.GroupBuilder root) {
         List<ConfiguredNode> nodes = DistributionBuilder.buildConfiguredNodes(root.totalNodeCount());
         Distribution distribution = DistributionBuilder.forHierarchicCluster(root);
-        ContentCluster cluster = new ContentCluster("foo", nodes, distribution, 0, 0.0);
+        ContentCluster cluster = new ContentCluster("foo", nodes, distribution, 0, 0.0, true);
 
         return new ClusterFixture(cluster, distribution);
     }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
@@ -34,8 +34,6 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +46,8 @@ import java.util.TreeSet;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.fail;
 
 /**
  * @author Håkon Humberset
@@ -157,7 +157,7 @@ public abstract class FleetControllerTest implements Waiter {
                 options.nodes,
                 options.storageDistribution,
                 options.minStorageNodesUp,
-                options.minRatioOfStorageNodesUp);
+                options.minRatioOfStorageNodesUp, true);
         NodeStateGatherer stateGatherer = new NodeStateGatherer(timer, timer, log);
         Communicator communicator = new RPCCommunicator(
                 RPCCommunicator.createRealSupervisor(),

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -61,14 +61,14 @@ public class NodeStateChangeCheckerTest {
     }
 
     private NodeStateChangeChecker createChangeChecker(ContentCluster cluster) {
-        return new NodeStateChangeChecker(minStorageNodesUp, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo());
+        return new NodeStateChangeChecker(minStorageNodesUp, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo(), true);
     }
 
     private ContentCluster createCluster(Collection<ConfiguredNode> nodes) {
         Distribution distribution = mock(Distribution.class);
         Group group = new Group(2, "to");
         when(distribution.getRootGroup()).thenReturn(group);
-        return new ContentCluster("Clustername", nodes, distribution, minStorageNodesUp, 0.0);
+        return new ContentCluster("Clustername", nodes, distribution, minStorageNodesUp, 0.0, true);
     }
 
     private StorageNodeInfo createStorageNodeInfo(int index, State state) {
@@ -78,7 +78,7 @@ public class NodeStateChangeCheckerTest {
 
         String clusterName = "Clustername";
         Set<ConfiguredNode> configuredNodeIndexes = new HashSet<>();
-        ContentCluster cluster = new ContentCluster(clusterName, configuredNodeIndexes, distribution, minStorageNodesUp, 0.0);
+        ContentCluster cluster = new ContentCluster(clusterName, configuredNodeIndexes, distribution, minStorageNodesUp, 0.0, true);
 
         String rpcAddress = "";
         StorageNodeInfo storageNodeInfo = new StorageNodeInfo(cluster, index, false, rpcAddress, distribution);
@@ -136,7 +136,7 @@ public class NodeStateChangeCheckerTest {
     public void testUnknownStorageNode() {
         ContentCluster cluster = createCluster(createNodes(4));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo());
+                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo(), true);
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -161,7 +161,7 @@ public class NodeStateChangeCheckerTest {
         ContentCluster cluster = createCluster(createNodes(4));
         setAllNodesUp(cluster, HostInfo.createHostInfo(createDistributorHostInfo(4, 5, 6)));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo());
+                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo(), true);
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 nodeStorage, defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -549,12 +549,48 @@ public class NodeStateChangeCheckerTest {
                         "        \"dimensions\":\n" +
                         "        {\n" +
                         "        }\n" +
+                        "      },\n" +
+                        "      {\n" +
+                        "        \"name\":\"vds.datastored.bucket_space.buckets_total\",\n" +
+                        "        \"description\":\"Total number buckets present in the bucket space (ready + not ready)\",\n" +
+                        "        \"values\":\n" +
+                        "        {\n" +
+                        "          \"average\":0.0,\n" +
+                        "          \"sum\":0.0,\n" +
+                        "          \"count\":1,\n" +
+                        "          \"rate\":0.016666,\n" +
+                        "          \"min\":0,\n" +
+                        "          \"max\":0,\n" +
+                        "          \"last\":0\n" +
+                        "        },\n" +
+                        "        \"dimensions\":\n" +
+                        "        {\n" +
+                        "          \"bucketSpace\":\"global\"\n" +
+                        "        }\n" +
+                        "      },\n" +
+                        "      {\n" +
+                        "        \"name\":\"vds.datastored.bucket_space.buckets_total\",\n" +
+                        "        \"description\":\"Total number buckets present in the bucket space (ready + not ready)\",\n" +
+                        "        \"values\":\n" +
+                        "        {\n" +
+                        "          \"average\":129.0,\n" +
+                        "          \"sum\":129.0,\n" +
+                        "          \"count\":1,\n" +
+                        "          \"rate\":0.016666,\n" +
+                        "          \"min\":129,\n" +
+                        "          \"max\":129,\n" +
+                        "          \"last\":%d\n" +
+                        "        },\n" +
+                        "        \"dimensions\":\n" +
+                        "        {\n" +
+                        "          \"bucketSpace\":\"default\"\n" +
+                        "        }\n" +
                         "      }\n" +
                         "    ]\n" +
                         "  },\n" +
                         "  \"cluster-state-version\":%d\n" +
                         "}",
-                lastAlldisksBuckets, clusterStateVersion));
+                lastAlldisksBuckets, lastAlldisksBuckets, clusterStateVersion));
     }
 
     private List<ConfiguredNode> createNodes(int count) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeHandlerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeHandlerTest.java
@@ -80,7 +80,7 @@ public class StateChangeHandlerTest {
         Distribution distribution = new Distribution(Distribution.getDefaultDistributionConfig(2, 100));
         this.config = config;
         for (int i=0; i<config.nodeCount; ++i) configuredNodes.add(new ConfiguredNode(i, false));
-        cluster = new ContentCluster("testcluster", configuredNodes, distribution, 0, 0.0);
+        cluster = new ContentCluster("testcluster", configuredNodes, distribution, 0, 0.0, true);
         nodeStateChangeHandler = new StateChangeHandler(clock, eventLog, null);
         params.minStorageNodesUp(1).minDistributorNodesUp(1)
                 .minRatioOfStorageNodesUp(0.0).minRatioOfDistributorNodesUp(0.0)

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -53,7 +53,7 @@ public class StateChangeTest extends FleetControllerTest {
         MetricUpdater metricUpdater = new MetricUpdater(new NoMetricReporter(), options.fleetControllerIndex);
         eventLog = new EventLog(timer, metricUpdater);
         ContentCluster cluster = new ContentCluster(options.clusterName, options.nodes, options.storageDistribution,
-                                                    options.minStorageNodesUp, options.minRatioOfStorageNodesUp);
+                                                    options.minStorageNodesUp, options.minRatioOfStorageNodesUp, true);
         NodeStateGatherer stateGatherer = new NodeStateGatherer(timer, timer, eventLog);
         DatabaseHandler database = new DatabaseHandler(new ZooKeeperDatabaseFactory(), timer, options.zooKeeperServerAddress, options.fleetControllerIndex, timer);
         StateChangeHandler stateGenerator = new StateChangeHandler(timer, eventLog, metricUpdater);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/HostInfoTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/HostInfoTest.java
@@ -59,9 +59,14 @@ public class HostInfoTest {
         assertThat(metrics.get(3).getName(), equalTo("vds.datastored.bucket_space.buckets_total"));
         assertThat(hostInfo.getClusterStateVersionOrNull(), is(123));
 
-        Optional<Metrics.Value> value = hostInfo.getMetrics()
-                .getValueAt("vds.datastored.bucket_space.buckets_total", Map.of("bucketSpace", "default"));
-        assertThat(value.map(Metrics.Value::getLast), equalTo(Optional.of(129L)));
+        assertThat(hostInfo.getMetrics()
+                        .getValueAt("vds.datastored.bucket_space.buckets_total", Map.of("bucketSpace", "default"))
+                        .map(Metrics.Value::getLast),
+                equalTo(Optional.of(129L)));
+        assertThat(hostInfo.getMetrics()
+                        .getValueAt("vds.datastored.bucket_space.buckets_total", Map.of("bucketSpace", "global"))
+                        .map(Metrics.Value::getLast),
+                equalTo(Optional.of(0L)));
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/HostInfoTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/HostInfoTest.java
@@ -10,12 +10,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HostInfoTest {
 
@@ -49,11 +52,16 @@ public class HostInfoTest {
         assertThat(storageNodeList.size(), is(2));
         assertThat(storageNodeList.get(0).getIndex(), is(0));
         List<Metrics.Metric> metrics = hostInfo.getMetrics().getMetrics();
-        assertThat(metrics.size(), is(2));
-        Metrics.Value value = metrics.get(0).getValue();
-        assertThat(value.getLast(), is(5095L));
+        assertThat(metrics.size(), is(4));
+        assertThat(metrics.get(0).getValue().getLast(), is(5095L));
         assertThat(metrics.get(0).getName(), equalTo("vds.datastored.alldisks.buckets"));
+        assertThat(metrics.get(3).getValue().getLast(), is(129L));
+        assertThat(metrics.get(3).getName(), equalTo("vds.datastored.bucket_space.buckets_total"));
         assertThat(hostInfo.getClusterStateVersionOrNull(), is(123));
+
+        Optional<Metrics.Value> value = hostInfo.getMetrics()
+                .getValueAt("vds.datastored.bucket_space.buckets_total", Map.of("bucketSpace", "default"));
+        assertThat(value.map(Metrics.Value::getLast), equalTo(Optional.of(129L)));
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/NodeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/NodeTest.java
@@ -121,7 +121,7 @@ public class NodeTest extends StateRestApiTest {
     public void testNodeNotSeenInSlobrok() throws Exception {
         setUp(true);
         ContentCluster old = music.context.cluster;
-        music.context.cluster = new ContentCluster(old.getName(), old.getConfiguredNodes().values(), old.getDistribution(), 0, 0.0);
+        music.context.cluster = new ContentCluster(old.getName(), old.getConfiguredNodes().values(), old.getDistribution(), 0, 0.0, true);
         NodeState currentState = new NodeState(NodeType.STORAGE, State.DOWN);
         currentState.setDescription("Not seen");
         music.context.currentConsolidatedState.setNodeState(new Node(NodeType.STORAGE, 1), currentState);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
@@ -42,7 +42,8 @@ public abstract class StateRestApiTest {
         {
             Set<ConfiguredNode> nodes = FleetControllerTest.toNodes(0, 1, 2, 3);
             ContentCluster cluster = new ContentCluster(
-                    "books", nodes, distribution, 6 /* minStorageNodesUp*/, 0.9, /* minRatioOfStorageNodesUp */true);
+                    "books", nodes, distribution, 6 /* minStorageNodesUp*/, 0.9 /* minRatioOfStorageNodesUp */,
+                    true /* determineBucketsFromBucketSpaceMetric */);
             initializeCluster(cluster, nodes);
             AnnotatedClusterState baselineState = AnnotatedClusterState.withoutAnnotations(ClusterState.stateFromString("distributor:4 storage:4"));
             Map<String, AnnotatedClusterState> bucketSpaceStates = new HashMap<>();
@@ -56,7 +57,8 @@ public abstract class StateRestApiTest {
             Set<ConfiguredNode> nodesInSlobrok = FleetControllerTest.toNodes(1, 3, 5, 7);
 
             ContentCluster cluster = new ContentCluster(
-                    "music", nodes, distribution, 4 /* minStorageNodesUp*/, 0.0, /* minRatioOfStorageNodesUp */true);
+                    "music", nodes, distribution, 4 /* minStorageNodesUp*/, 0.0 /* minRatioOfStorageNodesUp */,
+                    true /* determineBucketsFromBucketSpaceMetric */);
             if (dontInitializeNode2) {
                 // TODO: this skips initialization of node 2 to fake that it is not answering
                 // which really leaves us in an illegal state

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
@@ -42,7 +42,7 @@ public abstract class StateRestApiTest {
         {
             Set<ConfiguredNode> nodes = FleetControllerTest.toNodes(0, 1, 2, 3);
             ContentCluster cluster = new ContentCluster(
-                    "books", nodes, distribution, 6 /* minStorageNodesUp*/, 0.9 /* minRatioOfStorageNodesUp */);
+                    "books", nodes, distribution, 6 /* minStorageNodesUp*/, 0.9, /* minRatioOfStorageNodesUp */true);
             initializeCluster(cluster, nodes);
             AnnotatedClusterState baselineState = AnnotatedClusterState.withoutAnnotations(ClusterState.stateFromString("distributor:4 storage:4"));
             Map<String, AnnotatedClusterState> bucketSpaceStates = new HashMap<>();
@@ -56,7 +56,7 @@ public abstract class StateRestApiTest {
             Set<ConfiguredNode> nodesInSlobrok = FleetControllerTest.toNodes(1, 3, 5, 7);
 
             ContentCluster cluster = new ContentCluster(
-                    "music", nodes, distribution, 4 /* minStorageNodesUp*/, 0.0 /* minRatioOfStorageNodesUp */);
+                    "music", nodes, distribution, 4 /* minStorageNodesUp*/, 0.0, /* minRatioOfStorageNodesUp */true);
             if (dontInitializeNode2) {
                 // TODO: this skips initialization of node 2 to fake that it is not answering
                 // which really leaves us in an illegal state

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -57,6 +57,7 @@ public interface ModelContext {
         // TODO: Remove temporary default implementation
         default Optional<TlsSecrets> tlsSecrets() { return Optional.empty(); }
         double defaultTermwiseLimit();
+        boolean useBucketSpaceMetric();
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -58,6 +58,7 @@ public class TestProperties implements ModelContext.Properties {
     @Override public boolean useDedicatedNodeForLogserver() { return useDedicatedNodeForLogserver; }
     @Override public Optional<TlsSecrets> tlsSecrets() { return tlsSecrets; }
     @Override public double defaultTermwiseLimit() { return defaultTermwiseLimit; }
+    @Override public boolean useBucketSpaceMetric() { return true; }
 
     public TestProperties setDefaultTermwiseLimit(double limit) {
         defaultTermwiseLimit = limit;

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
@@ -40,6 +40,8 @@ public class ClusterControllerConfig extends AbstractConfigProducer implements F
                 bucketSplittingMinimumBits = clusterTuning.childAsInteger("bucket-splitting.minimum-bits");
             }
 
+            boolean useBucketSpaceMetric = deployState.getProperties().useBucketSpaceMetric();
+
             if (tuning != null) {
                 return new ClusterControllerConfig(ancestor, clusterName,
                         tuning.childAsDuration("init-progress-time"),
@@ -49,10 +51,11 @@ public class ClusterControllerConfig extends AbstractConfigProducer implements F
                         tuning.childAsDouble("min-distributor-up-ratio"),
                         tuning.childAsDouble("min-storage-up-ratio"),
                         bucketSplittingMinimumBits,
-                        minNodeRatioPerGroup);
+                        minNodeRatioPerGroup,
+                        useBucketSpaceMetric);
             } else {
                 return new ClusterControllerConfig(ancestor, clusterName, null, null, null, null, null, null,
-                        bucketSplittingMinimumBits, minNodeRatioPerGroup);
+                        bucketSplittingMinimumBits, minNodeRatioPerGroup, useBucketSpaceMetric);
             }
         }
     }
@@ -66,6 +69,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer implements F
     Double minStorageUpRatio;
     Integer minSplitBits;
     private Double minNodeRatioPerGroup;
+    private boolean useBucketSpaceMetric;
 
     // TODO refactor; too many args
     private ClusterControllerConfig(AbstractConfigProducer parent,
@@ -77,7 +81,8 @@ public class ClusterControllerConfig extends AbstractConfigProducer implements F
                                     Double minDistributorUpRatio,
                                     Double minStorageUpRatio,
                                     Integer minSplitBits,
-                                    Double minNodeRatioPerGroup) {
+                                    Double minNodeRatioPerGroup,
+                                    boolean useBucketSpaceMetric) {
         super(parent, "fleetcontroller");
 
         this.clusterName = clusterName;
@@ -89,6 +94,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer implements F
         this.minStorageUpRatio = minStorageUpRatio;
         this.minSplitBits = minSplitBits;
         this.minNodeRatioPerGroup = minNodeRatioPerGroup;
+        this.useBucketSpaceMetric = useBucketSpaceMetric;
     }
 
     @Override
@@ -105,6 +111,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer implements F
         builder.index(0);
         builder.cluster_name(clusterName);
         builder.fleet_controller_count(getChildren().size());
+        builder.determine_buckets_from_bucket_space_metric(useBucketSpaceMetric);
 
         if (initProgressTime != null) {
             builder.init_progress_time((int) initProgressTime.getMilliSeconds());

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -178,3 +178,11 @@ min_merge_completion_ratio double default=1.0
 ## activation may happen at wildly different times throughout the cluster. The 2 phase
 ## transition logic aims to minimize the window of time where active states diverge.
 enable_two_phase_cluster_state_transitions bool default=false
+
+## Determines which metric will be used to decide whether a content node manages
+## zero buckets, when deciding whether it can be set permanently down (typically
+## to be removed from the application).
+## If true, use vds.datastored.bucket_space.buckets_total (new), otherwise use
+## vds.datastored.alldisks.buckets (legacy).
+## This setting is intended to be used to safely roll out the new metric.
+determine_buckets_from_bucket_space_metric bool default=true

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -132,6 +132,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean useAdaptiveDispatch;
         private final Optional<TlsSecrets> tlsSecrets;
         private final double defaultTermwiseLimit;
+        private final boolean useBucketSpaceMetric;
 
         public Properties(ApplicationId applicationId,
                           boolean multitenantFromConfig,
@@ -161,6 +162,8 @@ public class ModelContextImpl implements ModelContext {
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             this.tlsSecrets = tlsSecrets;
             defaultTermwiseLimit = Flags.DEFAULT_TERM_WISE_LIMIT.bindTo(flagSource)
+                    .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
+            this.useBucketSpaceMetric = Flags.USE_BUCKET_SPACE_METRIC.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
         }
 
@@ -209,6 +212,9 @@ public class ModelContextImpl implements ModelContext {
 
         @Override
         public double defaultTermwiseLimit() { return defaultTermwiseLimit; }
+
+        @Override
+        public boolean useBucketSpaceMetric() { return useBucketSpaceMetric; }
     }
 
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -87,7 +87,7 @@ public class Flags {
             "use-bucket-space-metric", true,
             "Whether to use vds.datastored.bucket_space.buckets_total (true) instead of " +
             "vds.datastored.alldisks.buckets (false, legacy).",
-            "Takes efefct on the next deployment of the application",
+            "Takes effect on the next deployment of the application",
             APPLICATION_ID);
 
     public static final UnboundBooleanFlag INCLUDE_SIS_IN_TRUSTSTORE = defineFeatureFlag(

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -83,6 +83,13 @@ public class Flags {
             "Takes effect on next node agent tick. Change is orchestrated, but does NOT require container restart",
             HOSTNAME, APPLICATION_ID);
 
+    public static final UnboundBooleanFlag USE_BUCKET_SPACE_METRIC = defineFeatureFlag(
+            "use-bucket-space-metric", true,
+            "Whether to use vds.datastored.bucket_space.buckets_total (true) instead of " +
+            "vds.datastored.alldisks.buckets (false, legacy).",
+            "Takes efefct on the next deployment of the application",
+            APPLICATION_ID);
+
     public static final UnboundBooleanFlag INCLUDE_SIS_IN_TRUSTSTORE = defineFeatureFlag(
             "include-sis-in-truststore", false,
             "Whether to use the trust store backed by Athenz and (in public) Service Identity certificates in " +

--- a/protocols/getnodestate/host_info.json
+++ b/protocols/getnodestate/host_info.json
@@ -30,6 +30,40 @@
                     "last": 3069833
                 },
                 "dimensions": {}
+            },
+            {
+                "name":"vds.datastored.bucket_space.buckets_total",
+                "description":"Total number buckets present in the bucket space (ready + not ready)",
+                "values":
+                {
+                    "average":0.0,
+                    "sum":0.0,
+                    "count":1,
+                    "rate":0.016666,
+                    "min":0,
+                    "max":0,
+                    "last":0
+                },
+                "dimensions":
+                {
+                    "bucketSpace":"global"
+                }
+            },
+            {
+                "name": "vds.datastored.bucket_space.buckets_total",
+                "description": "Total number buckets present in the bucket space (ready + not ready)",
+                "values": {
+                    "average": 129.0,
+                    "sum": 129.0,
+                    "count": 1,
+                    "rate": 0.016666,
+                    "min": 129,
+                    "max": 129,
+                    "last": 129
+                },
+                "dimensions": {
+                    "bucketSpace": "default"
+                }
             }
         ]
     },

--- a/protocols/getnodestate/slow_host_info.json
+++ b/protocols/getnodestate/slow_host_info.json
@@ -9,6 +9,40 @@
     "values":
     [
       {
+        "name":"vds.datastored.bucket_space.buckets_total",
+        "description":"Total number buckets present in the bucket space (ready + not ready)",
+        "values":
+        {
+          "average":0.0,
+          "sum":0.0,
+          "count":1,
+          "rate":0.016666,
+          "min":0,
+          "max":0,
+          "last":0
+        },
+        "dimensions":
+        {
+          "bucketSpace":"global"
+        }
+      },
+      {
+        "name": "vds.datastored.bucket_space.buckets_total",
+        "description": "Total number buckets present in the bucket space (ready + not ready)",
+        "values": {
+          "average": 129.0,
+          "sum": 129.0,
+          "count": 1,
+          "rate": 0.016666,
+          "min": 129,
+          "max": 129,
+          "last": 129
+        },
+        "dimensions": {
+          "bucketSpace": "default"
+        }
+      },
+      {
         "name":"vds.datastored.alldisks.buckets",
         "description":"buckets managed",
         "values":


### PR DESCRIPTION
This makes the Cluster Controller use the
vds.datastored.bucket_space.buckets_total, dimension bucketSpace=default, to
determine whether a content node manages zero buckets, and if so, will allow
the node to go permanently down. This is used when a node is retiring, and it
is to be removed from the application.

The change is guarded by the use-bucket-space-metric, default true. If the new
metric doesn't work as expected, we can revert to using the current/old metric
by flipping the flag. The flag can be controlled per application.