### PR TITLE
Add bindings for requests that should be sent to tester containers

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/ProxyResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/ProxyResponse.java
@@ -11,7 +11,8 @@ import java.util.Optional;
 /**
  * Proxies response back to client, keeps Content-Type header if it is present
  *
- * @author Ola Aunrønning
+ * @author olaa
+ * @author freva
  */
 class ProxyResponse extends HttpResponse {
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
@@ -1,0 +1,75 @@
+// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server.http;
+
+import ai.vespa.util.http.VespaHttpClientBuilder;
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.log.LogLevel;
+import com.yahoo.yolean.Exceptions;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.logging.Logger;
+
+/**
+ * @author musum
+ */
+public class TesterClient {
+
+    private final HttpClient httpClient = VespaHttpClientBuilder.create().build();
+    private static final Logger logger = Logger.getLogger(TesterClient.class.getName());
+
+    public HttpResponse getStatus(String testerHostname, int port) {
+        URI testerUri;
+        try {
+            testerUri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost(testerHostname)
+                    .setPort(port)
+                    .setPath("/tester/v1/status")
+                    .build();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return execute(new HttpGet(testerUri), "Failed to get tester status");
+    }
+
+    public HttpResponse getLog(String testerHostname, int port, Long after) {
+        URI testerUri;
+        try {
+            testerUri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost(testerHostname)
+                    .setPort(port)
+                    .setPath("/tester/v1/log")
+                    .addParameter("after", String.valueOf(after))
+                    .build();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return execute(new HttpGet(testerUri), "Failed to get tester logs");
+    }
+
+    public HttpResponse startTests(String testerHostname, String suite, String config) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+
+    private HttpResponse execute(HttpUriRequest request, String messageIfRequestFails) {
+        // TODO: Change log level to DEBUG
+        logger.log(LogLevel.INFO, "Sending request to tester container " + request.getURI().toString());
+        try {
+            return new ProxyResponse(httpClient.execute(request));
+        } catch (IOException e) {
+            logger.warning(messageIfRequestFails + ": " + Exceptions.toMessageString(e));
+            return HttpErrorResponse.internalServerError(Exceptions.toMessageString(e));
+        }
+    }
+
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
@@ -27,7 +27,7 @@ public class TesterClient {
         URI testerUri;
         try {
             testerUri = new URIBuilder()
-                    .setScheme("http")
+                    .setScheme("https")
                     .setHost(testerHostname)
                     .setPort(port)
                     .setPath("/tester/v1/status")
@@ -43,7 +43,7 @@ public class TesterClient {
         URI testerUri;
         try {
             testerUri = new URIBuilder()
-                    .setScheme("http")
+                    .setScheme("https")
                     .setHost(testerHostname)
                     .setPort(port)
                     .setPath("/tester/v1/log")

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -323,7 +323,8 @@ public class ApplicationRepositoryTest {
                                          orchestrator,
                                          new ConfigserverConfig(new ConfigserverConfig.Builder()),
                                          new MockLogRetriever(),
-                                         clock);
+                                         clock,
+                                         new MockTesterClient());
     }
 
     private PrepareResult prepareAndActivateApp(File application) throws IOException {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/MockTesterClient.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/MockTesterClient.java
@@ -1,0 +1,52 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server;
+
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.vespa.config.server.http.TesterClient;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author hmusum
+ */
+public class MockTesterClient extends TesterClient {
+
+    @Override
+    public HttpResponse getStatus(String testerHostname, int port) {
+        return new MockStatusResponse();
+    }
+
+    @Override
+    public HttpResponse getLog(String testerHostname, int port, Long after) {
+        return new MockLogResponse();
+    }
+
+    private static class MockStatusResponse extends HttpResponse {
+
+        private MockStatusResponse() {
+            super(200);
+        }
+
+        @Override
+        public void render(OutputStream outputStream) throws IOException {
+            outputStream.write("OK".getBytes(StandardCharsets.UTF_8));
+        }
+
+    }
+
+    private static class MockLogResponse extends HttpResponse {
+
+        private MockLogResponse() {
+            super(200);
+        }
+
+        @Override
+        public void render(OutputStream outputStream) throws IOException {
+            outputStream.write("log".getBytes(StandardCharsets.UTF_8));
+        }
+
+    }
+
+}

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -29,6 +29,7 @@ import com.yahoo.component.Version;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.config.server.ApplicationRepository;
+import com.yahoo.vespa.config.server.MockTesterClient;
 import com.yahoo.vespa.config.server.TestComponentRegistry;
 import com.yahoo.vespa.config.server.TimeoutBudget;
 import com.yahoo.vespa.config.server.application.OrchestratorMock;
@@ -135,7 +136,8 @@ public class DeployTester {
                                                           new OrchestratorMock(),
                                                           configserverConfig,
                                                           new LogRetriever(),
-                                                          clock);
+                                                          clock,
+                                                          new MockTesterClient());
     }
 
     public Tenant tenant() {


### PR DESCRIPTION
Add bindings to be able to send requests to /tester/v1 API on tester
containers (not fully implemented yet).
