### PR TITLE
Minor API fix

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -1075,8 +1075,8 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
                    .map(type -> new JobId(instance.id(), type))
                    .map(status.jobSteps()::get)
                    .ifPresent(stepStatus -> {
-                       response.setString("platform", deployment.version().toFullString());
-                       toSlime(deployment.applicationVersion(), response.setObject("applicationVersion"));
+                       JobControllerApiHandlerHelper.applicationVersionToSlime(
+                               response.setObject("applicationVersion"), deployment.applicationVersion());
                        if (!status.jobsToRun().containsKey(stepStatus.job().get()))
                            response.setString("status", "complete");
                        else if (stepStatus.readyAt(instance.change()).map(controller.clock().instant()::isBefore).orElse(false))

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -9,11 +9,13 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.restapi.MessageResponse;
+import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
 import com.yahoo.vespa.hosted.controller.Application;
-import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.NotExistsException;
 import com.yahoo.vespa.hosted.controller.api.integration.LogEntry;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
@@ -35,8 +37,6 @@ import com.yahoo.vespa.hosted.controller.deployment.RunLog;
 import com.yahoo.vespa.hosted.controller.deployment.RunStatus;
 import com.yahoo.vespa.hosted.controller.deployment.Step;
 import com.yahoo.vespa.hosted.controller.deployment.Versions;
-import com.yahoo.restapi.MessageResponse;
-import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 
 import java.net.URI;
@@ -404,7 +404,7 @@ class JobControllerApiHandlerHelper {
         versions.sourceApplication().ifPresent(version -> applicationVersionToSlime(runObject.setObject("currentApplication"), version));
     }
 
-    private static void applicationVersionToSlime(Cursor versionObject, ApplicationVersion version) {
+    static void applicationVersionToSlime(Cursor versionObject, ApplicationVersion version) {
         versionObject.setString("hash", version.id());
         if (version.isUnknown())
             return;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
@@ -23,10 +23,10 @@
   "gitRepository": "repository1",
   "gitBranch": "master",
   "gitCommit": "commit1",
-  "platform": "6.1.0",
   "applicationVersion": {
-    "buildNumber": 1,
-    "hash": "1.0.1-commit1", "source": {
+    "hash": "1.0.1-commit1",
+    "build": 1,
+    "source": {
       "gitRepository": "repository1",
       "gitBranch": "master",
       "gitCommit": "commit1"

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -26,10 +26,10 @@
       "lastUpdated": "(ignore)"
     }
   ],
-  "platform": "6.1.0",
   "applicationVersion": {
-    "buildNumber": 1,
-    "hash": "1.0.1-commit1", "source": {
+    "hash": "1.0.1-commit1",
+    "build": 1,
+    "source": {
       "gitRepository": "repository1",
       "gitBranch": "master",
       "gitCommit": "commit1"

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance-without-change-multiple-deployments.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance-without-change-multiple-deployments.json
@@ -253,10 +253,10 @@
           "lastUpdated": "(ignore)"
         }
       ],
-      "platform": "6.1.0",
       "applicationVersion": {
-        "buildNumber": 1,
-        "hash": "1.0.1-commit1", "source": {
+        "hash": "1.0.1-commit1",
+        "build": 1,
+        "source": {
           "gitRepository": "repository1",
           "gitBranch": "master",
           "gitCommit": "commit1"
@@ -283,10 +283,10 @@
           "lastUpdated": "(ignore)"
         }
       ],
-      "platform": "6.1.0",
       "applicationVersion": {
-        "buildNumber": 1,
-        "hash": "1.0.1-commit1", "source": {
+        "hash": "1.0.1-commit1",
+        "build": 1,
+        "source": {
           "gitRepository": "repository1",
           "gitBranch": "master",
           "gitCommit": "commit1"

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -29,10 +29,10 @@
       "lastUpdated": "(ignore)"
     }
   ],
-  "platform": "6.1.0",
   "applicationVersion": {
-    "buildNumber": 1,
-    "hash": "1.0.1-commit1", "source": {
+    "hash": "1.0.1-commit1",
+    "build": 1,
+    "source": {
       "gitRepository": "repository1",
       "gitBranch": "master",
       "gitCommit": "commit1"

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/recursive-root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/recursive-root.json
@@ -1,3 +1,4 @@
+
 [
   @include(tenant1-recursive.json),
   @include(tenant2.json)


### PR DESCRIPTION
Removes `platform` - redundant, will use `version` instead.
Renames `buildNumber` to `build` so the object is the same as the one returned by job APIs