### PR TITLE
Stop skipping install of perl-Net-INET6Glue on CentOS 8.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -116,9 +116,7 @@ Requires: perl-IO-Socket-IP
 Requires: perl-JSON
 Requires: perl-libwww-perl
 Requires: perl-LWP-Protocol-https
-%if !(0%{?centos} && 0%{?el8})
 Requires: perl-Net-INET6Glue
-%endif
 Requires: perl-Pod-Usage
 Requires: perl-URI
 Requires: valgrind


### PR DESCRIPTION
@geirst : please review
