### PR TITLE
Since-timestamp on Orc suspended status

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
@@ -149,7 +149,7 @@ public class OrchestratorImpl implements Orchestrator {
         OrchestratorContext context = OrchestratorContext.createContextForSingleAppOp(clock);
         try (MutableStatusRegistry statusRegistry = statusService
                 .lockApplicationInstance_forCurrentThreadOnly(context, appInstance.reference())) {
-            HostStatus currentHostState = statusRegistry.getHostStatus(hostName);
+            HostStatus currentHostState = statusRegistry.getHostInfo(hostName).status();
 
             if (HostStatus.NO_REMARKS == currentHostState) {
                 return;
@@ -318,7 +318,7 @@ public class OrchestratorImpl implements Orchestrator {
     }
 
     private HostStatus getNodeStatus(ApplicationInstanceReference applicationRef, HostName hostName) {
-        return statusService.getHostStatus(applicationRef, hostName);
+        return statusService.getHostInfo(applicationRef, hostName).status();
     }
 
     private void setApplicationStatus(ApplicationId appId, ApplicationInstanceStatus status) 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfo.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfo.java
@@ -16,8 +16,8 @@ public class HostInfo {
     private final Optional<Instant> suspendedSince;
 
     public static HostInfo createSuspended(HostStatus status, Instant suspendedSince) {
-        if (status == HostStatus.NO_REMARKS) {
-            throw new IllegalArgumentException("NO_REMARKS is not a suspended-status");
+        if (!status.isSuspended()) {
+            throw new IllegalArgumentException(status + " is not a suspended-status");
         }
 
         return new HostInfo(status, Optional.of(suspendedSince));
@@ -35,8 +35,8 @@ public class HostInfo {
     public HostStatus status() { return status; }
 
     /**
-     * The instant the host status was set to != NO_REMARKS. Is preserved when transitioning
-     * between non-NO_REMARKS states. Returns empty if and only if NO_REMARKS.
+     * The instant the host status was set to a suspended status. Is preserved when transitioning
+     * between suspended statuses. Returns empty if and only if NO_REMARKS.
      */
     public Optional<Instant> suspendedSince() { return suspendedSince; }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfo.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfo.java
@@ -1,0 +1,64 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * ZooKeeper-backed information Host status information about a host.
+ *
+ * @author hakonhall
+ */
+// @Immutable
+public class HostInfo {
+    private final HostStatus status;
+    private final Optional<Instant> suspendedSince;
+
+    public static HostInfo createSuspended(HostStatus status, Instant suspendedSince) {
+        if (status == HostStatus.NO_REMARKS) {
+            throw new IllegalArgumentException("NO_REMARKS is not a suspended-status");
+        }
+
+        return new HostInfo(status, Optional.of(suspendedSince));
+    }
+
+    public static HostInfo createNoRemarks() {
+        return new HostInfo(HostStatus.NO_REMARKS, Optional.empty());
+    }
+
+    private HostInfo(HostStatus status, Optional<Instant> suspendedSince) {
+        this.status = Objects.requireNonNull(status);
+        this.suspendedSince = Objects.requireNonNull(suspendedSince);
+    }
+
+    public HostStatus status() { return status; }
+
+    /**
+     * The instant the host status was set to != NO_REMARKS. Is preserved when transitioning
+     * between non-NO_REMARKS states. Returns empty if and only if NO_REMARKS.
+     */
+    public Optional<Instant> suspendedSince() { return suspendedSince; }
+
+    @Override
+    public String toString() {
+        return "HostInfo{" +
+                ", status=" + status +
+                ", suspendedSince=" + suspendedSince +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HostInfo hostInfo = (HostInfo) o;
+        return status == hostInfo.status &&
+                suspendedSince.equals(hostInfo.suspendedSince);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, suspendedSince);
+    }
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfos.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfos.java
@@ -22,7 +22,7 @@ public class HostInfos {
     /** Get all suspended hostnames. */
     public Set<HostName> suspendedHostsnames() {
         return hostInfos.entrySet().stream()
-                .filter(entry -> entry.getValue().status() != HostStatus.NO_REMARKS)
+                .filter(entry -> entry.getValue().status().isSuspended())
                 .map(entry -> entry.getKey())
                 .collect(Collectors.toSet());
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfos.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfos.java
@@ -1,0 +1,34 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status;
+
+import com.yahoo.vespa.applicationmodel.HostName;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Collection of suspended hosts.
+ *
+ * @author hakonhall
+ */
+public class HostInfos {
+    private final Map<HostName, HostInfo> hostInfos;
+
+    public HostInfos(Map<HostName, HostInfo> hostInfos) {
+        this.hostInfos = Map.copyOf(hostInfos);
+    }
+
+    /** Get all suspended hostnames. */
+    public Set<HostName> suspendedHostsnames() {
+        return hostInfos.entrySet().stream()
+                .filter(entry -> entry.getValue().status() != HostStatus.NO_REMARKS)
+                .map(entry -> entry.getKey())
+                .collect(Collectors.toSet());
+    }
+
+    /** Get host info for hostname, returning a NO_REMARKS HostInfo if unknown. */
+    public HostInfo get(HostName hostname) {
+        return hostInfos.getOrDefault(hostname, HostInfo.createNoRemarks());
+    }
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfosCache.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfosCache.java
@@ -1,0 +1,57 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status;
+
+import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
+import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.curator.Curator;
+import com.yahoo.vespa.curator.recipes.CuratorCounter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author hakonhall
+ */
+public class HostInfosCache implements HostInfosService {
+    final static String HOST_STATUS_CACHE_COUNTER_PATH = "/vespa/host-status-service-cache-counter";
+
+    private final CuratorCounter counter;
+    private final HostInfosService wrappedService;
+
+    private final AtomicLong cacheGeneration;
+    private final Map<ApplicationInstanceReference, HostInfos> suspendedHosts = new ConcurrentHashMap<>();
+
+    HostInfosCache(Curator curator, HostInfosService wrappedService) {
+        this.counter = new CuratorCounter(curator, HOST_STATUS_CACHE_COUNTER_PATH);
+        this.wrappedService = wrappedService;
+        this.cacheGeneration = new AtomicLong(counter.get());
+    }
+
+    @Override
+    public HostInfos getHostInfos(ApplicationInstanceReference application) {
+        long newCacheGeneration = counter.get();
+        if (cacheGeneration.getAndSet(newCacheGeneration) != newCacheGeneration) {
+            suspendedHosts.clear();
+        }
+
+        return suspendedHosts.computeIfAbsent(application, wrappedService::getHostInfos);
+    }
+
+    @Override
+    public boolean setHostStatus(ApplicationInstanceReference application, HostName hostName, HostStatus hostStatus) {
+        boolean isException = true;
+        boolean modified = false;
+        try {
+            modified = wrappedService.setHostStatus(application, hostName, hostStatus);
+            isException = false;
+        } finally {
+            if (modified || isException) {
+                // ensure the next get, on any config server, will repopulate the cache from zk.
+                counter.next();
+            }
+        }
+
+        return modified;
+    }
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfosService.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfosService.java
@@ -1,0 +1,15 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status;
+
+import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
+import com.yahoo.vespa.applicationmodel.HostName;
+
+/**
+ * @author hakonhall
+ */
+interface HostInfosService {
+    HostInfos getHostInfos(ApplicationInstanceReference application);
+
+    /** Returns false if it is known that the operation was a no-op. */
+    boolean setHostStatus(ApplicationInstanceReference application, HostName hostName, HostStatus hostStatus);
+}

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostStatus.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostStatus.java
@@ -2,11 +2,20 @@
 package com.yahoo.vespa.orchestrator.status;
 
 /**
- * Enumeration of the different status' a host can have.
+ * Enumeration of the different statuses a host can have.
  *
  * @author oyving
  */
 public enum HostStatus {
+    /** The services on the host is supposed to be up. */
     NO_REMARKS,
-    ALLOWED_TO_BE_DOWN;
+
+    /** The services on the host is allowed to be down. */
+    ALLOWED_TO_BE_DOWN,
+
+    /**
+     * Same as ALLOWED_TO_BE_DOWN, but in addition, it is expected
+     * the host may be removed from its application at any moment.
+     */
+    PERMANENTLY_DOWN;
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostStatus.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostStatus.java
@@ -8,14 +8,19 @@ package com.yahoo.vespa.orchestrator.status;
  */
 public enum HostStatus {
     /** The services on the host is supposed to be up. */
-    NO_REMARKS,
+    NO_REMARKS(false),
 
     /** The services on the host is allowed to be down. */
-    ALLOWED_TO_BE_DOWN,
+    ALLOWED_TO_BE_DOWN(true),
 
     /**
      * Same as ALLOWED_TO_BE_DOWN, but in addition, it is expected
      * the host may be removed from its application at any moment.
      */
-    PERMANENTLY_DOWN;
+    PERMANENTLY_DOWN(true);
+
+    private final boolean suspended;
+
+    HostStatus(boolean suspended) { this.suspended = suspended; }
+    public boolean isSuspended() { return suspended; }
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/MutableStatusRegistry.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/MutableStatusRegistry.java
@@ -19,10 +19,8 @@ public interface MutableStatusRegistry extends AutoCloseable {
      */
     ApplicationInstanceStatus getStatus();
 
-    /**
-     * Returns the status of the given host.
-     */
-    HostStatus getHostStatus(HostName hostName);
+    /** Returns the host info of the given host. */
+    HostInfo getHostInfo(HostName hostName);
 
     /**
      * Returns the set of all suspended hosts for this application.

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/StatusService.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/StatusService.java
@@ -64,15 +64,9 @@ public interface StatusService {
      */
     Function<ApplicationInstanceReference, Set<HostName>> getSuspendedHostsByApplication();
 
-    /**
-     * Returns the status of the given application. This is consistent if its lock is held.
-     */
+    /** Returns the status of the given application. This is consistent if its lock is held.*/
     ApplicationInstanceStatus getApplicationInstanceStatus(ApplicationInstanceReference application);
 
-
-    /**
-     * Returns the status of the given host, for the given application. This is consistent if the application's lock is held.
-     */
-    HostStatus getHostStatus(ApplicationInstanceReference application, HostName host);
-
+    /** Get host info for hostname in application. This is consistent if its lock is held. */
+    HostInfo getHostInfo(ApplicationInstanceReference applicationInstanceReference, HostName hostName);
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/ZookeeperStatusService.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/ZookeeperStatusService.java
@@ -45,7 +45,6 @@ public class ZookeeperStatusService implements StatusService {
 
     final static String HOST_STATUS_BASE_PATH = "/vespa/host-status-service";
     final static String APPLICATION_STATUS_BASE_PATH = "/vespa/application-status-service";
-    final static String HOST_STATUS_CACHE_COUNTER_PATH = "/vespa/host-status-service-cache-counter";
 
     private final Curator curator;
     private final HostInfosCache hostInfosCache;
@@ -307,7 +306,9 @@ public class ZookeeperStatusService implements StatusService {
         // Once that's true we can stop writing to hosts-allowed-down, remove this code, and all
         // data in hosts-allowed-down can be removed.
         Set<HostName> legacyHostsDown = hostsDownFor(application);
-        Map<HostName, HostInfo> legacyHostInfos = legacyHostsDown.stream().collect(Collectors.toMap(
+        Map<HostName, HostInfo> legacyHostInfos = legacyHostsDown.stream()
+                .filter(hostname -> !hostInfos.containsKey(hostname))
+                .collect(Collectors.toMap(
                 hostname -> hostname,
                 hostname -> {
                     Stat stat = uncheck(() -> curator.framework()

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/json/WireHostInfo.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/json/WireHostInfo.java
@@ -35,8 +35,8 @@ public class WireHostInfo {
     }
 
     public static byte[] serialize(HostInfo hostInfo) {
-        if (hostInfo.status() == HostStatus.NO_REMARKS) {
-            throw new IllegalArgumentException("Serialization of NO_REMARKS is not supported");
+        if (!hostInfo.status().isSuspended()) {
+            throw new IllegalArgumentException("Serialization of unsuspended status is not supported: " + hostInfo.status());
         }
 
         WireHostInfo wireHostInfo = new WireHostInfo();

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/json/WireHostInfo.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/json/WireHostInfo.java
@@ -1,0 +1,48 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.vespa.orchestrator.status.HostInfo;
+import com.yahoo.vespa.orchestrator.status.HostStatus;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Objects;
+
+import static com.yahoo.yolean.Exceptions.uncheck;
+
+/**
+ * Handles serialization/deserialization of HostInfo to/from byte array.
+ *
+ * @author hakonhall
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WireHostInfo {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @JsonProperty("status") public String status;
+    @JsonProperty("suspendedSince") public Long suspendedSinceInMillis;
+
+    public static HostInfo deserialize(byte[] bytes) {
+        String serializedString = new String(bytes, StandardCharsets.UTF_8);
+        WireHostInfo wireHostInfo = uncheck(() -> mapper.readValue(serializedString, WireHostInfo.class));
+        return HostInfo.createSuspended(HostStatus.valueOf(Objects.requireNonNull(wireHostInfo.status)),
+                                      Instant.ofEpochMilli(Objects.requireNonNull(wireHostInfo.suspendedSinceInMillis)));
+    }
+
+    public static byte[] serialize(HostInfo hostInfo) {
+        if (hostInfo.status() == HostStatus.NO_REMARKS) {
+            throw new IllegalArgumentException("Serialization of NO_REMARKS is not supported");
+        }
+
+        WireHostInfo wireHostInfo = new WireHostInfo();
+        wireHostInfo.status = hostInfo.status().name();
+        wireHostInfo.suspendedSinceInMillis = hostInfo.suspendedSince().get().toEpochMilli();
+
+        return uncheck(() -> mapper.writeValueAsBytes(wireHostInfo));
+    }
+}

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/status/HostInfoTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/status/HostInfoTest.java
@@ -1,0 +1,33 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status;
+
+import com.yahoo.jdisc.test.TestTimer;
+import com.yahoo.vespa.orchestrator.status.json.WireHostInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author hakonhall
+ */
+public class HostInfoTest {
+    private final TestTimer timer = new TestTimer();
+
+    @Before
+    public void setUp() {
+        timer.setMillis(3L);
+    }
+
+    @Test
+    public void equality() {
+        HostInfo info1 = HostInfo.createSuspended(HostStatus.ALLOWED_TO_BE_DOWN, timer.currentTime());
+        assertNotEquals(info1, HostInfo.createNoRemarks());
+        assertNotEquals(info1, HostInfo.createSuspended(HostStatus.PERMANENTLY_DOWN, timer.currentTime()));
+
+        byte[] serialized = WireHostInfo.serialize(info1);
+        HostInfo deserialized1 = WireHostInfo.deserialize(serialized);
+        assertEquals(info1, deserialized1);
+    }
+}

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/status/HostInfosCacheTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/status/HostInfosCacheTest.java
@@ -1,0 +1,56 @@
+// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.status;
+
+import com.yahoo.vespa.applicationmodel.ApplicationInstanceId;
+import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
+import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.applicationmodel.TenantId;
+import com.yahoo.vespa.curator.mock.MockCurator;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author hakonhall
+ */
+public class HostInfosCacheTest {
+    @Test
+    public void test() {
+        MockCurator curator = new MockCurator();
+        HostInfosService service = mock(HostInfosService.class);
+        HostInfosCache cache = new HostInfosCache(curator, service);
+
+        ApplicationInstanceReference application = new ApplicationInstanceReference(
+                new TenantId("tenantid"),
+                new ApplicationInstanceId("application:dev:region:default"));
+
+        HostInfos hostInfos = mock(HostInfos.class);
+        when(service.getHostInfos(application)).thenReturn(hostInfos);
+
+        // cache miss
+        HostInfos hostInfos1 = cache.getHostInfos(application);
+        verify(service, times(1)).getHostInfos(any());
+        assertSame(hostInfos1, hostInfos);
+
+        // cache hit
+        HostInfos hostInfos2 = cache.getHostInfos(application);
+        verify(service, times(1)).getHostInfos(any());
+        assertSame(hostInfos2, hostInfos);
+
+        when(service.setHostStatus(any(), any(), any())).thenReturn(true);
+        boolean modified = cache.setHostStatus(application, new HostName("hostname1"), HostStatus.ALLOWED_TO_BE_DOWN);
+        verify(service, times(1)).getHostInfos(any());
+        assertTrue(modified);
+
+        // cache miss
+        HostInfos hostInfos3 = cache.getHostInfos(application);
+        verify(service, times(2)).getHostInfos(any());
+        assertSame(hostInfos1, hostInfos);
+    }
+}


### PR DESCRIPTION
 - Introduce a new type of suspension status: PERMANENTLY_DOWN, which
   is set when a node is scheduled to be removed from the application.
   A normal resume call will NOT clear PERMANENTLY_DOWN.
 - Store a JSON for each suspended host: Contains status, and a since timestamp
   for the time when the node was suspended. The suspension timestamp
   is preserved when switching statuses between suspension statuses.
 - The JSON is stored in a new path, void of any zone. This means that
   we eventually can get rid of the zone-part of the application instance
   reference.