### PR TITLE
Support setting changing zone status in ConfigServer

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
@@ -67,14 +67,16 @@ public interface ConfigServer {
      *                     deployment in the shared routing layer
      * @param status       The new status
      */
-    // TODO(mpolden): Implement a zone-variant of this
     void setGlobalRotationStatus(DeploymentId deployment, String upstreamName, EndpointStatus status);
 
     /**
-     * Get the endpoint status for an app in one zone
+     * Set the new status for an entire zone.
      *
-     * @param deployment The application/zone pair
-     * @param endpoint The endpoint to modify
+     * @param zone the zone
+     * @param in whether to set zone status to 'in' or 'out'
+     */
+    void setGlobalRotationStatus(ZoneId zone, boolean in);
+
     /**
      * Get the endpoint status for an app in one zone.
      *
@@ -84,6 +86,14 @@ public interface ConfigServer {
      * @return The endpoint status with metadata
      */
     EndpointStatus getGlobalRotationStatus(DeploymentId deployment, String upstreamName);
+
+    /**
+     * Get the status for an entire zone.
+     *
+     * @param zone the zone
+     * @return whether the zone status is 'in'
+     */
+    boolean getGlobalRotationStatus(ZoneId zone);
 
     /** The node repository on this config server */
     NodeRepository nodeRepository();

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
@@ -60,23 +60,30 @@ public interface ConfigServer {
     List<String> getContentClusters(DeploymentId deployment);
 
     /**
-     * Set new status on en endpoint in one zone.
+     * Set new status for a endpoint of a single deployment.
      *
-     * @param deployment The application/zone pair
-     * @param endpoint The endpoint to modify
-     * @param status The new status with metadata
+     * @param deployment   The deployment to change
+     * @param upstreamName The upstream to modify. Upstream name is a unique identifier for the global route of a
+     *                     deployment in the shared routing layer
+     * @param status       The new status
      */
     // TODO(mpolden): Implement a zone-variant of this
-    void setGlobalRotationStatus(DeploymentId deployment, String endpoint, EndpointStatus status);
+    void setGlobalRotationStatus(DeploymentId deployment, String upstreamName, EndpointStatus status);
 
     /**
      * Get the endpoint status for an app in one zone
      *
      * @param deployment The application/zone pair
      * @param endpoint The endpoint to modify
+    /**
+     * Get the endpoint status for an app in one zone.
+     *
+     * @param deployment   The deployment to change
+     * @param upstreamName The upstream to query. Upstream name is a unique identifier for the global route of a
+     *                     deployment in the shared routing layer
      * @return The endpoint status with metadata
      */
-    EndpointStatus getGlobalRotationStatus(DeploymentId deployment, String endpoint);
+    EndpointStatus getGlobalRotationStatus(DeploymentId deployment, String upstreamName);
 
     /** The node repository on this config server */
     NodeRepository nodeRepository();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -407,8 +407,8 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
     }
 
     @Override
-    public void setGlobalRotationStatus(DeploymentId deployment, String endpoint, EndpointStatus status) {
-        endpoints.put(endpoint, status);
+    public void setGlobalRotationStatus(DeploymentId deployment, String upstreamName, EndpointStatus status) {
+        endpoints.put(upstreamName, status);
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -62,6 +62,7 @@ import static com.yahoo.config.provision.NodeResources.StorageType.remote;
 public class ConfigServerMock extends AbstractComponent implements ConfigServer {
 
     private final Map<DeploymentId, Application> applications = new LinkedHashMap<>();
+    private final Set<ZoneId> inactiveZones = new HashSet<>();
     private final Map<String, EndpointStatus> endpoints = new HashMap<>();
     private final NodeRepositoryMock nodeRepository = new NodeRepositoryMock();
     private final Map<DeploymentId, ServiceConvergence> serviceStatus = new HashMap<>();
@@ -412,9 +413,23 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
     }
 
     @Override
+    public void setGlobalRotationStatus(ZoneId zone, boolean in) {
+        if (in) {
+            inactiveZones.remove(zone);
+        } else {
+            inactiveZones.add(zone);
+        }
+    }
+
+    @Override
     public EndpointStatus getGlobalRotationStatus(DeploymentId deployment, String endpoint) {
         EndpointStatus result = new EndpointStatus(EndpointStatus.Status.in, "", "", 1497618757L);
         return endpoints.getOrDefault(endpoint, result);
+    }
+
+    @Override
+    public boolean getGlobalRotationStatus(ZoneId zone) {
+        return !inactiveZones.contains(zone);
     }
 
     @Override


### PR DESCRIPTION
Required for the controller to be able to change in/out status for applications
using rotation-based global routing.

With this the controller's `/routing/v1` can support manipulating status for
both policy-based and rotation-based global routing.

Depends on change in internal repo.