### PR TITLE
Unify routing control

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/GlobalRouting.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/GlobalRouting.java
@@ -80,6 +80,7 @@ public class GlobalRouting {
         operator,
         tenant,
         system,
+        unknown, // For compatibility old values from /routing/v1 on config server, which may contain a specific user name.
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -1,8 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.integration;
 
-import com.google.inject.Inject;
-import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.AthenzDomain;
@@ -27,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author mpolden
@@ -39,6 +38,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
     private SystemName system;
     private UpgradePolicy upgradePolicy = null;
     private Map<CloudName, UpgradePolicy> osUpgradePolicies = new HashMap<>();
+    private Set<ZoneApi> directlyRouted = Set.of();
 
     /**
      * This sets the default list of zones contained in this. If your test need a particular set of zones, use
@@ -55,6 +55,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
                 ZoneApiMock.fromId("prod.us-west-1"),
                 ZoneApiMock.fromId("prod.us-central-1"),
                 ZoneApiMock.fromId("prod.eu-west-1")));
+        setDirectlyRouted(Set.copyOf(this.zones));
     }
 
     public ZoneRegistryMock setDeploymentTimeToLive(ZoneId zone, Duration duration) {
@@ -91,6 +92,15 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
         return this;
     }
 
+    public ZoneRegistryMock setDirectlyRouted(ZoneApi... zones) {
+        return setDirectlyRouted(Set.of(zones));
+    }
+
+    public ZoneRegistryMock setDirectlyRouted(Set<ZoneApi> zones) {
+        directlyRouted = zones;
+        return this;
+    }
+
     @Override
     public SystemName system() {
         return system;
@@ -98,7 +108,7 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
 
     @Override
     public ZoneFilter zones() {
-        return ZoneFilterMock.from(List.copyOf(zones));
+        return ZoneFilterMock.from(zones, directlyRouted);
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/RoutingApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/RoutingApiTest.java
@@ -8,10 +8,14 @@ import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
 import com.yahoo.vespa.hosted.controller.restapi.ContainerTester;
 import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerTest;
+import com.yahoo.vespa.jdk8compat.List;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author mpolden
@@ -30,7 +34,7 @@ public class RoutingApiTest extends ControllerContainerTest {
     }
 
     @Test
-    public void requests() {
+    public void policy_based_routing() {
         var context = deploymentTester.newDeploymentContext();
 
         // Deploy application
@@ -47,7 +51,7 @@ public class RoutingApiTest extends ControllerContainerTest {
         // GET initial deployment status
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
                                               "", Request.Method.GET),
-                              new File("deployment-status-initial.json"));
+                              new File("policy/deployment-status-initial.json"));
 
         // POST sets deployment out
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
@@ -55,7 +59,7 @@ public class RoutingApiTest extends ControllerContainerTest {
                               "{\"message\":\"Set global routing status for tenant.application in prod.us-west-1 to 'out'\"}");
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
                                               "", Request.Method.GET),
-                              new File("deployment-status-out.json"));
+                              new File("policy/deployment-status-out.json"));
 
         // DELETE sets deployment in
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
@@ -63,12 +67,12 @@ public class RoutingApiTest extends ControllerContainerTest {
                               "{\"message\":\"Set global routing status for tenant.application in prod.us-west-1 to 'in'\"}");
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
                                               "", Request.Method.GET),
-                              new File("deployment-status-in.json"));
+                              new File("policy/deployment-status-in.json"));
 
         // GET initial zone status
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/environment/prod/region/us-west-1",
                                               "", Request.Method.GET),
-                              new File("zone-status-initial.json"));
+                              new File("policy/zone-status-initial.json"));
 
         // POST sets zone out
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/environment/prod/region/us-west-1",
@@ -76,7 +80,7 @@ public class RoutingApiTest extends ControllerContainerTest {
                               "{\"message\":\"Set global routing status for deployments in prod.us-west-1 to 'out'\"}");
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/environment/prod/region/us-west-1",
                                               "", Request.Method.GET),
-                              new File("zone-status-out.json"));
+                              new File("policy/zone-status-out.json"));
 
         // DELETE sets zone in
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/environment/prod/region/us-west-1",
@@ -84,7 +88,91 @@ public class RoutingApiTest extends ControllerContainerTest {
                               "{\"message\":\"Set global routing status for deployments in prod.us-west-1 to 'in'\"}");
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/environment/prod/region/us-west-1",
                                               "", Request.Method.GET),
-                              new File("zone-status-in.json"));
+                              new File("policy/zone-status-in.json"));
+    }
+
+    @Test
+    public void rotation_based_routing() {
+        // No zones support direct routing
+        deploymentTester.controllerTester().zoneRegistry().setDirectlyRouted(Set.of());
+        // Deploy application
+        var context = deploymentTester.newDeploymentContext();
+        var westZone = ZoneId.from("prod", "us-west-1");
+        var eastZone = ZoneId.from("prod", "us-east-3");
+        var applicationPackage = new ApplicationPackageBuilder()
+                .region(westZone.region())
+                .region(eastZone.region())
+                .endpoint("default", "qrs", eastZone.region().value(), westZone.region().value())
+                .build();
+        context.submit(applicationPackage).deploy();
+
+        assertNotEquals("Rotation is assigned", List.of(), context.instance().rotations());
+
+        // GET initial deployment status
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("rotation/deployment-status-initial.json"));
+
+        // POST sets deployment out
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.POST),
+                              "{\"message\":\"Set global routing status for tenant.application in prod.us-west-1 to 'out'\"}");
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("rotation/deployment-status-out.json"));
+
+        // DELETE sets deployment in
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.DELETE),
+                              "{\"message\":\"Set global routing status for tenant.application in prod.us-west-1 to 'in'\"}");
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("rotation/deployment-status-in.json"));
+
+        // GET initial zone status
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("rotation/zone-status-initial.json"));
+
+        // POST sets zone out
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/environment/prod/region/us-west-1",
+                                              "", Request.Method.POST),
+                              "{\"message\":\"Set global routing status for deployments in prod.us-west-1 to 'out'\"}");
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("rotation/zone-status-out.json"));
+
+        // DELETE sets zone in
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/environment/prod/region/us-west-1",
+                                              "", Request.Method.DELETE),
+                              "{\"message\":\"Set global routing status for deployments in prod.us-west-1 to 'in'\"}");
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("rotation/zone-status-in.json"));
+
+        // TODO(mpolden): Remove the following once a zone supports either of routing policy and rotation
+
+        // GET status with both policy and rotation assigned
+        context.addRoutingPolicy(westZone, true);
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("multi-status-initial.json"));
+
+        // POST sets deployment out
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.POST),
+                              "{\"message\":\"Set global routing status for tenant.application in prod.us-west-1 to 'out'\"}");
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("multi-status-out.json"));
+
+        // DELETE sets deployment in
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/inactive/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.DELETE),
+                              "{\"message\":\"Set global routing status for tenant.application in prod.us-west-1 to 'in'\"}");
+        tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
+                                              "", Request.Method.GET),
+                              new File("multi-status-in.json"));
     }
 
     @Test
@@ -92,7 +180,7 @@ public class RoutingApiTest extends ControllerContainerTest {
         // GET non-existent application
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/t1/application/a1/instance/default/environment/prod/region/us-west-1",
                                                    "", Request.Method.GET),
-                              "{\"error-code\":\"BAD_REQUEST\",\"message\":\"No such deployment: t1.a1 in prod.us-west-1\"}",
+                              "{\"error-code\":\"BAD_REQUEST\",\"message\":\"t1.a1 not found\"}",
                               400);
 
         // GET non-existent zone

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/multi-status-in.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/multi-status-in.json
@@ -1,0 +1,22 @@
+{
+  "deployments": [
+    {
+      "routingType": "rotation",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    },
+    {
+      "routingType": "policy",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/multi-status-initial.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/multi-status-initial.json
@@ -1,0 +1,22 @@
+{
+  "deployments": [
+    {
+      "routingType": "rotation",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    },
+    {
+      "routingType": "policy",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "system",
+      "changedAt": "(ignore)"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/multi-status-out.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/multi-status-out.json
@@ -1,0 +1,22 @@
+{
+  "deployments": [
+    {
+      "routingType": "rotation",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "out",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    },
+    {
+      "routingType": "policy",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "out",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/deployment-status-in.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/deployment-status-in.json
@@ -1,0 +1,13 @@
+{
+  "deployments": [
+    {
+      "routingType": "policy",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/deployment-status-initial.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/deployment-status-initial.json
@@ -1,8 +1,8 @@
 {
   "deployments": [
     {
+      "routingType": "policy",
       "instance": "tenant:application:default",
-      "cluster": "default",
       "environment": "prod",
       "region": "us-west-1",
       "status": "in",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/deployment-status-out.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/deployment-status-out.json
@@ -1,11 +1,11 @@
 {
   "deployments": [
     {
+      "routingType": "policy",
       "instance": "tenant:application:default",
-      "cluster": "default",
       "environment": "prod",
       "region": "us-west-1",
-      "status": "in",
+      "status": "out",
       "agent": "operator",
       "changedAt": "(ignore)"
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/zone-status-in.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/zone-status-in.json
@@ -1,4 +1,5 @@
 {
+  "routingType": "policy",
   "environment": "prod",
   "region": "us-west-1",
   "status": "in",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/zone-status-initial.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/zone-status-initial.json
@@ -1,4 +1,5 @@
 {
+  "routingType": "policy",
   "environment": "prod",
   "region": "us-west-1",
   "status": "in",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/zone-status-out.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/policy/zone-status-out.json
@@ -1,0 +1,8 @@
+{
+  "routingType": "policy",
+  "environment": "prod",
+  "region": "us-west-1",
+  "status": "out",
+  "agent": "operator",
+  "changedAt": "(ignore)"
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/deployment-status-in.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/deployment-status-in.json
@@ -1,0 +1,13 @@
+{
+  "deployments": [
+    {
+      "routingType": "rotation",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "operator",
+      "changedAt": "(ignore)"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/deployment-status-initial.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/deployment-status-initial.json
@@ -1,0 +1,13 @@
+{
+  "deployments": [
+    {
+      "routingType": "rotation",
+      "instance": "tenant:application:default",
+      "environment": "prod",
+      "region": "us-west-1",
+      "status": "in",
+      "agent": "unknown",
+      "changedAt": "(ignore)"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/deployment-status-out.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/deployment-status-out.json
@@ -1,8 +1,8 @@
 {
   "deployments": [
     {
+      "routingType": "rotation",
       "instance": "tenant:application:default",
-      "cluster": "default",
       "environment": "prod",
       "region": "us-west-1",
       "status": "out",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/zone-status-in.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/zone-status-in.json
@@ -1,0 +1,8 @@
+{
+  "routingType": "rotation",
+  "environment": "prod",
+  "region": "us-west-1",
+  "status": "in",
+  "agent": "operator",
+  "changedAt": "(ignore)"
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/zone-status-initial.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/zone-status-initial.json
@@ -1,0 +1,8 @@
+{
+  "routingType": "rotation",
+  "environment": "prod",
+  "region": "us-west-1",
+  "status": "in",
+  "agent": "operator",
+  "changedAt": "(ignore)"
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/zone-status-out.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/responses/rotation/zone-status-out.json
@@ -1,4 +1,5 @@
 {
+  "routingType": "rotation",
   "environment": "prod",
   "region": "us-west-1",
   "status": "out",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
@@ -262,7 +262,10 @@ public class RoutingPoliciesTest {
         var context = tester.newDeploymentContext("tenant1", "app1", "default");
         var emptyApplicationPackage = new ApplicationPackageBuilder().build();
         var zone = ZoneId.from("dev", "us-east-1");
-        tester.controllerTester().serviceRegistry().zoneRegistry().setZones(ZoneApiMock.from(zone.environment(), zone.region()));
+        var zoneApi = ZoneApiMock.from(zone.environment(), zone.region());
+        tester.controllerTester().serviceRegistry().zoneRegistry()
+              .setZones(zoneApi)
+              .setDirectlyRouted(zoneApi);
         tester.provisionLoadBalancers(1, context.instanceId(), zone);
 
         // Deploy to dev
@@ -282,7 +285,11 @@ public class RoutingPoliciesTest {
         var context = tester.newDeploymentContext("tenant1", "app1", "default");
         context.submit(applicationPackage).deploy();
         var zone = ZoneId.from("dev", "us-east-1");
-        tester.controllerTester().serviceRegistry().zoneRegistry().setZones(ZoneApiMock.from(zone.environment(), zone.region()));
+        var zoneApi = ZoneApiMock.from(zone.environment(), zone.region());
+        tester.controllerTester().serviceRegistry().zoneRegistry()
+              .setZones(zoneApi)
+              .setDirectlyRouted(zoneApi);
+
 
         // Deploy to dev under different instance
         var devInstance = context.application().id().instance("user");


### PR DESCRIPTION
Support global routing control of deployments using rotations as well. The
existing implementation of this is in internal repo and will be
removed/simplified.

FYI @oyving