### PR TITLE
avoid float-double conversion for join/mul and reduce/add

### DIFF
--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_view.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_view.cpp
@@ -301,7 +301,7 @@ DenseTensorView::join(join_fun_t function, const Tensor &arg) const
         return joinDenseTensors(*this, arg, "join", function);
     }
     if (function == eval::operation::Mul::f) {
-        return dense::generic_join(*this, arg, [](double a, double b) { return (a * b); });
+        return dense::generic_join(*this, arg, [](auto a, auto b) { return (a * b); });
     }
     if (function == eval::operation::Add::f) {
         return dense::generic_join(*this, arg, [](double a, double b) { return (a + b); });
@@ -323,7 +323,7 @@ DenseTensorView::reduce_all(join_fun_t op, const std::vector<vespalib::string> &
         return dense::reduce(*this, dims, [](double a, double b) { return (a * b);});
     }
     if (op == eval::operation::Add::f) {
-        return dense::reduce(*this, dims, [](double a, double b) { return (a + b);});
+        return dense::reduce(*this, dims, [](auto a, auto b) { return (a + b);});
     }
     return dense::reduce(*this, dims, op);
 }


### PR DESCRIPTION
A shot in the dark to see if it affects the under-performing float version of un-optimized matrix-matrix multiplication.

@arnej27959 please review