### PR TITLE
Upgrade nodes on lowest OS version first

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.NodeType;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -77,6 +78,16 @@ public class NodeList implements Iterable<Node> {
     /** Returns the subset of nodes that are currently changing their OS version */
     public NodeList changingOsVersion() {
         return filter(node -> node.status().osVersion().changing());
+    }
+
+    /** Returns a copy of this sorted by current OS version (lowest to highest) */
+    public NodeList byIncreasingOsVersion() {
+        return nodes.stream()
+                    .sorted(Comparator.comparing(node -> node.status()
+                                                             .osVersion()
+                                                             .current()
+                                                             .orElse(Version.emptyVersion)))
+                    .collect(collectingAndThen(Collectors.toList(), NodeList::wrap));
     }
 
     /** Returns the subset of nodes that are currently on the given OS version */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsVersions.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsVersions.java
@@ -123,6 +123,7 @@ public class OsVersions {
         var numberToUpgrade = Math.max(0, maxActiveUpgrades - nodes.changingOsVersion().size());
         var nodesToUpgrade = nodes.not().changingOsVersion()
                                   .not().onOsVersion(version)
+                                  .byIncreasingOsVersion()
                                   .first(numberToUpgrade);
         if (nodesToUpgrade.size() == 0) return;
         log.info("Upgrading " + nodesToUpgrade.size() + " nodes of type " + type + " to OS version " + version);


### PR DESCRIPTION
A minor optimization of the following scenario: Nodes are on v1, upgrade to v2
is ongoing, and upgrade to v3 is started before v2 is complete.