### PR TITLE
Eliminate clang warning when casting to pointer with larger alignment.

### DIFF
--- a/eval/src/tests/ann/sift_benchmark.cpp
+++ b/eval/src/tests/ann/sift_benchmark.cpp
@@ -33,7 +33,7 @@ static PointVector *aligned_alloc(size_t num) {
     size_t val = (size_t)mem;
     size_t unalign = val % 512;
     mem -= unalign;
-    return (PointVector *)mem;
+    return reinterpret_cast<PointVector *>(mem);
 }
 
 static PointVector *generatedQueries = aligned_alloc(NUM_Q);


### PR DESCRIPTION
@arnej27959 : please review
