### PR TITLE
Stop using memset to overwrite a member variable that doesn't have a

### DIFF
--- a/vespamalloc/src/vespamalloc/malloc/globalpool.hpp
+++ b/vespamalloc/src/vespamalloc/malloc/globalpool.hpp
@@ -15,12 +15,13 @@ size_t AllocPoolT<MemBlockPtrT>::_alwaysReuseLimit __attribute__((visibility("hi
 template <typename MemBlockPtrT>
 AllocPoolT<MemBlockPtrT>::AllocPoolT(DataSegment<MemBlockPtrT> & ds)
     : _chunkPool(NULL),
+      _scList(),
       _dataSegment(ds),
       _getChunks(0),
       _getChunksSum(0),
-      _allocChunkList(0)
+      _allocChunkList(0),
+      _stat()
 {
-    memset(_scList, 0, sizeof(_scList));
 }
 
 template <typename MemBlockPtrT>


### PR DESCRIPTION
trivial copy-assignment. Use value-initialization instead.

@baldersheim : please review