### PR TITLE
Adjust vespa.spec openblas dependency for RHEL 8 / CentOS 8.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -124,7 +124,11 @@ Requires: valgrind
 Requires: Judy
 Requires: xxhash
 Requires: xxhash-libs >= 0.6.5
+%if 0%{?el8}
+Requires: openblas
+%else
 Requires: openblas-serial
+%endif
 Requires: lz4
 Requires: libzstd
 Requires: zlib


### PR DESCRIPTION
@havardpe : please review
@baldersheim : FYI
