### PR TITLE
Use /usr/bin/sudo instead of searching $PATH to avoid broken

### DIFF
--- a/zookeeper-command-line-client/src/main/sh/vespa-zkcli
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkcli
@@ -83,7 +83,7 @@ usage() {
     echo "-nosudo                do not use sudo when running command"
 }
 
-sudo="sudo -u ${VESPA_USER}"
+sudo="/usr/bin/sudo -u ${VESPA_USER}"
 while [ $# -gt 0 ]; do
     case $1 in
         -h|-help)        usage; exit 0;;


### PR DESCRIPTION
sudo wrapper script.

@geirst : please review
@baldersheim : FYI
