### PR TITLE
Make new host-status canonical

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfos.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/status/HostInfos.java
@@ -19,6 +19,10 @@ public class HostInfos {
         this.hostInfos = Map.copyOf(hostInfos);
     }
 
+    public HostInfos() {
+        this.hostInfos = Map.of();
+    }
+
     /** Get all suspended hostnames. */
     public Set<HostName> suspendedHostsnames() {
         return hostInfos.entrySet().stream()


### PR DESCRIPTION
In moving from old host-status-service/APP/hosts to new host-status/APP/hosts:
 1. Currently and before this PR, the ALLOWED_TO_BE_DOWN hosts are the union of
    the hosts in new and old. Other hosts are NO_REMARKS.
 2. With this PR, we'll stop writing ALLOWED_TO_BE_DOWN in old, but still remove
    them.

This PR is not supposed to have any user-visible effect for clients of the
Orchestrator.

Once this PR has rolled out,
 A. The remaining code accessing old can be removed
 B. All data in old can be removed.