### PR TITLE
Add ReadableAttributeVector accessor to IAttributeManager

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/i_attribute_functor.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/i_attribute_functor.h
@@ -17,19 +17,19 @@ class IConstAttributeFunctor
 {
 public:
     virtual void operator()(const IAttributeVector &attributeVector) = 0;
-    virtual ~IConstAttributeFunctor() { }
+    virtual ~IConstAttributeFunctor() = default;
 };
 
 class IAttributeFunctor
 {
 public:
     virtual void operator()(IAttributeVector &attributeVector) = 0;
-    virtual ~IAttributeFunctor() { }
+    virtual ~IAttributeFunctor() = default;
 };
 
 class IAttributeExecutor {
 public:
-    virtual ~IAttributeExecutor() { }
+    virtual ~IAttributeExecutor() = default;
     virtual void asyncForAttribute(const vespalib::string &name, std::unique_ptr<IAttributeFunctor> func) const = 0;
 };
 

--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -20,6 +20,7 @@
 #include <vespa/searchcore/proton/test/attribute_utils.h>
 #include <vespa/searchcorespi/flush/iflushtarget.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/bitvector_search_cache.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector.h>
 #include <vespa/searchlib/attribute/imported_attribute_vector_factory.h>
@@ -588,8 +589,8 @@ struct FilterFixture
 
 TEST_F("require that filter attribute manager can filter attributes", FilterFixture)
 {
-    EXPECT_TRUE(f._filterMgr.getAttribute("a1").get() == NULL);
-    EXPECT_TRUE(f._filterMgr.getAttribute("a2").get() != NULL);
+    EXPECT_TRUE(f._filterMgr.getAttribute("a1").get() == nullptr);
+    EXPECT_TRUE(f._filterMgr.getAttribute("a2").get() != nullptr);
     std::vector<AttributeGuard> attrs;
     f._filterMgr.getAttributeList(attrs);
     EXPECT_EQUAL(1u, attrs.size());
@@ -605,6 +606,16 @@ TEST_F("require that filter attribute manager can return flushed serial number",
     f._baseMgr->flushAll(100);
     EXPECT_EQUAL(0u, f._filterMgr.getFlushedSerialNum("a1"));
     EXPECT_EQUAL(100u, f._filterMgr.getFlushedSerialNum("a2"));
+}
+
+TEST_F("readable_attribute_vector filters attributes", FilterFixture)
+{
+    auto av = f._filterMgr.readable_attribute_vector("a2");
+    ASSERT_TRUE(av);
+    EXPECT_EQUAL("a2", av->makeReadGuard(false)->attribute()->getName());
+
+    av = f._filterMgr.readable_attribute_vector("a1");
+    EXPECT_FALSE(av);
 }
 
 namespace {

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -11,6 +11,7 @@
 #include <vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.h>
 #include <vespa/searchlib/attribute/attributecontext.h>
 #include <vespa/searchlib/attribute/attribute_read_guard.h>
+#include <vespa/searchlib/attribute/imported_attribute_vector.h>
 #include <vespa/searchcommon/attribute/i_attribute_functor.h>
 #include <vespa/searchlib/attribute/interlock.h>
 #include <vespa/searchlib/common/isequencedtaskexecutor.h>
@@ -611,6 +612,16 @@ void
 AttributeManager::setImportedAttributes(std::unique_ptr<ImportedAttributesRepo> attributes)
 {
     _importedAttributes = std::move(attributes);
+}
+
+std::shared_ptr<search::attribute::ReadableAttributeVector>
+AttributeManager::readable_attribute_vector(const string& name) const
+{
+    auto attribute = findAttribute(name);
+    if (attribute || !_importedAttributes) {
+        return attribute;
+    }
+    return _importedAttributes->get(name);
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
@@ -178,6 +178,8 @@ public:
     void setImportedAttributes(std::unique_ptr<ImportedAttributesRepo> attributes) override;
 
     const ImportedAttributesRepo *getImportedAttributes() const override { return _importedAttributes.get(); }
+
+    std::shared_ptr<search::attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
@@ -231,4 +231,13 @@ FilterAttributeManager::getImportedAttributes() const
     throw vespalib::IllegalArgumentException("Not implemented");
 }
 
+std::shared_ptr<search::attribute::ReadableAttributeVector>
+FilterAttributeManager::readable_attribute_vector(const string& name) const
+{
+    if (acceptAttribute(name)) {
+        return _mgr->readable_attribute_vector(name);
+    }
+    return {};
+}
+
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.h
@@ -54,6 +54,7 @@ public:
     ExclusiveAttributeReadAccessor::UP getExclusiveReadAccessor(const vespalib::string &name) const override;
     void setImportedAttributes(std::unique_ptr<ImportedAttributesRepo> attributes) override;
     const ImportedAttributesRepo *getImportedAttributes() const override;
+    std::shared_ptr<search::attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const override;
 
     void asyncForAttribute(const vespalib::string &name, std::unique_ptr<IAttributeFunctor> func) const override;
 };

--- a/searchcore/src/vespa/searchcore/proton/common/attributefieldvaluenode.h
+++ b/searchcore/src/vespa/searchcore/proton/common/attributefieldvaluenode.h
@@ -3,18 +3,19 @@
 
 #include <vespa/document/select/valuenodes.h>
 
-namespace search { class AttributeVector; }
+namespace search { class ReadableAttributeVector; }
 namespace proton {
 
 class AttributeFieldValueNode : public document::select::FieldValueNode
 {
     using Context = document::select::Context;
-    std::shared_ptr<search::AttributeVector> _attribute;
+    uint32_t _attr_guard_index;
 
 public:
+    // Precondition: attribute must be of a single-value type.
     AttributeFieldValueNode(const vespalib::string& doctype,
                             const vespalib::string& field,
-                            const std::shared_ptr<search::AttributeVector> &attribute);
+                            uint32_t attr_guard_index);
 
     std::unique_ptr<document::select::Value> getValue(const Context &context) const override;
     std::unique_ptr<document::select::Value> traceValue(const Context &context, std::ostream& out) const override;

--- a/searchcore/src/vespa/searchcore/proton/common/cachedselect.h
+++ b/searchcore/src/vespa/searchcore/proton/common/cachedselect.h
@@ -15,6 +15,8 @@ namespace search {
     class IAttributeManager;
 }
 
+namespace search::attribute { class ReadableAttributeVector; }
+
 namespace proton {
 
 class SelectContext;
@@ -44,7 +46,7 @@ public:
         const document::select::Node &selectNode() const;
     };
 
-    using AttributeVectors = std::vector<std::shared_ptr<search::AttributeVector>>;
+    using AttributeVectors = std::vector<std::shared_ptr<search::attribute::ReadableAttributeVector>>;
 
 private:
     // Single value attributes referenced from selection expression

--- a/searchcore/src/vespa/searchcore/proton/common/selectcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/selectcontext.cpp
@@ -3,20 +3,22 @@
 #include "selectcontext.h"
 #include "cachedselect.h"
 #include <vespa/document/select/value.h>
-#include <vespa/searchlib/attribute/attributeguard.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
+#include <vespa/searchlib/attribute/readable_attribute_vector.h>
+#include <cassert>
 
 namespace proton {
 
 using document::select::Value;
 using document::select::Context;
-using search::AttributeGuard;
 using search::AttributeVector;
+using search::attribute::AttributeReadGuard;
 
 namespace select {
-    struct Guards : public std::vector<AttributeGuard> {
-        using Parent = std::vector<AttributeGuard>;
-        using Parent::Parent;
-    };
+struct Guards : public std::vector<std::unique_ptr<AttributeReadGuard>> {
+    using Parent = std::vector<std::unique_ptr<AttributeReadGuard>>;
+    using Parent::Parent;
+};
 }
 
 SelectContext::SelectContext(const CachedSelect &cachedSelect)
@@ -26,23 +28,30 @@ SelectContext::SelectContext(const CachedSelect &cachedSelect)
       _cachedSelect(cachedSelect)
 { }
 
-SelectContext::~SelectContext() { }
+SelectContext::~SelectContext() = default;
 
 void
 SelectContext::getAttributeGuards()
 {
-    _guards->resize(_cachedSelect.attributes().size());
-    auto j(_cachedSelect.attributes().begin());
-    for (std::vector<AttributeGuard>::iterator i(_guards->begin()), ie(_guards->end()); i != ie; ++i, ++j) {
-        *i = AttributeGuard(*j);
+    _guards->clear();
+    _guards->reserve(_cachedSelect.attributes().size());
+    for (const auto& attr : _cachedSelect.attributes()) {
+        _guards->emplace_back(attr->makeReadGuard(false));
     }
 }
-
 
 void
 SelectContext::dropAttributeGuards()
 {
     _guards->clear();
+}
+
+const search::attribute::AttributeReadGuard&
+SelectContext::read_guard_at_index(uint32_t index) const noexcept
+{
+    assert(index < _guards->size());
+    assert((*_guards)[index].get() != nullptr);
+    return *((*_guards)[index]);
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/common/selectcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/common/selectcontext.h
@@ -3,6 +3,8 @@
 
 #include <vespa/document/select/context.h>
 
+namespace search::attribute { class AttributeReadGuard; }
+
 namespace proton {
 
 class CachedSelect;
@@ -19,6 +21,8 @@ public:
     void dropAttributeGuards();
 
     uint32_t _docId;
+
+    const search::attribute::AttributeReadGuard& read_guard_at_index(uint32_t index) const noexcept;
 private:
     std::unique_ptr<select::Guards> _guards;
     const CachedSelect &_cachedSelect;

--- a/searchcore/src/vespa/searchcore/proton/common/selectpruner.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/selectpruner.cpp
@@ -12,6 +12,7 @@
 #include <vespa/document/select/invalidconstant.h>
 #include <vespa/document/select/valuenodes.h>
 #include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/iattributemanager.h>
 
 using document::select::And;
@@ -395,7 +396,6 @@ SelectPruner::visitIdValueNode(const IdValueNode &expr)
     CloningVisitor::visitIdValueNode(expr);
 }
 
-
 void
 SelectPruner::visitFieldValueNode(const FieldValueNode &expr)
 {
@@ -440,11 +440,11 @@ SelectPruner::visitFieldValueNode(const FieldValueNode &expr)
     bool svAttr = false;
     bool attrField = false;
     if (_amgr != nullptr) {
-        AttributeGuard::UP ag(_amgr->getAttribute(name));
-        if (ag->valid()) {
+        auto attr = _amgr->readable_attribute_vector(name);
+        if (attr) {
             attrField = true;
-            auto av(ag->getSP());
-            if (av->getCollectionType() == CollectionType::SINGLE && !complex) {
+            auto ag = attr->makeReadGuard(false);
+            if ((ag->attribute()->getCollectionType() == CollectionType::SINGLE) && !complex) {
                 svAttr = true;
             }
         }

--- a/searchcore/src/vespa/searchcore/proton/test/mock_attribute_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_attribute_manager.h
@@ -78,6 +78,9 @@ public:
     void asyncForAttribute(const vespalib::string & name, std::unique_ptr<IAttributeFunctor> func) const override {
         _mock.asyncForAttribute(name, std::move(func));
     }
+    std::shared_ptr<search::attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const override {
+        return _mock.readable_attribute_vector(name);
+    }
 };
 
 }

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -34,6 +34,7 @@ private:
     void testGuards();
     void testConfigConvert();
     void testContext();
+    void can_get_readable_attribute_vector_by_name();
 
     bool
     assertDataType(BT::Type exp,
@@ -377,6 +378,21 @@ AttributeManagerTest::testContext()
     }
 }
 
+void
+AttributeManagerTest::can_get_readable_attribute_vector_by_name()
+{
+    auto attr = AttributeFactory::createAttribute("cool_attr", Config(BT::INT32, CT::SINGLE));
+    // Ensure there's something to actually load, or fetching the attribute will throw.
+    attr->addDocs(64);
+    attr->commit();
+    AttributeManager manager;
+    manager.add(attr);
+    auto av = manager.readable_attribute_vector("cool_attr");
+    EXPECT_EQUAL(av.get(), static_cast<ReadableAttributeVector*>(attr.get()));
+    av = manager.readable_attribute_vector("uncool_attr");
+    EXPECT_TRUE(av.get() == nullptr);
+}
+
 int AttributeManagerTest::Main()
 {
     TEST_INIT("attributemanager_test");
@@ -385,6 +401,7 @@ int AttributeManagerTest::Main()
     testGuards();
     testConfigConvert();
     testContext();
+    can_get_readable_attribute_vector_by_name();
 
     TEST_DONE();
 }

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -123,6 +123,15 @@ public:
         return IAttributeContext::UP();
     }
 
+    std::shared_ptr<attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const override {
+        if (name == field) {
+            return _attribute_vector;
+        } else if (name == other) {
+            return _other;
+        }
+        return {};
+    }
+
     void asyncForAttribute(const vespalib::string &name, std::unique_ptr<IAttributeFunctor> func) const override;
 };
 

--- a/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
@@ -100,6 +100,10 @@ public:
     void asyncForAttribute(const vespalib::string &, std::unique_ptr<IAttributeFunctor>) const override {
         assert(!"Not implemented");
     }
+
+    std::shared_ptr<attribute::ReadableAttributeVector> readable_attribute_vector(const string&) const override {
+        return _attribute_vector;
+    }
 };
 
 constexpr uint32_t DOCID_LIMIT = 3;

--- a/searchlib/src/vespa/searchlib/attribute/attributemanager.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributemanager.cpp
@@ -131,7 +131,7 @@ bool AttributeManager::hasReaders() const
 const AttributeManager::VectorHolder *
 AttributeManager::findAndLoadAttribute(const string & name) const
 {
-    const VectorHolder * loadedVector(NULL);
+    const VectorHolder * loadedVector(nullptr);
     AttributeMap::const_iterator found = _attributes.find(name);
     if (found != _attributes.end()) {
         AttributeVector & vec = *found->second;
@@ -263,5 +263,14 @@ AttributeManager::asyncForAttribute(const vespalib::string &, std::unique_ptr<at
     throw std::runtime_error("search::AttributeManager::asyncForAttribute should never be called.");
 }
 
+std::shared_ptr<attribute::ReadableAttributeVector>
+AttributeManager::readable_attribute_vector(const string& name) const
+{
+    const auto* attr = findAndLoadAttribute(name);
+    if (attr) {
+        return *attr;
+    }
+    return {};
+}
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/attributemanager.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributemanager.h
@@ -49,6 +49,8 @@ public:
     void getAttributeList(AttributeList & list) const override;
     attribute::IAttributeContext::UP createContext() const override;
 
+    std::shared_ptr<attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const override;
+
     const Snapshot & getSnapshot()         const { return _snapShot; }
     const string & getBaseDir()       const { return _baseDir; }
     void setBaseDir(const string & base);

--- a/searchlib/src/vespa/searchlib/attribute/iattributemanager.h
+++ b/searchlib/src/vespa/searchlib/attribute/iattributemanager.h
@@ -8,7 +8,10 @@
 
 namespace search {
 
-namespace attribute { class AttributeReadGuard; }
+namespace attribute {
+class AttributeReadGuard;
+class ReadableAttributeVector;
+}
 
 /**
  * This is an interface used to access all registered attribute vectors.
@@ -17,11 +20,16 @@ class IAttributeManager : public attribute::IAttributeExecutor {
 public:
     IAttributeManager(const IAttributeManager &) = delete;
     IAttributeManager & operator = (const IAttributeManager &) = delete;
-    typedef std::shared_ptr<IAttributeManager> SP;
-    typedef vespalib::string string;
+    using SP = std::shared_ptr<IAttributeManager>;
+    using string = vespalib::string;
 
     /**
      * Returns a view of the attribute vector with the given name.
+     *
+     * NOTE: this method is deprecated! Prefer using readable_attribute_vector(name) instead,
+     * as that enforces appropriate guards to be taken before accessing the underlying vector.
+     *
+     * TODO remove this when all usages are gone.
      *
      * @param name name of the attribute vector.
      * @return view of the attribute vector or empty view if the attribute vector does not exists.
@@ -52,9 +60,15 @@ public:
     virtual attribute::IAttributeContext::UP createContext() const = 0;
 
     /**
-     * Virtual destructor to allow safe subclassing.
-     **/
-    virtual ~IAttributeManager() {}
+     * Looks up and returns a readable attribute vector shared_ptr with the provided name.
+     * This transparently supports imported attribute vectors.
+     *
+     * @param name name of the attribute vector.
+     * @return The attribute vector, or an empty shared_ptr if no vector was found with the given name.
+     */
+    virtual std::shared_ptr<attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const = 0;
+
+    ~IAttributeManager() override = default;
 protected:
     IAttributeManager() = default;
 };

--- a/searchlib/src/vespa/searchlib/attribute/readable_attribute_vector.h
+++ b/searchlib/src/vespa/searchlib/attribute/readable_attribute_vector.h
@@ -13,7 +13,7 @@ class AttributeReadGuard;
  */
 class ReadableAttributeVector {
 public:
-    virtual ~ReadableAttributeVector() {}
+    virtual ~ReadableAttributeVector() = default;
     virtual std::unique_ptr<AttributeReadGuard> makeReadGuard(bool stableEnumGuard) const = 0;
 };
 

--- a/searchlib/src/vespa/searchlib/test/mock_attribute_manager.cpp
+++ b/searchlib/src/vespa/searchlib/test/mock_attribute_manager.cpp
@@ -61,4 +61,9 @@ MockAttributeManager::addAttribute(const AttributeVector::SP &attr) {
     addAttribute(attr->getName(), attr);
 }
 
+std::shared_ptr<attribute::ReadableAttributeVector>
+MockAttributeManager::readable_attribute_vector(const string& name) const {
+    return findAttribute(name);
+}
+
 }

--- a/searchlib/src/vespa/searchlib/test/mock_attribute_manager.h
+++ b/searchlib/src/vespa/searchlib/test/mock_attribute_manager.h
@@ -28,6 +28,7 @@ public:
     IAttributeContext::UP createContext() const override;
     void addAttribute(const vespalib::string &name, const AttributeVector::SP &attr);
     void addAttribute(const AttributeVector::SP &attr);
+    std::shared_ptr<attribute::ReadableAttributeVector> readable_attribute_vector(const string& name) const override;
 };
 
 }

--- a/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
@@ -100,6 +100,10 @@ public:
     IAttributeContext::UP createContext() const override {
         return IAttributeContext::UP(new MyAttributeContext(_attr));
     }
+
+    std::shared_ptr<attribute::ReadableAttributeVector> readable_attribute_vector(const string&) const override {
+        LOG_ABORT("should not be reached");
+    }
 };
 
 struct MyGetDocsumsStateCallback : GetDocsumsStateCallback {


### PR DESCRIPTION
@geirst @toregge please review

Provides a unified interface for fetching both regular as well as
imported attributes. Exposing `ReadableAttributeVector` instead of
raw `AttributeVector` instances enforces that all access is done via
appropriate acquired read guards.

Refactor document selection processing code to use the new interface
in order to prepare for imported field support in selections.

