### PR TITLE
Check for tester endpoint only when needed

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -183,16 +183,17 @@ public class JobController {
             if (step.isEmpty())
                 return run;
 
-            Optional<URI> testerEndpoint = testerEndpoint(id);
-            if (testerEndpoint.isEmpty())
-                return run;
-
             List<LogEntry> entries;
             ZoneId zone = id.type().zone(controller.system());
-            if (useConfigServerForTesterAPI(zone))
+            if (useConfigServerForTesterAPI(zone)) {
                 entries = cloud.getLog(new DeploymentId(id.application(), zone), run.lastTestLogEntry());
-            else
+            } else {
+                Optional<URI> testerEndpoint = testerEndpoint(id);
+                if (testerEndpoint.isEmpty())
+                    return run;
+
                 entries = cloud.getLog(testerEndpoint.get(), run.lastTestLogEntry());
+            }
             if (entries.isEmpty())
                 return run;
 


### PR DESCRIPTION
Do not check for tester endpoint when using config server for tester API calls,
since tester endpoint might not be a part of the routing policies in that case
