### PR TITLE
Set suspendedSeconds even if zero

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -129,17 +129,15 @@ public class MetricsReporter extends Maintainer {
         metric.set("wantToDeprovision", node.status().wantToDeprovision() ? 1 : 0, context);
         metric.set("failReport", NodeFailer.reasonsToFailParentHost(node).isEmpty() ? 0 : 1, context);
 
-        orchestrator.apply(new HostName(node.hostname()))
-                .ifPresent(info -> {
-                    int suspended = info.status().isSuspended() ? 1 : 0;
-                    metric.set("suspended", suspended, context);
-                    metric.set("allowedToBeDown", suspended, context); // remove summer 2020.
-
-                    info.suspendedSince().ifPresent(suspendedSince -> {
-                        Duration duration = Duration.between(suspendedSince, clock.instant());
-                        metric.set("suspendedSeconds", duration.getSeconds(), context);
-                    });
-                });
+        orchestrator.apply(new HostName(node.hostname())).ifPresent(info -> {
+            int suspended = info.status().isSuspended() ? 1 : 0;
+            metric.set("suspended", suspended, context);
+            metric.set("allowedToBeDown", suspended, context); // remove summer 2020.
+            long suspendedSeconds = info.suspendedSince()
+                    .map(suspendedSince -> Duration.between(suspendedSince, clock.instant()).getSeconds())
+                    .orElse(0L);
+            metric.set("suspendedSeconds", suspendedSeconds, context);
+        });
 
         long numberOfServices;
         HostName hostName = new HostName(node.hostname());


### PR DESCRIPTION
If suspendedSeconds is not set the previous value is kept, which is wrong as it
is logically 0 at that time, and is especially confusing in staging where a
single node is reused often, and therefore may have multiple applications with
a supendedSeconds>0 at any given time.