### PR TITLE
Allow SSLContext implementation that supports TLSv1.3+

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
@@ -35,7 +35,7 @@ public interface TlsContext extends AutoCloseable {
             "TLS_CHACHA20_POLY1305_SHA256"); // TLSv1.3, Java 12
 
     Set<String> ALLOWED_PROTOCOLS = com.yahoo.vespa.jdk8compat.Set.of("TLSv1.2"); // TODO Enable TLSv1.3
-    String SSL_CONTEXT_VERSION = "TLSv1.2"; // TODO Enable TLSv1.3
+    String SSL_CONTEXT_VERSION = "TLS"; // Use SSLContext implementations that supports all TLS versions
 
     /**
      * @return the allowed cipher suites supported by the provided context instance

--- a/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
+++ b/zookeeper-server/zookeeper-server-3.5/src/test/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImplTest.java
@@ -221,7 +221,7 @@ public class VespaZooKeeperServerImplTest {
                "ssl.quorum.clientAuth=NEED\n" +
                "ssl.quorum.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n" +
                "ssl.quorum.enabledProtocols=TLSv1.2\n" +
-               "ssl.quorum.protocol=TLSv1.2\n";
+               "ssl.quorum.protocol=TLS\n";
     }
 
     private String commonTlsClientServerConfig() {
@@ -229,7 +229,7 @@ public class VespaZooKeeperServerImplTest {
                "ssl.clientAuth=NEED\n" +
                "ssl.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n" +
                "ssl.enabledProtocols=TLSv1.2\n" +
-               "ssl.protocol=TLSv1.2\n";
+               "ssl.protocol=TLS\n";
     }
 
     private void validateConfigFileMultipleHosts(File cfgFile) throws IOException {


### PR DESCRIPTION
Same as https://github.com/vespa-engine/vespa/pull/11532, with fixup commits squashed.