### PR TITLE
Use CMAKE_CURRENT_LIST_DIR instead of CMAKE_SOURCE_DIR, to allow

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -1,7 +1,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 # @author Vegard Sjonfjell
 
-include(vtag.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/vtag.cmake)
 
 # Build options
 # Whether to build unit tests as part of the 'all' target

--- a/vtag.cmake
+++ b/vtag.cmake
@@ -1,10 +1,10 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-if(NOT EXISTS "${CMAKE_SOURCE_DIR}/dist/vtag.map")
+if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/dist/vtag.map")
     message(FATAL_ERROR "dist/vtag.map does not exist, please run bootstrap.sh before configuring cmake" )
 endif()
 
 function(get_vtag_define KEY)
-    file(STRINGS dist/vtag.map VALUE REGEX "${KEY}")
+    file(STRINGS ${CMAKE_CURRENT_LIST_DIR}/dist/vtag.map VALUE REGEX "${KEY}")
     list(GET VALUE 0 LINE)
     separate_arguments(DATA UNIX_COMMAND "${LINE}")
     list(GET DATA 1 VALUE)


### PR DESCRIPTION
inclusion from dependent extra projects.

@aressem : please review
