### PR TITLE
Reduce access logging

### DIFF
--- a/application/src/main/java/com/yahoo/application/Application.java
+++ b/application/src/main/java/com/yahoo/application/Application.java
@@ -124,6 +124,7 @@ public final class Application implements AutoCloseable {
                     .applicationPackage(FilesApplicationPackage.fromFile(path.toFile(), true))
                     .modelImporters(modelImporters)
                     .deployLogger((level, s) -> { })
+                    .accessLoggingEnabledByDefault(false)
                     .build();
             return new VespaModel(new NullConfigModelRegistry(), deployState);
         } catch (IOException | SAXException e) {

--- a/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/ca/restapi/ContainerTester.java
+++ b/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/ca/restapi/ContainerTester.java
@@ -54,6 +54,7 @@ public class ContainerTester {
 
     private static String servicesXml() {
         return "<container version='1.0'>\n" +
+               "  <accesslog type=\"disabled\"/>\n" +
                "  <config name=\"container.handler.threadpool\">\n" +
                "    <maxthreads>10</maxthreads>\n" +
                "  </config>\n" +

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -67,6 +67,7 @@ public class DeployState implements ConfigDefinitionStore {
     private final Optional<ConfigDefinitionRepo> configDefinitionRepo;
     private final Optional<ApplicationPackage> permanentApplicationPackage;
     private final Optional<Model> previousModel;
+    private final boolean accessLoggingEnabledByDefault;
     private final ModelContext.Properties properties;
     private final Version vespaVersion;
     private final Set<ContainerEndpoint> endpoints;
@@ -101,14 +102,15 @@ public class DeployState implements ConfigDefinitionStore {
                         Version vespaVersion,
                         Optional<ApplicationPackage> permanentApplicationPackage,
                         Optional<ConfigDefinitionRepo> configDefinitionRepo,
-                        java.util.Optional<Model> previousModel,
+                        Optional<Model> previousModel,
                         Set<ContainerEndpoint> endpoints,
                         Collection<MlModelImporter> modelImporters,
                         Zone zone,
                         QueryProfiles queryProfiles,
                         SemanticRules semanticRules,
                         Instant now,
-                        Version wantedNodeVespaVersion) {
+                        Version wantedNodeVespaVersion,
+                        boolean accessLoggingEnabledByDefault) {
         this.logger = deployLogger;
         this.fileRegistry = fileRegistry;
         this.rankProfileRegistry = rankProfileRegistry;
@@ -116,6 +118,7 @@ public class DeployState implements ConfigDefinitionStore {
         this.properties = properties;
         this.vespaVersion = vespaVersion;
         this.previousModel = previousModel;
+        this.accessLoggingEnabledByDefault = accessLoggingEnabledByDefault;
         this.provisioner = hostProvisioner.orElse(getDefaultModelHostProvisioner(applicationPackage));
         this.searchDefinitions = searchDocumentModel.getSearchDefinitions();
         this.documentModel = searchDocumentModel.getDocumentModel();
@@ -217,6 +220,10 @@ public class DeployState implements ConfigDefinitionStore {
         return logger;
     }
 
+    public boolean getAccessLoggingEnabledByDefault() {
+        return accessLoggingEnabledByDefault;
+    }
+
     public FileRegistry getFileRegistry() {
         return fileRegistry;
     }
@@ -289,6 +296,7 @@ public class DeployState implements ConfigDefinitionStore {
         private Zone zone = Zone.defaultZone();
         private Instant now = Instant.now();
         private Version wantedNodeVespaVersion = Vtag.currentVersion;
+        private boolean accessLoggingEnabledByDefault = true;
 
         public Builder applicationPackage(ApplicationPackage applicationPackage) {
             this.applicationPackage = applicationPackage;
@@ -360,6 +368,15 @@ public class DeployState implements ConfigDefinitionStore {
             return this;
         }
 
+        /**
+         * Whether access logging is enabled for an application without an accesslog element in services.xml.
+         * True by default.
+         */
+        public Builder accessLoggingEnabledByDefault(boolean accessLoggingEnabledByDefault) {
+            this.accessLoggingEnabledByDefault = accessLoggingEnabledByDefault;
+            return this;
+        }
+
         public DeployState build() {
             return build(new ValidationParameters());
         }
@@ -386,7 +403,8 @@ public class DeployState implements ConfigDefinitionStore {
                                    queryProfiles,
                                    semanticRules,
                                    now,
-                                   wantedNodeVespaVersion);
+                                   wantedNodeVespaVersion,
+                                   accessLoggingEnabledByDefault);
         }
 
         private SearchDocumentModel createSearchDocumentModel(RankProfileRegistry rankProfileRegistry,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -302,7 +302,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             AccessLogBuilder.buildIfNotDisabled(deployState, cluster, accessLog).ifPresent(cluster::addComponent);
         }
 
-        if (accessLogElements.isEmpty())
+        if (accessLogElements.isEmpty() && deployState.getAccessLoggingEnabledByDefault())
             cluster.addDefaultSearchAccessLog();
     }
 

--- a/container-integration-test/src/test/java/com/yahoo/search/query/gui/GUIHandlerTest.java
+++ b/container-integration-test/src/test/java/com/yahoo/search/query/gui/GUIHandlerTest.java
@@ -72,6 +72,7 @@ public class GUIHandlerTest {
 
     private String servicesXml() {
         return "<container version='1.0'>\n" +
+                "  <accesslog type='disabled'/>\n" +
                 "  <handler id='com.yahoo.search.query.gui.GUIHandler'>\n" +
                 "    <binding>http://*/querybuilder/*</binding>\n" +
                 "  </handler>\n" +

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/ApplicationSuspensionResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/ApplicationSuspensionResourceTest.java
@@ -155,6 +155,7 @@ public class ApplicationSuspensionResourceTest {
 
         return "<services>\n" +
                 "    <container version=\"1.0\" jetty=\"true\">\n" +
+                "        <accesslog type=\"disabled\"/>\n" +
                 "        <config name=\"container.handler.threadpool\">\n" +
                 "            <maxthreads>10</maxthreads>\n" +
                 "        </config>\n" +

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/RestApiTest.java
@@ -202,7 +202,7 @@ public class RestApiTest {
 
     // Get logs through some hackish fetch method. Logs is something the mocked backend write.
     String getLog() throws IOException {
-        // The mocked backend will throw a runtime exception wtih a log if delete is called three times..
+        // The mocked backend will throw a runtime exception with a log if delete is called three times..
         Request request = new Request("http://localhost:" + getFirstListenPort() + remove_test_uri);
         HttpDelete delete = new HttpDelete(request.getUri());
         doRest(delete);

--- a/vespaclient-container-plugin/src/test/rest-api-application/services.xml
+++ b/vespaclient-container-plugin/src/test/rest-api-application/services.xml
@@ -2,6 +2,8 @@
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <container version="1.0" jetty="true">
 
+    <accesslog type="disabled"/>
+
     <handler id="com.yahoo.document.restapi.resource.RestApiWithTestDocumentHandler" bundle="integration-test">
         <binding>http://*/document/v1/*</binding>
     </handler>


### PR DESCRIPTION
Avoids writing access logs in various tests.

1. Disables by-default access logging with Application, since it is used in
unit tests.  2. However many tests create additional DeployState which renders
this ineffective, and so this PR also explicitly disables access logging in
services.xml of some tests.

(1) might be unnecessary if we anyway have to do (2) everywhere, but this is
not clear to me.
