### PR TITLE
Revert "Always set new config (which also sets generation) when generation ha…"

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -93,7 +93,11 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
         log.log(LogLevel.DEBUG, () -> "Polled queue and found config " + jrtReq);
         if (jrtReq.hasUpdatedGeneration()) {
             setInternalRedeploy(jrtReq.responseIsInternalRedeploy());
-            setNewConfig(jrtReq);
+            if (jrtReq.hasUpdatedConfig()) {
+                setNewConfig(jrtReq);
+            } else {
+                setGeneration(jrtReq.getNewGeneration());
+            }
         }
         return true;
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#12087

Seems like this broke some system tests