### PR TITLE
Revert "Change default value for use-config-server-for-tester-api-calls from …"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -194,7 +194,7 @@ public class Flags {
             APPLICATION_ID);
 
     public static final UnboundBooleanFlag USE_CONFIG_SERVER_FOR_TESTER_API_CALLS = defineFeatureFlag(
-            "use-config-server-for-tester-api-calls", true,
+            "use-config-server-for-tester-api-calls", false,
             "Whether controller should send requests to tester API through config server (if false) or tester endpoint (if true)",
             "Takes effect immediately",
             ZONE_ID);


### PR DESCRIPTION
Reverts vespa-engine/vespa#12105

Broke 77 unit tests 🔥 