### PR TITLE
 Added query_setup_time to default public metric set, replacing query_collateral_time

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -84,6 +84,7 @@ public class DefaultPublicMetrics {
 
         metrics.add(new Metric("content.proton.documentdb.matching.docs_matched.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.docs_reranked.rate"));
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_latency.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.average"));
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -463,7 +463,6 @@ public class VespaMetricSet {
         metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.max"));
         metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.sum"));
         metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.count"));
-        metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.docs_matched.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.queries.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate"));
@@ -482,7 +481,6 @@ public class VespaMetricSet {
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.max"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.sum"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.count"));
-        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.max"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.sum"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.count"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -456,10 +456,14 @@ public class VespaMetricSet {
         metrics.add(new Metric("content.proton.documentdb.matching.query_latency.sum"));
         metrics.add(new Metric("content.proton.documentdb.matching.query_latency.count"));
         metrics.add(new Metric("content.proton.documentdb.matching.query_latency.average")); // TODO: Remove in Vespa 8
-        metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.max"));
-        metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.sum"));
-        metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.count"));
+        metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.max")); // TODO: Remove in Vespa 8
+        metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.sum")); // TODO: Remove in Vespa 8
+        metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.count")); // TODO: Remove in Vespa 8
         metrics.add(new Metric("content.proton.documentdb.matching.query_collateral_time.average")); // TODO: Remove in Vespa 8
+        metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.max"));
+        metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.sum"));
+        metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.count"));
+        metrics.add(new Metric("content.proton.documentdb.matching.query_setup_time.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.docs_matched.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.queries.rate"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate"));
@@ -471,10 +475,14 @@ public class VespaMetricSet {
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_latency.sum"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_latency.count"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_latency.average")); // TODO: Remove in Vespa 8
-        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.max"));
-        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.sum"));
-        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.count"));
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.max")); // TODO: Remove in Vespa 8
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.sum")); // TODO: Remove in Vespa 8
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.count")); // TODO: Remove in Vespa 8
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_collateral_time.average")); // TODO: Remove in Vespa 8
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.max"));
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.sum"));
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.count"));
+        metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.query_setup_time.average"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.max"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.sum"));
         metrics.add(new Metric("content.proton.documentdb.matching.rank_profile.rerank_time.count"));

--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -48,43 +48,51 @@ TEST("requireThatAverageTimesAreRecorded") {
     EXPECT_APPROX(0.0, stats.groupingTimeAvg(), 0.00001);
     EXPECT_APPROX(0.0, stats.rerankTimeAvg(), 0.00001);
     EXPECT_APPROX(0.0, stats.queryCollateralTimeAvg(), 0.00001);
+    EXPECT_APPROX(0.0, stats.querySetupTimeAvg(), 0.00001);
     EXPECT_APPROX(0.0, stats.queryLatencyAvg(), 0.00001);
     EXPECT_EQUAL(0u, stats.matchTimeCount());
     EXPECT_EQUAL(0u, stats.groupingTimeCount());
     EXPECT_EQUAL(0u, stats.rerankTimeCount());
     EXPECT_EQUAL(0u, stats.queryCollateralTimeCount());
+    EXPECT_EQUAL(0u, stats.querySetupTimeCount());
     EXPECT_EQUAL(0u, stats.queryLatencyCount());
-    stats.matchTime(0.01).groupingTime(0.1).rerankTime(0.5).queryCollateralTime(2.0).queryLatency(1.0);
+    stats.matchTime(0.01).groupingTime(0.1).rerankTime(0.5).queryCollateralTime(2.0).querySetupTime(2.0).queryLatency(1.0);
     EXPECT_APPROX(0.01, stats.matchTimeAvg(), 0.00001);
     EXPECT_APPROX(0.1, stats.groupingTimeAvg(), 0.00001);
     EXPECT_APPROX(0.5, stats.rerankTimeAvg(), 0.00001);
     EXPECT_APPROX(2.0, stats.queryCollateralTimeAvg(), 0.00001);
+    EXPECT_APPROX(2.0, stats.querySetupTimeAvg(), 0.00001);
     EXPECT_APPROX(1.0, stats.queryLatencyAvg(), 0.00001);
-    stats.add(MatchingStats().matchTime(0.03).groupingTime(0.3).rerankTime(1.5).queryCollateralTime(6.0).queryLatency(3.0));
+    stats.add(MatchingStats().matchTime(0.03).groupingTime(0.3).rerankTime(1.5).queryCollateralTime(6.0).querySetupTime(6.0).queryLatency(3.0));
     EXPECT_APPROX(0.02, stats.matchTimeAvg(), 0.00001);
     EXPECT_APPROX(0.2, stats.groupingTimeAvg(), 0.00001);
     EXPECT_APPROX(1.0, stats.rerankTimeAvg(), 0.00001);
     EXPECT_APPROX(4.0, stats.queryCollateralTimeAvg(), 0.00001);
+    EXPECT_APPROX(4.0, stats.querySetupTimeAvg(), 0.00001);
     EXPECT_APPROX(2.0, stats.queryLatencyAvg(), 0.00001);
     stats.add(MatchingStats().matchTime(0.05)
               .groupingTime(0.5)
               .rerankTime(2.5)
               .queryCollateralTime(10.0)
+              .querySetupTime(10.0)
               .queryLatency(5.0));
     stats.add(MatchingStats().matchTime(0.05).matchTime(0.03)
               .groupingTime(0.5).groupingTime(0.3)
               .rerankTime(2.5).rerankTime(1.5)
               .queryCollateralTime(10.0).queryCollateralTime(6.0)
+              .querySetupTime(10.0).querySetupTime(6.0)
               .queryLatency(5.0).queryLatency(3.0));
     EXPECT_APPROX(0.03, stats.matchTimeAvg(), 0.00001);
     EXPECT_APPROX(0.3, stats.groupingTimeAvg(), 0.00001);
     EXPECT_APPROX(1.5, stats.rerankTimeAvg(), 0.00001);
     EXPECT_APPROX(6.0, stats.queryCollateralTimeAvg(), 0.00001);
+    EXPECT_APPROX(6.0, stats.querySetupTimeAvg(), 0.00001);
     EXPECT_APPROX(3.0, stats.queryLatencyAvg(), 0.00001);
     EXPECT_EQUAL(4u, stats.matchTimeCount());
     EXPECT_EQUAL(4u, stats.groupingTimeCount());
     EXPECT_EQUAL(4u, stats.rerankTimeCount());
     EXPECT_EQUAL(4u, stats.queryCollateralTimeCount());
+    EXPECT_EQUAL(4u, stats.querySetupTimeCount());
     EXPECT_EQUAL(4u, stats.queryLatencyCount());
 }
 
@@ -94,53 +102,63 @@ TEST("requireThatMinMaxTimesAreRecorded") {
     EXPECT_APPROX(0.0, stats.groupingTimeMin(), 0.00001);
     EXPECT_APPROX(0.0, stats.rerankTimeMin(), 0.00001);
     EXPECT_APPROX(0.0, stats.queryCollateralTimeMin(), 0.00001);
+    EXPECT_APPROX(0.0, stats.querySetupTimeMin(), 0.00001);
     EXPECT_APPROX(0.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_APPROX(0.0, stats.matchTimeMax(), 0.00001);
     EXPECT_APPROX(0.0, stats.groupingTimeMax(), 0.00001);
     EXPECT_APPROX(0.0, stats.rerankTimeMax(), 0.00001);
     EXPECT_APPROX(0.0, stats.queryCollateralTimeMax(), 0.00001);
+    EXPECT_APPROX(0.0, stats.querySetupTimeMax(), 0.00001);
     EXPECT_APPROX(0.0, stats.queryLatencyMax(), 0.00001);
-    stats.matchTime(0.01).groupingTime(0.1).rerankTime(0.5).queryCollateralTime(2.0).queryLatency(1.0);
+    stats.matchTime(0.01).groupingTime(0.1).rerankTime(0.5).queryCollateralTime(2.0).querySetupTime(2.0).queryLatency(1.0);
     EXPECT_APPROX(0.01, stats.matchTimeMin(), 0.00001);
     EXPECT_APPROX(0.1, stats.groupingTimeMin(), 0.00001);
     EXPECT_APPROX(0.5, stats.rerankTimeMin(), 0.00001);
     EXPECT_APPROX(2.0, stats.queryCollateralTimeMin(), 0.00001);
+    EXPECT_APPROX(2.0, stats.querySetupTimeMin(), 0.00001);
     EXPECT_APPROX(1.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_APPROX(0.01, stats.matchTimeMax(), 0.00001);
     EXPECT_APPROX(0.1, stats.groupingTimeMax(), 0.00001);
     EXPECT_APPROX(0.5, stats.rerankTimeMax(), 0.00001);
     EXPECT_APPROX(2.0, stats.queryCollateralTimeMax(), 0.00001);
+    EXPECT_APPROX(2.0, stats.querySetupTimeMax(), 0.00001);
     EXPECT_APPROX(1.0, stats.queryLatencyMax(), 0.00001);
-    stats.add(MatchingStats().matchTime(0.03).groupingTime(0.3).rerankTime(1.5).queryCollateralTime(6.0).queryLatency(3.0));
+    stats.add(MatchingStats().matchTime(0.03).groupingTime(0.3).rerankTime(1.5).queryCollateralTime(6.0).querySetupTime(6.0).queryLatency(3.0));
     EXPECT_APPROX(0.01, stats.matchTimeMin(), 0.00001);
     EXPECT_APPROX(0.1, stats.groupingTimeMin(), 0.00001);
     EXPECT_APPROX(0.5, stats.rerankTimeMin(), 0.00001);
     EXPECT_APPROX(2.0, stats.queryCollateralTimeMin(), 0.00001);
+    EXPECT_APPROX(2.0, stats.querySetupTimeMin(), 0.00001);
     EXPECT_APPROX(1.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_APPROX(0.03, stats.matchTimeMax(), 0.00001);
     EXPECT_APPROX(0.3, stats.groupingTimeMax(), 0.00001);
     EXPECT_APPROX(1.5, stats.rerankTimeMax(), 0.00001);
     EXPECT_APPROX(6.0, stats.queryCollateralTimeMax(), 0.00001);
+    EXPECT_APPROX(6.0, stats.querySetupTimeMax(), 0.00001);
     EXPECT_APPROX(3.0, stats.queryLatencyMax(), 0.00001);
     stats.add(MatchingStats().matchTime(0.05)
               .groupingTime(0.5)
               .rerankTime(2.5)
               .queryCollateralTime(10.0)
+              .querySetupTime(10.0)
               .queryLatency(5.0));
     stats.add(MatchingStats().matchTime(0.05).matchTime(0.03)
               .groupingTime(0.5).groupingTime(0.3)
               .rerankTime(2.5).rerankTime(1.5)
               .queryCollateralTime(10.0).queryCollateralTime(6.0)
+              .querySetupTime(10.0).querySetupTime(6.0)
               .queryLatency(5.0).queryLatency(3.0));
     EXPECT_APPROX(0.01, stats.matchTimeMin(), 0.00001);
     EXPECT_APPROX(0.1, stats.groupingTimeMin(), 0.00001);
     EXPECT_APPROX(0.5, stats.rerankTimeMin(), 0.00001);
     EXPECT_APPROX(2.0, stats.queryCollateralTimeMin(), 0.00001);
+    EXPECT_APPROX(2.0, stats.querySetupTimeMin(), 0.00001);
     EXPECT_APPROX(1.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_APPROX(0.05, stats.matchTimeMax(), 0.00001);
     EXPECT_APPROX(0.5, stats.groupingTimeMax(), 0.00001);
     EXPECT_APPROX(2.5, stats.rerankTimeMax(), 0.00001);
     EXPECT_APPROX(10.0, stats.queryCollateralTimeMax(), 0.00001);
+    EXPECT_APPROX(10.0, stats.querySetupTimeMax(), 0.00001);
     EXPECT_APPROX(5.0, stats.queryLatencyMax(), 0.00001);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -287,7 +287,9 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
             numThreadsPerSearch, _rankSetup->getNumThreadsPerSearch(), estHits, reply->totalHitCount,
             request.ranking.c_str());
     }
-    my_stats.queryCollateralTime(vespalib::to_s(total_matching_time.elapsed()) - my_stats.queryLatencyAvg());
+    double querySetupTime = vespalib::to_s(total_matching_time.elapsed()) - my_stats.queryLatencyAvg()
+    my_stats.queryCollateralTime(querySetupTime);
+    my_stats.querySetupTime(querySetupTime);
     {
         vespalib::duration duration = request.getTimeUsed();
         std::lock_guard<std::mutex> guard(_statsLock);

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -287,8 +287,8 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
             numThreadsPerSearch, _rankSetup->getNumThreadsPerSearch(), estHits, reply->totalHitCount,
             request.ranking.c_str());
     }
-    double querySetupTime = vespalib::to_s(total_matching_time.elapsed()) - my_stats.queryLatencyAvg()
-    my_stats.queryCollateralTime(querySetupTime);
+    double querySetupTime = vespalib::to_s(total_matching_time.elapsed()) - my_stats.queryLatencyAvg();
+    my_stats.queryCollateralTime(querySetupTime); // TODO: Remove in Vespa 8
     my_stats.querySetupTime(querySetupTime);
     {
         vespalib::duration duration = request.getTimeUsed();

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -30,6 +30,7 @@ MatchingStats::MatchingStats()
       _doomOvertime(),
       _softDoomFactor(INITIAL_SOFT_DOOM_FACTOR),
       _queryCollateralTime(),
+      _querySetupTime(),
       _queryLatency(),
       _matchTime(),
       _groupingTime(),
@@ -70,6 +71,7 @@ MatchingStats::add(const MatchingStats &rhs)
     _doomOvertime.add(rhs._doomOvertime);
 
     _queryCollateralTime.add(rhs._queryCollateralTime);
+    _querySetupTime.add(rhs._querySetupTime);
     _queryLatency.add(rhs._queryLatency);
     _matchTime.add(rhs._matchTime);
     _groupingTime.add(rhs._groupingTime);

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -29,7 +29,7 @@ MatchingStats::MatchingStats()
       _softDoomed(0),
       _doomOvertime(),
       _softDoomFactor(INITIAL_SOFT_DOOM_FACTOR),
-      _queryCollateralTime(),
+      _queryCollateralTime(), // TODO: Remove in Vespa 8
       _querySetupTime(),
       _queryLatency(),
       _matchTime(),
@@ -70,7 +70,7 @@ MatchingStats::add(const MatchingStats &rhs)
     _softDoomed += rhs.softDoomed();
     _doomOvertime.add(rhs._doomOvertime);
 
-    _queryCollateralTime.add(rhs._queryCollateralTime);
+    _queryCollateralTime.add(rhs._queryCollateralTime); // TODO: Remove in Vespa 8
     _querySetupTime.add(rhs._querySetupTime);
     _queryLatency.add(rhs._queryLatency);
     _matchTime.add(rhs._matchTime);

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -126,6 +126,7 @@ private:
     Avg                    _doomOvertime;
     double                 _softDoomFactor;
     Avg                    _queryCollateralTime;
+    Avg                    _querySetupTime;
     Avg                    _queryLatency;
     Avg                    _matchTime;
     Avg                    _groupingTime;
@@ -173,6 +174,12 @@ public:
     size_t queryCollateralTimeCount() const { return _queryCollateralTime.count(); }
     double queryCollateralTimeMin() const { return _queryCollateralTime.min(); }
     double queryCollateralTimeMax() const { return _queryCollateralTime.max(); }
+
+    MatchingStats &querySetupTime(double time_s) { _querySetupTime.set(time_s); return *this; }
+    double querySetupTimeAvg() const { return _querySetupTime.avg(); }
+    size_t querySetupTimeCount() const { return _querySetupTime.count(); }
+    double querySetupTimeMin() const { return _querySetupTime.min(); }
+    double querySetupTimeMax() const { return _querySetupTime.max(); }
 
     MatchingStats &queryLatency(double time_s) { _queryLatency.set(time_s); return *this; }
     double queryLatencyAvg() const { return _queryLatency.avg(); }

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -125,7 +125,7 @@ private:
     size_t                 _softDoomed;
     Avg                    _doomOvertime;
     double                 _softDoomFactor;
-    Avg                    _queryCollateralTime;
+    Avg                    _queryCollateralTime; // TODO: Remove in Vespa 8
     Avg                    _querySetupTime;
     Avg                    _queryLatency;
     Avg                    _matchTime;
@@ -169,6 +169,7 @@ public:
     double softDoomFactor() const { return _softDoomFactor; }
     MatchingStats &updatesoftDoomFactor(vespalib::duration hardLimit, vespalib::duration softLimit, vespalib::duration duration);
 
+    // TODO: Remove in Vespa 8
     MatchingStats &queryCollateralTime(double time_s) { _queryCollateralTime.set(time_s); return *this; }
     double queryCollateralTimeAvg() const { return _queryCollateralTime.avg(); }
     size_t queryCollateralTimeCount() const { return _queryCollateralTime.count(); }

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
@@ -119,6 +119,8 @@ DocumentDBTaggedMetrics::MatchingMetrics::update(const MatchingStats &stats)
     queries.inc(stats.queries());
     queryCollateralTime.addValueBatch(stats.queryCollateralTimeAvg(), stats.queryCollateralTimeCount(),
                                       stats.queryCollateralTimeMin(), stats.queryCollateralTimeMax());
+    querySetupTime.addValueBatch(stats.querySetupTimeAvg(), stats.querySetupTimeCount(),
+                                      stats.querySetupTimeMin(), stats.querySetupTimeMax());
     queryLatency.addValueBatch(stats.queryLatencyAvg(), stats.queryLatencyCount(),
                                stats.queryLatencyMin(), stats.queryLatencyMax());
 }
@@ -131,6 +133,7 @@ DocumentDBTaggedMetrics::MatchingMetrics::MatchingMetrics(MetricSet *parent)
       queries("queries", {}, "Number of queries executed", this),
       softDoomedQueries("soft_doomed_queries", {}, "Number of queries hitting the soft timeout", this),
       queryCollateralTime("query_collateral_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
+      querySetupTime("query_setup_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
       queryLatency("query_latency", {}, "Total average latency (sec) when matching and ranking a query", this)
 {
 }
@@ -152,6 +155,7 @@ DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::RankProfileMetrics
       groupingTime("grouping_time", {}, "Average time (sec) spent on grouping", this),
       rerankTime("rerank_time", {}, "Average time (sec) spent on 2nd phase ranking", this),
       queryCollateralTime("query_collateral_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
+      querySetupTime("query_setup_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
       queryLatency("query_latency", {}, "Total average latency (sec) when matching and ranking a query", this)
 {
     softDoomFactor.set(MatchingStats::INITIAL_SOFT_DOOM_FACTOR);
@@ -204,6 +208,8 @@ DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::update(const Match
                              stats.rerankTimeMin(), stats.rerankTimeMax());
     queryCollateralTime.addValueBatch(stats.queryCollateralTimeAvg(), stats.queryCollateralTimeCount(),
                                       stats.queryCollateralTimeMin(), stats.queryCollateralTimeMax());
+    querySetupTime.addValueBatch(stats.querySetupTimeAvg(), stats.querySetupTimeCount(),
+                                      stats.querySetupTimeMin(), stats.querySetupTimeMax());
     queryLatency.addValueBatch(stats.queryLatencyAvg(), stats.queryLatencyCount(),
                                stats.queryLatencyMin(), stats.queryLatencyMax());
     if (stats.getNumPartitions() > 0) {

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
@@ -116,6 +116,7 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
         metrics::LongCountMetric queries;
         metrics::LongCountMetric softDoomedQueries;
         metrics::DoubleAverageMetric queryCollateralTime;
+        metrics::DoubleAverageMetric querySetupTime;
         metrics::DoubleAverageMetric queryLatency;
 
         struct RankProfileMetrics : metrics::MetricSet {
@@ -145,6 +146,7 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
             metrics::DoubleAverageMetric groupingTime;
             metrics::DoubleAverageMetric rerankTime;
             metrics::DoubleAverageMetric queryCollateralTime;
+            metrics::DoubleAverageMetric querySetupTime;
             metrics::DoubleAverageMetric queryLatency;
             DocIdPartitions              partitions;
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
