### PR TITLE
If debugging of SearchHandler is turned on, the 1k first request will…

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
@@ -93,7 +93,7 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
 
     /** Render and return whether the channel was closed */
     private void render(HttpRequest request, HttpResponse httpResponse,
-                        LazyContentChannel channel, long startTime) throws IOException {
+                        LazyContentChannel channel, long startTime) {
         LoggingCompletionHandler logOnCompletion = null;
         ContentChannelOutputStream output = null;
         try {
@@ -168,7 +168,7 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
         @Override
         public void close(CompletionHandler completionHandler) {
             if ( closed ) return;
-            try { httpRequest.getData().close(); } catch (IOException e) {};
+            try { httpRequest.getData().close(); } catch (IOException e) {}
             if (channel == null)
                 channel = handleResponse();
             try {

--- a/container-core/src/main/resources/configdefinitions/container-http.def
+++ b/container-core/src/main/resources/configdefinitions/container-http.def
@@ -3,3 +3,6 @@ namespace=container.core
 
 ## If non-empty, handlers should emit a header containing this string as key and the local host name as value
 hostResponseHeaderKey string default=""
+
+## For debugging, number of requests to add trace and timing information too if debugging is enabled.
+numQueriesToTraceOnDebugAfterConstruction int default=1000

--- a/container-search/src/main/java/com/yahoo/search/handler/HttpSearchResponse.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/HttpSearchResponse.java
@@ -69,14 +69,14 @@ public class HttpSearchResponse extends ExtendedResponse {
         }
     }
 
-    public ListenableFuture<Boolean> waitableRender(OutputStream stream) throws IOException {
+    public ListenableFuture<Boolean> waitableRender(OutputStream stream) {
         return waitableRender(result, query, rendererCopy, stream);
     }
 
     public static ListenableFuture<Boolean> waitableRender(Result result,
                                                            Query query,
                                                            Renderer<Result> renderer,
-                                                           OutputStream stream) throws IOException {
+                                                           OutputStream stream) {
         SearchResponse.trimHits(result);
         SearchResponse.removeEmptySummaryFeatureFields(result);
         return renderer.render(stream, result, query.getModel().getExecution(), query);

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -159,10 +159,10 @@ public class SearchHandler extends LoggingRequestHandler {
         this.maxThreads = examineExecutor(executor);
 
         searchConnections = new Value(SEARCH_CONNECTIONS, statistics,
-                new Value.Parameters().setLogRaw(true).setLogMax(true)
-                        .setLogMean(true).setLogMin(true)
-                        .setNameExtension(true)
-                        .setCallback(new MeanConnections()));
+                                      new Value.Parameters().setLogRaw(true).setLogMax(true)
+                                                            .setLogMean(true).setLogMin(true)
+                                                            .setNameExtension(true)
+                                                            .setCallback(new MeanConnections()));
 
         this.hostResponseHeaderKey = hostResponseHeaderKey;
         this.numRequestsLeftToTrace = new AtomicLong(numQueriesToTraceOnDebugAfterStartup);

--- a/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
@@ -3,7 +3,6 @@ package com.yahoo.search.searchchain;
 
 import com.yahoo.component.chain.Chain;
 import com.yahoo.language.Linguistics;
-import com.yahoo.log.LogLevel;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.Ping;
 import com.yahoo.prelude.Pong;
@@ -11,7 +10,6 @@ import com.yahoo.prelude.query.parser.SpecialTokenRegistry;
 import com.yahoo.processing.Processor;
 import com.yahoo.processing.Request;
 import com.yahoo.processing.Response;
-import com.yahoo.protect.Validator;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;

--- a/processing/src/main/java/com/yahoo/processing/execution/Execution.java
+++ b/processing/src/main/java/com/yahoo/processing/execution/Execution.java
@@ -206,7 +206,7 @@ public class Execution {
          * Creates an empty environment. Only useful for some limited testing
          */
         public static <C extends Processor> Environment<C> createEmpty() {
-            return new Environment<C>(new ChainRegistry<C>());
+            return new Environment<>(new ChainRegistry<>());
         }
 
         /**
@@ -254,7 +254,7 @@ public class Execution {
         /**
          * If true, do timing logic, even though trace level is low.
          */
-        private boolean forceTimestamps = false;
+        private boolean forceTimestamps;
 
         /**
          * Creates an empty root trace with a given level of tracing

--- a/searchlib/src/tests/fef/fef_test.cpp
+++ b/searchlib/src/tests/fef/fef_test.cpp
@@ -94,6 +94,7 @@ TEST("verify size of essential fef classes") {
     EXPECT_EQUAL(24u,sizeof(TermFieldMatchDataPosition));
     EXPECT_EQUAL(24u,sizeof(TermFieldMatchData::Features));
     EXPECT_EQUAL(40u,sizeof(TermFieldMatchData));
+    EXPECT_EQUAL(48u, sizeof(search::fef::FeatureExecutor));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }


### PR DESCRIPTION
… have trace and timing information.

The 1k number is configurable in the container-http config.

@bratseth PR
@yngveaasheim FYI
