### PR TITLE
Reapply "Only use 2 cores for config proxy"

### DIFF
--- a/config-proxy/src/main/sh/vespa-config-ctl.sh
+++ b/config-proxy/src/main/sh/vespa-config-ctl.sh
@@ -113,7 +113,7 @@ case $1 in
         if [ "$userargs" == "" ]; then
             userargs=$services__jvmargs_configproxy
         fi
-        jvmopts="-Xms32M -Xmx256M -XX:ThreadStackSize=256 -XX:MaxJavaStackTraceDepth=1000000"
+        jvmopts="-Xms32M -Xmx256M -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=256 -XX:MaxJavaStackTraceDepth=1000"
 
         VESPA_SERVICE_NAME=configproxy
         export VESPA_SERVICE_NAME
@@ -122,6 +122,7 @@ case $1 in
             java ${jvmopts} \
                  -XX:+ExitOnOutOfMemoryError $(getJavaOptionsIPV46) \
                  -Dproxyconfigsources="${configsources}" ${userargs} \
+                 -XX:ActiveProcessorCount=2 \
                  -cp $cp com.yahoo.vespa.config.proxy.ProxyServer 19090
 
         echo "Waiting for config proxy to start"

--- a/logserver/bin/logserver-start.sh
+++ b/logserver/bin/logserver-start.sh
@@ -78,7 +78,7 @@ ROOT=${VESPA_HOME%/}
 export ROOT
 cd $ROOT || { echo "Cannot cd to $ROOT" 1>&2; exit 1; }
 
-addopts="-server -Xms32m -Xmx256m -XX:MaxDirectMemorySize=76m -XX:MaxJavaStackTraceDepth=1000000"
+addopts="-server -Xms32m -Xmx256m -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=256-XX:MaxJavaStackTraceDepth=1000 -XX:ActiveProcessorCount=2"
 
 oomopt="-XX:+ExitOnOutOfMemoryError"
 

--- a/logserver/bin/logserver-start.sh
+++ b/logserver/bin/logserver-start.sh
@@ -78,7 +78,7 @@ ROOT=${VESPA_HOME%/}
 export ROOT
 cd $ROOT || { echo "Cannot cd to $ROOT" 1>&2; exit 1; }
 
-addopts="-server -Xms32m -Xmx256m -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=256-XX:MaxJavaStackTraceDepth=1000 -XX:ActiveProcessorCount=2"
+addopts="-server -Xms32m -Xmx256m -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=256 -XX:MaxJavaStackTraceDepth=1000 -XX:ActiveProcessorCount=2"
 
 oomopt="-XX:+ExitOnOutOfMemoryError"
 


### PR DESCRIPTION
First commit is the same as https://github.com/vespa-engine/vespa/pull/12167, second commit fixes a missing space in logserver start script
