### PR TITLE
Use larger thread stacks (128 kiB) in FRT standalone supervisor

### DIFF
--- a/fnet/src/vespa/fnet/frt/supervisor.cpp
+++ b/fnet/src/vespa/fnet/frt/supervisor.cpp
@@ -409,7 +409,7 @@ FRT_Supervisor::SchedulerPtr::SchedulerPtr(FNET_TransportThread *transport_threa
 namespace fnet::frt {
 
 StandaloneFRT::StandaloneFRT()
-    : _threadPool(std::make_unique<FastOS_ThreadPool>(1024*60)),
+    : _threadPool(std::make_unique<FastOS_ThreadPool>(1024*128)),
       _transport(std::make_unique<FNET_Transport>()),
       _supervisor(std::make_unique<FRT_Supervisor>(_transport.get()))
 {
@@ -417,7 +417,7 @@ StandaloneFRT::StandaloneFRT()
 }
 
 StandaloneFRT::StandaloneFRT(vespalib::CryptoEngine::SP crypto)
-    : _threadPool(std::make_unique<FastOS_ThreadPool>(1024*60)),
+    : _threadPool(std::make_unique<FastOS_ThreadPool>(1024*128)),
       _transport(std::make_unique<FNET_Transport>(std::move(crypto), 1)),
       _supervisor(std::make_unique<FRT_Supervisor>(_transport.get()))
 {


### PR DESCRIPTION
(used by unit tests).  60 kiB is not sufficent when running on
Darwin and using lz4 library.

@baldersheim : please review
