### PR TITLE
Rename field name -> jobName to follow /deployment api

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -192,7 +192,7 @@ class JobControllerApiHandlerHelper {
                       return;
 
                   Cursor jobObject = jobsArray.addObject();
-                  jobObject.setString("name", job.type().jobName());
+                  jobObject.setString("jobName", job.type().jobName());
                   toSlime(jobObject.setArray("runs"), runs, baseUriForJobs);
               });
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-overview.json
@@ -32,7 +32,7 @@
   },
   "deployment": [
     {
-      "name": "dev-us-east-1",
+      "jobName": "dev-us-east-1",
       "runs": [
         {
           "id": 1,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobs.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/jobs.json
@@ -331,7 +331,7 @@
   },
   "deployment": [
     {
-      "name": "dev-us-east-1",
+      "jobName": "dev-us-east-1",
       "runs": [
         {
           "id": 1,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview-user-instance.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview-user-instance.json
@@ -53,7 +53,7 @@
   },
   "deployment": [
     {
-      "name": "dev-aws-us-east-2a",
+      "jobName": "dev-aws-us-east-2a",
       "runs": [
         {
           "id": 1,


### PR DESCRIPTION
Rename job name field used for dev deployments to be the same as used in /deployment API:
https://github.com/vespa-engine/vespa/blob/20f84687ed1362a7f76404e2f20a6619fca05119/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java#L630