### PR TITLE
Production tests must start after a successful deployment

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatusList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatusList.java
@@ -3,15 +3,9 @@ package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.yahoo.collections.AbstractFilteringList;
 import com.yahoo.component.Version;
-import com.yahoo.config.application.api.DeploymentSpec;
-import com.yahoo.vespa.hosted.controller.Instance;
-import com.yahoo.vespa.hosted.controller.application.ApplicationList;
-import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * List for filtering deployment status of applications, for inspection and decision making.
@@ -48,14 +42,14 @@ public class DeploymentStatusList extends AbstractFilteringList<DeploymentStatus
 
     private static boolean failingUpgradeToVersionSince(JobList jobs, Version version, Instant threshold) {
         return ! jobs.not().failingApplicationChange()
-                     .firstFailing().endedBefore(threshold)
+                     .firstFailing().endedNoLaterThan(threshold)
                      .lastCompleted().on(version)
                      .isEmpty();
     }
 
     private static boolean failingApplicationChangeSince(JobList jobs, Instant threshold) {
         return ! jobs.failingApplicationChange()
-                     .firstFailing().endedBefore(threshold)
+                     .firstFailing().endedNoLaterThan(threshold)
                      .isEmpty();
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
@@ -141,24 +141,9 @@ public class JobList extends AbstractFilteringList<JobStatus, JobList> {
             return mapToList(Function.identity());
         }
 
-        /** Returns the subset of jobs where the run of the given type occurred before the given instant */
-        public JobList endedBefore(Instant threshold) {
-            return matching(run -> run.end().orElse(Instant.MAX).isBefore(threshold));
-        }
-
-        /** Returns the subset of jobs where the run of the given type occurred after the given instant */
-        public JobList endedAfter(Instant threshold) {
-            return matching(run -> run.end().orElse(Instant.MIN).isAfter(threshold));
-        }
-
-        /** Returns the subset of jobs where the run of the given type occurred before the given instant */
-        public JobList startedBefore(Instant threshold) {
-            return matching(run -> run.start().isBefore(threshold));
-        }
-
-        /** Returns the subset of jobs where the run of the given type occurred after the given instant */
-        public JobList startedAfter(Instant threshold) {
-            return matching(run -> run.start().isAfter(threshold));
+        /** Returns the subset of jobs where the run of the given type occurred at or before the given instant */
+        public JobList endedNoLaterThan(Instant threshold) {
+            return matching(run -> ! run.end().orElse(Instant.MAX).isAfter(threshold));
         }
 
         /** Returns the subset of jobs where the run of the given type was on the given version */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobList.java
@@ -117,7 +117,7 @@ public class JobList extends AbstractFilteringList<JobStatus, JobList> {
         return new RunFilter(JobStatus::firstFailing);
     }
 
-    /** Allows sub-filters for runs of the given kind */
+    /** Allows sub-filters for runs of the indicated kind */
     public class RunFilter {
 
         private final Function<JobStatus, Optional<Run>> which;
@@ -126,32 +126,32 @@ public class JobList extends AbstractFilteringList<JobStatus, JobList> {
             this.which = which;
         }
 
-        /** Returns the subset of jobs where the run of the given type exists */
+        /** Returns the subset of jobs where the run of the indicated type exists */
         public JobList present() {
             return matching(run -> true);
         }
 
-        /** Returns the runs of the given kind, mapped by the given function, as a list. */
+        /** Returns the runs of the indicated kind, mapped by the given function, as a list. */
         public <OtherType> List<OtherType> mapToList(Function<? super Run, OtherType> mapper) {
             return present().mapToList(which.andThen(Optional::get).andThen(mapper));
         }
 
-        /** Returns the runs of the given kind. */
+        /** Returns the runs of the indicated kind. */
         public List<Run> asList() {
             return mapToList(Function.identity());
         }
 
-        /** Returns the subset of jobs where the run of the given type occurred at or before the given instant */
+        /** Returns the subset of jobs where the run of the indicated type ended no later than the given instant */
         public JobList endedNoLaterThan(Instant threshold) {
             return matching(run -> ! run.end().orElse(Instant.MAX).isAfter(threshold));
         }
 
-        /** Returns the subset of jobs where the run of the given type was on the given version */
+        /** Returns the subset of jobs where the run of the indicated type was on the given version */
         public JobList on(ApplicationVersion version) {
             return matching(run -> run.versions().targetApplication().equals(version));
         }
 
-        /** Returns the subset of jobs where the run of the given type was on the given version */
+        /** Returns the subset of jobs where the run of the indicated type was on the given version */
         public JobList on(Version version) {
             return matching(run -> run.versions().targetPlatform().equals(version));
         }


### PR DESCRIPTION
@mpolden please review and merge. This fixes an error where a production test would be marked as complete as long as it was on the correct version, and _any_ production deployment had previously completed
