### PR TITLE
Implement TLS client SNI and hostname validation in OpenSSL codec

### DIFF
--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -86,10 +86,13 @@ FBench::init_crypto_engine(const std::string &ca_certs_file_name,
         return false;
     }
     bool load_failed = false;
-    vespalib::net::tls::TransportSecurityOptions
-        tls_opts(maybe_load(ca_certs_file_name, load_failed),
-                 maybe_load(cert_chain_file_name, load_failed),
-                 maybe_load(private_key_file_name, load_failed));
+    auto ts_builder = vespalib::net::tls::TransportSecurityOptions::Params().
+            ca_certs_pem(maybe_load(ca_certs_file_name, load_failed)).
+            cert_chain_pem(maybe_load(cert_chain_file_name, load_failed)).
+            private_key_pem(maybe_load(private_key_file_name, load_failed)).
+            authorized_peers(vespalib::net::tls::AuthorizedPeers::allow_all_authenticated()).
+            disable_hostname_validation(true); // TODO configurable or default false!
+    vespalib::net::tls::TransportSecurityOptions tls_opts(std::move(ts_builder));
     if (load_failed) {
         fprintf(stderr, "failed to load transport security options\n");
         return false;

--- a/vbench/src/vbench/vbench/vbench.cpp
+++ b/vbench/src/vbench/vbench/vbench.cpp
@@ -29,11 +29,13 @@ CryptoEngine::SP setup_crypto(const vespalib::slime::Inspector &tls) {
     if (!tls.valid()) {
         return std::make_shared<vespalib::NullCryptoEngine>();
     }
-    vespalib::net::tls::TransportSecurityOptions
-        tls_opts(maybe_load(tls["ca-certificates"]),
-                 maybe_load(tls["certificates"]),
-                 maybe_load(tls["private-key"]));
-    return std::make_shared<vespalib::TlsCryptoEngine>(tls_opts);
+    auto ts_builder = vespalib::net::tls::TransportSecurityOptions::Params().
+            ca_certs_pem(maybe_load(tls["ca-certificates"])).
+            cert_chain_pem(maybe_load(tls["certificates"])).
+            private_key_pem(maybe_load(tls["private-key"])).
+            authorized_peers(vespalib::net::tls::AuthorizedPeers::allow_all_authenticated()).
+            disable_hostname_validation(true); // TODO configurable or default false!
+    return std::make_shared<vespalib::TlsCryptoEngine>(vespalib::net::tls::TransportSecurityOptions(std::move(ts_builder)));
 }
 
 } // namespace vbench::<unnamed>

--- a/vespalib/src/tests/net/tls/transport_options/transport_options_reading_test.cpp
+++ b/vespalib/src/tests/net/tls/transport_options/transport_options_reading_test.cpp
@@ -155,6 +155,47 @@ TEST("accepted cipher list is populated if specified") {
     EXPECT_EQUAL("bar", ciphers[1]);
 }
 
+// FIXME this is temporary until we know enabling it by default won't break the world!
+TEST("hostname validation is DISABLED by default when creating options from config file") {
+    const char* json = R"({"files":{"private-key":"dummy_privkey.txt",
+                                    "certificates":"dummy_certs.txt",
+                                    "ca-certificates":"dummy_ca_certs.txt"}})";
+    EXPECT_TRUE(read_options_from_json_string(json)->disable_hostname_validation());
+}
+
+TEST("TransportSecurityOptions builder does not disable hostname validation by default") {
+    auto ts_builder = vespalib::net::tls::TransportSecurityOptions::Params().
+            ca_certs_pem("foo").
+            cert_chain_pem("bar").
+            private_key_pem("fantonald");
+    TransportSecurityOptions ts_opts(std::move(ts_builder));
+    EXPECT_FALSE(ts_opts.disable_hostname_validation());
+}
+
+TEST("hostname validation can be explicitly disabled") {
+    const char* json = R"({"files":{"private-key":"dummy_privkey.txt",
+                                    "certificates":"dummy_certs.txt",
+                                    "ca-certificates":"dummy_ca_certs.txt"},
+                           "disable-hostname-validation": true})";
+    EXPECT_TRUE(read_options_from_json_string(json)->disable_hostname_validation());
+}
+
+TEST("hostname validation can be explicitly enabled") {
+    const char* json = R"({"files":{"private-key":"dummy_privkey.txt",
+                                    "certificates":"dummy_certs.txt",
+                                    "ca-certificates":"dummy_ca_certs.txt"},
+                           "disable-hostname-validation": false})";
+    EXPECT_FALSE(read_options_from_json_string(json)->disable_hostname_validation());
+}
+
+TEST("unknown fields are ignored at parse-time") {
+    const char* json = R"({"files":{"private-key":"dummy_privkey.txt",
+                                    "certificates":"dummy_certs.txt",
+                                    "ca-certificates":"dummy_ca_certs.txt"},
+                           "flipper-the-dolphin": "*weird dolphin noises*"})";
+    EXPECT_TRUE(read_options_from_json_string(json).get() != nullptr); // And no exception thrown.
+}
+
 // TODO test parsing of multiple policies
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/vespa/vespalib/net/socket_spec.cpp
+++ b/vespalib/src/vespa/vespalib/net/socket_spec.cpp
@@ -41,7 +41,7 @@ SocketSpec::address(bool server) const
     return SocketAddress();
 }
 
-SocketSpec SocketSpec::invalid;
+const SocketSpec SocketSpec::invalid;
 
 SocketSpec::SocketSpec(const vespalib::string &spec)
     : SocketSpec()

--- a/vespalib/src/vespa/vespalib/net/socket_spec.h
+++ b/vespalib/src/vespa/vespalib/net/socket_spec.h
@@ -24,7 +24,7 @@ private:
         : _type(type), _node(node), _port(port) {}
     SocketAddress address(bool server) const;
 public:
-    static SocketSpec invalid;
+    static const SocketSpec invalid;
     explicit SocketSpec(const vespalib::string &spec);
     vespalib::string spec() const;
     SocketSpec replace_host(const vespalib::string &new_host) const;

--- a/vespalib/src/vespa/vespalib/net/tls/crypto_codec.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/crypto_codec.cpp
@@ -6,12 +6,23 @@
 
 namespace vespalib::net::tls {
 
-std::unique_ptr<CryptoCodec> CryptoCodec::create_default_codec(
-        std::shared_ptr<TlsContext> ctx, const SocketAddress& peer_address, Mode mode)
+std::unique_ptr<CryptoCodec>
+CryptoCodec::create_default_client_codec(std::shared_ptr<TlsContext> ctx,
+                                         const SocketSpec& peer_spec,
+                                         const SocketAddress& peer_address)
 {
     auto ctx_impl = std::dynamic_pointer_cast<impl::OpenSslTlsContextImpl>(ctx); // only takes by const ref
     assert(ctx_impl);
-    return std::make_unique<impl::OpenSslCryptoCodecImpl>(std::move(ctx_impl), peer_address, mode);
+    return impl::OpenSslCryptoCodecImpl::make_client_codec(std::move(ctx_impl), peer_spec, peer_address);
+}
+
+std::unique_ptr<CryptoCodec>
+CryptoCodec::create_default_server_codec(std::shared_ptr<TlsContext> ctx,
+                                         const SocketAddress& peer_address)
+{
+    auto ctx_impl = std::dynamic_pointer_cast<impl::OpenSslTlsContextImpl>(ctx); // only takes by const ref
+    assert(ctx_impl);
+    return impl::OpenSslCryptoCodecImpl::make_server_codec(std::move(ctx_impl), peer_address);
 }
 
 }

--- a/vespalib/src/vespa/vespalib/net/tls/crypto_codec.h
+++ b/vespalib/src/vespa/vespalib/net/tls/crypto_codec.h
@@ -4,6 +4,8 @@
 #include <vespa/vespalib/net/socket_address.h>
 #include <memory>
 
+namespace vespalib { class SocketSpec; }
+
 namespace vespalib::net::tls {
 
 struct HandshakeResult {
@@ -179,9 +181,13 @@ public:
      *
      * Throws CryptoException if resources cannot be allocated for the codec.
      */
-    static std::unique_ptr<CryptoCodec> create_default_codec(std::shared_ptr<TlsContext> ctx,
-                                                             const SocketAddress& peer_address,
-                                                             Mode mode);
+    static std::unique_ptr<CryptoCodec>
+    create_default_client_codec(std::shared_ptr<TlsContext> ctx,
+                                const SocketSpec& peer_spec,
+                                const SocketAddress& peer_address);
+    static std::unique_ptr<CryptoCodec>
+    create_default_server_codec(std::shared_ptr<TlsContext> ctx,
+                                const SocketAddress& peer_address);
 };
 
 }

--- a/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
@@ -64,18 +64,23 @@ public:
 class AuthorizedPeers {
     // A peer will be authorized iff it matches _one or more_ policies.
     std::vector<PeerPolicy> _peer_policies;
-    bool _allow_all_if_empty = false;
+    bool _allow_all_if_empty;
 
     explicit AuthorizedPeers(bool allow_all_if_empty)
         : _peer_policies(),
           _allow_all_if_empty(allow_all_if_empty)
     {}
 public:
-    AuthorizedPeers() = default;
+    AuthorizedPeers() : _peer_policies(), _allow_all_if_empty(false) {}
     explicit AuthorizedPeers(std::vector<PeerPolicy> peer_policies_)
         : _peer_policies(std::move(peer_policies_)),
           _allow_all_if_empty(false)
     {}
+
+    AuthorizedPeers(const AuthorizedPeers&) = default;
+    AuthorizedPeers& operator=(const AuthorizedPeers&) = default;
+    AuthorizedPeers(AuthorizedPeers&&) noexcept = default;
+    AuthorizedPeers& operator=(AuthorizedPeers&&) noexcept = default;
 
     static AuthorizedPeers allow_all_authenticated() {
         return AuthorizedPeers(true);

--- a/vespalib/src/vespa/vespalib/net/tls/tls_crypto_engine.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/tls_crypto_engine.cpp
@@ -12,18 +12,16 @@ TlsCryptoEngine::TlsCryptoEngine(net::tls::TransportSecurityOptions tls_opts, ne
 }
 
 std::unique_ptr<TlsCryptoSocket>
-TlsCryptoEngine::create_tls_client_crypto_socket(SocketHandle socket, const SocketSpec &)
+TlsCryptoEngine::create_tls_client_crypto_socket(SocketHandle socket, const SocketSpec &peer_spec)
 {
-    auto mode = net::tls::CryptoCodec::Mode::Client;
-    auto codec = net::tls::CryptoCodec::create_default_codec(_tls_ctx, SocketAddress::peer_address(socket.get()), mode);
+    auto codec = net::tls::CryptoCodec::create_default_client_codec(_tls_ctx, peer_spec, SocketAddress::peer_address(socket.get()));
     return std::make_unique<net::tls::CryptoCodecAdapter>(std::move(socket), std::move(codec));
 }
 
 std::unique_ptr<TlsCryptoSocket>
 TlsCryptoEngine::create_tls_server_crypto_socket(SocketHandle socket)
 {
-    auto mode = net::tls::CryptoCodec::Mode::Server;
-    auto codec = net::tls::CryptoCodec::create_default_codec(_tls_ctx, SocketAddress::peer_address(socket.get()), mode);
+    auto codec = net::tls::CryptoCodec::create_default_server_codec(_tls_ctx, SocketAddress::peer_address(socket.get()));
     return std::make_unique<net::tls::CryptoCodecAdapter>(std::move(socket), std::move(codec));
 }
 

--- a/vespalib/src/vespa/vespalib/net/tls/transport_security_options.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/transport_security_options.cpp
@@ -11,40 +11,56 @@ TransportSecurityOptions::TransportSecurityOptions(Params params)
       _cert_chain_pem(std::move(params._cert_chain_pem)),
       _private_key_pem(std::move(params._private_key_pem)),
       _authorized_peers(std::move(params._authorized_peers)),
-      _accepted_ciphers(std::move(params._accepted_ciphers))
-{
-}
-
-TransportSecurityOptions::TransportSecurityOptions(vespalib::string ca_certs_pem,
-                                                   vespalib::string cert_chain_pem,
-                                                   vespalib::string private_key_pem)
-    : _ca_certs_pem(std::move(ca_certs_pem)),
-      _cert_chain_pem(std::move(cert_chain_pem)),
-      _private_key_pem(std::move(private_key_pem)),
-      _authorized_peers(AuthorizedPeers::allow_all_authenticated())
+      _accepted_ciphers(std::move(params._accepted_ciphers)),
+      _disable_hostname_validation(params._disable_hostname_validation)
 {
 }
 
 TransportSecurityOptions::TransportSecurityOptions(vespalib::string ca_certs_pem,
                                                    vespalib::string cert_chain_pem,
                                                    vespalib::string private_key_pem,
-                                                   AuthorizedPeers authorized_peers)
+                                                   AuthorizedPeers authorized_peers,
+                                                   bool disable_hostname_validation)
     : _ca_certs_pem(std::move(ca_certs_pem)),
       _cert_chain_pem(std::move(cert_chain_pem)),
       _private_key_pem(std::move(private_key_pem)),
-      _authorized_peers(std::move(authorized_peers))
+      _authorized_peers(std::move(authorized_peers)),
+      _disable_hostname_validation(disable_hostname_validation)
 {
+}
+
+TransportSecurityOptions TransportSecurityOptions::copy_without_private_key() const {
+    return TransportSecurityOptions(_ca_certs_pem, _cert_chain_pem, "",
+                                    _authorized_peers, _disable_hostname_validation);
 }
 
 void secure_memzero(void* buf, size_t size) noexcept {
     OPENSSL_cleanse(buf, size);
 }
 
-TransportSecurityOptions::Params::Params() = default;
+TransportSecurityOptions::Params::Params()
+    : _ca_certs_pem(),
+      _cert_chain_pem(),
+      _private_key_pem(),
+      _authorized_peers(),
+      _accepted_ciphers(),
+      _disable_hostname_validation(false)
+{
+}
 
 TransportSecurityOptions::Params::~Params() {
     secure_memzero(&_private_key_pem[0], _private_key_pem.size());
 }
+
+TransportSecurityOptions::Params::Params(const Params&) = default;
+
+TransportSecurityOptions::Params&
+TransportSecurityOptions::Params::operator=(const TransportSecurityOptions::Params&) = default;
+
+TransportSecurityOptions::Params::Params(Params&&) noexcept = default;
+
+TransportSecurityOptions::Params&
+TransportSecurityOptions::Params::operator=(TransportSecurityOptions::Params&&) noexcept = default;
 
 TransportSecurityOptions::~TransportSecurityOptions() {
     secure_memzero(&_private_key_pem[0], _private_key_pem.size());

--- a/vespalib/src/vespa/vespalib/net/tls/transport_security_options.h
+++ b/vespalib/src/vespa/vespalib/net/tls/transport_security_options.h
@@ -14,18 +14,22 @@ class TransportSecurityOptions {
     vespalib::string _private_key_pem;
     AuthorizedPeers  _authorized_peers;
     std::vector<vespalib::string> _accepted_ciphers;
+    bool _disable_hostname_validation;
 public:
-    TransportSecurityOptions() = default;
-
     struct Params {
         vespalib::string _ca_certs_pem;
         vespalib::string _cert_chain_pem;
         vespalib::string _private_key_pem;
         AuthorizedPeers  _authorized_peers;
         std::vector<vespalib::string> _accepted_ciphers;
+        bool _disable_hostname_validation;
 
         Params();
         ~Params();
+        Params(const Params&);
+        Params& operator=(const Params&);
+        Params(Params&&) noexcept;
+        Params& operator=(Params&&) noexcept;
 
         Params& ca_certs_pem(vespalib::stringref pem) { _ca_certs_pem = pem; return *this; }
         Params& cert_chain_pem(vespalib::stringref pem) { _cert_chain_pem = pem; return *this; }
@@ -35,18 +39,13 @@ public:
             _accepted_ciphers = std::move(ciphers);
             return *this;
         }
+        Params& disable_hostname_validation(bool disable) {
+            _disable_hostname_validation = disable;
+            return *this;
+        }
     };
 
     explicit TransportSecurityOptions(Params params);
-
-    TransportSecurityOptions(vespalib::string ca_certs_pem,
-                             vespalib::string cert_chain_pem,
-                             vespalib::string private_key_pem);
-
-    TransportSecurityOptions(vespalib::string ca_certs_pem,
-                             vespalib::string cert_chain_pem,
-                             vespalib::string private_key_pem,
-                             AuthorizedPeers authorized_peers);
 
     ~TransportSecurityOptions();
 
@@ -55,10 +54,16 @@ public:
     const vespalib::string& private_key_pem() const noexcept { return _private_key_pem; }
     const AuthorizedPeers& authorized_peers() const noexcept { return _authorized_peers; }
 
-    TransportSecurityOptions copy_without_private_key() const {
-        return TransportSecurityOptions(_ca_certs_pem, _cert_chain_pem, "", _authorized_peers);
-    }
+    TransportSecurityOptions copy_without_private_key() const;
     const std::vector<vespalib::string>& accepted_ciphers() const noexcept { return _accepted_ciphers; }
+    bool disable_hostname_validation() const noexcept { return _disable_hostname_validation; }
+
+private:
+    TransportSecurityOptions(vespalib::string ca_certs_pem,
+                             vespalib::string cert_chain_pem,
+                             vespalib::string private_key_pem,
+                             AuthorizedPeers authorized_peers,
+                             bool disable_hostname_validation);
 };
 
 // Zeroes out `size` bytes in `buf` in a way that shall never be optimized

--- a/vespalib/src/vespa/vespalib/net/tls/transport_security_options_reading.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/transport_security_options_reading.cpp
@@ -123,6 +123,12 @@ std::unique_ptr<TransportSecurityOptions> load_from_input(Input& input) {
     auto priv_key = load_file_referenced_by_field(files, "private-key");
     auto authorized_peers = parse_authorized_peers(root["authorized-peers"]);
     auto accepted_ciphers = parse_accepted_ciphers(root["accepted-ciphers"]);
+    // FIXME this is temporary until we know it won't break a bunch of things!
+    // It's still possible to explicitly enable hostname validation by setting this to false.
+    bool disable_hostname_validation = true;
+    if (root["disable-hostname-validation"].valid()) {
+        disable_hostname_validation = root["disable-hostname-validation"].asBool();
+    }
 
     auto options = std::make_unique<TransportSecurityOptions>(
             TransportSecurityOptions::Params()
@@ -130,7 +136,8 @@ std::unique_ptr<TransportSecurityOptions> load_from_input(Input& input) {
                 .cert_chain_pem(certs)
                 .private_key_pem(priv_key)
                 .authorized_peers(std::move(authorized_peers))
-                .accepted_ciphers(std::move(accepted_ciphers)));
+                .accepted_ciphers(std::move(accepted_ciphers))
+                .disable_hostname_validation(disable_hostname_validation));
     secure_memzero(&priv_key[0], priv_key.size());
     return options;
 }

--- a/vespalib/src/vespa/vespalib/test/make_tls_options_for_testing.cpp
+++ b/vespalib/src/vespa/vespalib/test/make_tls_options_for_testing.cpp
@@ -70,7 +70,13 @@ namespace vespalib::test {
 SocketSpec local_spec("tcp/localhost:123");
 
 vespalib::net::tls::TransportSecurityOptions make_tls_options_for_testing() {
-    return vespalib::net::tls::TransportSecurityOptions(ca_pem, cert_pem, key_pem);
+    auto ts_builder = vespalib::net::tls::TransportSecurityOptions::Params().
+            ca_certs_pem(ca_pem).
+            cert_chain_pem(cert_pem).
+            private_key_pem(key_pem).
+            authorized_peers(vespalib::net::tls::AuthorizedPeers::allow_all_authenticated()).
+            disable_hostname_validation(true); // FIXME this is to avoid mass breakage of TLS'd networking tests.
+    return vespalib::net::tls::TransportSecurityOptions(std::move(ts_builder));
 }
 
 } // namespace vespalib::test


### PR DESCRIPTION
@havardpe please review
@bjorncs FYI

Also adds `disable-hostname-validation` config entry to TLS JSON
config file parsing in C++.

For the time being, hostname validation is implicitly disabled
unless explicitly specified in the config file. This will be
gradually changed over to be implicitly enabled by default.
SNI is always sent when a valid connection spec is provided.
