### PR TITLE
Use non-legacy path for getting tester log

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
@@ -34,7 +34,7 @@ public class TesterClient {
     public HttpResponse getLog(String testerHostname, int port, Long after) {
         URI testerUri;
         try {
-            testerUri = createBuilder(testerHostname, port, "/tester/v1/log2")
+            testerUri = createBuilder(testerHostname, port, "/tester/v1/log")
                     .addParameter("after", String.valueOf(after))
                     .build();
         } catch (URISyntaxException e) {


### PR DESCRIPTION
/log2 is going away, we want to use /log. Both have been supported since 7.177.11 (see https://github.com/vespa-engine/vespa/pull/12100)