### PR TITLE
Revert "Upgrade to ZooKeeper 3.5.7"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -768,8 +768,7 @@
         <protobuf.version>3.7.0</protobuf.version>
         <surefire.version>2.22.0</surefire.version>
         <tensorflow.version>1.12.0</tensorflow.version>
-        <zookeeper.client.version>3.5.7</zookeeper.client.version>
-        <zookeeper.server.version>3.5.7</zookeeper.server.version>
+        <zookeeper.client.version>3.5.6</zookeeper.client.version>
 
         <doclint>all</doclint>
         <test.hide>true</test.hide>

--- a/zookeeper-command-line-client/pom.xml
+++ b/zookeeper-command-line-client/pom.xml
@@ -14,7 +14,8 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>${zookeeper.client.version}</version>
+      <!-- TODO: Testing out 3.5 version, set to zookeeper.client.version when that has been set to 3.5.x -->
+      <version>3.5.6</version>
     </dependency>
     <dependency>
       <!-- Needed by vespa-zkcli -->

--- a/zookeeper-server/zookeeper-server-3.5/pom.xml
+++ b/zookeeper-server/zookeeper-server-3.5/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>${zookeeper.server.version}</version>
+      <version>3.5.6</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Reverts vespa-engine/vespa#12235

Seeing connection issues and "No route to host" between zookeeper servers in an aws zone, revert to see if this is related to upgrade