### PR TITLE
Resume host on freeze timeout

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdater.java
@@ -114,6 +114,10 @@ public class NodeAdminStateUpdater {
             // To avoid node agents stalling for too long, we'll force unfrozen ticks now.
             adjustNodeAgentsToRunFromNodeRepository();
             nodeAdmin.setFrozen(false);
+
+            NodeState currentNodeState = nodeRepository.getNode(hostHostname).state();
+            if (currentNodeState == NodeState.active) orchestrator.resume(hostHostname);
+
             throw new ConvergenceException("Timed out trying to freeze all nodes: will force an unfrozen tick");
         }
 


### PR DESCRIPTION
Observed on host: The host tries to suspend all services on the host, but is
not allowed to do so for a long period. However the host itself is allowed to
be down, and that is not released even during freeze timeouts (when the nodes
are resumed once). This is unfortunate as the host is suspended unnecessarily.