### PR TITLE
Use level INFO for uninstalling bundles

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -19,6 +19,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import static com.yahoo.log.LogLevel.DEBUG;
+import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 
@@ -50,11 +52,11 @@ public class Deconstructor implements ComponentDeconstructor {
                 }
             } else if (component instanceof Provider) {
                 // TODO Providers should most likely be deconstructed similarly to AbstractComponent
-                log.log(LogLevel.DEBUG, () -> "Starting deconstruction of provider " + component);
+                log.log(DEBUG, () -> "Starting deconstruction of provider " + component);
                 ((Provider<?>) component).deconstruct();
-                log.log(LogLevel.DEBUG, () -> "Finished deconstruction of provider " + component);
+                log.log(DEBUG, () -> "Finished deconstruction of provider " + component);
             } else if (component instanceof SharedResource) {
-                log.log(LogLevel.DEBUG, () -> "Releasing container reference to resource " + component);
+                log.log(DEBUG, () -> "Releasing container reference to resource " + component);
                 // No need to delay release, as jdisc does ref-counting
                 ((SharedResource) component).release();
             }
@@ -87,10 +89,10 @@ public class Deconstructor implements ComponentDeconstructor {
         @Override
         public void run() {
             for (var component : components) {
-                log.log(LogLevel.DEBUG, () -> "Starting deconstruction of component " + component);
+                log.log(DEBUG, () -> "Starting deconstruction of component " + component);
                 try {
                     component.deconstruct();
-                    log.log(LogLevel.DEBUG, () -> "Finished deconstructing of component " + component);
+                    log.log(DEBUG, () -> "Finished deconstructing of component " + component);
                 } catch (Exception | NoClassDefFoundError e) { // May get class not found due to it being already unloaded
                     log.log(WARNING, "Exception thrown when deconstructing component " + component, e);
                 } catch (Error e) {
@@ -110,7 +112,7 @@ public class Deconstructor implements ComponentDeconstructor {
             // It should now be safe to uninstall the old bundles.
             for (var bundle : bundles) {
                 try {
-                    log.log(LogLevel.DEBUG, () -> "Uninstalling bundle " + bundle);
+                    log.log(INFO, "Uninstalling bundle " + bundle);
                     bundle.uninstall();
                 } catch (BundleException e) {
                     log.log(SEVERE, "Could not uninstall bundle " + bundle);


### PR DESCRIPTION
Installing bundles, and the set of installed bundles, are logged with
INFO as well. This is only logged for application bundles upon
redeploy, so it does not generate many messages.

FYI: @hmusum 