### PR TITLE
Simplify and reduce logging.

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/CfgConfigPayloadBuilder.java
+++ b/config/src/main/java/com/yahoo/config/subscription/CfgConfigPayloadBuilder.java
@@ -8,7 +8,8 @@ import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.ConfigPayloadBuilder;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Deserializes config payload (cfg format) to a ConfigPayload.
@@ -33,15 +34,10 @@ public class CfgConfigPayloadBuilder {
         int lineNum = 1;
         ConfigPayloadBuilder payloadBuilder = new ConfigPayloadBuilder();
         for (String line : lines) {
-            if (log.isLoggable(LogLevel.SPAM)) {
-               log.log(LogLevel.SPAM, "line " + lineNum + ": '" + line + "'");
-            }
             parseLine(line, lineNum, payloadBuilder);
             lineNum++;
         }
-        if (log.isLoggable(LogLevel.DEBUG)) {
-            log.log(LogLevel.DEBUG, "payload=" + payloadBuilder.toString());
-        }
+        log.log(LogLevel.SPAM, () -> "payload=" + payloadBuilder.toString());
         return payloadBuilder;
     }
 
@@ -52,16 +48,13 @@ public class CfgConfigPayloadBuilder {
         String field = fieldAndValue.getFirst();
         String value = fieldAndValue.getSecond();
         if (field==null || value==null) {
-            log.log(LogLevel.DEBUG, "Got field without value in line " + lineNum + ": " + line + ", skipping");
+            log.log(LogLevel.DEBUG, () -> "Got field without value in line " + lineNum + ": " + line + ", skipping");
             return;
         }
         field=field.trim();
         value=value.trim();
         validateField(field, trimmedLine, lineNum);
         validateValue(value, trimmedLine, lineNum);
-        if (log.isLoggable(LogLevel.DEBUG)) {
-            log.log(LogLevel.DEBUG, "field=" + field + ",value=" + value);
-        }
         List<String> fields = parseFieldList(field);
         ConfigPayloadBuilder currentBuilder = payloadBuilder;
         for (int fieldNum = 0; fieldNum < fields.size(); fieldNum++) {

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
@@ -325,7 +325,7 @@ public class ConfigSubscriber implements AutoCloseable {
             h.subscription().close();
         }
         closeRequesters();
-        log.log(LogLevel.DEBUG, "Config subscriber has been closed.");
+        log.log(LogLevel.DEBUG, () -> "Config subscriber has been closed.");
     }
 
     /**

--- a/config/src/main/java/com/yahoo/config/subscription/impl/GenericJRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/GenericJRTConfigSubscription.java
@@ -33,9 +33,7 @@ public class GenericJRTConfigSubscription extends JRTConfigSubscription<RawConfi
     @Override
     protected void setNewConfig(JRTClientConfigRequest jrtReq) {
         setConfig(jrtReq.getNewGeneration(), jrtReq.responseIsInternalRedeploy(), RawConfig.createFromResponseParameters(jrtReq) );
-        if (log.isLoggable(LogLevel.DEBUG)) {
-            log.log(LogLevel.DEBUG, "in setNewConfig, config=" + this.getConfigState().getConfig());
-        }
+        log.log(LogLevel.DEBUG, () -> "in setNewConfig, config=" + this.getConfigState().getConfig());
     }
 
     // This method is overridden because config needs to have its generation

--- a/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
@@ -479,15 +479,11 @@ public class ConfigPayloadApplier<T extends ConfigInstance.Builder> {
     }
 
     private void debug(String message) {
-        if (log.isLoggable(LogLevel.DEBUG)) {
-            log.log(LogLevel.DEBUG, message);
-        }
+        log.log(LogLevel.DEBUG, () -> message);
     }
 
     private void trace(String message) {
-        if (log.isLoggable(LogLevel.SPAM)) {
-            log.log(LogLevel.SPAM, message);
-        }
+        log.log(LogLevel.SPAM, () -> message);
     }
 
     private void printStack() {

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
@@ -74,18 +74,14 @@ public class JRTConnectionPool implements ConnectionPool {
     public synchronized JRTConnection setNewCurrentConnection() {
         List<JRTConnection> sources = getSources();
         currentConnection = sources.get(ThreadLocalRandom.current().nextInt(0, sources.size()));
-        if (log.isLoggable(LogLevel.DEBUG)) {
-            log.log(LogLevel.DEBUG, "Choosing new connection: " + currentConnection);
-        }
+        log.log(LogLevel.DEBUG, () -> "Choosing new connection: " + currentConnection);
         return currentConnection;
     }
 
     List<JRTConnection> getSources() {
-        List<JRTConnection> ret = new ArrayList<>();
+        List<JRTConnection> ret;
         synchronized (connections) {
-            for (JRTConnection source : connections.values()) {
-                ret.add(source);
-            }
+            ret = new ArrayList<>(connections.values());
         }
         return ret;
     }

--- a/config/src/main/java/com/yahoo/vespa/config/UrlDownloader.java
+++ b/config/src/main/java/com/yahoo/vespa/config/UrlDownloader.java
@@ -47,7 +47,7 @@ public class UrlDownloader {
                 Request request = new Request("frt.rpc.ping");
                 target.invokeSync(request, 5.0);
                 if (! request.isError()) {
-                    log.log(LogLevel.DEBUG, "Successfully connected to '" + spec + "', this = " + System.identityHashCode(this));
+                    log.log(LogLevel.DEBUG, () -> "Successfully connected to '" + spec + "', this = " + System.identityHashCode(this));
                     return;
                 } else {
                     target.close();
@@ -78,7 +78,7 @@ public class UrlDownloader {
             request.parameters().add(new StringValue(urlReference.value()));
 
             double rpcTimeout = Math.min(timeLeft, 60 * 60.0);
-            log.log(LogLevel.DEBUG, "InvokeSync waitFor " + urlReference + " with " + rpcTimeout + " seconds timeout");
+            log.log(LogLevel.DEBUG, () -> "InvokeSync waitFor " + urlReference + " with " + rpcTimeout + " seconds timeout");
             target.invokeSync(request, rpcTimeout);
 
             if (request.checkReturnTypes("s")) {

--- a/config/src/main/java/com/yahoo/vespa/config/protocol/JRTServerConfigRequestV3.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/JRTServerConfigRequestV3.java
@@ -7,7 +7,6 @@ import com.yahoo.jrt.DataValue;
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.StringValue;
 import com.yahoo.jrt.Value;
-import com.yahoo.log.LogLevel;
 import com.yahoo.text.Utf8Array;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ErrorCode;
@@ -92,9 +91,7 @@ public class JRTServerConfigRequestV3 implements JRTServerConfigRequest {
             }
             compressionInfo.serialize(jsonGenerator);
             jsonGenerator.writeEndObject();
-            if (log.isLoggable(LogLevel.SPAM)) {
-                log.log(LogLevel.SPAM, getConfigKey() + ": response dataXXXXX" + payload.withCompression(CompressionType.UNCOMPRESSED) + "XXXXX");
-            }
+
             jsonGenerator.writeEndObject();
             jsonGenerator.close();
         } catch (IOException e) {


### PR DESCRIPTION
Make sure to allocate log strings only when they will be printed

