### PR TITLE
Revert "Allow vespa.runtime|compile.version for those versions"

### DIFF
--- a/tenant-base/pom.xml
+++ b/tenant-base/pom.xml
@@ -253,28 +253,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile> <!-- Alias vespaversion with a more descriptive vespa.compile.version -->
-            <activation>
-                <property>
-                    <name>vespa.compile.version</name>
-                </property>
-            </activation>
-            <properties>
-                <vespaversion>${vespa.compile.version}</vespaversion>
-            </properties>
-        </profile>
-
-        <profile> <!-- Alias vespaVersion with a more descriptive vespa.runtime.version -->
-            <activation>
-                <property>
-                    <name>vespa.runtime.version</name>
-                </property>
-            </activation>
-            <properties>
-                <vespaVersion>${vespa.runtime.version}</vespaVersion>
-            </properties>
-        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
Reverts vespa-engine/vespa#12268

Broke centos-build:
` 07:51:39 [ERROR]   The project com.yahoo.vespa:tenant-base:7.181.2 (/workdir/vespa/tenant-base/pom.xml) has 1 error
07:51:39 [ERROR]     'profiles.profile.id' must be unique but found duplicate profile with id default @ line 317, column 14
07:51:39 [ERROR] `