### PR TITLE
Use 'localhost' for TLS hostname validation if spec uses wildcard address

### DIFF
--- a/jrt/src/com/yahoo/jrt/TlsCryptoEngine.java
+++ b/jrt/src/com/yahoo/jrt/TlsCryptoEngine.java
@@ -21,7 +21,8 @@ public class TlsCryptoEngine implements CryptoEngine {
 
     @Override
     public TlsCryptoSocket createClientCryptoSocket(SocketChannel channel, Spec spec)  {
-        SSLEngine sslEngine = tlsContext.createSslEngine(spec.host(), spec.port());
+        String peerHost = spec.host() != null ? spec.host() : "localhost"; // Use localhost for wildcard address
+        SSLEngine sslEngine = tlsContext.createSslEngine(peerHost, spec.port());
         sslEngine.setUseClientMode(true);
         return new TlsCryptoSocket(channel, sslEngine);
     }


### PR DESCRIPTION
FYI @havardpe 