### PR TITLE
Revert "Control -XX:CompressedClassSpaceSize jvm option."

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -8,6 +8,8 @@ import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.component.Handler;
 
+import java.util.Objects;
+
 /**
  * @author hmusum
  */

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -215,7 +215,6 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         super.getConfig(builder);
         builder.jvm.verbosegc(true)
                 .availableProcessors(0)
-                .compressedClassSpaceSize(0)  //TODO Reduce, next step is 512m
                 .minHeapsize(1536)
                 .heapsize(1536);
         if (getMemoryPercentage().isPresent()) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -484,7 +484,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         builder.jvm
                 .verbosegc(false)
                 .availableProcessors(2)
-                .compressedClassSpaceSize(32)
                 .minHeapsize(32)
                 .heapsize(512)
                 .heapSizeAsPercentageOfPhysicalMemory(0)

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -60,7 +60,6 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -111,7 +110,6 @@ public class MetricsProxyContainerClusterTest {
         assertEquals("-XX:+UseG1GC -XX:MaxTenuringThreshold=15", qrStartConfig.jvm().gcopts());
         assertEquals(512, qrStartConfig.jvm().stacksize());
         assertEquals(0, qrStartConfig.jvm().directMemorySizeCache());
-        assertEquals(32, qrStartConfig.jvm().compressedClassSpaceSize());
         assertEquals(75, qrStartConfig.jvm().baseMaxDirectMemorySize());
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -97,7 +97,6 @@ public class ContainerClusterTest {
         cluster.getConfig(qsB);
         QrStartConfig qsC= new QrStartConfig(qsB);
         assertEquals(expectedMemoryPercentage, qsC.jvm().heapSizeAsPercentageOfPhysicalMemory());
-        assertEquals(0, qsC.jvm().compressedClassSpaceSize());
     }
 
     @Test
@@ -157,7 +156,6 @@ public class ContainerClusterTest {
         QrStartConfig qrStartConfig = new QrStartConfig(qrBuilder);
         assertEquals(32, qrStartConfig.jvm().minHeapsize());
         assertEquals(512, qrStartConfig.jvm().heapsize());
-        assertEquals(32, qrStartConfig.jvm().compressedClassSpaceSize());
         assertEquals(0, qrStartConfig.jvm().heapSizeAsPercentageOfPhysicalMemory());
 
         ThreadpoolConfig.Builder tpBuilder = new ThreadpoolConfig.Builder();

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
@@ -28,11 +28,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-
+import static org.junit.Assert.*;
 
 /**
  * @author einarmr
@@ -208,25 +204,24 @@ public class DocprocBuilderTest extends DomBuilderTest {
 
     @Test
     public void testBundlesConfig() {
-        assertTrue(bundlesConfig.bundle().isEmpty());
+        assertThat(bundlesConfig.bundle().size(), is(0));
     }
 
     @Test
     public void testSchemaMappingConfig() {
-        assertTrue(schemamappingConfig.fieldmapping().isEmpty());
+        assertThat(schemamappingConfig.fieldmapping().size(), is(0));
     }
 
     @Test
     public void testQrStartConfig() {
         QrStartConfig.Jvm jvm = qrStartConfig.jvm();
-        assertTrue(jvm.server());
-        assertTrue(jvm.verbosegc());
-        assertEquals("-XX:+UseG1GC -XX:MaxTenuringThreshold=15", jvm.gcopts());
-        assertEquals(1536, jvm.minHeapsize());
-        assertEquals(1536, jvm.heapsize());
-        assertEquals(512, jvm.stacksize());
-        assertTrue(qrStartConfig.ulimitv().isEmpty());
-        assertEquals(0, jvm.compressedClassSpaceSize());
+        assertThat(jvm.server(), is(true));
+        assertThat(jvm.verbosegc(), is(true));
+        assertThat(jvm.gcopts(), is("-XX:+UseG1GC -XX:MaxTenuringThreshold=15"));
+        assertThat(jvm.minHeapsize(), is(1536));
+        assertThat(jvm.heapsize(), is(1536));
+        assertThat(jvm.stacksize(), is(512));
+        assertThat(qrStartConfig.ulimitv(), is(""));
     }
 
 }

--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -64,7 +64,6 @@ configure_memory() {
     consider_fallback jvm_heapsize 1536
     consider_fallback jvm_stacksize 512
     consider_fallback jvm_baseMaxDirectMemorySize 75
-    consider_fallback jvm_compressedClassSpaceSize 32
     consider_fallback jvm_directMemorySizeCache 0
 
     # Update jvm_heapsize only if percentage is explicitly set (default is 0).
@@ -81,20 +80,16 @@ configure_memory() {
     fi
 
     # Safety measure against bad min vs max heapsize.
-    if ((jvm_minHeapsize > jvm_heapsize)); then
+   if ((jvm_minHeapsize > jvm_heapsize)); then
         jvm_minHeapsize=${jvm_heapsize}
         echo "Misconfigured heap size, jvm_minHeapsize(${jvm_minHeapsize} is larger than jvm_heapsize(${jvm_heapsize}). It has been capped."
-    fi
+   fi
 
     maxDirectMemorySize=$(( jvm_baseMaxDirectMemorySize + jvm_heapsize / 8 + jvm_directMemorySizeCache ))
 
     memory_options="-Xms${jvm_minHeapsize}m -Xmx${jvm_heapsize}m"
     memory_options="${memory_options} -XX:ThreadStackSize=${jvm_stacksize}"
-    memory_options="${memory_options} -XX:MaxDirectMemorySize=${maxDirectMemorySize}m"
-
-    if ((jvm_compressedClassSpaceSize != 0)); then
-        memory_options="${memory_options} -XX:CompressedClassSpaceSize=${compressedClassSpaceSize}m"
-    fi
+    memory_options="${memory_options} -XX:MaxDirectMemorySize=${maxDirectMemorySize}m"    
 
     if [ "${VESPA_USE_HUGEPAGES}" ]; then
         memory_options="${memory_options} -XX:+UseLargePages"

--- a/container-search/src/main/resources/configdefinitions/qr-start.def
+++ b/container-search/src/main/resources/configdefinitions/qr-start.def
@@ -20,9 +20,6 @@ jvm.minHeapsize int default=1536 restart
 ## Stack size (in kilobytes)
 jvm.stacksize int default=512 restart
 
-## CompressedOOps size in megabytes
-jvm.compressedClassSpaceSize int default=32 restart
-
 ## Base value of maximum direct memory size (in megabytes)
 jvm.baseMaxDirectMemorySize int default=75 restart
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#12283

Caused most system tests to fail
```
2020-02-20 13:37:42.537520 +0000          8971                container-clustercontroller     stderr                                                                                    warning     Improperly specified VM option 'CompressedClassSpaceSize=m'
2020-02-20 13:37:42.537598 +0000          8971                container-clustercontroller     stderr                                                                                    warning     Error: Could not create the Java Virtual Machine.
2020-02-20 13:37:42.537618 +0000          8971                container-clustercontroller     stderr                                                                                    warning     Error: A fatal exception has occurred. Program will exit.
```