### PR TITLE
Move crypto utility code out into vespalib and use for test credentials

### DIFF
--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -3,10 +3,10 @@
 #include <httpclient/httpclient.h>
 #include <util/filereader.h>
 #include <util/clientstatus.h>
+#include <vespa/vespalib/crypto/crypto_exception.h>
 #include <vespa/vespalib/net/crypto_engine.h>
 #include <vespa/vespalib/net/tls/transport_security_options.h>
 #include <vespa/vespalib/net/tls/tls_crypto_engine.h>
-#include <vespa/vespalib/net/tls/crypto_exception.h>
 #include <vespa/vespalib/io/mapped_file_input.h>
 #include "client.h"
 #include "fbench.h"
@@ -99,7 +99,7 @@ FBench::init_crypto_engine(const std::string &ca_certs_file_name,
     }
     try {
         _crypto_engine = std::make_shared<vespalib::TlsCryptoEngine>(tls_opts);
-    } catch (vespalib::net::tls::CryptoException &e) {
+    } catch (vespalib::crypto::CryptoException &e) {
         fprintf(stderr, "%s\n", e.what());
         return false;
     }

--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -30,6 +30,7 @@ vespa_define_module(
     src/tests/component
     src/tests/compress
     src/tests/compression
+    src/tests/crypto
     src/tests/data/databuffer
     src/tests/data/input_reader
     src/tests/data/lz4_encode_decode
@@ -139,6 +140,7 @@ vespa_define_module(
     src/vespa/vespalib
     src/vespa/vespalib/btree
     src/vespa/vespalib/component
+    src/vespa/vespalib/crypto
     src/vespa/vespalib/data
     src/vespa/vespalib/data/slime
     src/vespa/vespalib/datastore

--- a/vespalib/src/tests/crypto/CMakeLists.txt
+++ b/vespalib/src/tests/crypto/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_crypto_crypto_test_app TEST
+    SOURCES
+    crypto_test.cpp
+    DEPENDS
+    vespalib
+    gtest
+)
+vespa_add_test(NAME vespalib_crypto_crypto_test_app COMMAND vespalib_crypto_crypto_test_app)
+

--- a/vespalib/src/tests/crypto/crypto_test.cpp
+++ b/vespalib/src/tests/crypto/crypto_test.cpp
@@ -1,0 +1,37 @@
+// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/crypto/private_key.h>
+#include <vespa/vespalib/crypto/x509_certificate.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace ::testing;
+
+namespace vespalib::crypto {
+
+// FIXME these tests are very high level and simple since the current crypto utility API we provide
+// is extremely simple and does not support loading PEMs, signing or verifying.
+
+TEST(CryptoTest, generated_p256_ec_private_key_can_be_exported_to_pem_format) {
+    auto key = PrivateKey::generate_p256_ec_key();
+    auto pem = key->private_to_pem();
+    EXPECT_THAT(pem, StartsWith("-----BEGIN PRIVATE KEY-----"));
+}
+
+TEST(CryptoTest, generated_x509_certificate_can_be_exported_to_pem_format) {
+    auto dn = X509Certificate::DistinguishedName()
+            .country("NO").locality("Trondheim")
+            .organization("Cool Unit Test Writers")
+            .organizational_unit("Only the finest tests, yes")
+            .add_common_name("cooltests.example.com");
+    auto subject = X509Certificate::SubjectInfo(std::move(dn));
+    auto key = PrivateKey::generate_p256_ec_key();
+    auto params = X509Certificate::Params::self_signed(std::move(subject), key);
+    auto cert = X509Certificate::generate_from(std::move(params));
+    auto pem = cert->to_pem();
+    EXPECT_THAT(pem, StartsWith("-----BEGIN CERTIFICATE-----"));
+}
+
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/tests/net/tls/direct_buffer_bio/direct_buffer_bio_test.cpp
+++ b/vespalib/src/tests/net/tls/direct_buffer_bio/direct_buffer_bio_test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 
 using namespace vespalib;
+using namespace vespalib::crypto;
 using namespace vespalib::net::tls::impl;
 
 struct Fixture {

--- a/vespalib/src/tests/net/tls/openssl_impl/CMakeLists.txt
+++ b/vespalib/src/tests/net/tls/openssl_impl/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_executable(vespalib_net_tls_openssl_impl_test_app TEST
     SOURCES
-    crypto_utils.cpp
     openssl_impl_test.cpp
     DEPENDS
     vespalib

--- a/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
+++ b/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include "crypto_utils.h"
+#include <vespa/vespalib/crypto/private_key.h>
+#include <vespa/vespalib/crypto/x509_certificate.h>
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/data/smart_buffer.h>
 #include <vespa/vespalib/net/tls/authorization_mode.h>
@@ -11,11 +12,11 @@
 #include <vespa/vespalib/net/tls/impl/openssl_tls_context_impl.h>
 #include <vespa/vespalib/test/make_tls_options_for_testing.h>
 #include <vespa/vespalib/test/peer_policy_utils.h>
-#include <iostream>
 #include <stdexcept>
 #include <stdlib.h>
 
 using namespace vespalib;
+using namespace vespalib::crypto;
 using namespace vespalib::net::tls;
 using namespace vespalib::net::tls::impl;
 

--- a/vespalib/src/vespa/vespalib/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_library(vespalib
     SOURCES
     $<TARGET_OBJECTS:vespalib_vespalib_btree>
     $<TARGET_OBJECTS:vespalib_vespalib_component>
+    $<TARGET_OBJECTS:vespalib_vespalib_crypto>
     $<TARGET_OBJECTS:vespalib_vespalib_data>
     $<TARGET_OBJECTS:vespalib_vespalib_data_slime>
     $<TARGET_OBJECTS:vespalib_vespalib_datastore>

--- a/vespalib/src/vespa/vespalib/crypto/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/crypto/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_library(vespalib_vespalib_crypto OBJECT
+    SOURCES
+    crypto_exception.cpp
+    openssl_crypto_impl.cpp
+    private_key.cpp
+    x509_certificate.cpp
+    DEPENDS
+)
+find_package(OpenSSL)
+target_include_directories(vespalib_vespalib_crypto PUBLIC ${OPENSSL_INCLUDE_DIR})

--- a/vespalib/src/vespa/vespalib/crypto/crypto_exception.cpp
+++ b/vespalib/src/vespa/vespalib/crypto/crypto_exception.cpp
@@ -2,7 +2,7 @@
 
 #include "crypto_exception.h"
 
-namespace vespalib::net::tls {
+namespace vespalib::crypto {
 
 VESPA_IMPLEMENT_EXCEPTION(CryptoException, Exception);
 

--- a/vespalib/src/vespa/vespalib/crypto/crypto_exception.h
+++ b/vespalib/src/vespa/vespalib/crypto/crypto_exception.h
@@ -3,7 +3,7 @@
 
 #include <vespa/vespalib/util/exception.h>
 
-namespace vespalib::net::tls {
+namespace vespalib::crypto {
 
 VESPA_DEFINE_EXCEPTION(CryptoException, Exception);
 

--- a/vespalib/src/vespa/vespalib/crypto/openssl_crypto_impl.h
+++ b/vespalib/src/vespa/vespalib/crypto/openssl_crypto_impl.h
@@ -1,0 +1,44 @@
+// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/crypto/openssl_typedefs.h>
+#include "private_key.h"
+#include "x509_certificate.h"
+
+namespace vespalib::crypto::openssl_impl {
+
+class PrivateKeyImpl : public PrivateKey {
+    EvpPkeyPtr _pkey;
+    Type _type;
+public:
+    PrivateKeyImpl(EvpPkeyPtr pkey, Type type)
+        : _pkey(std::move(pkey)),
+          _type(type)
+    {}
+    ~PrivateKeyImpl() override = default;
+
+    ::EVP_PKEY* native_key() noexcept { return _pkey.get(); }
+    const ::EVP_PKEY* native_key() const noexcept { return _pkey.get(); }
+
+    Type type() const noexcept override { return _type; }
+    vespalib::string private_to_pem() const override;
+
+    static std::shared_ptr<PrivateKeyImpl> generate_openssl_p256_ec_key();
+};
+
+class X509CertificateImpl : public X509Certificate {
+    X509Ptr _cert;
+public:
+    explicit X509CertificateImpl(X509Ptr cert) : _cert(std::move(cert)) {}
+    ~X509CertificateImpl() = default;
+
+    ::X509* native_cert() noexcept { return _cert.get(); }
+    const ::X509* native_cert() const noexcept { return _cert.get(); }
+
+    vespalib::string to_pem() const override;
+
+    // Generates an X509 certificate using a SHA-256 digest
+    static std::shared_ptr<X509CertificateImpl> generate_openssl_x509_from(Params params);
+};
+
+}

--- a/vespalib/src/vespa/vespalib/crypto/openssl_typedefs.h
+++ b/vespalib/src/vespa/vespalib/crypto/openssl_typedefs.h
@@ -6,7 +6,7 @@
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
 
-namespace vespalib::net::tls::impl {
+namespace vespalib::crypto {
 
 struct BioDeleter {
     void operator()(::BIO* bio) const noexcept {

--- a/vespalib/src/vespa/vespalib/crypto/private_key.cpp
+++ b/vespalib/src/vespa/vespalib/crypto/private_key.cpp
@@ -1,0 +1,11 @@
+// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "private_key.h"
+#include "openssl_crypto_impl.h"
+
+namespace vespalib::crypto {
+
+std::shared_ptr<PrivateKey> PrivateKey::generate_p256_ec_key() {
+    return openssl_impl::PrivateKeyImpl::generate_openssl_p256_ec_key();
+}
+
+}

--- a/vespalib/src/vespa/vespalib/crypto/private_key.h
+++ b/vespalib/src/vespa/vespalib/crypto/private_key.h
@@ -1,0 +1,34 @@
+// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/stllike/string.h>
+#include <memory>
+
+namespace vespalib::crypto {
+
+/*
+ * Represents an asymmetric cryptographic private key.
+ *
+ * Can only be used for private/public key crypto, not for secret key (e.g. AES) crypto.
+ * Currently only supports generating EC keys on the standard P-256 curve.
+ */
+class PrivateKey {
+public:
+    enum class Type {
+        EC,
+        RSA // TODO implement support..!
+    };
+
+    virtual ~PrivateKey() = default;
+
+    virtual Type type() const noexcept = 0;
+    // TODO should have a wrapper for this that takes care to securely erase
+    // string memory on destruction.
+    virtual vespalib::string private_to_pem() const = 0;
+
+    static std::shared_ptr<PrivateKey> generate_p256_ec_key();
+protected:
+    PrivateKey() = default;
+};
+
+}

--- a/vespalib/src/vespa/vespalib/crypto/x509_certificate.cpp
+++ b/vespalib/src/vespa/vespalib/crypto/x509_certificate.cpp
@@ -1,0 +1,62 @@
+// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "x509_certificate.h"
+#include "openssl_crypto_impl.h"
+
+namespace vespalib::crypto {
+
+X509Certificate::DistinguishedName::DistinguishedName() = default;
+X509Certificate::DistinguishedName::DistinguishedName(const DistinguishedName&) = default;
+X509Certificate::DistinguishedName& X509Certificate::DistinguishedName::operator=(const DistinguishedName&) = default;
+X509Certificate::DistinguishedName::DistinguishedName(DistinguishedName&&) noexcept = default;
+X509Certificate::DistinguishedName& X509Certificate::DistinguishedName::operator=(DistinguishedName&&) noexcept = default;
+X509Certificate::DistinguishedName::~DistinguishedName() = default;
+
+X509Certificate::Params::Params() = default;
+X509Certificate::Params::~Params() = default;
+
+X509Certificate::Params::Params(const Params&) = default;
+X509Certificate::Params& X509Certificate::Params::operator=(const Params&) = default;
+X509Certificate::Params::Params(Params&&) noexcept = default;
+X509Certificate::Params& X509Certificate::Params::operator=(Params&&) noexcept = default;
+
+X509Certificate::Params
+X509Certificate::Params::self_signed(SubjectInfo subject,
+                                     std::shared_ptr<PrivateKey> key)
+{
+    Params params;
+    params.subject_info = std::move(subject);
+    params.subject_key = key;
+    params.issuer_key = std::move(key); // self-signed, subject == issuer
+    params.is_ca = true;
+    return params;
+}
+
+X509Certificate::Params
+X509Certificate::Params::issued_by(SubjectInfo subject,
+                                   std::shared_ptr<PrivateKey> subject_key,
+                                   std::shared_ptr<X509Certificate> issuer,
+                                   std::shared_ptr<PrivateKey> issuer_key)
+{
+    Params params;
+    params.subject_info = std::move(subject);
+    params.issuer = std::move(issuer);
+    params.subject_key = std::move(subject_key);
+    params.issuer_key = std::move(issuer_key);
+    params.is_ca = false; // By default, caller can change for intermediate CAs
+    return params;
+}
+
+std::shared_ptr<X509Certificate> X509Certificate::generate_from(Params params) {
+    return openssl_impl::X509CertificateImpl::generate_openssl_x509_from(std::move(params));
+}
+
+CertKeyWrapper::CertKeyWrapper(std::shared_ptr<X509Certificate> cert_,
+                               std::shared_ptr<PrivateKey> key_)
+        : cert(std::move(cert_)),
+          key(std::move(key_))
+{}
+
+CertKeyWrapper::~CertKeyWrapper() = default;
+
+}

--- a/vespalib/src/vespa/vespalib/net/crypto_engine.cpp
+++ b/vespalib/src/vespa/vespalib/net/crypto_engine.cpp
@@ -2,9 +2,9 @@
 
 #include "crypto_engine.h"
 #include <vespa/vespalib/data/smart_buffer.h>
+#include <vespa/vespalib/crypto/crypto_exception.h>
 #include <vespa/vespalib/net/tls/authorization_mode.h>
 #include <vespa/vespalib/net/tls/auto_reloading_tls_crypto_engine.h>
-#include <vespa/vespalib/net/tls/crypto_exception.h>
 #include <vespa/vespalib/net/tls/maybe_tls_crypto_engine.h>
 #include <vespa/vespalib/net/tls/statistics.h>
 #include <vespa/vespalib/net/tls/tls_crypto_engine.h>
@@ -232,7 +232,7 @@ CryptoEngine::SP create_default_crypto_engine() {
 CryptoEngine::SP try_create_default_crypto_engine() {
     try {
         return create_default_crypto_engine();
-    } catch (net::tls::CryptoException &e) {
+    } catch (crypto::CryptoException &e) {
         LOG(error, "failed to create default crypto engine: %s", e.what());
         std::_Exit(78);
     }

--- a/vespalib/src/vespa/vespalib/net/tls/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/net/tls/CMakeLists.txt
@@ -5,7 +5,6 @@ vespa_add_library(vespalib_vespalib_net_tls OBJECT
     auto_reloading_tls_crypto_engine.cpp
     crypto_codec.cpp
     crypto_codec_adapter.cpp
-    crypto_exception.cpp
     maybe_tls_crypto_engine.cpp
     maybe_tls_crypto_socket.cpp
     peer_credentials.cpp

--- a/vespalib/src/vespa/vespalib/net/tls/impl/direct_buffer_bio.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/direct_buffer_bio.cpp
@@ -1,10 +1,9 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "direct_buffer_bio.h"
-#include <vespa/vespalib/net/tls/crypto_exception.h>
+#include <vespa/vespalib/crypto/crypto_exception.h>
+#include <vespa/vespalib/util/backtrace.h>
 #include <utility>
 #include <cassert>
-
-#include <vespa/vespalib/util/backtrace.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".vespalib.net.tls.impl.direct_buffer_bio");
@@ -18,6 +17,8 @@ LOG_SETUP(".vespalib.net.tls.impl.direct_buffer_bio");
  *  - https://github.com/openssl/openssl/blob/master/crypto/bio/bss_mem.c
  *  - https://github.com/indutny/uv_ssl_t/blob/master/src/bio.c
  */
+
+using namespace vespalib::crypto;
 
 namespace vespalib::net::tls::impl {
 

--- a/vespalib/src/vespa/vespalib/net/tls/impl/direct_buffer_bio.h
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/direct_buffer_bio.h
@@ -1,7 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "openssl_typedefs.h"
+#include <vespa/vespalib/crypto/openssl_typedefs.h>
 #include <openssl/bio.h>
 
 /*
@@ -22,8 +22,8 @@
 
 namespace vespalib::net::tls::impl {
 
-BioPtr new_mutable_direct_buffer_bio();
-BioPtr new_const_direct_buffer_bio();
+crypto::BioPtr new_mutable_direct_buffer_bio();
+crypto::BioPtr new_const_direct_buffer_bio();
 
 struct MutableBufferView {
     // Could use a pointer pair instead (or just modify the ptr), but being explicit is good for readability.

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_crypto_codec_impl.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_crypto_codec_impl.cpp
@@ -3,8 +3,8 @@
 #include "openssl_tls_context_impl.h"
 #include "direct_buffer_bio.h"
 
+#include <vespa/vespalib/crypto/crypto_exception.h>
 #include <vespa/vespalib/net/tls/crypto_codec.h>
-#include <vespa/vespalib/net/tls/crypto_exception.h>
 #include <vespa/vespalib/net/tls/statistics.h>
 
 #include <mutex>
@@ -35,6 +35,8 @@ LOG_SETUP(".vespalib.net.tls.openssl_crypto_codec_impl");
  * pretend to not know of the beasts that lurk beyond where the torch's
  * light fades and turns to all-enveloping darkness.
  */
+
+using namespace vespalib::crypto;
 
 namespace vespalib::net::tls::impl {
 

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_crypto_codec_impl.h
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_crypto_codec_impl.h
@@ -1,7 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "openssl_typedefs.h"
+#include <vespa/vespalib/crypto/openssl_typedefs.h>
 #include <vespa/vespalib/net/socket_address.h>
 #include <vespa/vespalib/net/socket_spec.h>
 #include <vespa/vespalib/net/tls/transport_security_options.h>
@@ -47,12 +47,12 @@ class OpenSslCryptoCodecImpl : public CryptoCodec {
     // The context maintains shared verification callback state, so it must be
     // kept alive explictly for at least as long as any codecs.
     std::shared_ptr<OpenSslTlsContextImpl> _ctx;
-    SocketSpec    _peer_spec;
-    SocketAddress _peer_address;
-    SslPtr        _ssl;
-    ::BIO*        _input_bio;  // Owned by _ssl
-    ::BIO*        _output_bio; // Owned by _ssl
-    Mode          _mode;
+    SocketSpec     _peer_spec;
+    SocketAddress  _peer_address;
+    crypto::SslPtr _ssl;
+    ::BIO*         _input_bio;  // Owned by _ssl
+    ::BIO*         _output_bio; // Owned by _ssl
+    Mode           _mode;
     std::optional<DeferredHandshakeParams> _deferred_handshake_params;
     std::optional<HandshakeResult>         _deferred_handshake_result;
 public:

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.cpp
@@ -1,9 +1,9 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "iana_cipher_map.h"
-#include "openssl_typedefs.h"
 #include "openssl_tls_context_impl.h"
 #include "openssl_crypto_codec_impl.h"
-#include <vespa/vespalib/net/tls/crypto_exception.h>
+#include <vespa/vespalib/crypto/crypto_exception.h>
+#include <vespa/vespalib/crypto/openssl_typedefs.h>
 #include <vespa/vespalib/net/tls/statistics.h>
 #include <vespa/vespalib/net/tls/transport_security_options.h>
 #include <vespa/vespalib/util/stringfmt.h>
@@ -25,6 +25,8 @@ LOG_SETUP(".vespalib.net.tls.openssl_tls_context_impl");
 // < 1.0 requires explicit thread ID callback support.
 #  error "Provided OpenSSL version is too darn old, need at least 1.0.0"
 #endif
+
+using namespace vespalib::crypto;
 
 namespace vespalib::net::tls::impl {
 

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.h
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.h
@@ -1,7 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "openssl_typedefs.h"
+#include <vespa/vespalib/crypto/openssl_typedefs.h>
 #include <vespa/vespalib/net/socket_address.h>
 #include <vespa/vespalib/net/tls/tls_context.h>
 #include <vespa/vespalib/net/tls/transport_security_options.h>
@@ -13,7 +13,7 @@
 namespace vespalib::net::tls::impl {
 
 class OpenSslTlsContextImpl : public TlsContext {
-    SslCtxPtr _ctx;
+    crypto::SslCtxPtr _ctx;
     AuthorizationMode _authorization_mode;
     std::shared_ptr<CertificateVerificationCallback> _cert_verify_callback;
     TransportSecurityOptions _redacted_transport_options;


### PR DESCRIPTION
@havardpe please review
@bjorncs FYI

Currently offers only the following functionality:
* Generate P-256 EC private keys and export to PEM
* Generate X509v3 certificates and export to PEM

Instead of using hardcoded private key/certs for unit tests, use crypto
utility code to generate new credentials once per test process. Since
these certs now use a SAN of `localhost` it also means we no longer need
to disable hostname validation for networked unit tests.

