### PR TITLE
Define completeness of SuperModel and DuperModel

### DIFF
--- a/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceValidatorTest.java
+++ b/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/instanceconfirmation/InstanceValidatorTest.java
@@ -201,7 +201,8 @@ public class InstanceValidatorTest {
                                                                   ApplicationInfo::getApplicationId,
                                                                   Function.identity()
                                                                    )
-                                                          ));
+                                                          ),
+                                               true);
 
         SuperModelProvider superModelProvider = mock(SuperModelProvider.class);
         when(superModelProvider.getSuperModel()).thenReturn(superModel);

--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -990,13 +990,16 @@
     ],
     "methods": [
       "public void <init>()",
-      "public void <init>(java.util.Map)",
+      "public void <init>(java.util.Map, boolean)",
       "public java.util.Map getModelsPerTenant()",
       "public java.util.Map getModels()",
+      "public boolean isComplete()",
       "public java.util.List getAllApplicationInfos()",
       "public java.util.Optional getApplicationInfo(com.yahoo.config.provision.ApplicationId)",
-      "public com.yahoo.config.model.api.SuperModel cloneAndSetApplication(com.yahoo.config.model.api.ApplicationInfo)",
-      "public com.yahoo.config.model.api.SuperModel cloneAndRemoveApplication(com.yahoo.config.provision.ApplicationId)"
+      "public com.yahoo.config.model.api.SuperModel cloneAndSetApplication(com.yahoo.config.model.api.ApplicationInfo, boolean)",
+      "public com.yahoo.config.model.api.SuperModel cloneAndRemoveApplication(com.yahoo.config.provision.ApplicationId)",
+      "public com.yahoo.config.model.api.SuperModel cloneAsComplete()",
+      "public java.util.Set getApplicationIds()"
     ],
     "fields": []
   },
@@ -1010,7 +1013,8 @@
     ],
     "methods": [
       "public abstract void applicationActivated(com.yahoo.config.model.api.SuperModel, com.yahoo.config.model.api.ApplicationInfo)",
-      "public abstract void applicationRemoved(com.yahoo.config.model.api.SuperModel, com.yahoo.config.provision.ApplicationId)"
+      "public abstract void applicationRemoved(com.yahoo.config.model.api.SuperModel, com.yahoo.config.provision.ApplicationId)",
+      "public abstract void notifyOfCompleteness(com.yahoo.config.model.api.SuperModel)"
     ],
     "fields": []
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/SuperModel.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/SuperModel.java
@@ -20,13 +20,15 @@ import java.util.Set;
 public class SuperModel {
 
     private final Map<ApplicationId, ApplicationInfo> models;
+    private final boolean complete;
 
     public SuperModel() {
-        this.models = Collections.emptyMap();
+        this(Collections.emptyMap(), false);
     }
 
-    public SuperModel(Map<ApplicationId, ApplicationInfo> models) {
+    public SuperModel(Map<ApplicationId, ApplicationInfo> models, boolean complete) {
         this.models = models;
+        this.complete = complete;
     }
 
     public Map<TenantName, Set<ApplicationInfo>> getModelsPerTenant() {
@@ -45,6 +47,8 @@ public class SuperModel {
         return ImmutableMap.copyOf(models);
     }
 
+    public boolean isComplete() { return complete; }
+
     public List<ApplicationInfo> getAllApplicationInfos() {
         return new ArrayList<>(models.values());
     }
@@ -54,19 +58,21 @@ public class SuperModel {
         return applicationInfo == null ? Optional.empty() : Optional.of(applicationInfo);
     }
 
-    public SuperModel cloneAndSetApplication(ApplicationInfo application) {
+    public SuperModel cloneAndSetApplication(ApplicationInfo application, boolean complete) {
         Map<ApplicationId, ApplicationInfo> newModels = cloneModels(models);
         newModels.put(application.getApplicationId(), application);
-
-        return new SuperModel(newModels);
+        return new SuperModel(newModels, complete);
     }
 
     public SuperModel cloneAndRemoveApplication(ApplicationId applicationId) {
         Map<ApplicationId, ApplicationInfo> newModels = cloneModels(models);
         newModels.remove(applicationId);
-
-        return new SuperModel(newModels);
+        return new SuperModel(newModels, complete);
     }
+
+    public SuperModel cloneAsComplete() { return new SuperModel(models, true); }
+
+    public Set<ApplicationId> getApplicationIds() { return models.keySet(); }
 
     private static Map<ApplicationId, ApplicationInfo> cloneModels(Map<ApplicationId, ApplicationInfo> models) {
         return new LinkedHashMap<>(models);

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/SuperModelListener.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/SuperModelListener.java
@@ -17,4 +17,12 @@ public interface SuperModelListener {
      * Application has been removed.
      */
     void applicationRemoved(SuperModel superModel, ApplicationId id);
+
+    /**
+     * Invoked once all applications that were supposed to be deployed on bootstrap
+     * have been activated (and the respective {@link #applicationActivated(SuperModel, ApplicationInfo)
+     * applicationActivated} have been invoked). The SuperModel is then said to be "complete".
+     * @param superModel
+     */
+    void notifyOfCompleteness(SuperModel superModel);
 }

--- a/config-provisioning/abi-spec.json
+++ b/config-provisioning/abi-spec.json
@@ -506,7 +506,7 @@
     ],
     "methods": [
       "public abstract java.util.Optional getDeployment(com.yahoo.config.provision.ApplicationId)",
-      "public abstract java.util.Map getSupportedInfraDeployments()"
+      "public abstract void activateAllSupportedInfraApplications()"
     ],
     "fields": []
   },

--- a/config-provisioning/abi-spec.json
+++ b/config-provisioning/abi-spec.json
@@ -506,7 +506,7 @@
     ],
     "methods": [
       "public abstract java.util.Optional getDeployment(com.yahoo.config.provision.ApplicationId)",
-      "public abstract void activateAllSupportedInfraApplications()"
+      "public abstract void activateAllSupportedInfraApplications(boolean)"
     ],
     "fields": []
   },

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/InfraDeployer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/InfraDeployer.java
@@ -17,6 +17,6 @@ public interface InfraDeployer {
      */
     Optional<Deployment> getDeployment(ApplicationId application);
 
-    /** Returns deployments by application id for the supported infrastructure applications in this zone */
-    Map<ApplicationId, Deployment> getSupportedInfraDeployments();
+    /** Deploys all supported infrastructure applications in this zone. */
+    void activateAllSupportedInfraApplications();
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/InfraDeployer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/InfraDeployer.java
@@ -1,7 +1,6 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -18,5 +17,5 @@ public interface InfraDeployer {
     Optional<Deployment> getDeployment(ApplicationId application);
 
     /** Deploys all supported infrastructure applications in this zone. */
-    void activateAllSupportedInfraApplications();
+    void activateAllSupportedInfraApplications(boolean propagateException);
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/SuperModelControllerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/SuperModelControllerTest.java
@@ -55,7 +55,7 @@ public class SuperModelControllerTest {
         ApplicationId app = ApplicationId.from(TenantName.from("a"),
                                                ApplicationName.from("foo"), InstanceName.defaultName());
         models.put(app, new ApplicationInfo(app, 4L, new VespaModel(FilesApplicationPackage.fromFile(testApp))));
-        SuperModel superModel = new SuperModel(models);
+        SuperModel superModel = new SuperModel(models, true);
         handler = new SuperModelController(new SuperModelConfigProvider(superModel, Zone.defaultZone(), new InMemoryFlagSource()), new TestConfigDefinitionRepo(), 2, new UncompressedConfigResponseFactory());
     }
     
@@ -98,7 +98,7 @@ public class SuperModelControllerTest {
         models.put(advanced, createApplicationInfo(testApp2, advanced, 4L));
         models.put(tooAdvanced, createApplicationInfo(testApp3, tooAdvanced, 4L));
 
-        SuperModel superModel = new SuperModel(models);
+        SuperModel superModel = new SuperModel(models, true);
         SuperModelController han = new SuperModelController(new SuperModelConfigProvider(superModel, Zone.defaultZone(), new InMemoryFlagSource()), new TestConfigDefinitionRepo(), 2, new UncompressedConfigResponseFactory());
         LbServicesConfig.Builder lb = new LbServicesConfig.Builder();
         han.getSuperModel().getConfig(lb);
@@ -126,7 +126,7 @@ public class SuperModelControllerTest {
         models.put(advanced, createApplicationInfo(testApp2, advanced, 4L));
         models.put(tooAdvanced, createApplicationInfo(testApp3, tooAdvanced, 4L));
 
-        SuperModel superModel = new SuperModel(models);
+        SuperModel superModel = new SuperModel(models, true);
         SuperModelController han = new SuperModelController(new SuperModelConfigProvider(superModel, Zone.defaultZone(), new InMemoryFlagSource()), new TestConfigDefinitionRepo(), 2, new UncompressedConfigResponseFactory());
         LbServicesConfig.Builder lb = new LbServicesConfig.Builder();
         han.getSuperModel().getConfig(lb);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.InfraDeployer;
+import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import java.time.Duration;
@@ -22,10 +23,22 @@ public class InfrastructureProvisioner extends Maintainer {
     InfrastructureProvisioner(NodeRepository nodeRepository, InfraDeployer infraDeployer, Duration interval) {
         super(nodeRepository, interval);
         this.infraDeployer = infraDeployer;
+
+        // If this fails, we fail the component graph construction and bootstrap of config server,
+        // which is what we want.
+        try {
+            infraDeployer.activateAllSupportedInfraApplications(true);
+        } catch (RuntimeException e) {
+            logger.log(LogLevel.INFO, "Failed to deploy supported infrastructure applications, " +
+                    "will sleep 30s before propagating failure, to allow inspection of zk",
+                    e.getMessage());
+            try { Thread.sleep(30_000); } catch (InterruptedException ignored) { }
+            throw e;
+        }
     }
 
     @Override
     protected void maintain() {
-        infraDeployer.activateAllSupportedInfraApplications();
+        infraDeployer.activateAllSupportedInfraApplications(false);
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
@@ -23,9 +23,9 @@ public class InfrastructureProvisioner extends Maintainer {
     InfrastructureProvisioner(NodeRepository nodeRepository, InfraDeployer infraDeployer, Duration interval) {
         super(nodeRepository, interval);
         this.infraDeployer = infraDeployer;
+    }
 
-        // If this fails, we fail the component graph construction and bootstrap of config server,
-        // which is what we want.
+    public void maintainButThrowOnException() {
         try {
             infraDeployer.activateAllSupportedInfraApplications(true);
         } catch (RuntimeException e) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/InfrastructureProvisioner.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.provision.maintenance;
 
 import com.yahoo.config.provision.InfraDeployer;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 
 import java.time.Duration;
@@ -27,13 +26,6 @@ public class InfrastructureProvisioner extends Maintainer {
 
     @Override
     protected void maintain() {
-        infraDeployer.getSupportedInfraDeployments().forEach((application, deployment) -> {
-            try {
-                deployment.activate();
-            } catch (RuntimeException e) {
-                logger.log(LogLevel.INFO, "Failed to activate " + application, e);
-                // loop around to activate the next application
-            }
-        });
+        infraDeployer.activateAllSupportedInfraApplications();
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -87,7 +87,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         rebalancer = new Rebalancer(deployer, nodeRepository, provisionServiceProvider.getHostResourcesCalculator(), provisionServiceProvider.getHostProvisioner(), metric, clock, defaults.rebalancerInterval);
 
         // The DuperModel is filled with infrastructure applications by the infrastructure provisioner, so explicitly run that now
-        infrastructureProvisioner.maintain();
+        infrastructureProvisioner.maintainButThrowOnException();
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
@@ -51,9 +51,19 @@ public class InfraDeployerImpl implements InfraDeployer {
     }
 
     @Override
-    public Map<ApplicationId, Deployment> getSupportedInfraDeployments() {
-        return duperModel.getSupportedInfraApplications().stream()
-                .collect(Collectors.toMap(InfraApplicationApi::getApplicationId, InfraDeployment::new));
+    public void activateAllSupportedInfraApplications() {
+        duperModel.getSupportedInfraApplications().forEach(api -> {
+            var application = api.getApplicationId();
+            var deployment = new InfraDeployment(api);
+            try {
+                deployment.activate();
+            } catch (RuntimeException e) {
+                logger.log(LogLevel.INFO, "Failed to activate " + application, e);
+                // loop around to activate the next application
+            }
+        });
+
+        duperModel.infraApplicationsIsNowComplete();
     }
 
     private class InfraDeployment implements Deployment {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
@@ -20,7 +20,6 @@ import com.yahoo.vespa.service.monitor.DuperModelInfraApi;
 import com.yahoo.vespa.service.monitor.InfraApplicationApi;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -51,7 +50,7 @@ public class InfraDeployerImpl implements InfraDeployer {
     }
 
     @Override
-    public void activateAllSupportedInfraApplications() {
+    public void activateAllSupportedInfraApplications(boolean propagateException) {
         duperModel.getSupportedInfraApplications().forEach(api -> {
             var application = api.getApplicationId();
             var deployment = new InfraDeployment(api);
@@ -59,6 +58,9 @@ public class InfraDeployerImpl implements InfraDeployer {
                 deployment.activate();
             } catch (RuntimeException e) {
                 logger.log(LogLevel.INFO, "Failed to activate " + application, e);
+                if (propagateException) {
+                    throw e;
+                }
                 // loop around to activate the next application
             }
         });

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDuperModel.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDuperModel.java
@@ -49,4 +49,8 @@ public class MockDuperModel implements DuperModelInfraApi {
     public void infraApplicationRemoved(ApplicationId applicationId) {
         activeApps.remove(applicationId);
     }
+
+    @Override
+    public void infraApplicationsIsNowComplete() {
+    }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockInfraDeployer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockInfraDeployer.java
@@ -5,7 +5,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.InfraDeployer;
 
-import java.util.Map;
 import java.util.Optional;
 
 public class MockInfraDeployer implements InfraDeployer {
@@ -15,5 +14,5 @@ public class MockInfraDeployer implements InfraDeployer {
     }
 
     @Override
-    public void activateAllSupportedInfraApplications() { }
+    public void activateAllSupportedInfraApplications(boolean propagateException) { }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockInfraDeployer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockInfraDeployer.java
@@ -15,7 +15,5 @@ public class MockInfraDeployer implements InfraDeployer {
     }
 
     @Override
-    public Map<ApplicationId, Deployment> getSupportedInfraDeployments() {
-        return Map.of();
-    }
+    public void activateAllSupportedInfraApplications() { }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModel.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModel.java
@@ -4,9 +4,9 @@ package com.yahoo.vespa.service.duper;
 import com.yahoo.config.model.api.ApplicationInfo;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.log.LogLevel;
+import com.yahoo.vespa.service.monitor.DuperModelListener;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -22,11 +22,15 @@ public class DuperModel {
 
     private final Map<ApplicationId, ApplicationInfo> applications = new TreeMap<>();
     private final List<DuperModelListener> listeners = new ArrayList<>();
+    private boolean isComplete = false;
 
     public void registerListener(DuperModelListener listener) {
         applications.values().forEach(listener::applicationActivated);
         listeners.add(listener);
     }
+
+    public void setCompleteness(boolean isComplete) { this.isComplete = isComplete; }
+    public boolean isComplete() { return isComplete; }
 
     public boolean contains(ApplicationId applicationId) {
         return applications.containsKey(applicationId);
@@ -47,6 +51,6 @@ public class DuperModel {
 
     public List<ApplicationInfo> getApplicationInfos() {
         logger.log(LogLevel.DEBUG, "Applications in duper model: " + applications.values().size());
-        return Collections.unmodifiableList(new ArrayList<>(applications.values()));
+        return List.copyOf(applications.values());
     }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
@@ -12,6 +12,8 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.service.monitor.DuperModelInfraApi;
+import com.yahoo.vespa.service.monitor.DuperModelListener;
+import com.yahoo.vespa.service.monitor.DuperModelProvider;
 import com.yahoo.vespa.service.monitor.InfraApplicationApi;
 
 import java.util.ArrayList;
@@ -27,7 +29,7 @@ import java.util.stream.Stream;
 /**
  * @author hakonhall
  */
-public class DuperModelManager implements DuperModelInfraApi {
+public class DuperModelManager implements DuperModelProvider, DuperModelInfraApi {
 
     // Infrastructure applications
     static final ControllerHostApplication controllerHostApplication = new ControllerHostApplication();
@@ -45,6 +47,8 @@ public class DuperModelManager implements DuperModelInfraApi {
     // The set of active infrastructure ApplicationInfo. Not all are necessarily in the DuperModel for historical reasons.
     private final Set<ApplicationId> activeInfraInfos = new HashSet<>(10);
 
+    private boolean superModelIsComplete = false;
+    private boolean infraApplicationsIsComplete = false;
 
     @Inject
     public DuperModelManager(ConfigserverConfig configServerConfig, FlagSource flagSource, SuperModelProvider superModelProvider) {
@@ -53,7 +57,7 @@ public class DuperModelManager implements DuperModelInfraApi {
              superModelProvider, new DuperModel(), flagSource, SystemName.from(configServerConfig.system()));
     }
 
-    /** For testing */
+    /** Non-private for testing */
     DuperModelManager(boolean multitenant, boolean isController, SuperModelProvider superModelProvider, DuperModel duperModel, FlagSource flagSource, SystemName system) {
         this.duperModel = duperModel;
 
@@ -86,6 +90,14 @@ public class DuperModelManager implements DuperModelInfraApi {
                     duperModel.remove(applicationId);
                 }
             }
+
+            @Override
+            public void notifyOfCompleteness(SuperModel superModel) {
+                synchronized (monitor) {
+                    superModelIsComplete = true;
+                    maybeSetDuperModelAsComplete();
+                }
+            }
         });
     }
 
@@ -93,6 +105,7 @@ public class DuperModelManager implements DuperModelInfraApi {
      * Synchronously call {@link DuperModelListener#applicationActivated(ApplicationInfo) listener.applicationActivated()}
      * for each currently active application, and forward future changes.
      */
+    @Override
     public void registerListener(DuperModelListener listener) {
         synchronized (monitor) {
             duperModel.registerListener(listener);
@@ -148,9 +161,23 @@ public class DuperModelManager implements DuperModelInfraApi {
         }
     }
 
+    @Override
+    public void infraApplicationsIsNowComplete() {
+        synchronized (monitor) {
+            this.infraApplicationsIsComplete = true;
+            maybeSetDuperModelAsComplete();
+        }
+    }
+
     public List<ApplicationInfo> getApplicationInfos() {
         synchronized (monitor) {
             return duperModel.getApplicationInfos();
+        }
+    }
+
+    private void maybeSetDuperModelAsComplete() {
+        if (superModelIsComplete && infraApplicationsIsComplete) {
+            duperModel.setCompleteness(true);
         }
     }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/DuperModelManager.java
@@ -94,8 +94,10 @@ public class DuperModelManager implements DuperModelProvider, DuperModelInfraApi
             @Override
             public void notifyOfCompleteness(SuperModel superModel) {
                 synchronized (monitor) {
-                    superModelIsComplete = true;
-                    maybeSetDuperModelAsComplete();
+                    if (!superModelIsComplete) {
+                        superModelIsComplete = true;
+                        maybeSetDuperModelAsComplete();
+                    }
                 }
             }
         });
@@ -164,8 +166,10 @@ public class DuperModelManager implements DuperModelProvider, DuperModelInfraApi
     @Override
     public void infraApplicationsIsNowComplete() {
         synchronized (monitor) {
-            this.infraApplicationsIsComplete = true;
-            maybeSetDuperModelAsComplete();
+            if (!infraApplicationsIsComplete) {
+                infraApplicationsIsComplete = true;
+                maybeSetDuperModelAsComplete();
+            }
         }
     }
 

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/health/HealthMonitorManager.java
@@ -92,6 +92,10 @@ public class HealthMonitorManager implements MonitorManager, HealthMonitorApi {
     }
 
     @Override
+    public void bootstrapComplete() {
+    }
+
+    @Override
     public ServiceStatusInfo getStatus(ApplicationId applicationId,
                                        ClusterId clusterId,
                                        ServiceType serviceType,

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/manager/MonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/manager/MonitorManager.java
@@ -1,7 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.service.manager;
 
-import com.yahoo.vespa.service.duper.DuperModelListener;
+import com.yahoo.vespa.service.monitor.DuperModelListener;
 import com.yahoo.vespa.service.monitor.ServiceStatusProvider;
 
 /**

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/manager/UnionMonitorManager.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/manager/UnionMonitorManager.java
@@ -51,4 +51,8 @@ public class UnionMonitorManager implements MonitorManager {
         slobrokMonitorManager.applicationRemoved(id);
         healthMonitorManager.applicationRemoved(id);
     }
+
+    @Override
+    public void bootstrapComplete() {
+    }
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelInfraApi.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelInfraApi.java
@@ -27,4 +27,7 @@ public interface DuperModelInfraApi {
 
     /** Update the DuperModel: A supported infrastructure application has been removed or is not active. */
     void infraApplicationRemoved(ApplicationId applicationId);
+
+    /** All infra applications that are supposed to activate on config server bootstrap has been activated. */
+    void infraApplicationsIsNowComplete();
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelListener.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelListener.java
@@ -1,34 +1,45 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.service.duper;
+package com.yahoo.vespa.service.monitor;
 
 import com.yahoo.config.model.api.ApplicationInfo;
 import com.yahoo.config.model.api.SuperModel;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.service.duper.DuperModel;
 
 /**
  * Interface for listening for changes to the {@link DuperModel}.
  *
- * @author hakon
+ * @author hakonhall
  */
 public interface DuperModelListener {
     /**
      * An application has been activated:
      *
      * <ul>
-     *     <li>A synthetic application like the config server application has been added/"activated"
+     *     <li>A synthetic application like the config server application has been added/activated
      *     <li>A super model application has been activated (see
      *     {@link com.yahoo.config.model.api.SuperModelListener#applicationActivated(SuperModel, ApplicationInfo)
      *     SuperModelListener}
      * </ul>
      *
-     * No other threads will concurrently call any methods on this interface.
+     * <p>No other threads will concurrently call any methods on this interface.</p>
      */
     void applicationActivated(ApplicationInfo application);
 
     /**
      * Application has been removed.
      *
-     * No other threads will concurrently call any methods on this interface.
+     * <p>No other threads will concurrently call any methods on this interface.</p>
      */
     void applicationRemoved(ApplicationId id);
+
+    /**
+     * During bootstrap of the config server, a number of applications are activated before
+     * resuming normal operations: The normal "tenant" application (making the super model) and
+     * the relevant infrastructure applications. Once all of these have been activated, this method
+     * will be invoked.
+     *
+     * <p>No other threads will concurrently call any methods on this interface.</p>
+     */
+    void bootstrapComplete();
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelProvider.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/DuperModelProvider.java
@@ -1,0 +1,6 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.monitor;
+
+public interface DuperModelProvider {
+    void registerListener(DuperModelListener listener);
+}

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/slobrok/SlobrokMonitorManagerImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/slobrok/SlobrokMonitorManagerImpl.java
@@ -73,6 +73,10 @@ public class SlobrokMonitorManagerImpl implements SlobrokApi, MonitorManager {
     }
 
     @Override
+    public void bootstrapComplete() {
+    }
+
+    @Override
     public List<Mirror.Entry> lookup(ApplicationId id, String pattern) {
         synchronized (monitor) {
             SlobrokMonitor slobrokMonitor = slobrokMonitors.get(id);

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/duper/DuperModelTest.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/duper/DuperModelTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.service.duper;
 
 import com.yahoo.config.model.api.ApplicationInfo;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.vespa.service.monitor.DuperModelListener;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/service-monitor/src/test/java/com/yahoo/vespa/service/model/ExampleModel.java
+++ b/service-monitor/src/test/java/com/yahoo/vespa/service/model/ExampleModel.java
@@ -47,7 +47,7 @@ public class ExampleModel {
 
         Map<ApplicationId, ApplicationInfo> applicationInfos = new HashMap<>();
         applicationInfos.put(applicationInfo.getApplicationId(), applicationInfo);
-        return new SuperModel(applicationInfos);
+        return new SuperModel(applicationInfos, true);
     }
 
     public static ApplicationBuilder createApplication(String tenant,


### PR DESCRIPTION
In order for Orchestrator to remove application data from ZooKeeper, it must
know which applications do NOT exist. Since the duper model starts with 0
applications, always, the only way of knowing what applications do not exist is
for the bootstrap code to notify the super model/duper model when bootstrap is
complete. There are 2 sources of applications that must signal completeness:

 - The super model, once all applications have been redeployed in
   ConfigServerBootstrap.
 - The infrastructure application, in the InfrastructureProvisioner the first
   time it runs.