### PR TITLE
Add count metric for number of documents garbage collected

### DIFF
--- a/storage/src/tests/distributor/garbagecollectiontest.cpp
+++ b/storage/src/tests/distributor/garbagecollectiontest.cpp
@@ -3,6 +3,7 @@
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h>
 #include <vespa/storage/distributor/idealstatemanager.h>
+#include <vespa/storage/distributor/idealstatemetricsset.h>
 #include <tests/distributor/distributortestutil.h>
 #include <vespa/storage/distributor/distributor.h>
 #include <vespa/document/test/make_document_bucket.h>
@@ -35,11 +36,13 @@ struct GarbageCollectionOperationTest : Test, DistributorTestUtil {
     }
 
     // FIXME fragile to assume that send order == node index, but that's the way it currently works
-    void reply_to_nth_request(GarbageCollectionOperation& op, size_t n, uint32_t bucket_info_checksum) {
+    void reply_to_nth_request(GarbageCollectionOperation& op, size_t n,
+                              uint32_t bucket_info_checksum, uint32_t n_docs_removed) {
         auto msg = _sender.command(n);
         assert(msg->getType() == api::MessageType::REMOVELOCATION);
         std::shared_ptr<api::StorageReply> reply(msg->makeReply());
         auto& gc_reply = dynamic_cast<api::RemoveLocationReply&>(*reply);
+        gc_reply.set_documents_removed(n_docs_removed);
         gc_reply.setBucketInfo(api::BucketInfo(bucket_info_checksum, 90, 500));
 
         op.receive(_sender, reply);
@@ -56,6 +59,13 @@ struct GarbageCollectionOperationTest : Test, DistributorTestUtil {
                     << entry->getNode(i)->getBucketInfo();
         }
     }
+
+    uint32_t gc_removed_documents_metric() {
+        auto metric_base = getIdealStateManager().getMetrics().operations[IdealStateOperation::GARBAGE_COLLECTION];
+        auto gc_metrics = std::dynamic_pointer_cast<GcMetricSet>(metric_base);
+        assert(gc_metrics);
+        return gc_metrics->documents_removed.getValue();
+    }
 };
 
 TEST_F(GarbageCollectionOperationTest, simple) {
@@ -63,29 +73,34 @@ TEST_F(GarbageCollectionOperationTest, simple) {
     op->start(_sender, framework::MilliSecTime(0));
 
     ASSERT_EQ(2, _sender.commands().size());
+    EXPECT_EQ(0u, gc_removed_documents_metric());
 
     for (uint32_t i = 0; i < 2; ++i) {
         std::shared_ptr<api::StorageCommand> msg = _sender.command(i);
         ASSERT_EQ(msg->getType(), api::MessageType::REMOVELOCATION);
         auto& tmp = dynamic_cast<api::RemoveLocationCommand&>(*msg);
         EXPECT_EQ("music.date < 34", tmp.getDocumentSelection());
-        reply_to_nth_request(*op, i, 777 + i);
+        reply_to_nth_request(*op, i, 777 + i, 50);
     }
     ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(777, 90, 500), api::BucketInfo(778, 90, 500)}, 34));
+    EXPECT_EQ(50u, gc_removed_documents_metric());
 }
 
 TEST_F(GarbageCollectionOperationTest, replica_bucket_info_not_added_to_db_until_all_replies_received) {
     auto op = create_op();
     op->start(_sender, framework::MilliSecTime(0));
     ASSERT_EQ(2, _sender.commands().size());
+    EXPECT_EQ(0u, gc_removed_documents_metric());
 
     // Respond to 1st request. Should _not_ cause bucket info to be merged into the database yet
-    reply_to_nth_request(*op, 0, 1234);
+    reply_to_nth_request(*op, 0, 1234, 70);
     ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(250, 50, 300), api::BucketInfo(250, 50, 300)}, 0));
 
     // Respond to 2nd request. This _should_ cause bucket info to be merged into the database.
-    reply_to_nth_request(*op, 1, 4567);
+    reply_to_nth_request(*op, 1, 4567, 60);
     ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(1234, 90, 500), api::BucketInfo(4567, 90, 500)}, 34));
+
+    EXPECT_EQ(70u, gc_removed_documents_metric()); // Use max of received metrics
 }
 
 TEST_F(GarbageCollectionOperationTest, gc_bucket_info_does_not_overwrite_later_sequenced_bucket_info_writes) {
@@ -93,10 +108,10 @@ TEST_F(GarbageCollectionOperationTest, gc_bucket_info_does_not_overwrite_later_s
     op->start(_sender, framework::MilliSecTime(0));
     ASSERT_EQ(2, _sender.commands().size());
 
-    reply_to_nth_request(*op, 0, 1234);
+    reply_to_nth_request(*op, 0, 1234, 0);
     // Change to replica on node 0 happens after GC op, but before GC info is merged into the DB. Must not be lost.
     insertBucketInfo(op->getBucketId(), 0, 7777, 100, 2000);
-    reply_to_nth_request(*op, 1, 4567);
+    reply_to_nth_request(*op, 1, 4567, 0);
     // Bucket info for node 0 is that of the later sequenced operation, _not_ from the earlier GC op.
     ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(7777, 100, 2000), api::BucketInfo(4567, 90, 500)}, 34));
 }

--- a/storage/src/vespa/storage/distributor/bucketdb/bucketdbmetricupdater.cpp
+++ b/storage/src/vespa/storage/distributor/bucketdb/bucketdbmetricupdater.cpp
@@ -4,8 +4,7 @@
 #include <vespa/storage/distributor/distributormetricsset.h>
 #include <vespa/storage/distributor/idealstatemetricsset.h>
 
-namespace storage {
-namespace distributor {
+namespace storage::distributor {
 
 BucketDBMetricUpdater::Stats::Stats()
     : _docCount(0),
@@ -27,9 +26,7 @@ BucketDBMetricUpdater::BucketDBMetricUpdater()
 {
 }
 
-BucketDBMetricUpdater::~BucketDBMetricUpdater()
-{
-}
+BucketDBMetricUpdater::~BucketDBMetricUpdater() = default;
 
 void
 BucketDBMetricUpdater::resetStats()
@@ -148,5 +145,4 @@ BucketDBMetricUpdater::reset()
     resetStats();
 }
 
-} // distributor
-} // storage
+} // storage::distributor

--- a/storage/src/vespa/storage/distributor/bucketdb/bucketdbmetricupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdb/bucketdbmetricupdater.h
@@ -7,12 +7,9 @@
 
 #include <unordered_map>
 
-namespace storage {
+namespace storage::distributor {
 
 class DistributorMetricSet;
-
-namespace distributor {
-
 class IdealStateMetricSet;
 
 class BucketDBMetricUpdater {
@@ -107,5 +104,4 @@ private:
     void resetStats();
 };
 
-} // distributor
-} // storage
+} // storage::distributor

--- a/storage/src/vespa/storage/distributor/distributorinterface.h
+++ b/storage/src/vespa/storage/distributor/distributorinterface.h
@@ -12,10 +12,10 @@ namespace storage::api { class MergeBucketReply; }
 namespace storage::lib { class ClusterStateBundle; }
 namespace storage {
    class DistributorConfiguration;
-   class DistributorMetricSet;
 }
 namespace storage::distributor {
 
+class DistributorMetricSet;
 class PendingMessageTracker;
 
 class DistributorInterface : public DistributorMessageSender

--- a/storage/src/vespa/storage/distributor/distributormetricsset.cpp
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.cpp
@@ -3,7 +3,7 @@
 #include <vespa/metrics/loadmetric.hpp>
 #include <vespa/metrics/summetric.hpp>
 
-namespace storage {
+namespace storage::distributor {
 
 using metrics::MetricSet;
 

--- a/storage/src/vespa/storage/distributor/distributormetricsset.h
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.h
@@ -7,7 +7,7 @@
 #include <vespa/metrics/metrics.h>
 #include <vespa/documentapi/loadtypes/loadtypeset.h>
 
-namespace storage {
+namespace storage::distributor {
 
 class DistributorMetricSet : public metrics::MetricSet
 {

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -13,11 +13,11 @@
 
 namespace storage {
 
-class DistributorMetricSet;
 class PersistenceOperationMetricSet;
 
 namespace distributor {
 
+class DistributorMetricSet;
 class Distributor;
 class MaintenanceOperationGenerator;
 class DirectDispatchSender;

--- a/storage/src/vespa/storage/distributor/idealstatemetricsset.h
+++ b/storage/src/vespa/storage/distributor/idealstatemetricsset.h
@@ -16,13 +16,21 @@ public:
     metrics::LongCountMetric failed;
 
     OperationMetricSet(const std::string& name, metrics::Metric::Tags tags, const std::string& description, MetricSet* owner);
-    ~OperationMetricSet();
+    ~OperationMetricSet() override;
+};
+
+struct GcMetricSet : OperationMetricSet {
+    metrics::LongCountMetric documents_removed;
+
+    GcMetricSet(const std::string& name, metrics::Metric::Tags tags,
+                const std::string& description, MetricSet* owner);
+    ~GcMetricSet() override;
 };
 
 class IdealStateMetricSet : public metrics::MetricSet
 {
 public:
-    std::vector<std::shared_ptr<OperationMetricSet> > operations;
+    std::vector<std::shared_ptr<OperationMetricSet>> operations;
     metrics::LongValueMetric idealstate_diff;
     metrics::LongValueMetric buckets_toofewcopies;
     metrics::LongValueMetric buckets_toomanycopies;
@@ -35,7 +43,7 @@ public:
     void createOperationMetrics();
 
     IdealStateMetricSet();
-    ~IdealStateMetricSet();
+    ~IdealStateMetricSet() override;
 
     void setPendingOperations(const std::vector<uint64_t>& newMetrics);
 };

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
@@ -26,8 +26,10 @@ protected:
     MessageTracker _tracker;
 private:
     std::vector<BucketCopy> _replica_info;
+    uint32_t _max_documents_removed;
 
     void merge_received_bucket_info_into_db();
+    void update_gc_metrics();
 };
 
 }

--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
@@ -16,7 +16,7 @@ class PersistenceFailuresMetricSet : public metrics::MetricSet
 {
 public:
     explicit PersistenceFailuresMetricSet(metrics::MetricSet* owner);
-    ~PersistenceFailuresMetricSet();
+    ~PersistenceFailuresMetricSet() override;
 
     metrics::SumMetric<metrics::LongCountMetric> sum;
     metrics::LongCountMetric notready;
@@ -44,7 +44,7 @@ public:
     PersistenceFailuresMetricSet failures;
 
     PersistenceOperationMetricSet(const std::string& name, metrics::MetricSet* owner = nullptr);
-    ~PersistenceOperationMetricSet();
+    ~PersistenceOperationMetricSet() override;
 
     MetricSet * clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
                       metrics::MetricSet* owner, bool includeUnused) const override;

--- a/storageapi/src/tests/mbusprot/storageprotocoltest.cpp
+++ b/storageapi/src/tests/mbusprot/storageprotocoltest.cpp
@@ -522,8 +522,15 @@ TEST_P(StorageProtocolTest, remove_location) {
     EXPECT_EQ("id.group == \"mygroup\"", cmd2->getDocumentSelection());
     EXPECT_EQ(_bucket, cmd2->getBucket());
 
-    auto reply = std::make_shared<RemoveLocationReply>(*cmd2);
+    uint32_t n_docs_removed = 12345;
+    auto reply = std::make_shared<RemoveLocationReply>(*cmd2, n_docs_removed);
     auto reply2 = copyReply(reply);
+    if (GetParam().getMajor() == 7) {
+        // Statistics are only available for protobuf-enabled version.
+        EXPECT_EQ(n_docs_removed, reply2->documents_removed());
+    } else {
+        EXPECT_EQ(0, reply2->documents_removed());
+    }
 }
 
 TEST_P(StorageProtocolTest, create_visitor) {

--- a/storageapi/src/vespa/storageapi/mbusprot/protobuf/feed.proto
+++ b/storageapi/src/vespa/storageapi/mbusprot/protobuf/feed.proto
@@ -90,7 +90,12 @@ message RemoveLocationRequest {
     bytes  document_selection = 2;
 }
 
+message RemoveLocationStats {
+    uint32 documents_removed = 1;
+}
+
 message RemoveLocationResponse {
     BucketInfo bucket_info        = 1;
     BucketId   remapped_bucket_id = 2;
+    RemoveLocationStats stats     = 3;
 }

--- a/storageapi/src/vespa/storageapi/message/removelocation.cpp
+++ b/storageapi/src/vespa/storageapi/message/removelocation.cpp
@@ -25,8 +25,9 @@ RemoveLocationCommand::print(std::ostream& out, bool verbose, const std::string&
     BucketInfoCommand::print(out, verbose, indent);
 }
 
-RemoveLocationReply::RemoveLocationReply(const RemoveLocationCommand& cmd)
-    : BucketInfoReply(cmd)
+RemoveLocationReply::RemoveLocationReply(const RemoveLocationCommand& cmd, uint32_t docs_removed)
+    : BucketInfoReply(cmd),
+      _documents_removed(docs_removed)
 {
 }
 

--- a/storageapi/src/vespa/storageapi/message/removelocation.h
+++ b/storageapi/src/vespa/storageapi/message/removelocation.h
@@ -11,7 +11,7 @@ class RemoveLocationCommand : public BucketInfoCommand
 {
 public:
     RemoveLocationCommand(vespalib::stringref documentSelection, const document::Bucket &bucket);
-    ~RemoveLocationCommand();
+    ~RemoveLocationCommand() override;
 
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     const vespalib::string& getDocumentSelection() const { return _documentSelection; }
@@ -22,8 +22,13 @@ private:
 
 class RemoveLocationReply : public BucketInfoReply
 {
+    uint32_t _documents_removed;
 public:
-    RemoveLocationReply(const RemoveLocationCommand& cmd);
+    explicit RemoveLocationReply(const RemoveLocationCommand& cmd, uint32_t docs_removed = 0);
+    void set_documents_removed(uint32_t docs_removed) noexcept {
+        _documents_removed = docs_removed;
+    }
+    uint32_t documents_removed() const noexcept { return _documents_removed; }
     DECLARE_STORAGEREPLY(RemoveLocationReply, onRemoveLocationReply)
 };
 


### PR DESCRIPTION
@geirst please review. Moving StorageAPI to protobuf keeps paying off with dividends 🦄✨ 

New distributor metric available as:
```
vds.idealstate.garbage_collection.documents_removed
```
Add documents removed statistics to `RemoveLocation` responses,
which is what GC is currently built around. Could technically have
been implemented as a diff of before/after BucketInfo, but GC is
very low priority so many other mutating ops may have changed the
bucket document set in the time span between sending the GC ops
and receiving the replies.

This relates to issue #12139

