### PR TITLE
Determine endpoints from routing policies for all routing methods

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/RoutingMethod.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/RoutingMethod.java
@@ -22,4 +22,9 @@ public enum RoutingMethod {
         return this == exclusive || this == sharedLayer4;
     }
 
+    /** Returns whether this method routes requests through a shared routing layer */
+    public boolean isShared() {
+        return this == shared || this == sharedLayer4;
+    }
+
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/ServiceRegistry.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/ServiceRegistry.java
@@ -31,7 +31,6 @@ import java.time.Clock;
  *
  * @author mpolden
  */
-// TODO(mpolden): Access all services through this
 public interface ServiceRegistry {
 
     ConfigServer configServer();
@@ -42,6 +41,7 @@ public interface ServiceRegistry {
 
     GlobalRoutingService globalRoutingService();
 
+    // TODO(mpolden): Remove
     RoutingGenerator routingGenerator();
 
     Mailer mailer();

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingEndpoint.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingEndpoint.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 /**
  * @author smorgrav
  */
+// TODO(mpolden): Remove together with RoutingGenerator and its implementations
 public class RoutingEndpoint {
 
     private final boolean isGlobal;

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingGenerator.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingGenerator.java
@@ -12,6 +12,7 @@ import java.util.Map;
  * @author bratseth
  * @author smorgrav
  */
+// TODO(mpolden): Remove
 public interface RoutingGenerator {
 
     /**

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingGeneratorMock.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/routing/RoutingGeneratorMock.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
  * @author bratseth
  * @author jonmv
  */
+// TODO(mpolden): Remove
 public class RoutingGeneratorMock implements RoutingGenerator {
 
     public static final List<RoutingEndpoint> TEST_ENDPOINTS =

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -342,7 +342,7 @@ public class ApplicationController {
 
                 endpointCertificateMetadata = endpointCertificateManager.getEndpointCertificateMetadata(application.get().require(instance), zone);
 
-                endpoints = controller.routingController().registerEndpointsInDns(applicationPackage.deploymentSpec(), application.get().require(instanceId.instance()), zone);
+                endpoints = controller.routing().registerEndpointsInDns(applicationPackage.deploymentSpec(), application.get().require(instanceId.instance()), zone);
             } // Release application lock while doing the deployment, which is a lengthy task.
 
             // Carry out deployment without holding the application lock.
@@ -398,7 +398,7 @@ public class ApplicationController {
 
         for (InstanceName instance : declaredInstances)
             if (applicationPackage.deploymentSpec().requireInstance(instance).concerns(Environment.prod))
-                application = controller.routingController().assignRotations(application, instance);
+                application = controller.routing().assignRotations(application, instance);
 
         store(application);
         return application;
@@ -444,7 +444,7 @@ public class ApplicationController {
         } finally {
             // Even if prepare fails, a load balancer may have been provisioned. Always refresh routing policies so that
             // any DNS updates can be propagated as early as possible.
-            controller.routingController().policies().refresh(application, applicationPackage.deploymentSpec(), zone);
+            controller.routing().policies().refresh(application, applicationPackage.deploymentSpec(), zone);
         }
     }
 
@@ -516,7 +516,7 @@ public class ApplicationController {
                 throw new IllegalArgumentException("Could not delete '" + application + "': It has active deployments: " + deployments);
 
             for (Instance instance : application.get().instances().values()) {
-                controller.routingController().removeEndpointsInDns(instance);
+                controller.routing().removeEndpointsInDns(instance);
                 application = application.without(instance.name());
             }
 
@@ -551,7 +551,7 @@ public class ApplicationController {
                 &&   application.get().deploymentSpec().instanceNames().contains(instanceId.instance()))
                 throw new IllegalArgumentException("Can not delete '" + instanceId + "', which is specified in 'deployment.xml'; remove it there first");
 
-            controller.routingController().removeEndpointsInDns(application.get().require(instanceId.instance()));
+            controller.routing().removeEndpointsInDns(application.get().require(instanceId.instance()));
             curator.writeApplication(application.without(instanceId.instance()).get());
             controller.jobController().collectGarbage();
             log.info("Deleted " + instanceId);
@@ -633,7 +633,7 @@ public class ApplicationController {
         } catch (NotFoundException ignored) {
             // ok; already gone
         } finally {
-            controller.routingController().policies().refresh(application.get().id().instance(instanceName), application.get().deploymentSpec(), zone);
+            controller.routing().policies().refresh(application.get().id().instance(instanceName), application.get().deploymentSpec(), zone);
         }
         return application.with(instanceName, instance -> instance.withoutDeploymentIn(zone));
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -124,7 +124,7 @@ public class Controller extends AbstractComponent implements ApplicationIdSource
     public JobController jobController() { return jobController; }
 
     /** Returns the instance controlling routing */
-    public RoutingController routingController() {
+    public RoutingController routing() {
         return routingController;
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Instance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Instance.java
@@ -7,7 +7,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
@@ -16,8 +15,6 @@ import com.yahoo.vespa.hosted.controller.application.Change;
 import com.yahoo.vespa.hosted.controller.application.ClusterInfo;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
-import com.yahoo.vespa.hosted.controller.application.EndpointId;
-import com.yahoo.vespa.hosted.controller.application.EndpointList;
 import com.yahoo.vespa.hosted.controller.rotation.RotationStatus;
 
 import java.time.Instant;
@@ -164,20 +161,6 @@ public class Instance {
     /** Returns all rotations assigned to this */
     public List<AssignedRotation> rotations() {
         return rotations;
-    }
-
-    /** Returns the default global endpoints for this in given system - for a given endpoint ID */
-    public EndpointList endpointsIn(SystemName system, EndpointId endpointId) {
-        if (rotations.isEmpty()) return EndpointList.EMPTY;
-        return EndpointList.create(id, endpointId, system);
-    }
-
-    /** Returns the default global endpoints for this in given system */
-    public EndpointList endpointsIn(SystemName system) {
-        if (rotations.isEmpty()) return EndpointList.EMPTY;
-        final var endpointStream = rotations.stream()
-                .flatMap(rotation -> EndpointList.create(id, rotation.endpointId(), system).asList().stream());
-        return EndpointList.of(endpointStream);
     }
 
     /** Returns the status of the global rotation(s) assigned to this */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -115,7 +115,7 @@ public class RoutingController {
         return EndpointList.copyOf(endpoints);
     }
 
-    /** Returns all non-global endpoints for given deployments, grouped by their cluster ID and zone */
+    /** Returns all non-global endpoints and corresponding cluster IDs for given deployments, grouped by their zone */
     public Map<ZoneId, Map<URI, ClusterSpec.Id>> zoneEndpointsOf(Collection<DeploymentId> deployments) {
         var endpoints = new TreeMap<ZoneId, Map<URI, ClusterSpec.Id>>(Comparator.comparing(ZoneId::value));
         for (var deployment : deployments) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
@@ -41,9 +41,9 @@ public class EndpointList extends AbstractFilteringList<Endpoint, EndpointList> 
         return matching(endpoint -> endpoint.name().equals(id.id()));
     }
 
-    /** Returns the subset of endpoints are either legacy or not */
-    public EndpointList legacy(boolean legacy) {
-        return matching(endpoint -> endpoint.legacy() == legacy);
+    /** Returns the subset of endpoints that are considered legacy */
+    public EndpointList legacy() {
+        return matching(Endpoint::legacy);
     }
 
     /** Returns the subset of endpoints that require a rotation */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
@@ -2,16 +2,15 @@
 package com.yahoo.vespa.hosted.controller.application;
 
 import com.yahoo.collections.AbstractFilteringList;
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.vespa.hosted.controller.application.Endpoint.Port;
+import com.yahoo.vespa.hosted.controller.routing.RoutingId;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 
 /**
@@ -20,8 +19,6 @@ import java.util.stream.Stream;
  * @author mpolden
  */
 public class EndpointList extends AbstractFilteringList<Endpoint, EndpointList> {
-
-    public static final EndpointList EMPTY = new EndpointList(List.of());
 
     private EndpointList(Collection<? extends Endpoint> endpoints, boolean negate) {
         super(endpoints, negate, EndpointList::new);
@@ -34,9 +31,14 @@ public class EndpointList extends AbstractFilteringList<Endpoint, EndpointList> 
         this(endpoints, false);
     }
 
-    /** Returns the main endpoint, if any */
-    public Optional<Endpoint> main() {
-        return asList().stream().filter(Predicate.not(Endpoint::legacy)).findFirst();
+    /** Returns the primary (non-legacy) endpoint, if any */
+    public Optional<Endpoint> primary() {
+        return not().matching(Endpoint::legacy).asList().stream().findFirst();
+    }
+
+    /** Returns the subset of endpoints named according to given ID */
+    public EndpointList named(EndpointId id) {
+        return matching(endpoint -> endpoint.name().equals(id.id()));
     }
 
     /** Returns the subset of endpoints are either legacy or not */
@@ -44,27 +46,50 @@ public class EndpointList extends AbstractFilteringList<Endpoint, EndpointList> 
         return matching(endpoint -> endpoint.legacy() == legacy);
     }
 
+    /** Returns the subset of endpoints that require a rotation */
+    public EndpointList requiresRotation() {
+        return matching(Endpoint::requiresRotation);
+    }
+
     /** Returns the subset of endpoints with given scope */
     public EndpointList scope(Endpoint.Scope scope) {
         return matching(endpoint -> endpoint.scope() == scope);
     }
 
-    public static EndpointList of(Stream<Endpoint> endpoints) {
-        return new EndpointList(endpoints.collect(Collectors.toUnmodifiableList()));
+    /** Returns all global endpoints for given routing ID and system provided by given routing methods */
+    public static EndpointList global(RoutingId routingId, SystemName system, List<RoutingMethod> routingMethods) {
+        var endpoints = new ArrayList<Endpoint>();
+        for (var method : routingMethods) {
+            endpoints.add(Endpoint.of(routingId.application())
+                                  .named(routingId.endpointId())
+                                  .on(Port.fromRoutingMethod(method))
+                                  .routingMethod(method)
+                                  .in(system));
+            // TODO(mpolden): Remove this once all applications have migrated away from legacy endpoints
+            if (method == RoutingMethod.shared) {
+                endpoints.add(Endpoint.of(routingId.application())
+                                      .named(routingId.endpointId())
+                                      .on(Port.plain(4080))
+                                      .legacy()
+                                      .routingMethod(method)
+                                      .in(system));
+                endpoints.add(Endpoint.of(routingId.application())
+                                      .named(routingId.endpointId())
+                                      .on(Port.tls(4443))
+                                      .legacy()
+                                      .routingMethod(method)
+                                      .in(system));
+            }
+        }
+        return new EndpointList(endpoints);
     }
 
-    /** Returns the default global endpoints in given system. Default endpoints are served by a pre-provisioned routing layer */
-    public static EndpointList create(ApplicationId application, EndpointId endpointId, SystemName system) {
-        switch (system) {
-            case cd:
-            case main:
-                return new EndpointList(List.of(
-                        Endpoint.of(application).named(endpointId).on(Port.plain(4080)).legacy().in(system),
-                        Endpoint.of(application).named(endpointId).on(Port.tls(4443)).legacy().in(system),
-                        Endpoint.of(application).named(endpointId).on(Port.tls(4443)).in(system)
-                ));
-        }
-        return EMPTY;
+    public static EndpointList global(RoutingId routingId, SystemName system, RoutingMethod routingMethod) {
+        return global(routingId, system, List.of(routingMethod));
+    }
+
+    public static EndpointList copyOf(Collection<Endpoint> endpoints) {
+        return new EndpointList(endpoints);
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -454,7 +454,7 @@ public class InternalStepRunner implements StepRunner {
         if ( ! endpoints.containsKey(zoneId))
             return false;
 
-        for (URI endpoint : endpoints.get(zoneId).values()) {
+        for (var endpoint : endpoints.get(zoneId).keySet()) {
             boolean ready = controller.jobController().cloud().ready(endpoint);
             if (!ready) {
                 logger.log("Failed to get 100 consecutive OKs from " + endpoint);
@@ -482,7 +482,7 @@ public class InternalStepRunner implements StepRunner {
             logger.log("Endpoints not yet ready.");
             return false;
         }
-        for (var endpoint : endpoints.get(zone).values())
+        for (var endpoint : endpoints.get(zone).keySet())
             if ( ! controller.jobController().cloud().exists(endpoint)) {
                 logger.log(INFO, "DNS lookup yielded no IP address for '" + endpoint + "'.");
                 return false;
@@ -492,12 +492,12 @@ public class InternalStepRunner implements StepRunner {
         return true;
     }
 
-    private void logEndpoints(Map<ZoneId, Map<ClusterSpec.Id, URI>> endpoints, DualLogger logger) {
+    private void logEndpoints(Map<ZoneId, Map<URI, ClusterSpec.Id>> endpoints, DualLogger logger) {
         List<String> messages = new ArrayList<>();
         messages.add("Found endpoints:");
-        endpoints.forEach((zone, uris) -> {
+        endpoints.forEach((zone, urls) -> {
             messages.add("- " + zone);
-            uris.forEach((cluster, uri) -> messages.add(" |-- " + uri + " (" + cluster + ")"));
+            urls.forEach((url, cluster) -> messages.add(" |-- " + url + " (" + cluster + ")"));
         });
         logger.log(messages);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -450,7 +450,7 @@ public class InternalStepRunner implements StepRunner {
 
     /** Returns true iff all containers in the deployment give 100 consecutive 200 OK responses on /status.html. */
     private boolean containersAreUp(ApplicationId id, ZoneId zoneId, DualLogger logger) {
-        var endpoints = controller.routingController().zoneEndpointsOf(Set.of(new DeploymentId(id, zoneId)));
+        var endpoints = controller.routing().zoneEndpointsOf(Set.of(new DeploymentId(id, zoneId)));
         if ( ! endpoints.containsKey(zoneId))
             return false;
 
@@ -477,7 +477,7 @@ public class InternalStepRunner implements StepRunner {
     }
 
     private boolean endpointsAvailable(ApplicationId id, ZoneId zone, DualLogger logger) {
-        var endpoints = controller.routingController().zoneEndpointsOf(Set.of(new DeploymentId(id, zone)));
+        var endpoints = controller.routing().zoneEndpointsOf(Set.of(new DeploymentId(id, zone)));
         if ( ! endpoints.containsKey(zone)) {
             logger.log("Endpoints not yet ready.");
             return false;
@@ -550,7 +550,7 @@ public class InternalStepRunner implements StepRunner {
         deployments.add(new DeploymentId(id.application(), zoneId));
 
         logger.log("Attempting to find endpoints ...");
-        var endpoints = controller.routingController().zoneEndpointsOf(deployments);
+        var endpoints = controller.routing().zoneEndpointsOf(deployments);
         if ( ! endpoints.containsKey(zoneId)) {
             logger.log(WARNING, "Endpoints for the deployment to test vanished again, while it was still active!");
             return Optional.of(error);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -531,12 +531,6 @@ public class JobController {
                                     .collect(toList()));
     }
 
-    /** Returns the tester endpoint URL, if any */
-    Optional<URI> testerEndpoint(RunId id) {
-        var testerId = new DeploymentId(id.tester().id(), id.type().zone(controller.system()));
-        return controller.routing().zoneEndpointsOf(testerId).values().stream().findFirst();
-    }
-
     private void prunePackages(TenantAndApplicationId id) {
         controller.applications().lockApplicationIfPresent(id, application -> {
             application.get().productionDeployments().values().stream()

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -26,7 +26,6 @@ import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
 import com.yahoo.vespa.hosted.controller.persistence.BufferedLogStore;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
-import com.yahoo.vespa.hosted.controller.tenant.Tenant;
 
 import java.net.URI;
 import java.security.cert.X509Certificate;
@@ -504,7 +503,7 @@ public class JobController {
         } finally {
             // Passing an empty DeploymentSpec here is fine as it's used for registering global endpoint names, and
             // tester instances have none.
-            controller.routingController().policies().refresh(id.id(), DeploymentSpec.empty, zone);
+            controller.routing().policies().refresh(id.id(), DeploymentSpec.empty, zone);
         }
     }
 
@@ -535,7 +534,7 @@ public class JobController {
     /** Returns the tester endpoint URL, if any */
     Optional<URI> testerEndpoint(RunId id) {
         var testerId = new DeploymentId(id.tester().id(), id.type().zone(controller.system()));
-        return controller.routingController().zoneEndpointsOf(testerId).values().stream().findFirst();
+        return controller.routing().zoneEndpointsOf(testerId).values().stream().findFirst();
     }
 
     private void prunePackages(TenantAndApplicationId id) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/TestConfigSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/TestConfigSerializer.java
@@ -32,7 +32,7 @@ public class TestConfigSerializer {
     public Slime configSlime(ApplicationId id,
                              JobType type,
                              boolean isCI,
-                             Map<ZoneId, Map<ClusterSpec.Id, URI>> deployments,
+                             Map<ZoneId, Map<URI, ClusterSpec.Id>> deployments,
                              Map<ZoneId, List<String>> clusters) {
         Slime slime = new Slime();
         Cursor root = slime.setObject();
@@ -45,14 +45,14 @@ public class TestConfigSerializer {
         Cursor endpointsObject = root.setObject("endpoints"); // TODO jvenstad: remove.
         deployments.forEach((zone, endpoints) -> {
             Cursor endpointArray = endpointsObject.setArray(zone.value());
-            for (URI endpoint : endpoints.values())
+            for (URI endpoint : endpoints.keySet())
                 endpointArray.addString(endpoint.toString());
         });
 
         Cursor zoneEndpointsObject = root.setObject("zoneEndpoints");
         deployments.forEach((zone, endpoints) -> {
             Cursor clusterEndpointsObject = zoneEndpointsObject.setObject(zone.value());
-            endpoints.forEach((cluster, endpoint) -> {
+            endpoints.forEach((endpoint, cluster) -> {
                 clusterEndpointsObject.setString(cluster.value(), endpoint.toString());
             });
         });
@@ -73,7 +73,7 @@ public class TestConfigSerializer {
     public byte[] configJson(ApplicationId id,
                              JobType type,
                              boolean isCI,
-                             Map<ZoneId, Map<ClusterSpec.Id, URI>> deployments,
+                             Map<ZoneId, Map<URI, ClusterSpec.Id>> deployments,
                              Map<ZoneId, List<String>> clusters) {
         try {
             return SlimeUtils.toJsonBytes(configSlime(id, type, isCI, deployments, clusters));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporter.java
@@ -64,8 +64,8 @@ public class MetricsReporter extends Maintainer {
     }
 
     private void reportRemainingRotations() {
-        try (RotationLock lock = controller().routingController().rotations().lock()) {
-            int availableRotations = controller().routingController().rotations().availableRotations(lock).size();
+        try (RotationLock lock = controller().routing().rotations().lock()) {
+            int availableRotations = controller().routing().rotations().availableRotations(lock).size();
             metric.set(REMAINING_ROTATIONS, availableRotations, metric.createContext(Map.of()));
         }
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RotationStatusUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/RotationStatusUpdater.java
@@ -82,7 +82,7 @@ public class RotationStatusUpdater extends Maintainer {
     private RotationStatus getStatus(Instance instance) {
         var statusMap = new LinkedHashMap<RotationId, RotationStatus.Targets>();
         for (var assignedRotation : instance.rotations()) {
-            var rotation = controller().routingController().rotations().getRotation(assignedRotation.rotationId());
+            var rotation = controller().routing().rotations().getRotation(assignedRotation.rotationId());
             if (rotation.isEmpty()) continue;
             var targets = service.getHealthStatus(rotation.get().name()).entrySet().stream()
                                  .collect(Collectors.toMap(Map.Entry::getKey, (kv) -> from(kv.getValue())));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -858,7 +858,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         // Add global endpoints backed by rotations
         controller.routing().endpointsOf(instance.id())
                   .requiresRotation()
-                  .legacy(false) // Hide legacy names
+                  .not().legacy() // Hide legacy names
                   .asList().stream()
                   .map(Endpoint::url)
                   .map(URI::toString)
@@ -1066,7 +1066,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         }
         // Add global endpoints
         if (deploymentId.zoneId().environment().isProduction()) { // Global endpoints can only point to production deployments
-            for (var endpoint : controller.routing().endpointsOf(deploymentId.applicationId())) {
+            for (var endpoint : controller.routing().endpointsOf(instance).not().legacy()) {
                 // TODO(mpolden): Pass cluster name. Cluster that a global endpoint points to is not available at this level.
                 toSlime(endpoint, "", endpointArray.addObject());
             }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -108,6 +108,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Comparator;
@@ -850,28 +851,20 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         }
     }
 
+    // TODO(mpolden): Remove once legacy dashboard and integration tests stop expecting these fields
     private void globalEndpointsToSlime(Cursor object, Instance instance) {
         var globalEndpointUrls = new LinkedHashSet<String>();
 
-        // Add default global endpoints. These are backed by rotations.
-        instance.endpointsIn(controller.system())
-                .scope(Endpoint.Scope.global)
-                .legacy(false) // Hide legacy names
-                .asList().stream()
-                .map(Endpoint::url)
-                .map(URI::toString)
-                .forEach(globalEndpointUrls::add);
-
-        // Per-cluster endpoints. These are backed by load balancers.
-        var routingPolicies = controller.routing().policies().get(instance.id()).values();
-        for (var policy : routingPolicies) {
-            policy.globalEndpointsIn(controller.system()).asList().stream()
+        // Add global endpoints backed by rotations
+        controller.routing().endpointsOf(instance.id())
+                  .requiresRotation()
+                  .legacy(false) // Hide legacy names
+                  .asList().stream()
                   .map(Endpoint::url)
                   .map(URI::toString)
                   .forEach(globalEndpointUrls::add);
-        }
 
-        // TODO(mpolden): Remove once clients stop expecting this field
+
         var globalRotationsArray = object.setArray("globalRotations");
         globalEndpointUrls.forEach(globalRotationsArray::addString);
 
@@ -1044,6 +1037,14 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
               .ifPresent(version -> toSlime(version, object.setObject("revision")));
     }
 
+    private void toSlime(Endpoint endpoint, String cluster, Cursor object) {
+        object.setString("cluster", cluster);
+        object.setBool("tls", endpoint.tls());
+        object.setString("url", endpoint.url().toString());
+        object.setString("scope", endpointScopeString(endpoint.scope()));
+        object.setString("routingMethod", routingMethodString(endpoint.routingMethod()));
+    }
+
     private void toSlime(Cursor response, DeploymentId deploymentId, Deployment deployment, HttpRequest request) {
         response.setString("tenant", deploymentId.applicationId().tenant().value());
         response.setString("application", deploymentId.applicationId().application().value());
@@ -1051,68 +1052,28 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         response.setString("environment", deploymentId.zoneId().environment().value());
         response.setString("region", deploymentId.zoneId().region().value());
 
-        // Add zone endpoints defined by routing policies
-        var endpointArray = response.setArray("endpoints");
-        for (var policy : controller.routing().policies().get(deploymentId).values()) {
-            // TODO(mpolden): Always add endpoints from all policies, independent of routing method. This allows removal
-            //                of RoutingGenerator and eliminates the external call to the routing layer below.
-            if (!controller.routing().supportsRoutingMethod(RoutingMethod.exclusive, deployment.zone())) continue;
-            if (!policy.status().isActive()) continue;
-            {
-                var endpointObject = endpointArray.addObject();
-                var endpoint = policy.endpointIn(controller.system());
-                endpointObject.setString("cluster", policy.id().cluster().value());
-                endpointObject.setBool("tls", endpoint.tls());
-                endpointObject.setString("url", endpoint.url().toString());
-                endpointObject.setString("scope", endpointScopeString(endpoint.scope()));
-                endpointObject.setString("routingMethod", routingMethodString(RoutingMethod.exclusive));
-            }
-            // Add global endpoints that point to this policy
-            for (var endpoint : policy.globalEndpointsIn(controller.system()).asList()) {
-                var endpointObject = endpointArray.addObject();
-                endpointObject.setString("cluster", policy.id().cluster().value());
-                endpointObject.setBool("tls", endpoint.tls());
-                endpointObject.setString("url", endpoint.url().toString());
-                endpointObject.setString("scope", endpointScopeString(endpoint.scope()));
-                endpointObject.setString("routingMethod", routingMethodString(RoutingMethod.exclusive));
-            }
-        }
-        // Add zone endpoints served by shared routing layer
-        for (var clusterAndUrl : controller.routing().legacyZoneEndpointsOf(deploymentId).entrySet()) {
-            var endpointObject = endpointArray.addObject();
-            endpointObject.setString("cluster", clusterAndUrl.getKey().value());
-            endpointObject.setBool("tls", true);
-            endpointObject.setString("url", clusterAndUrl.getValue().toString());
-            endpointObject.setString("scope", endpointScopeString(Endpoint.Scope.zone));
-            endpointObject.setString("routingMethod", routingMethodString(RoutingMethod.shared));
-        }
-        // Add global endpoints served by shared routing layer
         var application = controller.applications().requireApplication(TenantAndApplicationId.from(deploymentId.applicationId()));
         var instance = application.instances().get(deploymentId.applicationId().instance());
-        if (deploymentId.zoneId().environment().isProduction()) { // Global endpoints can only point to production deployments
-            for (var rotation : instance.rotations()) {
-                var endpoints = instance.endpointsIn(controller.system(), rotation.endpointId())
-                                        .legacy(false)
-                                        .scope(Endpoint.Scope.global)
-                                        .asList();
-                for (var endpoint : endpoints) {
-                    var endpointObject = endpointArray.addObject();
-                    endpointObject.setString("cluster", rotation.clusterId().value());
-                    endpointObject.setBool("tls", true);
-                    endpointObject.setString("url", endpoint.url().toString());
-                    endpointObject.setString("scope", endpointScopeString(endpoint.scope()));
-                    endpointObject.setString("routingMethod", routingMethodString(RoutingMethod.shared));
-                }
+
+        // Add zone endpoints
+        var endpointArray = response.setArray("endpoints");
+        var serviceUrls = new ArrayList<URI>();
+        for (var endpoint : controller.routing().endpointsOf(deploymentId)) {
+            toSlime(endpoint, endpoint.name(), endpointArray.addObject());
+            if (endpoint.routingMethod() == RoutingMethod.shared) {
+                serviceUrls.add(endpoint.url());
             }
         }
-
-        // serviceUrls contains all valid endpoints for this deployment, including global. The name of these endpoints
-        // may contain the cluster name (if non-default). Since the controller has no knowledge of clusters for legacy
-        // endpoints, we can't generate these URLs on-the-fly and we have to query the routing layer.
-        // TODO(mpolden): Remove this once all clients stop reading this.
+        // Add global endpoints
+        if (deploymentId.zoneId().environment().isProduction()) { // Global endpoints can only point to production deployments
+            for (var endpoint : controller.routing().endpointsOf(deploymentId.applicationId())) {
+                // TODO(mpolden): Pass cluster name. Cluster that a global endpoint points to is not available at this level.
+                toSlime(endpoint, "", endpointArray.addObject());
+            }
+        }
+        // TODO(mpolden): Remove this once all clients stop reading it
         Cursor serviceUrlArray = response.setArray("serviceUrls");
-        controller.routing().legacyEndpointsOf(deploymentId)
-                  .forEach(endpoint -> serviceUrlArray.addString(endpoint.toString()));
+        serviceUrls.forEach(url -> serviceUrlArray.addString(url.toString()));
 
         response.setString("nodes", withPath("/zone/v2/" + deploymentId.zoneId().environment() + "/" + deploymentId.zoneId().region() + "/nodes/v2/node/?&recursive=true&application=" + deploymentId.applicationId().tenant() + "." + deploymentId.applicationId().application() + "." + deploymentId.applicationId().instance(), request.getUri()).toString());
         response.setString("yamasUrl", monitoringSystemUri(deploymentId).toString());
@@ -1275,7 +1236,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         Cursor array = slime.setObject().setArray("globalrotationoverride");
         controller.routing().globalRotationStatus(deploymentId)
                   .forEach((endpoint, status) -> {
-                      array.addString(endpoint.upstreamName());
+                      array.addString(endpoint.upstreamIdOf(deploymentId));
                       Cursor statusObject = array.addObject();
                       statusObject.setString("status", status.getStatus().name());
                       statusObject.setString("reason", status.getReason() == null ? "" : status.getReason());
@@ -2123,6 +2084,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         switch (method) {
             case exclusive: return "exclusive";
             case shared: return "shared";
+            case sharedLayer4: return "sharedLayer4";
         }
         throw new IllegalArgumentException("Unknown routing method " + method);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/routing/RoutingApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/routing/RoutingApiHandler.java
@@ -170,7 +170,7 @@ public class RoutingApiHandler extends AuditLoggingRequestHandler {
         var zone = zoneFrom(path);
         if (controller.zoneRegistry().zones().directlyRouted().ids().contains(zone)) {
             var status = in ? GlobalRouting.Status.in : GlobalRouting.Status.out;
-            controller.routingController().policies().setGlobalRoutingStatus(zone, status);
+            controller.routing().policies().setGlobalRoutingStatus(zone, status);
         } else {
             controller.serviceRegistry().configServer().setGlobalRotationStatus(zone, in);
         }
@@ -188,7 +188,7 @@ public class RoutingApiHandler extends AuditLoggingRequestHandler {
 
     private void toSlime(ZoneId zone, Cursor zoneObject) {
         if (controller.zoneRegistry().zones().directlyRouted().ids().contains(zone)) {
-            var zonePolicy = controller.routingController().policies().get(zone);
+            var zonePolicy = controller.routing().policies().get(zone);
             zoneStatusToSlime(zoneObject, zonePolicy.zone(), zonePolicy.globalRouting(), RoutingMethod.exclusive);
         } else {
             // Rotation status per zone only exposes in/out status, no agent or time of change.
@@ -210,11 +210,11 @@ public class RoutingApiHandler extends AuditLoggingRequestHandler {
             var endpointStatus = new EndpointStatus(in ? EndpointStatus.Status.in : EndpointStatus.Status.out, "",
                                                     agent.name(),
                                                     controller.clock().instant().getEpochSecond());
-            controller.routingController().setGlobalRotationStatus(deployment, endpointStatus);
+            controller.routing().setGlobalRotationStatus(deployment, endpointStatus);
         }
 
         // Set policy status
-        controller.routingController().policies().setGlobalRoutingStatus(deployment, status, agent);
+        controller.routing().policies().setGlobalRoutingStatus(deployment, status, agent);
         return new MessageResponse("Set global routing status for " + deployment + " to " + (in ? "IN" : "OUT"));
     }
 
@@ -242,7 +242,7 @@ public class RoutingApiHandler extends AuditLoggingRequestHandler {
                     var deploymentId = new DeploymentId(instance.id(), zone);
                     // Include status from rotation
                     if (rotationCanRouteTo(zone, instance)) {
-                        var rotationStatus = controller.routingController().globalRotationStatus(deploymentId);
+                        var rotationStatus = controller.routing().globalRotationStatus(deploymentId);
                         // Status is equal across all global endpoints, as the status is per deployment, not per endpoint.
                         var endpointStatus = rotationStatus.values().stream().findFirst();
                         if (endpointStatus.isPresent()) {
@@ -263,7 +263,7 @@ public class RoutingApiHandler extends AuditLoggingRequestHandler {
                     }
 
                     // Include status from routing policies
-                    var routingPolicies = controller.routingController().policies().get(deploymentId);
+                    var routingPolicies = controller.routing().policies().get(deploymentId);
                     for (var policy : routingPolicies.values()) {
                         deploymentStatusToSlime(deploymentsArray.addObject(), policy);
                     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingId.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingId.java
@@ -48,4 +48,8 @@ public class RoutingId {
         return "routing id for " + endpointId + " of " + application;
     }
 
+    public static RoutingId of(ApplicationId application, EndpointId endpoint) {
+        return new RoutingId(application, endpoint);
+    }
+
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicies.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicies.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.controller.routing;
 
 import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.hosted.controller.Controller;
@@ -13,6 +14,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
 import com.yahoo.vespa.hosted.controller.application.EndpointId;
+import com.yahoo.vespa.hosted.controller.dns.NameServiceForwarder;
 import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue.Priority;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
 
@@ -56,14 +58,9 @@ public class RoutingPolicies {
 
     /** Read all known routing policies for given deployment */
     public Map<RoutingPolicyId, RoutingPolicy> get(DeploymentId deployment) {
-        return get(deployment.applicationId(), deployment.zoneId());
-    }
-
-    /** Read all known routing policies for given deployment */
-    public Map<RoutingPolicyId, RoutingPolicy> get(ApplicationId application, ZoneId zone) {
-        return db.readRoutingPolicies(application).entrySet()
+        return db.readRoutingPolicies(deployment.applicationId()).entrySet()
                  .stream()
-                 .filter(kv -> kv.getKey().zone().equals(zone))
+                 .filter(kv -> kv.getKey().zone().equals(deployment.zoneId()))
                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
@@ -77,16 +74,15 @@ public class RoutingPolicies {
      * load balancers for given application have changed.
      */
     public void refresh(ApplicationId application, DeploymentSpec deploymentSpec, ZoneId zone) {
-        if (!controller.zoneRegistry().zones().directlyRouted().ids().contains(zone)) return;
         var loadBalancers = new AllocatedLoadBalancers(application, zone, controller.serviceRegistry().configServer()
                                                                                     .getLoadBalancers(application, zone),
                                                        deploymentSpec);
         var inactiveZones = inactiveZones(application, deploymentSpec);
         try (var lock = db.lockRoutingPolicies()) {
-            if (!application.instance().isTester()) removeGlobalDnsUnreferencedBy(loadBalancers, lock);
+            removeGlobalDnsUnreferencedBy(loadBalancers, lock);
             storePoliciesOf(loadBalancers, lock);
             removePoliciesUnreferencedBy(loadBalancers, lock);
-            if (!application.instance().isTester()) updateGlobalDnsOf(get(loadBalancers.application).values(), inactiveZones, lock);
+            updateGlobalDnsOf(get(loadBalancers.deployment.applicationId()).values(), inactiveZones, lock);
         }
     }
 
@@ -127,6 +123,7 @@ public class RoutingPolicies {
             var staleTargets = new LinkedHashSet<AliasTarget>();
             for (var policy : routeEntry.getValue()) {
                 if (policy.dnsZone().isEmpty()) continue;
+                if (!controller.zoneRegistry().routingMethods(policy.id().zone()).contains(RoutingMethod.exclusive)) continue;
                 var target = new AliasTarget(policy.canonicalName(), policy.dnsZone().get(), policy.id().zone());
                 var zonePolicy = db.readZoneRoutingPolicy(policy.id().zone());
                 // Remove target zone if global routing status is set out at:
@@ -146,9 +143,10 @@ public class RoutingPolicies {
                 staleTargets.clear();
             }
             if (!targets.isEmpty()) {
-                var endpoint = RoutingPolicy.globalEndpointOf(routeEntry.getKey().application(),
-                                                              routeEntry.getKey().endpointId(), controller.system());
-                controller.nameServiceForwarder().createAlias(RecordName.from(endpoint.dnsName()), targets, Priority.normal);
+                var endpoints = controller.routing().endpointsOf(routeEntry.getKey().application())
+                                          .named(routeEntry.getKey().endpointId())
+                                          .not().requiresRotation();
+                endpoints.forEach(endpoint -> controller.nameServiceForwarder().createAlias(RecordName.from(endpoint.dnsName()), targets, Priority.normal));
             }
             staleTargets.forEach(t -> controller.nameServiceForwarder().removeRecords(Record.Type.ALIAS,
                                                                                       RecordData.fqdn(t.name().value()),
@@ -158,9 +156,9 @@ public class RoutingPolicies {
 
     /** Store routing policies for given load balancers */
     private void storePoliciesOf(AllocatedLoadBalancers loadBalancers, @SuppressWarnings("unused") Lock lock) {
-        var policies = new LinkedHashMap<>(get(loadBalancers.application));
+        var policies = new LinkedHashMap<>(get(loadBalancers.deployment.applicationId()));
         for (LoadBalancer loadBalancer : loadBalancers.list) {
-            var policyId = new RoutingPolicyId(loadBalancer.application(), loadBalancer.cluster(), loadBalancers.zone);
+            var policyId = new RoutingPolicyId(loadBalancer.application(), loadBalancer.cluster(), loadBalancers.deployment.zoneId());
             var existingPolicy = policies.get(policyId);
             var newPolicy = new RoutingPolicy(policyId, loadBalancer.hostname(), loadBalancer.dnsZone(),
                                               loadBalancers.endpointIdsOf(loadBalancer),
@@ -172,42 +170,45 @@ public class RoutingPolicies {
             updateZoneDnsOf(newPolicy);
             policies.put(newPolicy.id(), newPolicy);
         }
-        db.writeRoutingPolicies(loadBalancers.application, policies);
+        db.writeRoutingPolicies(loadBalancers.deployment.applicationId(), policies);
     }
 
     /** Update zone DNS record for given policy */
     private void updateZoneDnsOf(RoutingPolicy policy) {
-        var name = RecordName.from(policy.endpointIn(controller.system()).dnsName());
+        var name = RecordName.from(policy.endpointIn(controller.system(), RoutingMethod.exclusive).dnsName());
         var data = RecordData.fqdn(policy.canonicalName().value());
-        controller.nameServiceForwarder().createCname(name, data, Priority.normal);
+        nameUpdaterIn(policy.id().zone()).createCname(name, data);
     }
 
     /** Remove policies and zone DNS records unreferenced by given load balancers */
     private void removePoliciesUnreferencedBy(AllocatedLoadBalancers loadBalancers, @SuppressWarnings("unused") Lock lock) {
-        var policies = get(loadBalancers.application);
+        var policies = get(loadBalancers.deployment.applicationId());
         var newPolicies = new LinkedHashMap<>(policies);
         var activeLoadBalancers = loadBalancers.list.stream().map(LoadBalancer::hostname).collect(Collectors.toSet());
         for (var policy : policies.values()) {
             // Leave active load balancers and irrelevant zones alone
             if (activeLoadBalancers.contains(policy.canonicalName()) ||
-                !policy.id().zone().equals(loadBalancers.zone)) continue;
+                !policy.id().zone().equals(loadBalancers.deployment.zoneId())) continue;
 
-            var dnsName = policy.endpointIn(controller.system()).dnsName();
-            controller.nameServiceForwarder().removeRecords(Record.Type.CNAME, RecordName.from(dnsName), Priority.normal);
+            var dnsName = policy.endpointIn(controller.system(), RoutingMethod.exclusive).dnsName();
+            nameUpdaterIn(loadBalancers.deployment.zoneId()).removeRecords(Record.Type.CNAME, RecordName.from(dnsName));
             newPolicies.remove(policy.id());
         }
-        db.writeRoutingPolicies(loadBalancers.application, newPolicies);
+        db.writeRoutingPolicies(loadBalancers.deployment.applicationId(), newPolicies);
     }
 
     /** Remove unreferenced global endpoints from DNS */
     private void removeGlobalDnsUnreferencedBy(AllocatedLoadBalancers loadBalancers, @SuppressWarnings("unused") Lock lock) {
-        var zonePolicies = get(loadBalancers.application, loadBalancers.zone).values();
+        var zonePolicies = get(loadBalancers.deployment).values();
         var removalCandidates = new HashSet<>(routingTableFrom(zonePolicies).keySet());
         var activeRoutingIds = routingIdsFrom(loadBalancers);
         removalCandidates.removeAll(activeRoutingIds);
         for (var id : removalCandidates) {
-            var endpoint = RoutingPolicy.globalEndpointOf(id.application(), id.endpointId(), controller.system());
-            controller.nameServiceForwarder().removeRecords(Record.Type.ALIAS, RecordName.from(endpoint.dnsName()), Priority.normal);
+            var endpoints = controller.routing().endpointsOf(id.application())
+                                      .not().requiresRotation()
+                                      .named(id.endpointId());
+            var nameUpdater = nameUpdaterIn(loadBalancers.deployment.zoneId());
+            endpoints.forEach(endpoint -> nameUpdater.removeRecords(Record.Type.ALIAS, RecordName.from(endpoint.dnsName())));
         }
     }
 
@@ -258,22 +259,20 @@ public class RoutingPolicies {
     /** Load balancers allocated to a deployment */
     private static class AllocatedLoadBalancers {
 
-        private final ApplicationId application;
-        private final ZoneId zone;
+        private final DeploymentId deployment;
         private final List<LoadBalancer> list;
         private final DeploymentSpec deploymentSpec;
 
         private AllocatedLoadBalancers(ApplicationId application, ZoneId zone, List<LoadBalancer> loadBalancers,
                                        DeploymentSpec deploymentSpec) {
-            this.application = application;
-            this.zone = zone;
+            this.deployment = new DeploymentId(application, zone);
             this.list = List.copyOf(loadBalancers);
             this.deploymentSpec = deploymentSpec;
         }
 
         /** Compute all endpoint IDs for given load balancer */
         private Set<EndpointId> endpointIdsOf(LoadBalancer loadBalancer) {
-            if (!zone.environment().isProduction()) { // Only production deployments have configurable endpoints
+            if (!deployment.zoneId().environment().isProduction()) { // Only production deployments have configurable endpoints
                 return Set.of();
             }
             var instanceSpec = deploymentSpec.instance(loadBalancer.application().instance());
@@ -282,7 +281,7 @@ public class RoutingPolicies {
             }
             return instanceSpec.get().endpoints().stream()
                                .filter(endpoint -> endpoint.containerId().equals(loadBalancer.cluster().value()))
-                               .filter(endpoint -> endpoint.regions().contains(zone.region()))
+                               .filter(endpoint -> endpoint.regions().contains(deployment.zoneId().region()))
                                .map(com.yahoo.config.application.api.Endpoint::endpointId)
                                .map(EndpointId::of)
                                .collect(Collectors.toSet());
@@ -299,6 +298,55 @@ public class RoutingPolicies {
                            .filter(zone -> !zone.active())
                            .map(zone -> ZoneId.from(zone.environment(), zone.region().get()))
                            .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /** Returns the name updater to use for given zone */
+    private NameUpdater nameUpdaterIn(ZoneId zone) {
+        if (controller.zoneRegistry().routingMethods(zone).contains(RoutingMethod.exclusive)) {
+            return new NameUpdater(controller.nameServiceForwarder());
+        }
+        return new DiscardingNameUpdater();
+    }
+
+    /** A name updater that passes name service operations to the next handler */
+    private static class NameUpdater {
+
+        private final NameServiceForwarder forwarder;
+
+        public NameUpdater(NameServiceForwarder forwarder) {
+            this.forwarder = forwarder;
+        }
+
+        public void removeRecords(Record.Type type, RecordName name) {
+            forwarder.removeRecords(type, name, Priority.normal);
+        }
+
+        public void createAlias(RecordName name, Set<AliasTarget> targets) {
+            forwarder.createAlias(name, targets, Priority.normal);
+        }
+
+        public void createCname(RecordName name, RecordData data) {
+            forwarder.createCname(name, data, Priority.normal);
+        }
+
+    }
+
+    /** A name updater that does nothing */
+    private static class DiscardingNameUpdater extends NameUpdater {
+
+        private DiscardingNameUpdater() {
+            super(null);
+        }
+
+        @Override
+        public void removeRecords(Record.Type type, RecordName name) {}
+
+        @Override
+        public void createAlias(RecordName name, Set<AliasTarget> target) {}
+
+        @Override
+        public void createCname(RecordName name, RecordData data) {}
+
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
@@ -2,14 +2,12 @@
 package com.yahoo.vespa.hosted.controller.routing;
 
 import com.google.common.collect.ImmutableSortedSet;
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.vespa.hosted.controller.application.Endpoint;
 import com.yahoo.vespa.hosted.controller.application.Endpoint.Port;
 import com.yahoo.vespa.hosted.controller.application.EndpointId;
-import com.yahoo.vespa.hosted.controller.application.EndpointList;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -70,16 +68,12 @@ public class RoutingPolicy {
     }
 
     /** Returns the endpoint of this */
-    public Endpoint endpointIn(SystemName system) {
-        return Endpoint.of(id.owner()).target(id.cluster(), id.zone())
-                       .routingMethod(RoutingMethod.exclusive)
-                       .on(Port.tls())
+    public Endpoint endpointIn(SystemName system, RoutingMethod routingMethod) {
+        return Endpoint.of(id.owner())
+                       .target(id.cluster(), id.zone())
+                       .on(Port.fromRoutingMethod(routingMethod))
+                       .routingMethod(routingMethod)
                        .in(system);
-    }
-
-    /** Returns global endpoints which this is a member of */
-    public EndpointList globalEndpointsIn(SystemName system) {
-        return EndpointList.of(endpoints.stream().map(endpointId -> globalEndpointOf(id.owner(), endpointId, system)));
     }
 
     @Override
@@ -100,14 +94,6 @@ public class RoutingPolicy {
         return String.format("%s [endpoints: %s%s], %s owned by %s, in %s", canonicalName, endpoints,
                              dnsZone.map(z -> ", DNS zone: " + z).orElse(""), id.cluster(), id.owner().toShortString(),
                              id.zone().value());
-    }
-
-    /** Creates a global endpoint for given application */
-    public static Endpoint globalEndpointOf(ApplicationId application, EndpointId endpointId, SystemName system) {
-        return Endpoint.of(application).named(endpointId)
-                       .on(Port.tls())
-                       .routingMethod(RoutingMethod.exclusive)
-                       .in(system);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -190,7 +190,7 @@ public class ControllerTest {
                 new RoutingEndpoint("http://alias-endpoint.vespa.yahooapis.com:4080", "host1", true, "upstream1")
         ));
 
-        Supplier<Map<RoutingEndpoint, EndpointStatus>> globalRotationStatus = () -> tester.controller().routingController().globalRotationStatus(deployment);
+        Supplier<Map<RoutingEndpoint, EndpointStatus>> globalRotationStatus = () -> tester.controller().routing().globalRotationStatus(deployment);
         Supplier<List<EndpointStatus>> upstreamOneEndpoints = () -> {
             return globalRotationStatus.get()
                                        .entrySet().stream()
@@ -206,7 +206,7 @@ public class ControllerTest {
 
         // Set the global rotations out of service
         EndpointStatus status = new EndpointStatus(EndpointStatus.Status.out, "unit-test", "Test", tester.clock().instant().getEpochSecond());
-        tester.controller().routingController().setGlobalRotationStatus(deployment, status);
+        tester.controller().routing().setGlobalRotationStatus(deployment, status);
         assertEquals(2, upstreamOneEndpoints.get().size());
         assertTrue("All upstreams are out", upstreamOneEndpoints.get().stream().allMatch(es -> es.getStatus() == EndpointStatus.Status.out));
         assertTrue("Reason is set", upstreamOneEndpoints.get().stream().allMatch(es -> es.getReason().equals("unit-test")));
@@ -517,9 +517,9 @@ public class ControllerTest {
             context.submit(applicationPackage);
             tester.applications().deleteApplication(context.application().id(),
                                                     tester.controllerTester().credentialsFor(context.application().id().tenant()));
-            try (RotationLock lock = tester.controller().routingController().rotations().lock()) {
+            try (RotationLock lock = tester.controller().routing().rotations().lock()) {
                 assertTrue("Rotation is unassigned",
-                           tester.controller().routingController().rotations().availableRotations(lock)
+                           tester.controller().routing().rotations().availableRotations(lock)
                                  .containsKey(new RotationId("rotation-id-01")));
             }
             context.flushDnsUpdates();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
@@ -217,7 +217,7 @@ public class DeploymentContext {
         return this;
     }
 
-    /** Add a routing policy for this in given zone, with status set to active */
+    /** Add a routing policy for this in given zone, with status set to inactive */
     public DeploymentContext addInactiveRoutingPolicy(ZoneId zone) {
         var clusterId = "default-inactive";
         var id = new RoutingPolicyId(instanceId, ClusterSpec.Id.from(clusterId), zone);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/TestConfigSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/TestConfigSerializerTest.java
@@ -29,8 +29,8 @@ public class TestConfigSerializerTest {
         byte[] json = new TestConfigSerializer(SystemName.PublicCd).configJson(instanceId,
                                                                                JobType.systemTest,
                                                                                true,
-                                                                               Map.of(zone, Map.of(ClusterSpec.Id.from("ai"),
-                                                                                                   URI.create("https://server/"))),
+                                                                               Map.of(zone, Map.of(URI.create("https://server/"),
+                                                                                                   ClusterSpec.Id.from("ai"))),
                                                                                Map.of(zone, List.of("facts")));
         byte[] expected = Files.readAllBytes(Paths.get("src/test/resources/testConfig.json"));
         assertEquals(new String(SlimeUtils.toJsonBytes(SlimeUtils.jsonToSlime(expected))),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneRegistryMock.java
@@ -116,6 +116,9 @@ public class ZoneRegistryMock extends AbstractComponent implements ZoneRegistry 
     }
 
     public ZoneRegistryMock setRoutingMethod(ZoneApi zone, List<RoutingMethod> routingMethods) {
+        if (routingMethods.stream().distinct().count() != routingMethods.size()) {
+            throw new IllegalArgumentException("Routing methods must be distinct");
+        }
         this.zoneRoutingMethods.put(zone, List.copyOf(routingMethods));
         return this;
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -1643,7 +1643,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
     private void assertGlobalRouting(DeploymentId deployment, GlobalRouting.Status status, GlobalRouting.Agent agent) {
         var changedAt = tester.controller().clock().instant();
-        var westPolicies = tester.controller().routingController().policies().get(deployment);
+        var westPolicies = tester.controller().routing().policies().get(deployment);
         assertEquals(1, westPolicies.size());
         var westPolicy = westPolicies.values().iterator().next();
         assertEquals(status, westPolicy.status().globalRouting().status());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelperTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelperTest.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 import java.util.Optional;
 
 import static com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException.ErrorCode.INVALID_APPLICATION_PACKAGE;
@@ -153,7 +152,6 @@ public class JobControllerApiHandlerHelperTest {
 
         tester.configServer().setLogStream("Nope, this won't be logged");
         tester.configServer().convergeServices(app.instanceId(), zone);
-        tester.setEndpoints(app.instanceId(), zone);
         tester.runner().run();
 
         assertResponse(JobControllerApiHandlerHelper.jobTypeResponse(tester.controller(), app.instanceId(), URI.create("https://some.url:43/root")), "dev-overview.json");

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
@@ -15,20 +15,13 @@
     {
       "cluster": "default",
       "tls": true,
-      "url": "https://c0.instance1.application1.tenant1.global.vespa.oath.cloud/",
-      "scope": "global",
-      "routingMethod": "exclusive"
-    },
-    {
-      "cluster": "default",
-      "tls": true,
-      "url": "https://instance1--application1--tenant1.us-west-1.prod.vespa:43",
+      "url": "https://instance1--application1--tenant1.us-west-1.vespa.oath.cloud:4443/",
       "scope": "zone",
       "routingMethod": "shared"
     }
   ],
   "serviceUrls": [
-    "https://instance1--application1--tenant1.us-west-1.prod.vespa:43"
+    "https://instance1--application1--tenant1.us-west-1.vespa.oath.cloud:4443/"
   ],
   "nodes": "http://localhost:8080/zone/v2/prod/us-west-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-west-1&application=tenant1.application1.instance1",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -8,12 +8,12 @@
     {
       "cluster": "default",
       "tls": true,
-      "url": "https://instance1--application1--tenant1.us-central-1.prod.vespa:43",
+      "url": "https://instance1--application1--tenant1.us-central-1.vespa.oath.cloud:4443/",
       "scope": "zone",
       "routingMethod": "shared"
     },
     {
-      "cluster": "foo",
+      "cluster": "",
       "tls": true,
       "url": "https://instance1--application1--tenant1.global.vespa.oath.cloud:4443/",
       "scope": "global",
@@ -21,7 +21,7 @@
     }
   ],
   "serviceUrls": [
-    "https://instance1--application1--tenant1.us-central-1.prod.vespa:43"
+    "https://instance1--application1--tenant1.us-central-1.vespa.oath.cloud:4443/"
   ],
   "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-central-1&application=tenant1.application1.instance1",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1-log-second-part.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1-log-second-part.json
@@ -6,7 +6,7 @@
       {
         "at": 0,
         "type": "info",
-        "message": " |-- https://default--application--tenant.us-east-1.dev.vespa:43 (cluster 'default')"
+        "message": " |-- https://application--tenant.us-east-1.dev.vespa.oath.cloud:4443/ (cluster 'default')"
       },
       {
         "at": 0,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1.json
@@ -8,13 +8,13 @@
     {
       "cluster": "default",
       "tls": true,
-      "url": "https://instance1--application1--tenant1.us-east-1.dev.vespa:43",
+      "url": "https://instance1--application1--tenant1.us-east-1.dev.vespa.oath.cloud:4443/",
       "scope": "zone",
       "routingMethod": "shared"
     }
   ],
   "serviceUrls": [
-    "https://instance1--application1--tenant1.us-east-1.dev.vespa:43"
+    "https://instance1--application1--tenant1.us-east-1.dev.vespa.oath.cloud:4443/"
   ],
   "nodes": "http://localhost:8080/zone/v2/dev/us-east-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=dev&region=us-east-1&application=tenant1.application1.instance1",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-get.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/global-rotation-get.json
@@ -1,1 +1,11 @@
-{"globalrotationoverride":["cluster1.application1.tenant1.us-west-1.prod",{"status":"in","reason":"","agent":"","timestamp":1497618757}]}
+{
+  "globalrotationoverride": [
+    "instance1.tenant1.application1.us-west-1.prod",
+    {
+      "status": "in",
+      "reason": "",
+      "agent": "",
+      "timestamp": 1497618757
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance-with-routing-policy.json
@@ -180,9 +180,7 @@
   ],
   "changeBlockers": [],
   "compileVersion": "(ignore)",
-  "globalRotations": [
-    "https://c0.instance1.application1.tenant1.global.vespa.oath.cloud/"
-  ],
+  "globalRotations": [],
   "instances": [
     {
       "environment": "prod",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -11,12 +11,12 @@
     {
       "cluster": "default",
       "tls": true,
-      "url": "https://instance1--application1--tenant1.us-central-1.prod.vespa:43",
+      "url": "https://instance1--application1--tenant1.us-central-1.vespa.oath.cloud:4443/",
       "scope": "zone",
       "routingMethod": "shared"
     },
     {
-      "cluster": "foo",
+      "cluster": "",
       "tls": true,
       "url": "https://instance1--application1--tenant1.global.vespa.oath.cloud:4443/",
       "scope": "global",
@@ -24,7 +24,7 @@
     }
   ],
   "serviceUrls": [
-    "https://instance1--application1--tenant1.us-central-1.prod.vespa:43"
+    "https://instance1--application1--tenant1.us-central-1.vespa.oath.cloud:4443/"
   ],
   "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-central-1&application=tenant1.application1.instance1",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-details.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-details.json
@@ -212,7 +212,7 @@
       {
         "at": "(ignore)",
         "type": "info",
-        "message": " |-- https://instance1--application1--tenant1.us-east-1.test.vespa:43 (cluster 'default')"
+        "message": " |-- https://instance1--application1--tenant1.us-east-1.test.vespa.oath.cloud:4443/ (cluster 'default')"
       },
       {
         "at": "(ignore)",
@@ -239,7 +239,7 @@
       {
         "at": "(ignore)",
         "type": "info",
-        "message": " |-- https://instance1--application1--tenant1.us-east-1.test.vespa:43 (cluster 'default')"
+        "message": " |-- https://instance1--application1--tenant1.us-east-1.test.vespa.oath.cloud:4443/ (cluster 'default')"
       },
       {
         "at": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/test-config-dev.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/test-config-dev.json
@@ -5,18 +5,18 @@
   "isCI": false,
   "endpoints": {
     "dev.us-east-1": [
-      "https://us-east-1.dev.my-user"
+      "https://my-user--application1--tenant1.us-east-1.dev.vespa.oath.cloud:4443/"
     ],
     "prod.us-central-1": [
-      "https://us-central-1.prod.default"
+      "https://application1--tenant1.us-central-1.vespa.oath.cloud:4443/"
     ]
   },
   "zoneEndpoints": {
     "dev.us-east-1": {
-      "default": "https://us-east-1.dev.my-user"
+      "default": "https://my-user--application1--tenant1.us-east-1.dev.vespa.oath.cloud:4443/"
     },
     "prod.us-central-1": {
-      "default": "https://us-central-1.prod.default"
+      "default": "https://application1--tenant1.us-central-1.vespa.oath.cloud:4443/"
     }
   },
   "clusters": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/test-config.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/test-config.json
@@ -5,12 +5,12 @@
   "isCI": false,
   "endpoints": {
     "prod.us-central-1": [
-      "https://us-central-1.prod.default"
+      "https://application1--tenant1.us-central-1.vespa.oath.cloud:4443/"
     ]
   },
   "zoneEndpoints": {
     "prod.us-central-1": {
-      "default": "https://us-central-1.prod.default"
+      "default": "https://application1--tenant1.us-central-1.vespa.oath.cloud:4443/"
     }
   },
   "clusters": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/RoutingApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/routing/RoutingApiTest.java
@@ -131,8 +131,6 @@ public class RoutingApiTest extends ControllerContainerTest {
                 .endpoint("default", "default", eastZone.region().value(), westZone.region().value())
                 .build();
         context.submit(applicationPackage).deploy();
-        context.addRoutingPolicy(westZone, true);
-        context.addRoutingPolicy(eastZone, true);
 
         // GET initial deployment status
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",
@@ -254,9 +252,6 @@ public class RoutingApiTest extends ControllerContainerTest {
                 .endpoint("default", "default", eastZone.region().value(), westZone.region().value())
                 .build();
         context.submit(applicationPackage).deploy();
-
-        // Assign policy in one zone
-        context.addRoutingPolicy(westZone, true);
 
         // GET status with both policy and rotation assigned
         tester.assertResponse(operatorRequest("http://localhost:8080/routing/v1/status/tenant/tenant/application/application/instance/default/environment/prod/region/us-west-1",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepositoryTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepositoryTest.java
@@ -55,7 +55,7 @@ public class RotationRepositoryTest {
     @Before
     public void before() {
         tester = new DeploymentTester(new ControllerTester(rotationsConfig));
-        repository = tester.controller().routingController().rotations();
+        repository = tester.controller().routing().rotations();
         application = tester.newDeploymentContext("tenant1", "app1", "default");
     }
 
@@ -83,7 +83,7 @@ public class RotationRepositoryTest {
     @Test
     public void strips_whitespace_in_rotation_fqdn() {
         tester = new DeploymentTester(new ControllerTester(rotationsConfigWhitespaces));
-        RotationRepository repository = tester.controller().routingController().rotations();
+        RotationRepository repository = tester.controller().routing().rotations();
         var application2 = tester.newDeploymentContext("tenant1", "app2", "default");
 
         application2.submit(applicationPackage);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepositoryTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/rotation/RotationRepositoryTest.java
@@ -2,12 +2,16 @@
 package com.yahoo.vespa.hosted.controller.rotation;
 
 import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.AssignedRotation;
+import com.yahoo.vespa.hosted.controller.application.EndpointId;
+import com.yahoo.vespa.hosted.controller.application.EndpointList;
 import com.yahoo.vespa.hosted.controller.deployment.ApplicationPackageBuilder;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentContext;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTester;
+import com.yahoo.vespa.hosted.controller.routing.RoutingId;
 import com.yahoo.vespa.hosted.rotation.config.RotationsConfig;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +71,8 @@ public class RotationRepositoryTest {
 
         assertEquals(List.of(expected.id()), rotationIds(application.instance().rotations()));
         assertEquals(URI.create("https://app1--tenant1.global.vespa.oath.cloud:4443/"),
-                     application.instance().endpointsIn(SystemName.main).main().get().url());
+                     EndpointList.global(RoutingId.of(application.instanceId(), EndpointId.defaultId()), SystemName.main, RoutingMethod.shared)
+                                 .primary().get().url());
         try (RotationLock lock = repository.lock()) {
             List<AssignedRotation> rotations = repository.getOrAssignRotations(application.application().deploymentSpec(),
                                                                                application.instance(),
@@ -143,7 +148,8 @@ public class RotationRepositoryTest {
         application2.submit(applicationPackage);
         assertEquals(List.of(new RotationId("foo-1")), rotationIds(application2.instance().rotations()));
         assertEquals("https://cd--app2--tenant2.global.vespa.oath.cloud:4443/",
-                     application2.instance().endpointsIn(SystemName.cd).main().get().url().toString());
+                     EndpointList.global(RoutingId.of(application2.instanceId(), EndpointId.defaultId()), SystemName.cd, RoutingMethod.shared)
+                                 .primary().get().url().toString());
     }
 
     @Test
@@ -159,9 +165,11 @@ public class RotationRepositoryTest {
         assertEquals(List.of(new RotationId("foo-1")), rotationIds(instance1.instance().rotations()));
         assertEquals(List.of(new RotationId("foo-2")), rotationIds(instance2.instance().rotations()));
         assertEquals(URI.create("https://instance1--application1--tenant1.global.vespa.oath.cloud:4443/"),
-                     instance1.instance().endpointsIn(SystemName.main).main().get().url());
+                     EndpointList.global(RoutingId.of(instance1.instanceId(), EndpointId.defaultId()), SystemName.main, RoutingMethod.shared)
+                                 .primary().get().url());
         assertEquals(URI.create("https://instance2--application1--tenant1.global.vespa.oath.cloud:4443/"),
-                     instance2.instance().endpointsIn(SystemName.main).main().get().url());
+                     EndpointList.global(RoutingId.of(instance2.instanceId(), EndpointId.defaultId()), SystemName.main, RoutingMethod.shared)
+                                 .primary().get().url());
     }
 
     @Test
@@ -179,9 +187,11 @@ public class RotationRepositoryTest {
         assertEquals(List.of(new RotationId("foo-2")), rotationIds(instance2.instance().rotations()));
 
         assertEquals(URI.create("https://instance1--application1--tenant1.global.vespa.oath.cloud:4443/"),
-                     instance1.instance().endpointsIn(SystemName.main).main().get().url());
+                     EndpointList.global(RoutingId.of(instance1.instanceId(), EndpointId.defaultId()), SystemName.main, RoutingMethod.shared)
+                                 .primary().get().url());
         assertEquals(URI.create("https://instance2--application1--tenant1.global.vespa.oath.cloud:4443/"),
-                     instance2.instance().endpointsIn(SystemName.main).main().get().url());
+                     EndpointList.global(RoutingId.of(instance2.instanceId(), EndpointId.defaultId()), SystemName.main, RoutingMethod.shared)
+                                 .primary().get().url());
     }
 
     private void assertSingleRotation(Rotation expected, List<AssignedRotation> assignedRotations, RotationRepository repository) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
@@ -260,7 +260,7 @@ public class RoutingPoliciesTest {
                             URI.create("https://c1.app1.tenant1.us-west-1.vespa.oath.cloud/"),
                             ClusterSpec.Id.from("c2"),
                             URI.create("https://c2.app1.tenant1.us-west-1.vespa.oath.cloud/")),
-                     tester.controllerTester().controller().routingController().zoneEndpointsOf(context.deploymentIdIn(zone1)));
+                     tester.controllerTester().controller().routing().zoneEndpointsOf(context.deploymentIdIn(zone1)));
     }
 
     @Test
@@ -618,7 +618,7 @@ public class RoutingPoliciesTest {
         }
 
         public RoutingPolicies routingPolicies() {
-            return tester.controllerTester().controller().routingController().policies();
+            return tester.controllerTester().controller().routing().policies();
         }
 
         public DeploymentContext newDeploymentContext(String tenant, String application, String instance) {

--- a/vespajlib/src/main/java/com/yahoo/collections/AbstractFilteringList.java
+++ b/vespajlib/src/main/java/com/yahoo/collections/AbstractFilteringList.java
@@ -4,15 +4,14 @@ package com.yahoo.collections;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.reducing;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
@@ -20,7 +19,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
  *
  * @author jonmv
  */
-public abstract class AbstractFilteringList<Type, ListType extends AbstractFilteringList<Type, ListType>> {
+public abstract class AbstractFilteringList<Type, ListType extends AbstractFilteringList<Type, ListType>> implements Iterable<Type> {
 
     private final List<Type> items;
     private final boolean negate;
@@ -83,5 +82,10 @@ public abstract class AbstractFilteringList<Type, ListType extends AbstractFilte
     public final boolean isEmpty() { return items.isEmpty(); }
 
     public final int size() { return items.size(); }
+
+    @Override
+    public Iterator<Type> iterator() {
+        return items.iterator();
+    }
 
 }


### PR DESCRIPTION
* Routing policies are now always fetched and stored on deploy. All zones
  already provide useful data in `/loadbalancers/v1/` independent of routing
  method used.
* All consumers now retrieve endpoints through `RoutingController`.
* There's a fallback that retrieves endpoints from `RoutingGenerator` which must
  exist until all applications have deployed at least once.
* Tests no longer use `RoutingGenerator` (except in the test for the previous bullet point)

FYI @tokle