### PR TITLE
Revert "Only use json access log for config server"

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -6,6 +6,7 @@
       <initialStatus>initializing</initialStatus>
     </config>
 
+    <accesslog type="vespa" fileNamePattern="logs/vespa/configserver/access.log.%Y%m%d%H%M%S" compressOnRotation="true" symlinkName="access.log" />
     <accesslog type="json"  fileNamePattern="logs/vespa/configserver/access-json.log.%Y%m%d%H%M%S" symlinkName="access-json.log" compressOnRotation="true" />
 
     <component id="com.yahoo.vespa.config.server.ConfigServerBootstrap" bundle="configserver" />


### PR DESCRIPTION
Reverts vespa-engine/vespa#12350

Seems to have broken:
https://factory-web.vespa.corp.yahoo.com/versions/1/builds/53870/products/1/tests/275607/testruns/38797158
