### PR TITLE
Export distributor GC documents_removed metric

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -608,6 +608,8 @@ public class VespaMetricSet {
         metrics.add(new Metric("vds.idealstate.garbage_collection.done_ok.rate"));
         metrics.add(new Metric("vds.idealstate.garbage_collection.done_failed.rate"));
         metrics.add(new Metric("vds.idealstate.garbage_collection.pending.average"));
+        metrics.add(new Metric("vds.idealstate.garbage_collection.documents_removed.count"));
+        metrics.add(new Metric("vds.idealstate.garbage_collection.documents_removed.rate"));
 
         metrics.add(new Metric("vds.distributor.puts.sum.latency.max"));
         metrics.add(new Metric("vds.distributor.puts.sum.latency.sum"));


### PR DESCRIPTION
@geirst please review

Exports both absolute document count within snapshot and rate of
change, as they can both be useful pieces of information when looking
at how many documents have been garbage collected.

This relates to issue #12139
