### PR TITLE
Ensure we retrieve the actual vector (used by nearest neighbor index)...

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -226,7 +226,6 @@ struct Fixture
         while (_attr->getNumDocs() <= docId) {
             uint32_t newDocId = 0u;
             _attr->addDoc(newDocId);
-            _attr->commit();
         }
     }
 
@@ -326,7 +325,6 @@ Fixture::testSetTensorValue()
 {
     ensureSpace(4);
     EXPECT_EQUAL(5u, _attr->getNumDocs());
-    EXPECT_EQUAL(5u, _attr->getCommittedDocIdLimit());
     TEST_DO(assertGetNoTensor(4));
     EXPECT_EXCEPTION(set_tensor(4, TensorSpec("double")),
                      WrongTensorTypeException,

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -207,7 +207,9 @@ vespalib::tensor::TypedCells
 DenseTensorAttribute::get_vector(uint32_t docid) const
 {
     MutableDenseTensorView tensor_view(_denseTensorStore.type());
-    getTensor(docid, tensor_view);
+    assert(docid < _refVector.size());
+    EntryRef ref = _refVector[docid];
+    _denseTensorStore.getTensor(ref, tensor_view);
     return tensor_view.cellsRef();
 }
 


### PR DESCRIPTION
… for a document being added instead of the origo vector.

Before the fix, getTensor() would return the default origo tensor as docid would not be less than getCommittedDocIdLimit().
This happened as the docid limit is updated at the end of handling a document being added, which is too late.
The fix is to ignore the docid limit in is this particular case.

Also update the unit test for tensor attributes to do commit() (which updates the docid limit) later.
Before the fix, this triggered the bug in the test "setTensor() updates nearest neighbor index".

@arnej27959 please review
@toregge @jobergum FYI