### PR TITLE
Use Google RE2 as underlying regex engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,11 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 include(functions.cmake)
-list(APPEND CMAKE_MODULE_PATH "$ENV{HOME}/share/cmake/Modules" "/opt/vespa-deps/share/cmake/Modules")
+list(APPEND CMAKE_MODULE_PATH
+     "$ENV{HOME}/share/cmake/Modules"
+     "/opt/vespa-deps/share/cmake/Modules"
+     "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+)
 include(default_build_settings.cmake)
 vespa_detect_build_platform()
 message("-- Vespa build platform is ${VESPA_OS_DISTRO} ${VESPA_OS_DISTRO_VERSION}")

--- a/cmake/FindRE2.cmake
+++ b/cmake/FindRE2.cmake
@@ -1,0 +1,19 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+# There is no bundled FindRE2, so we supply our own minimal version to find
+# the system RE2 library and header files.
+
+find_path(RE2_INCLUDE_DIR
+    NAMES re2/re2.h
+)
+
+find_library(RE2_LIBRARIES
+    NAMES re2
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(RE2
+    FOUND_VAR RE2_FOUND
+    REQUIRED_VARS RE2_LIBRARIES RE2_INCLUDE_DIR
+)
+

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -519,12 +519,12 @@ public:
 
     void visit(StringTerm & n) override { visitTerm(n, true); }
     void visit(SubstringTerm & n) override {
-        query::SimpleRegExpTerm re(vespalib::Regexp::make_from_substring(n.getTerm()),
+        query::SimpleRegExpTerm re(vespalib::RegexpUtil::make_from_substring(n.getTerm()),
                                    n.getView(), n.getId(), n.getWeight());
         visitTerm(re);
     }
     void visit(SuffixTerm & n) override {
-        query::SimpleRegExpTerm re(vespalib::Regexp::make_from_suffix(n.getTerm()),
+        query::SimpleRegExpTerm re(vespalib::RegexpUtil::make_from_suffix(n.getTerm()),
                                    n.getView(), n.getId(), n.getWeight());
         visitTerm(re);
     }

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
@@ -123,7 +123,7 @@ StringTemplSearchContext(QueryTermSimpleUP qTerm, const AttrType & toBeSearched)
             auto comp = enumStore.make_folded_comparator(queryTerm()->getTerm(), true);
             lookupRange(comp, comp);
         } else if (this->isRegex()) {
-            vespalib::string prefix(vespalib::Regexp::get_prefix(this->queryTerm()->getTerm()));
+            vespalib::string prefix(vespalib::RegexpUtil::get_prefix(this->queryTerm()->getTerm()));
             auto comp = enumStore.make_folded_comparator(prefix.c_str(), true);
             lookupRange(comp, comp);
         } else {

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -183,14 +183,14 @@ private:
     using PostingList = typename AggregationTraits::PostingList;
     using Parent = PostingSearchContext<BaseSC, PostingListFoldedSearchContextT<DataT>, AttrT>;
     using FoldedComparatorType = typename Parent::EnumStore::FoldedComparatorType;
-    using Regexp = vespalib::Regexp;
+    using RegexpUtil = vespalib::RegexpUtil;
     using QueryTermSimpleUP = typename Parent::QueryTermSimpleUP;
     using Parent::_toBeSearched;
     using Parent::_enumStore;
     using Parent::isRegex;
     using Parent::getRegex;
     bool useThis(const PostingListSearchContext::DictionaryConstIterator & it) const override {
-        return isRegex() ? (getRegex() ? std::regex_search(_enumStore.get_value(it.getKey()), *getRegex()) : false ) : true;
+        return isRegex() ? (getRegex() ? getRegex()->partial_match(_enumStore.get_value(it.getKey())) : false ) : true;
     }
 public:
     StringPostingSearchContext(QueryTermSimpleUP qTerm, bool useBitVector, const AttrT &toBeSearched);
@@ -288,7 +288,7 @@ StringPostingSearchContext(QueryTermSimpleUP qTerm, bool useBitVector, const Att
             auto comp = _enumStore.make_folded_comparator(this->queryTerm()->getTerm(), true);
             this->lookupRange(comp, comp);
         } else if (this->isRegex()) {
-            vespalib::string prefix(Regexp::get_prefix(this->queryTerm()->getTerm()));
+            vespalib::string prefix(RegexpUtil::get_prefix(this->queryTerm()->getTerm()));
             auto comp = _enumStore.make_folded_comparator(prefix.c_str(), true);
             this->lookupRange(comp, comp);
         } else {

--- a/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
@@ -59,7 +59,7 @@ SingleValueStringAttributeT<B>::StringTemplSearchContext::StringTemplSearchConte
             auto comp = enumStore.make_folded_comparator(queryTerm()->getTerm(), true);
             lookupRange(comp, comp);
         } else if (this->isRegex()) {
-            vespalib::string prefix(vespalib::Regexp::get_prefix(this->queryTerm()->getTerm()));
+            vespalib::string prefix(vespalib::RegexpUtil::get_prefix(this->queryTerm()->getTerm()));
             auto comp = enumStore.make_folded_comparator(prefix.c_str(), true);
             lookupRange(comp, comp);
         } else {

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
@@ -231,10 +231,7 @@ StringAttribute::StringSearchContext::StringSearchContext(QueryTermSimple::UP qT
     _regex()
 {
     if (isRegex()) {
-        try {
-            _regex = std::regex(_queryTerm->getTerm(), std::regex::icase);
-        } catch (std::regex_error &) {
-        }
+        _regex = vespalib::Regex::from_pattern(_queryTerm->getTerm(), vespalib::Regex::Options::IgnoreCase);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -9,10 +9,10 @@
 #include <vespa/searchlib/attribute/i_enum_store.h>
 #include <vespa/searchlib/attribute/loadedenumvalue.h>
 #include <vespa/searchlib/util/foldedstringcompare.h>
+#include <vespa/vespalib/regex/regex.h>
 #include <vespa/vespalib/text/lowercase.h>
 #include <vespa/vespalib/text/utf8.h>
 #include <optional>
-#include <regex>
 
 namespace search {
 
@@ -103,7 +103,7 @@ protected:
         const QueryTermUCS4 * queryTerm() const override;
         bool isMatch(const char *src) const {
             if (__builtin_expect(isRegex(), false)) {
-                return _regex ? std::regex_search(src, *_regex) : false;
+                return _regex ? _regex->partial_match(std::string_view(src)) : false;
             }
             vespalib::Utf8ReaderForZTS u8reader(src);
             uint32_t j = 0;
@@ -162,7 +162,7 @@ protected:
         bool  isRegex() const { return _isRegex; }
         QueryTermSimpleUP         _queryTerm;
         std::vector<ucs4_t>       _termUCS4;
-        const std::optional<std::regex>& getRegex() const { return _regex; }
+        const std::optional<vespalib::Regex>& getRegex() const { return _regex; }
     private:
         WeightedConstChar * getBuffer() const {
             if (_buffer == nullptr) {
@@ -170,9 +170,9 @@ protected:
             }
             return _buffer;
         }
-        unsigned                    _bufferLen;
-        mutable WeightedConstChar * _buffer;
-        std::optional<std::regex>   _regex;
+        unsigned                       _bufferLen;
+        mutable WeightedConstChar *    _buffer;
+        std::optional<vespalib::Regex> _regex;
     };
 private:
     SearchContext::UP getSearch(QueryTermSimpleUP term, const attribute::SearchContextParams & params) const override;

--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -305,3 +305,52 @@
    fun:__add_to_environ
    fun:setenv
 }
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Cond
+   fun:contains
+   ...
+   fun:_ZN3re28Compiler7CompileEPNS_6RegexpEbl
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Cond
+   fun:has_index
+   ...
+   fun:_ZN3re28Compiler7CompileEPNS_6RegexpEbl
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Value8
+   fun:has_index
+   ...
+   fun:_ZN3re28Compiler7CompileEPNS_6RegexpEbl
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Cond
+   fun:contains
+   ...
+   fun:_ZN3re23RE2C1ERKNS_11StringPieceERKNS0_7OptionsE
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Value8
+   fun:contains
+   ...
+   fun:_ZN3re23RE2C1ERKNS_11StringPieceERKNS0_7OptionsE
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Value8
+   fun:contains
+   ...
+   fun:_ZNK3re23RE25MatchERKNS_11StringPieceEmmNS0_6AnchorEPS1_i
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Cond
+   fun:contains
+   ...
+   fun:_ZNK3re23RE25MatchERKNS_11StringPieceEmmNS0_6AnchorEPS1_i
+}

--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -153,6 +153,7 @@ vespa_define_module(
     src/vespa/vespalib/net/tls/impl
     src/vespa/vespalib/objects
     src/vespa/vespalib/portal
+    src/vespa/vespalib/regex
     src/vespa/vespalib/stllike
     src/vespa/vespalib/test
     src/vespa/vespalib/testkit

--- a/vespalib/src/tests/net/tls/policy_checking_certificate_verifier/policy_checking_certificate_verifier_test.cpp
+++ b/vespalib/src/tests/net/tls/policy_checking_certificate_verifier/policy_checking_certificate_verifier_test.cpp
@@ -1,11 +1,8 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/net/tls/transport_security_options.h>
-#include <vespa/vespalib/net/tls/transport_security_options_reading.h>
 #include <vespa/vespalib/net/tls/policy_checking_certificate_verifier.h>
 #include <vespa/vespalib/test/peer_policy_utils.h>
 #include <vespa/vespalib/testkit/test_kit.h>
-#include <vespa/vespalib/util/exceptions.h>
 
 using namespace vespalib;
 using namespace vespalib::net::tls;

--- a/vespalib/src/tests/regex/regex.cpp
+++ b/vespalib/src/tests/regex/regex.cpp
@@ -1,70 +1,147 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
-
+#include <vespa/vespalib/regex/regex.h>
 #include <vespa/vespalib/util/regexp.h>
-#include <vespa/vespalib/util/exception.h>
-#include <regex>
+#include <string>
 
 using namespace vespalib;
 
 TEST("require that prefix detection works") {
-    EXPECT_EQUAL("", Regexp::get_prefix(""));
-    EXPECT_EQUAL("", Regexp::get_prefix("foo"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo"));
-    EXPECT_EQUAL("", Regexp::get_prefix("^foo|bar"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo$"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo[a-z]"));
-    EXPECT_EQUAL("fo", Regexp::get_prefix("^foo{0,1}"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo."));
-    EXPECT_EQUAL("fo", Regexp::get_prefix("^foo*"));
-    EXPECT_EQUAL("fo", Regexp::get_prefix("^foo?"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo+"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix(""));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("foo"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("^foo|bar"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo$"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo[a-z]"));
+    EXPECT_EQUAL("fo", RegexpUtil::get_prefix("^foo{0,1}"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo."));
+    EXPECT_EQUAL("fo", RegexpUtil::get_prefix("^foo*"));
+    EXPECT_EQUAL("fo", RegexpUtil::get_prefix("^foo?"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo+"));
 }
 
 TEST("require that prefix detection sometimes underestimates the prefix size") {
-    EXPECT_EQUAL("", Regexp::get_prefix("^^foo"));
-    EXPECT_EQUAL("", Regexp::get_prefix("^foo(bar|baz)"));
-    EXPECT_EQUAL("fo", Regexp::get_prefix("^foo{1,2}"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo\\."));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo(bar)"));
-    EXPECT_EQUAL("", Regexp::get_prefix("(^foo)"));
-    EXPECT_EQUAL("", Regexp::get_prefix("^(foo)"));
-    EXPECT_EQUAL("foo", Regexp::get_prefix("^foo[a]"));
-    EXPECT_EQUAL("", Regexp::get_prefix("^foo|^foobar"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("^^foo"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("^foo(bar|baz)"));
+    EXPECT_EQUAL("fo", RegexpUtil::get_prefix("^foo{1,2}"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo\\."));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo(bar)"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("(^foo)"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("^(foo)"));
+    EXPECT_EQUAL("foo", RegexpUtil::get_prefix("^foo[a]"));
+    EXPECT_EQUAL("", RegexpUtil::get_prefix("^foo|^foobar"));
 }
 
-const vespalib::string special("^|()[]{}.*?+\\$");
+const std::string special("^|()[]{}.*?+\\$");
 
 struct ExprFixture {
-    std::vector<vespalib::string> expressions;
+    std::vector<std::string> expressions;
     ExprFixture() {
         expressions.push_back(special);
         for (char c: special) {
-            expressions.push_back(vespalib::string(&c, 1));
+            expressions.emplace_back(std::string(&c, 1));
         }
-        expressions.push_back("abc");
-        expressions.push_back("[:digit:]");
+        expressions.emplace_back("abc");
+        expressions.emplace_back("[:digit:]");
     }
 };
 
 TEST_F("require that regexp can be made from suffix string", ExprFixture()) {
-    for (vespalib::string str: f1.expressions) {
-        std::regex re(std::string(Regexp::make_from_suffix(str)));
-        EXPECT_TRUE(std::regex_search(std::string(str), re));
-        EXPECT_FALSE(std::regex_search(std::string(str + "foo"), re));
-        EXPECT_TRUE(std::regex_search(std::string("foo" + str), re));
-        EXPECT_FALSE(std::regex_search(std::string("foo" + str + "bar"), re));
+    for (const auto& str: f1.expressions) {
+        auto re = Regex::from_pattern(std::string(RegexpUtil::make_from_suffix(str)));
+        ASSERT_TRUE(re.parsed_ok());
+
+        EXPECT_TRUE(re.partial_match(str));
+        EXPECT_FALSE(re.partial_match(str + "foo"));
+        EXPECT_TRUE(re.partial_match("foo" + str));
+        EXPECT_FALSE(re.partial_match("foo" + str + "bar"));
     }
 }
 
 TEST_F("require that regexp can be made from substring string", ExprFixture()) {
-    for (vespalib::string str: f1.expressions) {
-        std::regex re(std::string(Regexp::make_from_substring(str)));
-        EXPECT_TRUE(std::regex_search(std::string(str), re));
-        EXPECT_TRUE(std::regex_search(std::string(str + "foo"), re));
-        EXPECT_TRUE(std::regex_search(std::string("foo" + str), re));
-        EXPECT_TRUE(std::regex_search(std::string("foo" + str + "bar"), re));
+    for (const auto& str: f1.expressions) {
+        auto re = Regex::from_pattern(std::string(RegexpUtil::make_from_substring(str)));
+        ASSERT_TRUE(re.parsed_ok());
+
+        EXPECT_TRUE(re.partial_match(str));
+        EXPECT_TRUE(re.partial_match(str + "foo"));
+        EXPECT_TRUE(re.partial_match("foo" + str));
+        EXPECT_TRUE(re.partial_match("foo" + str + "bar"));
     }
+}
+
+TEST("full_match requires expression to match entire input string") {
+    std::string pattern = "[Aa][Bb][Cc]";
+    auto re = Regex::from_pattern(pattern);
+    ASSERT_TRUE(re.parsed_ok());
+
+    EXPECT_TRUE(re.full_match("abc"));
+    EXPECT_TRUE(re.full_match("ABC"));
+    EXPECT_FALSE(re.full_match("abcd"));
+    EXPECT_FALSE(re.full_match("aabc"));
+    EXPECT_FALSE(re.full_match("aabcc"));
+
+    EXPECT_TRUE(Regex::full_match("abc", pattern));
+    EXPECT_TRUE(Regex::full_match("ABC", pattern));
+    EXPECT_FALSE(Regex::full_match("abcd", pattern));
+    EXPECT_FALSE(Regex::full_match("aabc", pattern));
+    EXPECT_FALSE(Regex::full_match("aabcc", pattern));
+}
+
+TEST("partial_match requires expression to match substring of input string") {
+    std::string pattern = "[Aa][Bb][Cc]";
+    auto re = Regex::from_pattern(pattern);
+    ASSERT_TRUE(re.parsed_ok());
+
+    EXPECT_TRUE(re.partial_match("abc"));
+    EXPECT_TRUE(re.partial_match("ABC"));
+    EXPECT_TRUE(re.partial_match("abcd"));
+    EXPECT_TRUE(re.partial_match("aabc"));
+    EXPECT_TRUE(re.partial_match("aabcc"));
+    EXPECT_FALSE(re.partial_match("abd"));
+
+    EXPECT_TRUE(Regex::partial_match("abc", pattern));
+    EXPECT_TRUE(Regex::partial_match("ABC", pattern));
+    EXPECT_TRUE(Regex::partial_match("abcd", pattern));
+    EXPECT_TRUE(Regex::partial_match("aabc", pattern));
+    EXPECT_TRUE(Regex::partial_match("aabcc", pattern));
+    EXPECT_FALSE(Regex::partial_match("abd", pattern));
+}
+
+TEST("partial_match can be explicitly anchored") {
+    EXPECT_TRUE(Regex::partial_match("abcc", "^abc"));
+    EXPECT_FALSE(Regex::partial_match("aabc", "^abc"));
+    EXPECT_TRUE(Regex::partial_match("aabc", "abc$"));
+    EXPECT_FALSE(Regex::partial_match("abcc", "abc$"));
+    EXPECT_TRUE(Regex::partial_match("abc", "^abc$"));
+    EXPECT_FALSE(Regex::partial_match("aabc", "^abc$"));
+    EXPECT_FALSE(Regex::partial_match("abcc", "^abc$"));
+}
+
+TEST("Regex instance returns parsed_ok() == false upon parse failure") {
+    auto re = Regex::from_pattern("[a-z"); // Unterminated set
+    EXPECT_FALSE(re.parsed_ok());
+}
+
+TEST("Regex that has failed parsing immediately returns false for matches") {
+    auto re = Regex::from_pattern("[a-z");
+    EXPECT_FALSE(re.parsed_ok());
+    EXPECT_FALSE(re.partial_match("a"));
+    EXPECT_FALSE(re.full_match("b"));
+}
+
+TEST("can create case-insensitive regex matcher") {
+    auto re = Regex::from_pattern("hello", Regex::Options::IgnoreCase);
+    ASSERT_TRUE(re.parsed_ok());
+    EXPECT_TRUE(re.partial_match("HelLo world"));
+    EXPECT_TRUE(re.full_match("HELLO"));
+}
+
+TEST("regex is case sensitive by default") {
+    auto re = Regex::from_pattern("hello");
+    ASSERT_TRUE(re.parsed_ok());
+    EXPECT_FALSE(re.partial_match("HelLo world"));
+    EXPECT_FALSE(re.full_match("HELLO"));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/vespa/vespalib/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/CMakeLists.txt
@@ -16,6 +16,7 @@ vespa_add_library(vespalib
     $<TARGET_OBJECTS:vespalib_vespalib_net_tls_impl>
     $<TARGET_OBJECTS:vespalib_vespalib_objects>
     $<TARGET_OBJECTS:vespalib_vespalib_portal>
+    $<TARGET_OBJECTS:vespalib_vespalib_regex>
     $<TARGET_OBJECTS:vespalib_vespalib_stllike>
     $<TARGET_OBJECTS:vespalib_vespalib_test>
     $<TARGET_OBJECTS:vespalib_vespalib_testkit>
@@ -30,3 +31,5 @@ vespa_add_library(vespalib
 )
 
 vespa_add_target_package_dependency(vespalib OpenSSL)
+vespa_add_target_package_dependency(vespalib RE2)
+

--- a/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
@@ -10,7 +10,7 @@ namespace vespalib::net::tls {
 
 struct HostGlobPattern {
     virtual ~HostGlobPattern() = default;
-    virtual bool matches(vespalib::stringref str) const = 0;
+    [[nodiscard]] virtual bool matches(vespalib::stringref str) const = 0;
 
     static std::shared_ptr<const HostGlobPattern> create_from_glob(vespalib::stringref pattern);
 };
@@ -36,7 +36,7 @@ public:
                 && (_original_pattern == rhs._original_pattern));
     }
 
-    bool matches(vespalib::stringref str) const {
+    [[nodiscard]] bool matches(vespalib::stringref str) const {
         return (_match_pattern && _match_pattern->matches(str));
     }
 
@@ -89,7 +89,7 @@ public:
     bool operator==(const AuthorizedPeers& rhs) const {
         return (_peer_policies == rhs._peer_policies);
     }
-    bool allows_all_authenticated() const noexcept {
+    [[nodiscard]] bool allows_all_authenticated() const noexcept {
         return _allow_all_if_empty;
     }
     const std::vector<PeerPolicy>& peer_policies() const noexcept { return _peer_policies; }

--- a/vespalib/src/vespa/vespalib/regex/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/regex/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_library(vespalib_vespalib_regex OBJECT
+    SOURCES
+    regex.cpp
+    DEPENDS
+)
+
+find_package(RE2 REQUIRED)
+# TODO can this be PRIVATE since we don't expose it transitively?
+target_include_directories(vespalib_vespalib_regex PUBLIC ${RE2_INCLUDE_DIR})

--- a/vespalib/src/vespa/vespalib/regex/regex.cpp
+++ b/vespalib/src/vespa/vespalib/regex/regex.cpp
@@ -58,7 +58,7 @@ Regex Regex::from_pattern(std::string_view pattern, uint32_t opt_mask) {
     if ((opt_mask & Options::IgnoreCase) != 0) {
         opts.set_case_sensitive(false);
     }
-    return Regex(std::make_shared<Impl>(pattern, opts));
+    return Regex(std::make_shared<const Impl>(pattern, opts));
 }
 
 bool Regex::parsed_ok() const noexcept {

--- a/vespalib/src/vespa/vespalib/regex/regex.cpp
+++ b/vespalib/src/vespa/vespalib/regex/regex.cpp
@@ -1,0 +1,88 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "regex.h"
+#include <re2/re2.h>
+#include <cassert>
+#include <cstdint>
+
+namespace vespalib {
+
+using re2::StringPiece;
+
+// All RE2 instances use a Quiet option to prevent the library from
+// complaining to stderr if pattern compilation fails.
+
+Regex::Regex(std::shared_ptr<const Impl> impl)
+    : _impl(std::move(impl))
+{}
+
+Regex::Regex(const Regex&) = default;
+Regex& Regex::operator=(const Regex&) = default;
+Regex::Regex(Regex&&) noexcept = default;
+Regex& Regex::operator=(Regex&&) noexcept = default;
+
+Regex::~Regex() = default;
+
+class Regex::Impl {
+    RE2 _regex;
+public:
+    Impl(std::string_view pattern, const re2::RE2::Options& opts)
+        : _regex(StringPiece(pattern.data(), pattern.size()), opts)
+    {}
+
+    bool parsed_ok() const noexcept {
+        return _regex.ok();
+    }
+
+    bool partial_match(std::string_view input) const noexcept {
+        assert(input.size() <= INT32_MAX);
+        if (!_regex.ok()) {
+            return false;
+        }
+        return RE2::PartialMatch(StringPiece(input.data(), input.size()), _regex);
+    }
+
+    bool full_match(std::string_view input) const noexcept {
+        assert(input.size() <= INT32_MAX);
+        if (!_regex.ok()) {
+            return false;
+        }
+        return RE2::FullMatch(StringPiece(input.data(), input.size()), _regex);
+    }
+};
+
+Regex Regex::from_pattern(std::string_view pattern, uint32_t opt_mask) {
+    assert(pattern.size() <= INT32_MAX); // StringPiece limitation
+    RE2::Options opts;
+    opts.set_log_errors(false);
+    if ((opt_mask & Options::IgnoreCase) != 0) {
+        opts.set_case_sensitive(false);
+    }
+    return Regex(std::make_shared<Impl>(pattern, opts));
+}
+
+bool Regex::parsed_ok() const noexcept {
+    return _impl->parsed_ok();
+}
+
+bool Regex::partial_match(std::string_view input) const noexcept {
+    return _impl->partial_match(input);
+}
+
+bool Regex::full_match(std::string_view input) const noexcept {
+    return _impl->full_match(input);
+}
+
+bool Regex::partial_match(std::string_view input, std::string_view pattern) noexcept {
+    assert(pattern.size() <= INT32_MAX);
+    Impl impl(pattern, RE2::Quiet);
+    return impl.partial_match(input);
+}
+
+bool Regex::full_match(std::string_view input, std::string_view pattern) noexcept {
+    assert(pattern.size() <= INT32_MAX);
+    Impl impl(pattern, RE2::Quiet);
+    return impl.full_match(input);
+}
+
+}

--- a/vespalib/src/vespa/vespalib/regex/regex.h
+++ b/vespalib/src/vespa/vespalib/regex/regex.h
@@ -1,0 +1,69 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace vespalib {
+
+/**
+ * A simple Regex library wrapper which provides for both just-in-time
+ * pattern evaluation as well as pattern precompilation and reuse.
+ *
+ * Robustness and input safety:
+ * The underlying regex engine implementation must ensure that pattern
+ * parsing and input processing is safe to be run on _untrusted_ inputs.
+ * This means the underlying implementation shall provide upper bounds
+ * on both memory and CPU time and may never crash or corrupt the process.
+ *
+ * We currently use Google RE2 under the hood to achieve this.
+ *
+ * Note: due to underlying RE2 limitations, string lengths may
+ * not be longer than INT_MAX.
+ *
+ * Thread safety:
+ * A Regex object is safe to be used from multiple threads.
+ *
+ * Exception safety:
+ * Exceptions shall never be thrown from the regex code itself, neither
+ * at parse time nor at match time (ancillary exceptions _could_ be thrown
+ * from memory allocation failures etc, but we assume that the caller
+ * is running vespamalloc which terminates the process instead, making
+ * the whole thing effectively noexcept).
+ *
+ * If the provided regular expression pattern is malformed, parsing
+ * fails silently; all match functions will return false immediately.
+ */
+class Regex {
+    class Impl;
+    std::shared_ptr<const Impl> _impl; // shared_ptr to allow for cheap copying.
+
+    explicit Regex(std::shared_ptr<const Impl> impl);
+public:
+    // TODO consider using type-safe parameter instead.
+    enum Options {
+        None       = 0,
+        IgnoreCase = 1
+    };
+
+    ~Regex();
+    Regex(const Regex&);
+    Regex& operator=(const Regex&);
+    Regex(Regex&&) noexcept;
+    Regex& operator=(Regex&&) noexcept;
+
+    [[nodiscard]] bool parsed_ok() const noexcept;
+
+    [[nodiscard]] bool partial_match(std::string_view input) const noexcept;
+    [[nodiscard]] bool full_match(std::string_view input) const noexcept;
+
+    static Regex from_pattern(std::string_view pattern, uint32_t opt_flags = Options::None);
+
+    // Utility matchers for non-precompiled expressions.
+    [[nodiscard]] static bool partial_match(std::string_view input, std::string_view pattern) noexcept;
+    [[nodiscard]] static bool full_match(std::string_view input, std::string_view pattern) noexcept;
+};
+
+}
+

--- a/vespalib/src/vespa/vespalib/util/regexp.cpp
+++ b/vespalib/src/vespa/vespalib/util/regexp.cpp
@@ -41,7 +41,7 @@ vespalib::string escape(vespalib::stringref str) {
 } // namespace vespalib::<unnamed>
 
 vespalib::string
-Regexp::get_prefix(vespalib::stringref re)
+RegexpUtil::get_prefix(vespalib::stringref re)
 {
     vespalib::string prefix;
     if ((re.size() > 0) && (re.data()[0] == '^') && !has_option(re)) {
@@ -58,13 +58,13 @@ Regexp::get_prefix(vespalib::stringref re)
 }
 
 vespalib::string
-Regexp::make_from_suffix(vespalib::stringref suffix)
+RegexpUtil::make_from_suffix(vespalib::stringref suffix)
 {
     return escape(suffix) + "$";
 }
 
 vespalib::string
-Regexp::make_from_substring(vespalib::stringref substring)
+RegexpUtil::make_from_substring(vespalib::stringref substring)
 {
     return escape(substring);
 }

--- a/vespalib/src/vespa/vespalib/util/regexp.h
+++ b/vespalib/src/vespa/vespalib/util/regexp.h
@@ -8,7 +8,7 @@ namespace vespalib {
 /**
  * Utility class inspecting and generating regular expression strings.
  **/
-class Regexp
+class RegexpUtil
 {
 public:
     /**


### PR DESCRIPTION
@geirst please review
@toregge please take a look at my CMake changes to see if they make sense (and the rest too if you want!)

This introduces guaranteed upper bounds for memory usage and
CPU time during regex evaluation. Most importantly, it removes
the danger of catastrophic backtracking that is currrently
present in GCC's `std::regex` implementation.

With this commit, RE2 will be used instead of `std::regex` for:
* Document selection regex/glob operators
* Attribute regex search
* Evaluation of mTLS authorization rules

This relates to issue #12068