### PR TITLE
Restrict global endpoints to routing methods common to all targets

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -159,16 +159,10 @@ public class ApplicationController {
         return curator.readApplication(id);
     }
 
-    /** Returns the application with the given id, or null if it is not present */
-    // TODO jonmv: remove
-    public Optional<Application> getApplication(ApplicationId id) {
-        return getApplication(TenantAndApplicationId.from(id));
-    }
-
     /** Returns the instance with the given id, or null if it is not present */
     // TODO jonmv: remove or inline
     public Optional<Instance> getInstance(ApplicationId id) {
-        return getApplication(id).flatMap(application -> application.get(id.instance()));
+        return getApplication(TenantAndApplicationId.from(id)).flatMap(application -> application.get(id.instance()));
     }
 
     /**

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Endpoint.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/Endpoint.java
@@ -115,13 +115,12 @@ public class Endpoint {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Endpoint endpoint = (Endpoint) o;
-        return url.equals(endpoint.url) &&
-               routingMethod == endpoint.routingMethod;
+        return url.equals(endpoint.url);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(url, routingMethod);
+        return Objects.hash(url);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
@@ -59,7 +59,12 @@ public class EndpointList extends AbstractFilteringList<Endpoint, EndpointList> 
     /** Returns all global endpoints for given routing ID and system provided by given routing methods */
     public static EndpointList global(RoutingId routingId, SystemName system, List<RoutingMethod> routingMethods) {
         var endpoints = new ArrayList<Endpoint>();
+        var directMethods = 0;
         for (var method : routingMethods) {
+            if (method.isDirect() && ++directMethods > 1) {
+                throw new IllegalArgumentException("Invalid routing methods for " + routingId + ": Exceeded maximum " +
+                                                   "direct methods, got " + routingMethods);
+            }
             endpoints.add(Endpoint.of(routingId.application())
                                   .named(routingId.endpointId())
                                   .on(Port.fromRoutingMethod(method))

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTest.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
+import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.DeployOptions;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.EndpointStatus;
@@ -19,6 +20,8 @@ import com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCe
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.SourceRevision;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
+import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
 import com.yahoo.vespa.hosted.controller.api.integration.routing.RoutingEndpoint;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.AssignedRotation;
@@ -801,6 +804,50 @@ public class ControllerTest {
         context.deferLoadBalancerProvisioningIn(zones.stream().map(ZoneId::environment).collect(Collectors.toSet()))
                .submit(applicationPackage)
                .deploy();
+    }
+
+    @Test
+    public void testDeployWithGlobalEndpointsAndMultipleRoutingMethods() {
+        var context = tester.newDeploymentContext();
+        var zone1 = ZoneId.from("prod", "us-west-1");
+        var zone2 = ZoneId.from("prod", "us-east-3");
+        var applicationPackage = new ApplicationPackageBuilder()
+                .upgradePolicy("default")
+                .environment(Environment.prod)
+                .endpoint("default", "default", zone1.region().value(), zone2.region().value())
+                .endpoint("east", "default", zone2.region().value())
+                .region(zone1.region())
+                .region(zone2.region())
+                .build();
+
+        // Zone 1 supports shared and sharedLayer4
+        tester.controllerTester().zoneRegistry().setRoutingMethod(ZoneApiMock.from(zone1), RoutingMethod.shared,
+                                                                  RoutingMethod.sharedLayer4);
+        // Zone 2 supports shared and exclusive
+        tester.controllerTester().zoneRegistry().setRoutingMethod(ZoneApiMock.from(zone2), RoutingMethod.shared,
+                                                                  RoutingMethod.exclusive);
+
+        context.submit(applicationPackage).deploy();
+        var expectedRecords = List.of(
+                // The 'east' global endpoint, pointing to zone 2 with exclusive routing
+                new Record(Record.Type.ALIAS,
+                           RecordName.from("east.application.tenant.global.vespa.oath.cloud"),
+                           RecordData.from("lb-0--tenant:application:default--prod.us-east-3/dns-zone-1/prod.us-east-3")),
+                // The 'default' global endpoint, pointing to both zones with shared routing, via rotation
+                new Record(Record.Type.CNAME,
+                           RecordName.from("application--tenant.global.vespa.oath.cloud"),
+                           RecordData.from("rotation-fqdn-01.")),
+
+                // The zone-scoped endpoint pointing to zone 2 with exclusive routing
+                new Record(Record.Type.CNAME,
+                           RecordName.from("application.tenant.us-east-3.vespa.oath.cloud"),
+                           RecordData.from("lb-0--tenant:application:default--prod.us-east-3.")),
+
+                // The 'east' global endpoint, pointing to zone 2 with shared routing, via rotation
+                new Record(Record.Type.CNAME,
+                           RecordName.from("east--application--tenant.global.vespa.oath.cloud"),
+                           RecordData.from("rotation-fqdn-02.")));
+        assertEquals(expectedRecords, List.copyOf(tester.controllerTester().nameService().records()));
     }
 
 }


### PR DESCRIPTION
Review, but hold merge. After this is merged, `sharedLayer4` can be enabled
again.