### PR TITLE
Add projectId to deployment API

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -578,6 +578,7 @@ class JobControllerApiHandlerHelper {
         Cursor responseObject = slime.setObject();
         responseObject.setString("tenant", id.tenant().value());
         responseObject.setString("application", id.application().value());
+        application.projectId().ifPresent(projectId -> responseObject.setLong("projectId", projectId));
 
         Map<JobId, List<Versions>> jobsToRun = status.jobsToRun();
         Cursor stepsArray = responseObject.setArray("steps");

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
@@ -1,6 +1,7 @@
 {
   "tenant": "tenant",
   "application": "application",
+  "projectId": 1001,
   "steps": [
     {
       "type": "instance",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
@@ -1,6 +1,7 @@
 {
   "tenant": "tenant1",
   "application": "application1",
+  "projectId": 123,
   "steps": [
     {
       "type": "instance",


### PR DESCRIPTION
We can change & rename this field to something with URL later on so public system is supported, but adding it here for now to be able to display simple link back to SD (VESPA-17713).