### PR TITLE
lz4 seems to be unused here.

### DIFF
--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -215,11 +215,6 @@
       <artifactId>jersey-proxy-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/docker-api/pom.xml
+++ b/docker-api/pom.xml
@@ -94,11 +94,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <!-- We explicitly specify the version of httpcore to be used by


### PR DESCRIPTION
@hmusum and @freva PR
I am preparing to upgrade lz4 from 1.3.0 from 2014 to current version.
But trying to clean up first.
