### PR TITLE
Handle SSLHandshakeException without message

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/SslHandshakeFailedListener.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/SslHandshakeFailedListener.java
@@ -72,6 +72,7 @@ class SslHandshakeFailedListener implements SslHandshakeListener {
 
         static Optional<SslHandshakeFailure> fromSslHandshakeException(SSLHandshakeException exception) {
             String message = exception.getMessage();
+            if (message == null || message.isBlank()) return Optional.empty();
             for (SslHandshakeFailure failure : values()) {
                 if (failure.messageMatcher.test(message)) {
                     return Optional.of(failure);


### PR DESCRIPTION
We have observed in production that some SSLHandshakeException instances do not have a message.