### PR TITLE
Rename the default public metric set from 'public' -> 'default'

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultPublicMetrics.java
@@ -20,10 +20,12 @@ import static java.util.Collections.singleton;
  */
 public class DefaultPublicMetrics {
 
+    public static final String DEFAULT_METRIC_SET_ID = "default";
+
     public static MetricSet defaultPublicMetricSet = createMetricSet();
 
     private static MetricSet createMetricSet() {
-        return new MetricSet("public",
+        return new MetricSet(DEFAULT_METRIC_SET_ID,
                              getAllMetrics(),
                              singleton(defaultVespaMetricSet));
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsConsumersTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsConsumersTest.java
@@ -197,14 +197,14 @@ public class MetricsConsumersTest {
     }
 
     @Test
-    public void consumer_with_default_public_metric_set_has_all_public_metrics_plus_all_system_metrics_plus_its_own() {
+    public void consumer_with_default_metric_set_has_all_its_metrics_plus_all_system_metrics_plus_its_own() {
         String services = String.join("\n",
                                       "<services>",
                                       "    <admin version='2.0'>",
                                       "        <adminserver hostalias='node1'/>",
                                       "        <metrics>",
                                       "            <consumer id='consumer-with-public-default-set'>",
-                                      "                <metric-set id='public'/>",
+                                      "                <metric-set id='default'/>",
                                       "                <metric id='custom.metric'/>",
                                       "            </consumer>",
                                       "        </metrics>",


### PR DESCRIPTION
It was intended to be named 'default' but this was not reflected in the code. I have verified that no hosted apps use the set that so far has been called 'public' in the code.