### PR TITLE
Revert "Upgrade from net.jpountz.lz4 1.3.0 to org.lz4 1.7.1"

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -97,7 +97,7 @@
                                                 <include>javax.ws.rs:javax.ws.rs-api:[${javax.ws.rs-api.version}]:jar:provided</include>
                                                 <include>javax.xml.bind:jaxb-api:[${jaxb.version}]:jar:provided</include>
                                                 <include>net.jcip:jcip-annotations:[1.0]:jar:provided</include>
-                                                <include>org.lz4:lz4-java:[${org.lz4.version}]:jar:provided</include>
+                                                <include>net.jpountz.lz4:lz4:[${lz4.version}]:jar:provided</include>
                                                 <include>org.apache.felix:org.apache.felix.framework:[${felix.version}]:jar:provided</include>
                                                 <include>org.apache.felix:org.apache.felix.log:[${felix.log.version}]:jar:provided</include>
                                                 <include>org.apache.felix:org.apache.felix.main:[${felix.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -179,9 +179,9 @@
                 <version>1.0</version>
             </dependency>
             <dependency>
-                <groupId>org.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>${org.lz4.version}</version>
+                <groupId>net.jpountz.lz4</groupId>
+                <artifactId>lz4</artifactId>
+                <version>${lz4.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -447,7 +447,7 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
         <jetty.version>9.4.27.v20200227</jetty.version>
-        <org.lz4.version>1.7.1</org.lz4.version>
+        <lz4.version>1.3.0</lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.5</slf4j.version>
         <xml-apis.version>1.4.01</xml-apis.version>

--- a/vespajlib/pom.xml
+++ b/vespajlib/pom.xml
@@ -20,8 +20,8 @@
 
     <!-- compile scope -->
     <dependency>
-      <groupId>org.lz4</groupId>
-      <artifactId>lz4-java</artifactId>
+      <groupId>net.jpountz.lz4</groupId>
+      <artifactId>lz4</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/vespajlib/src/main/java/net/jpountz/lz4/package-info.java
+++ b/vespajlib/src/main/java/net/jpountz/lz4/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 1, minor = 7, micro = 1))
+@ExportPackage(version = @Version(major = 1, minor = 3, micro = 0))
 package net.jpountz.lz4;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/vespajlib/src/main/java/net/jpountz/util/package-info.java
+++ b/vespajlib/src/main/java/net/jpountz/util/package-info.java
@@ -1,5 +1,0 @@
-// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 1, minor = 7, micro = 1))
-package net.jpountz.util;
-import com.yahoo.osgi.annotation.ExportPackage;
-import com.yahoo.osgi.annotation.Version;

--- a/vespajlib/src/main/java/net/jpountz/xxhash/package-info.java
+++ b/vespajlib/src/main/java/net/jpountz/xxhash/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 1, minor = 7, micro = 1))
+@ExportPackage(version = @Version(major = 1, minor = 3, micro = 0))
 package net.jpountz.xxhash;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;


### PR DESCRIPTION
Reverts vespa-engine/vespa#12480

vespa-grid-log not happy with this:
18:35:57 [INFO] Scanning for projects...
18:35:59 [ERROR] [ERROR] Some problems were encountered while processing the POMs:
18:35:59 [ERROR] 'dependencies.dependency.version' for net.jpountz.lz4:lz4:jar is missing. @ line 82, column 21
18:35:59  @ 
18:35:59 [ERROR] The build could not read 1 project -> [Help 1]
18:35:59 [ERROR]   
18:35:59 [ERROR]   The project com.yahoo.vespa:vespa-grid-log:7.146.592 (/sd/workspace/src/git.ouroath.com/vespa/vespa-yahoo/vespa-grid-log/pom.xml) has 1 error
18:35:59 [ERROR]     'dependencies.dependency.version' for net.jpountz.lz4:lz4:jar is missing. @ line 82, column 21
18:35:59 [ERROR] 
18:35:59 [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
18:35:59 [ERROR] Re-run Maven using the -X switch to enable full debug logging.
18:35:59 [ERROR] 
18:35:59 [ERROR] For more information about the errors and possible solutions, please read the following articles:
18:35:59 [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
18:35:59 make: *** [java] Error 1