### PR TITLE
Throw if accessing duper model while holding status service application lock

### DIFF
--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyAntiServiceMonitor.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyAntiServiceMonitor.java
@@ -1,0 +1,15 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator;
+
+import com.yahoo.vespa.service.monitor.AntiServiceMonitor;
+import com.yahoo.vespa.service.monitor.CriticalRegion;
+
+/**
+ * @author hakonhall
+ */
+public class DummyAntiServiceMonitor implements AntiServiceMonitor {
+    @Override
+    public CriticalRegion disallowDuperModelLockAcquisition(String regionDescription) {
+        return () -> {};
+    }
+}

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyServiceMonitor.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/DummyServiceMonitor.java
@@ -15,6 +15,8 @@ import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.applicationmodel.TenantId;
 import com.yahoo.vespa.orchestrator.model.NodeGroup;
 import com.yahoo.vespa.orchestrator.model.VespaModelUtil;
+import com.yahoo.vespa.service.monitor.AntiServiceMonitor;
+import com.yahoo.vespa.service.monitor.CriticalRegion;
 import com.yahoo.vespa.service.monitor.ServiceModel;
 import com.yahoo.vespa.service.monitor.ServiceMonitor;
 
@@ -31,7 +33,7 @@ import java.util.stream.Collectors;
  * @author oyving
  * @author smorgrav
  */
-public class DummyServiceMonitor implements ServiceMonitor {
+public class DummyServiceMonitor implements ServiceMonitor, AntiServiceMonitor {
 
     public static final HostName TEST1_HOST_NAME = new HostName("test1.hostname.tld");
     public static final HostName TEST3_HOST_NAME = new HostName("test3.hostname.tld");
@@ -163,6 +165,11 @@ public class DummyServiceMonitor implements ServiceMonitor {
     @Override
     public Map<HostName, List<ServiceInstance>> getServicesByHostname() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CriticalRegion disallowDuperModelLockAcquisition(String regionDescription) {
+        return () -> {};
     }
 
     public static Set<HostName> getContentHosts(ApplicationInstanceReference appRef) {

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
@@ -76,7 +76,12 @@ public class OrchestratorImplTest {
     private final ApplicationApiFactory applicationApiFactory = new ApplicationApiFactory(3);
     private final InMemoryFlagSource flagSource = new InMemoryFlagSource();
     private final MockCurator curator = new MockCurator();
-    private ZkStatusService statusService = new ZkStatusService(curator, mock(Metric.class), new TestTimer(), flagSource);
+    private ZkStatusService statusService = new ZkStatusService(
+            curator,
+            mock(Metric.class),
+            new TestTimer(),
+            flagSource,
+            new DummyAntiServiceMonitor());
 
     private ApplicationId app1;
     private ApplicationId app2;
@@ -394,7 +399,12 @@ public class OrchestratorImplTest {
     @Test
     public void testGetHost() throws Exception {
         ClusterControllerClientFactory clusterControllerClientFactory = new ClusterControllerClientFactoryMock();
-        StatusService statusService = new ZkStatusService(new MockCurator(), mock(Metric.class), new TestTimer(), flagSource);
+        StatusService statusService = new ZkStatusService(
+                new MockCurator(),
+                mock(Metric.class),
+                new TestTimer(),
+                flagSource,
+                new DummyAntiServiceMonitor());
 
         HostName hostName = new HostName("host.yahoo.com");
         TenantId tenantId = new TenantId("tenant");

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ModelTestUtils.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ModelTestUtils.java
@@ -17,6 +17,7 @@ import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.applicationmodel.TenantId;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
+import com.yahoo.vespa.orchestrator.DummyAntiServiceMonitor;
 import com.yahoo.vespa.orchestrator.OrchestrationException;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.orchestrator.OrchestratorContext;
@@ -57,9 +58,13 @@ class ModelTestUtils {
     private final Map<ApplicationInstanceReference, ApplicationInstance> applications = new HashMap<>();
     private final ClusterControllerClientFactory clusterControllerClientFactory = new ClusterControllerClientFactoryMock();
     private final Map<HostName, HostStatus> hostStatusMap = new HashMap<>();
-    private final StatusService statusService = new ZkStatusService(new MockCurator(), mock(Metric.class), new TestTimer(), flagSource);
-    private final TestTimer timer = new TestTimer();
     private final ServiceMonitor serviceMonitor = () -> new ServiceModel(applications);
+    private final StatusService statusService = new ZkStatusService(
+            new MockCurator(),
+            mock(Metric.class),
+            new TestTimer(),
+            flagSource,
+            new DummyAntiServiceMonitor());
     private final Orchestrator orchestrator = new OrchestratorImpl(new HostedVespaPolicy(new HostedVespaClusterPolicy(), clusterControllerClientFactory, applicationApiFactory()),
                                                                    clusterControllerClientFactory,
                                                                    statusService,

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/HostResourceTest.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.orchestrator.BatchHostNameNotFoundException;
 import com.yahoo.vespa.orchestrator.BatchInternalErrorException;
+import com.yahoo.vespa.orchestrator.DummyAntiServiceMonitor;
 import com.yahoo.vespa.orchestrator.Host;
 import com.yahoo.vespa.orchestrator.HostNameNotFoundException;
 import com.yahoo.vespa.orchestrator.OrchestrationException;
@@ -79,11 +80,12 @@ public class HostResourceTest {
     private static final int SERVICE_MONITOR_CONVERGENCE_LATENCY_SECONDS = 0;
     private static final TenantId TENANT_ID = new TenantId("tenantId");
     private static final ApplicationInstanceId APPLICATION_INSTANCE_ID = new ApplicationInstanceId("applicationId");
+    private static final ServiceMonitor serviceMonitor = mock(ServiceMonitor.class);
     private static final StatusService EVERY_HOST_IS_UP_HOST_STATUS_SERVICE = new ZkStatusService(
-            new MockCurator(), mock(Metric.class), new TestTimer(), new InMemoryFlagSource());
+            new MockCurator(), mock(Metric.class), new TestTimer(), new InMemoryFlagSource(),
+            new DummyAntiServiceMonitor());
     private static final ApplicationApiFactory applicationApiFactory = new ApplicationApiFactory(3);
 
-    private static final ServiceMonitor serviceMonitor = mock(ServiceMonitor.class);
     static {
         when(serviceMonitor.getApplication(any(HostName.class)))
                 .thenReturn(Optional.of(

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/CriticalRegionChecker.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/CriticalRegionChecker.java
@@ -1,0 +1,63 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.duper;
+
+import com.yahoo.vespa.service.monitor.CriticalRegion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * To detect and throw an {@link IllegalStateException} if the execution of the current thread has
+ * reached code point P, some time after the start of a critical region R and before the end of it:
+ *
+ * <ol>
+ *     <li>Declare a static final instance of {@link CriticalRegionChecker}.</li>
+ *     <li>Invoke {@link #startCriticalRegion(String)} when entering region R, and close
+ *     the returned {@link CriticalRegion} when leaving it.</li>
+ *     <li>Invoke {@link #assertOutsideCriticalRegions(String)} at code point P.</li>
+ * </ol>
+ *
+ * @author hakonhall
+ */
+public class CriticalRegionChecker {
+
+    private final ThreadLocalDescriptions threadLocalDescriptions = new ThreadLocalDescriptions();
+    private final String name;
+
+    public CriticalRegionChecker(String name) {
+        this.name = name;
+    }
+
+    /** Start of the critical region, within which {@link #assertOutsideCriticalRegions(String)} will throw. */
+    public CriticalRegion startCriticalRegion(String regionDescription) {
+        List<String> regionDescriptions = threadLocalDescriptions.get();
+        regionDescriptions.add(regionDescription);
+        Thread threadAtStart = Thread.currentThread();
+
+        return () -> {
+            regionDescriptions.remove(regionDescription);
+
+            Thread treadAtClose = Thread.currentThread();
+            if (threadAtStart != treadAtClose) {
+                throw new IllegalStateException(name + ": A critical region cannot cross threads: " +
+                        regionDescription);
+            }
+        };
+    }
+
+    /** @throws IllegalStateException if within one or more critical regions. */
+    public void assertOutsideCriticalRegions(String codePointDescription) throws IllegalStateException {
+        List<String> regionDescriptions = threadLocalDescriptions.get();
+        if (regionDescriptions.size() > 0) {
+            throw new IllegalStateException(name + ": Code point " + codePointDescription +
+                    " is within these critical regions: " + regionDescriptions);
+        }
+    }
+
+    private static class ThreadLocalDescriptions extends ThreadLocal<List<String>> {
+        @Override
+        protected List<String> initialValue() {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/model/ServiceMonitorImpl.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/model/ServiceMonitorImpl.java
@@ -14,6 +14,8 @@ import com.yahoo.vespa.applicationmodel.ServiceInstance;
 import com.yahoo.vespa.service.duper.DuperModelManager;
 import com.yahoo.vespa.service.manager.MonitorManager;
 import com.yahoo.vespa.service.manager.UnionMonitorManager;
+import com.yahoo.vespa.service.monitor.AntiServiceMonitor;
+import com.yahoo.vespa.service.monitor.CriticalRegion;
 import com.yahoo.vespa.service.monitor.ServiceHostListener;
 import com.yahoo.vespa.service.monitor.ServiceModel;
 import com.yahoo.vespa.service.monitor.ServiceMonitor;
@@ -24,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public class ServiceMonitorImpl implements ServiceMonitor {
+public class ServiceMonitorImpl implements ServiceMonitor, AntiServiceMonitor {
 
     private final ServiceMonitorMetrics metrics;
     private final DuperModelManager duperModelManager;
@@ -103,6 +105,11 @@ public class ServiceMonitorImpl implements ServiceMonitor {
     public void registerListener(ServiceHostListener listener) {
         var duperModelListener = ServiceHostListenerAdapter.asDuperModelListener(listener, modelGenerator);
         duperModelManager.registerListener(duperModelListener);
+    }
+
+    @Override
+    public CriticalRegion disallowDuperModelLockAcquisition(String regionDescription) {
+        return duperModelManager.disallowDuperModelLockAcquisition(regionDescription);
     }
 
     private Optional<ApplicationInfo> getApplicationInfo(ApplicationInstanceReference reference) {

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/AntiServiceMonitor.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/AntiServiceMonitor.java
@@ -1,0 +1,25 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.monitor;
+
+import com.yahoo.vespa.service.duper.DuperModelManager;
+
+/**
+ * Interface that allows a thread to declare it must NOT access certain parts of the ServiceMonitor.
+ *
+ * @author hakonhall
+ */
+public interface AntiServiceMonitor {
+    /**
+     * Disallow the current thread to acquire the "duper model lock" (see {@link DuperModelManager}),
+     * necessarily acquired by most of the {@link ServiceMonitor} methods, starting from now and
+     * up until the returned region is closed.
+     *
+     * <p>For instance, if an application is activated the duper model is notified:  The duper model
+     * will acquire a lock to update the model atomically, and while having that lock notify
+     * the status service.  The status service will typically acquire an application lock and prune
+     * hosts no longer part of the application.  If a thread were to try to acquire these locks
+     * in the reverse order, it might become deadlocked. This method allows one to detect this
+     * and throw an exception, causing it to be caught earlier or at least easier to debug.</p>
+     */
+    CriticalRegion disallowDuperModelLockAcquisition(String regionDescription);
+}

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/CriticalRegion.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/monitor/CriticalRegion.java
@@ -1,0 +1,18 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.service.monitor;
+
+/**
+ * Represents a region of execution, e.g. the block of a try-with-resources.
+ *
+ * @author hakonhall
+ */
+@FunctionalInterface
+public interface CriticalRegion extends AutoCloseable {
+    /**
+     * Ends the critical region.
+     *
+     * @throws IllegalStateException if the current thread is different from the one that started
+     *         the critical region.
+     */
+    @Override void close() throws IllegalStateException;
+}


### PR DESCRIPTION
When the duper model is updated, ZooKeeper is atomically updated to e.g. remove
extraneous hosts.  This is done by acquiring the duper model lock first, then
the relevant application lock in the status service.

Acquiring these two locks in the reverse order may lead to a deadlock.

This PR throws an IllegalStateException when detecting the current thread is
about to acquire the duper model lock when the current thread has acquired the
application lock.