### PR TITLE
Reduce number of indirections when returning tensor via get_vector() …

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -210,11 +210,9 @@ DenseTensorAttribute::removeOldGenerations(generation_t first_used_gen)
 vespalib::tensor::TypedCells
 DenseTensorAttribute::get_vector(uint32_t docid) const
 {
-    MutableDenseTensorView tensor_view(_denseTensorStore.type());
     assert(docid < _refVector.size());
     EntryRef ref = _refVector[docid];
-    _denseTensorStore.getTensor(ref, tensor_view);
-    return tensor_view.cellsRef();
+    return _denseTensorStore.get_typed_cells(ref);
 }
 
 }

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_store.cpp
@@ -153,6 +153,15 @@ DenseTensorStore::getTensor(EntryRef ref, MutableDenseTensorView &tensor) const
     }
 }
 
+vespalib::tensor::TypedCells
+DenseTensorStore::get_typed_cells(EntryRef ref) const
+{
+    if (!ref.valid()) {
+        return vespalib::tensor::TypedCells(&_emptySpace[0], _type.cell_type(), getNumCells());
+    }
+    return vespalib::tensor::TypedCells(getRawBuffer(ref), _type.cell_type(), getNumCells());
+}
+
 template <class TensorType>
 TensorStore::EntryRef
 DenseTensorStore::setDenseTensor(const TensorType &tensor)

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_store.h
@@ -4,6 +4,7 @@
 
 #include "tensor_store.h"
 #include <vespa/eval/eval/value_type.h>
+#include <vespa/eval/tensor/dense/typed_cells.h>
 
 namespace vespalib { namespace tensor { class MutableDenseTensorView; }}
 
@@ -65,6 +66,7 @@ public:
     EntryRef move(EntryRef ref) override;
     std::unique_ptr<Tensor> getTensor(EntryRef ref) const;
     void getTensor(EntryRef ref, vespalib::tensor::MutableDenseTensorView &tensor) const;
+    vespalib::tensor::TypedCells get_typed_cells(EntryRef ref) const;
     EntryRef setTensor(const Tensor &tensor);
     // The following method is meant to be used only for unit tests.
     uint32_t getArraySize() const { return _bufferType.getArraySize(); }


### PR DESCRIPTION
…used by hnsw index.

@toregge please review and merge
@arnej27959 FYI
