### PR TITLE
Remove support for setting vespa version in config requests

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/protocol/JRTConfigRequestFactory.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/JRTConfigRequestFactory.java
@@ -6,7 +6,9 @@ import com.yahoo.config.subscription.impl.JRTConfigSubscription;
 import com.yahoo.vespa.config.RawConfig;
 import com.yahoo.vespa.config.util.ConfigUtils;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * To hide JRT implementations.
@@ -18,7 +20,6 @@ public class JRTConfigRequestFactory {
     public static final String VESPA_CONFIG_PROTOCOL_VERSION = "VESPA_CONFIG_PROTOCOL_VERSION"; // Unused, but should be used if we add a new version
     private static final CompressionType compressionType = getCompressionType();
     private static final String VESPA_CONFIG_PROTOCOL_COMPRESSION = "VESPA_CONFIG_PROTOCOL_COMPRESSION";
-    public static final String VESPA_VERSION = "VESPA_VERSION";
 
     public static <T extends ConfigInstance> JRTClientConfigRequest createFromSub(JRTConfigSubscription<T> sub) {
         // TODO: Get trace from caller
@@ -53,10 +54,6 @@ public class JRTConfigRequestFactory {
     }
 
     static Optional<VespaVersion> getVespaVersion() {
-        final String envValue = ConfigUtils.getEnvValue("", System.getenv(VESPA_VERSION), System.getProperty(VESPA_VERSION));
-        if (envValue != null && !envValue.isEmpty()) {
-            return Optional.of(VespaVersion.fromString(envValue));
-        }
         return Optional.of(getCompiledVespaVersion());
     }
 

--- a/config/src/test/java/com/yahoo/vespa/config/protocol/JRTConfigRequestFactoryTest.java
+++ b/config/src/test/java/com/yahoo/vespa/config/protocol/JRTConfigRequestFactoryTest.java
@@ -106,15 +106,6 @@ public class JRTConfigRequestFactoryTest {
         JRTClientConfigRequest request = JRTConfigRequestFactory.createFromSub(sub);
         assertThat(request.getProtocolVersion(), is(3L));
         assertThat(request.getVespaVersion().get(), is(defaultVespaVersion));
-
-        // Create with vespa version set
-        String version = "5.37.38";
-        System.setProperty(JRTConfigRequestFactory.VESPA_VERSION, version);
-        request = JRTConfigRequestFactory.createFromSub(sub);
-        assertThat(request.getProtocolVersion(), is(3L));
-        assertThat(request.getVespaVersion().get(), is(VespaVersion.fromString(version)));
-
-        System.clearProperty(JRTConfigRequestFactory.VESPA_VERSION);
     }
 
     @Test
@@ -127,15 +118,6 @@ public class JRTConfigRequestFactoryTest {
         JRTClientConfigRequest request = JRTConfigRequestFactory.createFromRaw(config, 1000);
         assertThat(request.getProtocolVersion(), is(3L));
         assertThat(request.getVespaVersion().get(), is(defaultVespaVersion));
-
-        // Create with vespa version set
-        String version = "5.37.38";
-        System.setProperty(JRTConfigRequestFactory.VESPA_VERSION, version);
-        request = JRTConfigRequestFactory.createFromRaw(config, 1000);
-        assertThat(request.getProtocolVersion(), is(3L));
-        assertThat(request.getVespaVersion().get(), is(VespaVersion.fromString(version)));
-
-        System.clearProperty(JRTConfigRequestFactory.VESPA_VERSION);
     }
 
 }


### PR DESCRIPTION
Using VESPA_VERSION environment variable or Java system property is not documented or
system tested, remove it.
