### PR TITLE
In order to drain Q faster on sync, and also detect that we are in sy… 

### DIFF
--- a/searchlib/src/vespa/searchlib/common/sequencedtaskexecutor.cpp
+++ b/searchlib/src/vespa/searchlib/common/sequencedtaskexecutor.cpp
@@ -62,6 +62,13 @@ void
 SequencedTaskExecutor::sync()
 {
     for (auto &executor : *_executors) {
+        SingleExecutor * single = dynamic_cast<vespalib::SingleExecutor *>(executor.get());
+        if (single) {
+            //Enforce parallel wakeup of napping executors.
+            single->startSync();
+        }
+    }
+    for (auto &executor : *_executors) {
         executor->sync();
     }
 }

--- a/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
@@ -29,6 +29,10 @@ private:
     uint64_t addTask(Task::UP task);
     void run() override;
     void drain_tasks();
+    void wakeupConsumer();
+    void sleepConsumer();
+    void wakeupProducer();
+    void sleepProducer(MonitorGuard & guard);
     void run_tasks_till(uint64_t available);
     void wait_for_room(MonitorGuard & guard);
     uint64_t index(uint64_t counter) const {

--- a/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
@@ -23,15 +23,17 @@ public:
     Task::UP execute(Task::UP task) override;
     void setTaskLimit(uint32_t taskLimit) override;
     SingleExecutor & sync() override;
+    void startSync();
     size_t getNumThreads() const override;
     uint32_t getTaskLimit() const { return _taskLimit.load(std::memory_order_relaxed); }
     Stats getStats() override;
 private:
     using Lock = std::unique_lock<std::mutex>;
     uint64_t addTask(Task::UP task);
+    void drain(Lock & lock);
     void run() override;
     void drain_tasks();
-    void sleepProducer(Lock & guard, duration maxWaitTime);
+    void sleepProducer(Lock & guard, duration maxWaitTime, uint64_t wakeupAt);
     void run_tasks_till(uint64_t available);
     void wait_for_room(Lock & guard);
     uint64_t index(uint64_t counter) const {
@@ -45,15 +47,14 @@ private:
     std::atomic<uint32_t>       _wantedTaskLimit;
     std::atomic<uint64_t>       _rp;
     std::unique_ptr<Task::UP[]> _tasks;
-    std::mutex                  _consumerMutex;
+    std::mutex                  _mutex;
     std::condition_variable     _consumerCondition;
-    std::mutex                  _producerMutex;
     std::condition_variable     _producerCondition;
     vespalib::Thread            _thread;
     uint64_t                    _lastAccepted;
     std::atomic<uint64_t>       _maxPending;
     std::atomic<uint64_t>       _wakeupConsumerAt;
-    std::atomic<bool>           _producerNeedWakeup;
+    std::atomic<uint64_t>       _producerNeedWakeupAt;
     std::atomic<uint64_t>       _wp;
 };
 


### PR DESCRIPTION
…nc faster,

we wake the consumer unconditionally on sync, and also unconditionally wake the producer when consumer is idle.

@havardpe and @vekterli PR
