### PR TITLE
Gjoranv/allow stealing builtin handler bindings  

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.builder.xml.dom;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.text.XML;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import org.w3c.dom.Element;
@@ -13,6 +14,10 @@ import org.w3c.dom.Element;
  * @since 5.1.6
  */
 public class DomClientProviderBuilder extends DomHandlerBuilder {
+
+    public DomClientProviderBuilder(ApplicationContainerCluster cluster) {
+        super(cluster);
+    }
 
     @Override
     protected Handler doBuild(DeployState deployState, AbstractConfigProducer parent, Element clientElement) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
@@ -15,7 +15,7 @@ import org.w3c.dom.Element;
 public class DomClientProviderBuilder extends DomHandlerBuilder {
 
     @Override
-    protected Handler doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element clientElement) {
+    protected Handler doBuild(DeployState deployState, AbstractConfigProducer parent, Element clientElement) {
         Handler<? super Component<?, ?>> client = createHandler(clientElement);
 
         for (Element binding : XML.getChildren(clientElement, "binding"))
@@ -24,7 +24,7 @@ public class DomClientProviderBuilder extends DomHandlerBuilder {
         for (Element serverBinding : XML.getChildren(clientElement, "serverBinding"))
             client.addServerBindings(XML.getValue(serverBinding));
 
-        DomComponentBuilder.addChildren(deployState, ancestor, clientElement, client);
+        DomComponentBuilder.addChildren(deployState, parent, clientElement, client);
 
         return client;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
@@ -16,7 +16,7 @@ public class DomClientProviderBuilder extends DomHandlerBuilder {
 
     @Override
     protected Handler doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element clientElement) {
-        Handler<? super Component<?, ?>> client = getHandler(clientElement);
+        Handler<? super Component<?, ?>> client = createHandler(clientElement);
 
         for (Element binding : XML.getChildren(clientElement, "binding"))
             client.addClientBindings(XML.getValue(binding));

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -17,7 +17,7 @@ import org.w3c.dom.Element;
 public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
 
     @Override
-    protected Handler doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element handlerElement) {
+    protected Handler doBuild(DeployState deployState, AbstractConfigProducer parent, Element handlerElement) {
         Handler<? super Component<?, ?>> handler = createHandler(handlerElement);
 
         for (Element binding : XML.getChildren(handlerElement, "binding"))
@@ -26,7 +26,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         for (Element clientBinding : XML.getChildren(handlerElement, "clientBinding"))
             handler.addClientBindings(XML.getValue(clientBinding));
 
-        DomComponentBuilder.addChildren(deployState, ancestor, handlerElement, handler);
+        DomComponentBuilder.addChildren(deployState, parent, handlerElement, handler);
 
         return handler;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -2,10 +2,11 @@
 package com.yahoo.vespa.model.builder.xml.dom;
 
 import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.text.XML;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuilder;
@@ -15,6 +16,12 @@ import org.w3c.dom.Element;
  * @author gjoranv
  */
 public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
+
+    private final ApplicationContainerCluster cluster;
+
+    public DomHandlerBuilder(ApplicationContainerCluster cluster) {
+        this.cluster = cluster;
+    }
 
     @Override
     protected Handler doBuild(DeployState deployState, AbstractConfigProducer parent, Element handlerElement) {
@@ -35,4 +42,5 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         BundleInstantiationSpecification bundleSpec = BundleInstantiationSpecificationBuilder.build(handlerElement);
         return new Handler<>(new ComponentModel(bundleSpec));
     }
+
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom;
 
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
@@ -12,10 +13,15 @@ import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuilder;
 import org.w3c.dom.Element;
 
+import java.util.Set;
+import static java.util.logging.Level.INFO;
+
 /**
  * @author gjoranv
  */
 public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
+
+    private static final Set<String> reservedBindings = Set.of();
 
     private final ApplicationContainerCluster cluster;
 
@@ -28,7 +34,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         Handler<? super Component<?, ?>> handler = createHandler(handlerElement);
 
         for (Element binding : XML.getChildren(handlerElement, "binding"))
-            handler.addServerBindings(XML.getValue(binding));
+            addServerBinding(handler, XML.getValue(binding), deployState.getDeployLogger());
 
         for (Element clientBinding : XML.getChildren(handlerElement, "clientBinding"))
             handler.addClientBindings(XML.getValue(clientBinding));
@@ -41,6 +47,31 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
     Handler<? super Component<?, ?>> createHandler(Element handlerElement) {
         BundleInstantiationSpecification bundleSpec = BundleInstantiationSpecificationBuilder.build(handlerElement);
         return new Handler<>(new ComponentModel(bundleSpec));
+    }
+
+    private void addServerBinding(Handler<? super Component<?, ?>> handler, String binding, DeployLogger log) {
+        throwIfBindingIsReserved(binding, handler);
+        handler.addServerBindings(binding);
+        removeExistingServerBinding(binding, handler, log);
+    }
+
+    private void throwIfBindingIsReserved(String binding, Handler<?> newHandler) {
+        for (var reserved : reservedBindings) {
+            if (binding.equals(reserved)) {
+                throw new IllegalArgumentException("Binding '" + binding + "' is a reserved Vespa binding and " +
+                                                           "cannot be used by handler: " + newHandler.getComponentId());
+            }
+        }
+    }
+
+    private void removeExistingServerBinding(String binding, Handler<?> newHandler, DeployLogger log) {
+        for (var handler : cluster.getHandlers()) {
+            if (handler.getServerBindings().contains(binding)) {
+                handler.removeServerBinding(binding);
+                log.log(INFO, "Binding '" + binding + "' was already in use by handler '" +
+                        handler.getComponentId() + "', but will now be taken over by handler: " + newHandler.getComponentId());
+            }
+        }
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -16,12 +16,16 @@ import org.w3c.dom.Element;
 import java.util.Set;
 import static java.util.logging.Level.INFO;
 
+import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_1;
+import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_2;
+
 /**
  * @author gjoranv
  */
 public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
 
-    private static final Set<String> reservedBindings = Set.of();
+    private static final Set<String> reservedBindings = Set.of(METRICS_V2_HANDLER_BINDING_1,
+                                                               METRICS_V2_HANDLER_BINDING_2);
 
     private final ApplicationContainerCluster cluster;
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -18,15 +18,18 @@ import static java.util.logging.Level.INFO;
 
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_1;
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_2;
+import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_1;
+import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_2;
 
 /**
  * @author gjoranv
  */
 public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
 
-    private static final Set<String> reservedBindings = Set.of(METRICS_V2_HANDLER_BINDING_1,
+    private static final Set<String> reservedBindings = Set.of(STATE_HANDLER_BINDING_1,
+                                                               STATE_HANDLER_BINDING_2,
+                                                               METRICS_V2_HANDLER_BINDING_1,
                                                                METRICS_V2_HANDLER_BINDING_2);
-
     private final ApplicationContainerCluster cluster;
 
     public DomHandlerBuilder(ApplicationContainerCluster cluster) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -38,7 +38,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         return handler;
     }
 
-    protected Handler<? super Component<?, ?>> createHandler(Element handlerElement) {
+    Handler<? super Component<?, ?>> createHandler(Element handlerElement) {
         BundleInstantiationSpecification bundleSpec = BundleInstantiationSpecificationBuilder.build(handlerElement);
         return new Handler<>(new ComponentModel(bundleSpec));
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -18,7 +18,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
 
     @Override
     protected Handler doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element handlerElement) {
-        Handler<? super Component<?, ?>> handler = getHandler(handlerElement);
+        Handler<? super Component<?, ?>> handler = createHandler(handlerElement);
 
         for (Element binding : XML.getChildren(handlerElement, "binding"))
             handler.addServerBindings(XML.getValue(binding));
@@ -31,7 +31,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         return handler;
     }
 
-    protected Handler<? super Component<?, ?>> getHandler(Element handlerElement) {
+    protected Handler<? super Component<?, ?>> createHandler(Element handlerElement) {
         BundleInstantiationSpecification bundleSpec = BundleInstantiationSpecificationBuilder.build(handlerElement);
         return new Handler<>(new ComponentModel(bundleSpec));
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -14,22 +14,24 @@ import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuild
 import org.w3c.dom.Element;
 
 import java.util.Set;
-import static java.util.logging.Level.INFO;
 
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_1;
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_2;
 import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_1;
 import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_2;
+import static com.yahoo.vespa.model.container.ContainerCluster.VIP_HANDLER_BINDING;
+import static java.util.logging.Level.INFO;
 
 /**
  * @author gjoranv
  */
 public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
 
-    private static final Set<String> reservedBindings = Set.of(STATE_HANDLER_BINDING_1,
+    private static final Set<String> reservedBindings = Set.of(METRICS_V2_HANDLER_BINDING_1,
+                                                               METRICS_V2_HANDLER_BINDING_2,
+                                                               STATE_HANDLER_BINDING_1,
                                                                STATE_HANDLER_BINDING_2,
-                                                               METRICS_V2_HANDLER_BINDING_1,
-                                                               METRICS_V2_HANDLER_BINDING_2);
+                                                               VIP_HANDLER_BINDING);
     private final ApplicationContainerCluster cluster;
 
     public DomHandlerBuilder(ApplicationContainerCluster cluster) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -54,6 +54,8 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         MetricsProxyApiConfig.Producer {
 
     public static final String METRICS_V2_HANDLER_CLASS = MetricsV2Handler.class.getName();
+    public static final String METRICS_V2_HANDLER_BINDING_1 = "http://*" + MetricsV2Handler.V2_PATH;
+    public static final String METRICS_V2_HANDLER_BINDING_2 = METRICS_V2_HANDLER_BINDING_1 + "/*";
 
     private final Set<FileReference> applicationBundles = new LinkedHashSet<>();
 
@@ -111,8 +113,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     public void addMetricsV2Handler() {
         Handler<AbstractConfigProducer<?>> handler = new Handler<>(
                 new ComponentModel(METRICS_V2_HANDLER_CLASS, null, null, null));
-        handler.addServerBindings("http://*" + MetricsV2Handler.V2_PATH,
-                                  "http://*" + MetricsV2Handler.V2_PATH + "/*");
+        handler.addServerBindings(METRICS_V2_HANDLER_BINDING_1, METRICS_V2_HANDLER_BINDING_2);
         addComponent(handler);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -111,11 +111,14 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     public static final String APPLICATION_STATUS_HANDLER_CLASS = "com.yahoo.container.handler.observability.ApplicationStatusHandler";
     public static final String BINDINGS_OVERVIEW_HANDLER_CLASS = BindingsOverviewHandler.class.getName();
-    public static final String STATE_HANDLER_CLASS = "com.yahoo.container.jdisc.state.StateHandler";
     public static final String LOG_HANDLER_CLASS = com.yahoo.container.handler.LogHandler.class.getName();
     public static final String DEFAULT_LINGUISTICS_PROVIDER = "com.yahoo.language.provider.DefaultLinguisticsProvider";
     public static final String CMS = "-XX:+UseConcMarkSweepGC -XX:MaxTenuringThreshold=15 -XX:NewRatio=1";
     public static final String G1GC = "-XX:+UseG1GC -XX:MaxTenuringThreshold=15";
+
+    public static final String STATE_HANDLER_CLASS = "com.yahoo.container.jdisc.state.StateHandler";
+    public static final String STATE_HANDLER_BINDING_1 = "http://*" + StateHandler.STATE_API_ROOT;
+    public static final String STATE_HANDLER_BINDING_2 = STATE_HANDLER_BINDING_1 + "/*";
 
     public static final String ROOT_HANDLER_PATH = "/";
     public static final String ROOT_HANDLER_BINDING = "http://*" + ROOT_HANDLER_PATH;
@@ -200,8 +203,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public void addMetricStateHandler() {
         Handler<AbstractConfigProducer<?>> stateHandler = new Handler<>(
                 new ComponentModel(STATE_HANDLER_CLASS, null, null, null));
-        stateHandler.addServerBindings("http://*" + StateHandler.STATE_API_ROOT,
-                                       "http://*" + StateHandler.STATE_API_ROOT + "/*");
+        stateHandler.addServerBindings(STATE_HANDLER_BINDING_1, STATE_HANDLER_BINDING_2);
         addComponent(stateHandler);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -123,6 +123,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public static final String ROOT_HANDLER_PATH = "/";
     public static final String ROOT_HANDLER_BINDING = "http://*" + ROOT_HANDLER_PATH;
 
+    public static final String VIP_HANDLER_BINDING = "http://*/status.html";
+
     private final String name;
 
     protected List<CONTAINER> containers = new ArrayList<>();
@@ -234,7 +236,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     public void addVipHandler() {
         Handler<?> vipHandler = Handler.fromClassName(FileStatusHandlerComponent.CLASS);
-        vipHandler.addServerBindings("http://*/status.html");
+        vipHandler.addServerBindings(VIP_HANDLER_BINDING);
         addComponent(vipHandler);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -206,9 +206,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     }
 
     public void addDefaultRootHandler() {
-        if (hasHandlerWithBinding(ROOT_HANDLER_BINDING))
-            return;
-
         Handler<AbstractConfigProducer<?>> handler = new Handler<>(
                 new ComponentModel(BundleInstantiationSpecification.getFromStrings(
                         BINDINGS_OVERVIEW_HANDLER_CLASS, null, null), null));  // null bundle, as the handler is in container-disc
@@ -216,13 +213,13 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         addComponent(handler);
     }
 
-    private boolean hasHandlerWithBinding(String binding) {
+    public Optional<Handler<?>> handlerWithBinding(String binding) {
         Collection<Handler<?>> handlers = getHandlers();
         for (Handler handler : handlers) {
             if (handler.getServerBindings().contains(binding))
-                return true;
+                return Optional.of(handler);
         }
-        return false;
+        return Optional.empty();
     }
 
     public void addApplicationStatusHandler() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -42,6 +42,10 @@ public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<
         serverBindings.addAll(Arrays.asList(bindings));
     }
 
+    public void removeServerBinding(String binding) {
+        serverBindings.remove(binding);
+    }
+
     public void addClientBindings(String... bindings) {
         clientBindings.addAll(Arrays.asList(bindings));
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -8,7 +8,9 @@ import com.yahoo.config.model.producer.AbstractConfigProducer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Models a jdisc RequestHandler (including ClientProvider).
@@ -21,7 +23,7 @@ import java.util.List;
  */
 public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<CHILD, ComponentModel> {
 
-    private List<String> serverBindings = new ArrayList<>();
+    private Set<String> serverBindings = new LinkedHashSet<>();
     private List<String> clientBindings = new ArrayList<>();
 
     public Handler(ComponentModel model) {
@@ -44,8 +46,8 @@ public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<
         clientBindings.addAll(Arrays.asList(bindings));
     }
 
-    public final List<String> getServerBindings() {
-        return Collections.unmodifiableList(serverBindings);
+    public final Set<String> getServerBindings() {
+        return Collections.unmodifiableSet(serverBindings);
     }
 
     public final List<String> getClientBindings() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilder.java
@@ -9,6 +9,8 @@ import org.w3c.dom.Element;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.yahoo.vespa.model.container.xml.ContainerModelBuilder.SEARCH_HANDLER_CLASS;
+
 /**
  * This object builds a bundle instantiation spec from an XML element.
  *
@@ -36,7 +38,7 @@ public class BundleInstantiationSpecificationBuilder {
 
     private static void validate(BundleInstantiationSpecification instSpec) {
         List<String> forbiddenClasses = Arrays.asList(
-                "com.yahoo.search.handler.SearchHandler",
+                SEARCH_HANDLER_CLASS,
                 "com.yahoo.processing.handler.ProcessingHandler");
 
         for (String forbiddenClass: forbiddenClasses) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -106,6 +106,9 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private static final String DEPRECATED_CONTAINER_TAG = "jdisc";
     private static final String ENVIRONMENT_VARIABLES_ELEMENT = "environment-variables";
 
+    static final String SEARCH_HANDLER_CLASS = com.yahoo.search.handler.SearchHandler.class.getName();
+    static final String SEARCH_HANDLER_BINDING = "http://*/search/*";
+
     public enum Networking { disable, enable }
 
     private ApplicationPackage app;
@@ -769,7 +772,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
         ProcessingHandler<SearchChains> searchHandler = new ProcessingHandler<>(cluster.getSearch().getChains(),
                                                                                 "com.yahoo.search.handler.SearchHandler");
-        String[] defaultBindings = {"http://*/search/*"};
+        String[] defaultBindings = {SEARCH_HANDLER_BINDING};
         for (String binding: serverBindings(searchElement, defaultBindings)) {
             searchHandler.addServerBindings(binding);
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -178,7 +178,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         DocumentFactoryBuilder.buildDocumentFactories(cluster, spec);
         addConfiguredComponents(deployState, cluster, spec);
         addSecretStore(cluster, spec);
-        addHandlers(deployState, cluster, spec);
 
         addRestApis(deployState, spec, cluster);
         addServlets(deployState, spec, cluster);
@@ -191,6 +190,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
         cluster.addDefaultHandlersExceptStatus();
         addStatusHandlers(cluster, context.getDeployState().isHosted());
+        addUserHandlers(deployState, cluster, spec);
 
         addHttp(deployState, spec, cluster, context.getApplicationType(), deployState.getProperties().applicationId().instance().isTester());
 
@@ -445,7 +445,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         containerSearch.setPageTemplates(PageTemplates.create(applicationPackage));
     }
 
-    private void addHandlers(DeployState deployState, ApplicationContainerCluster cluster, Element spec) {
+    private void addUserHandlers(DeployState deployState, ApplicationContainerCluster cluster, Element spec) {
         for (Element component: XML.getChildren(spec, "handler")) {
             cluster.addComponent(
                     new DomHandlerBuilder(cluster).build(deployState, cluster, component));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -290,7 +290,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private void addClientProviders(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {
         for (Element clientSpec: XML.getChildren(spec, "client")) {
-            cluster.addComponent(new DomClientProviderBuilder().build(deployState, cluster, clientSpec));
+            cluster.addComponent(new DomClientProviderBuilder(cluster).build(deployState, cluster, clientSpec));
         }
     }
 
@@ -448,7 +448,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private void addHandlers(DeployState deployState, ApplicationContainerCluster cluster, Element spec) {
         for (Element component: XML.getChildren(spec, "handler")) {
             cluster.addComponent(
-                    new DomHandlerBuilder().build(deployState, cluster, component));
+                    new DomHandlerBuilder(cluster).build(deployState, cluster, component));
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -66,6 +66,7 @@ import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static com.yahoo.test.LinePatternMatcher.containsLineWithPattern;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import static com.yahoo.vespa.model.container.ContainerCluster.ROOT_HANDLER_BINDING;
+import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_1;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -252,6 +253,23 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         // .. but it has no bindings
         var discBindingsConfig = root.getConfig(JdiscBindingsConfig.class, "default");
         assertThat(discBindingsConfig.handlers(BindingsOverviewHandler.class.getName()), is(nullValue()));
+    }
+
+    @Test
+    public void reserved_binding_cannot_be_stolen_by_user_configured_handler() {
+        Element clusterElem = DomBuilderTest.parse(
+                "<container id='default' version='1.0'>" +
+                        "  <handler id='userHandler'>" +
+                        "    <binding>" + STATE_HANDLER_BINDING_1 + "</binding>" +
+                        "  </handler>" +
+                        "</container>");
+        try {
+            createModel(root, clusterElem);
+            fail("Expected exception when stealing a reserved binding.");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("Binding 'http://*/state/v1' is a reserved Vespa binding " +
+                                                  "and cannot be used by handler: userHandler"));
+        }
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -47,7 +47,6 @@ import com.yahoo.vespa.model.container.http.ConnectorFactory;
 import com.yahoo.vespa.model.content.utils.ContentClusterUtils;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -66,8 +65,10 @@ import java.util.stream.Collectors;
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static com.yahoo.test.LinePatternMatcher.containsLineWithPattern;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
+import static com.yahoo.vespa.model.container.ContainerCluster.ROOT_HANDLER_BINDING;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -235,17 +236,22 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     }
 
     @Test
-    public void default_root_handler_is_disabled_when_user_adds_a_handler_with_same_binding() {
+    public void default_root_handler_binding_can_be_stolen_by_user_configured_handler() {
         Element clusterElem = DomBuilderTest.parse(
                 "<container id='default' version='1.0'>" +
                         "  <handler id='userRootHandler'>" +
-                        "    <binding>" + ContainerCluster.ROOT_HANDLER_BINDING + "</binding>" +
+                        "    <binding>" + ROOT_HANDLER_BINDING + "</binding>" +
                         "  </handler>" +
                         "</container>");
         createModel(root, clusterElem);
 
+        // The handler is still set up.
         ComponentsConfig.Components userRootHandler = getComponent(componentsConfig(), BindingsOverviewHandler.class.getName());
-        assertThat(userRootHandler, nullValue());
+        assertThat(userRootHandler, notNullValue());
+
+        // .. but it has no bindings
+        var discBindingsConfig = root.getConfig(JdiscBindingsConfig.class, "default");
+        assertThat(discBindingsConfig.handlers(BindingsOverviewHandler.class.getName()), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Should status.html also be protected from stealing?

I didn't add an `isHosted` check before throwing when a reserved binding is used. If you try to steal a binding today, the built-in handler wins, but deployment does not fail. 
