### PR TITLE
allow arbitrarily large radius 

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/Location.java
+++ b/container-search/src/main/java/com/yahoo/prelude/Location.java
@@ -126,8 +126,8 @@ public class Location {
         if (ns < -90.1 || ns > +90.1) {
             throw new IllegalArgumentException("n/s location must be in range [-90,+90]");
         }
-        if (radius_in_degrees < 0 || radius_in_degrees > 180.0) {
-            throw new IllegalArgumentException("radius must be in range [0,180] degrees, approximately upto 20000km");
+        if (radius_in_degrees < 0) {
+            pr = 512 * 1024 * 1024;
         }
         x = px;
         y = py;

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/PosSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/PosSearcher.java
@@ -147,7 +147,9 @@ public class PosSearcher extends Searcher {
         String radius = query.properties().getString(posRadius);
         int radiusUnits;
         if (radius == null) {
-            radiusUnits = 5000;
+            double radiuskm = 50.0;
+            double radiusdegrees = radiuskm * km2deg;
+            radiusUnits = (int)(radiusdegrees * 1000000);
         } else if (radius.endsWith("km")) {
             double radiuskm = Double.valueOf(radius.substring(0, radius.length()-2));
             double radiusdegrees = radiuskm * km2deg;

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/PosSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/PosSearcherTestCase.java
@@ -118,6 +118,12 @@ public class PosSearcherTestCase {
         q.properties().set("pos.units", "udeg");
         doSearch(searcher, q, 0, 10);
         assertEquals("(2,0,0,18026,0,1,0,4294967295)", q.getRanking().getLocation().toString());
+
+        q = new Query();
+        q.properties().set("pos.ll", "N0;E0");
+        q.properties().set("pos.radius", "-1");
+        doSearch(searcher, q, 0, 10);
+        assertEquals("(2,0,0,536870912,0,1,0,4294967295)", q.getRanking().getLocation().toString());
     }
 
     /**
@@ -128,13 +134,13 @@ public class PosSearcherTestCase {
         Query q = new Query();
         q.properties().set("pos.xy", "22500;22500");
         doSearch(searcher, q, 0, 10);
-        assertEquals("(2,22500,22500,5000,0,1,0)", q.getRanking().getLocation().toString());
+        assertEquals("(2,22500,22500,450668,0,1,0)", q.getRanking().getLocation().toString());
 
         q = new Query();
         q.properties().set("pos.xy", "22500;22500");
         q.properties().set("pos.units", "unknown");
         doSearch(searcher, q, 0, 10);
-        assertEquals("(2,22500,22500,5000,0,1,0)", q.getRanking().getLocation().toString());
+        assertEquals("(2,22500,22500,450668,0,1,0)", q.getRanking().getLocation().toString());
     }
 
     @Test


### PR DESCRIPTION
* also, take negative radius to mean "infinitely" large
* also, fix default for pos.xy case to be same as pos.ll case.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

partial workaround for
https://github.com/vespa-engine/vespa/issues/12567
@bratseth please review

