### PR TITLE
use label marker for distance and closeness features

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -134,6 +134,7 @@ vespa_define_module(
     src/tests/features/item_raw_score
     src/tests/features/max_reduce_prod_join_replacer
     src/tests/features/native_dot_product
+    src/tests/features/nns_closeness
     src/tests/features/nns_distance
     src/tests/features/ranking_expression
     src/tests/features/raw_score

--- a/searchlib/src/tests/features/item_raw_score/item_raw_score_test.cpp
+++ b/searchlib/src/tests/features/item_raw_score/item_raw_score_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/indexenvironmentbuilder.h>
 #include <vespa/searchlib/fef/test/queryenvironment.h>
+#include <vespa/searchlib/fef/test/labels.h>
 #include <vespa/searchlib/features/item_raw_score_feature.h>
 #include <vespa/searchlib/fef/fef.h>
 #include <vespa/searchlib/fef/test/dummy_dependency_handler.h>
@@ -42,26 +43,6 @@ struct FeatureDumpFixture : public IDumpFeatureVisitor {
         TEST_ERROR("no features should be dumped");
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}
-};
-
-struct Labels {
-    virtual void inject(Properties &p) const = 0;
-    virtual ~Labels() {}
-};
-struct NoLabel : public Labels {
-    virtual void inject(Properties &) const override {}    
-};
-struct SingleLabel : public Labels {
-    vespalib::string label;
-    uint32_t uid;
-    SingleLabel(const vespalib::string &l, uint32_t x) : label(l), uid(x) {}
-    virtual void inject(Properties &p) const override {
-        vespalib::asciistream key;
-        key << "vespa.label." << label << ".id";
-        vespalib::asciistream value;
-        value << uid;
-        p.add(key.str(), value.str());
-    }
 };
 
 struct RankFixture : BlueprintFactoryFixture, IndexFixture {

--- a/searchlib/src/tests/features/nns_closeness/CMakeLists.txt
+++ b/searchlib/src/tests/features/nns_closeness/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+vespa_add_executable(searchlib_nns_closeness_test_app TEST
+    SOURCES
+    nns_closeness_test.cpp
+    DEPENDS
+    searchlib
+)
+vespa_add_test(NAME searchlib_nns_closeness_test_app COMMAND searchlib_nns_closeness_test_app)

--- a/searchlib/src/tests/features/nns_closeness/nns_closeness_test.cpp
+++ b/searchlib/src/tests/features/nns_closeness/nns_closeness_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/indexenvironmentbuilder.h>
 #include <vespa/searchlib/fef/test/queryenvironment.h>
+#include <vespa/searchlib/fef/test/labels.h>
 #include <vespa/searchlib/features/closenessfeature.h>
 #include <vespa/searchlib/fef/fef.h>
 #include <vespa/searchlib/fef/test/dummy_dependency_handler.h>
@@ -44,26 +45,6 @@ struct FeatureDumpFixture : public IDumpFeatureVisitor {
         TEST_ERROR("no features should be dumped");
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}
-};
-
-struct Labels {
-    virtual void inject(Properties &p) const = 0;
-    virtual ~Labels() {}
-};
-struct NoLabel : public Labels {
-    virtual void inject(Properties &) const override {}    
-};
-struct SingleLabel : public Labels {
-    vespalib::string label;
-    uint32_t uid;
-    SingleLabel(const vespalib::string &l, uint32_t x) : label(l), uid(x) {}
-    virtual void inject(Properties &p) const override {
-        vespalib::asciistream key;
-        key << "vespa.label." << label << ".id";
-        vespalib::asciistream value;
-        value << uid;
-        p.add(key.str(), value.str());
-    }
 };
 
 struct RankFixture : BlueprintFactoryFixture, IndexFixture {

--- a/searchlib/src/tests/features/nns_closeness/nns_closeness_test.cpp
+++ b/searchlib/src/tests/features/nns_closeness/nns_closeness_test.cpp
@@ -5,7 +5,7 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/indexenvironmentbuilder.h>
 #include <vespa/searchlib/fef/test/queryenvironment.h>
-#include <vespa/searchlib/features/distancefeature.h>
+#include <vespa/searchlib/features/closenessfeature.h>
 #include <vespa/searchlib/fef/fef.h>
 #include <vespa/searchlib/fef/test/dummy_dependency_handler.h>
 #include <vespa/vespalib/stllike/asciistream.h>
@@ -18,8 +18,8 @@ using namespace search::features;
 using CollectionType = FieldInfo::CollectionType;
 using DataType = FieldInfo::DataType;
 
-const vespalib::string labelFeatureName("distance(label,label)");
-const vespalib::string fieldFeatureName("distance(bar)");
+const vespalib::string labelFeatureName("closeness(label,nns)");
+const vespalib::string fieldFeatureName("closeness(bar)");
 
 struct BlueprintFactoryFixture {
     BlueprintFactory factory;
@@ -119,51 +119,45 @@ struct RankFixture : BlueprintFactoryFixture, IndexFixture {
 };
 
 TEST_F("require that blueprint can be created from factory", BlueprintFactoryFixture) {
-    Blueprint::SP bp = f.factory.createBlueprint("distance");
+    Blueprint::SP bp = f.factory.createBlueprint("closeness");
     EXPECT_TRUE(bp.get() != 0);
-    EXPECT_TRUE(dynamic_cast<DistanceBlueprint*>(bp.get()) != 0);
+    EXPECT_TRUE(dynamic_cast<ClosenessBlueprint*>(bp.get()) != 0);
 }
 
-TEST_FFF("require that no features are dumped", DistanceBlueprint, IndexFixture, FeatureDumpFixture) {
+TEST_FFF("require that no features are dumped", ClosenessBlueprint, IndexFixture, FeatureDumpFixture) {
     f1.visitDumpFeatures(f2.indexEnv, f3);
 }
 
-TEST_FF("require that setup can be done on random label", DistanceBlueprint, IndexFixture) {
+TEST_FF("require that setup can be done on random label", ClosenessBlueprint, IndexFixture) {
     DummyDependencyHandler deps(f1);
     f1.setName(vespalib::make_string("%s(label,random_label)", f1.getBaseName().c_str()));
     EXPECT_TRUE(static_cast<Blueprint&>(f1).setup(f2.indexEnv, std::vector<vespalib::string>{"label", "random_label"}));
 }
 
-TEST_FF("require that setup with unknown field fails", DistanceBlueprint, IndexFixture) {
-    DummyDependencyHandler deps(f1);
-    f1.setName(vespalib::make_string("%s(field,random_fieldname)", f1.getBaseName().c_str()));
-    EXPECT_FALSE(static_cast<Blueprint&>(f1).setup(f2.indexEnv, std::vector<vespalib::string>{"field", "random_fieldname"}));
+TEST_FF("require that no label gives 0 closeness", NoLabel(), RankFixture(2, 2, f1, labelFeatureName)) {
+    EXPECT_EQUAL(0.0, f2.getScore(10));
 }
 
-TEST_FF("require that no label gives max-double distance", NoLabel(), RankFixture(2, 2, f1, labelFeatureName)) {
-    EXPECT_EQUAL(std::numeric_limits<feature_t>::max(), f2.getScore(10));
+TEST_FF("require that unrelated label gives 0 closeness", SingleLabel("unrelated", 1), RankFixture(2, 2, f1, labelFeatureName)) {
+    EXPECT_EQUAL(0.0, f2.getScore(10));
 }
 
-TEST_FF("require that unrelated label gives max-double distance", SingleLabel("unrelated", 1), RankFixture(2, 2, f1, labelFeatureName)) {
-    EXPECT_EQUAL(std::numeric_limits<feature_t>::max(), f2.getScore(10));
-}
-
-TEST_FF("require that labeled item raw score can be obtained", SingleLabel("label", 1), RankFixture(2, 2, f1, labelFeatureName)) {
+TEST_FF("require that labeled item raw score can be obtained", SingleLabel("nns", 1), RankFixture(2, 2, f1, labelFeatureName)) {
     f2.setFooScore(0, 10, 5.0);
-    EXPECT_EQUAL(5.0, f2.getScore(10));
+    EXPECT_EQUAL(1/(1+5.0), f2.getScore(10));
 }
 
 TEST_FF("require that field raw score can be obtained", NoLabel(), RankFixture(2, 2, f1, fieldFeatureName)) {
     f2.setBarScore(0, 10, 5.0);
-    EXPECT_EQUAL(5.0, f2.getScore(10));
+    EXPECT_EQUAL(1/(1+5.0), f2.getScore(10));
 }
 
-TEST_FF("require that other raw scores are ignored", SingleLabel("label", 2), RankFixture(2, 2, f1, labelFeatureName)) {
+TEST_FF("require that other raw scores are ignored", SingleLabel("nns", 2), RankFixture(2, 2, f1, labelFeatureName)) {
     f2.setFooScore(0, 10, 1.0);
     f2.setFooScore(1, 10, 2.0);
     f2.setBarScore(0, 10, 5.0);
     f2.setBarScore(1, 10, 6.0);
-    EXPECT_EQUAL(2.0, f2.getScore(10));
+    EXPECT_EQUAL(1/(1+2.0), f2.getScore(10));
 }
 
 TEST_FF("require that the correct raw score is used", NoLabel(), RankFixture(2, 2, f1, fieldFeatureName)) {
@@ -171,13 +165,13 @@ TEST_FF("require that the correct raw score is used", NoLabel(), RankFixture(2, 
     f2.setFooScore(1, 10, 4.0);
     f2.setBarScore(0, 10, 8.0);
     f2.setBarScore(1, 10, 7.0);
-    EXPECT_EQUAL(7.0, f2.getScore(10));
+    EXPECT_EQUAL(1/(1+7.0), f2.getScore(10));
 }
 
-TEST_FF("require that stale data is ignored", SingleLabel("label", 2), RankFixture(2, 2, f1, labelFeatureName)) {
+TEST_FF("require that stale data is ignored", SingleLabel("nns", 2), RankFixture(2, 2, f1, labelFeatureName)) {
     f2.setFooScore(0, 10, 1.0);
     f2.setFooScore(1, 5, 2.0);
-    EXPECT_EQUAL(std::numeric_limits<feature_t>::max(), f2.getScore(10));
+    EXPECT_EQUAL(0, f2.getScore(10));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/features/nns_distance/nns_distance_test.cpp
+++ b/searchlib/src/tests/features/nns_distance/nns_distance_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/indexenvironmentbuilder.h>
 #include <vespa/searchlib/fef/test/queryenvironment.h>
+#include <vespa/searchlib/fef/test/labels.h>
 #include <vespa/searchlib/features/distancefeature.h>
 #include <vespa/searchlib/fef/fef.h>
 #include <vespa/searchlib/fef/test/dummy_dependency_handler.h>
@@ -44,26 +45,6 @@ struct FeatureDumpFixture : public IDumpFeatureVisitor {
         TEST_ERROR("no features should be dumped");
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}
-};
-
-struct Labels {
-    virtual void inject(Properties &p) const = 0;
-    virtual ~Labels() {}
-};
-struct NoLabel : public Labels {
-    virtual void inject(Properties &) const override {}    
-};
-struct SingleLabel : public Labels {
-    vespalib::string label;
-    uint32_t uid;
-    SingleLabel(const vespalib::string &l, uint32_t x) : label(l), uid(x) {}
-    virtual void inject(Properties &p) const override {
-        vespalib::asciistream key;
-        key << "vespa.label." << label << ".id";
-        vespalib::asciistream value;
-        value << uid;
-        p.add(key.str(), value.str());
-    }
 };
 
 struct RankFixture : BlueprintFactoryFixture, IndexFixture {

--- a/searchlib/src/tests/features/prod_features.cpp
+++ b/searchlib/src/tests/features/prod_features.cpp
@@ -479,6 +479,8 @@ Test::testCloseness()
         assertCloseness(0,   "pos", 9013306);
         // use non-existing attribute -> default distance
         TEST_DO(assertCloseness(0, "no", 0));
+        // two-argument version
+        TEST_DO(assertCloseness(0.8, "field,pos", 1802661));
 
         // use non-default maxDistance
         assertCloseness(1,   "pos", 0,   100);
@@ -857,11 +859,11 @@ Test::testDistance()
                 ASSERT_TRUE(ft.setup());
                 ASSERT_TRUE(ft.execute(RankResult().addScore("distance(pos)", 6400000000.0)));
             }
-            { // non-existing field
-                FtFeatureTest ft(_factory, "distance(pos)");
+            { // label
+                FtFeatureTest ft(_factory, "distance(label,foo)");
                 ft.getQueryEnv().getLocation().setValid(true);
                 ASSERT_TRUE(ft.setup());
-                ASSERT_TRUE(ft.execute(RankResult().addScore("distance(pos)", std::numeric_limits<feature_t>::max())));
+                ASSERT_TRUE(ft.execute(RankResult().addScore("distance(label,foo)", std::numeric_limits<feature_t>::max())));
             }
             { // wrong attribute type (float)
                 FtFeatureTest ft(_factory, "distance(pos)");

--- a/searchlib/src/vespa/searchlib/features/closenessfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/closenessfeature.cpp
@@ -2,6 +2,7 @@
 
 #include "closenessfeature.h"
 #include "utils.h"
+#include <vespa/searchcommon/common/schema.h>
 #include <vespa/searchlib/fef/properties.h>
 #include <vespa/vespalib/util/stash.h>
 
@@ -11,6 +12,66 @@ LOG_SETUP(".features.closenessfeature");
 using namespace search::fef;
 
 namespace search::features {
+
+/** Implements the executor for converting NNS rawscore to a closeness feature. */
+class ConvertRawScoreToCloseness : public fef::FeatureExecutor {
+private:
+    std::vector<fef::TermFieldHandle> _handles;
+    const fef::MatchData             *_md;
+    void handle_bind_match_data(const fef::MatchData &md) override {
+        _md = &md;
+    }
+public:
+    ConvertRawScoreToCloseness(const fef::IQueryEnvironment &env, uint32_t fieldId);
+    ConvertRawScoreToCloseness(const fef::IQueryEnvironment &env, const vespalib::string &label);
+    void execute(uint32_t docId) override;
+};
+
+ConvertRawScoreToCloseness::ConvertRawScoreToCloseness(const fef::IQueryEnvironment &env, uint32_t fieldId)
+  : _handles(),
+    _md(nullptr)
+{
+    _handles.reserve(env.getNumTerms());
+    for (uint32_t i = 0; i < env.getNumTerms(); ++i) {
+        search::fef::TermFieldHandle handle = util::getTermFieldHandle(env, i, fieldId);
+        if (handle != search::fef::IllegalHandle) {
+            _handles.push_back(handle);
+        }
+    }
+}
+
+ConvertRawScoreToCloseness::ConvertRawScoreToCloseness(const fef::IQueryEnvironment &env, const vespalib::string &label)
+  : _handles(),
+    _md(nullptr)
+{
+    const ITermData *term = util::getTermByLabel(env, label);
+    if (term != nullptr) {
+        // expect numFields() == 1
+        for (uint32_t i = 0; i < term->numFields(); ++i) {
+            TermFieldHandle handle = term->field(i).getHandle();
+            if (handle != IllegalHandle) {
+                _handles.push_back(handle);
+            }
+        }
+    }
+}
+
+void
+ConvertRawScoreToCloseness::execute(uint32_t docId)
+{
+    feature_t max_closeness = 0.0;
+    assert(_md);
+    for (auto handle : _handles) {
+        const TermFieldMatchData *tfmd = _md->resolveTermField(handle);
+        if (tfmd->getDocId() == docId) {
+            // remove conversion to "closeness" RawScore later:
+            feature_t converted =  1.0 / (1.0 + tfmd->getRawScore());
+            max_closeness = std::max(max_closeness, converted);
+        }
+    }
+    outputs().set_number(0, max_closeness);
+}
+
 
 ClosenessExecutor::ClosenessExecutor(feature_t maxDistance, feature_t scaleDistance) :
     FeatureExecutor(),
@@ -38,7 +99,12 @@ ClosenessBlueprint::ClosenessBlueprint() :
     Blueprint("closeness"),
     _maxDistance(9013305.0),     // default value (about 250 km)
     _scaleDistance(5.0*9013.305), // default value (about 5 km)
-    _halfResponse(1)
+    _halfResponse(1),
+    _arg_string(),
+    _attr_id(search::index::Schema::UNKNOWN_FIELD_ID),
+    _use_geo_pos(false),
+    _use_nns_tensor(false),
+    _use_item_label(false)
 {
 }
 
@@ -53,6 +119,38 @@ ClosenessBlueprint::setup(const IIndexEnvironment & env,
                           const search::fef::ParameterList & params)
 {
     // params[0] = attribute name
+    vespalib::string arg = params[0].getValue();
+    if (params.size() == 2) {
+        // params[0] = field / label
+        // params[0] = attribute name / label value
+        if (arg == "label") {
+            _arg_string = params[1].getValue();
+            _use_item_label = true;
+            describeOutput("out", "The closeness from the labeled query item.");
+            return true;
+        } else if (arg == "field") {
+            arg = params[1].getValue();
+            // sanity checking happens in distance feature
+        } else {
+            LOG(error, "first argument must be 'field' or 'label', but was '%s'",
+                arg.c_str());
+            return false;
+        }
+    }
+    const FieldInfo *fi = env.getFieldByName(arg);
+    if (fi != nullptr && fi->hasAttribute()) {
+        auto dt = fi->get_data_type();
+        auto ct = fi->collection();
+        if (dt == search::index::schema::DataType::TENSOR &&
+            ct == search::index::schema::CollectionType::SINGLE)
+        {
+            _arg_string = arg;
+            _use_nns_tensor = true;
+            _attr_id = fi->id();
+            describeOutput("out", "The closeness for the given tensor field.");
+            return true;
+        }
+    }
     Property p = env.getProperties().lookup(getName(), "maxDistance");
     if (p.found()) {
         _maxDistance = util::strToNum<feature_t>(p.get());
@@ -85,8 +183,12 @@ ClosenessBlueprint::setup(const IIndexEnvironment & env,
         _scaleDistance = LogarithmCalculator::getScale(_halfResponse, _maxDistance);
     }
 
-
-    defineInput("distance(" + params[0].getValue() + ")");
+    _use_geo_pos = true;
+    if (params.size() == 2) {
+        defineInput("distance(field," + arg + ")");
+    } else {
+        defineInput("distance(" + arg + ")");
+    }
     describeOutput("out", "The closeness of the document (linear)");
     describeOutput("logscale", "The closeness of the document (logarithmic shape)");
 
@@ -100,8 +202,15 @@ ClosenessBlueprint::createInstance() const
 }
 
 FeatureExecutor &
-ClosenessBlueprint::createExecutor(const IQueryEnvironment &, vespalib::Stash &stash) const
+ClosenessBlueprint::createExecutor(const IQueryEnvironment &env, vespalib::Stash &stash) const
 {
+    if (_use_item_label) {
+        return stash.create<ConvertRawScoreToCloseness>(env, _arg_string);
+    }
+    if (_use_nns_tensor) {
+        return stash.create<ConvertRawScoreToCloseness>(env, _attr_id);
+    }
+    assert(_use_geo_pos);
     return stash.create<ClosenessExecutor>(_maxDistance, _scaleDistance);
 }
 

--- a/searchlib/src/vespa/searchlib/features/closenessfeature.h
+++ b/searchlib/src/vespa/searchlib/features/closenessfeature.h
@@ -29,6 +29,11 @@ private:
     feature_t _maxDistance;
     feature_t _scaleDistance;
     feature_t _halfResponse;
+    vespalib::string _arg_string;
+    uint32_t _attr_id;
+    bool _use_geo_pos;
+    bool _use_nns_tensor;
+    bool _use_item_label;
 
 public:
 
@@ -36,7 +41,7 @@ public:
     void visitDumpFeatures(const fef::IIndexEnvironment & env, fef::IDumpFeatureVisitor & visitor) const override;
     fef::Blueprint::UP createInstance() const override;
     fef::ParameterDescriptions getDescriptions() const override {
-        return fef::ParameterDescriptions().desc().string();
+        return fef::ParameterDescriptions().desc().string().desc().string().string();
     }
     bool setup(const fef::IIndexEnvironment & env, const fef::ParameterList & params) override;
     fef::FeatureExecutor &createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const override;

--- a/searchlib/src/vespa/searchlib/features/distancefeature.h
+++ b/searchlib/src/vespa/searchlib/features/distancefeature.h
@@ -52,7 +52,7 @@ public:
     void visitDumpFeatures(const fef::IIndexEnvironment & env, fef::IDumpFeatureVisitor & visitor) const override;
     fef::Blueprint::UP createInstance() const override;
     fef::ParameterDescriptions getDescriptions() const override {
-        return fef::ParameterDescriptions().desc().string();
+        return fef::ParameterDescriptions().desc().string().desc().string().string();
     }
     bool setup(const fef::IIndexEnvironment & env, const fef::ParameterList & params) override;
     fef::FeatureExecutor &createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const override;

--- a/searchlib/src/vespa/searchlib/fef/test/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/fef/test/CMakeLists.txt
@@ -7,6 +7,7 @@ vespa_add_library(searchlib_fef_test OBJECT
     ftlib.cpp
     indexenvironment.cpp
     indexenvironmentbuilder.cpp
+    labels.cpp
     matchdatabuilder.cpp
     mock_attribute_context.cpp
     queryenvironment.cpp

--- a/searchlib/src/vespa/searchlib/fef/test/labels.cpp
+++ b/searchlib/src/vespa/searchlib/fef/test/labels.cpp
@@ -1,0 +1,3 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "labels.h"

--- a/searchlib/src/vespa/searchlib/fef/test/labels.h
+++ b/searchlib/src/vespa/searchlib/fef/test/labels.h
@@ -1,0 +1,28 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchlib/fef/properties.h>
+#include <vespa/vespalib/stllike/asciistream.h>
+
+namespace search::fef::test {
+
+struct Labels {
+    virtual void inject(Properties &p) const = 0;
+    virtual ~Labels() {}
+};
+struct NoLabel : public Labels {
+    virtual void inject(Properties &) const override {}    
+};
+struct SingleLabel : public Labels {
+    vespalib::string label;
+    uint32_t uid;
+    SingleLabel(const vespalib::string &l, uint32_t x) : label(l), uid(x) {}
+    virtual void inject(Properties &p) const override {
+        vespalib::asciistream key;
+        key << "vespa.label." << label << ".id";
+        vespalib::asciistream value;
+        value << uid;
+        p.add(key.str(), value.str());
+    }
+};
+
+}


### PR DESCRIPTION
* distance feature now has a two arguments version, allowing
  the user to explicitly specify label or field
* extend closeness feature the same ways as distance feature
* add unit test for NNS closeness

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

as discussed earlier today.
@geirst please review
@havardpe FYI
system test must be updated when merging this, i have the changes ready and will make PR.
