### PR TITLE
Account for stripe index when performing a multi-lock

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -207,8 +207,12 @@ public:
             // and the stripe an operation ends up on.
             return bucket.getBucketId().getId() * 1099511628211ULL;
         }
+        // We make a fairly reasonable assumption that there will be less than 64k stripes.
+        uint16_t stripe_index(const document::Bucket& bucket) const noexcept {
+            return static_cast<uint16_t>(dispersed_bucket_bits(bucket) % _stripes.size());
+        }
         Stripe & stripe(const document::Bucket & bucket) {
-            return _stripes[dispersed_bucket_bits(bucket) % _stripes.size()];
+            return _stripes[stripe_index(bucket)];
         }
         std::vector<Stripe> & getStripes() { return _stripes; }
     private:


### PR DESCRIPTION
@baldersheim please review

Legacy locking code had a hidden assumption that each disk
had only a single queue associated with it and locking requests
could therefore be deduped at the disk level. Since we now
only have a single logical disk with a number of queues striped
over it, this would introduce race conditions when splits/joins
would cross stripe boundaries for their target/source buckets.

Use a composite disk/stripe multi lock key to ensure we only
dedupe locking requests at the stripe-level.

