### PR TITLE
Node spec constraints

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AddNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AddNode.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.node.admin.configserver.noderepository;
 
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.host.FlavorOverrides;
 
 import java.util.Objects;
@@ -20,30 +19,27 @@ public class AddNode {
     public final Optional<String> nodeFlavor;
     public final Optional<FlavorOverrides> flavorOverrides;
     public final Optional<NodeResources> nodeResources;
-    public final Optional<TenantName> reservedTo;
     public final NodeType nodeType;
     public final Set<String> ipAddresses;
     public final Set<String> additionalIpAddresses;
 
-    public static AddNode forHost(String hostname, String nodeFlavor, Optional<FlavorOverrides> flavorOverrides, Optional<TenantName> reservedTo, NodeType nodeType, Set<String> ipAddresses, Set<String> additionalIpAddresses) {
-        return new AddNode(hostname, Optional.empty(), Optional.of(nodeFlavor), flavorOverrides, Optional.empty(), reservedTo, nodeType, ipAddresses, additionalIpAddresses);
+    public static AddNode forHost(String hostname, String nodeFlavor, Optional<FlavorOverrides> flavorOverrides, NodeType nodeType, Set<String> ipAddresses, Set<String> additionalIpAddresses) {
+        return new AddNode(hostname, Optional.empty(), Optional.of(nodeFlavor), flavorOverrides, Optional.empty(), nodeType, ipAddresses, additionalIpAddresses);
     }
 
     public static AddNode forNode(String hostname, String parentHostname, NodeResources nodeResources, NodeType nodeType, Set<String> ipAddresses) {
-        return new AddNode(hostname, Optional.of(parentHostname), Optional.empty(), Optional.empty(), Optional.of(nodeResources), Optional.empty(), nodeType, ipAddresses, Set.of());
+        return new AddNode(hostname, Optional.of(parentHostname), Optional.empty(), Optional.empty(), Optional.of(nodeResources), nodeType, ipAddresses, Set.of());
     }
 
     private AddNode(String hostname, Optional<String> parentHostname,
                     Optional<String> nodeFlavor, Optional<FlavorOverrides> flavorOverrides,
                     Optional<NodeResources> nodeResources,
-                    Optional<TenantName> reservedTo,
                     NodeType nodeType, Set<String> ipAddresses, Set<String> additionalIpAddresses) {
         this.hostname = hostname;
         this.parentHostname = parentHostname;
         this.nodeFlavor = nodeFlavor;
         this.flavorOverrides = flavorOverrides;
         this.nodeResources = nodeResources;
-        this.reservedTo = reservedTo;
         this.nodeType = nodeType;
         this.ipAddresses = ipAddresses;
         this.additionalIpAddresses = additionalIpAddresses;
@@ -57,7 +53,6 @@ public class AddNode {
         return Objects.equals(hostname, addNode.hostname) &&
                 Objects.equals(parentHostname, addNode.parentHostname) &&
                 Objects.equals(nodeFlavor, addNode.nodeFlavor) &&
-                Objects.equals(reservedTo, addNode.reservedTo) &&
                 nodeType == addNode.nodeType &&
                 Objects.equals(ipAddresses, addNode.ipAddresses) &&
                 Objects.equals(additionalIpAddresses, addNode.additionalIpAddresses);
@@ -65,7 +60,7 @@ public class AddNode {
 
     @Override
     public int hashCode() {
-        return Objects.hash(hostname, parentHostname, nodeFlavor, reservedTo, nodeType, ipAddresses, additionalIpAddresses);
+        return Objects.hash(hostname, parentHostname, nodeFlavor, nodeType, ipAddresses, additionalIpAddresses);
     }
 
     @Override
@@ -74,7 +69,6 @@ public class AddNode {
                 "hostname='" + hostname + '\'' +
                 ", parentHostname=" + parentHostname +
                 ", nodeFlavor='" + nodeFlavor + '\'' +
-               (reservedTo.isPresent() ? ", reservedTo='" + reservedTo.get().value() + "'" : "") +
                 ", nodeType=" + nodeType +
                 ", ipAddresses=" + ipAddresses +
                 ", additionalIpAddresses=" + additionalIpAddresses +

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeAttributes.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeAttributes.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.node.admin.configserver.noderepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.DockerImage;
-import com.yahoo.config.provision.TenantName;
 
 import java.time.Instant;
 import java.util.Map;
@@ -29,8 +28,6 @@ public class NodeAttributes {
     private Optional<Version> vespaVersion = Optional.empty();
     private Optional<Version> currentOsVersion = Optional.empty();
     private Optional<Instant> currentFirmwareCheck = Optional.empty();
-    private Optional<Boolean> wantToDeprovision = Optional.empty();
-    private Optional<TenantName> reservedTo = Optional.empty();
     /** The list of reports to patch. A null value is used to remove the report. */
     private Map<String, JsonNode> reports = new TreeMap<>();
 
@@ -67,12 +64,6 @@ public class NodeAttributes {
 
     public NodeAttributes withCurrentFirmwareCheck(Instant currentFirmwareCheck) {
         this.currentFirmwareCheck = Optional.of(currentFirmwareCheck);
-        return this;
-    }
-
-
-    public NodeAttributes withWantToDeprovision(boolean wantToDeprovision) {
-        this.wantToDeprovision = Optional.of(wantToDeprovision);
         return this;
     }
 
@@ -115,22 +106,14 @@ public class NodeAttributes {
         return currentFirmwareCheck;
     }
 
-    public Optional<Boolean> getWantToDeprovision() {
-        return wantToDeprovision;
-    }
-
     public Map<String, JsonNode> getReports() {
         return reports;
-    }
-
-    public Optional<TenantName> getReservedTo() {
-        return reservedTo;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(restartGeneration, rebootGeneration, dockerImage, vespaVersion, currentOsVersion,
-                            currentFirmwareCheck, wantToDeprovision, reports, reservedTo);
+                            currentFirmwareCheck, reports);
     }
 
     public boolean isEmpty() {
@@ -150,9 +133,7 @@ public class NodeAttributes {
                 && Objects.equals(vespaVersion, other.vespaVersion)
                 && Objects.equals(currentOsVersion, other.currentOsVersion)
                 && Objects.equals(currentFirmwareCheck, other.currentFirmwareCheck)
-                && Objects.equals(reports, other.reports)
-                && Objects.equals(reservedTo, other.reservedTo)
-                && Objects.equals(wantToDeprovision, other.wantToDeprovision);
+                && Objects.equals(reports, other.reports);
     }
 
     @Override
@@ -164,9 +145,7 @@ public class NodeAttributes {
                         vespaVersion.map(ver -> "vespaVersion=" + ver.toFullString()),
                         currentOsVersion.map(ver -> "currentOsVersion=" + ver.toFullString()),
                         currentFirmwareCheck.map(at -> "currentFirmwareCheck=" + at),
-                        Optional.ofNullable(reports.isEmpty() ? null : "reports=" + reports),
-                        Optional.ofNullable(reservedTo.isEmpty() ? null : "reservedTo=" + reservedTo),
-                        wantToDeprovision.map(depr -> "wantToDeprovision=" + depr))
+                        Optional.ofNullable(reports.isEmpty() ? null : "reports=" + reports))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.joining(", ", "{", "}"));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -49,7 +49,6 @@ public class NodeSpec {
     private final Optional<String> modelName;
 
     private final Optional<Boolean> allowedToBeDown;
-    private final Optional<Boolean> wantToDeprovision;
     private final Optional<ApplicationId> owner;
     private final Optional<NodeMembership> membership;
 
@@ -74,7 +73,6 @@ public class NodeSpec {
             Optional<Version> wantedOsVersion,
             Optional<Version> currentOsVersion,
             Optional<Boolean> allowedToBeDown,
-            Optional<Boolean> wantToDeprovision,
             Optional<ApplicationId> owner,
             Optional<NodeMembership> membership,
             Optional<Long> wantedRestartGeneration,
@@ -111,7 +109,6 @@ public class NodeSpec {
         this.wantedOsVersion = Objects.requireNonNull(wantedOsVersion);
         this.currentOsVersion = Objects.requireNonNull(currentOsVersion);
         this.allowedToBeDown = Objects.requireNonNull(allowedToBeDown);
-        this.wantToDeprovision = Objects.requireNonNull(wantToDeprovision);
         this.owner = Objects.requireNonNull(owner);
         this.membership = Objects.requireNonNull(membership);
         this.wantedRestartGeneration = wantedRestartGeneration;
@@ -203,10 +200,6 @@ public class NodeSpec {
         return allowedToBeDown;
     }
 
-    public Optional<Boolean> wantToDeprovision() {
-        return wantToDeprovision;
-    }
-
     public Optional<ApplicationId> owner() {
         return owner;
     }
@@ -272,7 +265,6 @@ public class NodeSpec {
                 Objects.equals(wantedOsVersion, that.wantedOsVersion) &&
                 Objects.equals(currentOsVersion, that.currentOsVersion) &&
                 Objects.equals(allowedToBeDown, that.allowedToBeDown) &&
-                Objects.equals(wantToDeprovision, that.wantToDeprovision) &&
                 Objects.equals(owner, that.owner) &&
                 Objects.equals(membership, that.membership) &&
                 Objects.equals(wantedRestartGeneration, that.wantedRestartGeneration) &&
@@ -303,7 +295,6 @@ public class NodeSpec {
                 wantedOsVersion,
                 currentOsVersion,
                 allowedToBeDown,
-                wantToDeprovision,
                 owner,
                 membership,
                 wantedRestartGeneration,
@@ -334,7 +325,6 @@ public class NodeSpec {
                 + " wantedOsVersion=" + wantedOsVersion
                 + " currentOsVersion=" + currentOsVersion
                 + " allowedToBeDown=" + allowedToBeDown
-                + " wantToDeprovision=" + wantToDeprovision
                 + " owner=" + owner
                 + " membership=" + membership
                 + " wantedRestartGeneration=" + wantedRestartGeneration
@@ -364,7 +354,6 @@ public class NodeSpec {
         private Optional<Version> wantedOsVersion = Optional.empty();
         private Optional<Version> currentOsVersion = Optional.empty();
         private Optional<Boolean> allowedToBeDown = Optional.empty();
-        private Optional<Boolean> wantToDeprovision = Optional.empty();
         private Optional<ApplicationId> owner = Optional.empty();
         private Optional<NodeMembership> membership = Optional.empty();
         private Optional<Long> wantedRestartGeneration = Optional.empty();
@@ -401,7 +390,6 @@ public class NodeSpec {
             node.wantedOsVersion.ifPresent(this::wantedOsVersion);
             node.currentOsVersion.ifPresent(this::currentOsVersion);
             node.allowedToBeDown.ifPresent(this::allowedToBeDown);
-            node.wantToDeprovision.ifPresent(this::wantToDeprovision);
             node.owner.ifPresent(this::owner);
             node.membership.ifPresent(this::membership);
             node.wantedRestartGeneration.ifPresent(this::wantedRestartGeneration);
@@ -468,11 +456,6 @@ public class NodeSpec {
 
         public Builder allowedToBeDown(boolean allowedToBeDown) {
             this.allowedToBeDown = Optional.of(allowedToBeDown);
-            return this;
-        }
-
-        public Builder wantToDeprovision(boolean wantToDeprovision) {
-            this.wantToDeprovision = Optional.of(wantToDeprovision);
             return this;
         }
 
@@ -576,7 +559,6 @@ public class NodeSpec {
             attributes.getCurrentOsVersion().ifPresent(this::currentOsVersion);
             attributes.getRebootGeneration().ifPresent(this::currentRebootGeneration);
             attributes.getRestartGeneration().ifPresent(this::currentRestartGeneration);
-            attributes.getWantToDeprovision().ifPresent(this::wantToDeprovision);
             NodeReports.fromMap(attributes.getReports());
 
             return this;
@@ -626,10 +608,6 @@ public class NodeSpec {
             return allowedToBeDown;
         }
 
-        public Optional<Boolean> wantToDeprovision() {
-            return wantToDeprovision;
-        }
-
         public Optional<ApplicationId> owner() {
             return owner;
         }
@@ -676,7 +654,7 @@ public class NodeSpec {
 
         public NodeSpec build() {
             return new NodeSpec(hostname, wantedDockerImage, currentDockerImage, state, type, flavor, cpuCores,
-                    wantedVespaVersion, currentVespaVersion, wantedOsVersion, currentOsVersion, allowedToBeDown, wantToDeprovision,
+                    wantedVespaVersion, currentVespaVersion, wantedOsVersion, currentOsVersion, allowedToBeDown,
                     owner, membership,
                     wantedRestartGeneration, currentRestartGeneration,
                     wantedRebootGeneration, currentRebootGeneration,

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -682,5 +683,34 @@ public class NodeSpec {
                     reports, parentHostname);
         }
 
+
+        public static Builder testSpec(String hostname) {
+            return testSpec(hostname, NodeState.active);
+        }
+
+        /**
+         * Creates a NodeSpec.Builder that has the given hostname, in a given state, and some
+         * reasonable values for the remaining required NodeSpec fields.
+         */
+        public static Builder testSpec(String hostname, NodeState state) {
+            Builder builder = new Builder()
+                    .hostname(hostname)
+                    .state(state)
+                    .type(NodeType.tenant)
+                    .flavor("d-2-8-50")
+                    .resources(new NodeResources(2, 8, 50, 10));
+
+            // Set the required allocated fields
+            if (EnumSet.of(NodeState.active, NodeState.inactive, NodeState.reserved).contains(state)) {
+                builder .owner(ApplicationId.defaultId())
+                        .membership(new NodeMembership("container", "my-id", "group", 0, false))
+                        .wantedVespaVersion(Version.fromString("7.1.1"))
+                        .wantedDockerImage(DockerImage.fromString("docker.domain.tld/repo/image:7.1.1"))
+                        .currentRestartGeneration(0)
+                        .wantedRestartGeneration(0);
+            }
+
+            return builder;
+        }
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -90,10 +90,12 @@ public class NodeSpec {
             NodeReports reports,
             Optional<String> parentHostname) {
         if (state == NodeState.active) {
-            Objects.requireNonNull(wantedVespaVersion, "Unknown vespa version for active node");
-            Objects.requireNonNull(wantedDockerImage, "Unknown docker image for active node");
-            Objects.requireNonNull(wantedRestartGeneration, "Unknown restartGeneration for active node");
-            Objects.requireNonNull(currentRestartGeneration, "Unknown currentRestartGeneration for active node");
+            requireOptional(owner, "owner");
+            requireOptional(membership, "membership");
+            requireOptional(wantedVespaVersion, "wantedVespaVersion");
+            requireOptional(wantedDockerImage, "wantedDockerImage");
+            requireOptional(wantedRestartGeneration, "restartGeneration");
+            requireOptional(currentRestartGeneration, "currentRestartGeneration");
         }
 
         this.hostname = Objects.requireNonNull(hostname);
@@ -712,5 +714,10 @@ public class NodeSpec {
 
             return builder;
         }
+    }
+
+    private static void requireOptional(Optional<?> optional, String name) {
+        if (optional == null || optional.isEmpty())
+            throw new IllegalArgumentException(name + " must be set, was " + optional);
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -8,7 +8,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.host.FlavorOverrides;
 import com.yahoo.vespa.hosted.node.admin.configserver.ConfigServerApi;
 import com.yahoo.vespa.hosted.node.admin.configserver.HttpException;
@@ -164,7 +163,6 @@ public class RealNodeRepository implements NodeRepository {
                 Optional.ofNullable(node.wantedOsVersion).map(Version::fromString),
                 Optional.ofNullable(node.currentOsVersion).map(Version::fromString),
                 Optional.ofNullable(node.allowedToBeDown),
-                Optional.ofNullable(node.wantToDeprovision),
                 Optional.ofNullable(node.owner).map(o -> ApplicationId.from(o.tenant, o.application, o.instance)),
                 membership,
                 Optional.ofNullable(node.restartGeneration),
@@ -244,7 +242,6 @@ public class RealNodeRepository implements NodeRepository {
             node.resources.diskSpeed = toString(resources.diskSpeed());
             node.resources.storageType = toString(resources.storageType());
         });
-        node.reservedTo = addNode.reservedTo.map(TenantName::value).orElse(null);
         node.type = addNode.nodeType.name();
         node.ipAddresses = addNode.ipAddresses;
         node.additionalIpAddresses = addNode.additionalIpAddresses;
@@ -259,8 +256,6 @@ public class RealNodeRepository implements NodeRepository {
         node.vespaVersion = nodeAttributes.getVespaVersion().map(Version::toFullString).orElse(null);
         node.currentOsVersion = nodeAttributes.getCurrentOsVersion().map(Version::toFullString).orElse(null);
         node.currentFirmwareCheck = nodeAttributes.getCurrentFirmwareCheck().map(Instant::toEpochMilli).orElse(null);
-        node.wantToDeprovision = nodeAttributes.getWantToDeprovision().orElse(null);
-        node.reservedTo = nodeAttributes.getReservedTo().map(TenantName::value).orElse(null);
 
         Map<String, JsonNode> reports = nodeAttributes.getReports();
         node.reports = reports == null || reports.isEmpty() ? null : new TreeMap<>(reports);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.node.admin.nodeagent;
 
 import com.yahoo.config.provision.CloudName;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -11,7 +10,6 @@ import com.yahoo.vespa.athenz.api.AthenzService;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.Acl;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeState;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerNetworking;
 
 import java.nio.file.FileSystem;
@@ -187,7 +185,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
 
     /** For testing only! */
     public static class Builder {
-        private NodeSpec.Builder nodeSpecBuilder = new NodeSpec.Builder();
+        private NodeSpec.Builder nodeSpecBuilder;
         private Acl acl;
         private AthenzIdentity identity;
         private DockerNetworking dockerNetworking;
@@ -209,11 +207,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
          * if you want to control the entire NodeSpec.
          */
         public Builder(String hostname) {
-            this.nodeSpecBuilder
-                    .hostname(hostname)
-                    .state(NodeState.active)
-                    .type(NodeType.tenant)
-                    .flavor("d-2-8-50");
+            this.nodeSpecBuilder = NodeSpec.Builder.testSpec(hostname);
         }
 
         public Builder nodeSpecBuilder(Function<NodeSpec.Builder, NodeSpec.Builder> nodeSpecBuilderModifier) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -164,7 +164,6 @@ public class RealNodeRepositoryTest {
         AddNode host = AddNode.forHost("host123.domain.tld",
                                        "default",
                                        Optional.of(FlavorOverrides.ofDisk(123)),
-                                       Optional.empty(),
                                        NodeType.confighost,
                                        Set.of("::1"), Set.of("::2", "::3"));
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerFailTest.java
@@ -2,10 +2,8 @@
 package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
 import com.yahoo.config.provision.DockerImage;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeState;
 import org.junit.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -24,18 +22,10 @@ public class DockerFailTest {
             final DockerImage dockerImage = DockerImage.fromString("dockerImage");
             final ContainerName containerName = new ContainerName("host1");
             final String hostname = "host1.test.yahoo.com";
-            tester.addChildNodeRepositoryNode(new NodeSpec.Builder()
-                    .hostname(hostname)
+            tester.addChildNodeRepositoryNode(NodeSpec.Builder
+                    .testSpec(hostname)
                     .wantedDockerImage(dockerImage)
                     .currentDockerImage(dockerImage)
-                    .state(NodeState.active)
-                    .type(NodeType.tenant)
-                    .flavor("docker")
-                    .wantedRestartGeneration(1L)
-                    .currentRestartGeneration(1L)
-                    .vcpu(1)
-                    .memoryGb(1)
-                    .diskGb(1)
                     .build());
 
             tester.inOrder(tester.docker).createContainerCommand(eq(dockerImage), eq(containerName));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -7,7 +7,6 @@ import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.dockerapi.Docker;
 import com.yahoo.vespa.hosted.dockerapi.metrics.Metrics;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeState;
 import com.yahoo.vespa.hosted.node.admin.configserver.orchestrator.Orchestrator;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperationsImpl;
@@ -76,14 +75,7 @@ public class DockerTester implements AutoCloseable {
 
         TerminalImpl terminal = new TerminalImpl(command -> new TestChildProcess2(0, ""));
 
-        NodeSpec hostSpec = new NodeSpec.Builder()
-                .hostname(HOST_HOSTNAME.value())
-                .state(NodeState.active)
-                .type(NodeType.host)
-                .flavor("default")
-                .wantedRestartGeneration(1L)
-                .currentRestartGeneration(1L)
-                .build();
+        NodeSpec hostSpec = NodeSpec.Builder.testSpec(HOST_HOSTNAME.value()).type(NodeType.host).build();
         nodeRepository.updateNodeRepositoryNode(hostSpec);
 
         Clock clock = Clock.systemUTC();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/MultiDockerTest.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
 import com.yahoo.config.provision.DockerImage;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeAttributes;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
@@ -25,13 +24,7 @@ public class MultiDockerTest {
             NodeSpec nodeSpec2 = addAndWaitForNode(
                     tester, "host2.test.yahoo.com", DockerImage.fromString("image2"));
 
-            tester.addChildNodeRepositoryNode(
-                    new NodeSpec.Builder(nodeSpec2)
-                            .state(NodeState.dirty)
-                            .vcpu(1)
-                            .memoryGb(1)
-                            .diskGb(1)
-                            .build());
+            tester.addChildNodeRepositoryNode(NodeSpec.Builder.testSpec(nodeSpec2.hostname(), NodeState.dirty).build());
 
             tester.inOrder(tester.docker).deleteContainer(eq(new ContainerName("host2")));
             tester.inOrder(tester.storageMaintainer).archiveNodeStorage(
@@ -43,19 +36,7 @@ public class MultiDockerTest {
     }
 
     private NodeSpec addAndWaitForNode(DockerTester tester, String hostName, DockerImage dockerImage) {
-        NodeSpec nodeSpec = new NodeSpec.Builder()
-                .hostname(hostName)
-                .wantedDockerImage(dockerImage)
-                .state(NodeState.active)
-                .type(NodeType.tenant)
-                .flavor("docker")
-                .wantedRestartGeneration(1L)
-                .currentRestartGeneration(1L)
-                .vcpu(2)
-                .memoryGb(4)
-                .diskGb(1)
-                .build();
-
+        NodeSpec nodeSpec = NodeSpec.Builder.testSpec(hostName).wantedDockerImage(dockerImage).build();
         tester.addChildNodeRepositoryNode(nodeSpec);
 
         ContainerName containerName = ContainerName.fromHostname(hostName);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RebootTest.java
@@ -1,12 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
-import com.yahoo.component.Version;
 import com.yahoo.config.provision.DockerImage;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeState;
 import com.yahoo.vespa.hosted.node.admin.nodeadmin.NodeAdminStateUpdater;
 import org.junit.Test;
 
@@ -31,7 +28,7 @@ public class RebootTest {
     @Test
     public void test() {
         try (DockerTester tester = new DockerTester()) {
-            tester.addChildNodeRepositoryNode(createNodeRepositoryNode());
+            tester.addChildNodeRepositoryNode(NodeSpec.Builder.testSpec(hostname).wantedDockerImage(dockerImage).build());
 
             tester.inOrder(tester.docker).createContainerCommand(eq(dockerImage), eq(new ContainerName("host1")));
 
@@ -45,18 +42,5 @@ public class RebootTest {
                     eq(new ContainerName("host1")), eq("root"), eq(OptionalLong.empty()), eq(NODE_PROGRAM), eq("stop"));
             assertTrue(tester.nodeAdmin.setFrozen(true));
         }
-    }
-
-    private NodeSpec createNodeRepositoryNode() {
-        return new NodeSpec.Builder()
-                .hostname(hostname)
-                .wantedDockerImage(dockerImage)
-                .state(NodeState.active)
-                .type(NodeType.tenant)
-                .flavor("docker")
-                .currentVespaVersion(Version.fromString("6.50.0"))
-                .wantedRestartGeneration(1L)
-                .currentRestartGeneration(1L)
-                .build();
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/RestartTest.java
@@ -2,11 +2,9 @@
 package com.yahoo.vespa.hosted.node.admin.integrationTests;
 
 import com.yahoo.config.provision.DockerImage;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeAttributes;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeState;
 import org.junit.Test;
 
 import static com.yahoo.vespa.hosted.node.admin.integrationTests.DockerTester.NODE_PROGRAM;
@@ -26,15 +24,7 @@ public class RestartTest {
             String hostname = "host1.test.yahoo.com";
             DockerImage dockerImage = DockerImage.fromString("dockerImage:1.2.3");
 
-            tester.addChildNodeRepositoryNode(new NodeSpec.Builder()
-                    .hostname(hostname)
-                    .state(NodeState.active)
-                    .wantedDockerImage(dockerImage)
-                    .type(NodeType.tenant)
-                    .flavor("docker")
-                    .wantedRestartGeneration(1)
-                    .currentRestartGeneration(1)
-                    .build());
+            tester.addChildNodeRepositoryNode(NodeSpec.Builder.testSpec(hostname).wantedDockerImage(dockerImage).build());
 
             tester.inOrder(tester.docker).createContainerCommand(eq(dockerImage), eq(new ContainerName("host1")));
             tester.inOrder(tester.nodeRepository).updateNodeAttributes(

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminStateUpdaterTest.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.node.admin.nodeadmin;
 
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.Acl;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeRepository;
@@ -258,28 +257,12 @@ public class NodeAdminStateUpdaterTest {
 
     private void mockNodeRepo(NodeState hostState, int numberOfNodes) {
         List<NodeSpec> containersToRun = IntStream.range(1, numberOfNodes + 1)
-                .mapToObj(i -> new NodeSpec.Builder()
-                        .hostname("host" + i + ".yahoo.com")
-                        .state(NodeState.active)
-                        .type(NodeType.tenant)
-                        .flavor("docker")
-                        .vcpu(1)
-                        .memoryGb(1)
-                        .diskGb(1)
-                        .build())
+                .mapToObj(i -> NodeSpec.Builder.testSpec("host" + i + ".yahoo.com").build())
                 .collect(Collectors.toList());
 
         when(nodeRepository.getNodes(eq(hostHostname.value()))).thenReturn(containersToRun);
-
-        when(nodeRepository.getNode(eq(hostHostname.value()))).thenReturn(new NodeSpec.Builder()
-                .hostname(hostHostname.value())
-                .state(hostState)
-                .type(NodeType.tenant)
-                .flavor("default")
-                .vcpu(1)
-                .memoryGb(1)
-                .diskGb(1)
-                .build());
+        when(nodeRepository.getNode(eq(hostHostname.value()))).thenReturn(
+                NodeSpec.Builder.testSpec(hostHostname.value(), hostState).build());
     }
 
     private void mockAcl(Acl acl, int... nodeIds) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -52,13 +52,7 @@ import static org.mockito.Mockito.when;
 public class NodeAgentImplTest {
     private static final NodeResources resources = new NodeResources(2, 16, 250, 1, NodeResources.DiskSpeed.fast, NodeResources.StorageType.local);
     private static final Version vespaVersion = Version.fromString("1.2.3");
-
-    private final String hostName = "host1.test.yahoo.com";
-    private final NodeSpec.Builder nodeBuilder = new NodeSpec.Builder()
-            .hostname(hostName)
-            .type(NodeType.tenant)
-            .flavor("docker")
-            .resources(resources);
+    private static final String hostName = "host1.test.yahoo.com";
 
     private final NodeAgentContextSupplier contextSupplier = mock(NodeAgentContextSupplier.class);
     private final DockerImage dockerImage = DockerImage.fromString("dockerImage");
@@ -75,11 +69,9 @@ public class NodeAgentImplTest {
 
     @Test
     public void upToDateContainerIsUntouched() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .allowedToBeDown(false)
                 .build();
 
@@ -104,11 +96,9 @@ public class NodeAgentImplTest {
 
     @Test
     public void verifyRemoveOldFilesIfDiskFull() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -124,11 +114,9 @@ public class NodeAgentImplTest {
     @Test
     public void startsAfterStoppingServices() {
         final InOrder inOrder = inOrder(dockerOperations);
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -160,11 +148,9 @@ public class NodeAgentImplTest {
 
     @Test
     public void absentContainerCausesStart() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -195,11 +181,9 @@ public class NodeAgentImplTest {
     @Test
     public void containerIsNotStoppedIfNewImageMustBePulled() {
         final DockerImage newDockerImage = DockerImage.fromString("new-image");
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(newDockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -221,11 +205,9 @@ public class NodeAgentImplTest {
 
     @Test
     public void containerIsUpdatedIfCpuChanged() {
-        NodeSpec.Builder specBuilder = nodeBuilder
-                .state(NodeState.active)
+        NodeSpec.Builder specBuilder = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .allowedToBeDown(false);
 
         NodeAgentContext firstContext = createContext(specBuilder.build());
@@ -271,8 +253,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void containerIsRecreatedIfMemoryChanged() {
-        NodeSpec.Builder specBuilder = nodeBuilder
-                .state(NodeState.active)
+        NodeSpec.Builder specBuilder = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
                 .wantedRestartGeneration(2).currentRestartGeneration(1);
@@ -304,8 +285,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void noRestartIfOrchestratorSuspendFails() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
                 .wantedRestartGeneration(2).currentRestartGeneration(1)
@@ -332,11 +312,9 @@ public class NodeAgentImplTest {
     @Test
     public void recreatesContainerIfRebootWanted() {
         final long wantedRebootGeneration = 2;
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1)
                 .wantedRebootGeneration(wantedRebootGeneration).currentRebootGeneration(1)
                 .build();
 
@@ -373,8 +351,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void failedNodeRunningContainerShouldStillBeRunning() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.failed)
+        final NodeSpec node = nodeBuilder(NodeState.failed)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
                 .build();
@@ -393,9 +370,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void readyNodeLeadsToNoAction() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.ready)
-                .build();
+        final NodeSpec node = nodeBuilder(NodeState.ready).build();
 
         NodeAgentContext context = createContext(node);
         NodeAgentImpl nodeAgent = makeNodeAgent(null,false);
@@ -417,8 +392,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void inactiveNodeRunningContainerShouldStillBeRunning() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.inactive)
+        final NodeSpec node = nodeBuilder(NodeState.inactive)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
                 .build();
@@ -439,8 +413,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void reservedNodeDoesNotUpdateNodeRepoWithVersion() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.reserved)
+        final NodeSpec node = nodeBuilder(NodeState.reserved)
                 .wantedDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion)
                 .build();
@@ -456,14 +429,12 @@ public class NodeAgentImplTest {
     }
 
     private void nodeRunningContainerIsTakenDownAndCleanedAndRecycled(NodeState nodeState, Optional<Long> wantedRestartGeneration) {
-        wantedRestartGeneration.ifPresent(restartGeneration -> nodeBuilder
+        NodeSpec.Builder builder = nodeBuilder(nodeState)
+                .wantedDockerImage(dockerImage).currentDockerImage(dockerImage);
+        wantedRestartGeneration.ifPresent(restartGeneration -> builder
                 .wantedRestartGeneration(restartGeneration).currentRestartGeneration(restartGeneration));
 
-        final NodeSpec node = nodeBuilder
-                .state(nodeState)
-                .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
-                .build();
-
+        NodeSpec node = builder.build();
         NodeAgentContext context = createContext(node);
         NodeAgentImpl nodeAgent = makeNodeAgent(dockerImage, true);
 
@@ -501,9 +472,8 @@ public class NodeAgentImplTest {
 
     @Test
     public void provisionedNodeIsMarkedAsDirty() {
-        final NodeSpec node = nodeBuilder
+        final NodeSpec node = nodeBuilder(NodeState.provisioned)
                 .wantedDockerImage(dockerImage)
-                .state(NodeState.provisioned)
                 .build();
 
         NodeAgentContext context = createContext(node);
@@ -516,8 +486,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void testRestartDeadContainerAfterNodeAdminRestart() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .currentDockerImage(dockerImage).wantedDockerImage(dockerImage)
                 .currentVespaVersion(vespaVersion)
                 .build();
@@ -537,8 +506,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void resumeProgramRunsUntilSuccess() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .currentVespaVersion(vespaVersion)
                 .wantedRestartGeneration(1).currentRestartGeneration(1)
@@ -575,8 +543,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void start_container_subtask_failure_leads_to_container_restart() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion)
                 .wantedRestartGeneration(1).currentRestartGeneration(1)
@@ -612,8 +579,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void testRunningConfigServer() {
-        final NodeSpec node = nodeBuilder
-                .state(NodeState.active)
+        final NodeSpec node = nodeBuilder(NodeState.active)
                 .type(NodeType.config)
                 .wantedDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion)
@@ -656,11 +622,9 @@ public class NodeAgentImplTest {
 
     @Test
     public void initial_cpu_cap_test() {
-        NodeSpec.Builder specBuilder = nodeBuilder
-                .state(NodeState.active)
+        NodeSpec.Builder specBuilder = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
-                .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
-                .wantedRestartGeneration(1).currentRestartGeneration(1);
+                .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion);
 
         NodeAgentContext context = createContext(specBuilder.build());
         NodeAgentImpl nodeAgent = makeNodeAgent(null, false, Duration.ofSeconds(30));
@@ -712,8 +676,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void resumes_normally_if_container_is_already_capped_on_start() {
-        NodeSpec.Builder specBuilder = nodeBuilder
-                .state(NodeState.active)
+        NodeSpec.Builder specBuilder = nodeBuilder(NodeState.active)
                 .wantedDockerImage(dockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)
                 .wantedRestartGeneration(1).currentRestartGeneration(1);
@@ -813,5 +776,9 @@ public class NodeAgentImplTest {
     
     private NodeAgentContext createContext(NodeSpec nodeSpec) {
         return new NodeAgentContextImpl.Builder(nodeSpec).build();
+    }
+
+    private NodeSpec.Builder nodeBuilder(NodeState state) {
+        return NodeSpec.Builder.testSpec(hostName, state).resources(resources);
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/DefaultEnvWriterTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/DefaultEnvWriterTest.java
@@ -23,8 +23,8 @@ public class DefaultEnvWriterTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private static final Path EXAMPLE_FILE = Paths.get(DefaultEnvWriterTest.class.getResource("/default-env-example.txt").getFile());
-    private static final Path EXPECTED_RESULT_FILE = Paths.get(DefaultEnvWriterTest.class.getResource("/default-env-rewritten.txt").getFile());
+    private static final Path EXAMPLE_FILE = Paths.get("src/test/resources/default-env-example.txt");
+    private static final Path EXPECTED_RESULT_FILE = Paths.get("src/test/resources/default-env-rewritten.txt");
 
     @Test
     public void default_env_is_correctly_rewritten() throws IOException {


### PR DESCRIPTION
Most of this is just refactoring to make it easier to create a NodeSpec to use in tests.
The 3rd commit ensures that certain fields that are always set for allocated nodes are set, since rest of the code often calls `.get()` directly on those `Optional`s. This is needed to avoid bugs fixed in the corresponding PR in `vespa-yahoo`