### PR TITLE
Revert "Hold a JVM-wide reentrant lock to grab mutex — helps ZK stale reads?" 

### DIFF
--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Lock.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Lock.java
@@ -7,7 +7,6 @@ import org.apache.curator.framework.recipes.locks.InterProcessLock;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * A cluster-wide re-entrant mutex which is released on (the last symmetric) close
@@ -16,46 +15,31 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class Lock implements Mutex {
 
-    private final ReentrantLock lock;
     private final InterProcessLock mutex;
     private final String lockPath;
 
     public Lock(String lockPath, Curator curator) {
         this.lockPath = lockPath;
-        this.lock = new ReentrantLock(true);
         mutex = curator.createMutex(lockPath);
     }
 
     /** Take the lock with the given timeout. This may be called multiple times from the same thread - each matched by a close */
     public void acquire(Duration timeout) throws UncheckedTimeoutException {
+        boolean acquired;
         try {
-            if ( ! mutex.acquire(timeout.toMillis(), TimeUnit.MILLISECONDS))
-                throw new UncheckedTimeoutException("Timed out after waiting " + timeout +
-                                                    " to acquire lock '" + lockPath + "'");
-            if ( ! lock.tryLock()) { // Should be available to only this thread, while holding the above mutex.
-                release();
-                throw new IllegalStateException("InterProcessMutex acquired, but guarded lock held by someone else, for lock '" + lockPath + "'");
-            }
-        }
-        catch (UncheckedTimeoutException | IllegalStateException e) {
-            throw e;
+            acquired = mutex.acquire(timeout.toMillis(), TimeUnit.MILLISECONDS);
         }
         catch (Exception e) {
             throw new RuntimeException("Exception acquiring lock '" + lockPath + "'", e);
         }
+
+        if (! acquired)
+            throw new UncheckedTimeoutException("Timed out after waiting " + timeout +
+                                                " to acquire lock '" + lockPath + "'");
     }
 
     @Override
     public void close() {
-        try {
-            lock.unlock();
-        }
-        finally {
-            release();
-        }
-    }
-
-    private void release() {
         try {
             mutex.release();
         }


### PR DESCRIPTION
Reverts vespa-engine/vespa#11815

@hakonhall let's revert if this doesn't help. We should know within a week or two.