### PR TITLE
Revert "Set phrase-segmenting default off"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -250,7 +250,7 @@ public class Flags {
             "Takes effect on next deployment of the application", APPLICATION_ID);
 
     public static final UnboundBooleanFlag PHRASE_SEGMENTING = defineFeatureFlag(
-            "phrase-segmenting", false,
+            "phrase-segmenting", true,
             "Should 'implicit phrases' in queries we parsed to a phrase or and?",
             "Takes effect on redeploy",
             ZONE_ID, APPLICATION_ID);


### PR DESCRIPTION
Reverts vespa-engine/vespa#12649

This might be the cause of the specialtokens_dotnet__ELASTIC system test failure?

```
<"my_str:\"yahoo .net\""> expected but was
<nil>.
```

https://factory-web.vespa.corp.yahoo.com/versions/1/builds/54647/products/1/tests/279720/testruns/39494814