### PR TITLE
Track metrics for new inconsistent update phases

### DIFF
--- a/storage/src/vespa/storage/distributor/distributormetricsset.cpp
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.cpp
@@ -13,6 +13,7 @@ DistributorMetricSet::DistributorMetricSet(const metrics::LoadTypeSet& lt)
       updates(lt, UpdateMetricSet(), this),
       update_puts(lt, PersistenceOperationMetricSet("update_puts"), this),
       update_gets(lt, PersistenceOperationMetricSet("update_gets"), this),
+      update_metadata_gets(lt, PersistenceOperationMetricSet("update_metadata_gets"), this),
       removes(lt, PersistenceOperationMetricSet("removes"), this),
       removelocations(lt, PersistenceOperationMetricSet("removelocations"), this),
       gets(lt, PersistenceOperationMetricSet("gets"), this),

--- a/storage/src/vespa/storage/distributor/distributormetricsset.h
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.h
@@ -16,6 +16,7 @@ public:
     metrics::LoadMetric<UpdateMetricSet> updates;
     metrics::LoadMetric<PersistenceOperationMetricSet> update_puts;
     metrics::LoadMetric<PersistenceOperationMetricSet> update_gets;
+    metrics::LoadMetric<PersistenceOperationMetricSet> update_metadata_gets;
     metrics::LoadMetric<PersistenceOperationMetricSet> removes;
     metrics::LoadMetric<PersistenceOperationMetricSet> removelocations;
     metrics::LoadMetric<PersistenceOperationMetricSet> gets;

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -7,6 +7,7 @@
 #include <vespa/storage/distributor/operations/sequenced_operation.h>
 #include <vespa/document/update/documentupdate.h>
 #include <set>
+#include <optional>
 
 namespace document {
 class Document;
@@ -116,6 +117,7 @@ private:
                                                 api::GetReply&,
                                                 const std::optional<NewestReplica>&,
                                                 bool any_replicas_failed);
+    void handle_safe_path_received_single_full_get(DistributorMessageSender&, api::GetReply&);
     void handleSafePathReceivedGet(DistributorMessageSender&, api::GetReply&);
     void handleSafePathReceivedPut(DistributorMessageSender&, const api::PutReply&);
     bool shouldCreateIfNonExistent() const;
@@ -136,6 +138,7 @@ private:
     UpdateMetricSet& _updateMetric;
     PersistenceOperationMetricSet& _putMetric;
     PersistenceOperationMetricSet& _getMetric;
+    PersistenceOperationMetricSet& _metadata_get_metrics;
     std::shared_ptr<api::UpdateCommand> _updateCmd;
     std::shared_ptr<api::StorageReply> _updateReply;
     DistributorComponent& _manager;
@@ -146,6 +149,7 @@ private:
     mbus::TraceNode _trace;
     document::BucketId _updateDocBucketId;
     std::vector<std::pair<document::BucketId, uint16_t>> _replicas_at_get_send_time;
+    std::optional<framework::MilliSecTimer> _single_get_latency_timer;
     uint16_t _fast_path_repair_source_node;
     bool _use_initial_cheap_metadata_fetch_phase;
     bool _replySent;


### PR DESCRIPTION
@geirst please review

Reuses the old update-get metric for the single full Get sent
after the initial metadata-only phase. Adds new metric set for
the initial metadata Gets.
