### PR TITLE
Reapply "Set default value for tls-for-zookeeper-quorum-communication to TLS_W…"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -176,7 +176,7 @@ public class Flags {
             NODE_TYPE, APPLICATION_ID, HOSTNAME);
 
     public static final UnboundStringFlag TLS_FOR_ZOOKEEPER_QUORUM_COMMUNICATION = defineStringFlag(
-            "tls-for-zookeeper-quorum-communication", "OFF",
+            "tls-for-zookeeper-quorum-communication", "TLS_WITH_PORT_UNIFICATION",
             "How to setup TLS for ZooKeeper quorum communication. Valid values are OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY",
             "Takes effect on restart of config server",
             NODE_TYPE, HOSTNAME);


### PR DESCRIPTION
Reverts vespa-engine/vespa#12678

Review only, needs to be coordinated with merge in internal repo