### PR TITLE
Use name of the consumer instead of the metric set.

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcher.java
@@ -59,7 +59,7 @@ public class NodeMetricsFetcher extends AbstractComponent implements NodeMetrics
                                                           .stream()
                                                           .findFirst();
         if (metricsV2Container.isEmpty()) return Collections.emptyList();
-        String url = "http://" + metricsV2Container.get().hostname() + ":" + 4080 + apiPath + "?consumer=Vespa";
+        String url = "http://" + metricsV2Container.get().hostname() + ":" + 4080 + apiPath + "?consumer=default";
         String response = httpClient.get(url);
         return new MetricsResponse(response).metrics();
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcher.java
@@ -59,7 +59,7 @@ public class NodeMetricsFetcher extends AbstractComponent implements NodeMetrics
                                                           .stream()
                                                           .findFirst();
         if (metricsV2Container.isEmpty()) return Collections.emptyList();
-        String url = "http://" + metricsV2Container.get().hostname() + ":" + 4080 + apiPath + "?consumer=vespa-consumer-metrics";
+        String url = "http://" + metricsV2Container.get().hostname() + ":" + 4080 + apiPath + "?consumer=Vespa";
         String response = httpClient.get(url);
         return new MetricsResponse(response).metrics();
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcherTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcherTest.java
@@ -37,7 +37,7 @@ public class NodeMetricsFetcherTest {
         {
             httpClient.cannedResponse = cannedResponseForApplication1;
             List<NodeMetrics.MetricValue> values = new ArrayList<>(fetcher.fetchMetrics(application1));
-            assertEquals("http://host-1.yahoo.com:4080/metrics/v2/values?consumer=Vespa",
+            assertEquals("http://host-1.yahoo.com:4080/metrics/v2/values?consumer=default",
                          httpClient.requestsReceived.get(0));
             assertEquals(5, values.size());
             assertEquals("metric value cpu.util: 16.2 at 1970-01-01T00:20:34Z for host-1.yahoo.com", values.get(0).toString());
@@ -50,7 +50,7 @@ public class NodeMetricsFetcherTest {
         {
             httpClient.cannedResponse = cannedResponseForApplication2;
             List<NodeMetrics.MetricValue> values = new ArrayList<>(fetcher.fetchMetrics(application2));
-            assertEquals("http://host-3.yahoo.com:4080/metrics/v2/values?consumer=Vespa",
+            assertEquals("http://host-3.yahoo.com:4080/metrics/v2/values?consumer=default",
                          httpClient.requestsReceived.get(1));
             assertEquals(3, values.size());
             assertEquals("metric value cpu.util: 10.0 at 1970-01-01T00:21:40Z for host-3.yahoo.com", values.get(0).toString());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcherTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsFetcherTest.java
@@ -37,7 +37,7 @@ public class NodeMetricsFetcherTest {
         {
             httpClient.cannedResponse = cannedResponseForApplication1;
             List<NodeMetrics.MetricValue> values = new ArrayList<>(fetcher.fetchMetrics(application1));
-            assertEquals("http://host-1.yahoo.com:4080/metrics/v2/values?consumer=vespa-consumer-metrics",
+            assertEquals("http://host-1.yahoo.com:4080/metrics/v2/values?consumer=Vespa",
                          httpClient.requestsReceived.get(0));
             assertEquals(5, values.size());
             assertEquals("metric value cpu.util: 16.2 at 1970-01-01T00:20:34Z for host-1.yahoo.com", values.get(0).toString());
@@ -50,7 +50,7 @@ public class NodeMetricsFetcherTest {
         {
             httpClient.cannedResponse = cannedResponseForApplication2;
             List<NodeMetrics.MetricValue> values = new ArrayList<>(fetcher.fetchMetrics(application2));
-            assertEquals("http://host-3.yahoo.com:4080/metrics/v2/values?consumer=vespa-consumer-metrics",
+            assertEquals("http://host-3.yahoo.com:4080/metrics/v2/values?consumer=Vespa",
                          httpClient.requestsReceived.get(1));
             assertEquals(3, values.size());
             assertEquals("metric value cpu.util: 10.0 at 1970-01-01T00:21:40Z for host-3.yahoo.com", values.get(0).toString());


### PR DESCRIPTION
I assume that you intended to use the Vespa consumer (the one with a lot of metrics). The current name is invalid, so you get the 'default' instead (the one with the "public" metrics).

FYI: @yngveaasheim 