### PR TITLE
Revert "Support api key variable for signature based test framework controlle…"

### DIFF
--- a/hosted-api/src/main/java/ai/vespa/hosted/api/Properties.java
+++ b/hosted-api/src/main/java/ai/vespa/hosted/api/Properties.java
@@ -52,7 +52,7 @@ public class Properties {
         return getNonBlankProperty("apiCertificateFile").map(Paths::get);
     }
 
-    /** Returns the actual private key as a string. */
+    /** Returns the actual private key as a string */
     public static Optional<String> apiKey() {
         return getNonBlankProperty("apiKey");
     }

--- a/tenant-auth/src/main/java/ai/vespa/hosted/auth/ApiAuthenticator.java
+++ b/tenant-auth/src/main/java/ai/vespa/hosted/auth/ApiAuthenticator.java
@@ -13,12 +13,10 @@ public class ApiAuthenticator implements ai.vespa.hosted.api.ApiAuthenticator {
                          .map(certificateFile -> ControllerHttpClient.withKeyAndCertificate(Properties.apiEndpoint(),
                                                                                             Properties.apiKeyFile(),
                                                                                             certificateFile))
-                         .or(() -> Properties.apiKey().map(apiKey -> ControllerHttpClient.withSignatureKey(Properties.apiEndpoint(),
-                                                                                                           apiKey,
-                                                                                                           Properties.application())))
-                         .orElseGet(() -> ControllerHttpClient.withSignatureKey(Properties.apiEndpoint(),
-                                                                                Properties.apiKeyFile(),
-                                                                                Properties.application()));
+                         .orElseGet(() ->
+                                            ControllerHttpClient.withSignatureKey(Properties.apiEndpoint(),
+                                                                                  Properties.apiKeyFile(),
+                                                                                  Properties.application()));
     }
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#12682

All public integration tests fail on deploy, this is the only PR that I could find that might be related. Shot in the dark, I really don't know if this is correct to do