### PR TITLE
Revert "Don't take combined clusters of size 1 down"

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -78,10 +78,10 @@ public class SearchCluster implements NodeManager<Node> {
         this.nodesByHost = nodesByHostBuilder.build();
 
         this.localCorpusDispatchTarget = findLocalCorpusDispatchTarget(HostName.getLocalhost(),
-                                                                       size,
-                                                                       containerClusterSize,
-                                                                       nodesByHost,
-                                                                       groups);
+                size,
+                containerClusterSize,
+                nodesByHost,
+                groups);
     }
 
     /* Testing only */
@@ -217,10 +217,7 @@ public class SearchCluster implements NodeManager<Node> {
                 setInRotationOnlyIf(hasWorkingNodes());
         }
         else if (usesLocalCorpusIn(node)) { // follow the status of this node
-            // Do not take this out of rotation if we're a combined cluster of size 1,
-            // as that can't be helpful, and leads to a deadlock where this node is never taken back in servic e
-            if (nodeIsWorking || size() > 1)
-                setInRotationOnlyIf(nodeIsWorking);
+            setInRotationOnlyIf(nodeIsWorking);
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
@@ -191,22 +191,8 @@ public class SearchClusterTest {
     }
 
     @Test
-    public void requireThatVipStatusStaysUpWithLocalDispatchAndClusterSize1() {
+    public void requireThatVipStatusIsDefaultDownWithOnlySingleLocalDispatch() {
         try (State test = new State("cluster.1", 1, HostName.getLocalhost())) {
-            assertTrue(test.searchCluster.localCorpusDispatchTarget().isPresent());
-
-            assertFalse(test.vipStatus.isInRotation());
-            test.waitOneFullPingRound();
-            assertTrue(test.vipStatus.isInRotation());
-            test.numDocsPerNode.get(0).set(-1);
-            test.waitOneFullPingRound();
-            assertTrue(test.vipStatus.isInRotation());
-        }
-    }
-
-    @Test
-    public void requireThatVipStatusIsDefaultDownWithLocalDispatchAndClusterSize2() {
-        try (State test = new State("cluster.1", 1, HostName.getLocalhost(), "otherhost")) {
             assertTrue(test.searchCluster.localCorpusDispatchTarget().isPresent());
 
             assertFalse(test.vipStatus.isInRotation());


### PR DESCRIPTION
Reverts vespa-engine/vespa#12704

Breaks a system test, might be that the test just needs an update...