### PR TITLE
Use image for child node type if set 

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerImages.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerImages.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
- * Multithread safe class to get and set docker images for given host types.
+ * Multithread safe class to get and set docker images for given node types.
  *
  * @author freva
  */
@@ -57,9 +57,30 @@ public class DockerImages {
         return dockerImages.get();
     }
 
-    /** Returns the current docker image for given node type, or default */
+    /** Returns the current docker image for given node type, or the type for corresponding child nodes
+     * if it is a Docker host, or default */
     public DockerImage dockerImageFor(NodeType type) {
-        return getDockerImages().getOrDefault(type, defaultImage);
+        NodeType typeToUseForLookup = type;
+        if (type.isDockerHost()) {
+            switch (type) {
+                case confighost:
+                    typeToUseForLookup = NodeType.config;
+                    break;
+                case controllerhost:
+                    typeToUseForLookup = NodeType.controller;
+                    break;
+                case host:
+                    typeToUseForLookup = NodeType.tenant;
+                    break;
+                case proxyhost:
+                    typeToUseForLookup = NodeType.proxy;
+                    break;
+                default:
+                    break; // do not change
+            }
+        }
+
+        return getDockerImages().getOrDefault(typeToUseForLookup, defaultImage);
     }
 
     /** Set the docker image for nodes of given type */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerImages.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/DockerImages.java
@@ -60,26 +60,7 @@ public class DockerImages {
     /** Returns the current docker image for given node type, or the type for corresponding child nodes
      * if it is a Docker host, or default */
     public DockerImage dockerImageFor(NodeType type) {
-        NodeType typeToUseForLookup = type;
-        if (type.isDockerHost()) {
-            switch (type) {
-                case confighost:
-                    typeToUseForLookup = NodeType.config;
-                    break;
-                case controllerhost:
-                    typeToUseForLookup = NodeType.controller;
-                    break;
-                case host:
-                    typeToUseForLookup = NodeType.tenant;
-                    break;
-                case proxyhost:
-                    typeToUseForLookup = NodeType.proxy;
-                    break;
-                default:
-                    break; // do not change
-            }
-        }
-
+        NodeType typeToUseForLookup = type.isDockerHost() ? type.childNodeType() : type;
         return getDockerImages().getOrDefault(typeToUseForLookup, defaultImage);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/v2/NodesResponse.java
@@ -219,7 +219,7 @@ class NodesResponse extends HttpResponse {
         object.setString("storageType", serializer.toString(resources.storageType()));
     }
 
-    // Hack: For non-docker noder, return current docker image as default prefix + current Vespa version
+    // Hack: For non-docker nodes, return current docker image as default prefix + current Vespa version
     // TODO: Remove current + wanted docker image from response for non-docker types
     private Optional<DockerImage> currentDockerImage(Node node) {
         return node.status().dockerImage()


### PR DESCRIPTION
If docker image is set for a node type, use that image when preloading docker image by host-admin for the corresponding host type. Avoids unnecessarily downloading an image that will not be used.
