### PR TITLE
Revert 12736 revert 12731 hmusum/remove dead code 4

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -110,12 +110,6 @@ public class ClusterMembership {
     @Override
     public String toString() { return stringValue(); }
 
-    // TODO: Remove when when 7.195 is oldest model version in use
-    @Deprecated
-    public static ClusterMembership from(String stringValue, Version vespaVersion) {
-        return new ClusterMembership(stringValue, vespaVersion, Optional.empty());
-    }
-
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<String> dockerImageRepo) {
         return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo);
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -110,6 +110,10 @@ public class ClusterMembership {
     @Override
     public String toString() { return stringValue(); }
 
+    public static ClusterMembership from(String stringValue, Version vespaVersion) {
+        return new ClusterMembership(stringValue, vespaVersion, Optional.empty());
+    }
+
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<String> dockerImageRepo) {
         return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo);
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
@@ -77,27 +77,13 @@ public final class ClusterSpec {
         return new ClusterSpec(type, id, groupId, vespaVersion, exclusive, combinedId, dockerImageRepo);
     }
 
-    // TODO: Remove when when 7.195 is oldest model version in use
-    // TODO: Add @Deprecated when internal repo has been updated to not use this method
-    // @Deprecated
-    public static ClusterSpec request(Type type, Id id, Version vespaVersion, boolean exclusive,
-                                      Optional<Id> combinedId) {
-        return request(type, id, vespaVersion, exclusive, combinedId, Optional.empty());
-    }
-
+    // TODO: Remove when when 7.200 is oldest model version in use
     public static ClusterSpec request(Type type, Id id, Version vespaVersion, boolean exclusive,
                                       Optional<Id> combinedId, Optional<String> dockerImageRepo) {
         return new ClusterSpec(type, id, Optional.empty(), vespaVersion, exclusive, combinedId, dockerImageRepo);
     }
 
-    // TODO: Remove when when 7.195 is oldest model version in use
-    // TODO: Add @Deprecated when internal repo has been updated to not use this method
-    // @Deprecated
-    public static ClusterSpec from(Type type, Id id, Group groupId, Version vespaVersion, boolean exclusive,
-                                   Optional<Id> combinedId) {
-        return from(type, id, groupId, vespaVersion, exclusive, combinedId, Optional.empty());
-    }
-
+    // TODO: Remove when when 7.200 is oldest model version in use
     public static ClusterSpec from(Type type, Id id, Group groupId, Version vespaVersion, boolean exclusive,
                                    Optional<Id> combinedId, Optional<String> dockerImageRepo) {
         return new ClusterSpec(type, id, Optional.of(groupId), vespaVersion, exclusive, combinedId, dockerImageRepo);


### PR DESCRIPTION
Same as https://github.com/vespa-engine/vespa/pull/12731, but keeps method in ClusterMembership that was actually in use
