### PR TITLE
Increase ZooKeeper test server tick time

### DIFF
--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ZooKeeperTestServer.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ZooKeeperTestServer.java
@@ -8,6 +8,7 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 /**
  * This class sets up a zookeeper server, such that we can test fleetcontroller zookeeper parts without stubbing in the client.
@@ -15,7 +16,7 @@ import java.net.InetSocketAddress;
 public class ZooKeeperTestServer {
     private File zooKeeperDir;
     private ZooKeeperServer server;
-    private static final int tickTime = 100;
+    private static final Duration tickTime = Duration.ofMillis(2000);
     private NIOServerCnxnFactory factory;
     private static final String DIR_PREFIX = "test_fltctrl_zk";
     private static final String DIR_POSTFIX = "sdir";
@@ -31,7 +32,7 @@ public class ZooKeeperTestServer {
             throw new IllegalStateException("Failed to create directory " + zooKeeperDir);
         }
         zooKeeperDir.deleteOnExit();
-        server = new ZooKeeperServer(zooKeeperDir, zooKeeperDir, tickTime);
+        server = new ZooKeeperServer(zooKeeperDir, zooKeeperDir, (int)tickTime.toMillis());
         final int maxcc = 10000; // max number of connections from the same client
         factory = new NIOServerCnxnFactory();
         factory.configure(new InetSocketAddress(port), maxcc); // Use any port


### PR DESCRIPTION
@geirst please review

Tests running under heavy concurrent CI build load appear
to struggle maintaining ZK sessions, causing flakiness. This
is an attempt to mitigate that by bumping the ZK server's tick
interval (and therefore session timeout) by 20x.

According to local testing, this does not increase testing time
in the common case.
