### PR TITLE
Reduce warmup time with one second to avoid lockstep with tick

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -52,7 +52,8 @@ public class NodeAgentImpl implements NodeAgent {
     private static final long BYTES_IN_GB = 1_000_000_000L;
 
     // Container is started with uncapped CPU and is kept that way until the first successful health check + this duration
-    private static final Duration DEFAULT_WARM_UP_DURATION = Duration.ofMinutes(1);
+    // Subtract 1 second to avoid warmup coming in lockstep with tick time and always end up using an extra tick when there are just a few ms left
+    private static final Duration DEFAULT_WARM_UP_DURATION = Duration.ofMinutes(1).minus(Duration.ofSeconds(1));
 
     private static final Logger logger = Logger.getLogger(NodeAgentImpl.class.getName());
 


### PR DESCRIPTION
Reduce the chance of using an extra tick when there are some milliseconds
left of warmup time

I very often see logs like this:
` Refusing to resume until warm up period ends (in PT0.096547S)`

this PR tries to avoid spending an extra tick (30 seconds) when there are just some ms left before warm up period ends
