### PR TITLE
Set warmup duration based on zone

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -609,7 +609,7 @@ public class NodeAgentImpl implements NodeAgent {
 
     private static Duration warmUpDurationForZone(ZoneApi zone) {
         return zone.getSystemName().isCd() || zone.getEnvironment().isTest()
-                ? Duration.ZERO
+                ? Duration.ofSeconds(-1)
                 : DEFAULT_WARM_UP_DURATION;
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -608,7 +608,7 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     private static Duration warmUpDurationForZone(ZoneApi zone) {
-        return zone.getSystemName() == SystemName.cd || zone.getEnvironment().isTest()
+        return zone.getSystemName().isCd() || zone.getEnvironment().isTest()
                 ? Duration.ZERO
                 : DEFAULT_WARM_UP_DURATION;
     }


### PR DESCRIPTION
No warmup time necessary in cd or test environments. Set
default warmup time to 89 seconds, as the previous value of 60
seconds (which ended up being ~90 seconds) was the wanted one based
on experience with prod applications.

Merge needs to be coordinated with change in internal repo, please review only.
