### PR TITLE
Revert "It is more efficient to use connection per target until limit is reac…"

### DIFF
--- a/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/FeederParams.java
+++ b/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/FeederParams.java
@@ -34,7 +34,7 @@ class FeederParams {
     private boolean benchmarkMode = false;
     private int numDispatchThreads = 1;
     private int maxPending = 0;
-    private int numConnectionsPerTarget = 1;
+    private int numConnectionsPerTarget = 2;
     private List<InputStream> inputStreams = new ArrayList<>();
 
     FeederParams() {


### PR DESCRIPTION
Reverts vespa-engine/vespa#12754

Sorry, missed that this broke unit tests before I merged.

Alternatively, just merge the fix in https://github.com/vespa-engine/vespa/pull/12756