### PR TITLE
Block SIGTERM on application shutdown.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/signalhandler.cpp
+++ b/vespalib/src/vespa/vespalib/util/signalhandler.cpp
@@ -108,17 +108,18 @@ SignalHandler::unhook()
 void
 SignalHandler::shutdown()
 {
-    // Block SIGTERM at shutdown in case valgrind is used.
-    sigset_t signals_to_block;
-    sigemptyset(&signals_to_block);
-    sigaddset(&signals_to_block, SIGTERM);
-    sigprocmask(SIG_BLOCK, &signals_to_block, nullptr);
     for (std::vector<SignalHandler*>::iterator
              it = _handlers.begin(), ite = _handlers.end();
          it != ite;
          ++it) {
-        if (*it != nullptr)
-            (*it)->unhook();
+        if (*it != nullptr) {
+            // Ignore SIGTERM at shutdown in case valgrind is used.
+            if ((*it)->_signal == SIGTERM) {
+                (*it)->ignore();
+            } else {
+                (*it)->unhook();
+            }
+        }
     }
     std::vector<SignalHandler *>().swap(_handlers);
 }

--- a/vespalib/src/vespa/vespalib/util/signalhandler.cpp
+++ b/vespalib/src/vespa/vespalib/util/signalhandler.cpp
@@ -19,9 +19,6 @@ public:
 
 }
 
-// Clear SignalHandler::_handlers in a slightly less unsafe manner.
-Shutdown shutdown;
-
 SignalHandler SignalHandler::HUP(SIGHUP);
 SignalHandler SignalHandler::INT(SIGINT);
 SignalHandler SignalHandler::TERM(SIGTERM);
@@ -35,6 +32,9 @@ SignalHandler SignalHandler::TRAP(SIGTRAP);
 SignalHandler SignalHandler::FPE(SIGFPE);
 SignalHandler SignalHandler::QUIT(SIGQUIT);
 SignalHandler SignalHandler::USR1(SIGUSR1);
+
+// Clear SignalHandler::_handlers in a slightly less unsafe manner.
+Shutdown shutdown;
 
 void
 SignalHandler::handleSignal(int signal)

--- a/vespalib/src/vespa/vespalib/util/signalhandler.cpp
+++ b/vespalib/src/vespa/vespalib/util/signalhandler.cpp
@@ -108,6 +108,11 @@ SignalHandler::unhook()
 void
 SignalHandler::shutdown()
 {
+    // Block SIGTERM at shutdown in case valgrind is used.
+    sigset_t signals_to_block;
+    sigemptyset(&signals_to_block);
+    sigaddset(&signals_to_block, SIGTERM);
+    sigprocmask(SIG_BLOCK, &signals_to_block, nullptr);
     for (std::vector<SignalHandler*>::iterator
              it = _handlers.begin(), ite = _handlers.end();
          it != ite;


### PR DESCRIPTION
This closes a window where SIGTERM will immediate terminate the program, possibly causing valgrind errors.

@aressem : please review
