### PR TITLE
Revert "Change default of 'tls-insecure-mixed-mode' to 'tls_client_tls_server' "

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -110,7 +110,7 @@ public class Flags {
             APPLICATION_ID);
 
     public static final UnboundStringFlag TLS_INSECURE_MIXED_MODE = defineStringFlag(
-            "tls-insecure-mixed-mode", "tls_client_tls_server",
+            "tls-insecure-mixed-mode", "tls_client_mixed_server",
             "TLS insecure mixed mode. Allowed values: ['plaintext_client_mixed_server', 'tls_client_mixed_server', 'tls_client_tls_server']",
             "Takes effect on restart of Docker container",
             NODE_TYPE, APPLICATION_ID, HOSTNAME);


### PR DESCRIPTION
Reverts vespa-engine/vespa#10931

[ERROR]   HostedNodeAgentTest$ContainerDataTests.writes_container_environment_variables_config_aws:231->assertEnvironment:331 expected:<...XED_MODE tls_client_[mixed]_server
override VES...> but was:<...XED_MODE tls_client_[tls]_server
override VES...>
