### PR TITLE
ensure consistent offset in logcontrol file

### DIFF
--- a/vespalog/src/main/java/com/yahoo/log/VespaLevelControllerRepo.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaLevelControllerRepo.java
@@ -116,17 +116,17 @@ public class VespaLevelControllerRepo implements LevelControllerRepo {
                 ctlFile.writeBytes(appPrefix);
             }
             ctlFile.writeBytes("\n");
-            for (int i = appLen; i < maxPrefix; i++) {
+            for (int i = appLen; i < maxPrefix + 2; i++) {
                 byte space = ' ';
                 ctlFile.write(space);
             }
             ctlFile.writeBytes("\n");
             ctlFile.setLength(ctlFile.getFilePointer());
-            if (ctlFile.getFilePointer() != controlFileHeaderLength) {
+            if (ctlFile.getFilePointer() != (controlFileHeaderLength + 2)) {
                 System.err.println("internal error, bad header length: "
                                    + ctlFile.getFilePointer()
                                    + " (should have been: "
-                                   + controlFileHeaderLength
+                                   + (controlFileHeaderLength + 2)
                                    + ")");
             }
         }

--- a/vespalog/src/test/java/com/yahoo/log/VespaLevelControllerRepoTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLevelControllerRepoTest.java
@@ -62,12 +62,14 @@ public class VespaLevelControllerRepoTest {
 
             RandomAccessFile lcfile = new RandomAccessFile(lcf, "rw");
 
-            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength);
+            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength+1);
+            assertEquals(lcfile.readByte(), '\n');
+            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength+2);
             assertEquals(lcfile.readByte(), 'd');
-            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength + 7);
+            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength+2 + 7);
             assertEquals(lcfile.readByte(), ':');
-            assertEquals(0, (VespaLevelControllerRepo.controlFileHeaderLength+9) % 4);
-            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength + 9);
+            assertEquals(0, (VespaLevelControllerRepo.controlFileHeaderLength+13) % 4);
+            lcfile.seek(VespaLevelControllerRepo.controlFileHeaderLength + 13);
             assertEquals(0x20204f4e, lcfile.readInt());
 
             int off = findControlString(lcfile, "com.yahoo.log.test");

--- a/vespalog/src/vespa/log/control-file.cpp
+++ b/vespalog/src/vespa/log/control-file.cpp
@@ -69,7 +69,7 @@ ControlFile::ensureHeader()
 	    perror("log::ControlFile write(A) failed");
 	}
 
-        char spaces[_maxPrefix + 1];
+        char spaces[_maxPrefix + 3];
         memset(spaces, ' ', sizeof spaces);
         spaces[sizeof(spaces) - 1] = '\0';
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This is in preparation for using append instead of seeking to EOF and then doing write.  This change is enough to ensure consistent alignment for all logcontrol lines.  I have tested manually that both roll-forward and roll-back seems to work (luckily the old code was quite robust to small deviations in the file format).

@gjoranv please review and merge
@bjorncs FYI