### PR TITLE
Ensure that obsolete bundles are uninstalled

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -61,7 +61,7 @@ public class Deconstructor implements ComponentDeconstructor {
                 ((SharedResource) component).release();
             }
         }
-        if (! destructibleComponents.isEmpty())
+        if (! destructibleComponents.isEmpty() || ! bundles.isEmpty())
             executor.schedule(new DestructComponentTask(destructibleComponents, bundles),
                               delay.getSeconds(), TimeUnit.SECONDS);
     }

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
@@ -68,14 +68,14 @@ public class DeconstructorTest {
     }
 
     private static class TestProvider implements Provider<Void> {
-        boolean destructed = false;
+        volatile boolean destructed = false;
 
         @Override public Void get() { return null; }
         @Override public void deconstruct() { destructed = true; }
     }
 
     private static class TestSharedResource implements SharedResource {
-        boolean released = false;
+        volatile boolean released = false;
 
         @Override public ResourceReference refer() { return null; }
         @Override public void release() { released = true; }


### PR DESCRIPTION
.. even when there are no components to deconstruct.
This happens for e.g. pure document-api containers when the
user bundle(s) only contain searchers.

