### PR TITLE
Add verbose property to print docId when set

### DIFF
--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/pig/VespaDocumentOperation.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/pig/VespaDocumentOperation.java
@@ -67,7 +67,7 @@ public class VespaDocumentOperation extends EvalFunc<String> {
     private static final String PROPERTY_CREATE_IF_NON_EXISTENT = "create-if-non-existent";
     private static final String PROPERTY_ID_TEMPLATE = "docid";
     private static final String PROPERTY_OPERATION = "operation";
-    private static final String PROPERTY_PRINT_DOCID_WHEN_ERROR = "print-docid-when-error";
+    private static final String PROPERTY_VERBOSE = "verbose";
     private static final String BAG_AS_MAP_FIELDS = "bag-as-map-fields";
     private static final String SIMPLE_ARRAY_FIELDS = "simple-array-fields";
     private static final String SIMPLE_OBJECT_FIELDS = "simple-object-fields";
@@ -81,7 +81,7 @@ public class VespaDocumentOperation extends EvalFunc<String> {
     private static final String PARTIAL_UPDATE_ASSIGN = "assign";
     private static final String PARTIAL_UPDATE_ADD = "add";
     private static final String PARTIAL_UPDATE_REMOVE = "remove";
-    private static boolean printIdOnError;
+    private static boolean printId;
 
     private static Map<String, String> mapPartialOperationMap;
 
@@ -115,7 +115,7 @@ public class VespaDocumentOperation extends EvalFunc<String> {
         properties = VespaConfiguration.loadProperties(params);
         template = properties.getProperty(PROPERTY_ID_TEMPLATE);
         operation = Operation.fromString(properties.getProperty(PROPERTY_OPERATION, "put"));
-        printIdOnError = Boolean.parseBoolean(properties.getProperty(PROPERTY_PRINT_DOCID_WHEN_ERROR, "false"));
+        printId = Boolean.parseBoolean(properties.getProperty(PROPERTY_VERBOSE, "false"));
     }
 
     @Override
@@ -148,6 +148,9 @@ public class VespaDocumentOperation extends EvalFunc<String> {
             Schema inputSchema = getInputSchema();
             Map<String, Object> fields = TupleTools.tupleMap(inputSchema, tuple);
             String docId = TupleTools.toString(fields, template);
+            if (printId) {
+                System.out.println("Processing docId: "+ docId);
+            }
             // create json
             json = create(operation, docId, fields, properties, inputSchema);
             if (json == null || json.length() == 0) {
@@ -159,12 +162,6 @@ public class VespaDocumentOperation extends EvalFunc<String> {
         } catch (Exception e) {
             if (statusReporter != null) {
                 statusReporter.incrCounter("Vespa Document Operation Counters", "Document operation failed", 1);
-            }
-            if (printIdOnError) {
-                Schema inputSchema = getInputSchema();
-                Map<String, Object> fields = TupleTools.tupleMap(inputSchema, tuple);
-                String docId = TupleTools.toString(fields, template);
-                System.out.println("Error occur when processing document with docID: " +docId);
             }
             StringBuilder sb = new StringBuilder();
             sb.append("Caught exception processing input row: \n");

--- a/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/pig/VespaDocumentOperation.java
+++ b/vespa-hadoop/src/main/java/com/yahoo/vespa/hadoop/pig/VespaDocumentOperation.java
@@ -81,7 +81,6 @@ public class VespaDocumentOperation extends EvalFunc<String> {
     private static final String PARTIAL_UPDATE_ASSIGN = "assign";
     private static final String PARTIAL_UPDATE_ADD = "add";
     private static final String PARTIAL_UPDATE_REMOVE = "remove";
-    private static boolean printId;
 
     private static Map<String, String> mapPartialOperationMap;
 
@@ -101,6 +100,7 @@ public class VespaDocumentOperation extends EvalFunc<String> {
         partialOperationMap.put(UPDATE_MAP_FIELDS, PARTIAL_UPDATE_ASSIGN);
     }
 
+    private final boolean verbose;
     private final String template;
     private final Operation operation;
     private final Properties properties;
@@ -115,7 +115,7 @@ public class VespaDocumentOperation extends EvalFunc<String> {
         properties = VespaConfiguration.loadProperties(params);
         template = properties.getProperty(PROPERTY_ID_TEMPLATE);
         operation = Operation.fromString(properties.getProperty(PROPERTY_OPERATION, "put"));
-        printId = Boolean.parseBoolean(properties.getProperty(PROPERTY_VERBOSE, "false"));
+        verbose = Boolean.parseBoolean(properties.getProperty(PROPERTY_VERBOSE, "false"));
     }
 
     @Override
@@ -148,7 +148,7 @@ public class VespaDocumentOperation extends EvalFunc<String> {
             Schema inputSchema = getInputSchema();
             Map<String, Object> fields = TupleTools.tupleMap(inputSchema, tuple);
             String docId = TupleTools.toString(fields, template);
-            if (printId) {
+            if (verbose) {
                 System.out.println("Processing docId: "+ docId);
             }
             // create json

--- a/vespa-hadoop/src/test/java/com/yahoo/vespa/hadoop/pig/VespaDocumentOperationTest.java
+++ b/vespa-hadoop/src/test/java/com/yahoo/vespa/hadoop/pig/VespaDocumentOperationTest.java
@@ -558,7 +558,7 @@ public class VespaDocumentOperationTest {
     }
 
     @Test
-    public void requireThatUDFPrintIdWhenError() throws IOException {
+    public void requireThatUDFPrintIdWhenVerbose() throws IOException {
         DataBag bag = BagFactory.getInstance().newDefaultBag();
 
         Schema objectSchema = new Schema();
@@ -577,11 +577,38 @@ public class VespaDocumentOperationTest {
         Tuple tuple = TupleFactory.getInstance().newTuple();
         addToTuple("bag", DataType.BAG, bag, objectSchema, schema, tuple);
 
-        VespaDocumentOperation docOp = new VespaDocumentOperation("docid=7654321", "simple-object-fields=bag","print-docid-when-error=true");
+        VespaDocumentOperation docOp = new VespaDocumentOperation("docid=7654321", "bag-as-map-fields=bag","verbose=true");
         docOp.setInputSchema(schema);
         String json = docOp.exec(tuple);
 
-        assertThat(outContent.toString(), CoreMatchers.containsString("Error occur when processing document with docID: 7654321"));
+        assertThat(outContent.toString(), CoreMatchers.containsString("Processing docId: 7654321"));
+    }
+
+    @Test
+    public void requireThatUDFVerboseSetToFalseByDefault() throws IOException {
+        DataBag bag = BagFactory.getInstance().newDefaultBag();
+
+        Schema objectSchema = new Schema();
+        Tuple objectTuple = TupleFactory.getInstance().newTuple();
+        addToTuple("key", DataType.CHARARRAY, "123456", objectSchema, objectTuple);
+        addToTuple("value", DataType.INTEGER, 123456, objectSchema, objectTuple);
+        bag.add(objectTuple);
+
+        objectSchema = new Schema();
+        objectTuple = TupleFactory.getInstance().newTuple();
+        addToTuple("key", DataType.CHARARRAY, "234567", objectSchema, objectTuple);
+        addToTuple("value", DataType.INTEGER, 234567, objectSchema, objectTuple);
+        bag.add(objectTuple);
+
+        Schema schema = new Schema();
+        Tuple tuple = TupleFactory.getInstance().newTuple();
+        addToTuple("bag", DataType.BAG, bag, objectSchema, schema, tuple);
+
+        VespaDocumentOperation docOp = new VespaDocumentOperation("docid=7654321", "bag-as-map-fields=bag");
+        docOp.setInputSchema(schema);
+        String json = docOp.exec(tuple);
+
+        assertEquals("", outContent.toString());
     }
 
     private void addToTuple(String alias, byte type, Object value, Schema schema, Tuple tuple) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

- add a property to enable printing docid when there is an error parsing the document