### PR TITLE
Invoke SubRef on RPC request before exiting process

### DIFF
--- a/config/src/apps/vespa-ping-configproxy/pingproxy.cpp
+++ b/config/src/apps/vespa-ping-configproxy/pingproxy.cpp
@@ -146,6 +146,7 @@ PingProxy::Main()
             retval = 1;
         }
     }
+    req->SubRef();
     finiRPC();
     return retval;
 }


### PR DESCRIPTION
@arnej27959 please review

Is reported as memory leak by AddressSanitizer, but slips
between the cracks when run under Valgrind.
