### PR TITLE
Ensure RPC target is freed if exception thrown in ctor 

### DIFF
--- a/logd/src/logd/rpc_forwarder.cpp
+++ b/logd/src/logd/rpc_forwarder.cpp
@@ -57,19 +57,15 @@ RpcForwarder::RpcForwarder(Metrics& metrics, const ForwardMap& forward_filter, F
       _connection_spec(make_string("tcp/%s:%d", hostname.c_str(), rpc_port)),
       _rpc_timeout_secs(rpc_timeout_secs),
       _max_messages_per_request(max_messages_per_request),
-      _target(),
+      _target(supervisor.GetTarget(_connection_spec.c_str())),
       _messages(),
       _bad_lines(0),
       _forward_filter(forward_filter)
 {
-    _target = supervisor.GetTarget(_connection_spec.c_str());
     ping_logserver();
 }
 
-RpcForwarder::~RpcForwarder()
-{
-    _target->SubRef();
-}
+RpcForwarder::~RpcForwarder() = default;
 
 namespace {
 

--- a/logd/src/logd/rpc_forwarder.h
+++ b/logd/src/logd/rpc_forwarder.h
@@ -6,11 +6,19 @@
 #include "proto_converter.h"
 #include <vespa/log/log_message.h>
 #include <vespa/fnet/frt/frt.h>
+#include <memory>
 #include <vector>
 
 namespace logdemon {
 
 struct Metrics;
+
+struct RpcTargetSubRef {
+    void operator()(FRT_Target* target) const noexcept {
+        target->SubRef();
+    }
+};
+using RpcTargetGuard = std::unique_ptr<FRT_Target, RpcTargetSubRef>;
 
 /**
  * Implementation of the Forwarder interface that uses RPC to send protobuf encoded log messages to the logserver.
@@ -21,7 +29,7 @@ private:
     vespalib::string _connection_spec;
     double _rpc_timeout_secs;
     size_t _max_messages_per_request;
-    FRT_Target* _target;
+    RpcTargetGuard _target;
     std::vector<ns_log::LogMessage> _messages;
     int _bad_lines;
     ForwardMap _forward_filter;


### PR DESCRIPTION
@geirst please review

`RpcForwarder::ping_logserver()` throws if the ping request fails.
Since this happens at construction time the `RpcForwarder` destructor
is not invoked, and therefore `SubRef()` won't be called on the
target. Replace with field-level RAII guard instead

