### PR TITLE
Disable trimming of stack traces in maven-surefire-plugin 

### DIFF
--- a/bundle-plugin-test/integration-test/pom.xml
+++ b/bundle-plugin-test/integration-test/pom.xml
@@ -62,7 +62,6 @@
           <systemPropertyVariables>
             <test.bundle.path>${project.build.directory}/dependency</test.bundle.path>
           </systemPropertyVariables>
-          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -222,6 +222,7 @@
                         <systemPropertyVariables>
                             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
                         </systemPropertyVariables>
+                        <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
