### PR TITLE
Handle add updates to non-existing tensors.

### DIFF
--- a/searchcore/src/tests/proton/common/attribute_updater/attribute_updater_test.cpp
+++ b/searchcore/src/tests/proton/common/attribute_updater/attribute_updater_test.cpp
@@ -85,13 +85,13 @@ makeDocumentTypeRepo()
     return std::make_unique<DocumentTypeRepo>(builder.config());
 }
 
+std::unique_ptr<DocumentTypeRepo> repo = makeDocumentTypeRepo();
+
 struct Fixture {
-    std::unique_ptr<DocumentTypeRepo> repo;
     const DocumentType *docType;
 
     Fixture()
-        : repo(makeDocumentTypeRepo()),
-          docType(repo->getDocumentType("testdoc"))
+        : docType(repo->getDocumentType("testdoc"))
     {
     }
 
@@ -460,6 +460,14 @@ TEST_F("require that tensor add update is applied",
         TensorFixture<GenericTensorAttribute>("tensor(x{})", "sparse_tensor"))
 {
     f.setTensor(TensorSpec(f.type).add({{"x", "a"}}, 2));
+    f.applyValueUpdate(*f.attribute, 1,
+                       TensorAddUpdate(makeTensorFieldValue(TensorSpec(f.type).add({{"x", "a"}}, 3))));
+    f.assertTensor(TensorSpec(f.type).add({{"x", "a"}}, 3));
+}
+
+TEST_F("require that tensor add update to non-existing tensor creates empty tensor first",
+       TensorFixture<GenericTensorAttribute>("tensor(x{})", "sparse_tensor"))
+{
     f.applyValueUpdate(*f.attribute, 1,
                        TensorAddUpdate(makeTensorFieldValue(TensorSpec(f.type).add({{"x", "a"}}, 3))));
     f.assertTensor(TensorSpec(f.type).add({{"x", "a"}}, 3));

--- a/searchcore/src/vespa/searchcore/proton/common/attribute_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/attribute_updater.cpp
@@ -208,9 +208,13 @@ namespace {
 
 template <typename TensorUpdateType>
 void
-applyTensorUpdate(TensorAttribute &vec, uint32_t lid, const TensorUpdateType &update)
+applyTensorUpdate(TensorAttribute &vec, uint32_t lid, const TensorUpdateType &update,
+                  bool create_empty_if_non_existing)
 {
     auto oldTensor = vec.getTensor(lid);
+    if (!oldTensor && create_empty_if_non_existing) {
+        oldTensor = vec.getEmptyTensor();
+    }
     if (oldTensor) {
         auto newTensor = update.applyTo(*oldTensor);
         if (newTensor) {
@@ -235,11 +239,11 @@ AttributeUpdater::handleUpdate(TensorAttribute &vec, uint32_t lid, const ValueUp
             updateValue(vec, lid, assign.getValue());
         }
     } else if (op == ValueUpdate::TensorModifyUpdate) {
-        applyTensorUpdate(vec, lid, static_cast<const TensorModifyUpdate &>(upd));
+        applyTensorUpdate(vec, lid, static_cast<const TensorModifyUpdate &>(upd), false);
     } else if (op == ValueUpdate::TensorAddUpdate) {
-        applyTensorUpdate(vec, lid, static_cast<const TensorAddUpdate &>(upd));
+        applyTensorUpdate(vec, lid, static_cast<const TensorAddUpdate &>(upd), true);
     } else if (op == ValueUpdate::TensorRemoveUpdate) {
-        applyTensorUpdate(vec, lid, static_cast<const TensorRemoveUpdate &>(upd));
+        applyTensorUpdate(vec, lid, static_cast<const TensorRemoveUpdate &>(upd), false);
     } else if (op == ValueUpdate::Clear) {
         vec.clearDoc(lid);
     } else {


### PR DESCRIPTION
In this case, instead of ignoring the update, create an empty tensor before applying the update.

@toregge please review