### PR TITLE
Balder/let feeder control throttlepolicy

### DIFF
--- a/messagebus/abi-spec.json
+++ b/messagebus/abi-spec.json
@@ -120,6 +120,7 @@
       "public void processReply(com.yahoo.messagebus.Reply)",
       "public com.yahoo.messagebus.DynamicThrottlePolicy setEfficiencyThreshold(double)",
       "public com.yahoo.messagebus.DynamicThrottlePolicy setWindowSizeIncrement(double)",
+      "public com.yahoo.messagebus.DynamicThrottlePolicy setWindowSizeDecrementFactor(double)",
       "public com.yahoo.messagebus.DynamicThrottlePolicy setWindowSizeBackOff(double)",
       "public com.yahoo.messagebus.DynamicThrottlePolicy setResizeRate(double)",
       "public com.yahoo.messagebus.DynamicThrottlePolicy setWeight(double)",

--- a/messagebus/src/main/java/com/yahoo/messagebus/DynamicThrottlePolicy.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/DynamicThrottlePolicy.java
@@ -27,6 +27,7 @@ public class DynamicThrottlePolicy extends StaticThrottlePolicy {
     private double windowSizeIncrement = 20;
     private double windowSize = windowSizeIncrement;
     private double minWindowSize = windowSizeIncrement;
+    private double decrementFactor = 2.0;
     private double maxWindowSize = Integer.MAX_VALUE;
     private double windowSizeBackOff = 0.9;
     private double weight = 1.0;
@@ -93,15 +94,15 @@ public class DynamicThrottlePolicy extends StaticThrottlePolicy {
         numSent = 0;
         numOk = 0;
 
-        if (log.isLoggable(LogLevel.DEBUG)) {
-            log.log(LogLevel.DEBUG, "windowSize " + windowSize + " throughput " + throughput);
-        }
 
         if (maxThroughput > 0 && throughput > maxThroughput * 0.95) {
             // No need to increase window when we're this close to max.
         } else if (throughput > localMaxThroughput * 1.01) {
             localMaxThroughput = throughput;
             windowSize += weight*windowSizeIncrement;
+            if (log.isLoggable(LogLevel.DEBUG)) {
+                log.log(LogLevel.DEBUG, "windowSize " + windowSize + " throughput " + throughput + " local max " + localMaxThroughput);
+            }
         } else {
             // scale up/down throughput for comparing to window size
             double period = 1;
@@ -113,10 +114,13 @@ public class DynamicThrottlePolicy extends StaticThrottlePolicy {
             }
             double efficiency = throughput*period/windowSize;
             if (efficiency < efficiencyThreshold) {
-                windowSize = Math.min(windowSize * windowSizeBackOff, windowSize - 2* windowSizeIncrement);
+                windowSize = Math.max(windowSize * windowSizeBackOff, windowSize - decrementFactor * windowSizeIncrement);
                 localMaxThroughput = 0;
             } else {
                 windowSize += weight*windowSizeIncrement;
+            }
+            if (log.isLoggable(LogLevel.DEBUG)) {
+                log.log(LogLevel.DEBUG, "windowSize " + windowSize + " throughput " + throughput + " local max " + localMaxThroughput + " efficiency " + efficiency);
             }
         }
         windowSize = Math.max(minWindowSize, windowSize);
@@ -153,6 +157,17 @@ public class DynamicThrottlePolicy extends StaticThrottlePolicy {
      */
     public DynamicThrottlePolicy setWindowSizeIncrement(double windowSizeIncrement) {
         this.windowSizeIncrement = windowSizeIncrement;
+        return this;
+    }
+
+    /**
+     * Sets the relative stepsize when decreasing window size.
+     *
+     * @param decrementFactor the step size to set
+     * @return this, to allow chaining
+     */
+    public DynamicThrottlePolicy setWindowSizeDecrementFactor(double decrementFactor) {
+        this.decrementFactor = decrementFactor;
         return this;
     }
 

--- a/messagebus/src/main/java/com/yahoo/messagebus/DynamicThrottlePolicy.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/DynamicThrottlePolicy.java
@@ -114,7 +114,7 @@ public class DynamicThrottlePolicy extends StaticThrottlePolicy {
             }
             double efficiency = throughput*period/windowSize;
             if (efficiency < efficiencyThreshold) {
-                windowSize = Math.max(windowSize * windowSizeBackOff, windowSize - decrementFactor * windowSizeIncrement);
+                windowSize = Math.min(windowSize * windowSizeBackOff, windowSize - decrementFactor * windowSizeIncrement);
                 localMaxThroughput = 0;
             } else {
                 windowSize += weight*windowSizeIncrement;

--- a/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/FeederParams.java
+++ b/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/FeederParams.java
@@ -34,6 +34,12 @@ class FeederParams {
     private boolean benchmarkMode = false;
     private int numDispatchThreads = 1;
     private int maxPending = 0;
+
+    private double windowSizeBackOff = 0.95;
+    private double windowDecrementFactor = 1.2;
+    private double windowResizeRate = 3;
+    private int windowIncrementSize = 20;
+
     private int numConnectionsPerTarget = 1;
     private long numMessagesToSend = Long.MAX_VALUE;
     private List<InputStream> inputStreams = new ArrayList<>();
@@ -83,6 +89,21 @@ class FeederParams {
         this.configId = configId;
         return this;
     }
+    public double getWindowSizeBackOff() {
+        return windowSizeBackOff;
+    }
+
+    public double getWindowDecrementFactor() {
+        return windowDecrementFactor;
+    }
+
+    public double getWindowResizeRate() {
+        return windowResizeRate;
+    }
+
+    public int getWindowIncrementSize() {
+        return windowIncrementSize;
+    }
 
     int getNumConnectionsPerTarget() { return numConnectionsPerTarget; }
 
@@ -117,6 +138,10 @@ class FeederParams {
         opts.addOption("o", "output", true, "File to write to. Extensions gives format (.xml, .json, .vespa) json will be produced if no extension.");
         opts.addOption("c", "numconnections", true, "Number of connections per host.");
         opts.addOption("l", "nummessages", true, "Number of messages to send (all is default).");
+        opts.addOption("wi", "window_incrementsize", true, "Dynamic window increment step size. default = " + windowIncrementSize);
+        opts.addOption("wd", "window_decrementfactor", true, "Dynamic window decrement step size factor. default = " + windowDecrementFactor);
+        opts.addOption("wb", "window_backoffactor", true, "Dynamic window backoff factor. default = " + windowSizeBackOff);
+        opts.addOption("wr", "window_resizerate", true, "Dynamic window resize rate. default = " + windowResizeRate);
 
         CommandLine cmd = new DefaultParser().parse(opts, args);
 
@@ -128,6 +153,18 @@ class FeederParams {
         }
         if (cmd.hasOption('c')) {
             numConnectionsPerTarget = Integer.valueOf(cmd.getOptionValue('c').trim());
+        }
+        if (cmd.hasOption("wi")) {
+            windowIncrementSize = Integer.valueOf(cmd.getOptionValue("wi").trim());
+        }
+        if (cmd.hasOption("wi")) {
+            windowDecrementFactor = Double.valueOf(cmd.getOptionValue("wi").trim());
+        }
+        if (cmd.hasOption("wb")) {
+            windowSizeBackOff = Double.valueOf(cmd.getOptionValue("wb").trim());
+        }
+        if (cmd.hasOption("wr")) {
+            windowResizeRate = Double.valueOf(cmd.getOptionValue("wr").trim());
         }
         if (cmd.hasOption('r')) {
             route = Route.parse(cmd.getOptionValue('r').trim());

--- a/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/FeederParams.java
+++ b/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/FeederParams.java
@@ -157,8 +157,8 @@ class FeederParams {
         if (cmd.hasOption("wi")) {
             windowIncrementSize = Integer.valueOf(cmd.getOptionValue("wi").trim());
         }
-        if (cmd.hasOption("wi")) {
-            windowDecrementFactor = Double.valueOf(cmd.getOptionValue("wi").trim());
+        if (cmd.hasOption("wd")) {
+            windowDecrementFactor = Double.valueOf(cmd.getOptionValue("wd").trim());
         }
         if (cmd.hasOption("wb")) {
             windowSizeBackOff = Double.valueOf(cmd.getOptionValue("wb").trim());

--- a/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
+++ b/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
@@ -101,6 +101,32 @@ public class FeederParamsTest {
     }
 
     @Test
+    public void requireThatWindowSizeIncrementIsParsed() throws ParseException, FileNotFoundException {
+        assertEquals(20, new FeederParams().getWindowIncrementSize());
+        assertEquals(17, new FeederParams().parseArgs("--window_incrementsize", "17").getWindowIncrementSize());
+    }
+
+    static final double SMALL_NUMBER = 0.000000000001;
+
+    @Test
+    public void requireThatWindowSizeDecrementFactorIsParsed() throws ParseException, FileNotFoundException {
+        assertEquals(1.2, new FeederParams().getWindowDecrementFactor(), SMALL_NUMBER);
+        assertEquals(1.3, new FeederParams().parseArgs("--window_decrementfactor", "1.3").getWindowIncrementSize(), SMALL_NUMBER);
+    }
+
+    @Test
+    public void requireThatWindowResizeRateIsParsed() throws ParseException, FileNotFoundException {
+        assertEquals(3.0, new FeederParams().getWindowResizeRate(), SMALL_NUMBER);
+        assertEquals(5.5, new FeederParams().parseArgs("--window_resizerate", "5.5").getWindowResizeRate(), SMALL_NUMBER);
+    }
+
+    @Test
+    public void requireThatWindowBackOffIsParsed() throws ParseException, FileNotFoundException {
+        assertEquals(0.95, new FeederParams().getWindowSizeBackOff(), SMALL_NUMBER);
+        assertEquals(0.97, new FeederParams().parseArgs("--window_backoff", "0.97").getWindowSizeBackOff(), SMALL_NUMBER);
+    }
+
+    @Test
     public void requireThatDumpStreamAreParsed() throws ParseException, IOException {
         assertNull(new FeederParams().getDumpStream());
 

--- a/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
+++ b/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
@@ -111,7 +111,7 @@ public class FeederParamsTest {
     @Test
     public void requireThatWindowSizeDecrementFactorIsParsed() throws ParseException, FileNotFoundException {
         assertEquals(1.2, new FeederParams().getWindowDecrementFactor(), SMALL_NUMBER);
-        assertEquals(1.3, new FeederParams().parseArgs("--window_decrementfactor", "1.3").getWindowIncrementSize(), SMALL_NUMBER);
+        assertEquals(1.3, new FeederParams().parseArgs("--window_decrementfactor", "1.3").getWindowSizeDecrementFactor(), SMALL_NUMBER);
     }
 
     @Test

--- a/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
+++ b/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
@@ -106,24 +106,24 @@ public class FeederParamsTest {
         assertEquals(17, new FeederParams().parseArgs("--window_incrementsize", "17").getWindowIncrementSize());
     }
 
-    static final double SMALL_NUMBER = 0.000000000001;
+    static final double EPSILON = 0.000000000001;
 
     @Test
     public void requireThatWindowSizeDecrementFactorIsParsed() throws ParseException, FileNotFoundException {
-        assertEquals(1.2, new FeederParams().getWindowDecrementFactor(), SMALL_NUMBER);
-        assertEquals(1.3, new FeederParams().parseArgs("--window_decrementfactor", "1.3").getWindowSizeDecrementFactor(), SMALL_NUMBER);
+        assertEquals(1.2, new FeederParams().getWindowDecrementFactor(), EPSILON);
+        assertEquals(1.3, new FeederParams().parseArgs("--window_decrementfactor", "1.3").getWindowDecrementFactor(), EPSILON);
     }
 
     @Test
     public void requireThatWindowResizeRateIsParsed() throws ParseException, FileNotFoundException {
-        assertEquals(3.0, new FeederParams().getWindowResizeRate(), SMALL_NUMBER);
-        assertEquals(5.5, new FeederParams().parseArgs("--window_resizerate", "5.5").getWindowResizeRate(), SMALL_NUMBER);
+        assertEquals(3.0, new FeederParams().getWindowResizeRate(), EPSILON);
+        assertEquals(5.5, new FeederParams().parseArgs("--window_resizerate", "5.5").getWindowResizeRate(), EPSILON);
     }
 
     @Test
     public void requireThatWindowBackOffIsParsed() throws ParseException, FileNotFoundException {
-        assertEquals(0.95, new FeederParams().getWindowSizeBackOff(), SMALL_NUMBER);
-        assertEquals(0.97, new FeederParams().parseArgs("--window_backoff", "0.97").getWindowSizeBackOff(), SMALL_NUMBER);
+        assertEquals(0.95, new FeederParams().getWindowSizeBackOff(), EPSILON);
+        assertEquals(0.97, new FeederParams().parseArgs("--window_backoff", "0.97").getWindowSizeBackOff(), EPSILON);
     }
 
     @Test


### PR DESCRIPTION
@vekterli PR

This should hopefully reduce variation on feed performance tests, by not being so eager on the backoff. No change in defaults for anything but vespa-feed-perf.
