### PR TITLE
Only update bucket DB memory statistics at certain intervals

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -18,6 +18,8 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".distributor-main");
 
+using namespace std::chrono_literals;
+
 namespace storage::distributor {
 
 class Distributor::Status {
@@ -100,9 +102,9 @@ Distributor::Distributor(DistributorComponentRegister& compReg,
       _bucketSpacesStats(),
       _bucketDbStats(),
       _hostInfoReporter(*this, *this),
-      _ownershipSafeTimeCalc(
-            std::make_unique<OwnershipTransferSafeTimePointCalculator>(
-                std::chrono::seconds(0))), // Set by config later
+      _ownershipSafeTimeCalc(std::make_unique<OwnershipTransferSafeTimePointCalculator>(0s)), // Set by config later
+      _db_memory_sample_interval(30s),
+      _last_db_memory_sample_time_point(),
       _must_send_updated_host_info(false),
       _use_btree_database(use_btree_database)
 {
@@ -769,15 +771,23 @@ Distributor::updateInternalMetricsForCompletedScan()
         _must_send_updated_host_info = true;
     }
     _bucketSpacesStats = std::move(new_space_stats);
-    update_bucket_db_memory_usage_stats();
+    maybe_update_bucket_db_memory_usage_stats();
 }
 
-void Distributor::update_bucket_db_memory_usage_stats() {
-    for (auto& space : *_bucketSpaceRepo) {
-        _bucketDBMetricUpdater.update_db_memory_usage(space.second->getBucketDatabase().memory_usage(), true);
-    }
-    for (auto& space : *_readOnlyBucketSpaceRepo) {
-        _bucketDBMetricUpdater.update_db_memory_usage(space.second->getBucketDatabase().memory_usage(), false);
+void Distributor::maybe_update_bucket_db_memory_usage_stats() {
+    auto now = _component.getClock().getMonotonicTime();
+    if ((now - _last_db_memory_sample_time_point) > _db_memory_sample_interval) {
+        for (auto& space : *_bucketSpaceRepo) {
+            _bucketDBMetricUpdater.update_db_memory_usage(space.second->getBucketDatabase().memory_usage(), true);
+        }
+        for (auto& space : *_readOnlyBucketSpaceRepo) {
+            _bucketDBMetricUpdater.update_db_memory_usage(space.second->getBucketDatabase().memory_usage(), false);
+        }
+        _last_db_memory_sample_time_point = now;
+    } else {
+        // Reuse previous memory statistics instead of sampling new.
+        _bucketDBMetricUpdater.update_db_memory_usage(_bucketDbStats._mutable_db_mem_usage, true);
+        _bucketDBMetricUpdater.update_db_memory_usage(_bucketDbStats._read_only_db_mem_usage, false);
     }
 }
 

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -191,6 +191,10 @@ public:
         Distributor& _self;
     };
 
+    std::chrono::steady_clock::duration db_memory_sample_interval() const noexcept {
+        return _db_memory_sample_interval;
+    }
+
 private:
     friend struct DistributorTest;
     friend class BucketDBUpdaterTest;
@@ -226,7 +230,7 @@ private:
      * Takes metric lock.
      */
     void updateInternalMetricsForCompletedScan();
-    void update_bucket_db_memory_usage_stats();
+    void maybe_update_bucket_db_memory_usage_stats();
     void scanAllBuckets();
     MaintenanceScanner::ScanResult scanNextBucket();
     void enableNextConfig();
@@ -330,6 +334,8 @@ private:
     BucketDBMetricUpdater::Stats _bucketDbStats;
     DistributorHostInfoReporter _hostInfoReporter;
     std::unique_ptr<OwnershipTransferSafeTimePointCalculator> _ownershipSafeTimeCalc;
+    std::chrono::steady_clock::duration _db_memory_sample_interval;
+    std::chrono::steady_clock::time_point _last_db_memory_sample_time_point;
     bool _must_send_updated_host_info;
     const bool _use_btree_database;
 };


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

B-tree/datastore stats can be expensive to sample, so don't do
this after every full DB iteration. For now, wait at least 30s.