### PR TITLE
remove latest vespa.log if it is filling the disk too quickly.

### DIFF
--- a/logd/src/logd/watcher.cpp
+++ b/logd/src/logd/watcher.cpp
@@ -117,6 +117,7 @@ Watcher::watchfile()
 {
     struct donecache already;
     char newfn[FILENAME_MAX];
+    int spamfill_counter = 0;
 
     char *target = getenv("VESPA_LOG_TARGET");
     if (target == nullptr || strncmp(target, "file:", 5) != 0) {
@@ -215,23 +216,30 @@ Watcher::watchfile()
 
         if (rotate) {
             vespalib::duration rotTime = rotTimer.elapsed();
-            if (rotTime > 59s || (sb.st_size == offset && rotTime > 4s)) {
-                removeOldLogs(filename);
+            off_t overflow_size = (1.1 * _confsubscriber.getRotateSize());
+            if ((rotTime > 59s) ||
+                (sb.st_size == offset && rotTime > 4s) ||
+                (sb.st_size > overflow_size && rotTime > 2s))
+            {
                 if (sb.st_size != offset) {
                     LOG(warning, "logfile rotation incomplete after %2.3f s (dropping %" PRIu64 " bytes)",
                         vespalib::to_s(rotTime), static_cast<uint64_t>(sb.st_size - offset));
                 } else {
                     LOG(debug, "logfile rotation complete after %2.3f s", vespalib::to_s(rotTime));
                 }
-                if (((now - created) < (rotTime + 300s))
-                    && (sb.st_size > (1.1 * _confsubscriber.getRotateSize())))
-                {
-                    LOG(warning, "logfile spamming, aggressively removing %s", newfn);
-                    unlink(newfn);
+                if (((now - created) < (rotTime + 180s)) && (sb.st_size > overflow_size)) {
+                    ++spamfill_counter;
+                } else {
+                    spamfill_counter = 0;
                 }
                 created = now;
                 rotate = false;
                 close(_wfd);
+                if (spamfill_counter > 2) {
+                    LOG(warning, "logfile spamming %d times, aggressively removing %s", spamfill_counter, newfn);
+                    unlink(newfn);
+                }
+                removeOldLogs(filename);
                 goto again;
             }
         } else if (stat(filename, &sb) != 0


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review

tested manually by running a system test and then turning on spam logging.  not sure if the limits here are reasonable (5 minutes to fill a log file, and filled to 110% of configured rotate limit).