### PR TITLE
Add fastos::UNIX_File_RW_Ops class to simplify error injection in unit tests.

### DIFF
--- a/fastos/src/vespa/fastos/CMakeLists.txt
+++ b/fastos/src/vespa/fastos/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(fastos_objects OBJECT
     app.cpp
     backtrace.c
     file.cpp
+    file_rw_ops.cpp
     linux_file.cpp
     process.cpp
     thread.cpp

--- a/fastos/src/vespa/fastos/file_rw_ops.cpp
+++ b/fastos/src/vespa/fastos/file_rw_ops.cpp
@@ -1,0 +1,13 @@
+// Copyright 2020 Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "file_rw_ops.h"
+#include <unistd.h>
+
+namespace fastos {
+
+File_RW_Ops::ReadFunc File_RW_Ops::_read = ::read;
+File_RW_Ops::WriteFunc File_RW_Ops::_write = ::write;
+File_RW_Ops::PreadFunc File_RW_Ops::_pread = ::pread;
+File_RW_Ops::PwriteFunc File_RW_Ops::_pwrite = ::pwrite;
+
+}

--- a/fastos/src/vespa/fastos/file_rw_ops.h
+++ b/fastos/src/vespa/fastos/file_rw_ops.h
@@ -1,0 +1,33 @@
+// Copyright 2020 Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <sys/types.h>
+
+
+namespace fastos {
+
+/*
+ * Class handling pointers to functions used by FastOS_File for read
+ * and writa access. Unit tests might modify pointers to inject errors.
+ */
+class File_RW_Ops
+{
+    using ReadFunc = ssize_t (*)(int fd, void* buf, size_t count);
+    using WriteFunc = ssize_t (*)(int fd, const void* buf, size_t count);
+    using PreadFunc = ssize_t (*)(int fd, void* buf, size_t count, off_t offset);
+    using PwriteFunc = ssize_t (*)(int fd, const void* buf, size_t count, off_t offset);
+
+public:
+    static ReadFunc _read;
+    static WriteFunc _write;
+    static PreadFunc _pread;
+    static PwriteFunc _pwrite;
+
+    static ssize_t read(int fd, void* buf, size_t count) { return _read(fd, buf, count); }
+    static ssize_t write(int fd, const void* buf, size_t count) { return _write(fd, buf, count); }
+    static ssize_t pread(int fd, void* buf, size_t count, off_t offset) { return _pread(fd, buf, count, offset); }
+    static ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset) { return _pwrite(fd, buf, count, offset); }
+};
+
+}

--- a/fastos/src/vespa/fastos/linux_file.cpp
+++ b/fastos/src/vespa/fastos/linux_file.cpp
@@ -12,6 +12,9 @@
 #include <sstream>
 #include <unistd.h>
 #include <fcntl.h>
+#include "file_rw_ops.h"
+
+using fastos::File_RW_Ops;
 
 const size_t FastOS_Linux_File::_directIOFileAlign = 4096;
 const size_t FastOS_Linux_File::_directIOMemAlign = 4096;
@@ -31,7 +34,7 @@ FastOS_Linux_File::FastOS_Linux_File(const char *filename)
 ssize_t
 FastOS_Linux_File::readInternal(int fh, void *buffer, size_t length, int64_t readOffset)
 {
-    ssize_t readResult = ::pread(fh, buffer, length, readOffset);
+    ssize_t readResult = File_RW_Ops::pread(fh, buffer, length, readOffset);
     if (readResult < 0 && _failedHandler != nullptr) {
         int error = errno;
         const char *fileName = GetFileName();
@@ -45,7 +48,7 @@ FastOS_Linux_File::readInternal(int fh, void *buffer, size_t length, int64_t rea
 ssize_t
 FastOS_Linux_File::readInternal(int fh, void *buffer, size_t length)
 {
-    ssize_t readResult = ::read(fh, buffer, length);
+    ssize_t readResult = File_RW_Ops::read(fh, buffer, length);
     if (readResult < 0 && _failedHandler != nullptr) {
         int error = errno;
         int64_t readOffset = GetPosition();
@@ -60,7 +63,7 @@ FastOS_Linux_File::readInternal(int fh, void *buffer, size_t length)
 ssize_t
 FastOS_Linux_File::writeInternal(int fh, const void *buffer, size_t length, int64_t writeOffset)
 {
-    ssize_t writeRes = ::pwrite(fh, buffer, length, writeOffset);
+    ssize_t writeRes = File_RW_Ops::pwrite(fh, buffer, length, writeOffset);
     if (writeRes < 0 && _failedHandler != nullptr) {
         int error = errno;
         const char *fileName = GetFileName();
@@ -73,7 +76,7 @@ FastOS_Linux_File::writeInternal(int fh, const void *buffer, size_t length, int6
 ssize_t
 FastOS_Linux_File::writeInternal(int fh, const void *buffer, size_t length)
 {
-    ssize_t writeRes = ::write(fh, buffer, length);
+    ssize_t writeRes = File_RW_Ops::write(fh, buffer, length);
     if (writeRes < 0 && _failedHandler != nullptr) {
         int error = errno;
         int64_t writeOffset = GetPosition();

--- a/fastos/src/vespa/fastos/unix_file.cpp
+++ b/fastos/src/vespa/fastos/unix_file.cpp
@@ -21,11 +21,14 @@
 #else
 #include <sys/mount.h>
 #endif
+#include "file_rw_ops.h"
+
+using fastos::File_RW_Ops;
 
 ssize_t
 FastOS_UNIX_File::Read(void *buffer, size_t len)
 {
-    ssize_t nRead = read(_filedes, buffer, len);
+    ssize_t nRead = File_RW_Ops::read(_filedes, buffer, len);
     if (nRead < 0 && _failedHandler != nullptr) {
         int error = errno;
         int64_t readOffset = GetPosition();
@@ -40,7 +43,7 @@ FastOS_UNIX_File::Read(void *buffer, size_t len)
 ssize_t
 FastOS_UNIX_File::Write2(const void *buffer, size_t len)
 {
-    ssize_t writeRes = write(_filedes, buffer, len);
+    ssize_t writeRes = File_RW_Ops::write(_filedes, buffer, len);
     if (writeRes < 0 && _failedHandler != nullptr) {
         int error = errno;
         int64_t writeOffset = GetPosition();
@@ -71,7 +74,7 @@ void FastOS_UNIX_File::ReadBuf(void *buffer, size_t length,
 {
     ssize_t readResult;
 
-    readResult = pread(_filedes, buffer, length, readOffset);
+    readResult = File_RW_Ops::pread(_filedes, buffer, length, readOffset);
     if (readResult < 0 && _failedHandler != nullptr) {
         int error = errno;
         const char *fileName = GetFileName();


### PR DESCRIPTION
@baldersheim : please review
