### PR TITLE
Hold config lock when modifying load balancers

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/Maintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/Maintainer.java
@@ -48,19 +48,13 @@ public abstract class Maintainer extends AbstractComponent implements Runnable {
     @Override
     @SuppressWarnings({"try", "unused"})
     public void run() {
-        try (Lock lock = lock(lockRoot.append(name()))) {
+        try (Lock lock = curator.lock(lockRoot.append(name()), Duration.ofSeconds(1))) {
             maintain();
         } catch (UncheckedTimeoutException e) {
             // another config server instance is running this job at the moment; ok
         } catch (Throwable t) {
             log.log(Level.WARNING, this + " failed. Will retry in " + maintenanceInterval.toMinutes() + " minutes", t);
         }
-    }
-
-    private Lock lock(Path path) {
-        Lock lock = new Lock(path.getAbsolute(), curator);
-        lock.acquire(Duration.ofSeconds(1));
-        return lock;
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
@@ -120,11 +120,13 @@ public class LoadBalancerExpirer extends Maintainer {
     /** Apply operation to all load balancers that exist in given state, while holding lock */
     private void withLoadBalancersIn(LoadBalancer.State state, Consumer<LoadBalancer> operation) {
         for (var id : db.readLoadBalancerIds()) {
-            try (var lock = db.lockLoadBalancers(id.application())) {
-                var loadBalancer = db.readLoadBalancer(id);
-                if (loadBalancer.isEmpty()) continue;              // Load balancer was removed during loop
-                if (loadBalancer.get().state() != state) continue; // Wrong state
-                operation.accept(loadBalancer.get());
+            try (var lock = db.lockConfig(id.application())) {
+                try (var legacyLock = db.lockLoadBalancers(id.application())) {
+                    var loadBalancer = db.readLoadBalancer(id);
+                    if (loadBalancer.isEmpty()) continue;              // Load balancer was removed during loop
+                    if (loadBalancer.get().state() != state) continue; // Wrong state
+                    operation.accept(loadBalancer.get());
+                }
             }
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabase.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabase.java
@@ -38,16 +38,10 @@ public class CuratorDatabase {
     /** A partial cache of the Curator database, which is only valid if generations match */
     private final AtomicReference<Cache> cache = new AtomicReference<>();
 
-    /** Whether we should return data from the cache or always read fro ZooKeeper */
+    /** Whether we should return data from the cache or always read from ZooKeeper */
     private final boolean useCache;
 
     private final Object cacheCreationLock = new Object();
-
-    /**
-     * All keys, to allow reentrancy.
-     * This will grow forever with the number of applications seen, but this should be too slow to be a problem.
-     */
-    private final ConcurrentHashMap<Path, Lock> locks = new ConcurrentHashMap<>();
 
     /**
      * Creates a curator database
@@ -72,11 +66,8 @@ public class CuratorDatabase {
     }
 
     /** Create a reentrant lock */
-    // Locks are not cached in the in-memory state
     public Lock lock(Path path, Duration timeout) {
-        Lock lock = locks.computeIfAbsent(path, (pathArg) -> new Lock(pathArg.getAbsolute(), curator));
-        lock.acquire(timeout);
-        return lock;
+        return curator.lock(path, timeout);
     }
 
     // --------- Write operations ------------------------------------------------------------------------------

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -52,9 +52,11 @@ public class LoadBalancerProvisioner {
         this.service = service;
         // Read and write all load balancers to make sure they are stored in the latest version of the serialization format
         for (var id : db.readLoadBalancerIds()) {
-            try (var lock = db.lockLoadBalancers(id.application())) {
-                var loadBalancer = db.readLoadBalancer(id);
-                loadBalancer.ifPresent(db::writeLoadBalancer);
+            try (var lock = db.lockConfig(id.application())) {
+                try (var legacyLock = db.lockLoadBalancers(id.application())) {
+                    var loadBalancer = db.readLoadBalancer(id);
+                    loadBalancer.ifPresent(db::writeLoadBalancer);
+                }
             }
         }
     }
@@ -73,8 +75,10 @@ public class LoadBalancerProvisioner {
         if (requestedNodes.type() != NodeType.tenant) return; // Nothing to provision for this node type
         if (!cluster.type().isContainer()) return; // Nothing to provision for this cluster type
         if (application.instance().isTester()) return; // Do not provision for tester instances
-        try (var lock = db.lockLoadBalancers(application)) {
-            provision(application, effectiveId(cluster), false, lock);
+        try (var lock = db.lockConfig(application)) {
+            try (var legacyLock = db.lockLoadBalancers(application)) {
+                provision(application, effectiveId(cluster), false, lock);
+            }
         }
     }
 
@@ -90,15 +94,17 @@ public class LoadBalancerProvisioner {
      */
     public void activate(ApplicationId application, Set<ClusterSpec> clusters,
                          @SuppressWarnings("unused") Mutex applicationLock, NestedTransaction transaction) {
-        try (var lock = db.lockLoadBalancers(application)) {
-            var containerClusters = containerClustersOf(clusters);
-            for (var clusterId : containerClusters) {
-                // Provision again to ensure that load balancer instance is re-configured with correct nodes
-                provision(application, clusterId, true, lock);
+        try (var lock = db.lockConfig(application)) {
+            try (var legacyLock = db.lockLoadBalancers(application)) {
+                var containerClusters = containerClustersOf(clusters);
+                for (var clusterId : containerClusters) {
+                    // Provision again to ensure that load balancer instance is re-configured with correct nodes
+                    provision(application, clusterId, true, legacyLock);
+                }
+                // Deactivate any surplus load balancers, i.e. load balancers for clusters that have been removed
+                var surplusLoadBalancers = surplusLoadBalancersOf(application, containerClusters);
+                deactivate(surplusLoadBalancers, transaction);
             }
-            // Deactivate any surplus load balancers, i.e. load balancers for clusters that have been removed
-            var surplusLoadBalancers = surplusLoadBalancersOf(application, containerClusters);
-            deactivate(surplusLoadBalancers, transaction);
         }
     }
 
@@ -108,8 +114,10 @@ public class LoadBalancerProvisioner {
      */
     public void deactivate(ApplicationId application, NestedTransaction transaction) {
         try (var applicationLock = nodeRepository.lock(application)) {
-            try (var lock = db.lockLoadBalancers(application)) {
-                deactivate(nodeRepository.loadBalancers(application).asList(), transaction);
+            try (var lock = db.lockConfig(application)) {
+                try (var legacyLock = db.lockLoadBalancers(application)) {
+                    deactivate(nodeRepository.loadBalancers(application).asList(), transaction);
+                }
             }
         }
     }

--- a/zkfacade/abi-spec.json
+++ b/zkfacade/abi-spec.json
@@ -85,6 +85,7 @@
       "public java.util.List getChildren(com.yahoo.path.Path)",
       "public java.util.Optional getData(com.yahoo.path.Path)",
       "public java.util.Optional getStat(com.yahoo.path.Path)",
+      "public com.yahoo.vespa.curator.Lock lock(com.yahoo.path.Path, java.time.Duration)",
       "public org.apache.curator.framework.CuratorFramework framework()",
       "public void close()",
       "public java.lang.String zooKeeperEnsembleConnectionSpec()",

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -48,27 +48,23 @@ import java.util.logging.Logger;
  */
 public class Curator implements AutoCloseable {
 
-    private static final Logger logger = Logger.getLogger(Curator.class.getName());
-
-    private static final int ZK_SESSION_TIMEOUT = 30000;
-    private static final int ZK_CONNECTION_TIMEOUT = 30000;
-
-    private static final int BASE_SLEEP_TIME = 1000; //ms
+    private static final Logger LOG = Logger.getLogger(Curator.class.getName());
+    private static final File ZK_CLIENT_CONFIG_FILE = new File(Defaults.getDefaults().underVespaHome("conf/zookeeper/zookeeper-client.cfg"));
+    private static final Duration ZK_SESSION_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration ZK_CONNECTION_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration BASE_SLEEP_TIME = Duration.ofSeconds(1);
     private static final int MAX_RETRIES = 10;
-
-    private static final File zkClientConfigFile = new File(Defaults.getDefaults().underVespaHome("conf/zookeeper/zookeeper-client.cfg"));
 
     protected final RetryPolicy retryPolicy;
 
     private final CuratorFramework curatorFramework;
     private final String connectionSpec; // May be a subset of the servers in the ensemble
-
     private final String zooKeeperEnsembleConnectionSpec;
     private final int zooKeeperEnsembleCount;
 
     /** Creates a curator instance from a comma-separated string of ZooKeeper host:port strings */
     public static Curator create(String connectionSpec) {
-        return new Curator(connectionSpec, connectionSpec, Optional.of(zkClientConfigFile));
+        return new Curator(connectionSpec, connectionSpec, Optional.of(ZK_CLIENT_CONFIG_FILE));
     }
 
     // For testing only, use Optional.empty for clientConfigFile parameter to create default zookeeper client config
@@ -80,7 +76,7 @@ public class Curator implements AutoCloseable {
     // TODO: Move zookeeperserver config out of configserverconfig (requires update of controller services.xml as well)
     @Inject
     public Curator(ConfigserverConfig configserverConfig, VespaZooKeeperServer server) {
-        this(configserverConfig, Optional.of(zkClientConfigFile));
+        this(configserverConfig, Optional.of(ZK_CLIENT_CONFIG_FILE));
     }
 
     Curator(ConfigserverConfig configserverConfig, Optional<File> clientConfigFile) {
@@ -93,8 +89,8 @@ public class Curator implements AutoCloseable {
                 (retryPolicy) -> CuratorFrameworkFactory
                         .builder()
                         .retryPolicy(retryPolicy)
-                        .sessionTimeoutMs(ZK_SESSION_TIMEOUT)
-                        .connectionTimeoutMs(ZK_CONNECTION_TIMEOUT)
+                        .sessionTimeoutMs((int) ZK_SESSION_TIMEOUT.toMillis())
+                        .connectionTimeoutMs((int) ZK_CONNECTION_TIMEOUT.toMillis())
                         .connectString(connectionSpec)
                         .zookeeperFactory(new VespaZooKeeperFactory(createClientConfig(clientConfigFile)))
                         .dontUseContainerParents() // TODO: Remove when we know ZooKeeper 3.5 works fine, consider waiting until Vespa 8
@@ -105,7 +101,7 @@ public class Curator implements AutoCloseable {
                       String zooKeeperEnsembleConnectionSpec,
                       Function<RetryPolicy, CuratorFramework> curatorFactory) {
         this(connectionSpec, zooKeeperEnsembleConnectionSpec, curatorFactory,
-                new ExponentialBackoffRetry(BASE_SLEEP_TIME, MAX_RETRIES));
+                new ExponentialBackoffRetry((int) BASE_SLEEP_TIME.toMillis(), MAX_RETRIES));
     }
 
     private Curator(String connectionSpec,
@@ -193,7 +189,7 @@ public class Curator implements AutoCloseable {
 
     /** For internal use; prefer creating a {@link CuratorCounter} */
     public DistributedAtomicLong createAtomicCounter(String path) {
-        return new DistributedAtomicLong(curatorFramework, path, new ExponentialBackoffRetry(BASE_SLEEP_TIME, MAX_RETRIES));
+        return new DistributedAtomicLong(curatorFramework, path, new ExponentialBackoffRetry((int) BASE_SLEEP_TIME.toMillis(), MAX_RETRIES));
     }
 
     /** For internal use; prefer creating a {@link com.yahoo.vespa.curator.Lock} */
@@ -204,9 +200,9 @@ public class Curator implements AutoCloseable {
     private void addLoggingListener() {
         curatorFramework.getConnectionStateListenable().addListener((curatorFramework, connectionState) -> {
             switch (connectionState) {
-                case SUSPENDED: logger.info("ZK connection state change: SUSPENDED"); break;
-                case RECONNECTED: logger.info("ZK connection state change: RECONNECTED"); break;
-                case LOST: logger.warning("ZK connection state change: LOST"); break;
+                case SUSPENDED: LOG.info("ZK connection state change: SUSPENDED"); break;
+                case RECONNECTED: LOG.info("ZK connection state change: RECONNECTED"); break;
+                case LOST: LOG.warning("ZK connection state change: LOST"); break;
             }
         });
     }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Lock.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Lock.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.curator;
 
 import com.google.common.util.concurrent.UncheckedTimeoutException;
+import com.yahoo.path.Path;
 import com.yahoo.transaction.Mutex;
 import org.apache.curator.framework.recipes.locks.InterProcessLock;
 
@@ -10,7 +11,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A cluster-wide re-entrant mutex which is released on (the last symmetric) close
+ * A cluster-wide re-entrant mutex which is released on (the last symmetric) close.
+ *
+ * Re-entrancy is limited to the instance of this. To ensure re-entrancy callers should access the lock through
+ * {@link Curator#lock(Path, Duration)} instead of constructing this directly.
  *
  * @author bratseth
  */


### PR DESCRIPTION
Moves the lock map to `Curator` to allow re-entrant lock across modules. First
commit is the same as #12877.

@bratseth or @hmusum