### PR TITLE
Revert "Try to not install the conformancetest library."

### DIFF
--- a/persistence/src/vespa/persistence/CMakeLists.txt
+++ b/persistence/src/vespa/persistence/CMakeLists.txt
@@ -9,6 +9,7 @@ vespa_add_library(persistence
 vespa_add_library(persistence_persistence_conformancetest
     SOURCES
     $<TARGET_OBJECTS:persistence_conformancetest_lib>
+    INSTALL lib64
     DEPENDS
     persistence
     gtest


### PR DESCRIPTION
Reverts vespa-engine/vespa#12905

This did not work. Failing tests for the persistence module.