### PR TITLE
truncate doubles when converting to labels/indexes

### DIFF
--- a/eval/src/tests/eval/function/function_test.cpp
+++ b/eval/src/tests/eval/function/function_test.cpp
@@ -977,9 +977,9 @@ TEST("require that tensor peek can contain expressions") {
 }
 
 TEST("require that trivial tensor peek number expressions are converted to verbatim labels") {
-    TEST_DO(verify_parse("t{x:(5.7)}", "f(t)(t{x:\"6\"})"));
+    TEST_DO(verify_parse("t{x:(5.7)}", "f(t)(t{x:\"5\"})"));
     TEST_DO(verify_parse("t{x:(5.3)}", "f(t)(t{x:\"5\"})"));
-    TEST_DO(verify_parse("t{x:(-5.7)}", "f(t)(t{x:\"-6\"})"));
+    TEST_DO(verify_parse("t{x:(-5.7)}", "f(t)(t{x:\"-5\"})"));
     TEST_DO(verify_parse("t{x:(-5.3)}", "f(t)(t{x:\"-5\"})"));
 }
 

--- a/eval/src/tests/tensor/dense_tensor_peek_function/dense_tensor_peek_function_test.cpp
+++ b/eval/src/tests/tensor/dense_tensor_peek_function/dense_tensor_peek_function_test.cpp
@@ -73,13 +73,13 @@ TEST("require that tensor peek is not optimized for mixed tensor") {
     TEST_DO(verify("xmy2{x:(a),y:(b)}", 0.0, 0, 1));
 }
 
-TEST("require that indexes are rounded to nearest integer") {
-    TEST_DO(verify("x3{x:(a-0.3)}", 2.0, 1, 0));
+TEST("require that indexes are truncated when converted to integers") {
+    TEST_DO(verify("x3{x:(a+0.7)}", 2.0, 1, 0));
     TEST_DO(verify("x3{x:(a+0.3)}", 2.0, 1, 0));
-    TEST_DO(verify("xm{x:(a-0.3)}", 1.0, 0, 1));
+    TEST_DO(verify("xm{x:(a+0.7)}", 1.0, 0, 1));
     TEST_DO(verify("xm{x:(a+0.3)}", 1.0, 0, 1));
+    TEST_DO(verify("xm{x:(-a-0.7)}", 4.0, 0, 1));
     TEST_DO(verify("xm{x:(-a-0.3)}", 4.0, 0, 1));
-    TEST_DO(verify("xm{x:(-a+0.3)}", 4.0, 0, 1));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/eval/src/vespa/eval/eval/function.cpp
+++ b/eval/src/vespa/eval/eval/function.cpp
@@ -804,7 +804,7 @@ void parse_tensor_peek(ParseContext &ctx) {
         if (ctx.get() == '(') {
             auto expr = get_expression(ctx);
             if (auto num = nodes::as<nodes::Number>(*expr)) {
-                peek_spec.emplace(dim_name, make_string("%" PRId64, int64_t(round(num->value()))));
+                peek_spec.emplace(dim_name, make_string("%" PRId64, int64_t(num->value())));
             } else {
                 peek_spec.emplace(dim_name, std::move(expr));
             }

--- a/eval/src/vespa/eval/eval/tensor_function.cpp
+++ b/eval/src/vespa/eval/eval/tensor_function.cpp
@@ -182,7 +182,7 @@ void op_tensor_peek(State &state, uint64_t param) {
                            addr.emplace(pos->first, label);
                        },
                        [&](const TensorFunction::Child &) {
-                           double index = round(state.peek(child_cnt++).as_double());
+                           double index = state.peek(child_cnt++).as_double();
                            size_t dim_idx = self.param_type().dimension_index(pos->first);
                            assert(dim_idx != ValueType::Dimension::npos);
                            const auto &param_dim = self.param_type().dimensions()[dim_idx];

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_peek_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_peek_function.cpp
@@ -29,7 +29,7 @@ void my_tensor_peek_op(eval::InterpretedFunction::State &state, uint64_t param) 
         if (dim.first >= 0) {
             idx += (dim.first * factor);
         } else {
-            size_t dim_idx(round(state.peek(0).as_double()));
+            size_t dim_idx = state.peek(0).as_double();
             state.stack.pop_back();
             valid &= (dim_idx < dim.second);
             idx += (dim_idx * factor);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@lesters please review