### PR TITLE
Remove redundant bucket DB lookup in persistence reply handling.

### DIFF
--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -84,7 +84,6 @@ private:
     bool hasSentReply() const { return _reply.get() == 0; }
     bool shouldRevert() const;
     void sendReply(MessageSender& sender);
-    void checkCopiesDeleted();
     void updateFailureResult(const api::BucketInfoReply& reply);
     void handleCreateBucketReply(api::BucketInfoReply& reply, uint16_t node);
     void handlePersistenceReply(api::BucketInfoReply& reply, uint16_t node);


### PR DESCRIPTION
@geirst please review

Bucket DB updating happened unconditionally anyway; this was
only used for failing operations in an overly pessimistic way.

Removing this lookup has two benefits:
- Less CPU spent in (and around) DB
- Less impact expected during feeding during node state
  transitions since fewer operations will have to be needlessly
  retried by the client.

Rationale: an operation towards a given bucket completes (i.e.
is ACKed by all its replica nodes) at time _t_ and the bucket is
removed from the DB at time _T_. There is no fundamental change
in correctness or behavior from the client's perspective if
the order of events is _tT_ or _Tt_. Both are equally valid, as
the state transition edge happens independently of any reply
processing.
