### PR TITLE
Temporarily inhibit maintenance scans when node has heavy message load

### DIFF
--- a/storage/src/tests/distributor/distributortest.cpp
+++ b/storage/src/tests/distributor/distributortest.cpp
@@ -700,6 +700,14 @@ TEST_F(DistributorTest, replica_counting_mode_config_is_propagated_to_metric_upd
     EXPECT_EQ(ConfigBuilder::MinimumReplicaCountingMode::ANY, currentReplicaCountingMode());
 }
 
+TEST_F(DistributorTest, max_consecutively_inhibited_maintenance_ticks_config_is_propagated_to_internal_config) {
+    setupDistributor(Redundancy(2), NodeCount(2), "storage:2 distributor:1");
+    ConfigBuilder builder;
+    builder.maxConsecutivelyInhibitedMaintenanceTicks = 123;
+    getConfig().configure(builder);
+    EXPECT_EQ(getConfig().max_consecutively_inhibited_maintenance_ticks(), 123);
+}
+
 TEST_F(DistributorTest, bucket_activation_is_enabled_by_default) {
     setupDistributor(Redundancy(2), NodeCount(2), "storage:2 distributor:1");
     EXPECT_FALSE(getConfig().isBucketActivationDisabled());

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -22,6 +22,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _maxIdealStateOperations(100),
       _idealStateChunkSize(1000),
       _maxNodesPerMerge(16),
+      _max_consecutively_inhibited_maintenance_ticks(20),
       _lastGarbageCollectionChange(vespalib::duration::zero()),
       _garbageCollectionInterval(0),
       _minPendingMaintenanceOps(100),
@@ -44,7 +45,8 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _use_weak_internal_read_consistency_for_client_gets(false),
       _enable_metadata_only_fetch_phase_for_inconsistent_updates(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
-{ }
+{
+}
 
 DistributorConfiguration::~DistributorConfiguration() = default;
 
@@ -123,6 +125,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _docCountJoinLimit = config.joincount;
     _minimalBucketSplit = config.minsplitcount;
     _maxNodesPerMerge = config.maximumNodesPerMerge;
+    _max_consecutively_inhibited_maintenance_ticks = config.maxConsecutivelyInhibitedMaintenanceTicks;
 
     _garbageCollectionInterval = std::chrono::seconds(config.garbagecollection.interval);
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -242,6 +242,10 @@ public:
         return _enable_metadata_only_fetch_phase_for_inconsistent_updates;
     }
 
+    uint32_t max_consecutively_inhibited_maintenance_ticks() const noexcept {
+        return _max_consecutively_inhibited_maintenance_ticks;
+    }
+
     bool containsTimeStatement(const std::string& documentSelection) const;
     
 private:
@@ -258,6 +262,7 @@ private:
     uint32_t _maxIdealStateOperations;
     uint32_t _idealStateChunkSize;
     uint32_t _maxNodesPerMerge;
+    uint32_t _max_consecutively_inhibited_maintenance_ticks;
 
     std::string _garbageCollectionSelection;
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -237,3 +237,10 @@ use_weak_internal_read_consistency_for_client_gets bool default=false
 ## feature, so it's not required to set that config to true, nor will setting it
 ## to false actually disable the feature.
 enable_metadata_only_fetch_phase_for_inconsistent_updates bool default=false
+
+## If a distributor main thread tick is constantly processing requests or responses
+## originating from other nodes, setting this value above zero will prevent implicit
+## maintenance scans from being done as part of the tick for up to N rounds of ticking.
+## This is to reduce the amount of CPU spent on ideal state calculations and bucket DB
+## accesses when the distributor is heavily loaded with feed operations.
+max_consecutively_inhibited_maintenance_ticks int default=20

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -233,12 +233,15 @@ private:
     void maybe_update_bucket_db_memory_usage_stats();
     void scanAllBuckets();
     MaintenanceScanner::ScanResult scanNextBucket();
+    bool should_inhibit_current_maintenance_scan_tick() const noexcept;
+    void mark_current_maintenance_tick_as_inhibited() noexcept;
+    void mark_maintenance_tick_as_no_longer_inhibited() noexcept;
     void enableNextConfig();
     void fetchStatusRequests();
     void fetchExternalMessages();
     void startNextMaintenanceOperation();
     void signalWorkWasDone();
-    bool workWasDone();
+    bool workWasDone() const noexcept;
 
     void enterRecoveryMode();
     void leaveRecoveryMode();
@@ -336,6 +339,7 @@ private:
     std::unique_ptr<OwnershipTransferSafeTimePointCalculator> _ownershipSafeTimeCalc;
     std::chrono::steady_clock::duration _db_memory_sample_interval;
     std::chrono::steady_clock::time_point _last_db_memory_sample_time_point;
+    size_t _inhibited_maintenance_tick_count;
     bool _must_send_updated_host_info;
     const bool _use_btree_database;
 };

--- a/storageframework/src/tests/thread/tickingthreadtest.cpp
+++ b/storageframework/src/tests/thread/tickingthreadtest.cpp
@@ -234,21 +234,6 @@ TEST(TickingThreadTest, test_lock_critical_ticks)
     }
 }
 
-TEST(TickingThreadTest, test_fails_on_start_without_threads)
-{
-    TestComponentRegister testReg(
-            ComponentRegisterImpl::UP(new ComponentRegisterImpl));
-    int threadCount = 0;
-    MyApp app(threadCount, true);
-    try{
-        app.start(testReg.getThreadPoolImpl());
-        FAIL() << "Expected starting without threads to fail";
-    } catch (vespalib::Exception& e) {
-        EXPECT_EQ(vespalib::string("Makes no sense to start threadpool without threads"),
-                  e.getMessage());
-    }
-}
-
 namespace {
 
 RealClock clock;


### PR DESCRIPTION
@geirst please review.

If requests or responses from external sources are being constantly
processed as part of the distributor ticking, allow for up to _N_ ticks
to skip maintenance scanning, where _N_ is a configurable number.
This reduces the amount of CPU time spent on maintenance operations
when the node has a lot of incoming data to deal with.

Haven't seen much of a difference when testing locally, but I suspect that
my laptop is too scrawny to make the distributor the bottleneck when testing
end-to-end. Would like to get the factory performance tests' opinion on this.