### PR TITLE
Retry once if the acquired file bundle is not readable.

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/config/FileAcquirerBundleInstaller.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/FileAcquirerBundleInstaller.java
@@ -7,13 +7,16 @@ import com.yahoo.osgi.Osgi;
 import org.osgi.framework.Bundle;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 /**
  * @author gjoranv
  */
 public class FileAcquirerBundleInstaller implements BundleInstaller {
+    private static Logger log = Logger.getLogger(FileAcquirerBundleInstaller.class.getName());
 
     private final FileAcquirer fileAcquirer;
 
@@ -23,8 +26,30 @@ public class FileAcquirerBundleInstaller implements BundleInstaller {
 
     @Override
     public List<Bundle> installBundles(FileReference reference, Osgi osgi) throws InterruptedException {
-        File file = fileAcquirer.waitFor(reference, 7, TimeUnit.DAYS);
+        File file = acquireFile(reference);
+
+        // Retrying is added in case FileAcquirer returns right before the file is actually ready.
+        // This happened on rare occasions due to a (fixed) bug in file distribution.
+        int retries = 0;
+        while (notReadable(file) && retries < 1) {
+            log.warning("Unable to open bundle file with reference '" + reference + "'. Retrying.");
+            file = acquireFile(reference);
+            retries++;
+        }
+
+        if (notReadable(file)) {
+            com.yahoo.protect.Process.logAndDie("Shutting down - unable to read bundle file with reference '" + reference
+                                                        + "' and path " + file.getAbsolutePath());
+        }
         return osgi.install(file.getAbsolutePath());
+    }
+
+    private File acquireFile(FileReference reference) throws InterruptedException {
+        return fileAcquirer.waitFor(reference, 7, TimeUnit.DAYS);
+    }
+
+    private static boolean notReadable(File file) {
+        return ! Files.isReadable(file.toPath());
     }
 
 }


### PR DESCRIPTION
Should we actually retry (like it is now), or simply wait for a period after a single call to waitFor?

FYI: @bjorncs 