### PR TITLE
Ignore gcc stringop-truncation warning in vespalog.

### DIFF
--- a/vespalog/src/vespa/log/control-file.cpp
+++ b/vespalog/src/vespa/log/control-file.cpp
@@ -264,7 +264,12 @@ ControlFile::getLevels(const char *name)
     strcat(appendedString, &padSpaces[3 - padding]);
     int prefix_len = strlen(appendedString);
 
+#pragma GCC diagnostic push
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
     strncat(appendedString, inheritLevels, Logger::NUM_LOGLEVELS*sizeof(int));
+#pragma GCC diagnostic pop
     strcat(appendedString, "\n");
 
     int len = strlen(appendedString);


### PR DESCRIPTION
@baldersheim : please review
