### PR TITLE
Hide linux specific tuning from non-linux platforms.

### DIFF
--- a/searchlib/src/vespa/searchlib/common/tunefileinfo.hpp
+++ b/searchlib/src/vespa/searchlib/common/tunefileinfo.hpp
@@ -24,17 +24,21 @@ template <typename MMapConfig>
 void
 TuneFileRandRead::setFromMmapConfig(const MMapConfig & mmapFlags) {
     for (size_t i(0), m(mmapFlags.options.size()); i < m; i++) {
+#ifdef __linux__
         switch (mmapFlags.options[i]) {
             case MMapConfig::Options::MLOCK:    _mmapFlags |= MAP_LOCKED; break;
             case MMapConfig::Options::POPULATE: _mmapFlags |= MAP_POPULATE; break;
             case MMapConfig::Options::HUGETLB:  _mmapFlags |= MAP_HUGETLB; break;
         }
+#endif
     }
+#ifdef __linux__
     switch (mmapFlags.advise) {
         case MMapConfig::Advise::NORMAL:     setAdvise(POSIX_FADV_NORMAL); break;
         case MMapConfig::Advise::RANDOM:     setAdvise(POSIX_FADV_RANDOM); break;
         case MMapConfig::Advise::SEQUENTIAL: setAdvise(POSIX_FADV_SEQUENTIAL); break;
     }
+#endif
 }
 
 }


### PR DESCRIPTION
@baldersheim : please review
