### PR TITLE
There are so many combinations that the libstdc++ library can be buil…

### DIFF
--- a/vespalib/src/vespa/vespalib/util/time.cpp
+++ b/vespalib/src/vespa/vespalib/util/time.cpp
@@ -52,3 +52,29 @@ Timer::waitAtLeast(duration dur, bool busyWait) {
 }
 
 }
+
+namespace std::chrono {
+
+// This is a hack to avoid the slow clock computations on RHEL7/CentOS 7 due to using systemcalls.
+// This brings cost down from 550-560ns to 18-19ns
+
+inline namespace _V2 {
+
+system_clock::time_point
+system_clock::now() noexcept {
+    timespec tp;
+    clock_gettime(CLOCK_REALTIME, &tp);
+    return time_point(duration(chrono::seconds(tp.tv_sec)
+                               + chrono::nanoseconds(tp.tv_nsec)));
+}
+
+steady_clock::time_point
+steady_clock::now() noexcept {
+    timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    return time_point(duration(chrono::seconds(tp.tv_sec)
+                               + chrono::nanoseconds(tp.tv_nsec)));
+}
+
+}
+}


### PR DESCRIPTION
…t that the performance

you get from std::chrono::system_clock and stxad::chrono::steady_clock has a dramatic performance difference.
On RHEL7/Centos with an witout this patch is 18ns vs 550ns.

@vekterli and @toregge @havardpe PR
Any other suggestions ?
