### PR TITLE
A failed attempt at unlinking a directory causes another exception

### DIFF
--- a/vespalib/src/tests/io/fileutil/fileutiltest.cpp
+++ b/vespalib/src/tests/io/fileutil/fileutiltest.cpp
@@ -297,7 +297,11 @@ TEST("require that vespalib::unlink works")
         TEST_FATAL("Should work on directories.");
     } catch (IoException& e) {
         //std::cerr << e.what() << "\n";
+#ifdef __APPLE__
+        EXPECT_EQUAL(IoException::NO_PERMISSION, e.getType());
+#else
         EXPECT_EQUAL(IoException::ILLEGAL_PATH, e.getType());
+#endif
     }
         // Works for file
     {


### PR DESCRIPTION
on Darwin due to unlink system call returning a different error
code.

@baldersheim : please review
