### PR TITLE
Revert "Dump stack trace several times if config proxy does not start"

### DIFF
--- a/config-proxy/src/main/sh/vespa-config-ctl.sh
+++ b/config-proxy/src/main/sh/vespa-config-ctl.sh
@@ -153,11 +153,6 @@ case $1 in
             elif ! vespa-ping-configproxy -s $hname
             then
                 echo "failed to ping config proxy $hname" 1>&2
-                # TODO: Dump stack trace for debugging, remove after April 2020
-                kill -3 `pgrep -f -n configproxy`
-                sleep 2
-                kill -3 `pgrep -f -n configproxy`
-                sleep 2
                 kill -3 `pgrep -f -n configproxy`
             fi
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#12961

Not needed anymore