### PR TITLE
Revert "Reduce timeout for nodesDown and noNodeDown in cd"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -941,8 +941,8 @@ public class InternalStepRunner implements StepRunner {
         Duration endpoint() { return Duration.ofMinutes(15); }
         Duration endpointCertificate() { return Duration.ofMinutes(20); }
         Duration tester() { return Duration.ofMinutes(30); }
-        Duration nodesDown() { return Duration.ofMinutes(system.isCd() ? 20 : 60); }
-        Duration noNodesDown() { return Duration.ofMinutes(system.isCd() ? 20 : 120); }
+        Duration nodesDown() { return Duration.ofMinutes(system.isCd() ? 30 : 60); }
+        Duration noNodesDown() { return Duration.ofMinutes(system.isCd() ? 30 : 120); }
         Duration testerCertificate() { return Duration.ofMinutes(300); }
 
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#12777

20 minutes is not always enough to download an image, go back to 30 minutes