### PR TITLE
Disk cleanup 

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeMembership.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeMembership.java
@@ -1,26 +1,33 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.configserver.noderepository;
 
+import java.util.Objects;
+
 /**
  * @author freva
  */
 public class NodeMembership {
-    private final String clusterType;
+    private final ClusterType clusterType;
     private final String clusterId;
     private final String group;
     private final int index;
     private final boolean retired;
 
     public NodeMembership(String clusterType, String clusterId, String group, int index, boolean retired) {
-        this.clusterType = clusterType;
+        this.clusterType = new ClusterType(clusterType);
         this.clusterId = clusterId;
         this.group = group;
         this.index = index;
         this.retired = retired;
     }
 
-    public String clusterType() {
+    public ClusterType type() {
         return clusterType;
+    }
+
+    /** DEPRECATED: Use {@link #type()} instead */
+    public String clusterType() {
+        return clusterType.value();
     }
 
     public String clusterId() {
@@ -73,5 +80,40 @@ public class NodeMembership {
                 " index = " + index +
                 " retired = " + retired +
                 " }";
+    }
+
+    public static class ClusterType {
+        private final String type;
+
+        private ClusterType(String type) {
+            this.type = Objects.requireNonNull(type);
+        }
+
+        public boolean isAdmin() { return "admin".equals(type); }
+        public boolean isContent() { return "content".equals(type) || "combined".equals(type); }
+        public boolean isContainer() { return "container".equals(type) || "combined".equals(type); }
+
+        public String value() {
+            return type;
+        }
+
+        @Override
+        public String toString() {
+            return type;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ClusterType that = (ClusterType) o;
+            return type.equals(that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return type.hashCode();
+        }
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.hosted.node.admin.task.util.file.DiskSize;
 
 import java.time.Instant;
 import java.util.EnumSet;
@@ -218,6 +219,10 @@ public class NodeSpec {
 
     public double memoryGb() {
         return resources.memoryGb();
+    }
+
+    public DiskSize diskSize() {
+        return DiskSize.of(resources.diskGb(), DiskSize.Unit.GB);
     }
 
     public double diskGb() {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -88,7 +88,7 @@ public class DockerOperationsImpl implements DockerOperations {
         if (context.nodeType() != NodeType.proxy && context.nodeType() != NodeType.controller)
             command.withSecurityOpt("no-new-privileges");
 
-        if (context.node().membership().map(NodeMembership::clusterType).map("content"::equalsIgnoreCase).orElse(false))
+        if (context.node().membership().map(m -> m.type().isContent()).orElse(false))
             command.withSecurityOpt("seccomp=unconfined");
 
         DockerNetworking networking = context.dockerNetworking();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -89,7 +89,7 @@ public class StorageMaintainer {
 
         String[] results = output.split("\t");
         if (results.length != 2) {
-            throw new RuntimeException("Result from disk usage command not as expected: " + output);
+            throw new ConvergenceException("Result from disk usage command not as expected: " + output);
         }
 
         return 1024 * Long.parseLong(results[0]);
@@ -174,11 +174,11 @@ public class StorageMaintainer {
         String output = uncheck(() -> Files.readAllLines(Paths.get("/proc/cpuinfo")).stream()
                 .filter(line -> line.startsWith("microcode"))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("No microcode information found in /proc/cpuinfo")));
+                .orElseThrow(() -> new ConvergenceException("No microcode information found in /proc/cpuinfo")));
 
         String[] results = output.split(":");
         if (results.length != 2) {
-            throw new RuntimeException("Result from detect microcode command not as expected: " + output);
+            throw new ConvergenceException("Result from detect microcode command not as expected: " + output);
         }
 
         return results[1].trim();

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -3,10 +3,17 @@ package com.yahoo.vespa.hosted.node.admin.maintenance;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.yahoo.config.provision.NodeType;
 import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.hosted.dockerapi.Container;
+import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
 import com.yahoo.vespa.hosted.node.admin.maintenance.coredump.CoredumpHandler;
+import com.yahoo.vespa.hosted.node.admin.maintenance.disk.CoredumpCleanupRule;
+import com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanup;
+import com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule;
+import com.yahoo.vespa.hosted.node.admin.maintenance.disk.LinearCleanupRule;
+import com.yahoo.vespa.hosted.node.admin.nodeadmin.ConvergenceException;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixPath;
@@ -17,18 +24,20 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
-import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.nameMatches;
-import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.olderThan;
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.Priority;
 import static com.yahoo.yolean.Exceptions.uncheck;
 
 /**
@@ -42,34 +51,34 @@ public class StorageMaintainer {
     private final Terminal terminal;
     private final CoredumpHandler coredumpHandler;
     private final Path archiveContainerStoragePath;
+    private final DiskCleanup diskCleanup;
     private final Clock clock;
 
     // We cache disk usage to avoid doing expensive disk operations so often
-    private final Cache<Path, Long> diskUsage = CacheBuilder.newBuilder()
+    private final Cache<ContainerName, Long> diskUsage = CacheBuilder.newBuilder()
             .maximumSize(100)
             .expireAfterWrite(5, TimeUnit.MINUTES)
             .build();
 
     public StorageMaintainer(Terminal terminal, CoredumpHandler coredumpHandler, Path archiveContainerStoragePath) {
-        this(terminal, coredumpHandler, archiveContainerStoragePath, Clock.systemUTC());
+        this(terminal, coredumpHandler, archiveContainerStoragePath, new DiskCleanup(), Clock.systemUTC());
     }
 
-    public StorageMaintainer(Terminal terminal, CoredumpHandler coredumpHandler, Path archiveContainerStoragePath, Clock clock) {
+    public StorageMaintainer(Terminal terminal, CoredumpHandler coredumpHandler, Path archiveContainerStoragePath, DiskCleanup diskCleanup, Clock clock) {
         this.terminal = terminal;
         this.coredumpHandler = coredumpHandler;
         this.archiveContainerStoragePath = archiveContainerStoragePath;
+        this.diskCleanup = diskCleanup;
         this.clock = clock;
     }
 
     public Optional<Long> getDiskUsageFor(NodeAgentContext context) {
         try {
-            Path path = context.pathOnHostFromPathInNode("/");
-
-            Long cachedDiskUsage = diskUsage.getIfPresent(path);
+            Long cachedDiskUsage = diskUsage.getIfPresent(context.containerName());
             if (cachedDiskUsage != null) return Optional.of(cachedDiskUsage);
 
-            long diskUsageBytes = getDiskUsedInBytes(context, path);
-            diskUsage.put(path, diskUsageBytes);
+            long diskUsageBytes = getDiskUsedInBytes(context, context.pathOnHostFromPathInNode("/"));
+            diskUsage.put(context.containerName(), diskUsageBytes);
             return Optional.of(diskUsageBytes);
         } catch (Exception e) {
             context.log(logger, LogLevel.WARNING, "Failed to get disk usage", e);
@@ -95,37 +104,44 @@ public class StorageMaintainer {
         return 1024 * Long.parseLong(results[0]);
     }
 
+    public boolean cleanDiskIfFull(NodeAgentContext context) {
+        double totalBytes = context.node().diskGb() * 1_000_000_000L;
+        // Delete enough bytes to get below 80% disk usage, but only if we are already using more than 90% disk
+        long bytesToRemove = getDiskUsageFor(context)
+                .map(diskUsage -> (long) (diskUsage - 0.8 * totalBytes))
+                .filter(bytes -> bytes > totalBytes * 0.1)
+                .orElse(0L);
 
-    /** Deletes old log files for vespa and nginx */
-    public void removeOldFilesFromNode(NodeAgentContext context) {
-        Path[] logPaths = {
-                context.pathInNodeUnderVespaHome("logs/nginx"),
-                context.pathInNodeUnderVespaHome("logs/vespa")
-        };
-
-        for (Path pathToClean : logPaths) {
-            Path path = context.pathOnHostFromPathInNode(pathToClean);
-            FileFinder.files(path)
-                    .match(olderThan(Duration.ofDays(3)).and(nameMatches(Pattern.compile(".*\\.log.+"))))
-                    .maxDepth(1)
-                    .deleteRecursively(context);
+        if (bytesToRemove > 0 && diskCleanup.cleanup(context, createCleanupRules(context), bytesToRemove)) {
+            diskUsage.invalidate(context.containerName());
+            return true;
         }
+        return false;
+    }
 
-        FileFinder.files(context.pathOnHostFromPathInNode(context.pathInNodeUnderVespaHome("logs/vespa/qrs")))
-                .match(olderThan(Duration.ofDays(3)))
-                .deleteRecursively(context);
+    private List<DiskCleanupRule> createCleanupRules(NodeAgentContext context) {
+        Instant start = clock.instant();
+        double oneMonthSeconds = Duration.ofDays(30).getSeconds();
+        Function<Instant, Double> monthNormalizer = instant -> Duration.between(instant, start).getSeconds() / oneMonthSeconds;
+        Function<String, Path> pathOnHostUnderContainerVespaHome = path ->
+                context.pathOnHostFromPathInNode(context.pathInNodeUnderVespaHome(path));
+        List<DiskCleanupRule> rules = new ArrayList<>();
 
-        FileFinder.files(context.pathOnHostFromPathInNode(context.pathInNodeUnderVespaHome("logs/vespa/logarchive")))
-                .match(olderThan(Duration.ofDays(31)))
-                .deleteRecursively(context);
+        rules.add(CoredumpCleanupRule.forContainer(pathOnHostUnderContainerVespaHome.apply("var/crash")));
 
-        FileFinder.directories(context.pathOnHostFromPathInNode(context.pathInNodeUnderVespaHome("var/db/vespa/filedistribution")))
-                .match(olderThan(Duration.ofDays(31)))
-                .deleteRecursively(context);
+        if (context.node().membership().map(m -> m.type().isContainer()).orElse(false))
+            rules.add(new LinearCleanupRule(() -> FileFinder.files(pathOnHostUnderContainerVespaHome.apply("logs/vespa/qrs")).list(),
+                    fa -> monthNormalizer.apply(fa.lastModifiedTime()), Priority.LOWEST, Priority.HIGHEST));
 
-        FileFinder.directories(context.pathOnHostFromPathInNode(context.pathInNodeUnderVespaHome("var/db/vespa/download")))
-                .match(olderThan(Duration.ofDays(31)))
-                .deleteRecursively(context);
+        if (context.nodeType() == NodeType.tenant && context.node().membership().map(m -> m.type().isAdmin()).orElse(false))
+            rules.add(new LinearCleanupRule(() -> FileFinder.files(pathOnHostUnderContainerVespaHome.apply("logs/vespa/logarchive")).list(),
+                    fa -> monthNormalizer.apply(fa.lastModifiedTime()), Priority.LOWEST, Priority.HIGHEST));
+
+        if (context.nodeType() == NodeType.proxy)
+            rules.add(new LinearCleanupRule(() -> FileFinder.files(pathOnHostUnderContainerVespaHome.apply("logs/nginx")).list(),
+                    fa -> monthNormalizer.apply(fa.lastModifiedTime()), Priority.LOWEST, Priority.MEDIUM));
+
+        return rules;
     }
 
     /** Checks if container has any new coredumps, reports and archives them if so */

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
@@ -2,10 +2,8 @@
 package com.yahoo.vespa.hosted.node.admin.maintenance.coredump;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.hosted.dockerapi.metrics.Dimensions;
 import com.yahoo.vespa.hosted.dockerapi.metrics.Metrics;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeMembership;
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
@@ -44,7 +42,7 @@ public class CoredumpHandler {
     private static final String LZ4_PATH = "/usr/bin/lz4";
     private static final String PROCESSING_DIRECTORY_NAME = "processing";
     private static final String METADATA_FILE_NAME = "metadata.json";
-    private static final String COREDUMP_FILENAME_PREFIX = "dump_";
+    public static final String COREDUMP_FILENAME_PREFIX = "dump_";
 
     private final Logger logger = Logger.getLogger(CoredumpHandler.class.getName());
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -245,7 +243,7 @@ public class CoredumpHandler {
 
         node.membership().ifPresent(membership ->
             dimensionsBuilder
-                    .add("clustertype", membership.clusterType())
+                    .add("clustertype", membership.type().value())
                     .add("clusterid", membership.clusterId())
         );
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/CoredumpCleanupRule.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/CoredumpCleanupRule.java
@@ -1,0 +1,106 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import com.yahoo.vespa.hosted.node.admin.maintenance.coredump.CoredumpHandler;
+import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.PrioritizedFileAttributes;
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.Priority;
+import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.FileAttributes;
+import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.nameStartsWith;
+
+/**
+ * @author freva
+ */
+public class CoredumpCleanupRule {
+
+    private static final Comparator<FileAttributes> CORE_DUMP_FILE_ATTRIBUTE_COMPARATOR = Comparator
+            .comparing((FileAttributes fa) -> !fa.filename().contains("vespa-"))
+            .thenComparing(FileAttributes::lastModifiedTime);
+
+    public static DiskCleanupRule forContainer(Path containerCrashPath) {
+        return new ContainerCoredumpCleanupRule(containerCrashPath);
+    }
+
+    public static DiskCleanupRule forHost(Path processedCoredumpsPath) {
+        return new HostCoredumpCleanupRule(processedCoredumpsPath);
+    }
+
+    /** Assigns MEDIUM priority to the oldest, unprocessed coredump and HIGHEST for the remaining */
+    private static class ContainerCoredumpCleanupRule implements DiskCleanupRule {
+        private final Path containerCrashPath;
+
+        private ContainerCoredumpCleanupRule(Path containerCrashPath) {
+            this.containerCrashPath = containerCrashPath;
+        }
+
+        @Override
+        public Collection<PrioritizedFileAttributes> prioritize() {
+            List<FileAttributes> fileAttributes = FileFinder.files(containerCrashPath)
+                    .maxDepth(1).stream()
+                    .sorted(CORE_DUMP_FILE_ATTRIBUTE_COMPARATOR)
+                    .collect(Collectors.toList());
+
+            return mapFirstAndRemaining(fileAttributes, Priority.MEDIUM, Priority.HIGHEST).collect(Collectors.toList());
+        }
+    }
+
+    /** Assigns MEDIUM priority to the first coredump of the day for each container, HIGH for the remaining */
+    private static class HostCoredumpCleanupRule implements DiskCleanupRule {
+        private final Path processedCoredumpsPath;
+
+        private HostCoredumpCleanupRule(Path processedCoredumpsPath) {
+            this.processedCoredumpsPath = processedCoredumpsPath;
+        }
+
+        @Override
+        public Collection<PrioritizedFileAttributes> prioritize() {
+            Map<String, List<FileAttributes>> fileAttributesByContainerDay = FileFinder.files(processedCoredumpsPath)
+                    .match(nameStartsWith(CoredumpHandler.COREDUMP_FILENAME_PREFIX))
+                    .stream()
+                    .sorted(CORE_DUMP_FILE_ATTRIBUTE_COMPARATOR)
+                    .collect(Collectors.groupingBy(
+                            // Group FileAttributes by string [container-name]_[day of year], e.g. zt00534-v6-2_234
+                            fa -> containerNameFromProcessedCoredumpPath(fa.path()) + "_" + dayOfYear(fa.lastModifiedTime()),
+                            Collectors.collectingAndThen(
+                                    Collectors.toCollection(ArrayList::new),
+                                    l -> { l.sort(CORE_DUMP_FILE_ATTRIBUTE_COMPARATOR); return l; } )));
+
+            return fileAttributesByContainerDay.values().stream()
+                    .flatMap(fa -> mapFirstAndRemaining(fa, Priority.MEDIUM, Priority.HIGH))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Maps list of FileAttributes into list of PrioritizedFileAttributes where the first FileAttribute is given
+     * {@code first} priority, while the remaining FileAttributes are given {@code remaining} priority */
+    private static Stream<PrioritizedFileAttributes> mapFirstAndRemaining(List<FileAttributes> fileAttributes, Priority first, Priority remaining) {
+        return IntStream.range(0, fileAttributes.size())
+                .mapToObj(i -> new PrioritizedFileAttributes(fileAttributes.get(i), i == 0 ? first : remaining));
+    }
+
+    /** Extracts container-name from path under processed-coredumps or empty string */
+    private static String containerNameFromProcessedCoredumpPath(Path path) {
+        if (path.getNameCount() < 3) return ""; // Path is too short
+        return path.getName(path.getNameCount() - 3).toString();
+    }
+
+    /** Returns day number of the year (1-365 (or 366 for leap years)) */
+    private static int dayOfYear(Instant instant) {
+        return instant.atOffset(ZoneOffset.UTC).get(ChronoField.DAY_OF_YEAR);
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanup.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanup.java
@@ -1,0 +1,67 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.PrioritizedFileAttributes;
+import static com.yahoo.yolean.Exceptions.uncheck;
+
+/**
+ * @author freva
+ */
+public class DiskCleanup {
+
+    private static final Logger logger = Logger.getLogger(DiskCleanup.class.getName());
+    private static final char[] UNITS = "kMGTPE".toCharArray();
+    private static final Comparator<PrioritizedFileAttributes> PRIORITIZED_FILE_ATTRIBUTES_COMPARATOR = Comparator
+            .comparing(PrioritizedFileAttributes::priority)
+            .thenComparingLong(f -> f.fileAttributes().size())
+            .reversed();
+
+    public boolean cleanup(TaskContext context, List<DiskCleanupRule> rules, long bytesToRemove) {
+        if (bytesToRemove <= 0) return false;
+
+        long[] btr = new long[] { bytesToRemove };
+        List<Path> deletedPaths = new ArrayList<>();
+        try {
+            rules.stream()
+                    .flatMap(rule -> rule.prioritize().stream())
+                    .sorted(PRIORITIZED_FILE_ATTRIBUTES_COMPARATOR)
+                    .takeWhile(fa -> btr[0] > 0)
+                    .forEach(pfa -> {
+                        if (uncheck(() -> Files.deleteIfExists(pfa.fileAttributes().path()))) {
+                            btr[0] -= pfa.fileAttributes().size();
+                            deletedPaths.add(pfa.fileAttributes().path());
+                        }
+                    });
+
+        } finally {
+            String wantedDeleteSize = bytesToDisplayCount(bytesToRemove);
+            String deletedSize = bytesToDisplayCount(bytesToRemove - btr[0]);
+            if (deletedPaths.size() > 20) {
+                context.log(logger, "Deleted %d files (%s) because disk was getting full", deletedPaths.size(), deletedSize);
+            } else if (deletedPaths.size() > 0) {
+                context.log(logger, "Deleted %s because disk was getting full from: %s", deletedSize, deletedPaths);
+            } else {
+                context.log(logger, "Wanted to delete %s, but failed to find any files to delete", wantedDeleteSize);
+            }
+        }
+
+        return !deletedPaths.isEmpty();
+    }
+
+    static String bytesToDisplayCount(long bytes) {
+        if (bytes < 1000) return bytes + " bytes";
+
+        int unit = -1;
+        for (; bytes >= 1000; unit++) bytes /= 1000;
+        return bytes + " " + UNITS[unit] + "B";
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanup.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanup.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
 
 import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
+import com.yahoo.vespa.hosted.node.admin.task.util.file.DiskSize;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,8 +44,8 @@ public class DiskCleanup {
                     });
 
         } finally {
-            String wantedDeleteSize = bytesToDisplayCount(bytesToRemove);
-            String deletedSize = bytesToDisplayCount(bytesToRemove - btr[0]);
+            String wantedDeleteSize = DiskSize.of(bytesToRemove).asString();
+            String deletedSize = DiskSize.of(bytesToRemove - btr[0]).asString();
             if (deletedPaths.size() > 20) {
                 context.log(logger, "Deleted %d files (%s) because disk was getting full", deletedPaths.size(), deletedSize);
             } else if (deletedPaths.size() > 0) {
@@ -55,13 +56,5 @@ public class DiskCleanup {
         }
 
         return !deletedPaths.isEmpty();
-    }
-
-    static String bytesToDisplayCount(long bytes) {
-        if (bytes < 1000) return bytes + " bytes";
-
-        int unit = -1;
-        for (; bytes >= 1000; unit++) bytes /= 1000;
-        return bytes + " " + UNITS[unit] + "B";
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanupRule.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanupRule.java
@@ -1,0 +1,31 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
+
+import java.util.Collection;
+
+/**
+ * @author freva
+ */
+public interface DiskCleanupRule {
+
+    Collection<PrioritizedFileAttributes> prioritize();
+
+    enum Priority {
+        LOWEST, LOW, MEDIUM, HIGH, HIGHEST
+    }
+
+    class PrioritizedFileAttributes {
+        private final FileFinder.FileAttributes fileAttributes;
+        private final Priority priority;
+
+        public PrioritizedFileAttributes(FileFinder.FileAttributes fileAttributes, Priority priority) {
+            this.fileAttributes = fileAttributes;
+            this.priority = priority;
+        }
+
+        public Priority priority() { return priority; }
+        public FileFinder.FileAttributes fileAttributes() { return fileAttributes; }
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/LinearCleanupRule.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/LinearCleanupRule.java
@@ -1,0 +1,48 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.FileAttributes;
+
+/**
+ * Prioritizes files by first scoring them with the given scoring function and then mapping the scores to a
+ * priority within the given range.
+ * The priority room is evenly split between given lowest and highest priority for range [0, 1.0). Scores below 0
+ * are assigned lowest, while scores at or higher than 1 are assigned highest priority.
+ *
+ * Typical use-case is for log files. The scoring function calculates the file age and normalizes it by dividing it
+ * by expected max age of log files. The oldest logs will then by prioritized by highest given priority.
+ *
+ * @author freva
+ */
+public class LinearCleanupRule implements DiskCleanupRule {
+    private final Supplier<List<FileAttributes>> lister;
+    private final Function<FileAttributes, Priority> prioritizer;
+
+    public LinearCleanupRule(Supplier<List<FileAttributes>> lister,
+                             Function<FileAttributes, Double> scorer, Priority lowest, Priority highest) {
+        if (lowest.ordinal() > highest.ordinal())
+            throw new IllegalArgumentException("Lowest priority: " + lowest + " is higher than highest priority: " + highest);
+
+        this.lister = lister;
+
+        Priority[] values = Priority.values();
+        int range = highest.ordinal() - lowest.ordinal() + 1;
+        this.prioritizer = fa -> {
+            int ordinal = (int) (lowest.ordinal() + scorer.apply(fa) * range);
+            return values[Math.max(lowest.ordinal(), Math.min(highest.ordinal(), ordinal))];
+        };
+    }
+
+    @Override
+    public Collection<PrioritizedFileAttributes> prioritize() {
+        return lister.get().stream()
+                .map(fa -> new PrioritizedFileAttributes(fa, prioritizer.apply(fa)))
+                .collect(Collectors.toList());
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/package-info.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/package-info.java
@@ -1,0 +1,5 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/DiskSize.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/DiskSize.java
@@ -1,0 +1,63 @@
+package com.yahoo.vespa.hosted.node.admin.task.util.file;
+
+import java.util.Objects;
+
+/**
+ * @author freva
+ */
+public class DiskSize {
+
+    public static final DiskSize ZERO = DiskSize.of(0);
+    private static final char[] UNITS = "kMGTPE".toCharArray();
+
+    public enum Unit {
+        kB(1000), kiB(1 << 10),
+        MB(1_000_000), MiB(1 << 20),
+        GB(1_000_000_000), GiB(1 << 30),
+        PB(1_000_000_000_000L), PiB(1L << 40);
+
+        private final long size;
+        Unit(long size) { this.size = size; }
+    }
+
+    private final long bytes;
+    private DiskSize(long bytes) { this.bytes = bytes; }
+
+    public long bytes() { return bytes; }
+    public long as(Unit unit) { return bytes / unit.size; }
+    public double asDouble(Unit unit) { return (double) bytes / unit.size; }
+
+    public DiskSize add(DiskSize other) { return new DiskSize(bytes + other.bytes); }
+
+    public static DiskSize of(long bytes) { return new DiskSize(bytes); }
+    public static DiskSize of(double bytes, Unit unit) { return new DiskSize((long) (bytes * unit.size)); }
+    public static DiskSize of(long bytes, Unit unit) { return new DiskSize(bytes * unit.size); }
+
+    public String asString() { return asString(0); }
+    public String asString(int decimals) {
+        if (bytes < 1000) return bytes + " bytes";
+
+        int unit = -1;
+        double remaining = bytes;
+        for (; remaining >= 1000; unit++) remaining /= 1000;
+        return String.format("%." + decimals + "f %sB", remaining, UNITS[unit]);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DiskSize size = (DiskSize) o;
+        return bytes == size.bytes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return asString();
+    }
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileFinder.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileFinder.java
@@ -63,7 +63,7 @@ public class FileFinder {
     /**
      * Predicate that will be used to match files and directories under the base path.
      *
-     * NOTE: Consequtive calls to this method are ANDed (this include the initial filter from
+     * NOTE: Consecutive calls to this method are ANDed (this include the initial filter from
      * {@link #files(Path)} or {@link #directories(Path)}.
      */
     public FileFinder match(Predicate<FileAttributes> matcher) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileFinder.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileFinder.java
@@ -193,7 +193,7 @@ public class FileFinder {
         private final Path path;
         private final BasicFileAttributes attributes;
 
-        FileAttributes(Path path, BasicFileAttributes attributes) {
+        public FileAttributes(Path path, BasicFileAttributes attributes) {
             this.path = path;
             this.attributes = attributes;
         }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanup;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContextImpl;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
+import com.yahoo.vespa.hosted.node.admin.task.util.file.DiskSize;
 import com.yahoo.vespa.hosted.node.admin.task.util.process.TestTerminal;
 import com.yahoo.vespa.test.file.TestFileSystem;
 import org.junit.After;
@@ -52,17 +53,17 @@ public class StorageMaintainerTest {
             Files.createDirectories(context.pathOnHostFromPathInNode("/"));
 
             terminal.expectCommand("du -xsk /home/docker/host-1 2>&1", 0, "321\t/home/docker/host-1/");
-            assertEquals(Optional.of(328_704L), storageMaintainer.getDiskUsageFor(context));
+            assertEquals(Optional.of(DiskSize.of(328_704)), storageMaintainer.diskUsageFor(context));
 
             // Value should still be cached, no new execution against the terminal
-            assertEquals(Optional.of(328_704L), storageMaintainer.getDiskUsageFor(context));
+            assertEquals(Optional.of(DiskSize.of(328_704)), storageMaintainer.diskUsageFor(context));
         }
 
         @Test
         public void testNonExistingDiskUsed() {
             StorageMaintainer storageMaintainer = new StorageMaintainer(terminal, null, null);
-            long usedBytes = storageMaintainer.getDiskUsedInBytes(null, Paths.get("/fake/path"));
-            assertEquals(0L, usedBytes);
+            DiskSize size = storageMaintainer.getDiskUsed(null, Paths.get("/fake/path"));
+            assertEquals(DiskSize.ZERO, size);
         }
 
         @After

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/CoredumpCleanupRuleTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/CoredumpCleanupRuleTest.java
@@ -1,0 +1,103 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import com.yahoo.vespa.test.file.TestFileSystem;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.PrioritizedFileAttributes;
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.Priority;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author freva
+ */
+public class CoredumpCleanupRuleTest {
+
+    private final FileSystem fileSystem = TestFileSystem.create();
+
+    @Test
+    public void for_container_test() throws IOException {
+        Path path = fileSystem.getPath("/test/path");
+        DiskCleanupRule rule = CoredumpCleanupRule.forContainer(path);
+
+        assertPriorities(rule, Map.of());
+
+        createFile(path.resolve("core1"), Instant.ofEpochSecond(232));
+        assertPriorities(rule, Map.of("/test/path/core1", Priority.MEDIUM));
+
+        createFile(path.resolve("core2"), Instant.ofEpochSecond(123));
+        assertPriorities(rule, Map.of(
+                "/test/path/core2", Priority.MEDIUM,
+                "/test/path/core1", Priority.HIGHEST));
+
+        createFile(path.resolve("vespa-proton-bin.core.325"), Instant.ofEpochSecond(456));
+        createFile(path.resolve("vespa-distributor.core.764"), Instant.ofEpochSecond(256));
+        var expected = Map.of(
+                "/test/path/core2", Priority.HIGHEST,
+                "/test/path/core1", Priority.HIGHEST,
+                "/test/path/vespa-proton-bin.core.325", Priority.HIGHEST,
+                "/test/path/vespa-distributor.core.764", Priority.MEDIUM);
+        assertPriorities(rule, expected);
+
+        // processing core has no effect on this
+        Files.createDirectories(path.resolve("processing/abcd-1234"));
+        createFile(path.resolve("processing/abcd-1234/core5"), Instant.ofEpochSecond(67));
+        assertPriorities(rule, expected);
+    }
+
+    @Test
+    public void for_host_test() throws IOException {
+        Path path = fileSystem.getPath("/test/path");
+        DiskCleanupRule rule = CoredumpCleanupRule.forHost(path);
+
+        assertPriorities(rule, Map.of());
+
+        createFile(path.resolve("h123a/abcd-1234/dump_core1"), Instant.parse("2020-04-21T19:21:00Z"));
+        createFile(path.resolve("h123a/abcd-1234/metadata.json"), Instant.parse("2020-04-21T19:26:00Z"));
+        assertPriorities(rule, Map.of("/test/path/h123a/abcd-1234/dump_core1", Priority.MEDIUM));
+
+        createFile(path.resolve("h123a/abcd-efgh/dump_core1"), Instant.parse("2020-04-21T07:13:00Z"));
+        createFile(path.resolve("h123a/56ad-af42/dump_vespa-distributor.321"), Instant.parse("2020-04-21T23:37:00Z"));
+        createFile(path.resolve("h123a/4324-a23d/dump_core2"), Instant.parse("2020-04-22T04:56:00Z"));
+        createFile(path.resolve("h123a/8534-7da3/dump_vespa-proton-bin.123"), Instant.parse("2020-04-19T15:35:00Z"));
+
+        // Also create a core for a second container: h123b
+        createFile(path.resolve("h123b/db1a-ab34/dump_core1"), Instant.parse("2020-04-21T07:01:00Z"));
+        createFile(path.resolve("h123b/7392-59ad/dump_vespa-proton-bin.342"), Instant.parse("2020-04-22T12:05:00Z"));
+
+        assertPriorities(rule, Map.of(
+                "/test/path/h123a/abcd-1234/dump_core1", Priority.HIGH,
+                "/test/path/h123a/abcd-efgh/dump_core1", Priority.HIGH,
+
+                // Although it is the oldest core of the day for h123a, it is the first one that starts with vespa-
+                "/test/path/h123a/56ad-af42/dump_vespa-distributor.321", Priority.MEDIUM,
+                "/test/path/h123a/4324-a23d/dump_core2", Priority.MEDIUM,
+                "/test/path/h123a/8534-7da3/dump_vespa-proton-bin.123", Priority.MEDIUM,
+                "/test/path/h123b/db1a-ab34/dump_core1", Priority.MEDIUM,
+                "/test/path/h123b/7392-59ad/dump_vespa-proton-bin.342", Priority.MEDIUM
+        ));
+    }
+
+    private static void createFile(Path path, Instant instant) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.createFile(path);
+        Files.setLastModifiedTime(path, FileTime.from(instant));
+    }
+
+    private static void assertPriorities(DiskCleanupRule rule, Map<String, Priority> expected) {
+        Map<String, Priority> actual = rule.prioritize().stream()
+                .collect(Collectors.toMap(pfa -> pfa.fileAttributes().path().toString(), PrioritizedFileAttributes::priority));
+
+        assertEquals(new TreeMap<>(expected), new TreeMap<>(actual));
+    }
+}

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanupTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanupTest.java
@@ -88,19 +88,6 @@ public class DiskCleanupTest {
                 "/opt/vespa/var/crash/core4", "/opt/vespa/var/crash/vespa-proton-bin.core-232", "/opt/vespa/logs/vespa-2.log", "/opt/vespa/var/crash/core3");
     }
 
-    @Test
-    public void bytes_to_display_count_test() {
-        assertEquals("-1 bytes", DiskCleanup.bytesToDisplayCount(-1));
-        assertEquals("123 bytes", DiskCleanup.bytesToDisplayCount(123));
-        assertEquals("1 kB", DiskCleanup.bytesToDisplayCount(1_000));
-        assertEquals("15 MB", DiskCleanup.bytesToDisplayCount(15_000_000));
-        assertEquals("123 GB", DiskCleanup.bytesToDisplayCount(123_456_789_012L));
-        assertEquals("987 TB", DiskCleanup.bytesToDisplayCount(987_654_321_098_765L));
-        assertEquals("2 PB", DiskCleanup.bytesToDisplayCount(2_000_000_000_000_000L));
-        assertEquals("9 EB", DiskCleanup.bytesToDisplayCount(Long.MAX_VALUE));
-
-    }
-
     private static class DiskCleanupRuleMock implements DiskCleanupRule {
         private final ArrayList<PrioritizedFileAttributes> pfa = new ArrayList<>();
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanupTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/DiskCleanupTest.java
@@ -1,0 +1,142 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import com.yahoo.vespa.hosted.node.admin.component.TestTaskContext;
+import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
+import com.yahoo.vespa.test.file.TestFileSystem;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.FileAttributes;
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.Priority;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author freva
+ */
+public class DiskCleanupTest {
+
+    private final TestTaskContext context = new TestTaskContext();
+    private final DiskCleanupTester tester = new DiskCleanupTester();
+    private final DiskCleanup diskCleanup = new DiskCleanup();
+
+    @Test
+    public void nothing_deleted() throws IOException {
+        assertFalse(diskCleanup.cleanup(context, List.of(), 0));
+        assertFalse(diskCleanup.cleanup(context, List.of(), 10));
+
+        DiskCleanupRuleMock rule1 = new DiskCleanupRuleMock();
+        DiskCleanupRuleMock rule2 = new DiskCleanupRuleMock();
+        assertFalse(diskCleanup.cleanup(context, List.of(rule1, rule2), 0));
+        assertFalse(diskCleanup.cleanup(context, List.of(rule1, rule2), 10));
+
+        tester.createFile("/path/that-should-not-be-deleted", 5);
+        assertFalse(diskCleanup.cleanup(context, List.of(rule1, rule2), 10));
+        tester.assertAllFilesExistExcept();
+
+        // Create a file and let rule return it, but before cleanup is run, the file is deleted
+        rule1.addFile(tester.createFile("/path/file-does-not-exist", 1), Priority.HIGHEST);
+        Files.delete(tester.path("/path/file-does-not-exist"));
+        assertFalse(diskCleanup.cleanup(context, List.of(rule1, rule2), 10));
+    }
+
+    @Test
+    public void delete_test() throws IOException {
+        tester.createFile("/opt/vespa/var/db/do-not-delete-1.db", 1);
+        tester.createFile("/opt/vespa/var/db/do-not-delete-2.db", 1);
+        tester.createFile("/opt/vespa/var/zookeeper/do-not-delete-3", 1);
+        tester.createFile("/opt/vespa/var/index/something-important", 1);
+
+        DiskCleanupRuleMock rule1 = new DiskCleanupRuleMock()
+                .addFile(tester.createFile("/opt/vespa/logs/vespa-1.log", 10), Priority.MEDIUM)
+                .addFile(tester.createFile("/opt/vespa/logs/vespa-2.log", 8), Priority.HIGH)
+                .addFile(tester.createFile("/opt/vespa/logs/vespa-3.log", 13), Priority.HIGHEST)
+                .addFile(tester.createFile("/opt/vespa/logs/vespa-4.log", 10), Priority.HIGHEST);
+        DiskCleanupRuleMock rule2 = new DiskCleanupRuleMock()
+                .addFile(tester.createFile("/opt/vespa/var/crash/core1", 105), Priority.LOW)
+                .addFile(tester.createFile("/opt/vespa/var/crash/vespa-proton-bin.core-232", 190), Priority.HIGH)
+                .addFile(tester.createFile("/opt/vespa/var/crash/core3", 54), Priority.MEDIUM)
+                .addFile(tester.createFile("/opt/vespa/var/crash/core4", 300), Priority.HIGH);
+
+        // 2 files with HIGHEST priority, tie broken by the largest size which is won by "vespa-3.log", since
+        // it is >= 10 bytes, no more files are deleted
+        assertTrue(diskCleanup.cleanup(context, List.of(rule1, rule2), 10));
+        tester.assertAllFilesExistExcept("/opt/vespa/logs/vespa-3.log");
+
+        // Called with the same arguments, but vespa-3.log is still missing...
+        assertTrue(diskCleanup.cleanup(context, List.of(rule1, rule2), 10));
+        tester.assertAllFilesExistExcept("/opt/vespa/logs/vespa-3.log", "/opt/vespa/logs/vespa-4.log");
+
+        assertTrue(diskCleanup.cleanup(context, List.of(rule1, rule2), 500));
+        tester.assertAllFilesExistExcept("/opt/vespa/logs/vespa-3.log", "/opt/vespa/logs/vespa-4.log", // from before
+                // 300 + 190 + 8 + 54
+                "/opt/vespa/var/crash/core4", "/opt/vespa/var/crash/vespa-proton-bin.core-232", "/opt/vespa/logs/vespa-2.log", "/opt/vespa/var/crash/core3");
+    }
+
+    @Test
+    public void bytes_to_display_count_test() {
+        assertEquals("-1 bytes", DiskCleanup.bytesToDisplayCount(-1));
+        assertEquals("123 bytes", DiskCleanup.bytesToDisplayCount(123));
+        assertEquals("1 kB", DiskCleanup.bytesToDisplayCount(1_000));
+        assertEquals("15 MB", DiskCleanup.bytesToDisplayCount(15_000_000));
+        assertEquals("123 GB", DiskCleanup.bytesToDisplayCount(123_456_789_012L));
+        assertEquals("987 TB", DiskCleanup.bytesToDisplayCount(987_654_321_098_765L));
+        assertEquals("2 PB", DiskCleanup.bytesToDisplayCount(2_000_000_000_000_000L));
+        assertEquals("9 EB", DiskCleanup.bytesToDisplayCount(Long.MAX_VALUE));
+
+    }
+
+    private static class DiskCleanupRuleMock implements DiskCleanupRule {
+        private final ArrayList<PrioritizedFileAttributes> pfa = new ArrayList<>();
+
+        private DiskCleanupRuleMock addFile(Path path, Priority priority) throws IOException {
+            PosixFileAttributes attributes = Files.getFileAttributeView(path, PosixFileAttributeView.class).readAttributes();
+            pfa.add(new PrioritizedFileAttributes(new FileAttributes(path, attributes), priority));
+            return this;
+        }
+
+        @Override
+        public Collection<PrioritizedFileAttributes> prioritize() {
+            return Collections.unmodifiableList(pfa);
+        }
+    }
+
+    private static class DiskCleanupTester {
+        private final FileSystem fileSystem = TestFileSystem.create();
+        private final Set<String> files = new HashSet<>();
+
+        private Path path(String path) {
+            return fileSystem.getPath(path);
+        }
+
+        private Path createFile(String pathStr, int size) throws IOException {
+            Path path = path(pathStr);
+            Files.createDirectories(path.getParent());
+            Files.write(path, new byte[size]);
+            files.add(path.toString());
+            return path;
+        }
+
+        private void assertAllFilesExistExcept(String... deletedPaths) {
+            Set<String> actual = FileFinder.files(path("/")).stream().map(fa -> fa.path().toString()).collect(Collectors.toSet());
+            Set<String> expected = new HashSet<>(files);
+            expected.removeAll(Set.of(deletedPaths));
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/LinearCleanupRuleTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/disk/LinearCleanupRuleTest.java
@@ -1,0 +1,55 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.maintenance.disk;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.FileAttributes;
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.PrioritizedFileAttributes;
+import static com.yahoo.vespa.hosted.node.admin.maintenance.disk.DiskCleanupRule.Priority;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author freva
+ */
+public class LinearCleanupRuleTest {
+
+    @Test
+    public void basic() {
+        assertRule(Map.of(), Priority.LOWEST, Priority.HIGHEST);
+
+        assertRule(Map.of(0.0, Priority.LOW, 0.5, Priority.LOW, 1.0, Priority.LOW), Priority.LOW, Priority.LOW);
+        assertRule(Map.of(0.0, Priority.LOW, 0.5, Priority.MEDIUM, 1.0, Priority.MEDIUM), Priority.LOW, Priority.MEDIUM);
+
+        assertRule(Map.of(
+                -5.0, Priority.LOW,
+                0.0, Priority.LOW,
+                0.2, Priority.LOW,
+                0.35, Priority.MEDIUM,
+                0.65, Priority.MEDIUM,
+                0.8, Priority.HIGH,
+                1.0, Priority.HIGH,
+                5.0, Priority.HIGH),
+                Priority.LOW, Priority.HIGH);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fail_if_high_priority_lower_than_low() {
+        assertRule(Map.of(), Priority.HIGHEST, Priority.LOWEST);
+    }
+
+    private static void assertRule(Map<Double, Priority> expectedPriorities, Priority low, Priority high) {
+        Map<FileAttributes, Double> fileAttributesByScore = expectedPriorities.keySet().stream()
+                .collect(Collectors.toMap(score -> mock(FileAttributes.class), score -> score));
+        LinearCleanupRule rule = new LinearCleanupRule(
+                () -> List.copyOf(fileAttributesByScore.keySet()), fileAttributesByScore::get, low, high);
+
+        Map<Double, Priority> actualPriorities = rule.prioritize().stream()
+                .collect(Collectors.toMap(pfa -> fileAttributesByScore.get(pfa.fileAttributes()), PrioritizedFileAttributes::priority));
+        assertEquals(expectedPriorities, actualPriorities);
+    }
+}

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/file/DiskSizeTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/file/DiskSizeTest.java
@@ -1,0 +1,25 @@
+package com.yahoo.vespa.hosted.node.admin.task.util.file;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author freva
+ */
+public class DiskSizeTest {
+
+    @Test
+    public void bytes_to_display_count_test() {
+        assertEquals("-1 bytes", DiskSize.of(-1).asString());
+        assertEquals("123 bytes", DiskSize.of(123).asString());
+        assertEquals("1 kB", DiskSize.of(1_000).asString());
+        assertEquals("15 MB", DiskSize.of(15_000_000).asString());
+        assertEquals("123 GB", DiskSize.of(123_456_789_012L).asString());
+        assertEquals("988 TB", DiskSize.of(987_654_321_098_765L).asString());
+        assertEquals("987.7 TB", DiskSize.of(987_654_321_098_765L).asString(1));
+        assertEquals("987.65 TB", DiskSize.of(987_654_321_098_765L).asString(2));
+        assertEquals("2 PB", DiskSize.of(2_000_000_000_000_000L).asString());
+        assertEquals("9 EB", DiskSize.of(Long.MAX_VALUE).asString());
+    }
+}


### PR DESCRIPTION
This creates a fairly general component `DiskCleanup` that can take in several clean up rules, each of which can return a list of prioritized files for deletion (between `LOWEST`, `LOW`, `MEDIUM`, `HIGH` and `HIGHEST`, where `HIGHEST` is first to be deleted). If multiple files are prioritized equally, the file with largest size is prioritized.

For now I've added this for nodes, but I can quickly implement this for host as well. For nodes, the rules are:
* Delete coredumps not yet processed: Assign `MEDIUM` priority to the oldest un-processed coredump and `HIGHEST` to all the others.
* For `container` and `combined` nodes: Delete files under `$VESPA_HOME/logs/vespa/qrs`, evenly split priority by file age (0-6days `LOWEST`, 7d-12d `LOW`, ...,  24 days + at `HIGHEST`).
* For `admin` `tenant` nodes: Delete files under `$VESPA_HOME/logs/vespa/logarchive` using same prioritization as above.
* For `proxy` nodes: Delete files under `$VESPA_HOME/logs/nginx` using same prioritization as above.

Only start looking for stuff to delete if we are at > 90% disk util. Once we cross that threshold, delete until we get to lower threshold of 80%.