### PR TITLE
Lesters/bert searchlib and config model

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -680,11 +680,12 @@ public class RankProfile implements Cloneable {
         Map<String, RankingExpressionFunction> inlineFunctions =
                 compileFunctions(this::getInlineFunctions, queryProfiles, featureTypes, importedModels, Collections.emptyMap(), expressionTransforms);
 
+        firstPhaseRanking = compile(this.getFirstPhaseRanking(), queryProfiles, featureTypes, importedModels, getConstants(), inlineFunctions, expressionTransforms);
+        secondPhaseRanking = compile(this.getSecondPhaseRanking(), queryProfiles, featureTypes, importedModels, getConstants(), inlineFunctions, expressionTransforms);
+
         // Function compiling second pass: compile all functions and insert previously compiled inline functions
         functions = compileFunctions(this::getFunctions, queryProfiles, featureTypes, importedModels, inlineFunctions, expressionTransforms);
 
-        firstPhaseRanking = compile(this.getFirstPhaseRanking(), queryProfiles, featureTypes, importedModels, getConstants(), inlineFunctions, expressionTransforms);
-        secondPhaseRanking = compile(this.getSecondPhaseRanking(), queryProfiles, featureTypes, importedModels, getConstants(), inlineFunctions, expressionTransforms);
     }
 
     private void checkNameCollisions(Map<String, RankingExpressionFunction> functions, Map<String, Value> constants) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/RawRankProfile.java
@@ -17,6 +17,7 @@ import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
 import com.yahoo.searchlib.rankingexpression.rule.SerializationContext;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
+import org.tensorflow.op.core.Rank;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -200,9 +201,7 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
             if (functions.isEmpty()) return;
 
             List<ExpressionFunction> functionExpressions = functions.values().stream().map(f -> f.function()).collect(Collectors.toList());
-
             Map<String, String> functionProperties = new LinkedHashMap<>();
-            functionProperties.putAll(deriveFunctionProperties(functions, functionExpressions));
 
             if (firstPhaseRanking != null) {
                 functionProperties.putAll(firstPhaseRanking.getRankProperties(functionExpressions));
@@ -211,20 +210,30 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
                 functionProperties.putAll(secondPhaseRanking.getRankProperties(functionExpressions));
             }
 
+            SerializationContext context = new SerializationContext(functionExpressions, null, functionProperties);
+            replaceFunctionSummaryFeatures(context);
+
+            // First phase, second phase and summary features should add all required functions to the context.
+            // However, we need to add any functions not referenced in those anyway for model-evaluation.
+            deriveFunctionProperties(functions, functionExpressions, functionProperties);
+
             for (Map.Entry<String, String> e : functionProperties.entrySet()) {
                 rankProperties.add(new RankProfile.RankProperty(e.getKey(), e.getValue()));
             }
-            SerializationContext context = new SerializationContext(functionExpressions, null, functionProperties);
-            replaceFunctionSummaryFeatures(context);
         }
 
-        private Map<String, String> deriveFunctionProperties(Map<String, RankProfile.RankingExpressionFunction> functions,
-                                                             List<ExpressionFunction> functionExpressions) {
-            SerializationContext context = new SerializationContext(functionExpressions);
+        private void deriveFunctionProperties(Map<String, RankProfile.RankingExpressionFunction> functions,
+                                              List<ExpressionFunction> functionExpressions,
+                                              Map<String, String> functionProperties) {
+            SerializationContext context = new SerializationContext(functionExpressions, null, functionProperties);
             for (Map.Entry<String, RankProfile.RankingExpressionFunction> e : functions.entrySet()) {
+                String propertyName = RankingExpression.propertyName(e.getKey());
+                if (context.serializedFunctions().containsKey(propertyName)) {
+                    continue;
+                }
                 String expressionString = e.getValue().function().getBody().getRoot().toString(new StringBuilder(), context, null, null).toString();
-                context.addFunctionSerialization(RankingExpression.propertyName(e.getKey()), expressionString);
 
+                context.addFunctionSerialization(RankingExpression.propertyName(e.getKey()), expressionString);
                 for (Map.Entry<String, TensorType> argumentType : e.getValue().function().argumentTypes().entrySet())
                     context.addArgumentTypeSerialization(e.getKey(), argumentType.getKey(), argumentType.getValue());
                 if (e.getValue().function().returnType().isPresent())
@@ -232,7 +241,7 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
                 // else if (e.getValue().function().arguments().isEmpty()) TODO: Enable this check when we resolve all types
                 //     throw new IllegalStateException("Type of function '" + e.getKey() + "' is not resolved");
             }
-            return context.serializedFunctions();
+            functionProperties.putAll(context.serializedFunctions());
         }
 
         private void replaceFunctionSummaryFeatures(SerializationContext context) {
@@ -241,9 +250,11 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
             for (Iterator<ReferenceNode> i = summaryFeatures.iterator(); i.hasNext(); ) {
                 ReferenceNode referenceNode = i.next();
                 // Is the feature a function?
-                if (context.getFunction(referenceNode.getName()) != null) {
-                    context.addFunctionSerialization(RankingExpression.propertyName(referenceNode.getName()),
-                                                     referenceNode.toString(new StringBuilder(), context, null, null).toString());
+                ExpressionFunction function = context.getFunction(referenceNode.getName());
+                if (function != null) {
+                    String propertyName = RankingExpression.propertyName(referenceNode.getName());
+                    String expressionString = function.getBody().getRoot().toString(new StringBuilder(), context, null, null).toString();
+                    context.addFunctionSerialization(propertyName, expressionString);
                     ReferenceNode newReferenceNode = new ReferenceNode("rankingExpression(" + referenceNode.getName() + ")", referenceNode.getArguments().expressions(), referenceNode.getOutput());
                     functionSummaryFeatures.put(referenceNode.getName(), newReferenceNode);
                     i.remove(); // Will add the expanded one in next block

--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/RawRankProfile.java
@@ -17,7 +17,6 @@ import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
 import com.yahoo.searchlib.rankingexpression.rule.SerializationContext;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
-import org.tensorflow.op.core.Rank;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/config-model/src/test/java/com/yahoo/searchdefinition/RankingExpressionShadowingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/RankingExpressionShadowingTestCase.java
@@ -50,10 +50,10 @@ public class RankingExpressionShadowingTestCase extends SchemaTestCase {
                                                                            new QueryProfileRegistry(),
                                                                            new ImportedMlModels(),
                                                                            new AttributeFields(s)).configProperties();
-        assertEquals("(rankingExpression(sin).rankingScript,x * x)",
-                     testRankProperties.get(0).toString());
         assertEquals("(rankingExpression(sin@).rankingScript,2 * 2)",
-                     censorBindingHash(testRankProperties.get(1).toString()));
+                censorBindingHash(testRankProperties.get(0).toString()));
+        assertEquals("(rankingExpression(sin).rankingScript,x * x)",
+                     testRankProperties.get(1).toString());
         assertEquals("(vespa.rank.firstphase,rankingExpression(sin@))",
                      censorBindingHash(testRankProperties.get(2).toString()));
     }
@@ -94,26 +94,25 @@ public class RankingExpressionShadowingTestCase extends SchemaTestCase {
                                                                            new QueryProfileRegistry(),
                                                                            new ImportedMlModels(),
                                                                            new AttributeFields(s)).configProperties();
-        assertEquals("(rankingExpression(tan).rankingScript,x * x)",
-                     testRankProperties.get(0).toString());
-        assertEquals("(rankingExpression(tan@).rankingScript,x * x)",
-                     censorBindingHash(testRankProperties.get(1).toString()));
-        assertEquals("(rankingExpression(cos).rankingScript,rankingExpression(tan@))",
-                     censorBindingHash(testRankProperties.get(2).toString()));
-        assertEquals("(rankingExpression(cos@).rankingScript,rankingExpression(tan@))",
-                     censorBindingHash(testRankProperties.get(3).toString()));
-        assertEquals("(rankingExpression(sin).rankingScript,rankingExpression(cos@))",
-                     censorBindingHash(testRankProperties.get(4).toString()));
         assertEquals("(rankingExpression(tan@).rankingScript,2 * 2)",
+                censorBindingHash(testRankProperties.get(0).toString()));
+        assertEquals("(rankingExpression(cos@).rankingScript,rankingExpression(tan@))",
+                censorBindingHash(testRankProperties.get(1).toString()));
+        assertEquals("(rankingExpression(sin@).rankingScript,rankingExpression(cos@))",
+                censorBindingHash(testRankProperties.get(2).toString()));
+        assertEquals("(rankingExpression(tan).rankingScript,x * x)",
+                     testRankProperties.get(3).toString());
+        assertEquals("(rankingExpression(tan@).rankingScript,x * x)",
+                     censorBindingHash(testRankProperties.get(4).toString()));
+        assertEquals("(rankingExpression(cos).rankingScript,rankingExpression(tan@))",
                      censorBindingHash(testRankProperties.get(5).toString()));
         assertEquals("(rankingExpression(cos@).rankingScript,rankingExpression(tan@))",
-                     censorBindingHash(testRankProperties.get(6).toString()));
-        assertEquals("(rankingExpression(sin@).rankingScript,rankingExpression(cos@))",
+                censorBindingHash(testRankProperties.get(6).toString()));
+        assertEquals("(rankingExpression(sin).rankingScript,rankingExpression(cos@))",
                      censorBindingHash(testRankProperties.get(7).toString()));
         assertEquals("(vespa.rank.firstphase,rankingExpression(sin@))",
                      censorBindingHash(testRankProperties.get(8).toString()));
     }
-
 
     @Test
     public void testFunctionShadowingArguments() throws ParseException {
@@ -144,12 +143,12 @@ public class RankingExpressionShadowingTestCase extends SchemaTestCase {
                                                                            new QueryProfileRegistry(),
                                                                            new ImportedMlModels(),
                                                                            new AttributeFields(s)).configProperties();
-        assertEquals("(rankingExpression(sin).rankingScript,x * x)",
-                     testRankProperties.get(0).toString());
         assertEquals("(rankingExpression(sin@).rankingScript,4.0 * 4.0)",
-                     censorBindingHash(testRankProperties.get(1).toString()));
+                censorBindingHash(testRankProperties.get(0).toString()));
         assertEquals("(rankingExpression(sin@).rankingScript,cos(5.0) * cos(5.0))",
-                     censorBindingHash(testRankProperties.get(2).toString()));
+                censorBindingHash(testRankProperties.get(1).toString()));
+        assertEquals("(rankingExpression(sin).rankingScript,x * x)",
+                     testRankProperties.get(2).toString());
         assertEquals("(vespa.rank.firstphase,rankingExpression(firstphase))",
                      censorBindingHash(testRankProperties.get(3).toString()));
         assertEquals("(rankingExpression(firstphase).rankingScript,cos(rankingExpression(sin@)) + rankingExpression(sin@))",
@@ -208,17 +207,17 @@ public class RankingExpressionShadowingTestCase extends SchemaTestCase {
                                                                            queryProfiles,
                                                                            new ImportedMlModels(),
                                                                            new AttributeFields(s)).configProperties();
-        assertEquals("(rankingExpression(relu).rankingScript,max(1.0,x))",
-                     testRankProperties.get(0).toString());
         assertEquals("(rankingExpression(relu@).rankingScript,max(1.0,reduce(query(q) * constant(W_hidden), sum, input) + constant(b_input)))",
-                     censorBindingHash(testRankProperties.get(1).toString()));
+                censorBindingHash(testRankProperties.get(0).toString()));
         assertEquals("(rankingExpression(hidden_layer).rankingScript,rankingExpression(relu@))",
-                     censorBindingHash(testRankProperties.get(2).toString()));
+                censorBindingHash(testRankProperties.get(1).toString()));
         assertEquals("(rankingExpression(hidden_layer).type,tensor(x[]))",
-                     censorBindingHash(testRankProperties.get(3).toString()));
+                censorBindingHash(testRankProperties.get(2).toString()));
         assertEquals("(rankingExpression(final_layer).rankingScript,sigmoid(reduce(rankingExpression(hidden_layer) * constant(W_final), sum, hidden) + constant(b_final)))",
-                     testRankProperties.get(4).toString());
+                testRankProperties.get(3).toString());
         assertEquals("(rankingExpression(final_layer).type,tensor(x[]))",
+                testRankProperties.get(4).toString());
+        assertEquals("(rankingExpression(relu).rankingScript,max(1.0,x))",
                      testRankProperties.get(5).toString());
         assertEquals("(vespa.rank.secondphase,rankingExpression(secondphase))",
                      testRankProperties.get(6).toString());

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankProfileSearchFixture.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankProfileSearchFixture.java
@@ -41,6 +41,14 @@ class RankProfileSearchFixture {
     private Search search;
     private Map<String, RankProfile> compiledRankProfiles = new HashMap<>();
 
+    public RankProfileRegistry getRankProfileRegistry() {
+        return rankProfileRegistry;
+    }
+
+    public QueryProfileRegistry getQueryProfileRegistry() {
+        return queryProfileRegistry;
+    }
+
     RankProfileSearchFixture(String rankProfiles) throws ParseException {
         this(MockApplicationPackage.createEmpty(), new QueryProfileRegistry(), rankProfiles);
     }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithTensorFlowTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithTensorFlowTestCase.java
@@ -319,7 +319,7 @@ public class RankingExpressionWithTensorFlowTestCase {
     @Test
     public void testFunctionGeneration() {
         final String name = "mnist_saved";
-        final String expression = "join(join(reduce(join(join(join(reduce(constant(" + name + "_dnn_hidden2_Const), sum, d2), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(a * b)), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(max(a,b))), constant(" + name + "_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(" + name + "_dnn_outputs_bias_read), f(a,b)(a + b)), tensor(d0[1])(1.0), f(a,b)(a * b))";
+        final String expression = "join(reduce(join(join(join(reduce(constant(" + name + "_dnn_hidden2_Const), sum, d2), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(a * b)), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(max(a,b))), constant(" + name + "_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(" + name + "_dnn_outputs_bias_read), f(a,b)(a + b))";
         final String functionExpression1 = "join(reduce(join(reduce(rename(input, (d0, d1), (d0, d4)), sum, d0), constant(" + name + "_dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(" + name + "_dnn_hidden1_bias_read), f(a,b)(a + b))";
         final String functionExpression2 = "join(reduce(join(join(join(0.009999999776482582, imported_ml_function_" + name + "_dnn_hidden1_add, f(a,b)(a * b)), imported_ml_function_" + name + "_dnn_hidden1_add, f(a,b)(max(a,b))), constant(" + name + "_dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(" + name + "_dnn_hidden2_bias_read), f(a,b)(a + b))";
 
@@ -349,7 +349,7 @@ public class RankingExpressionWithTensorFlowTestCase {
                 "  rank-profile my_profile_child inherits my_profile {\n" +
                 "  }";
 
-        final String expression = "join(join(reduce(join(join(join(reduce(constant(" + name + "_dnn_hidden2_Const), sum, d2), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(a * b)), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(max(a,b))), constant(" + name + "_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(" + name + "_dnn_outputs_bias_read), f(a,b)(a + b)), tensor(d0[1])(1.0), f(a,b)(a * b))";
+        final String expression = "join(reduce(join(join(join(reduce(constant(" + name + "_dnn_hidden2_Const), sum, d2), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(a * b)), imported_ml_function_" + name + "_dnn_hidden2_add, f(a,b)(max(a,b))), constant(" + name + "_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(" + name + "_dnn_outputs_bias_read), f(a,b)(a + b))";
         final String functionExpression1 = "join(reduce(join(reduce(rename(input, (d0, d1), (d0, d4)), sum, d0), constant(" + name + "_dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(" + name + "_dnn_hidden1_bias_read), f(a,b)(a + b))";
         final String functionExpression2 = "join(reduce(join(join(join(0.009999999776482582, imported_ml_function_" + name + "_dnn_hidden1_add, f(a,b)(a * b)), imported_ml_function_" + name + "_dnn_hidden1_add, f(a,b)(max(a,b))), constant(" + name + "_dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(" + name + "_dnn_hidden2_bias_read), f(a,b)(a + b))";
 

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionsTestCase.java
@@ -44,20 +44,20 @@ public class RankingExpressionsTestCase extends SchemaTestCase {
                                                                        new AttributeFields(search)).configProperties();
         assertEquals(6, rankProperties.size());
 
-        assertEquals("rankingExpression(titlematch$).rankingScript", rankProperties.get(0).getFirst());
-        assertEquals("var1 * var2 + 890", rankProperties.get(0).getSecond());
+        assertEquals("rankingExpression(titlematch$).rankingScript", rankProperties.get(2).getFirst());
+        assertEquals("var1 * var2 + 890", rankProperties.get(2).getSecond());
 
-        assertEquals("rankingExpression(artistmatch).rankingScript", rankProperties.get(1).getFirst());
-        assertEquals("78 + closeness(distance)", rankProperties.get(1).getSecond());
+        assertEquals("rankingExpression(artistmatch).rankingScript", rankProperties.get(3).getFirst());
+        assertEquals("78 + closeness(distance)", rankProperties.get(3).getSecond());
 
         assertEquals("rankingExpression(firstphase).rankingScript", rankProperties.get(5).getFirst());
         assertEquals("0.8 + 0.2 * rankingExpression(titlematch$@126063073eb2deb.ab95cd69909927c) + 0.8 * rankingExpression(titlematch$@c7e4c2d0e6d9f2a1.1d4ed08e56cce2e6) * closeness(distance)", rankProperties.get(5).getSecond());
 
-        assertEquals("rankingExpression(titlematch$@c7e4c2d0e6d9f2a1.1d4ed08e56cce2e6).rankingScript", rankProperties.get(3).getFirst());
-        assertEquals("7 * 8 + 890", rankProperties.get(3).getSecond());
+        assertEquals("rankingExpression(titlematch$@c7e4c2d0e6d9f2a1.1d4ed08e56cce2e6).rankingScript", rankProperties.get(1).getFirst());
+        assertEquals("7 * 8 + 890", rankProperties.get(1).getSecond());
 
-        assertEquals("rankingExpression(titlematch$@126063073eb2deb.ab95cd69909927c).rankingScript", rankProperties.get(2).getFirst());
-        assertEquals("4 * 5 + 890", rankProperties.get(2).getSecond());
+        assertEquals("rankingExpression(titlematch$@126063073eb2deb.ab95cd69909927c).rankingScript", rankProperties.get(0).getFirst());
+        assertEquals("4 * 5 + 890", rankProperties.get(0).getSecond());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/config-model/src/test/java/com/yahoo/vespa/model/ml/MlModelsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ml/MlModelsTest.java
@@ -64,10 +64,10 @@ public class MlModelsTest {
     private final String testProfile =
             "rankingExpression(input).rankingScript: attribute(argument)\n" +
             "rankingExpression(input).type: tensor<float>(d0[],d1[784])\n" +
-            "rankingExpression(Placeholder).rankingScript: attribute(argument)\n" +
-            "rankingExpression(Placeholder).type: tensor<float>(d0[],d1[784])\n" +
             "rankingExpression(imported_ml_function_mnist_saved_dnn_hidden1_add).rankingScript: join(reduce(join(rename(rankingExpression(input), (d0, d1), (d0, d4)), constant(mnist_saved_dnn_hidden1_weights_read), f(a,b)(a * b)), sum, d4), constant(mnist_saved_dnn_hidden1_bias_read), f(a,b)(a + b))\n" +
             "rankingExpression(mnist_tensorflow).rankingScript: join(reduce(join(map(join(reduce(join(join(join(0.009999999776482582, rankingExpression(imported_ml_function_mnist_saved_dnn_hidden1_add), f(a,b)(a * b)), rankingExpression(imported_ml_function_mnist_saved_dnn_hidden1_add), f(a,b)(max(a,b))), constant(mnist_saved_dnn_hidden2_weights_read), f(a,b)(a * b)), sum, d3), constant(mnist_saved_dnn_hidden2_bias_read), f(a,b)(a + b)), f(a)(1.0507009873554805 * if (a >= 0, a, 1.6732632423543772 * (exp(a) - 1)))), constant(mnist_saved_dnn_outputs_weights_read), f(a,b)(a * b)), sum, d2), constant(mnist_saved_dnn_outputs_bias_read), f(a,b)(a + b))\n" +
+            "rankingExpression(Placeholder).rankingScript: attribute(argument)\n" +
+            "rankingExpression(Placeholder).type: tensor<float>(d0[],d1[784])\n" +
             "rankingExpression(mnist_softmax_tensorflow).rankingScript: join(reduce(join(rename(rankingExpression(Placeholder), (d0, d1), (d0, d2)), constant(mnist_softmax_saved_layer_Variable_read), f(a,b)(a * b)), sum, d2), constant(mnist_softmax_saved_layer_Variable_1_read), f(a,b)(a + b))\n" +
             "rankingExpression(mnist_softmax_onnx).rankingScript: join(reduce(join(rename(rankingExpression(Placeholder), (d0, d1), (d0, d2)), constant(mnist_softmax_Variable), f(a,b)(a * b)), sum, d2), constant(mnist_softmax_Variable_1), f(a,b)(a + b))\n" +
             "rankingExpression(my_xgboost).rankingScript: if (f29 < -0.1234567, if (!(f56 >= -0.242398), 1.71218, -1.70044), if (f109 < 0.8723473, -1.94071, 1.85965)) + if (!(f60 >= -0.482947), if (f29 < -4.2387498, 0.784718, -0.96853), -6.23624)\n" +

--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/MatMul.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/MatMul.java
@@ -126,7 +126,7 @@ public class MatMul extends IntermediateOperation {
             // a1 < a2 < a3 < a4
             for (int j = i+1; j < typeA.rank(); ++j) {
                 String jDim = typeA.dimensionNames().get(j);
-                renamer.addConstraint(iDim, jDim, DimensionRenamer.Constraint.lessThan(true), this);
+                renamer.addConstraint(iDim, jDim, DimensionRenamer.Constraint.lessThan(false), this);
             }
             // not equal to last 2 dimensions in B
             for (int j = typeB.rank()-2; j < typeB.rank(); ++j) {
@@ -148,7 +148,7 @@ public class MatMul extends IntermediateOperation {
             // b1 < b2 < b3 < b4
             for (int j = i+1; j < typeB.rank(); ++j) {
                 String jDim = typeB.dimensionNames().get(j);
-                renamer.addConstraint(iDim, jDim, DimensionRenamer.Constraint.lessThan(true), this);
+                renamer.addConstraint(iDim, jDim, DimensionRenamer.Constraint.lessThan(false), this);
             }
             // not equal to last 2 dimensions in A
             for (int j = typeA.rank()-2; j < typeA.rank(); ++j) {

--- a/searchlib/abi-spec.json
+++ b/searchlib/abi-spec.json
@@ -1416,7 +1416,8 @@
       "public com.yahoo.searchlib.rankingexpression.ExpressionFunction getFunction(java.lang.String)",
       "protected com.google.common.collect.ImmutableMap functions()",
       "public java.lang.String getBinding(java.lang.String)",
-      "public com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withBindings(java.util.Map)"
+      "public com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withBindings(java.util.Map)",
+      "public com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withoutBindings()"
     ],
     "fields": []
   },
@@ -1573,7 +1574,9 @@
       "public void addArgumentTypeSerialization(java.lang.String, java.lang.String, com.yahoo.tensor.TensorType)",
       "public void addFunctionTypeSerialization(java.lang.String, com.yahoo.tensor.TensorType)",
       "public com.yahoo.searchlib.rankingexpression.rule.SerializationContext withBindings(java.util.Map)",
+      "public com.yahoo.searchlib.rankingexpression.rule.SerializationContext withoutBindings()",
       "public java.util.Map serializedFunctions()",
+      "public bridge synthetic com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withoutBindings()",
       "public bridge synthetic com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withBindings(java.util.Map)"
     ],
     "fields": []

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/ExpressionFunction.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/ExpressionFunction.java
@@ -134,7 +134,10 @@ public class ExpressionFunction {
         for (int i = 0; i < arguments.size() && i < argumentValues.size(); ++i) {
             argumentBindings.put(arguments.get(i), argumentValues.get(i).toString(new StringBuilder(), context, path, null).toString());
         }
-        return new Instance(toSymbol(argumentBindings), body.getRoot().toString(new StringBuilder(), context.withBindings(argumentBindings), path, null).toString());
+        context = argumentBindings.isEmpty() ? context.withoutBindings() : context.withBindings(argumentBindings);
+        String symbol = toSymbol(argumentBindings);
+        String expressionString = body.getRoot().toString(new StringBuilder(), context, path, null).toString();
+        return new Instance(symbol, expressionString);
     }
 
     /**

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/FunctionReferenceContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/FunctionReferenceContext.java
@@ -68,4 +68,9 @@ public class FunctionReferenceContext {
         return new FunctionReferenceContext(this.functions, bindings);
     }
 
+    /** Returns a fresh context without bindings */
+    public FunctionReferenceContext withoutBindings() {
+        return new FunctionReferenceContext(this.functions);
+    }
+
 }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SerializationContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SerializationContext.java
@@ -95,6 +95,12 @@ public class SerializationContext extends FunctionReferenceContext {
         return new SerializationContext(functions(), bindings, this.serializedFunctions);
     }
 
+    /** Returns a fresh context without bindings */
+    @Override
+    public SerializationContext withoutBindings() {
+        return new SerializationContext(functions(), null, this.serializedFunctions);
+    }
+
     public Map<String, String> serializedFunctions() { return serializedFunctions; }
 
 }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
@@ -333,10 +333,16 @@ public class TensorFunctionNode extends CompositeNode {
         /** Returns a new context with the bindings replaced by the given bindings */
         @Override
         public ExpressionToStringContext withBindings(Map<String, String> bindings) {
-            return new ExpressionToStringContext(new SerializationContext(wrappedSerializationContext.functions().values(), bindings),
-                                                 wrappedToStringContext, path, parent);
+            SerializationContext serializationContext = new SerializationContext(functions(), bindings, serializedFunctions());
+            return new ExpressionToStringContext(serializationContext, wrappedToStringContext, path, parent);
         }
 
+        /** Returns a fresh context without bindings */
+        @Override
+        public SerializationContext withoutBindings() {
+            SerializationContext serializationContext = new SerializationContext(functions(), null, serializedFunctions());
+            return new ExpressionToStringContext(serializationContext, null, path, parent);
+        }
     }
 
     /** Turns an EvaluationContext into a Context */

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/transform/ConstantDereferencer.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/transform/ConstantDereferencer.java
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression.transform;
 
-import com.yahoo.searchlib.rankingexpression.evaluation.TensorValue;
+import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 import com.yahoo.searchlib.rankingexpression.rule.CompositeNode;
 import com.yahoo.searchlib.rankingexpression.rule.ConstantNode;
@@ -28,8 +28,15 @@ public class ConstantDereferencer extends ExpressionTransformer<TransformContext
             return node;
     }
 
+    /** Returns true if the given reference is an attribute, constant or query feature */
+    private static boolean isSimpleFeature(Reference reference) {
+        if ( ! reference.isSimple()) return false;
+        String name = reference.name();
+        return name.equals("attribute") || name.equals("constant") || name.equals("query");
+    }
+
     private ExpressionNode transformFeature(ReferenceNode node, TransformContext context) {
-        if (!node.getArguments().isEmpty())
+        if ( ! node.getArguments().isEmpty() && ! isSimpleFeature(node.reference()))
             return transformArguments(node, context);
         else
             return transformConstantReference(node, context);
@@ -44,7 +51,14 @@ public class ConstantDereferencer extends ExpressionTransformer<TransformContext
     }
 
     private ExpressionNode transformConstantReference(ReferenceNode node, TransformContext context) {
-        Value value = context.constants().get(node.getName());
+        String name = node.getName();
+        if (node.reference().name().equals("constant")) {
+            ExpressionNode arg = node.getArguments().expressions().get(0);
+            if (arg instanceof ReferenceNode) {
+                name = ((ReferenceNode)arg).getName();
+            }
+        }
+        Value value = context.constants().get(name);  // works if "constant(...)" is added
         if (value == null || value.type().rank() > 0) {
             return node; // not a number constant reference
         }


### PR DESCRIPTION
@bratseth Please review.

The main changes here are for resolving types and serializing functions. Both would break down for large rank profiles (e.g. imported ml models) with a large degree of diamond-shaped dependencies on functions without arguments.