### PR TITLE
Gjoranv/dont depend on vespalog3

### DIFF
--- a/application-preprocessor/pom.xml
+++ b/application-preprocessor/pom.xml
@@ -59,11 +59,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>vespalog</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/athenz-identity-provider-service/pom.xml
+++ b/athenz-identity-provider-service/pom.xml
@@ -39,12 +39,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>vespalog</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>

--- a/clustercontroller-core/pom.xml
+++ b/clustercontroller-core/pom.xml
@@ -19,6 +19,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>vespalog</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -60,7 +66,7 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
+       <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>zkfacade</artifactId>
             <version>${project.version}</version>

--- a/clustercontroller-utils/pom.xml
+++ b/clustercontroller-utils/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
-            <artifactId>vespalog</artifactId>
+            <artifactId>vespajlib</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/config-application-package/pom.xml
+++ b/config-application-package/pom.xml
@@ -50,12 +50,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>vespalog</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.thaiopensource</groupId>
             <artifactId>jing</artifactId>
             <version>20091111</version>

--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -191,12 +191,6 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
       <artifactId>statistics</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
+      <artifactId>defaults</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/config/src/main/java/com/yahoo/config/subscription/CfgConfigPayloadBuilder.java
+++ b/config/src/main/java/com/yahoo/config/subscription/CfgConfigPayloadBuilder.java
@@ -4,12 +4,14 @@ package com.yahoo.config.subscription;
 import com.yahoo.collections.Pair;
 import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.StringNode;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.ConfigPayloadBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
 
 /**
  * Deserializes config payload (cfg format) to a ConfigPayload.
@@ -37,7 +39,7 @@ public class CfgConfigPayloadBuilder {
             parseLine(line, lineNum, payloadBuilder);
             lineNum++;
         }
-        log.log(LogLevel.SPAM, () -> "payload=" + payloadBuilder.toString());
+        log.log(FINEST, () -> "payload=" + payloadBuilder.toString());
         return payloadBuilder;
     }
 
@@ -48,7 +50,7 @@ public class CfgConfigPayloadBuilder {
         String field = fieldAndValue.getFirst();
         String value = fieldAndValue.getSecond();
         if (field==null || value==null) {
-            log.log(LogLevel.DEBUG, () -> "Got field without value in line " + lineNum + ": " + line + ", skipping");
+            log.log(FINE, () -> "Got field without value in line " + lineNum + ": " + line + ", skipping");
             return;
         }
         field=field.trim();

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigDebug.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigDebug.java
@@ -2,16 +2,17 @@
 package com.yahoo.config.subscription;
 
 import com.yahoo.config.ConfigInstance;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
 
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.INFO;
 
 // Debug class that provides useful helper routines
 public class ConfigDebug {
     public static void logDebug(Logger logger, long timestamp, ConfigKey<?> key, String logmessage) {
         if (key.getConfigId().matches(".*container.?\\d+.*") || key.getConfigId().matches(".*doc.api.*")) {
-            logger.log(LogLevel.INFO,  timestamp + " " + key + " " + logmessage);
+            logger.log(INFO, timestamp + " " + key + " " + logmessage);
         }
     }
 

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSourceSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSourceSet.java
@@ -1,8 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription;
 
-import com.yahoo.log.LogLevel;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -10,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import static java.util.logging.Level.INFO;
 
 /**
  * An immutable set of connection endpoints, where each endpoint points to either a
@@ -98,7 +97,7 @@ public class ConfigSourceSet implements ConfigSource {
     public static ConfigSourceSet createDefault() {
         String configSources = System.getenv("VESPA_CONFIG_SOURCES");
         if (configSources != null) {
-            log.log(LogLevel.INFO, "Using config sources from VESPA_CONFIG_SOURCES: " + configSources);
+            log.log(INFO, "Using config sources from VESPA_CONFIG_SOURCES: " + configSources);
             return new ConfigSourceSet(checkSourcesSyntax(configSources));
         } else {
             String[] def = {"tcp/localhost:" + System.getProperty("vespa.config.port", "19090")};

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
@@ -5,7 +5,6 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.subscription.impl.ConfigSubscription;
 import com.yahoo.config.subscription.impl.JRTConfigRequester;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.TimingValues;
 import com.yahoo.yolean.Exceptions;
@@ -14,8 +13,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import java.util.logging.Logger;
 
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -326,7 +329,7 @@ public class ConfigSubscriber implements AutoCloseable {
             h.subscription().close();
         }
         closeRequesters();
-        log.log(LogLevel.DEBUG, () -> "Config subscriber has been closed.");
+        log.log(FINE, () -> "Config subscriber has been closed.");
     }
 
     /**
@@ -434,7 +437,7 @@ public class ConfigSubscriber implements AutoCloseable {
                             if (handle.isChanged()) singleSubscriber.configure(handle.getConfig());
                         }
                     } catch (Exception e) {
-                        log.log(LogLevel.ERROR, "Exception from config system, continuing config thread: " + Exceptions.toMessageString(e));
+                        log.log(SEVERE, "Exception from config system, continuing config thread: " + Exceptions.toMessageString(e));
                     }
                 }
             }
@@ -477,7 +480,7 @@ public class ConfigSubscriber implements AutoCloseable {
     protected void finalize() throws Throwable {
         try {
             if (!isClosed()) {
-                log.log(LogLevel.WARNING, stackTraceAtConstruction,
+                log.log(WARNING, stackTraceAtConstruction,
                         () -> String.format("%s: Closing subscription from finalizer() - close() has not been called (keys=%s)",
                                             super.toString(),
                                             subscriptionHandles.stream().map(handle -> handle.subscription().getKey().toString()).collect(toList())));

--- a/config/src/main/java/com/yahoo/config/subscription/impl/FileConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/FileConfigSubscription.java
@@ -1,10 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription.impl;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.subscription.CfgConfigPayloadBuilder;
@@ -13,7 +9,12 @@ import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.io.IOUtils;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConfigPayload;
-import com.yahoo.log.LogLevel;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static java.util.logging.Level.FINE;
 
 /**
  * Subscription used when config id is file:...
@@ -37,12 +38,12 @@ public class FileConfigSubscription<T extends ConfigInstance> extends ConfigSubs
     public boolean nextConfig(long timeout) {
         if (!file.exists() && !file.isFile()) throw new IllegalArgumentException("Not a file: "+file);
         if (checkReloaded()) {
-            log.log(LogLevel.DEBUG, "User forced config reload at " + System.currentTimeMillis());
+            log.log(FINE, "User forced config reload at " + System.currentTimeMillis());
             // User forced reload
             setConfigIfChanged(updateConfig());
             ConfigState<T> configState = getConfigState();
-            log.log(LogLevel.DEBUG, "Config updated at " + System.currentTimeMillis() + ", changed: " + configState.isConfigChanged());
-            log.log(LogLevel.DEBUG, "Config: " + configState.getConfig().toString());
+            log.log(FINE, "Config updated at " + System.currentTimeMillis() + ", changed: " + configState.isConfigChanged());
+            log.log(FINE, "Config: " + configState.getConfig().toString());
             return true;
         }
         if (file.lastModified()!=ts) {

--- a/config/src/main/java/com/yahoo/config/subscription/impl/GenericJRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/GenericJRTConfigSubscription.java
@@ -5,12 +5,13 @@ import java.util.List;
 
 import com.yahoo.config.subscription.ConfigSource;
 import com.yahoo.config.subscription.ConfigSubscriber;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.RawConfig;
 import com.yahoo.vespa.config.TimingValues;
 import com.yahoo.vespa.config.protocol.DefContent;
 import com.yahoo.vespa.config.protocol.JRTClientConfigRequest;
+
+import static java.util.logging.Level.FINE;
 
 /**
  * A JRT subscription which does not use the config class, but {@link com.yahoo.vespa.config.RawConfig} instead.
@@ -33,7 +34,7 @@ public class GenericJRTConfigSubscription extends JRTConfigSubscription<RawConfi
     @Override
     protected void setNewConfig(JRTClientConfigRequest jrtReq) {
         setConfig(jrtReq.getNewGeneration(), jrtReq.responseIsInternalRedeploy(), RawConfig.createFromResponseParameters(jrtReq) );
-        log.log(LogLevel.DEBUG, () -> "in setNewConfig, config=" + this.getConfigState().getConfig());
+        log.log(FINE, () -> "in setNewConfig, config=" + this.getConfigState().getConfig());
     }
 
     // This method is overridden because config needs to have its generation

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigRequester.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigRequester.java
@@ -6,7 +6,6 @@ import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.RequestWaiter;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.Connection;
 import com.yahoo.vespa.config.ConnectionPool;
 import com.yahoo.vespa.config.ErrorCode;
@@ -23,6 +22,12 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 
 /**
  * This class fetches config payload using JRT, and acts as the callback target.
@@ -90,9 +95,9 @@ public class JRTConfigRequester implements RequestWaiter {
         if ( ! req.validateParameters()) throw new ConfigurationRuntimeException("Error in parameters for config request: " + req);
 
         double jrtClientTimeout = getClientTimeout(req);
-        log.log(LogLevel.DEBUG, () -> "Requesting config for " + sub + " on connection " + connection
+        log.log(FINE, () -> "Requesting config for " + sub + " on connection " + connection
                                       + " with client timeout " + jrtClientTimeout +
-                                      (log.isLoggable(LogLevel.SPAM) ? (",defcontent=" + req.getDefContent().asString()) : ""));
+                                      (log.isLoggable(FINEST) ? (",defcontent=" + req.getDefContent().asString()) : ""));
         connection.invokeAsync(req.getRequest(), jrtClientTimeout, this);
     }
 
@@ -110,7 +115,7 @@ public class JRTConfigRequester implements RequestWaiter {
                 sub.setException(e);
             } else {
                 // Very unlikely
-                log.log(Level.SEVERE, "Failed to get subscription object from JRT config callback: " +
+                log.log(SEVERE, "Failed to get subscription object from JRT config callback: " +
                         Exceptions.toMessageString(e));
             }
         }
@@ -118,11 +123,11 @@ public class JRTConfigRequester implements RequestWaiter {
 
     private void doHandle(JRTConfigSubscription<ConfigInstance> sub, JRTClientConfigRequest jrtReq, Connection connection) {
         boolean validResponse = jrtReq.validateResponse();
-        log.log(LogLevel.DEBUG, () -> "Request callback " + (validResponse ? "valid" : "invalid") + ". Req: " + jrtReq + "\nSpec: " + connection);
+        log.log(FINE, () -> "Request callback " + (validResponse ? "valid" : "invalid") + ". Req: " + jrtReq + "\nSpec: " + connection);
         if (sub.getState() == ConfigSubscription.State.CLOSED) return; // Avoid error messages etc. after closing
         Trace trace = jrtReq.getResponseTrace();
         trace.trace(TRACELEVEL, "JRTConfigRequester.doHandle()");
-        log.log(LogLevel.SPAM, () -> trace.toString());
+        log.log(FINEST, () -> trace.toString());
         if (validResponse) {
             handleOKRequest(jrtReq, sub, connection);
         } else {
@@ -134,20 +139,20 @@ public class JRTConfigRequester implements RequestWaiter {
     private void logWhenErrorResponse(JRTClientConfigRequest jrtReq, Connection connection) {
         switch (jrtReq.errorCode()) {
             case com.yahoo.jrt.ErrorCode.CONNECTION:
-                log.log(LogLevel.DEBUG, () -> "Request callback failed: " + jrtReq.errorMessage() +
+                log.log(FINE, () -> "Request callback failed: " + jrtReq.errorMessage() +
                         "\nConnection spec: " + connection);
                 break;
             case ErrorCode.APPLICATION_NOT_LOADED:
             case ErrorCode.UNKNOWN_VESPA_VERSION:
                 if (noApplicationWarningLogged.isBefore(Instant.now().minus(delayBetweenWarnings))) {
-                    log.log(LogLevel.WARNING, "Request callback failed: " + ErrorCode.getName(jrtReq.errorCode()) +
+                    log.log(WARNING, "Request callback failed: " + ErrorCode.getName(jrtReq.errorCode()) +
                             ". Connection spec: " + connection.getAddress() +
                             ", error message: " + jrtReq.errorMessage());
                     noApplicationWarningLogged = Instant.now();
                 }
                 break;
             default:
-                log.log(LogLevel.WARNING, "Request callback failed. Req: " + jrtReq + "\nSpec: " + connection.getAddress() +
+                log.log(WARNING, "Request callback failed. Req: " + jrtReq + "\nSpec: " + connection.getAddress() +
                         " . Req error message: " + jrtReq.errorMessage());
                 break;
         }
@@ -157,7 +162,7 @@ public class JRTConfigRequester implements RequestWaiter {
         final boolean configured = (sub.getConfigState().getConfig() != null);
         if (configured) {
             // The subscription object has an "old" config, which is all we have to offer back now
-            log.log(LogLevel.INFO, "Failure of config subscription, clients will keep existing config until resolved: " + sub);
+            log.log(INFO, "Failure of config subscription, clients will keep existing config until resolved: " + sub);
         }
         ErrorType errorType = ErrorType.getErrorType(jrtReq.errorCode());
         connectionPool.setError(connection, jrtReq.errorCode());
@@ -192,7 +197,7 @@ public class JRTConfigRequester implements RequestWaiter {
                                          Connection connection) {
         transientFailures++;
         if (suspendWarningLogged.isBefore(Instant.now().minus(delayBetweenWarnings))) {
-            log.log(LogLevel.INFO, "Connection to " + connection.getAddress() +
+            log.log(INFO, "Connection to " + connection.getAddress() +
                     " failed or timed out, clients will keep existing config, will keep trying.");
             suspendWarningLogged = Instant.now();
         }
@@ -218,7 +223,7 @@ public class JRTConfigRequester implements RequestWaiter {
         if (sub.getState() != ConfigSubscription.State.OPEN) return;
         fatalFailures++;
         // The logging depends on whether we are configured or not.
-        Level logLevel = sub.getConfigState().getConfig() == null ? LogLevel.DEBUG : LogLevel.INFO;
+        Level logLevel = sub.getConfigState().getConfig() == null ? Level.FINE : Level.INFO;
         String logMessage = "Request for config " + jrtReq.getShortDescription() + "' failed with error code " +
                 jrtReq.errorCode() + " (" + jrtReq.errorMessage() + "), scheduling new connect " +
                 " in " + delay + " ms";
@@ -236,7 +241,7 @@ public class JRTConfigRequester implements RequestWaiter {
         noApplicationWarningLogged = Instant.MIN;
         connection.setSuccess();
         sub.setLastCallBackOKTS(Instant.now());
-        log.log(LogLevel.DEBUG, () -> "OK response received in handleOkRequest: " + jrtReq);
+        log.log(FINE, () -> "OK response received in handleOkRequest: " + jrtReq);
         if (jrtReq.hasUpdatedGeneration()) {
             // We only want this latest generation to be in the queue, we do not preserve history in this system
             sub.getReqQueue().clear();
@@ -260,8 +265,8 @@ public class JRTConfigRequester implements RequestWaiter {
     private void scheduleNextRequest(JRTClientConfigRequest jrtReq, JRTConfigSubscription<?> sub, long delay, long timeout) {
         long delayBeforeSendingRequest = (delay < 0) ? 0 : delay;
         JRTClientConfigRequest jrtReqNew = jrtReq.nextRequest(timeout);
-        log.log(LogLevel.SPAM, () -> timingValues.toString());
-        log.log(LogLevel.DEBUG, () -> "Scheduling new request " + delayBeforeSendingRequest + " millis from now for " + jrtReqNew.getConfigKey());
+        log.log(FINEST, () -> timingValues.toString());
+        log.log(FINE, () -> "Scheduling new request " + delayBeforeSendingRequest + " millis from now for " + jrtReqNew.getConfigKey());
         scheduler.schedule(new GetConfigTask(jrtReqNew, sub), delayBeforeSendingRequest, TimeUnit.MILLISECONDS);
     }
 

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -1,24 +1,25 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription.impl;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.subscription.ConfigInterruptedException;
 import com.yahoo.config.subscription.ConfigSource;
 import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.config.subscription.ConfigSubscriber;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConfigPayload;
-import com.yahoo.vespa.config.JRTConnectionPool;
 import com.yahoo.vespa.config.TimingValues;
 import com.yahoo.vespa.config.protocol.CompressionType;
 import com.yahoo.vespa.config.protocol.JRTClientConfigRequest;
 import com.yahoo.vespa.config.protocol.Payload;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.INFO;
 
 /**
  * A JRT config subscription uses one {@link JRTConfigRequester} to fetch config using Vespa RPC from a config source, typically proxy or server
@@ -90,7 +91,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
             // timed out, we know nothing new.
             return false;
         }
-        log.log(LogLevel.DEBUG, () -> "Polled queue and found config " + jrtReq);
+        log.log(FINE, () -> "Polled queue and found config " + jrtReq);
         if (jrtReq.hasUpdatedGeneration()) {
             setInternalRedeploy(jrtReq.responseIsInternalRedeploy());
             if (jrtReq.hasUpdatedConfig()) {
@@ -192,7 +193,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
 
     @Override
     public void reload(long generation) {
-        log.log(LogLevel.DEBUG, "reload() is without effect on a JRTConfigSubscription.");
+        log.log(FINE, "reload() is without effect on a JRTConfigSubscription.");
     }
 
     void setLastCallBackOKTS(Instant lastCallBackOKTS) {
@@ -204,7 +205,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     static void printStatus(JRTClientConfigRequest request, String message) {
         final String name = request.getConfigKey().getName();
         if (name.equals("components") || name.equals("chains")) {
-            log.log(LogLevel.INFO, message + ":" + name + ":" + ", request=" + request);
+            log.log(INFO, message + ":" + name + ":" + ", request=" + request);
         }
     }
 }

--- a/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
@@ -5,13 +5,12 @@ import com.yahoo.config.ConfigBuilder;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.FileReference;
 import com.yahoo.config.UrlReference;
-import com.yahoo.log.LogLevel;
-import com.yahoo.yolean.Exceptions;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.ObjectTraverser;
 import com.yahoo.slime.Type;
 import com.yahoo.text.Utf8;
+import com.yahoo.yolean.Exceptions;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -26,6 +25,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
 
 /**
  * A utility class that can be used to apply a payload to a config builder.
@@ -224,7 +227,7 @@ public class ConfigPayloadApplier<T extends ConfigInstance.Builder> {
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException("Name: " + methodName + ", value '" + value + "'", e);
         } catch (NoSuchMethodException e) {
-            log.log(LogLevel.INFO, "Skipping unknown field " + methodName + " in " + rootBuilder);
+            log.log(INFO, "Skipping unknown field " + methodName + " in " + rootBuilder);
         }
     }
 
@@ -279,7 +282,7 @@ public class ConfigPayloadApplier<T extends ConfigInstance.Builder> {
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException("Name: " + methodName + ", value '" + value + "'", e);
         } catch (NoSuchMethodException e) {
-            log.log(LogLevel.INFO, "Skipping unknown field " + methodName + " in " + builder.getClass());
+            log.log(INFO, "Skipping unknown field " + methodName + " in " + builder.getClass());
         }
     }
 
@@ -479,11 +482,11 @@ public class ConfigPayloadApplier<T extends ConfigInstance.Builder> {
     }
 
     private void debug(String message) {
-        log.log(LogLevel.DEBUG, () -> message);
+        log.log(FINE, () -> message);
     }
 
     private void trace(String message) {
-        log.log(LogLevel.SPAM, () -> message);
+        log.log(FINEST, () -> message);
     }
 
     private void printStack() {

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.config;
 import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Transport;
-import com.yahoo.log.LogLevel;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -12,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
 
 /**
  * A pool of JRT connections to a config source (either a config server or a config proxy).
@@ -74,7 +75,7 @@ public class JRTConnectionPool implements ConnectionPool {
     public synchronized JRTConnection setNewCurrentConnection() {
         List<JRTConnection> sources = getSources();
         currentConnection = sources.get(ThreadLocalRandom.current().nextInt(0, sources.size()));
-        log.log(LogLevel.DEBUG, () -> "Choosing new connection: " + currentConnection);
+        log.log(FINE, () -> "Choosing new connection: " + currentConnection);
         return currentConnection;
     }
 

--- a/config/src/main/java/com/yahoo/vespa/config/UrlDownloader.java
+++ b/config/src/main/java/com/yahoo/vespa/config/UrlDownloader.java
@@ -8,11 +8,13 @@ import com.yahoo.jrt.StringValue;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Target;
 import com.yahoo.jrt.Transport;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.defaults.Defaults;
 
 import java.io.File;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.INFO;
 
 /**
  * @author lesters
@@ -47,7 +49,7 @@ public class UrlDownloader {
                 Request request = new Request("frt.rpc.ping");
                 target.invokeSync(request, 5.0);
                 if (! request.isError()) {
-                    log.log(LogLevel.DEBUG, () -> "Successfully connected to '" + spec + "', this = " + System.identityHashCode(this));
+                    log.log(FINE, () -> "Successfully connected to '" + spec + "', this = " + System.identityHashCode(this));
                     return;
                 } else {
                     target.close();
@@ -78,7 +80,7 @@ public class UrlDownloader {
             request.parameters().add(new StringValue(urlReference.value()));
 
             double rpcTimeout = Math.min(timeLeft, 60 * 60.0);
-            log.log(LogLevel.DEBUG, () -> "InvokeSync waitFor " + urlReference + " with " + rpcTimeout + " seconds timeout");
+            log.log(FINE, () -> "InvokeSync waitFor " + urlReference + " with " + rpcTimeout + " seconds timeout");
             target.invokeSync(request, rpcTimeout);
 
             if (request.checkReturnTypes("s")) {
@@ -86,7 +88,7 @@ public class UrlDownloader {
             } else if (!request.isError()) {
                 throw new RuntimeException("Invalid response: " + request.returnValues());
             } else if (temporaryError(request)) {
-                log.log(LogLevel.INFO, "Retrying waitFor for " + urlReference + ": " + request.errorCode() + " -- " + request.errorMessage());
+                log.log(INFO, "Retrying waitFor for " + urlReference + ": " + request.errorCode() + " -- " + request.errorMessage());
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {

--- a/config/src/main/java/com/yahoo/vespa/config/protocol/RequestValidation.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/RequestValidation.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.protocol;
 
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.config.ConfigDefinition;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ErrorCode;
@@ -9,6 +8,8 @@ import com.yahoo.vespa.config.ErrorCode;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.util.logging.Level.INFO;
 
 /**
  * Static utility methods for verifying common request properties.
@@ -23,31 +24,31 @@ public class RequestValidation {
     public static int validateRequest(JRTConfigRequest request) {
         ConfigKey<?> key = request.getConfigKey();
         if (!RequestValidation.verifyName(key.getName())) {
-            log.log(LogLevel.INFO, "Illegal name '" + key.getName() + "'");
+            log.log(INFO, "Illegal name '" + key.getName() + "'");
             return ErrorCode.ILLEGAL_NAME;
         }
         if (!RequestValidation.verifyNamespace(key.getNamespace())) {
-            log.log(LogLevel.INFO, "Illegal name space '" + key.getNamespace() + "'");
+            log.log(INFO, "Illegal name space '" + key.getNamespace() + "'");
             return ErrorCode.ILLEGAL_NAME_SPACE;
         }
         if (!RequestValidation.verifyMd5(key.getMd5())) {
-            log.log(LogLevel.INFO, "Illegal md5 sum '" + key.getNamespace() + "'");
+            log.log(INFO, "Illegal md5 sum '" + key.getNamespace() + "'");
             return ErrorCode.ILLEGAL_DEF_MD5;
         }
         if (!RequestValidation.verifyMd5(request.getRequestConfigMd5())) {
-            log.log(LogLevel.INFO, "Illegal config md5 '" + request.getRequestConfigMd5() + "'");
+            log.log(INFO, "Illegal config md5 '" + request.getRequestConfigMd5() + "'");
             return ErrorCode.ILLEGAL_CONFIG_MD5;
         }
         if (!RequestValidation.verifyGeneration(request.getRequestGeneration())) {
-            log.log(LogLevel.INFO, "Illegal generation '" + request.getRequestGeneration() + "'");
+            log.log(INFO, "Illegal generation '" + request.getRequestGeneration() + "'");
             return ErrorCode.ILLEGAL_GENERATION;
         }
         if (!RequestValidation.verifyTimeout(request.getTimeout())) {
-            log.log(LogLevel.INFO, "Illegal timeout '" + request.getTimeout() + "'");
+            log.log(INFO, "Illegal timeout '" + request.getTimeout() + "'");
             return ErrorCode.ILLEGAL_TIMEOUT;
         }
         if (!RequestValidation.verifyHostname(request.getClientHostName())) {
-            log.log(LogLevel.INFO, "Illegal client host name '" + request.getClientHostName() + "'");
+            log.log(INFO, "Illegal client host name '" + request.getClientHostName() + "'");
             return ErrorCode.ILLEGAL_CLIENT_HOSTNAME;
         }
         return 0;

--- a/container-accesslogging/pom.xml
+++ b/container-accesslogging/pom.xml
@@ -51,6 +51,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vespalog</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -148,12 +148,6 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
       <artifactId>documentapi</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/filedistribution/pom.xml
+++ b/filedistribution/pom.xml
@@ -30,11 +30,6 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
-            <artifactId>vespalog</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.yahoo.vespa</groupId>
             <artifactId>config</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/flags/pom.xml
+++ b/flags/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
-            <artifactId>vespalog</artifactId>
+            <artifactId>vespajlib</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/metrics-proxy/pom.xml
+++ b/metrics-proxy/pom.xml
@@ -97,12 +97,6 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
       <artifactId>yolean</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/ExpressionFunction.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/ExpressionFunction.java
@@ -3,7 +3,6 @@ package com.yahoo.searchlib.rankingexpression;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.yahoo.log.event.Collection;
 import com.yahoo.searchlib.rankingexpression.rule.ExpressionNode;
 import com.yahoo.searchlib.rankingexpression.rule.SerializationContext;
 import com.yahoo.tensor.TensorType;

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/transform/SimplifierTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/transform/SimplifierTestCase.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression.transform;
 
-import com.yahoo.log.event.Collection;
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
 import com.yahoo.searchlib.rankingexpression.evaluation.Context;
 import com.yahoo.searchlib.rankingexpression.evaluation.MapContext;

--- a/vespa-maven-plugin/pom.xml
+++ b/vespa-maven-plugin/pom.xml
@@ -41,11 +41,6 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-application-package</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/zkfacade/pom.xml
+++ b/zkfacade/pom.xml
@@ -72,12 +72,6 @@
       <version>1.7.5</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>${zookeeper.client.version}</version>


### PR DESCRIPTION
The first commit should have been included in the previous PR, but was lost in the rebase to master. The rest is removing unnecessary dependencies and imports, except where vespalog is directly used.