### PR TITLE
Use /tmp/ for maven local repository

### DIFF
--- a/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
+++ b/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/TestRunner.java
@@ -104,6 +104,7 @@ public class TestRunner {
         else if (config.useTesterCertificate())
             command.add("-Dvespa.test.credentials.root=" + config.artifactsPath());
         command.add(String.format("-DargLine=-Xms%1$dm -Xmx%1$dm", config.surefireMemoryMb()));
+        command.add("-Dmaven.repo.local=/tmp/.m2/repository");
 
         ProcessBuilder builder = new ProcessBuilder(command);
         builder.environment().merge("MAVEN_OPTS", " -Djansi.force=true", String::concat);


### PR DESCRIPTION
Using $HOME/.m2/repository (default) does not work on ylinux7, use /tmp instead, which is better anyway.