### PR TITLE
Support blocking lid space compaction during high remove rate

### DIFF
--- a/searchcore/CMakeLists.txt
+++ b/searchcore/CMakeLists.txt
@@ -70,6 +70,7 @@ vespa_define_module(
     src/tests/proton/common/attribute_updater
     src/tests/proton/common/document_type_inspector
     src/tests/proton/common/hw_info_sampler
+    src/tests/proton/common/operation_rate_tracker
     src/tests/proton/common/state_reporter_utils
     src/tests/proton/docsummary
     src/tests/proton/document_iterator

--- a/searchcore/src/tests/proton/common/operation_rate_tracker/CMakeLists.txt
+++ b/searchcore/src/tests/proton/common/operation_rate_tracker/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchcore_operation_rate_tracker_test_app TEST
+    SOURCES
+    operation_rate_tracker_test.cpp
+    DEPENDS
+    searchcore_pcommon
+    gtest
+)
+vespa_add_test(NAME searchcore_operation_rate_tracker_test_app COMMAND searchcore_operation_rate_tracker_test_app)

--- a/searchcore/src/tests/proton/common/operation_rate_tracker/operation_rate_tracker_test.cpp
+++ b/searchcore/src/tests/proton/common/operation_rate_tracker/operation_rate_tracker_test.cpp
@@ -1,0 +1,90 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchcore/proton/common/operation_rate_tracker.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/time.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("operation_rate_tracker_test");
+
+using namespace proton;
+
+TEST(OperationRateTrackerTest, time_budget_per_op_is_inverse_of_rate_threshold)
+{
+    EXPECT_EQ(vespalib::from_s(0.25), OperationRateTracker(4).get_time_budget_per_op());
+    EXPECT_EQ(vespalib::from_s(2.0), OperationRateTracker(0.5).get_time_budget_per_op());
+}
+
+TEST(OperationRateTrackerTest, time_budget_window_is_minimum_1_sec)
+{
+    EXPECT_EQ(vespalib::from_s(1.0), OperationRateTracker(4).get_time_budget_window());
+    EXPECT_EQ(vespalib::from_s(2.0), OperationRateTracker(0.5).get_time_budget_window());
+}
+
+class Simulator {
+public:
+    vespalib::steady_time now;
+    OperationRateTracker ort;
+    Simulator(double rate_threshold)
+        : now(vespalib::steady_clock::now()),
+          ort(rate_threshold)
+    {
+    }
+    void tick(double real_rate) {
+        now = now + vespalib::from_s(1.0 / real_rate);
+        ort.observe(now);
+    }
+    bool above_threshold(double now_delta = 0) {
+        return ort.above_threshold(now + vespalib::from_s(now_delta));
+    }
+};
+
+TEST(OperationRateTrackerTest, tracks_whether_operation_rate_is_below_or_above_threshold)
+{
+    Simulator sim(2);
+
+    // Simulate an actual rate of 4 ops / sec
+    sim.tick(4); // Threshold time is 1.0s in the past (at time budget window start)
+    EXPECT_FALSE(sim.above_threshold(-1.0));
+    EXPECT_TRUE(sim.above_threshold(-1.01));
+
+    // Catch up with now
+    sim.tick(4);
+    sim.tick(4);
+    sim.tick(4);
+    sim.tick(4); // Threshold time is now.
+    EXPECT_FALSE(sim.above_threshold());
+    EXPECT_TRUE(sim.above_threshold(-0.01));
+
+    // Move into the future
+    sim.tick(4); // Threshold time is 0.25s into the future.
+    EXPECT_TRUE(sim.above_threshold(0.24));
+    EXPECT_FALSE(sim.above_threshold(0.25));
+
+    // Move to time budget window end
+    sim.tick(4);
+    sim.tick(4);
+    sim.tick(4); // Threshold time is 1.0s into the future (at time budget window end)
+    EXPECT_TRUE(sim.above_threshold(0.99));
+    EXPECT_FALSE(sim.above_threshold(1.0));
+
+    sim.tick(4); // Threshold time is still 1.0s into the future (at time budget window end)
+    EXPECT_TRUE(sim.above_threshold(0.99));
+    EXPECT_FALSE(sim.above_threshold(1.0));
+
+    // Reduce actual rate to 1 ops / sec
+    sim.tick(1); // Threshold time is 0.5s into the future.
+    EXPECT_TRUE(sim.above_threshold(0.49));
+    EXPECT_FALSE(sim.above_threshold(0.5));
+
+    sim.tick(1); // Threshold time is now.
+    EXPECT_FALSE(sim.above_threshold());
+    EXPECT_TRUE(sim.above_threshold(-0.01));
+
+    sim.tick(1);
+    sim.tick(1); // Threshold time is back at time budget window start
+    EXPECT_FALSE(sim.above_threshold(-1.0));
+    EXPECT_TRUE(sim.above_threshold(-1.01));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -2,11 +2,13 @@
 
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/test/make_bucket_space.h>
+#include <vespa/fastos/thread.h>
 #include <vespa/searchcore/proton/attribute/attribute_usage_filter.h>
 #include <vespa/searchcore/proton/attribute/i_attribute_manager.h>
 #include <vespa/searchcore/proton/bucketdb/bucket_create_notifier.h>
 #include <vespa/searchcore/proton/common/doctypename.h>
 #include <vespa/searchcore/proton/common/feedtoken.h>
+#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 #include <vespa/searchcore/proton/feedoperation/moveoperation.h>
 #include <vespa/searchcore/proton/feedoperation/pruneremoveddocumentsoperation.h>
 #include <vespa/searchcore/proton/feedoperation/putoperation.h>
@@ -34,7 +36,6 @@
 #include <vespa/vespalib/util/closuretask.h>
 #include <vespa/vespalib/util/gate.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
-#include <vespa/fastos/thread.h>
 #include <unistd.h>
 
 #include <vespa/log/log.h>

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -339,6 +339,7 @@ struct MockLidSpaceCompactionHandler : public ILidSpaceCompactionHandler
 
     MockLidSpaceCompactionHandler(const vespalib::string &name_) : name(name_) {}
     virtual vespalib::string getName() const override { return name; }
+    virtual void set_operation_listener(documentmetastore::OperationListener::SP) override {}
     virtual uint32_t getSubDbId() const override { return 0; }
     virtual search::LidUsageStats getLidStatus() const override { return search::LidUsageStats(); }
     virtual IDocumentScanIterator::UP getIterator() const override { return IDocumentScanIterator::UP(); }

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -2088,12 +2088,15 @@ TEST(DocumentMetaStoreTest, multiple_lids_can_be_removed_with_removeBatch)
 class MockOperationListener : public documentmetastore::OperationListener {
 public:
     size_t remove_batch_cnt;
+    size_t remove_cnt;
 
     MockOperationListener()
-        : remove_batch_cnt(0)
+        : remove_batch_cnt(0),
+          remove_cnt(0)
     {
     }
     void notify_remove_batch() override { ++remove_batch_cnt; }
+    void notify_remove() override { ++remove_cnt; }
 };
 
 TEST(DocumentMetaStoreTest, call_to_remove_batch_is_notified)
@@ -2106,6 +2109,18 @@ TEST(DocumentMetaStoreTest, call_to_remove_batch_is_notified)
 
     dms.removeBatch({1}, 5);
     EXPECT_EQ(1, listener->remove_batch_cnt);
+}
+
+TEST(DocumentMetaStoreTest, call_to_remove_is_notified)
+{
+    DocumentMetaStore dms(createBucketDB());
+    auto listener = std::make_shared<MockOperationListener>();
+    dms.set_operation_listener(listener);
+    dms.constructFreeList();
+    addLid(dms, 1);
+
+    dms.remove(1);
+    EXPECT_EQ(1, listener->remove_cnt);
 }
 
 }

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -369,6 +369,7 @@ lidspacecompaction.allowedlidbloat int default=1000
 ## The lid bloat factor must be >= allowedlidbloatfactor before considering compaction.
 lidspacecompaction.allowedlidbloatfactor double default=0.01
 
+## DEPRECATED (no longer used): Remove on Vespa 8
 ## The delay (in seconds) for when the last remove batch operation would be considered to block lid space compaction.
 ##
 ## When considering compaction, if the document meta store has received a remove batch operation in the last delay seconds,
@@ -378,6 +379,17 @@ lidspacecompaction.allowedlidbloatfactor double default=0.01
 ## This functionality ensures that during massive deleting of buckets (e.g. as part of redistribution of data to a new node),
 ## lid space compaction do not interfere, but instead is applied after deleting of buckets is complete.
 lidspacecompaction.removebatchblockdelay double default=2.0
+
+## The rate (ops / second) of remove batch operations for when to block lid space compaction.
+##
+## When considering compaction, if the current observed rate of remove batch operations
+## is higher than the given block rate, the lid space compaction job is blocked.
+## It is considered again at the next regular interval (see above).
+##
+## Remove batch operations are used when deleting buckets on a content node.
+## This functionality ensures that during massive deleting of buckets (e.g. as part of redistribution of data to a new node),
+## lid space compaction do not interfere, but instead is applied after deleting of buckets is complete.
+lidspacecompaction.removebatchblockrate double default=0.5
 
 ## This is the maximum value visibilitydelay you can have.
 ## A to higher value here will cost more memory while not improving too much.

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -391,6 +391,13 @@ lidspacecompaction.removebatchblockdelay double default=2.0
 ## lid space compaction do not interfere, but instead is applied after deleting of buckets is complete.
 lidspacecompaction.removebatchblockrate double default=0.5
 
+## The rate (ops / second) of remove operations for when to block lid space compaction.
+##
+## When considering compaction, if the current observed rate of remove operations
+## is higher than the given block rate, the lid space compaction job is blocked.
+## It is considered again at the next regular interval (see above).
+lidspacecompaction.removeblockrate double default=100000.0
+
 ## This is the maximum value visibilitydelay you can have.
 ## A to higher value here will cost more memory while not improving too much.
 maxvisibilitydelay double default=1.0

--- a/searchcore/src/vespa/searchcore/proton/common/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/common/CMakeLists.txt
@@ -14,9 +14,10 @@ vespa_add_library(searchcore_pcommon STATIC
     hw_info_sampler.cpp
     indexschema_inspector.cpp
     monitored_refcount.cpp
+    operation_rate_tracker.cpp
     select_utils.cpp
-    selectpruner.cpp
     selectcontext.cpp
+    selectpruner.cpp
     state_reporter_utils.cpp
     statusreport.cpp
     DEPENDS

--- a/searchcore/src/vespa/searchcore/proton/common/operation_rate_tracker.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/operation_rate_tracker.cpp
@@ -1,0 +1,33 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "operation_rate_tracker.h"
+
+namespace proton {
+
+OperationRateTracker::OperationRateTracker(double rate_threshold)
+    : _time_budget_per_op(vespalib::from_s(1.0 / rate_threshold)),
+      _time_budget_window(std::max(vespalib::from_s(1.0), _time_budget_per_op)),
+      _threshold_time()
+{
+}
+
+void
+OperationRateTracker::observe(vespalib::steady_time now)
+{
+    vespalib::steady_time cand_time = std::max(now - _time_budget_window, _threshold_time + _time_budget_per_op);
+    _threshold_time = std::min(cand_time, now + _time_budget_window);
+}
+
+bool
+OperationRateTracker::above_threshold(vespalib::steady_time now) const
+{
+    return _threshold_time > now;
+}
+
+void
+OperationRateTracker::reset(vespalib::steady_time now)
+{
+    _threshold_time = now - _time_budget_window;
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/common/operation_rate_tracker.h
+++ b/searchcore/src/vespa/searchcore/proton/common/operation_rate_tracker.h
@@ -1,0 +1,38 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/util/time.h>
+
+namespace proton {
+
+/**
+ * Tracks whether the rate (ops/sec) of an operation is above or below a given threshold.
+ *
+ * An operation is given a time budget which is the inverse of the rate threshold.
+ * When we observe an operation that much time is "spent", and we adjust a threshold time accordingly.
+ * If this time is into the future, the current observed rate is above the rate threshold.
+ *
+ * To avoid the threshold time racing into the future or lagging behind,
+ * it is capped in both directions by a time budget window.
+ */
+class OperationRateTracker {
+private:
+    vespalib::duration _time_budget_per_op;
+    vespalib::duration _time_budget_window;
+    vespalib::steady_time _threshold_time;
+
+public:
+    OperationRateTracker(double rate_threshold);
+
+    vespalib::duration get_time_budget_per_op() const { return _time_budget_per_op; }
+    vespalib::duration get_time_budget_window() const { return _time_budget_window; }
+
+    void observe(vespalib::steady_time now);
+    bool above_threshold(vespalib::steady_time now) const;
+
+    // Should only be used for testing
+    void reset(vespalib::steady_time now);
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -2,6 +2,7 @@
 
 #include "documentmetastore.h"
 #include "documentmetastoresaver.h"
+#include "operation_listener.h"
 #include "search_context.h"
 #include <vespa/fastos/file.h>
 #include <vespa/searchcore/proton/bucketdb/bucketsessionbase.h>
@@ -453,7 +454,7 @@ DocumentMetaStore::DocumentMetaStore(BucketDBOwner::SP bucketDB,
       _shrinkLidSpaceBlockers(0),
       _subDbType(subDbType),
       _trackDocumentSizes(true),
-      _last_remove_batch()
+      _op_listener()
 {
     ensureSpace(0);         // lid 0 is reserved
     setCommittedDocIdLimit(1u);         // lid 0 is reserved
@@ -668,7 +669,9 @@ DocumentMetaStore::removeBatch(const std::vector<DocId> &lidsToRemove, const uin
         (void) removed;
     }
     incGeneration();
-    _last_remove_batch = std::chrono::steady_clock::now();
+    if (_op_listener) {
+        _op_listener->notify_remove_batch();
+    }
 }
 
 void
@@ -776,8 +779,7 @@ DocumentMetaStore::getLidUsageStats() const
     return LidUsageStats(docIdLimit,
                          numDocs,
                          lowestFreeLid,
-                         highestUsedLid,
-                         _last_remove_batch);
+                         highestUsedLid);
 }
 
 Blueprint::UP
@@ -1018,6 +1020,12 @@ DocumentMetaStore::canShrinkLidSpace() const
 {
     return AttributeVector::canShrinkLidSpace() &&
         _shrinkLidSpaceBlockers == 0;
+}
+
+void
+DocumentMetaStore::set_operation_listener(documentmetastore::OperationListener::SP op_listener)
+{
+    _op_listener = std::move(op_listener);
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -622,6 +622,9 @@ DocumentMetaStore::remove(DocId lid)
     BucketDBOwner::Guard bucketGuard = _bucketDB->takeGuard();
     bool result = remove(lid, bucketGuard);
     incGeneration();
+    if (result && _op_listener) {
+        _op_listener->notify_remove();
+    }
     return result;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -74,7 +74,7 @@ private:
     uint32_t            _shrinkLidSpaceBlockers;
     const SubDbType     _subDbType;
     bool                _trackDocumentSizes;
-    documentmetastore::OperationListener::SP _op_listener;
+    std::shared_ptr<documentmetastore::OperationListener> _op_listener;
 
     DocId getFreeLid();
     DocId peekFreeLid();
@@ -228,7 +228,7 @@ public:
     void compactLidSpace(DocId wantedLidLimit) override;
     void holdUnblockShrinkLidSpace() override;
     bool canShrinkLidSpace() const override;
-    void set_operation_listener(documentmetastore::OperationListener::SP op_listener) override;
+    void set_operation_listener(std::shared_ptr<documentmetastore::OperationListener> op_listener) override;
 
     SerialNum getLastSerialNum() const override {
         return getStatus().getLastSyncToken();

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -17,11 +17,14 @@
 #include <vespa/vespalib/util/rcuvector.h>
 
 namespace proton::bucketdb {
-    class SplitBucketSession;
-    class JoinBucketsSession;
+class SplitBucketSession;
+class JoinBucketsSession;
 }
 
-namespace proton::documentmetastore { class Reader; }
+namespace proton::documentmetastore {
+class OperationListener;
+class Reader;
+}
 
 namespace proton {
     
@@ -71,7 +74,7 @@ private:
     uint32_t            _shrinkLidSpaceBlockers;
     const SubDbType     _subDbType;
     bool                _trackDocumentSizes;
-    search::LidUsageStats::TimePoint _last_remove_batch;
+    documentmetastore::OperationListener::SP _op_listener;
 
     DocId getFreeLid();
     DocId peekFreeLid();
@@ -225,6 +228,7 @@ public:
     void compactLidSpace(DocId wantedLidLimit) override;
     void holdUnblockShrinkLidSpace() override;
     bool canShrinkLidSpace() const override;
+    void set_operation_listener(documentmetastore::OperationListener::SP op_listener) override;
 
     SerialNum getLastSerialNum() const override {
         return getStatus().getLastSyncToken();

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/i_document_meta_store.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/i_document_meta_store.h
@@ -4,6 +4,7 @@
 
 #include "lid_gid_key_comparator.h"
 #include "i_simple_document_meta_store.h"
+#include "operation_listener.h"
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/common/idocumentmetastore.h>
 #include <vespa/searchlib/common/serialnum.h>
@@ -81,6 +82,8 @@ struct IDocumentMetaStore : public search::IDocumentMetaStore,
      * be shrunk.
      */
     virtual void compactLidSpace(DocId wantedLidLimit) = 0;
+
+    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) = 0;
 
 };
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/i_document_meta_store.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/i_document_meta_store.h
@@ -4,12 +4,13 @@
 
 #include "lid_gid_key_comparator.h"
 #include "i_simple_document_meta_store.h"
-#include "operation_listener.h"
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/common/idocumentmetastore.h>
 #include <vespa/searchlib/common/serialnum.h>
 #include <vespa/vespalib/btree/btree.h>
 #include <vespa/vespalib/btree/btreenodeallocator.h>
+
+namespace proton::documentmetastore { class OperationListener; }
 
 namespace proton {
 
@@ -83,7 +84,7 @@ struct IDocumentMetaStore : public search::IDocumentMetaStore,
      */
     virtual void compactLidSpace(DocId wantedLidLimit) = 0;
 
-    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) = 0;
+    virtual void set_operation_listener(std::shared_ptr<documentmetastore::OperationListener> op_listener) = 0;
 
 };
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/operation_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/operation_listener.h
@@ -14,6 +14,7 @@ public:
     using SP = std::shared_ptr<OperationListener>;
     virtual ~OperationListener() {}
     virtual void notify_remove_batch() = 0;
+    virtual void notify_remove() = 0;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/operation_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/operation_listener.h
@@ -1,0 +1,19 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <memory>
+
+namespace proton::documentmetastore {
+
+/**
+ * Interface used to listen to operations handled by the document meta store.
+ */
+class OperationListener {
+public:
+    using SP = std::shared_ptr<OperationListener>;
+    virtual ~OperationListener() {}
+    virtual void notify_remove_batch() = 0;
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -10,8 +10,8 @@ vespa_add_library(searchcore_server STATIC
     combiningfeedview.cpp
     ddbstate.cpp
     disk_mem_usage_filter.cpp
-    disk_mem_usage_sampler.cpp
     disk_mem_usage_forwarder.cpp
+    disk_mem_usage_sampler.cpp
     docstorevalidator.cpp
     document_db_config_owner.cpp
     document_db_directory_holder.cpp
@@ -30,8 +30,8 @@ vespa_add_library(searchcore_server STATIC
     documentdb_commit_job.cpp
     documentdb_metrics_updater.cpp
     documentdbconfig.cpp
-    documentdbconfigscout.cpp
     documentdbconfigmanager.cpp
+    documentdbconfigscout.cpp
     documentretriever.cpp
     documentretrieverbase.cpp
     documentsubdbcollection.cpp
@@ -63,8 +63,8 @@ vespa_add_library(searchcore_server STATIC
     maintenancejobrunner.cpp
     matchers.cpp
     matchview.cpp
-    memoryconfigstore.cpp
     memory_flush_config_updater.cpp
+    memoryconfigstore.cpp
     memoryflush.cpp
     minimal_document_retriever.cpp
     move_operation_limiter.cpp
@@ -82,6 +82,7 @@ vespa_add_library(searchcore_server STATIC
     putdonecontext.cpp
     reconfig_params.cpp
     remove_batch_done_context.cpp
+    remove_operations_rate_tracker.cpp
     removedonecontext.cpp
     removedonetask.cpp
     replaypacketdispatcher.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.cpp
@@ -53,7 +53,7 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig()
       _interval(3600s),
       _allowedLidBloat(1000000000),
       _allowedLidBloatFactor(1.0),
-      _remove_batch_block_delay(5s),
+      _remove_batch_block_rate(0.5),
       _disabled(false),
       _maxDocsToScan(10000)
 {
@@ -62,14 +62,14 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig()
 DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig(vespalib::duration interval,
                                                                        uint32_t allowedLidBloat,
                                                                        double allowedLidBloatFactor,
-                                                                       vespalib::duration remove_batch_block_delay,
+                                                                       double remove_batch_block_rate,
                                                                        bool disabled,
                                                                        uint32_t maxDocsToScan)
     : _delay(std::min(MAX_DELAY_SEC, interval)),
       _interval(interval),
       _allowedLidBloat(allowedLidBloat),
       _allowedLidBloatFactor(allowedLidBloatFactor),
-      _remove_batch_block_delay(remove_batch_block_delay),
+      _remove_batch_block_rate(remove_batch_block_rate),
       _disabled(disabled),
       _maxDocsToScan(maxDocsToScan)
 {

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.cpp
@@ -54,6 +54,7 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig()
       _allowedLidBloat(1000000000),
       _allowedLidBloatFactor(1.0),
       _remove_batch_block_rate(0.5),
+      _remove_block_rate(100000),
       _disabled(false),
       _maxDocsToScan(10000)
 {
@@ -63,6 +64,7 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig(vespalib:
                                                                        uint32_t allowedLidBloat,
                                                                        double allowedLidBloatFactor,
                                                                        double remove_batch_block_rate,
+                                                                       double remove_block_rate,
                                                                        bool disabled,
                                                                        uint32_t maxDocsToScan)
     : _delay(std::min(MAX_DELAY_SEC, interval)),
@@ -70,6 +72,7 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig(vespalib:
       _allowedLidBloat(allowedLidBloat),
       _allowedLidBloatFactor(allowedLidBloatFactor),
       _remove_batch_block_rate(remove_batch_block_rate),
+      _remove_block_rate(remove_block_rate),
       _disabled(disabled),
       _maxDocsToScan(maxDocsToScan)
 {

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.h
@@ -47,7 +47,7 @@ private:
     vespalib::duration   _interval;
     uint32_t             _allowedLidBloat;
     double               _allowedLidBloatFactor;
-    vespalib::duration   _remove_batch_block_delay;
+    double               _remove_batch_block_rate;
     bool                 _disabled;
     uint32_t             _maxDocsToScan;
 
@@ -56,7 +56,7 @@ public:
     DocumentDBLidSpaceCompactionConfig(vespalib::duration interval,
                                        uint32_t allowedLidBloat,
                                        double allowwedLidBloatFactor,
-                                       vespalib::duration remove_batch_block_delay,
+                                       double remove_batch_block_rate,
                                        bool disabled,
                                        uint32_t maxDocsToScan = 10000);
 
@@ -66,7 +66,7 @@ public:
     vespalib::duration getInterval() const { return _interval; }
     uint32_t getAllowedLidBloat() const { return _allowedLidBloat; }
     double getAllowedLidBloatFactor() const { return _allowedLidBloatFactor; }
-    vespalib::duration get_remove_batch_block_delay() const { return _remove_batch_block_delay; }
+    double get_remove_batch_block_rate() const { return _remove_batch_block_rate; }
     bool isDisabled() const { return _disabled; }
     uint32_t getMaxDocsToScan() const { return _maxDocsToScan; }
 };

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.h
@@ -48,6 +48,7 @@ private:
     uint32_t             _allowedLidBloat;
     double               _allowedLidBloatFactor;
     double               _remove_batch_block_rate;
+    double               _remove_block_rate;
     bool                 _disabled;
     uint32_t             _maxDocsToScan;
 
@@ -57,6 +58,7 @@ public:
                                        uint32_t allowedLidBloat,
                                        double allowwedLidBloatFactor,
                                        double remove_batch_block_rate,
+                                       double remove_block_rate,
                                        bool disabled,
                                        uint32_t maxDocsToScan = 10000);
 
@@ -67,6 +69,7 @@ public:
     uint32_t getAllowedLidBloat() const { return _allowedLidBloat; }
     double getAllowedLidBloatFactor() const { return _allowedLidBloatFactor; }
     double get_remove_batch_block_rate() const { return _remove_batch_block_rate; }
+    double get_remove_block_rate() const { return _remove_block_rate; }
     bool isDisabled() const { return _disabled; }
     uint32_t getMaxDocsToScan() const { return _maxDocsToScan; }
 };

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -135,6 +135,7 @@ buildMaintenanceConfig(const BootstrapConfig::SP &bootstrapConfig,
                     proton.lidspacecompaction.allowedlidbloat,
                     proton.lidspacecompaction.allowedlidbloatfactor,
                     proton.lidspacecompaction.removebatchblockrate,
+                    proton.lidspacecompaction.removeblockrate,
                     isDocumentTypeGlobal),
             AttributeUsageFilterConfig(
                     proton.writefilter.attribute.enumstorelimit,

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -134,7 +134,7 @@ buildMaintenanceConfig(const BootstrapConfig::SP &bootstrapConfig,
                     vespalib::from_s(proton.lidspacecompaction.interval),
                     proton.lidspacecompaction.allowedlidbloat,
                     proton.lidspacecompaction.allowedlidbloatfactor,
-                    vespalib::from_s(proton.lidspacecompaction.removebatchblockdelay),
+                    proton.lidspacecompaction.removebatchblockrate,
                     isDocumentTypeGlobal),
             AttributeUsageFilterConfig(
                     proton.writefilter.attribute.enumstorelimit,

--- a/searchcore/src/vespa/searchcore/proton/server/i_lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_lid_space_compaction_handler.h
@@ -4,6 +4,7 @@
 
 #include "i_document_scan_iterator.h"
 #include "ifrozenbuckethandler.h"
+#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 #include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
 #include <vespa/searchcore/proton/feedoperation/moveoperation.h>
 #include <vespa/searchlib/common/lid_usage_stats.h>
@@ -28,6 +29,13 @@ struct ILidSpaceCompactionHandler
      * Returns the name of this handler.
      */
     virtual vespalib::string getName() const = 0;
+
+    /**
+     * Sets the listener used to get notifications on the operations handled by the document meta store.
+     *
+     * A call to this function should replace the previous listener if set.
+     */
+    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) = 0;
 
     /**
      * Returns the id of the sub database this handler is operating over.

--- a/searchcore/src/vespa/searchcore/proton/server/i_lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_lid_space_compaction_handler.h
@@ -4,12 +4,13 @@
 
 #include "i_document_scan_iterator.h"
 #include "ifrozenbuckethandler.h"
-#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 #include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
 #include <vespa/searchcore/proton/feedoperation/moveoperation.h>
 #include <vespa/searchlib/common/lid_usage_stats.h>
 
 namespace search { class IDestructorCallback; }
+
+namespace proton::documentmetastore { class OperationListener; }
 
 namespace proton {
 
@@ -35,7 +36,7 @@ struct ILidSpaceCompactionHandler
      *
      * A call to this function should replace the previous listener if set.
      */
-    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) = 0;
+    virtual void set_operation_listener(std::shared_ptr<documentmetastore::OperationListener> op_listener) = 0;
 
     /**
      * Returns the id of the sub database this handler is operating over.

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.cpp
@@ -3,10 +3,11 @@
 #include "document_scan_iterator.h"
 #include "ifeedview.h"
 #include "lid_space_compaction_handler.h"
+#include <vespa/document/fieldvalue/document.h>
 #include <vespa/searchcore/proton/docsummary/isummarymanager.h>
 #include <vespa/searchcore/proton/documentmetastore/i_document_meta_store_context.h>
+#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 #include <vespa/searchlib/common/idestructorcallback.h>
-#include <vespa/document/fieldvalue/document.h>
 
 using document::BucketId;
 using document::Document;

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.cpp
@@ -23,6 +23,12 @@ LidSpaceCompactionHandler::LidSpaceCompactionHandler(const MaintenanceDocumentSu
 {
 }
 
+void
+LidSpaceCompactionHandler::set_operation_listener(documentmetastore::OperationListener::SP op_listener)
+{
+    return _subDb.meta_store()->set_operation_listener(std::move(op_listener));
+}
+
 LidUsageStats
 LidSpaceCompactionHandler::getLidStatus() const
 {

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
@@ -23,6 +23,7 @@ public:
     virtual vespalib::string getName() const override {
         return _docTypeName + "." + _subDb.name();
     }
+    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) override;
     virtual uint32_t getSubDbId() const override { return _subDb.sub_db_id(); }
     virtual search::LidUsageStats getLidStatus() const override;
     virtual IDocumentScanIterator::UP getIterator() const override;

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
@@ -23,7 +23,7 @@ public:
     virtual vespalib::string getName() const override {
         return _docTypeName + "." + _subDb.name();
     }
-    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) override;
+    virtual void set_operation_listener(std::shared_ptr<documentmetastore::OperationListener> op_listener) override;
     virtual uint32_t getSubDbId() const override { return _subDb.sub_db_id(); }
     virtual search::LidUsageStats getLidStatus() const override;
     virtual IDocumentScanIterator::UP getIterator() const override;

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
@@ -90,10 +90,9 @@ LidSpaceCompactionJob::compactLidSpace(const LidUsageStats &stats)
 }
 
 bool
-LidSpaceCompactionJob::remove_batch_is_ongoing(const LidUsageStats& stats) const
+LidSpaceCompactionJob::remove_batch_is_ongoing() const
 {
-    LidUsageStats::TimePoint now = std::chrono::steady_clock::now();
-    return (now - stats.get_last_remove_batch()) < std::chrono::duration<double>(_cfg.get_remove_batch_block_delay());
+    return _ops_rate_tracker->remove_batch_above_threshold();
 }
 
 LidSpaceCompactionJob::LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
@@ -114,13 +113,15 @@ LidSpaceCompactionJob::LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionC
       _retryFrozenDocument(false),
       _shouldCompactLidSpace(false),
       _diskMemUsageNotifier(diskMemUsageNotifier),
-      _clusterStateChangedNotifier(clusterStateChangedNotifier)
+      _clusterStateChangedNotifier(clusterStateChangedNotifier),
+      _ops_rate_tracker(std::make_shared<RemoveOperationsRateTracker>(config.get_remove_batch_block_rate()))
 {
     _diskMemUsageNotifier.addDiskMemUsageListener(this);
     _clusterStateChangedNotifier.addClusterStateChangedHandler(this);
     if (nodeRetired) {
         setBlocked(BlockedReason::CLUSTER_STATE);
     }
+    handler.set_operation_listener(_ops_rate_tracker);
 }
 
 LidSpaceCompactionJob::~LidSpaceCompactionJob()
@@ -136,7 +137,7 @@ LidSpaceCompactionJob::run()
         return true; // indicate work is done since no work can be done
     }
     LidUsageStats stats = _handler.getLidStatus();
-    if (remove_batch_is_ongoing(stats)) {
+    if (remove_batch_is_ongoing()) {
         // Note that we don't set the job as blocked as the decision to un-block it is not driven externally.
         LOG(info, "run(): Lid space compaction is disabled while remove batch (delete buckets) is ongoing");
         return true;

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
@@ -48,6 +48,7 @@ private:
     void refreshRunnable();
     void refreshAndConsiderRunnable();
     bool remove_batch_is_ongoing() const;
+    bool remove_is_ongoing() const;
 
 public:
     LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionConfig &config,

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
@@ -9,6 +9,7 @@
 #include "ibucketstatecalculator.h"
 #include "iclusterstatechangedhandler.h"
 #include "iclusterstatechangednotifier.h"
+#include "remove_operations_rate_tracker.h"
 
 namespace proton {
 
@@ -37,6 +38,7 @@ private:
     bool                          _shouldCompactLidSpace;
     IDiskMemUsageNotifier        &_diskMemUsageNotifier;
     IClusterStateChangedNotifier &_clusterStateChangedNotifier;
+    std::shared_ptr<RemoveOperationsRateTracker> _ops_rate_tracker;
 
     bool hasTooMuchLidBloat(const search::LidUsageStats &stats) const;
     bool shouldRestartScanDocuments(const search::LidUsageStats &stats) const;
@@ -45,7 +47,7 @@ private:
     void compactLidSpace(const search::LidUsageStats &stats);
     void refreshRunnable();
     void refreshAndConsiderRunnable();
-    bool remove_batch_is_ongoing(const search::LidUsageStats& stats) const;
+    bool remove_batch_is_ongoing() const;
 
 public:
     LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionConfig &config,

--- a/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.cpp
@@ -1,0 +1,31 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "remove_operations_rate_tracker.h"
+#include <vespa/vespalib/util/time.h>
+
+namespace proton {
+
+RemoveOperationsRateTracker::RemoveOperationsRateTracker(double remove_batch_rate_threshold)
+    : _remove_batch_tracker(remove_batch_rate_threshold)
+{
+}
+
+void
+RemoveOperationsRateTracker::notify_remove_batch()
+{
+    _remove_batch_tracker.observe(vespalib::steady_clock::now());
+}
+
+bool
+RemoveOperationsRateTracker::remove_batch_above_threshold() const
+{
+    return _remove_batch_tracker.above_threshold(vespalib::steady_clock::now());
+}
+
+void
+RemoveOperationsRateTracker::reset_remove_batch_tracker()
+{
+    _remove_batch_tracker.reset(vespalib::steady_clock::now());
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.cpp
@@ -5,8 +5,10 @@
 
 namespace proton {
 
-RemoveOperationsRateTracker::RemoveOperationsRateTracker(double remove_batch_rate_threshold)
-    : _remove_batch_tracker(remove_batch_rate_threshold)
+RemoveOperationsRateTracker::RemoveOperationsRateTracker(double remove_batch_rate_threshold,
+                                                         double remove_rate_threshold)
+    : _remove_batch_tracker(remove_batch_rate_threshold),
+      _remove_tracker(remove_rate_threshold)
 {
 }
 
@@ -16,16 +18,22 @@ RemoveOperationsRateTracker::notify_remove_batch()
     _remove_batch_tracker.observe(vespalib::steady_clock::now());
 }
 
+void
+RemoveOperationsRateTracker::notify_remove()
+{
+    _remove_tracker.observe(vespalib::steady_clock::now());
+}
+
 bool
 RemoveOperationsRateTracker::remove_batch_above_threshold() const
 {
     return _remove_batch_tracker.above_threshold(vespalib::steady_clock::now());
 }
 
-void
-RemoveOperationsRateTracker::reset_remove_batch_tracker()
+bool
+RemoveOperationsRateTracker::remove_above_threshold() const
 {
-    _remove_batch_tracker.reset(vespalib::steady_clock::now());
+    return _remove_tracker.above_threshold(vespalib::steady_clock::now());
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.h
+++ b/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.h
@@ -15,16 +15,21 @@ namespace proton {
 class RemoveOperationsRateTracker : public documentmetastore::OperationListener {
 private:
     OperationRateTracker _remove_batch_tracker;
+    OperationRateTracker _remove_tracker;
 
 public:
-    RemoveOperationsRateTracker(double remove_batch_rate_threshold);
+    RemoveOperationsRateTracker(double remove_batch_rate_threshold,
+                                double remove_rate_threshold);
 
     void notify_remove_batch() override;
+    void notify_remove() override;
 
     bool remove_batch_above_threshold() const;
+    bool remove_above_threshold() const;
 
     // Should only be used for testing
-    void reset_remove_batch_tracker();
+    OperationRateTracker& get_remove_batch_tracker() { return _remove_batch_tracker; }
+    OperationRateTracker& get_remove_tracker() { return _remove_tracker; }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.h
+++ b/searchcore/src/vespa/searchcore/proton/server/remove_operations_rate_tracker.h
@@ -1,0 +1,30 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchcore/proton/common/operation_rate_tracker.h>
+#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
+
+namespace proton {
+
+/**
+ * Class that tracks the rate of remove operations handled by the document meta store.
+ *
+ * For each operation we can tell if it is above or below a given rate threshold.
+ */
+class RemoveOperationsRateTracker : public documentmetastore::OperationListener {
+private:
+    OperationRateTracker _remove_batch_tracker;
+
+public:
+    RemoveOperationsRateTracker(double remove_batch_rate_threshold);
+
+    void notify_remove_batch() override;
+
+    bool remove_batch_above_threshold() const;
+
+    // Should only be used for testing
+    void reset_remove_batch_tracker();
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
@@ -185,6 +185,9 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
     virtual void foreach(const search::IGidToLidMapperVisitor &visitor) const override {
         _store.foreach(visitor);
     }
+    virtual void set_operation_listener(documentmetastore::OperationListener::SP op_listener) override {
+        _store.set_operation_listener(std::move(op_listener));
+    }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include <vespa/searchcore/proton/documentmetastore/i_document_meta_store.h>
+#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 
-namespace proton {
-namespace test {
+namespace proton::test {
 
 struct DocumentMetaStoreObserver : public IDocumentMetaStore
 {
@@ -190,6 +190,5 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
     }
 };
 
-}
 }
 

--- a/searchlib/src/vespa/searchlib/common/lid_usage_stats.h
+++ b/searchlib/src/vespa/searchlib/common/lid_usage_stats.h
@@ -18,34 +18,29 @@ private:
     uint32_t _usedLids;
     uint32_t _lowestFreeLid;
     uint32_t _highestUsedLid;
-    TimePoint _last_remove_batch;
 
 public:
     LidUsageStats()
         : _lidLimit(0),
           _usedLids(0),
           _lowestFreeLid(0),
-          _highestUsedLid(0),
-          _last_remove_batch()
+          _highestUsedLid(0)
     {
     }
     LidUsageStats(uint32_t lidLimit,
                   uint32_t usedLids,
                   uint32_t lowestFreeLid,
-                  uint32_t highestUsedLid,
-                  TimePoint last_remove_batch)
+                  uint32_t highestUsedLid)
         : _lidLimit(lidLimit),
           _usedLids(usedLids),
           _lowestFreeLid(lowestFreeLid),
-          _highestUsedLid(highestUsedLid),
-          _last_remove_batch(last_remove_batch)
+          _highestUsedLid(highestUsedLid)
     {
     }
     uint32_t getLidLimit() const { return _lidLimit; }
     uint32_t getUsedLids() const { return _usedLids; }
     uint32_t getLowestFreeLid() const { return _lowestFreeLid; }
     uint32_t getHighestUsedLid() const { return _highestUsedLid; }
-    const TimePoint& get_last_remove_batch() const { return _last_remove_batch; }
     uint32_t getLidBloat() const {
         // Account for reserved lid 0
         int32_t lidBloat = getLidLimit() - getUsedLids() - 1;


### PR DESCRIPTION
@toregge and @baldersheim please review

During a period with a high rate of remove operations, there is no use running lid space compaction
as this will interfere with the remove operations, increasing latency of those.
Moving a document as part of lid space compaction is a costly operation (similar to putting the document in the first place) and it typically uses both the index and attribute writer thread pools.
