### PR TITLE
Resize on resource reduce

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -213,8 +213,8 @@ public class NodePrioritizer {
             builder.parent(parent).freeParentCapacity(parentCapacity);
 
             if (!isNewNode)
-                builder.resizable(!allocateFully && requestedNodes.canResize(
-                        node.flavor().resources(), parentCapacity, isTopologyChange, currentClusterSize));
+                builder.resizable(!allocateFully
+                                  && requestedNodes.canResize(node.flavor().resources(), parentCapacity, isTopologyChange, currentClusterSize));
 
             if (spareHosts.contains(parent))
                 builder.violatesSpares(true);


### PR DESCRIPTION
We were missing a test of resize on straighforward resource reduce, and handling the case where we want to avoid resizing already retired nodes by unretiring broke it.