### PR TITLE
Ignore local port reported from proxy-protocol header

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/core/HttpServletRequestUtils.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/core/HttpServletRequestUtils.java
@@ -2,6 +2,7 @@
 package com.yahoo.jdisc.http.core;
 
 import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.ServerConnector;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -13,6 +14,15 @@ public class HttpServletRequestUtils {
 
     public static HttpConnection getConnection(HttpServletRequest request) {
         return (HttpConnection)request.getAttribute("org.eclipse.jetty.server.HttpConnection");
+    }
+
+    /**
+     * Note: {@link HttpServletRequest#getLocalPort()} may return the local port of the load balancer / reverse proxy if proxy-protocol is enabled.
+     * @return the actual local port of the underlying Jetty connector
+     */
+    public static int getConnectorLocalPort(HttpServletRequest request) {
+        ServerConnector jettyConnector = (ServerConnector) getConnection(request).getConnector();
+        return jettyConnector.getLocalPort();
     }
 
 }

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.yahoo.jdisc.http.core.HttpServletRequestUtils.getConnectorLocalPort;
+
 /**
  * This class is a bridge between Jetty's {@link org.eclipse.jetty.server.handler.RequestLogHandler}
  * and our own configurable access logging in different formats provided by {@link AccessLog}.
@@ -80,7 +82,7 @@ public class AccessLogRequestLog extends AbstractLifeCycle implements RequestLog
             }
             accessLogEntry.setHttpVersion(request.getProtocol());
             accessLogEntry.setScheme(request.getScheme());
-            accessLogEntry.setLocalPort(request.getLocalPort());
+            accessLogEntry.setLocalPort(getConnectorLocalPort(request));
             Principal principal = (Principal) request.getAttribute(ServletRequest.JDISC_REQUEST_PRINCIPAL);
             if (principal != null) {
                 accessLogEntry.setUserPrincipal(principal);

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.yahoo.jdisc.Response.Status.NOT_FOUND;
+import static com.yahoo.jdisc.http.core.HttpServletRequestUtils.getConnectorLocalPort;
 
 /**
  * A handler that proxies status.html health checks
@@ -84,7 +85,7 @@ class HealthCheckProxyHandler extends HandlerWrapper {
 
     @Override
     public void handle(String target, Request request, HttpServletRequest servletRequest, HttpServletResponse servletResponse) throws IOException, ServletException {
-        ProxyTarget proxyTarget = portToProxyTargetMapping.get(request.getLocalPort());
+        ProxyTarget proxyTarget = portToProxyTargetMapping.get(getConnectorLocalPort(servletRequest));
         if (proxyTarget != null) {
             if (servletRequest.getRequestURI().equals(HEALTH_CHECK_PATH)) {
                 try (CloseableHttpResponse proxyResponse = proxyTarget.requestStatusHtml()) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
@@ -15,6 +15,7 @@ import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 
 import static com.yahoo.jdisc.http.core.HttpServletRequestUtils.getConnection;
+import static com.yahoo.jdisc.http.core.HttpServletRequestUtils.getConnectorLocalPort;
 
 /**
  * @author Simon Thoresen Hult
@@ -38,11 +39,11 @@ class HttpRequestFactory {
         }
     }
 
-    // Implementation based on org.eclipse.jetty.server.Request.getRequestURL(), but with getLocalPort() as port
+    // Implementation based on org.eclipse.jetty.server.Request.getRequestURL(), but with the connector's local port instead
     public static URI getUri(HttpServletRequest servletRequest) {
         try {
             StringBuffer builder = new StringBuffer(128);
-            URIUtil.appendSchemeHostPort(builder, servletRequest.getScheme(), servletRequest.getServerName(), servletRequest.getLocalPort());
+            URIUtil.appendSchemeHostPort(builder, servletRequest.getScheme(), servletRequest.getServerName(), getConnectorLocalPort(servletRequest));
             builder.append(servletRequest.getRequestURI());
             String query = servletRequest.getQueryString();
             if (query != null) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/SecuredRedirectHandler.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/SecuredRedirectHandler.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.yahoo.jdisc.http.core.HttpServletRequestUtils.getConnectorLocalPort;
+
 /**
  * A secure redirect handler inspired by {@link org.eclipse.jetty.server.handler.SecuredRedirectHandler}.
  *
@@ -31,7 +33,7 @@ class SecuredRedirectHandler extends HandlerWrapper {
 
     @Override
     public void handle(String target, Request request, HttpServletRequest servletRequest, HttpServletResponse servletResponse) throws IOException, ServletException {
-        int localPort = servletRequest.getLocalPort();
+        int localPort = getConnectorLocalPort(servletRequest);
         if (!redirectMap.containsKey(localPort)) {
             _handler.handle(target, request, servletRequest, servletResponse);
             return;

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/TlsClientAuthenticationEnforcer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/TlsClientAuthenticationEnforcer.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.yahoo.jdisc.http.core.HttpServletRequestUtils.getConnectorLocalPort;
+
 /**
  * A Jetty handler that enforces TLS client authentication with configurable white list.
  *
@@ -59,7 +61,7 @@ class TlsClientAuthenticationEnforcer extends HandlerWrapper {
     }
 
     private boolean isRequestToWhitelistedBinding(HttpServletRequest servletRequest) {
-        int localPort = servletRequest.getLocalPort();
+        int localPort = getConnectorLocalPort(servletRequest);
         List<String> whiteListedPaths = getWhitelistedPathsForPort(localPort);
         if (whiteListedPaths == null) {
             return true; // enforcer not enabled

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactoryTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactoryTest.java
@@ -10,6 +10,7 @@ import com.yahoo.jdisc.handler.RequestHandler;
 import com.yahoo.jdisc.http.HttpRequest;
 import com.yahoo.jdisc.service.CurrentContainer;
 import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.ServerConnector;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
@@ -67,7 +68,10 @@ public class HttpRequestFactoryTest {
     private static HttpServletRequest createMockRequest(String scheme, String serverName, String path, String queryString) {
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpConnection connection = mock(HttpConnection.class);
+        ServerConnector connector = mock(ServerConnector.class);
+        when(connector.getLocalPort()).thenReturn(LOCAL_PORT);
         when(connection.getCreatedTimeStamp()).thenReturn(System.currentTimeMillis());
+        when(connection.getConnector()).thenReturn(connector);
         when(request.getAttribute("org.eclipse.jetty.server.HttpConnection")).thenReturn(connection);
         when(request.getProtocol()).thenReturn("HTTP/1.1");
         when(request.getScheme()).thenReturn(scheme);


### PR DESCRIPTION
Replace usage of ServletRequest.getLocalPort() with equivalent from
ServerConnector. The latter will not be overridden by the proxy-protocol
header if proxy-protocol is enabled for that connector.