### PR TITLE
Also map /opt/vespa/logs/vespa

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/docker/DockerOperationsImpl.java
@@ -293,6 +293,7 @@ public class DockerOperationsImpl implements DockerOperations {
                 "/var/spool/postfix/maildrop",
 
                 // Under VESPA_HOME in container
+                "logs/vespa",
                 "logs/ysar",
                 "tmp",
                 "var/crash", // core dumps


### PR DESCRIPTION
PR #13127 somehow dropped the volume mapping of /opt/vespa/logs/vespa.