### PR TITLE
- Reserve space upfront in the vectors.

### DIFF
--- a/searchlib/src/vespa/searchlib/features/fieldmatch/computer.h
+++ b/searchlib/src/vespa/searchlib/features/fieldmatch/computer.h
@@ -14,9 +14,7 @@
 #include "segmentstart.h"
 #include "simplemetrics.h"
 
-namespace search {
-namespace features {
-namespace fieldmatch {
+namespace search::features::fieldmatch {
 
 /**
  * <p>Calculates a set of metrics capturing information about the degree of agreement between a query and a field
@@ -330,7 +328,7 @@ private:
 
     struct SegmentData {
         SegmentData() : segment(), valid(false) {}
-        SegmentData(const SegmentStart::SP & ss, bool v = false) : segment(ss), valid(v) {}
+        SegmentData(SegmentStart::SP ss, bool v = false) : segment(std::move(ss)), valid(v) {}
         SegmentStart::SP segment;
         bool valid;
     };
@@ -364,7 +362,4 @@ private:
     std::vector<BitVectorData>                 _cachedHits;
 };
 
-} // fieldmatch
-} // features
-} // search
-
+}

--- a/searchlib/src/vespa/searchlib/features/fieldmatchfeature.h
+++ b/searchlib/src/vespa/searchlib/features/fieldmatchfeature.h
@@ -13,16 +13,13 @@ namespace search::features {
  */
 class FieldMatchExecutor : public fef::FeatureExecutor {
 private:
-    fef::PhraseSplitter             _splitter;
-    const fef::FieldInfo          & _field;
-    fieldmatch::Computer                    _cmp;
+    fef::PhraseSplitter    _splitter;
+    const fef::FieldInfo & _field;
+    fieldmatch::Computer   _cmp;
 
     void handle_bind_match_data(const fef::MatchData &md) override;
 
 public:
-    /**
-     * Constructs an executor.
-     */
     FieldMatchExecutor(const fef::IQueryEnvironment & queryEnv,
                        const fef::FieldInfo & field,
                        const fieldmatch::Params & params);

--- a/searchlib/src/vespa/searchlib/features/nativeproximityfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/nativeproximityfeature.cpp
@@ -61,9 +61,7 @@ NativeProximityExecutor::NativeProximityExecutor(const IQueryEnvironment & env,
         QueryTerm qt = QueryTermFactory::create(env, i);
 
         typedef search::fef::ITermFieldRangeAdapter FRA;
-
         for (FRA iter(*qt.termData()); iter.valid(); iter.next()) {
-
             uint32_t fieldId = iter.get().getFieldId();
             if (_params.considerField(fieldId)) { // only consider fields with contribution
                 qt.fieldHandle(iter.get().getHandle());
@@ -71,13 +69,13 @@ NativeProximityExecutor::NativeProximityExecutor(const IQueryEnvironment & env,
             }
         }
     }
-    for (std::map<uint32_t, QueryTermVector>::const_iterator itr = fields.begin(); itr != fields.end(); ++itr) {
-        if (itr->second.size() >= 2) {
-            FieldSetup setup(itr->first);
-            generateTermPairs(env, itr->second, _params.slidingWindow, setup);
+    for (const auto & entry : fields) {
+        if (entry.second.size() >= 2) {
+            FieldSetup setup(entry.first);
+            generateTermPairs(env, entry.second, _params.slidingWindow, setup);
             if (!setup.pairs.empty()) {
-                _setups.push_back(setup);
-                _totalFieldWeight += params.vector[itr->first].fieldWeight;
+                _setups.push_back(std::move(setup));
+                _totalFieldWeight += params.vector[entry.first].fieldWeight;
             }
         }
     }

--- a/searchlib/src/vespa/searchlib/features/nativeproximityfeature.h
+++ b/searchlib/src/vespa/searchlib/features/nativeproximityfeature.h
@@ -80,8 +80,8 @@ public:
 class NativeProximityBlueprint : public fef::Blueprint {
 private:
     NativeProximityParams _params;
-    vespalib::string           _defaultProximityBoost;
-    vespalib::string           _defaultRevProximityBoost;
+    vespalib::string      _defaultProximityBoost;
+    vespalib::string      _defaultRevProximityBoost;
 
 public:
     NativeProximityBlueprint();

--- a/searchlib/src/vespa/searchlib/fef/itermfielddata.h
+++ b/searchlib/src/vespa/searchlib/fef/itermfielddata.h
@@ -16,27 +16,28 @@ namespace search::fef {
  **/
 class ITermFieldData
 {
-protected:
-    virtual ~ITermFieldData() {}
-
 public:
+    ITermFieldData(uint32_t fieldId)
+        : _fieldId(fieldId),
+          _matching_doc_count(0),
+          _total_doc_count(1)
+    { }
     /**
      * Obtain the global field id.
      *
      * @return field id
      **/
-    virtual uint32_t getFieldId() const = 0;
-
+    uint32_t getFieldId() const { return _fieldId; }
 
     /**
      * Returns the number of documents matching this term.
      */
-    virtual uint32_t get_matching_doc_count() const = 0;
+    uint32_t get_matching_doc_count() const { return _matching_doc_count; }
 
     /**
      * Returns the total number of documents in the corpus.
      */
-    virtual uint32_t get_total_doc_count() const = 0;
+    uint32_t get_total_doc_count() const { return _total_doc_count; }
 
     /**
      * Obtain the document frequency. This is a value between 0 and 1
@@ -46,6 +47,15 @@ public:
     **/
     double getDocFreq() const {
         return (double)get_matching_doc_count() / (double)get_total_doc_count();
+    }
+
+    /**
+     * Sets the document frequency.
+     **/
+    ITermFieldData &setDocFreq(uint32_t matching_doc_count, uint32_t total_doc_count) {
+        _matching_doc_count = matching_doc_count;
+        _total_doc_count = total_doc_count;
+        return *this;
     }
 
     /**
@@ -65,6 +75,12 @@ public:
      * @return match handle (or IllegalHandle)
      **/
     virtual TermFieldHandle getHandle(MatchDataDetails requested_details) const = 0;
+protected:
+    virtual ~ITermFieldData() {}
+private:
+    uint32_t    _fieldId;
+    uint32_t    _matching_doc_count;
+    uint32_t    _total_doc_count;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/fef/phrasesplitter.cpp
+++ b/searchlib/src/vespa/searchlib/fef/phrasesplitter.cpp
@@ -2,8 +2,7 @@
 
 #include "phrasesplitter.h"
 
-namespace search {
-namespace fef {
+namespace search::fef {
 
 void
 PhraseSplitter::considerTerm(uint32_t termIdx, const ITermData &term, std::vector<PhraseTerm> &phraseTerms, uint32_t fieldId)
@@ -32,10 +31,9 @@ PhraseSplitter::considerTerm(uint32_t termIdx, const ITermData &term, std::vecto
     _termIdxMap.push_back(TermIdx(termIdx, false));
 }
 
-PhraseSplitter::PhraseSplitter(const IQueryEnvironment & queryEnv,
-                               uint32_t fieldId) :
+PhraseSplitter::PhraseSplitter(const IQueryEnvironment & queryEnv, uint32_t fieldId) :
     _queryEnv(queryEnv),
-    _matchData(NULL),
+    _matchData(nullptr),
     _terms(),
     _termMatches(),
     _termIdxMap(),
@@ -47,18 +45,18 @@ PhraseSplitter::PhraseSplitter(const IQueryEnvironment & queryEnv,
 
     for (uint32_t i = 0; i < queryEnv.getNumTerms(); ++i) {
         const ITermData *td = queryEnv.getTerm(i);
-        assert(td != NULL);
+        assert(td != nullptr);
         considerTerm(i, *td, phraseTerms, fieldId);
         numHandles += td->numFields();
     }
 
     _skipHandles = _maxHandle + 1 + numHandles;
-    for (uint32_t i = 0; i < _terms.size(); ++i) {
+    _termMatches.reserve(_terms.size());
+    for (auto & term : _terms) {
         // start at _skipHandles + 0
-        _terms[i].field(0).setHandle(_skipHandles + _termMatches.size());
-        TermFieldMatchData empty;
-        empty.setFieldId(fieldId);
-        _termMatches.push_back(empty);
+        term.field(0).setHandle(_skipHandles + _termMatches.size());
+        _termMatches.emplace_back();
+        _termMatches.back().setFieldId(fieldId);
     }
 
     for (uint32_t i = 0; i < phraseTerms.size(); ++i) {
@@ -76,7 +74,7 @@ PhraseSplitter::PhraseSplitter(const IQueryEnvironment & queryEnv,
     }
 }
 
-PhraseSplitter::~PhraseSplitter() {}
+PhraseSplitter::~PhraseSplitter() = default;
 
 void
 PhraseSplitter::copyTermFieldMatchData(TermFieldMatchData & dst, const TermFieldMatchData & src, uint32_t hitOffset)
@@ -96,11 +94,10 @@ PhraseSplitter::update()
     for (uint32_t i = 0; i < _copyInfo.size(); ++i) {
         const TermFieldMatchData *src = _matchData->resolveTermField(_copyInfo[i].orig_handle);
         TermFieldMatchData *dst = resolveSplittedTermField(_copyInfo[i].split_handle);
-        assert(src != NULL && dst != NULL);
+        assert(src != nullptr && dst != nullptr);
         copyTermFieldMatchData(*dst, *src, _copyInfo[i].offsetInPhrase);
     }
 
 }
 
-} // namespace fef
-} // namespace search
+}

--- a/searchlib/src/vespa/searchlib/fef/phrasesplitter.h
+++ b/searchlib/src/vespa/searchlib/fef/phrasesplitter.h
@@ -8,8 +8,7 @@
 #include "termfieldmatchdata.h"
 #include "fieldinfo.h"
 
-namespace search {
-namespace fef {
+namespace search::fef {
 
 /**
  * This class is used to split all phrase terms in a query environment
@@ -94,7 +93,7 @@ public:
 
     const ITermData * getTerm(uint32_t idx) const override {
         if (idx >= _termIdxMap.size()) {
-            return NULL;
+            return nullptr;
         }
         const TermIdx & ti = _termIdxMap[idx];
         return ti.splitted ? &_terms[ti.idx] : _queryEnv.getTerm(ti.idx);
@@ -104,8 +103,8 @@ public:
      * Inherit doc from MatchData.
      **/
     const TermFieldMatchData * resolveTermField(TermFieldHandle handle) const {
-        if (_matchData == NULL) {
-            return NULL;
+        if (_matchData == nullptr) {
+            return nullptr;
         }
         return handle < _skipHandles ? _matchData->resolveTermField(handle) : resolveSplittedTermField(handle);
     }
@@ -118,6 +117,4 @@ public:
     void bind_match_data(const fef::MatchData &md) { _matchData = &md; }
 };
 
-} // namespace fef
-} // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/fef/simpletermfielddata.cpp
+++ b/searchlib/src/vespa/searchlib/fef/simpletermfielddata.cpp
@@ -5,17 +5,13 @@
 namespace search::fef {
 
 SimpleTermFieldData::SimpleTermFieldData(uint32_t fieldId)
-    : _fieldId(fieldId),
-      _matching_doc_count(0),
-      _total_doc_count(1),
+    : ITermFieldData(fieldId),
       _handle(IllegalHandle)
 {
 }
 
 SimpleTermFieldData::SimpleTermFieldData(const ITermFieldData &rhs)
-    : _fieldId(rhs.getFieldId()),
-      _matching_doc_count(rhs.get_matching_doc_count()),
-      _total_doc_count(rhs.get_total_doc_count()),
+    : ITermFieldData(rhs),
       _handle(rhs.getHandle())
 {
 }

--- a/searchlib/src/vespa/searchlib/fef/simpletermfielddata.h
+++ b/searchlib/src/vespa/searchlib/fef/simpletermfielddata.h
@@ -15,9 +15,6 @@ namespace search::fef {
 class SimpleTermFieldData : public ITermFieldData
 {
 private:
-    uint32_t        _fieldId;
-    uint32_t        _matching_doc_count;
-    uint32_t        _total_doc_count;
     TermFieldHandle _handle;
 
 public:
@@ -33,26 +30,11 @@ public:
      **/
     SimpleTermFieldData(uint32_t fieldId);
 
-    uint32_t getFieldId() const override final { return _fieldId; }
-
-    uint32_t get_matching_doc_count() const override { return _matching_doc_count; }
-
-    uint32_t get_total_doc_count() const override { return _total_doc_count; }
-
     using ITermFieldData::getHandle;
 
     TermFieldHandle getHandle(MatchDataDetails requestedDetails) const override {
         (void) requestedDetails;
         return _handle;
-    }
-
-    /**
-     * Sets the document frequency.
-     **/
-    SimpleTermFieldData &setDocFreq(uint32_t matching_doc_count, uint32_t total_doc_count) {
-        _matching_doc_count = matching_doc_count;
-        _total_doc_count = total_doc_count;
-        return *this;
     }
 
     /**


### PR DESCRIPTION
- Remove virtual interface from some very frequently called methods that are not necessary.
- Use std::move for vector and shared_ptr.
- Some c++11ification.

@geirst or @havardpe PR
