### PR TITLE
Require the same FileSystem provider

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
@@ -15,7 +15,7 @@ import com.yahoo.vespa.hosted.node.admin.docker.DockerNetworking;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.ProviderMismatchException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
  * @author freva
  */
 public class NodeAgentContextImpl implements NodeAgentContext {
-    private static final Path ROOT = Paths.get("/");
 
     private final String logPrefix;
     private final NodeSpec node;
@@ -35,6 +34,8 @@ public class NodeAgentContextImpl implements NodeAgentContext {
     private final AthenzIdentity identity;
     private final DockerNetworking dockerNetworking;
     private final ZoneApi zone;
+    private final FileSystem fileSystem;
+    private final Path root;
     private final Path pathToNodeRootOnHost;
     private final Path pathToVespaHome;
     private final String vespaUser;
@@ -43,6 +44,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
 
     public NodeAgentContextImpl(NodeSpec node, Acl acl, AthenzIdentity identity,
                                 DockerNetworking dockerNetworking, ZoneApi zone,
+                                FileSystem fileSystem,
                                 Path pathToContainerStorage, Path pathToVespaHome,
                                 String vespaUser, String vespaUserOnHost, double cpuSpeedup) {
         if (cpuSpeedup <= 0)
@@ -54,8 +56,10 @@ public class NodeAgentContextImpl implements NodeAgentContext {
         this.identity = Objects.requireNonNull(identity);
         this.dockerNetworking = Objects.requireNonNull(dockerNetworking);
         this.zone = Objects.requireNonNull(zone);
-        this.pathToNodeRootOnHost = Objects.requireNonNull(pathToContainerStorage).resolve(containerName.asString());
-        this.pathToVespaHome = Objects.requireNonNull(pathToVespaHome);
+        this.fileSystem = fileSystem;
+        this.root = fileSystem.getPath("/");
+        this.pathToNodeRootOnHost = requireValidPath(pathToContainerStorage).resolve(containerName.asString());
+        this.pathToVespaHome = requireValidPath(pathToVespaHome);
         this.logPrefix = containerName.asString() + ": ";
         this.vespaUser = vespaUser;
         this.vespaUserOnHost = vespaUserOnHost;
@@ -108,48 +112,41 @@ public class NodeAgentContextImpl implements NodeAgentContext {
     }
 
     @Override
-    public Path pathOnHostFromPathInNode(Path pathInNode) {
-        if (! pathInNode.isAbsolute())
-            throw new IllegalArgumentException("Expected an absolute path in the container, got: " + pathInNode);
-
-        return pathToNodeRootOnHost.resolve(ROOT.relativize(pathInNode).toString());
+    public FileSystem fileSystem() {
+        return fileSystem;
     }
 
     @Override
-    public Path pathOnHostFromPathInNode(String pathInNode) {
-        // Ensure the path is on the proper FileSystem
-        return pathOnHostFromPathInNode(ROOT.getFileSystem().getPath(pathInNode));
+    public Path pathOnHostFromPathInNode(Path pathInNode) {
+        requireValidPath(pathInNode);
+
+        if (! pathInNode.isAbsolute())
+            throw new IllegalArgumentException("Expected an absolute path in the container, got: " + pathInNode);
+
+        return pathToNodeRootOnHost.resolve(pathInNode.getRoot().relativize(pathInNode).toString());
     }
 
     @Override
     public Path pathInNodeFromPathOnHost(Path pathOnHost) {
+        requireValidPath(pathOnHost);
+
         if (! pathOnHost.isAbsolute())
             throw new IllegalArgumentException("Expected an absolute path on the host, got: " + pathOnHost);
 
         if (!pathOnHost.startsWith(pathToNodeRootOnHost))
             throw new IllegalArgumentException("Path " + pathOnHost + " does not exist in the container");
 
-        return ROOT.resolve(pathToNodeRootOnHost.relativize(pathOnHost).toString());
-    }
-
-    @Override
-    public Path pathInNodeFromPathOnHost(String pathOnHost) {
-        // Ensure the path is on the proper FileSystem
-        return pathInNodeFromPathOnHost(pathToNodeRootOnHost.getFileSystem().getPath(pathOnHost));
+        return root.resolve(pathToNodeRootOnHost.relativize(pathOnHost).toString());
     }
 
     @Override
     public Path pathInNodeUnderVespaHome(Path relativePath) {
+        requireValidPath(relativePath);
+
         if (relativePath.isAbsolute())
             throw new IllegalArgumentException("Expected a relative path to the Vespa home, got: " + relativePath);
 
         return relativePath.getFileSystem().getPath(pathToVespaHome.resolve(relativePath.toString()).toString());
-    }
-
-    @Override
-    public Path pathInNodeUnderVespaHome(String relativePath) {
-        // Ensure the path is on the proper FileSystem
-        return pathInNodeUnderVespaHome(pathToVespaHome.getFileSystem().getPath(relativePath));
     }
 
     @Override
@@ -168,6 +165,18 @@ public class NodeAgentContextImpl implements NodeAgentContext {
     }
 
     @Override
+    public Path rewritePathInNodeForWantedDockerImage(Path path) {
+        requireValidPath(path);
+
+        if (!node().wantedDockerImage().get().repository().endsWith("/vespa/ci")) return path;
+
+        Path originalVespaHome = pathInNodeUnderVespaHome("");
+        if (!path.startsWith(originalVespaHome)) return path;
+
+        return fileSystem.getPath("/home/y").resolve(originalVespaHome.relativize(path));
+    }
+
+    @Override
     public String toString() {
         return "NodeAgentContextImpl{" +
                 "node=" + node +
@@ -183,6 +192,18 @@ public class NodeAgentContextImpl implements NodeAgentContext {
                 '}';
     }
 
+    private Path requireValidPath(Path path) {
+        Objects.requireNonNull(path);
+
+        Objects.requireNonNull(fileSystem); // to allow this method to be used in constructor.
+        if (!path.getFileSystem().provider().equals(fileSystem.provider())) {
+            throw new ProviderMismatchException("Expected file system provider " + fileSystem.provider() +
+                    " but " + path + " had " + path.getFileSystem().provider());
+        }
+
+        return path;
+    }
+
     /** For testing only! */
     public static class Builder {
         private NodeSpec.Builder nodeSpecBuilder;
@@ -190,8 +211,6 @@ public class NodeAgentContextImpl implements NodeAgentContext {
         private AthenzIdentity identity;
         private DockerNetworking dockerNetworking;
         private ZoneApi zone;
-        private Path pathToContainerStorage;
-        private Path pathToVespaHome;
         private String vespaUser;
         private String vespaUserOnHost;
         private FileSystem fileSystem = FileSystems.getDefault();
@@ -235,16 +254,6 @@ public class NodeAgentContextImpl implements NodeAgentContext {
             return this;
         }
 
-        public Builder pathToContainerStorageFromFileSystem(FileSystem fileSystem) {
-            this.pathToContainerStorage = fileSystem.getPath("/home/docker");
-            return this;
-        }
-
-        public Builder pathToVespaHome(Path pathToVespaHome) {
-            this.pathToVespaHome = pathToVespaHome;
-            return this;
-        }
-
         public Builder vespaUser(String vespaUser) {
             this.vespaUser = vespaUser;
             return this;
@@ -255,10 +264,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
             return this;
         }
 
-        /**
-         * Sets the default file system to use for paths. May be overridden for each path,
-         * e.g. {@link #pathToVespaHome(Path)}  pathToVespaHome()}.
-         */
+        /** Sets the file system to use for paths. */
         public Builder fileSystem(FileSystem fileSystem) {
             this.fileSystem = fileSystem;
             return this;
@@ -296,8 +302,9 @@ public class NodeAgentContextImpl implements NodeAgentContext {
                             return getId().region().value();
                         }
                     }),
-                    Optional.ofNullable(pathToContainerStorage).orElseGet(() -> fileSystem.getPath("/home/docker")),
-                    Optional.ofNullable(pathToVespaHome).orElseGet(() -> fileSystem.getPath("/opt/vespa")),
+                    fileSystem,
+                    fileSystem.getPath("/home/docker"),
+                    fileSystem.getPath("/opt/vespa"),
                     Optional.ofNullable(vespaUser).orElse("vespa"),
                     Optional.ofNullable(vespaUserOnHost).orElse("container_vespa"),
                     cpuSpeedUp);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
@@ -303,7 +303,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
                         }
                     }),
                     fileSystem,
-                    fileSystem.getPath("/home/docker"),
+                    fileSystem.getPath("/home/docker/container-storage"),
                     fileSystem.getPath("/opt/vespa"),
                     Optional.ofNullable(vespaUser).orElse("vespa"),
                     Optional.ofNullable(vespaUserOnHost).orElse("container_vespa"),

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImpl.java
@@ -35,7 +35,6 @@ public class NodeAgentContextImpl implements NodeAgentContext {
     private final DockerNetworking dockerNetworking;
     private final ZoneApi zone;
     private final FileSystem fileSystem;
-    private final Path root;
     private final Path pathToNodeRootOnHost;
     private final Path pathToVespaHome;
     private final String vespaUser;
@@ -57,7 +56,6 @@ public class NodeAgentContextImpl implements NodeAgentContext {
         this.dockerNetworking = Objects.requireNonNull(dockerNetworking);
         this.zone = Objects.requireNonNull(zone);
         this.fileSystem = fileSystem;
-        this.root = fileSystem.getPath("/");
         this.pathToNodeRootOnHost = requireValidPath(pathToContainerStorage).resolve(containerName.asString());
         this.pathToVespaHome = requireValidPath(pathToVespaHome);
         this.logPrefix = containerName.asString() + ": ";
@@ -123,7 +121,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
         if (! pathInNode.isAbsolute())
             throw new IllegalArgumentException("Expected an absolute path in the container, got: " + pathInNode);
 
-        return pathToNodeRootOnHost.resolve(pathInNode.getRoot().relativize(pathInNode).toString());
+        return pathToNodeRootOnHost.resolve(pathInNode.getRoot().relativize(pathInNode));
     }
 
     @Override
@@ -136,7 +134,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
         if (!pathOnHost.startsWith(pathToNodeRootOnHost))
             throw new IllegalArgumentException("Path " + pathOnHost + " does not exist in the container");
 
-        return root.resolve(pathToNodeRootOnHost.relativize(pathOnHost).toString());
+        return pathOnHost.getRoot().resolve(pathToNodeRootOnHost.relativize(pathOnHost));
     }
 
     @Override
@@ -146,7 +144,7 @@ public class NodeAgentContextImpl implements NodeAgentContext {
         if (relativePath.isAbsolute())
             throw new IllegalArgumentException("Expected a relative path to the Vespa home, got: " + relativePath);
 
-        return relativePath.getFileSystem().getPath(pathToVespaHome.resolve(relativePath.toString()).toString());
+        return pathToVespaHome.resolve(relativePath);
     }
 
     @Override

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integrationTests/DockerTester.java
@@ -88,7 +88,7 @@ public class DockerTester implements AutoCloseable {
                 Optional.empty(), Optional.empty(), Optional.empty(), clock, Duration.ofSeconds(-1));
         nodeAdmin = new NodeAdminImpl(nodeAgentFactory, metrics, clock, Duration.ofMillis(10), Duration.ZERO);
         NodeAgentContextFactory nodeAgentContextFactory = (nodeSpec, acl) ->
-                new NodeAgentContextImpl.Builder(nodeSpec).acl(acl).pathToContainerStorageFromFileSystem(fileSystem).build();
+                new NodeAgentContextImpl.Builder(nodeSpec).acl(acl).fileSystem(fileSystem).build();
         nodeAdminStateUpdater = new NodeAdminStateUpdater(nodeAgentContextFactory, nodeRepository, orchestrator,
                 nodeAdmin, HOST_HOSTNAME, clock);
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -122,7 +122,7 @@ public class StorageMaintainerTest {
 
         private NodeAgentContext createNodeAgentContextAndContainerStorage(FileSystem fileSystem, String containerName) throws IOException {
             NodeAgentContext context = new NodeAgentContextImpl.Builder(containerName + ".domain.tld")
-                    .pathToContainerStorageFromFileSystem(fileSystem).build();
+                    .fileSystem(fileSystem).build();
 
             Path containerVespaHomeOnHost = context.pathOnHostFromPathInNode(context.pathInNodeUnderVespaHome(""));
             Files.createDirectories(context.pathOnHostFromPathInNode("/etc/something"));
@@ -159,7 +159,7 @@ public class StorageMaintainerTest {
         private final FileSystem fileSystem = TestFileSystem.create();
         private final NodeAgentContext context = new NodeAgentContextImpl
                 .Builder(NodeSpec.Builder.testSpec("h123a.domain.tld").resources(new NodeResources(1, 1, 1, 1)).build())
-                .pathToContainerStorageFromFileSystem(fileSystem).build();
+                .fileSystem(fileSystem).build();
 
         @Test
         public void not_run_if_not_enough_used() throws IOException {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainerTest.java
@@ -52,7 +52,7 @@ public class StorageMaintainerTest {
             NodeAgentContext context = new NodeAgentContextImpl.Builder("host-1.domain.tld").fileSystem(fileSystem).build();
             Files.createDirectories(context.pathOnHostFromPathInNode("/"));
 
-            terminal.expectCommand("du -xsk /home/docker/host-1 2>&1", 0, "321\t/home/docker/host-1/");
+            terminal.expectCommand("du -xsk /home/docker/container-storage/host-1 2>&1", 0, "321\t/home/docker/container-storage/host-1/");
             assertEquals(Optional.of(DiskSize.of(328_704)), storageMaintainer.diskUsageFor(context));
 
             // Value should still be cached, no new execution against the terminal
@@ -80,7 +80,7 @@ public class StorageMaintainerTest {
             NodeAgentContext context1 = createNodeAgentContextAndContainerStorage(fileSystem, "container-1");
             createNodeAgentContextAndContainerStorage(fileSystem, "container-2");
 
-            Path pathToArchiveDir = fileSystem.getPath("/home/docker/container-archive");
+            Path pathToArchiveDir = fileSystem.getPath("/home/docker/container-storage/container-archive");
             Files.createDirectories(pathToArchiveDir);
 
             Path containerStorageRoot = context1.pathOnHostFromPathInNode("/").getParent();
@@ -181,7 +181,7 @@ public class StorageMaintainerTest {
         }
 
         private void mockDiskUsage(long kBytes) {
-            terminal.expectCommand("du -xsk /home/docker/h123a 2>&1", 0, kBytes + "\t/path");
+            terminal.expectCommand("du -xsk /home/docker/container-storage/h123a 2>&1", 0, kBytes + "\t/path");
         }
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.time.Instant;
@@ -164,7 +163,7 @@ public class CoredumpHandlerTest {
                 "}}";
 
 
-        Path coredumpDirectoryInContainer = Paths.get("/var/crash/id-123");
+        Path coredumpDirectoryInContainer = fileSystem.getPath("/var/crash/id-123");
         Path coredumpDirectory = context.pathOnHostFromPathInNode(coredumpDirectoryInContainer);
         Files.createDirectories(coredumpDirectory);
         Files.createFile(coredumpDirectory.resolve("dump_core.456"));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImplTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 public class NodeAgentContextImplTest {
     private final FileSystem fileSystem = TestFileSystem.create();
     private final NodeAgentContext context = new NodeAgentContextImpl.Builder("container-1.domain.tld")
-            .pathToContainerStorageFromFileSystem(fileSystem).build();
+            .fileSystem(fileSystem).build();
 
     @Test
     public void path_on_host_from_path_in_node_test() {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContextImplTest.java
@@ -22,11 +22,11 @@ public class NodeAgentContextImplTest {
     @Test
     public void path_on_host_from_path_in_node_test() {
         assertEquals(
-                "/home/docker/container-1",
+                "/home/docker/container-storage/container-1",
                 context.pathOnHostFromPathInNode("/").toString());
 
         assertEquals(
-                "/home/docker/container-1/dev/null",
+                "/home/docker/container-storage/container-1/dev/null",
                 context.pathOnHostFromPathInNode("/dev/null").toString());
     }
 
@@ -39,7 +39,7 @@ public class NodeAgentContextImplTest {
     public void path_in_node_from_path_on_host_test() {
         assertEquals(
                 "/dev/null",
-                context.pathInNodeFromPathOnHost(fileSystem.getPath("/home/docker/container-1/dev/null")).toString());
+                context.pathInNodeFromPathOnHost(fileSystem.getPath("/home/docker/container-storage/container-1/dev/null")).toString());
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -49,7 +49,7 @@ public class NodeAgentContextImplTest {
 
     @Test(expected=IllegalArgumentException.class)
     public void path_on_host_must_be_inside_container_storage_of_context() {
-        context.pathInNodeFromPathOnHost(fileSystem.getPath("/home/docker/container-2/dev/null"));
+        context.pathInNodeFromPathOnHost(fileSystem.getPath("/home/docker/container-storage/container-2/dev/null"));
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
TL;DR  Require all paths with NodeAgentContext[Impl] to use the same file system provider, and add a `FileSystem fileSystem()` method.

NodeAgentContext[Impl] requires paths to have specific providers, otherwise a ProviderMismatchException will be thrown, which it often does when adding tests involving ths class.  The current API is best described by defining a few terms:

* Let PathDefault be a Path with a file system provider matching that of FileSystems.getDefault().provider().
* Let PathContainerStorage be a Path with the same file system provider as the context's pathToContainerStorage constructor param
* Let PathVespaHome be a Path with the same file system provider as the context's pathToVespaHome constructor param.

The context methods handling paths have these requirements:

* `Path pathOnHostFromPathInNode(Path pathInNode)` maps a PathDefault to PathContainerStorage
* `Path pathInNodeFromPathOnHost(Path pathOnHost)` maps a PathContainerStorage to PathDefault
* `Path pathInNodeUnderVespaHome(Path relativePath)` maps a PathVespaHome to PathVespaHome
* `Path rewritePathInNodeForWantedDockerImage(Path path)` maps a PathDefault to PathDefault, and requires PathVespaHome == PathDefault, if it is to work under all circumstances.

This PR requires all paths with NAC[I] to have the same provider, otherwise we'll detect this and throw as early as possible.