### PR TITLE
Downgrade log level when node watch races with internal state resets

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
@@ -121,7 +121,10 @@ public class MasterDataGatherer {
                     if (nextMasterData.containsKey(index)) {
                         nextMasterData.remove(index);
                     } else {
-                        log.log(Level.SEVERE, "Fleetcontroller " + nodeIndex + ": Strangely, we already had data from node " + index + " when trying to remove it");
+                        // May happen when pending data watch error callbacks are triggered concurrently with
+                        // internal voting state having already been cleared due to connectivity issues.
+                        log.log(Level.INFO, String.format("Fleetcontroller %d: ignoring removal of vote from node %d " +
+                                "since it was not present in existing vote mapping", nodeIndex, index));
                     }
                 } else {
                     Integer value = Integer.valueOf(data);


### PR DESCRIPTION
@geirst please review. Causes spurious system test failures due to log error checks kicking in.

This appears to happen if pending data node watches are triggered with
failures after the cluster controller has already reset the internal
voting state due to connectivity issues. Internal state is rebuilt
automatically, so no need to scream errors into the logs for this.

