### PR TITLE
Reduce default maintainer interval for config server maintainers

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -50,7 +50,7 @@ athenzDnsSuffix string default=""
 ztsUrl string default=""
 
 # Maintainers
-maintainerIntervalMinutes int default=30
+maintainerIntervalMinutes int default=5
 # TODO: Default set to a high value (1 year) => maintainer will not run, change when maintainer verified out in prod
 tenantsMaintainerIntervalMinutes int default=525600
 keepUnusedFileReferencesHours int default=24


### PR DESCRIPTION
No reason to wait so long between each run.

Please review only, will merge after changes to expiry time for sessions have been rolled out.