### PR TITLE
Reapply "Reduce the time we keep expired remote sessions and fix comment"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -30,7 +30,8 @@ public class SessionsMaintainer extends ConfigServerMaintainer {
         // Expired remote sessions are sessions that belong to an application that have external deployments that
         // are no longer active
         if (hostedVespa) {
-            Duration expiryTime = Duration.ofDays(7);
+            // TODO: Reduce to 7 days in steps, otherwise startup of config servers takes a long time
+            Duration expiryTime = Duration.ofDays(28);
             applicationRepository.deleteExpiredRemoteSessions(expiryTime);
         }
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -27,11 +27,10 @@ public class SessionsMaintainer extends ConfigServerMaintainer {
     protected void maintain() {
         applicationRepository.deleteExpiredLocalSessions();
 
-        // Expired remote sessions are not expected to exist, they should have been deleted when
-        // a deployment happened or when the application was deleted. We still see them from time to time,
-        // probably due to some race or another bug
+        // Expired remote sessions are sessions that belong to an application that have external deployments that
+        // are no longer active
         if (hostedVespa) {
-            Duration expiryTime = Duration.ofDays(30);
+            Duration expiryTime = Duration.ofDays(7);
             applicationRepository.deleteExpiredRemoteSessions(expiryTime);
         }
     }


### PR DESCRIPTION
Same as https://github.com/vespa-engine/vespa/pull/13170, but with expiry time reduced from 30 to 28 days