### PR TITLE
signal if a blueprint wants a global filter

### DIFF
--- a/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
@@ -62,6 +62,9 @@ TEST("test AndNot Blueprint") {
         AndNotBlueprint a;
         a.addChild(ap(MyLeafSpec(10).addField(1, 1).create()));
         EXPECT_EQUAL(0u, a.exposeFields().size());
+        EXPECT_EQUAL(false, a.getState().want_global_filter());
+        a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
+        EXPECT_EQUAL(true, a.getState().want_global_filter());
     }
     {
         std::vector<Blueprint *> children;
@@ -130,6 +133,9 @@ TEST("test And Blueprint") {
         AndBlueprint a;
         a.addChild(ap(MyLeafSpec(10).addField(1, 1).create()));
         EXPECT_EQUAL(0u, a.exposeFields().size());
+        EXPECT_EQUAL(false, a.getState().want_global_filter());
+        a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
+        EXPECT_EQUAL(true, a.getState().want_global_filter());
     }
     {
         std::vector<Blueprint *> children;
@@ -202,6 +208,10 @@ TEST("test Or Blueprint") {
         EXPECT_EQUAL(2u, a->getState().numFields());
         o.addChild(ap(MyLeafSpec(0, true).create()));
         EXPECT_EQUAL(0u, a->getState().numFields());
+
+        EXPECT_EQUAL(false, o.getState().want_global_filter());
+        o.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
+        EXPECT_EQUAL(true, o.getState().want_global_filter());
     }
     {
         std::vector<Blueprint *> children;
@@ -349,6 +359,10 @@ TEST("test Rank Blueprint") {
         RankBlueprint a;
         a.addChild(ap(MyLeafSpec(10).addField(1, 1).create()));
         EXPECT_EQUAL(0u, a.exposeFields().size());
+
+        EXPECT_EQUAL(false, a.getState().want_global_filter());
+        a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
+        EXPECT_EQUAL(true, a.getState().want_global_filter());
     }
     {
         std::vector<Blueprint *> children;

--- a/searchlib/src/tests/queryeval/blueprint/mysearch.h
+++ b/searchlib/src/tests/queryeval/blueprint/mysearch.h
@@ -131,6 +131,7 @@ public:
         set_cost_tier(value);
         return *this;
     }
+    using LeafBlueprint::set_want_global_filter;
 };
 
 //-----------------------------------------------------------------------------
@@ -141,10 +142,11 @@ private:
     FieldSpecBaseList      _fields;
     Blueprint::HitEstimate _estimate;
     uint32_t               _cost_tier;
+    bool                   _want_global_filter;
 
 public:
     explicit MyLeafSpec(uint32_t estHits, bool empty = false)
-        : _fields(), _estimate(estHits, empty), _cost_tier(0) {}
+        : _fields(), _estimate(estHits, empty), _cost_tier(0), _want_global_filter(false) {}
 
     MyLeafSpec &addField(uint32_t fieldId, uint32_t handle) {
         _fields.add(FieldSpecBase(fieldId, handle));
@@ -153,6 +155,10 @@ public:
     MyLeafSpec &cost_tier(uint32_t value) {
         assert(value > 0);
         _cost_tier = value;
+        return *this;
+    }
+    MyLeafSpec &want_global_filter() {
+        _want_global_filter = true;
         return *this;
     }
     MyLeaf *create() const {
@@ -165,6 +171,7 @@ public:
         if (_cost_tier > 0) {
             leaf->cost_tier(_cost_tier);
         }
+        leaf->set_want_global_filter(_want_global_filter);
         return leaf;
     }
 };

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -69,7 +69,8 @@ Blueprint::State::State(const FieldSpecBaseList &fields_in)
       _estimate(),
       _cost_tier(COST_TIER_NORMAL),
       _tree_size(1),
-      _allow_termwise_eval(true)
+      _allow_termwise_eval(true),
+      _want_global_filter(false)
 {
 }
 
@@ -250,10 +251,10 @@ IntermediateBlueprint::infer_allow_termwise_eval() const
 };
 
 bool
-IntermediateBlueprint::infer_wants_global_filter() const
+IntermediateBlueprint::infer_want_global_filter() const
 {
     for (const Blueprint * child : _children) {
-        if (child->getState().wants_global_filter()) {
+        if (child->getState().want_global_filter()) {
             return true;
         }
     }
@@ -324,7 +325,7 @@ IntermediateBlueprint::calculateState() const
     state.estimate(calculateEstimate());
     state.cost_tier(calculate_cost_tier());
     state.allow_termwise_eval(infer_allow_termwise_eval());
-    state.wants_global_filter(infer_wants_global_filter());
+    state.want_global_filter(infer_want_global_filter());
     state.tree_size(calculate_tree_size());
     return state;
 }
@@ -577,9 +578,9 @@ LeafBlueprint::set_allow_termwise_eval(bool value)
 }
 
 void
-LeafBlueprint::set_wants_global_filter(bool value)
+LeafBlueprint::set_want_global_filter(bool value)
 {
-    _state.wants_global_filter(value);
+    _state.want_global_filter(value);
     notifyChange();
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -249,6 +249,17 @@ IntermediateBlueprint::infer_allow_termwise_eval() const
     return true;
 };
 
+bool
+IntermediateBlueprint::infer_wants_global_filter() const
+{
+    for (const Blueprint * child : _children) {
+        if (child->getState().wants_global_filter()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 size_t
 IntermediateBlueprint::count_termwise_nodes(const UnpackInfo &unpack) const
 {
@@ -313,6 +324,7 @@ IntermediateBlueprint::calculateState() const
     state.estimate(calculateEstimate());
     state.cost_tier(calculate_cost_tier());
     state.allow_termwise_eval(infer_allow_termwise_eval());
+    state.wants_global_filter(infer_wants_global_filter());
     state.tree_size(calculate_tree_size());
     return state;
 }
@@ -561,6 +573,13 @@ void
 LeafBlueprint::set_allow_termwise_eval(bool value)
 {
     _state.allow_termwise_eval(value);
+    notifyChange();
+}
+
+void
+LeafBlueprint::set_wants_global_filter(bool value)
+{
+    _state.wants_global_filter(value);
     notifyChange();
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -63,7 +63,7 @@ public:
         uint32_t          _cost_tier;
         uint32_t          _tree_size;
         bool              _allow_termwise_eval;
-        bool              _wants_global_filter;
+        bool              _want_global_filter;
 
     public:
         static constexpr uint32_t COST_TIER_NORMAL = 1;
@@ -102,8 +102,8 @@ public:
         uint32_t tree_size() const { return _tree_size; }
         void allow_termwise_eval(bool value) { _allow_termwise_eval = value; }
         bool allow_termwise_eval() const { return _allow_termwise_eval; }
-        void wants_global_filter(bool value) { _wants_global_filter = value; }
-        bool wants_global_filter() const { return _wants_global_filter; }
+        void want_global_filter(bool value) { _want_global_filter = value; }
+        bool want_global_filter() const { return _want_global_filter; }
         void cost_tier(uint32_t value) { _cost_tier = value; }
         uint32_t cost_tier() const { return _cost_tier; }
     };
@@ -247,7 +247,7 @@ private:
     uint32_t calculate_cost_tier() const;
     uint32_t calculate_tree_size() const;
     bool infer_allow_termwise_eval() const;
-    bool infer_wants_global_filter() const;
+    bool infer_want_global_filter() const;
 
     size_t count_termwise_nodes(const UnpackInfo &unpack) const;
     virtual double computeNextHitRate(const Blueprint & child, double hitRate) const;
@@ -308,7 +308,7 @@ protected:
     void setEstimate(HitEstimate est);
     void set_cost_tier(uint32_t value);
     void set_allow_termwise_eval(bool value);
-    void set_wants_global_filter(bool value);
+    void set_want_global_filter(bool value);
     void set_tree_size(uint32_t value);
 
     LeafBlueprint(const FieldSpecBaseList &fields, bool allow_termwise_eval);

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -63,6 +63,7 @@ public:
         uint32_t          _cost_tier;
         uint32_t          _tree_size;
         bool              _allow_termwise_eval;
+        bool              _wants_global_filter;
 
     public:
         static constexpr uint32_t COST_TIER_NORMAL = 1;
@@ -101,6 +102,8 @@ public:
         uint32_t tree_size() const { return _tree_size; }
         void allow_termwise_eval(bool value) { _allow_termwise_eval = value; }
         bool allow_termwise_eval() const { return _allow_termwise_eval; }
+        void wants_global_filter(bool value) { _wants_global_filter = value; }
+        bool wants_global_filter() const { return _wants_global_filter; }
         void cost_tier(uint32_t value) { _cost_tier = value; }
         uint32_t cost_tier() const { return _cost_tier; }
     };
@@ -244,6 +247,7 @@ private:
     uint32_t calculate_cost_tier() const;
     uint32_t calculate_tree_size() const;
     bool infer_allow_termwise_eval() const;
+    bool infer_wants_global_filter() const;
 
     size_t count_termwise_nodes(const UnpackInfo &unpack) const;
     virtual double computeNextHitRate(const Blueprint & child, double hitRate) const;
@@ -304,6 +308,7 @@ protected:
     void setEstimate(HitEstimate est);
     void set_cost_tier(uint32_t value);
     void set_allow_termwise_eval(bool value);
+    void set_wants_global_filter(bool value);
     void set_tree_size(uint32_t value);
 
     LeafBlueprint(const FieldSpecBaseList &fields, bool allow_termwise_eval);

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -77,6 +77,7 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
         est_hits = std::min(target_num_hits, est_hits);
     }
     setEstimate(HitEstimate(est_hits, false));
+    set_wants_global_filter(true);
 }
 
 NearestNeighborBlueprint::~NearestNeighborBlueprint() = default;

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -77,7 +77,7 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
         est_hits = std::min(target_num_hits, est_hits);
     }
     setEstimate(HitEstimate(est_hits, false));
-    set_wants_global_filter(true);
+    set_want_global_filter(true);
 }
 
 NearestNeighborBlueprint::~NearestNeighborBlueprint() = default;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst @toregge please review
@havardpe FYI

next is adding the API for sending the global filter into a blueprint - i guess something like
setup_global_filter(BitVector::UP global_filter)
where the unique_ptr may be null to signal that there is no global filter (so we can assume all hits from ANN are actually returned as hits).
