### PR TITLE
Revert "Enable async as default"

### DIFF
--- a/configdefinitions/src/vespa/stor-filestor.def
+++ b/configdefinitions/src/vespa/stor-filestor.def
@@ -29,7 +29,7 @@ num_threads int default=8 restart
 ## Number of threads for response processing and delivery
 ## 0 will give legacy sync behavior.
 ## Negative number will choose a good number based on # cores.
-num_response_threads int default=1
+num_response_threads int default=0
 
 ## When merging, if we find more than this number of documents that exist on all
 ## of the same copies, send a separate apply bucket diff with these entries


### PR DESCRIPTION
Reverts vespa-engine/vespa#13186

Unit test storage_filestorage_gtest_runner_app sometimes fails with heap-use-after-free.
