### PR TITLE
Make serialized format forward-compatible

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/OsVersionsSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/OsVersionsSerializer.java
@@ -42,10 +42,21 @@ public class OsVersionsSerializer {
         var versions = new TreeMap<NodeType, Version>(); // Use TreeMap to sort by node type
         var inspector = SlimeUtils.jsonToSlime(data).get();
         inspector.traverse((ObjectTraverser) (key, value) -> {
-            var version = Version.fromString(value.field(VERSION_FIELD).asString());
-            versions.put(NodeSerializer.nodeTypeFromString(key), version);
+            if (isNodeType(key)) {
+                var version = Version.fromString(value.field(VERSION_FIELD).asString());
+                versions.put(NodeSerializer.nodeTypeFromString(key), version);
+            }
         });
         return versions;
+    }
+
+    private static boolean isNodeType(String name) {
+        try {
+            NodeType.valueOf(name);
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/OsVersionsSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/OsVersionsSerializerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.component.Version;
 import com.yahoo.config.provision.NodeType;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -23,6 +24,31 @@ public class OsVersionsSerializerTest {
         );
         var serialized = OsVersionsSerializer.fromJson(OsVersionsSerializer.toJson(versions));
         assertEquals(serialized, versions);
+    }
+
+    @Test
+    public void ignores_unknown_keys() {
+        var jsonWithUnknownKeys = "{\n" +
+                                  "  \"foo\": \"bar\",\n" +
+                                  "  " +
+                                  "\"host\": {\n" +
+                                  "    \"version\": \"1.2.3\"\n" +
+                                  "  },\n" +
+                                  "  " +
+                                  "\"proxyhost\": {\n" +
+                                  "    \"version\": \"4.5.6\"\n" +
+                                  "  },\n" +
+                                  "  " +
+                                  "\"confighost\": {\n" +
+                                  "    \"version\": \"7.8.9\"\n" +
+                                  "  }\n" +
+                                  "}";
+        var versions = Map.of(
+                NodeType.host, Version.fromString("1.2.3"),
+                NodeType.proxyhost, Version.fromString("4.5.6"),
+                NodeType.confighost, Version.fromString("7.8.9")
+        );
+        assertEquals(versions, OsVersionsSerializer.fromJson(jsonWithUnknownKeys.getBytes(StandardCharsets.UTF_8)));
     }
 
 }


### PR DESCRIPTION
Old format is terrible. To prepare for future changes this must be deployed first.

@bratseth