### PR TITLE
actually call set_global_filter (with empty SP for now)

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -189,6 +189,13 @@ void
 Query::optimize()
 {
     _blueprint = Blueprint::optimize(std::move(_blueprint));
+    if (_blueprint->getState().want_global_filter()) {
+        // XXX we need to somehow compute a real global filter
+        std::shared_ptr<search::BitVector> empty_global_filter;
+        _blueprint->set_global_filter(empty_global_filter);
+        // optimized order may change after accounting for global filter:
+        _blueprint = Blueprint::optimize(std::move(_blueprint));
+    }
     LOG(debug, "optimized blueprint:\n%s\n", _blueprint->asString().c_str());
 }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

for discussion: i think this is the place to call set_global_filter, but we need to somehow wire in the whitelist bitvector (for now) as the global filter.

@geirst @toregge 