### PR TITLE
Correct anonymous subtype resolving

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileProperties.java
@@ -5,6 +5,7 @@ import com.yahoo.collections.Pair;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.processing.request.properties.PropertyMap;
 import com.yahoo.protect.Validator;
+import com.yahoo.search.Query;
 import com.yahoo.search.query.Properties;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfile;
 import com.yahoo.search.query.profile.compiled.DimensionalValue;
@@ -94,11 +95,15 @@ public class QueryProfileProperties extends Properties {
 
             // Check types
             if ( ! profile.getTypes().isEmpty()) {
-                QueryProfileType type = null;
+                QueryProfileType type;
+                QueryProfileType explicitTypeFromField = null;
                 for (int i = 0; i < name.size(); i++) {
-                    if (type == null) // We're on the first iteration, or no type is explicitly specified
+                    if (explicitTypeFromField != null)
+                        type = explicitTypeFromField;
+                    else
                         type = profile.getType(name.first(i), context);
                     if (type == null) continue;
+
                     String localName = name.get(i);
                     FieldDescription fieldDescription = type.getField(localName);
                     if (fieldDescription == null && type.isStrict())
@@ -115,7 +120,7 @@ public class QueryProfileProperties extends Properties {
                         }
                         else if (fieldDescription.getType() instanceof QueryProfileFieldType) {
                             // If a type is specified, use that instead of the type implied by the name
-                            type = ((QueryProfileFieldType) fieldDescription.getType()).getQueryProfileType();
+                            explicitTypeFromField = ((QueryProfileFieldType) fieldDescription.getType()).getQueryProfileType();
                         }
                     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -69,7 +69,7 @@ public class QueryProperties extends Properties {
                 if (key.last().equals(Ranking.QUERYCACHE)) return ranking.getQueryCache();
                 if (key.last().equals(Ranking.LIST_FEATURES)) return ranking.getListFeatures();
             }
-            else if (key.size()>=3 && key.get(1).equals(Ranking.MATCH_PHASE)) {
+            else if (key.size() >= 3 && key.get(1).equals(Ranking.MATCH_PHASE)) {
                 if (key.size() == 3) {
                     MatchPhase matchPhase = ranking.getMatchPhase();
                     if (key.last().equals(MatchPhase.ATTRIBUTE)) return matchPhase.getAttribute();
@@ -144,7 +144,6 @@ public class QueryProperties extends Properties {
         return super.get(key, context, substitution);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void set(CompoundName key, Object value, Map<String,String> context) {
         // Note: The defaults here are never used
@@ -172,7 +171,7 @@ public class QueryProperties extends Properties {
                 else if (key.last().equals(Model.RESTRICT))
                     model.setRestrict(asString(value,""));
                 else
-                    throwIllegalParameter(key.last(),Model.MODEL);
+                    throwIllegalParameter(key.last(), Model.MODEL);
             }
             else if (key.first().equals(Ranking.RANKING)) {
                 Ranking ranking = query.getRanking();
@@ -189,46 +188,66 @@ public class QueryProperties extends Properties {
                         ranking.setQueryCache(asBoolean(value, false));
                     else if (key.last().equals(Ranking.LIST_FEATURES))
                         ranking.setListFeatures(asBoolean(value,false));
+                    else
+                        throwIllegalParameter(key.last(), Ranking.RANKING);
                 }
-                else if (key.size()>=3 && key.get(1).equals(Ranking.MATCH_PHASE)) {
+                else if (key.size() >= 3 && key.get(1).equals(Ranking.MATCH_PHASE)) {
                     if (key.size() == 3) {
                         MatchPhase matchPhase = ranking.getMatchPhase();
-                        if (key.last().equals(MatchPhase.ATTRIBUTE)) {
+                        if (key.last().equals(MatchPhase.ATTRIBUTE))
                             matchPhase.setAttribute(asString(value, null));
-                        } else if (key.last().equals(MatchPhase.ASCENDING)) {
+                        else if (key.last().equals(MatchPhase.ASCENDING))
                             matchPhase.setAscending(asBoolean(value, false));
-                        } else if (key.last().equals(MatchPhase.MAX_HITS)) {
+                        else if (key.last().equals(MatchPhase.MAX_HITS))
                             matchPhase.setMaxHits(asLong(value, null));
-                        } else if (key.last().equals(MatchPhase.MAX_FILTER_COVERAGE)) {
+                        else if (key.last().equals(MatchPhase.MAX_FILTER_COVERAGE))
                             matchPhase.setMaxFilterCoverage(asDouble(value, 0.2));
-                        }
+                        else
+                            throwIllegalParameter(key.rest().toString(), Ranking.MATCH_PHASE);
                     } else if (key.size() > 3 && key.get(2).equals(Ranking.DIVERSITY)) {
                         Diversity diversity = ranking.getMatchPhase().getDiversity();
                         if (key.last().equals(Diversity.ATTRIBUTE)) {
                             diversity.setAttribute(asString(value, null));
-                        } else if (key.last().equals(Diversity.MINGROUPS)) {
+                        }
+                        else if (key.last().equals(Diversity.MINGROUPS)) {
                             diversity.setMinGroups(asLong(value, null));
-                        } else if ((key.size() > 4) && key.get(3).equals(Diversity.CUTOFF)) {
-                            if (key.last().equals(Diversity.FACTOR)) {
+                        }
+                        else if ((key.size() > 4) && key.get(3).equals(Diversity.CUTOFF)) {
+                            if (key.last().equals(Diversity.FACTOR))
                                 diversity.setCutoffFactor(asDouble(value, 10.0));
-                            } else if (key.last().equals(Diversity.STRATEGY)) {
+                            else if (key.last().equals(Diversity.STRATEGY))
                                 diversity.setCutoffStrategy(asString(value, "loose"));
-                            }
+                            else
+                                throwIllegalParameter(key.rest().toString(), Diversity.CUTOFF);
+                        }
+                        else {
+                            throwIllegalParameter(key.rest().toString(), Ranking.DIVERSITY);
                         }
                     }
                 }
                 else if (key.size() == 3 && key.get(1).equals(Ranking.SOFTTIMEOUT)) {
                     SoftTimeout soft = ranking.getSoftTimeout();
-                    if (key.last().equals(SoftTimeout.ENABLE)) soft.setEnable(asBoolean(value, true));
-                    if (key.last().equals(SoftTimeout.FACTOR)) soft.setFactor(asDouble(value, null));
-                    if (key.last().equals(SoftTimeout.TAILCOST)) soft.setTailcost(asDouble(value, null));
+                    if (key.last().equals(SoftTimeout.ENABLE))
+                        soft.setEnable(asBoolean(value, true));
+                    else if (key.last().equals(SoftTimeout.FACTOR))
+                        soft.setFactor(asDouble(value, null));
+                    else if (key.last().equals(SoftTimeout.TAILCOST))
+                        soft.setTailcost(asDouble(value, null));
+                    else
+                        throwIllegalParameter(key.rest().toString(), Ranking.SOFTTIMEOUT);
                 }
                 else if (key.size() == 3 && key.get(1).equals(Ranking.MATCHING)) {
                     Matching matching = ranking.getMatching();
-                    if (key.last().equals(Matching.TERMWISELIMIT)) matching.setTermwiselimit(asDouble(value, 1.0));
-                    if (key.last().equals(Matching.NUMTHREADSPERSEARCH)) matching.setNumThreadsPerSearch(asInteger(value, 1));
-                    if (key.last().equals(Matching.NUMSEARCHPARTITIIONS)) matching.setNumSearchPartitions(asInteger(value, 1));
-                    if (key.last().equals(Matching.MINHITSPERTHREAD)) matching.setMinHitsPerThread(asInteger(value, 0));
+                    if (key.last().equals(Matching.TERMWISELIMIT))
+                        matching.setTermwiselimit(asDouble(value, 1.0));
+                    else if (key.last().equals(Matching.NUMTHREADSPERSEARCH))
+                        matching.setNumThreadsPerSearch(asInteger(value, 1));
+                    else if (key.last().equals(Matching.NUMSEARCHPARTITIIONS))
+                        matching.setNumSearchPartitions(asInteger(value, 1));
+                    else if (key.last().equals(Matching.MINHITSPERTHREAD))
+                        matching.setMinHitsPerThread(asInteger(value, 0));
+                    else
+                        throwIllegalParameter(key.rest().toString(), Ranking.MATCHING);
                 }
                 else if (key.size() > 2) {
                     String restKey = key.rest().rest().toString();
@@ -237,7 +256,7 @@ public class QueryProperties extends Properties {
                     else if (key.get(1).equals(Ranking.PROPERTIES))
                         ranking.getProperties().put(restKey, toSpecifiedType(restKey, value, profileRegistry.getTypeRegistry().getComponent("properties")));
                     else
-                        throwIllegalParameter(key.rest().toString(),Ranking.RANKING);
+                        throwIllegalParameter(key.rest().toString(), Ranking.RANKING);
                 }
             }
             else if (key.size() == 2 && key.first().equals(Presentation.PRESENTATION)) {
@@ -259,11 +278,12 @@ public class QueryProperties extends Properties {
                     query.getSelect().setGroupingExpressionString(asString(value, ""));
                 }
                 else if (key.size() == 2) {
-                    if (key.last().equals(Select.WHERE)) {
+                    if (key.last().equals(Select.WHERE))
                         query.getSelect().setWhereString(asString(value, ""));
-                    } else if (key.last().equals(Select.GROUPING)) {
+                    else if (key.last().equals(Select.GROUPING))
                         query.getSelect().setGroupingString(asString(value, ""));
-                    }
+                    else
+                        throwIllegalParameter(key.rest().toString(), Select.SELECT);
                 }
                 else {
                     throwIllegalParameter(key.last(), Select.SELECT);
@@ -345,7 +365,7 @@ public class QueryProperties extends Properties {
 
     private void throwIllegalParameter(String key,String namespace) {
         throw new IllegalArgumentException("'" + key + "' is not a valid property in '" + namespace +
-                                           "'. See the search api for valid keys starting by '" + namespace + "'.");
+                                           "'. See the query api for valid keys starting by '" + namespace + "'.");
     }
 
     @Override

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
@@ -305,59 +305,64 @@ public class XmlReadingTestCase {
 
     @Test
     public void testNewsCase1() {
-        CompiledQueryProfileRegistry registry=new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase1").compile();
+        CompiledQueryProfileRegistry registry = new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase1").compile();
 
         Query query;
-        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),registry.getComponent("default"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),
+                          registry.getComponent("default"));
         assertEquals(0.0, query.properties().get("ranking.features.b"));
         assertEquals("0.0", query.properties().listProperties().get("ranking.features.b"));
-        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),registry.getComponent("default"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),
+                          registry.getComponent("default"));
         assertEquals(0.1, query.properties().get("ranking.features.b"));
         assertEquals("0.1", query.properties().listProperties().get("ranking.features.b"));
     }
 
     @Test
     public void testNewsCase2() {
-        CompiledQueryProfileRegistry registry=new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase2").compile();
+        CompiledQueryProfileRegistry registry = new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase2").compile();
 
         Query query;
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),registry.getComponent("default"));
-        assertEquals("0.0",query.properties().get("a.features.b"));
-        assertEquals("0.0",query.properties().listProperties().get("a.features.b"));
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),registry.getComponent("default"));
-        assertEquals("0.1",query.properties().get("a.features.b"));
-        assertEquals("0.1",query.properties().listProperties().get("a.features.b"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),
+                          registry.getComponent("default"));
+        assertEquals("0.0", query.properties().get("a.features.b"));
+        assertEquals("0.0", query.properties().listProperties().get("a.features.b"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),
+                          registry.getComponent("default"));
+        assertEquals("0.1", query.properties().get("a.features.b"));
+        assertEquals("0.1", query.properties().listProperties().get("a.features.b"));
     }
 
     @Test
     public void testNewsCase3() {
-        CompiledQueryProfileRegistry registry=new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase3").compile();
+        CompiledQueryProfileRegistry registry = new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase3").compile();
 
-        Query query;
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),registry.getComponent("default"));
+        Query query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),
+                                registry.getComponent("default"));
         assertEquals("0.0",query.properties().get("a.features"));
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),registry.getComponent("default"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),
+                          registry.getComponent("default"));
         assertEquals("0.1",query.properties().get("a.features"));
     }
 
-    // Should cause an exception on the first line as we are trying to create a profile setting an illegal value in "ranking"
     @Test
     public void testNewsCase4() {
-        CompiledQueryProfileRegistry registry=new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase4").compile();
+        CompiledQueryProfileRegistry registry = new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/newscase4").compile();
 
-        Query query;
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),registry.getComponent("default"));
-        assertEquals("0.0",query.properties().get("ranking.features"));
-        query=new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),registry.getComponent("default"));
-        assertEquals("0.1",query.properties().get("ranking.features"));
+        Query query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent", Method.GET),
+                                registry.getComponent("default"));
+        assertEquals(0.0, query.properties().get("ranking.features.foo"));
+        query = new Query(HttpRequest.createTestRequest("?query=test&custid_1=parent&custid_2=child", Method.GET),
+                          registry.getComponent("default"));
+        assertEquals(0.1, query.properties().get("ranking.features.foo"));
     }
 
     @Test
     public void testVersionRefs() {
-        CompiledQueryProfileRegistry registry=new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/versionrefs").compile();
+        CompiledQueryProfileRegistry registry = new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/versionrefs").compile();
 
-        Query query=new Query(HttpRequest.createTestRequest("?query=test", Method.GET),registry.getComponent("default"));
-        assertEquals("MyProfile:1.0.2",query.properties().get("profile1.name"));
+        Query query = new Query(HttpRequest.createTestRequest("?query=test", Method.GET), registry.getComponent("default"));
+        assertEquals("MyProfile:1.0.2", query.properties().get("profile1.name"));
     }
 
     @Test
@@ -366,26 +371,28 @@ public class XmlReadingTestCase {
 
         {
             // Original reference
-            Query query=new Query(HttpRequest.createTestRequest("?query=test", Method.GET),registry.getComponent("default"));
-            assertEquals(null,query.properties().get("profileRef"));
-            assertEquals("MyProfile1",query.properties().get("profileRef.name"));
-            assertEquals("myProfile1Only",query.properties().get("profileRef.myProfile1Only"));
+            Query query = new Query(HttpRequest.createTestRequest("?query=test", Method.GET),
+                                    registry.getComponent("default"));
+            assertEquals(null, query.properties().get("profileRef"));
+            assertEquals("MyProfile1", query.properties().get("profileRef.name"));
+            assertEquals("myProfile1Only", query.properties().get("profileRef.myProfile1Only"));
             assertNull(query.properties().get("profileRef.myProfile2Only"));
         }
 
         {
             // Overridden reference
-            Query query=new Query(HttpRequest.createTestRequest("?query=test&profileRef=ref:MyProfile2", Method.GET),registry.getComponent("default"));
+            Query query = new Query(HttpRequest.createTestRequest("?query=test&profileRef=ref:MyProfile2", Method.GET),registry.getComponent("default"));
             assertEquals(null,query.properties().get("profileRef"));
-            assertEquals("MyProfile2",query.properties().get("profileRef.name"));
-            assertEquals("myProfile2Only",query.properties().get("profileRef.myProfile2Only"));
+            assertEquals("MyProfile2", query.properties().get("profileRef.name"));
+            assertEquals("myProfile2Only", query.properties().get("profileRef.myProfile2Only"));
             assertNull(query.properties().get("profileRef.myProfile1Only"));
 
             // later assignment
             query.properties().set("profileRef.name", "newName");
             assertEquals("newName", query.properties().get("profileRef.name"));
             // ...will not impact others
-            query=new Query(HttpRequest.createTestRequest("?query=test&profileRef=ref:MyProfile2", Method.GET), registry.getComponent("default"));
+            query = new Query(HttpRequest.createTestRequest("?query=test&profileRef=ref:MyProfile2", Method.GET),
+                              registry.getComponent("default"));
             assertEquals("MyProfile2", query.properties().get("profileRef.name"));
         }
 

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/newscase4/default.xml
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/newscase4/default.xml
@@ -9,7 +9,7 @@
 
     <query-profile for="parent" inherits="parent" />
     <query-profile for="parent,child" >
-      <field name="ranking.features">0.1</field>
+      <field name="ranking.features.foo">0.1</field>
     </query-profile>
 </query-profile>
 

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/newscase4/parent.xml
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/newscase4/parent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <query-profile id="parent">
-    <field name="ranking.features">0.0</field>
+    <field name="ranking.features.foo">0.0</field>
 </query-profile>

--- a/container-search/src/test/java/com/yahoo/search/query/profile/types/test/QueryProfileTypeTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/types/test/QueryProfileTypeTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.query.profile.types.test;
 
 import com.yahoo.component.ComponentId;
+import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.prelude.query.QueryException;
 import com.yahoo.tensor.Tensor;
@@ -338,20 +339,22 @@ public class QueryProfileTypeTestCase {
      */
     @Test
     public void testTypedAssignmentOfQueryProfileReferencesNonStrictThroughQuery() {
-        QueryProfile profile=new QueryProfile("test");
+        QueryProfile profile = new QueryProfile("test");
         profile.setType(type);
 
-        QueryProfile newUser=new QueryProfile("newUser");
+        QueryProfile newUser = new QueryProfile("newUser");
         newUser.setType(user);
-        newUser.set("myUserString","newUserValue1", registry);
-        newUser.set("myUserInteger",845, registry);
+        newUser.set("myUserString", "newUserValue1", registry);
+        newUser.set("myUserInteger", 845, registry);
 
         registry.register(profile);
         registry.register(newUser);
         CompiledQueryProfileRegistry cRegistry = registry.compile();
         CompiledQueryProfile cprofile = cRegistry.getComponent("test");
 
-        Query query = new Query(HttpRequest.createTestRequest("?myUserQueryProfile=newUser", com.yahoo.jdisc.http.HttpRequest.Method.GET), cprofile);
+        Query query = new Query(HttpRequest.createTestRequest("?myUserQueryProfile=newUser",
+                                                              com.yahoo.jdisc.http.HttpRequest.Method.GET),
+                                cprofile);
 
         assertEquals(0, query.errors().size());
 
@@ -365,13 +368,13 @@ public class QueryProfileTypeTestCase {
      */
     @Test
     public void testTypedAssignmentOfQueryProfileReferencesStrictThroughQuery() {
-        QueryProfile profile=new QueryProfile("test");
+        QueryProfile profile = new QueryProfile("test");
         profile.setType(typeStrict);
 
-        QueryProfile newUser=new QueryProfile("newUser");
+        QueryProfile newUser = new QueryProfile("newUser");
         newUser.setType(userStrict);
-        newUser.set("myUserString","newUserValue1", registry);
-        newUser.set("myUserInteger",845, registry);
+        newUser.set("myUserString", "newUserValue1", registry);
+        newUser.set("myUserInteger", 845, registry);
 
         registry.register(profile);
         registry.register(newUser);
@@ -381,11 +384,11 @@ public class QueryProfileTypeTestCase {
         Query query = new Query(HttpRequest.createTestRequest("?myUserQueryProfile=newUser", com.yahoo.jdisc.http.HttpRequest.Method.GET), cRegistry.getComponent("test"));
         assertEquals(0, query.errors().size());
 
-        assertEquals("newUserValue1",query.properties().get("myUserQueryProfile.myUserString"));
-        assertEquals(845,query.properties().get("myUserQueryProfile.myUserInteger"));
+        assertEquals("newUserValue1", query.properties().get("myUserQueryProfile.myUserString"));
+        assertEquals(845, query.properties().get("myUserQueryProfile.myUserInteger"));
 
         try {
-            query.properties().set("myUserQueryProfile.someKey","value");
+            query.properties().set("myUserQueryProfile.someKey", "value");
             fail("Should not be allowed to set this");
         }
         catch (IllegalArgumentException e) {
@@ -405,7 +408,8 @@ public class QueryProfileTypeTestCase {
         String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
         Query query = new Query(HttpRequest.createTestRequest("?" + encode("ranking.features.query(myTensor1)") +
                                                               "=" + encode(tensorString),
-                                                              com.yahoo.jdisc.http.HttpRequest.Method.GET), cRegistry.getComponent("test"));
+                                                              com.yahoo.jdisc.http.HttpRequest.Method.GET),
+                                cRegistry.getComponent("test"));
         assertEquals(0, query.errors().size());
         assertEquals(Tensor.from(tensorString), query.properties().get("ranking.features.query(myTensor1)"));
         assertEquals(Tensor.from(tensorString), query.getRanking().getFeatures().getTensor("query(myTensor1)").get());
@@ -417,26 +421,23 @@ public class QueryProfileTypeTestCase {
 
     @Test
     public void testIllegalStrictAssignmentFromRequest() {
-        QueryProfile profile=new QueryProfile("test");
+        QueryProfile profile = new QueryProfile("test");
         profile.setType(typeStrict);
 
-        QueryProfile newUser=new QueryProfile("newUser");
+        QueryProfile newUser = new QueryProfile("newUser");
         newUser.setType(userStrict);
 
         profile.set("myUserQueryProfile", newUser, registry);
 
         try {
-            new Query(
-                    HttpRequest.createTestRequest(
-                            "?myUserQueryProfile.nondeclared=someValue",
-                            com.yahoo.jdisc.http.HttpRequest.Method.GET),
-                    profile.compile(null));
+            new Query(HttpRequest.createTestRequest("?myUserQueryProfile.nondeclared=someValue",
+                                                    com.yahoo.jdisc.http.HttpRequest.Method.GET),
+                      profile.compile(null));
             fail("Above statement should throw");
         } catch (QueryException e) {
             // As expected.
-            assertThat(
-                    Exceptions.toMessageString(e),
-                    containsString("Could not set 'myUserQueryProfile.nondeclared' to 'someValue': 'nondeclared' is not declared in query profile type 'userStrict', and the type is strict"));
+            assertThat(Exceptions.toMessageString(e),
+                       containsString("Could not set 'myUserQueryProfile.nondeclared' to 'someValue': 'nondeclared' is not declared in query profile type 'userStrict', and the type is strict"));
         }
     }
 
@@ -474,7 +475,9 @@ public class QueryProfileTypeTestCase {
         registry.register(newUser);
         CompiledQueryProfileRegistry cRegistry = registry.compile();
 
-        Query query = new Query(HttpRequest.createTestRequest("?subMap.typeProfile.myUserQueryProfile=newUser", com.yahoo.jdisc.http.HttpRequest.Method.GET), cRegistry.getComponent("topMap"));
+        Query query = new Query(HttpRequest.createTestRequest("?subMap.typeProfile.myUserQueryProfile=newUser",
+                                                              com.yahoo.jdisc.http.HttpRequest.Method.GET),
+                                cRegistry.getComponent("topMap"));
 
         assertEquals(0, query.errors().size());
 
@@ -487,25 +490,25 @@ public class QueryProfileTypeTestCase {
      */
     @Test
     public void testAnonTypedOverridingOfQueryProfileReferencesNonStrictThroughQueryNestedInAnUntypedProfile() {
-        QueryProfile topMap=new QueryProfile("topMap");
+        QueryProfile topMap = new QueryProfile("topMap");
 
-        QueryProfile subMap=new QueryProfile("topSubMap");
-        topMap.set("subMap",subMap, registry);
+        QueryProfile subMap = new QueryProfile("topSubMap");
+        topMap.set("subMap", subMap, registry);
 
-        QueryProfile test=new QueryProfile("test");
+        QueryProfile test = new QueryProfile("test");
         test.setType(type);
-        subMap.set("typeProfile",test, registry);
+        subMap.set("typeProfile", test, registry);
 
-        QueryProfile myUser=new QueryProfile("myUser");
+        QueryProfile myUser = new QueryProfile("myUser");
         myUser.setType(user);
-        myUser.set("myUserString","userValue1", registry);
-        myUser.set("myUserInteger",442, registry);
-        test.set("myQueryProfile",myUser, registry);
+        myUser.set("myUserString", "userValue1", registry);
+        myUser.set("myUserInteger", 442, registry);
+        test.set("myQueryProfile", myUser, registry);
 
-        QueryProfile newUser=new QueryProfile("newUser");
+        QueryProfile newUser = new QueryProfile("newUser");
         newUser.setType(user);
-        newUser.set("myUserString","newUserValue1", registry);
-        newUser.set("myUserInteger",845, registry);
+        newUser.set("myUserString", "newUserValue1", registry);
+        newUser.set("myUserInteger", 845, registry);
 
         registry.register(topMap);
         registry.register(subMap);
@@ -526,14 +529,14 @@ public class QueryProfileTypeTestCase {
      */
     @Test
     public void testSettingValueInStrictTypeNestedUnderUntypedMaps() {
-        QueryProfile topMap=new QueryProfile("topMap");
+        QueryProfile topMap = new QueryProfile("topMap");
 
-        QueryProfile subMap=new QueryProfile("topSubMap");
-        topMap.set("subMap",subMap, registry);
+        QueryProfile subMap = new QueryProfile("topSubMap");
+        topMap.set("subMap", subMap, registry);
 
-        QueryProfile test=new QueryProfile("test");
+        QueryProfile test = new QueryProfile("test");
         test.setType(typeStrict);
-        subMap.set("typeProfile",test, registry);
+        subMap.set("typeProfile", test, registry);
 
         registry.register(topMap);
         registry.register(subMap);
@@ -542,16 +545,14 @@ public class QueryProfileTypeTestCase {
 
         try {
             new Query(
-                    HttpRequest.createTestRequest(
-                            "?subMap.typeProfile.someValue=value",
-                            com.yahoo.jdisc.http.HttpRequest.Method.GET),
+                    HttpRequest.createTestRequest("?subMap.typeProfile.someValue=value",
+                                                  com.yahoo.jdisc.http.HttpRequest.Method.GET),
                     cRegistry.getComponent("topMap"));
             fail("Above statement should throw");
         } catch (QueryException e) {
             // As expected.
-            assertThat(
-                    Exceptions.toMessageString(e),
-                    containsString("Could not set 'subMap.typeProfile.someValue' to 'value': 'someValue' is not declared in query profile type 'testtypeStrict', and the type is strict"));
+            assertThat(Exceptions.toMessageString(e),
+                       containsString("Could not set 'subMap.typeProfile.someValue' to 'value': 'someValue' is not declared in query profile type 'testtypeStrict', and the type is strict"));
         }
     }
 
@@ -562,19 +563,19 @@ public class QueryProfileTypeTestCase {
      */
     @Test
     public void testTypedSettingOfQueryProfileReferencesNonStrictThroughQueryNestedInAnUntypedProfile() {
-        QueryProfile topMap=new QueryProfile("topMap");
+        QueryProfile topMap = new QueryProfile("topMap");
 
-        QueryProfile subMap=new QueryProfile("topSubMap");
+        QueryProfile subMap = new QueryProfile("topSubMap");
         topMap.set("subMap",subMap, registry);
 
-        QueryProfile test=new QueryProfile("test");
+        QueryProfile test = new QueryProfile("test");
         test.setType(type);
         subMap.set("typeProfile",test, registry);
 
-        QueryProfile newUser=new QueryProfile("newUser");
+        QueryProfile newUser = new QueryProfile("newUser");
         newUser.setType(user);
-        newUser.set("myUserString","newUserValue1", registry);
-        newUser.set("myUserInteger",845, registry);
+        newUser.set("myUserString", "newUserValue1", registry);
+        newUser.set("myUserInteger", 845, registry);
 
         registry.register(topMap);
         registry.register(subMap);
@@ -582,11 +583,64 @@ public class QueryProfileTypeTestCase {
         registry.register(newUser);
         CompiledQueryProfileRegistry cRegistry = registry.compile();
 
-        Query query = new Query(HttpRequest.createTestRequest("?subMap.typeProfile.myUserQueryProfile=newUser", com.yahoo.jdisc.http.HttpRequest.Method.GET), cRegistry.getComponent("topMap"));
+        Query query = new Query(HttpRequest.createTestRequest("?subMap.typeProfile.myUserQueryProfile=newUser",
+                                                              com.yahoo.jdisc.http.HttpRequest.Method.GET),
+                                cRegistry.getComponent("topMap"));
         assertEquals(0, query.errors().size());
 
         assertEquals("newUserValue1", query.properties().get("subMap.typeProfile.myUserQueryProfile.myUserString"));
         assertEquals(845, query.properties().get("subMap.typeProfile.myUserQueryProfile.myUserInteger"));
+    }
+
+    @Test
+    public void testNestedTypeName() {
+        ComponentId.resetGlobalCountersForTests();
+        QueryProfileRegistry registry = new QueryProfileRegistry();
+        QueryProfileType type = new QueryProfileType("testType");
+        registry.getTypeRegistry().register(type);
+        type.addField(new FieldDescription("ranking.features.query(embedding_profile)",
+                                           "tensor<float>(model{},x[128])"),
+                      registry.getTypeRegistry());
+        QueryProfile test = new QueryProfile("test");
+        registry.register(test);
+        test.setType(type);
+        CompiledQueryProfileRegistry cRegistry = registry.compile();
+        Query query = new Query("?query=foo", cRegistry.getComponent("test"));
+
+        // With a prefix we're not in the built-in type space
+        query.properties().set("prefix.ranking.foo", 0.1);
+        assertEquals(0.1, query.properties().get("prefix.ranking.foo"));
+    }
+
+    @Test
+    public void testNestedTypeNameUsingBuiltInTypes() {
+        ComponentId.resetGlobalCountersForTests();
+        QueryProfileRegistry registry = new QueryProfileRegistry();
+        QueryProfileType type = new QueryProfileType("testType");
+        type.inherited().add(Query.getArgumentType()); // Include native type checking
+        registry.getTypeRegistry().register(type);
+        type.addField(new FieldDescription("ranking.features.query(embedding_profile)",
+                                           "tensor<float>(model{},x[128])"),
+                      registry.getTypeRegistry());
+        QueryProfile test = new QueryProfile("test");
+        registry.register(test);
+        test.setType(type);
+        CompiledQueryProfileRegistry cRegistry = registry.compile();
+        Query query = new Query("?query=foo", cRegistry.getComponent("test"));
+
+        // Cannot set a property in a strict built-in type
+        try {
+            query.properties().set("ranking.foo", 0.1);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals("'foo' is not a valid property in 'ranking'. See the query api for valid keys starting by 'ranking'.",
+                         e.getCause().getMessage());
+        }
+
+        // With a prefix we're not in the built-in type space
+        query.properties().set("prefix.ranking.foo", 0.1);
+        assertEquals(0.1, query.properties().get("prefix.ranking.foo"));
     }
 
     private void assertWrongType(QueryProfile profile,String typeName,String name,Object value) {


### PR DESCRIPTION
- If an anonymous subtype is resolved, let it go out of scope when nesting
- Validate rather than ignoring all parameters in the query API
