### PR TITLE
Account and limit number of lids per file to reduce spkies during com…

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -250,6 +250,9 @@ summary.log.chunk.skipcrconread bool default=false
 ## Max size per summary file.
 summary.log.maxfilesize long default=1000000000
 
+## Max number of lid entries per file
+summary.log.maxnumlids int default=40000000
+
 ## Max disk bloat factor. This will trigger compacting.
 summary.log.maxdiskbloatfactor double default=0.1
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -192,6 +192,7 @@ deriveConfig(const ProtonConfig::Summary & summary, const ProtonConfig::Flush::M
     WriteableFileChunk::Config fileConfig(deriveCompression(chunk.compression), chunk.maxbytes);
     LogDataStore::Config logConfig;
     logConfig.setMaxFileSize(log.maxfilesize)
+            .setMaxNumLids(log.maxnumlids)
             .setMaxDiskBloatFactor(std::min(flush.diskbloatfactor, flush.each.diskbloatfactor))
             .setMaxBucketSpread(log.maxbucketspread).setMinFileSizeFactor(log.minfilesizefactor)
             .compactCompression(deriveCompression(log.compact.compression))

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -202,15 +202,24 @@ TEST("test that DirectIOPadding works accordng to spec") {
 }
 #endif
 
-TEST("testGrowing") {
-    FastOS_File::EmptyAndRemoveDirectory("growing");
-    EXPECT_TRUE(FastOS_File::MakeDirectory("growing"));
-    LogDataStore::Config config; //(100000, 0.1, 3.0, 0.2, 8, true, CompressionConfig::LZ4,
-                                // WriteableFileChunk::Config(CompressionConfig(CompressionConfig::LZ4, 9, 60), 1000));
-    config.setMaxFileSize(100000).setMaxDiskBloatFactor(0.1).setMaxBucketSpread(3.0).setMinFileSizeFactor(0.2)
-            .compactCompression({CompressionConfig::LZ4})
-            .setFileConfig({{CompressionConfig::LZ4, 9, 60}, 1000});
-    vespalib::ThreadStackExecutor executor(8, 128*1024);
+class TmpDirectory {
+public:
+    TmpDirectory(const vespalib::string & dir) : _dir(dir)
+    {
+        FastOS_File::EmptyAndRemoveDirectory(_dir.c_str());
+        ASSERT_TRUE(FastOS_File::MakeDirectory(_dir.c_str()));
+    }
+    ~TmpDirectory() {
+        FastOS_File::EmptyAndRemoveDirectory(_dir.c_str());
+    }
+    const vespalib::string & getDir() const { return _dir; }
+private:
+    vespalib::string _dir;
+};
+
+void verifyGrowing(const LogDataStore::Config & config, uint32_t minFiles, uint32_t maxFiles) {
+    TmpDirectory tmpDir("growing");
+    vespalib::ThreadStackExecutor executor(4, 128*1024);
     DummyFileHeaderContext fileHeaderContext;
     MyTlSyncer tlSyncer;
     {
@@ -243,30 +252,32 @@ TEST("testGrowing") {
         datastore.compact(30000);
         datastore.remove(31000, 0);
         checkStats(datastore, 31000, 30000);
+        EXPECT_LESS_EQUAL(minFiles, datastore.getAllActiveFiles().size());
+        EXPECT_GREATER_EQUAL(maxFiles, datastore.getAllActiveFiles().size());
     }
     {
         LogDataStore datastore(executor, "growing", config, GrowStrategy(),
                                TuneFileSummary(), fileHeaderContext, tlSyncer, nullptr);
         checkStats(datastore, 30000, 30000);
+        EXPECT_LESS_EQUAL(minFiles, datastore.getAllActiveFiles().size());
+        EXPECT_GREATER_EQUAL(maxFiles, datastore.getAllActiveFiles().size());
     }
-
-    FastOS_File::EmptyAndRemoveDirectory("growing");
+}
+TEST("testGrowingChunkedBySize") {
+    LogDataStore::Config config;
+    config.setMaxFileSize(100000).setMaxDiskBloatFactor(0.1).setMaxBucketSpread(3.0).setMinFileSizeFactor(0.2)
+            .compactCompression({CompressionConfig::LZ4})
+            .setFileConfig({{CompressionConfig::LZ4, 9, 60}, 1000});
+    verifyGrowing(config,60, 120);
 }
 
-class TmpDirectory {
-public:
-    TmpDirectory(const vespalib::string & dir) : _dir(dir)
-    {
-        FastOS_File::EmptyAndRemoveDirectory(_dir.c_str());
-        ASSERT_TRUE(FastOS_File::MakeDirectory(_dir.c_str()));
-    }
-    ~TmpDirectory() {
-        FastOS_File::EmptyAndRemoveDirectory(_dir.c_str());
-    }
-    const vespalib::string & getDir() const { return _dir; }
-private:
-    vespalib::string _dir;
-};
+TEST("testGrowingChunkedByNumLids") {
+    LogDataStore::Config config;
+    config.setMaxNumLids(1000).setMaxDiskBloatFactor(0.1).setMaxBucketSpread(3.0).setMinFileSizeFactor(0.2)
+            .compactCompression({CompressionConfig::LZ4})
+            .setFileConfig({{CompressionConfig::LZ4, 9, 60}, 1000});
+    verifyGrowing(config,10, 10);
+}
 
 void fetchAndTest(IDataStore & datastore, uint32_t lid, const void *a, size_t sz)
 {
@@ -357,8 +368,7 @@ private:
     LogDataStore                  _datastore;
 };
 
-VisitStore::~VisitStore() {
-}
+VisitStore::~VisitStore() =default;
 
 TEST("test visit cache does not cache empty ones and is able to access some backing store.") {
     const char * A7 = "aAaAaAa";

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -268,7 +268,7 @@ TEST("testGrowingChunkedBySize") {
     config.setMaxFileSize(100000).setMaxDiskBloatFactor(0.1).setMaxBucketSpread(3.0).setMinFileSizeFactor(0.2)
             .compactCompression({CompressionConfig::LZ4})
             .setFileConfig({{CompressionConfig::LZ4, 9, 60}, 1000});
-    verifyGrowing(config,60, 120);
+    verifyGrowing(config, 40, 120);
 }
 
 TEST("testGrowingChunkedByNumLids") {

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -22,6 +22,7 @@ using namespace search::docstore;
 using namespace search;
 using namespace vespalib::alloc;
 using search::index::DummyFileHeaderContext;
+using search::test::DirectoryHandler;
 
 class MyTlSyncer : public transactionlog::SyncProxy {
     SerialNum _syncedTo;
@@ -202,23 +203,8 @@ TEST("test that DirectIOPadding works accordng to spec") {
 }
 #endif
 
-class TmpDirectory {
-public:
-    TmpDirectory(const vespalib::string & dir) : _dir(dir)
-    {
-        FastOS_File::EmptyAndRemoveDirectory(_dir.c_str());
-        ASSERT_TRUE(FastOS_File::MakeDirectory(_dir.c_str()));
-    }
-    ~TmpDirectory() {
-        FastOS_File::EmptyAndRemoveDirectory(_dir.c_str());
-    }
-    const vespalib::string & getDir() const { return _dir; }
-private:
-    vespalib::string _dir;
-};
-
 void verifyGrowing(const LogDataStore::Config & config, uint32_t minFiles, uint32_t maxFiles) {
-    TmpDirectory tmpDir("growing");
+    DirectoryHandler tmpDir("growing");
     vespalib::ThreadStackExecutor executor(4, 128*1024);
     DummyFileHeaderContext fileHeaderContext;
     MyTlSyncer tlSyncer;
@@ -360,7 +346,7 @@ public:
     ~VisitStore();
     IDataStore & getStore() { return _datastore; }
 private:
-    TmpDirectory                  _myDir;
+    DirectoryHandler              _myDir;
     LogDataStore::Config          _config;
     DummyFileHeaderContext        _fileHeaderContext;
     vespalib::ThreadStackExecutor _executor;
@@ -510,7 +496,7 @@ private:
         vespalib::hash_set<uint32_t>  _actual;
         bool                          _allowVisitCaching;
     };
-    TmpDirectory                     _myDir;    
+    DirectoryHandler                 _myDir;
     document::DocumentTypeRepo       _repo;
     LogDocumentStore::Config         _config;
     DummyFileHeaderContext           _fileHeaderContext;
@@ -766,7 +752,7 @@ TEST("requireThatSyncTokenIsUpdatedAfterFlush") {
 }
 
 TEST("requireThatFlushTimeIsAvailableAfterFlush") {
-    TmpDirectory testDir("flushtime");
+    DirectoryHandler testDir("flushtime");
     vespalib::system_time before(vespalib::system_clock::now());
     DummyFileHeaderContext fileHeaderContext;
     LogDataStore::Config config;

--- a/searchlib/src/vespa/searchlib/docstore/chunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/chunk.cpp
@@ -57,7 +57,7 @@ Chunk::pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, const Compre
 Chunk::Chunk(uint32_t id, const Config & config) :
     _id(id),
     _lastSerial(static_cast<uint64_t>(-1l)),
-    _format(new ChunkFormatV2(config.getMaxBytes()))
+    _format(std::make_unique<ChunkFormatV2>(config.getMaxBytes()))
 {
     _lids.reserve(4096/sizeof(Entry));
 }

--- a/searchlib/src/vespa/searchlib/docstore/chunkformat.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/chunkformat.cpp
@@ -81,33 +81,26 @@ ChunkFormat::deserialize(const void * buffer, size_t len, bool skipcrc)
     uint32_t crc32(0);
     raw >> crc32;
     raw.rp(currPos);
-    ChunkFormat::UP format;
     if (version == ChunkFormatV1::VERSION) {
         if (skipcrc) {
-            format.reset(new ChunkFormatV1(raw));
+            return std::make_unique<ChunkFormatV1>(raw);
         } else {
-            format.reset(new ChunkFormatV1(raw, crc32));
+            return std::make_unique<ChunkFormatV1>(raw, crc32);
         }
     } else if (version == ChunkFormatV2::VERSION) {
         if (skipcrc) {
-            format.reset(new ChunkFormatV2(raw));
+            return std::make_unique<ChunkFormatV2>(raw);
         } else {
-            format.reset(new ChunkFormatV2(raw, crc32));
+            return std::make_unique<ChunkFormatV2>(raw, crc32);
         }
     } else {
         throw ChunkException(make_string("Unknown version %d", version), VESPA_STRLOC);
     }
-    return format;
 }
 
-ChunkFormat::ChunkFormat() :
-    _dataBuf()
-{
-}
+ChunkFormat::ChunkFormat() = default;
 
-ChunkFormat::~ChunkFormat()
-{
-}
+ChunkFormat::~ChunkFormat() = default;
 
 ChunkFormat::ChunkFormat(size_t maxSize) :
     _dataBuf(maxSize)

--- a/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
@@ -78,9 +78,10 @@ FileChunk::FileChunk(FileId fileId, NameId nameId, const vespalib::string & base
       _dataFileName(createDatFileName(_name)),
       _idxFileName(createIdxFileName(_name)),
       _chunkInfo(),
+      _lastPersistedSerialNum(0),
       _dataHeaderLen(0u),
       _idxHeaderLen(0u),
-      _lastPersistedSerialNum(0),
+      _numLids(0),
       _docIdLimit(std::numeric_limits<uint32_t>::max()),
       _modificationTime()
 {
@@ -228,6 +229,7 @@ FileChunk::updateLidMap(const LockGuard &guard, ISetLid &ds, uint64_t serialNum,
                                 globalBucketMap.recordLid(bucketId);
                             }
                             ds.setLid(guard, lidMeta.getLid(), LidInfo(getFileId().getId(), _chunkInfo.size(), lidMeta.size()));
+                            _numLids++;
                         } else {
                             remove(lidMeta.getLid(), lidMeta.size());
                         }

--- a/searchlib/src/vespa/searchlib/docstore/filechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.h
@@ -154,6 +154,7 @@ public:
 
     FileId getFileId() const { return _fileId; }
     NameId       getNameId() const { return _nameId; }
+    uint32_t getNumLids() const { return _numLids; }
     size_t   getBloatCount() const { return _erasedCount; }
     size_t   getAddedBytes() const { return _addedBytes; }
     size_t   getErasedBytes() const { return _erasedBytes; }
@@ -245,9 +246,10 @@ protected:
     vespalib::string      _dataFileName;
     vespalib::string      _idxFileName;
     ChunkInfoVector       _chunkInfo;
+    uint64_t              _lastPersistedSerialNum;
     uint32_t              _dataHeaderLen;
     uint32_t              _idxHeaderLen;
-    uint64_t              _lastPersistedSerialNum;
+    uint32_t              _numLids;
     uint32_t              _docIdLimit; // Limit when the file was created. Stored in idx file header.
     vespalib::system_time  _modificationTime;
 };

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -40,6 +40,7 @@ public:
         Config();
 
         Config & setMaxFileSize(size_t v) { _maxFileSize = v; return *this; }
+        Config & setMaxNumLids(size_t v) { _maxNumLids = v; return *this; }
         Config & setMaxDiskBloatFactor(double v) { _maxDiskBloatFactor = v; return *this; }
         Config & setMaxBucketSpread(double v) { _maxBucketSpread = v; return *this; }
         Config & setMinFileSizeFactor(double v) { _minFileSizeFactor = v; return *this; }
@@ -51,6 +52,7 @@ public:
         double getMaxDiskBloatFactor() const { return _maxDiskBloatFactor; }
         double getMaxBucketSpread() const { return _maxBucketSpread; }
         double getMinFileSizeFactor() const { return _minFileSizeFactor; }
+        uint32_t getMaxNumLids() const { return _maxNumLids; }
 
         bool crcOnReadDisabled() const { return _skipCrcOnRead; }
         const CompressionConfig & compactCompression() const { return _compactCompression; }
@@ -64,6 +66,7 @@ public:
         double                      _maxDiskBloatFactor;
         double                      _maxBucketSpread;
         double                      _minFileSizeFactor;
+        uint32_t                    _maxNumLids;
         bool                        _skipCrcOnRead;
         CompressionConfig           _compactCompression;
         WriteableFileChunk::Config  _fileConfig;

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.cpp
@@ -92,7 +92,7 @@ StoreByBucket::drain(IWrite & drainer)
     chunks.resize(_chunks.size());
     for (const auto & it : _chunks) {
         ConstBufferRef buf(it.second);
-        chunks[it.first].reset(new Chunk(it.first, buf.data(), buf.size()));
+        chunks[it.first] = std::make_unique<Chunk>(it.first, buf.data(), buf.size());
     }
     _chunks.clear();
     for (auto & it : _where) {

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
@@ -708,6 +708,7 @@ WriteableFileChunk::append(uint64_t serialNum, uint32_t lid, const void * buffer
     assert(serialNum >= _serialNum);
     _serialNum = serialNum;
     _addedBytes += adjustSize(len);
+    _numLids++;
     size_t oldSz(_active->size());
     LidMeta lm = _active->append(lid, buffer, len);
     setDiskFootprint(FileChunk::getDiskFootprint() - oldSz + _active->size());

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -47,7 +47,7 @@ public:
                        uint32_t docIdLimit, const Config & config,
                        const TuneFileSummary &tune, const common::FileHeaderContext &fileHeaderContext,
                        const IBucketizer * bucketizer, bool crcOnReadDisabled);
-    ~WriteableFileChunk();
+    ~WriteableFileChunk() override;
 
     ssize_t read(uint32_t lid, SubChunkId chunk, vespalib::DataBuffer & buffer) const override;
     void read(LidInfoWithLidV::const_iterator begin, size_t count, IBufferVisitor & visitor) const override;
@@ -128,8 +128,8 @@ private:
     bool              _writeTaskIsRunning;
     vespalib::Monitor _writeMonitor;
     ProcessedChunkQ   _writeQ;
-    vespalib::Executor & _executor;
-    ProcessedChunkMap _orderedChunks;
+    vespalib::Executor  & _executor;
+    ProcessedChunkMap     _orderedChunks;
     BucketDensityComputer _bucketMap;
 };
 

--- a/searchlib/src/vespa/searchlib/test/directory_handler.h
+++ b/searchlib/src/vespa/searchlib/test/directory_handler.h
@@ -5,8 +5,7 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/string.h>
 
-namespace search {
-namespace test {
+namespace search::test {
 
 class DirectoryHandler
 {
@@ -40,5 +39,3 @@ public:
 };
 
 }
-}
-

--- a/searchlib/src/vespa/searchlib/test/directory_handler.h
+++ b/searchlib/src/vespa/searchlib/test/directory_handler.h
@@ -16,11 +16,8 @@ private:
 
 public:
     DirectoryHandler(const vespalib::string &mkdir)
-        : _mkdir(mkdir),
-          _rmdir(mkdir),
-          _cleanup(true)
+        : DirectoryHandler(mkdir, mkdir)
     {
-        vespalib::mkdir(_mkdir);
     }
     DirectoryHandler(const vespalib::string &mkdir,
                      const vespalib::string &rmdir)
@@ -36,6 +33,7 @@ public:
         }
     }
     void cleanup(bool v) { _cleanup = v; }
+    const  vespalib::string & getDir() const { return _mkdir; }
 };
 
 }


### PR DESCRIPTION
…paction.

This is to avoid ending up with a very long listof lids that are removed but not compacted away due to lidspace compaction being disabled when
removes and delets are too frequent.

@toregge and @geirst  PR
