### PR TITLE
add default false require-all-up feature

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -26,6 +26,9 @@ public class VipStatus {
 
     private final boolean initiallyInRotation;
 
+    /** Override default, require all content clusters up */
+    private final boolean requireAllUp;
+
     /** The current state of this */
     private boolean currentlyInRotation;
 
@@ -59,6 +62,7 @@ public class VipStatus {
         this.clustersStatus = clustersStatus;
         this.healthState = healthState;
         initiallyInRotation = vipStatusConfig.initiallyInRotation();
+        requireAllUp = vipStatusConfig.requireAllUp();
         healthState.status(StateMonitor.Status.initializing);
         clustersStatus.setContainerHasClusters(! dispatchers.searchcluster().isEmpty());
         updateCurrentlyInRotation();
@@ -117,7 +121,8 @@ public class VipStatus {
                 currentlyInRotation = rotationOverride;
             } else {
                 if (healthState.status() == StateMonitor.Status.up) {
-                    currentlyInRotation = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ONE);
+                    currentlyInRotation = clustersStatus.containerShouldReceiveTraffic(
+                            requireAllUp ? ClustersStatus.Require.ALL : ClustersStatus.Require.ONE);
                 }
                 else if (healthState.status() == StateMonitor.Status.initializing) {
                     currentlyInRotation = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ALL)

--- a/container-core/src/main/resources/configdefinitions/vip-status.def
+++ b/container-core/src/main/resources/configdefinitions/vip-status.def
@@ -10,3 +10,6 @@ statusfile string default="share/qrsdocs/status.html"
 
 ## Not used TODO: Remove on Vespa 8
 initiallyInRotation bool default=true
+
+## Require all clusters UP to set container UP
+requireAllUp bool default=false


### PR DESCRIPTION
FYI @yngveaasheim @bratseth 

Add a config for requiring all content clusters to be up for container to be in rotation

I assume adding a new config param is safe wrt deployments