### PR TITLE
Expose underlying certificate and private key from SiaIdentityProvider 

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/X509CertificateWithKey.java
+++ b/security-utils/src/main/java/com/yahoo/security/X509CertificateWithKey.java
@@ -1,0 +1,33 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.security;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Wraps a {@link java.security.cert.X509Certificate} with its {@link java.security.PrivateKey}.
+ * Primary motivation is APIs where the callee must correctly observe an atomic update of both certificate and key.
+ *
+ * @author bjorncs
+ */
+public class X509CertificateWithKey {
+
+    private final List<X509Certificate> certificate;
+    private final PrivateKey privateKey;
+
+    public X509CertificateWithKey(X509Certificate certificate, PrivateKey privateKey) {
+        this(Collections.singletonList(certificate), privateKey);
+    }
+
+    public X509CertificateWithKey(List<X509Certificate> certificate, PrivateKey privateKey) {
+        if (certificate.isEmpty()) throw new IllegalArgumentException();
+        this.certificate = certificate;
+        this.privateKey = privateKey;
+    }
+
+    public X509Certificate certificate() { return certificate.get(0); }
+    public List<X509Certificate> certificateWithIntermediates() { return certificate; }
+    public PrivateKey privateKey() { return privateKey; }
+}

--- a/security-utils/src/main/java/com/yahoo/security/tls/AutoReloadingX509KeyManager.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/AutoReloadingX509KeyManager.java
@@ -5,19 +5,20 @@ import com.yahoo.security.KeyStoreBuilder;
 import com.yahoo.security.KeyStoreType;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.security.X509CertificateWithKey;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedKeyManager;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.Socket;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,13 @@ public class AutoReloadingX509KeyManager extends X509ExtendedKeyManager implemen
 
     public static AutoReloadingX509KeyManager fromPemFiles(Path privateKeyFile, Path certificatesFile) {
         return new AutoReloadingX509KeyManager(privateKeyFile, certificatesFile);
+    }
+
+    public X509CertificateWithKey getCurrentCertificateWithKey() {
+        X509ExtendedKeyManager manager = mutableX509KeyManager.currentManager();
+        X509Certificate[] certificateChain = manager.getCertificateChain(CERTIFICATE_ALIAS);
+        PrivateKey privateKey = manager.getPrivateKey(CERTIFICATE_ALIAS);
+        return new X509CertificateWithKey(Arrays.asList(certificateChain), privateKey);
     }
 
     private static KeyStore createKeystore(Path privateKey, Path certificateChain) {

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identity/ServiceIdentityProvider.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identity/ServiceIdentityProvider.java
@@ -2,18 +2,22 @@
 package com.yahoo.vespa.athenz.identity;
 
 import com.yahoo.container.jdisc.athenz.AthenzIdentityProvider;
+import com.yahoo.security.X509CertificateWithKey;
 import com.yahoo.vespa.athenz.api.AthenzIdentity;
-import com.yahoo.vespa.athenz.api.AthenzService;
 
 import javax.net.ssl.SSLContext;
+import java.nio.file.Path;
 
 /**
- * A interface for types that provides a service identity.
- * Some similarities to {@link AthenzIdentityProvider}, but this type is not public api and intended for internal use.
+ * A interface for types that provides the Athenz service identity (SIA) from the environment.
+ * Some similarities to {@link AthenzIdentityProvider}, but this type is not public API and intended for internal use.
  *
  * @author bjorncs
  */
 public interface ServiceIdentityProvider {
     AthenzIdentity identity();
     SSLContext getIdentitySslContext();
+    X509CertificateWithKey getIdentityCertificateWithKey();
+    Path certificatePath();
+    Path privateKeyPath();
 }

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identity/ServiceIdentityProvider.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identity/ServiceIdentityProvider.java
@@ -15,9 +15,43 @@ import java.nio.file.Path;
  * @author bjorncs
  */
 public interface ServiceIdentityProvider {
+    /**
+     *
+     * @return The Athenz identity of the environment
+     */
     AthenzIdentity identity();
+
+    /**
+     * @return {@link SSLContext} that is automatically updated.
+     */
     SSLContext getIdentitySslContext();
+
+    /**
+     * @return Current certificate and private key. Unlike {@link #getIdentitySslContext()} underlying credentials are not automatically updated.
+     */
     X509CertificateWithKey getIdentityCertificateWithKey();
+
+    /**
+     * @return Path to X.509 certificate in PEM format
+     */
     Path certificatePath();
+
+    /**
+     * @return Path to private key in PEM format
+     */
     Path privateKeyPath();
+
+    /**
+     * @return Path to Athenz truststore in PEM format
+     */
+    Path athenzTruststorePath();
+
+    /**
+     * The client truststore contains the Athenz certificates from {@link #athenzTruststorePath()}
+     * and additional certificate authorities that issues trusted server certificates.
+     *
+     * @return Path to client truststore in PEM format
+     */
+    Path clientTruststorePath();
+
 }

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identity/SiaIdentityProvider.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identity/SiaIdentityProvider.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.athenz.identity;
 
 import com.google.inject.Inject;
 import com.yahoo.component.AbstractComponent;
-import com.yahoo.security.KeyStoreType;
 import com.yahoo.security.SslContextBuilder;
 import com.yahoo.security.X509CertificateWithKey;
 import com.yahoo.security.tls.AutoReloadingX509KeyManager;
@@ -28,6 +27,8 @@ public class SiaIdentityProvider extends AbstractComponent implements ServiceIde
     private final AthenzIdentity service;
     private final Path certificateFile;
     private final Path privateKeyFile;
+    private final Path clientTruststoreFile;
+    private final Path athenzTruststoreFile;
 
     @Inject
     public SiaIdentityProvider(SiaProviderConfig config) {
@@ -35,29 +36,32 @@ public class SiaIdentityProvider extends AbstractComponent implements ServiceIde
              SiaUtils.getPrivateKeyFile(Paths.get(config.keyPathPrefix()), new AthenzService(config.athenzDomain(), config.athenzService())),
              SiaUtils.getCertificateFile(Paths.get(config.keyPathPrefix()), new AthenzService(config.athenzDomain(), config.athenzService())),
              Paths.get(config.trustStorePath()),
-             config.trustStoreType());
+             Paths.get(config.athenzTruststorePath()));
     }
 
     public SiaIdentityProvider(AthenzIdentity service,
                                Path siaPath,
-                               Path trustStoreFile) {
+                               Path clientTruststoreFile,
+                               Path athenzTruststoreFile) {
         this(service,
-             SiaUtils.getPrivateKeyFile(siaPath, service),
-             SiaUtils.getCertificateFile(siaPath, service),
-             trustStoreFile,
-             SiaProviderConfig.TrustStoreType.Enum.jks);
+                SiaUtils.getPrivateKeyFile(siaPath, service),
+                SiaUtils.getCertificateFile(siaPath, service),
+                athenzTruststoreFile,
+                clientTruststoreFile);
     }
 
     public SiaIdentityProvider(AthenzIdentity service,
                                Path privateKeyFile,
                                Path certificateFile,
-                               Path trustStoreFile,
-                               SiaProviderConfig.TrustStoreType.Enum trustStoreType) {
+                               Path athenzTruststoreFile,
+                               Path clientTruststoreFile) {
         this.service = service;
         this.keyManager = AutoReloadingX509KeyManager.fromPemFiles(privateKeyFile, certificateFile);
-        this.sslContext = createIdentitySslContext(keyManager, trustStoreFile, trustStoreType);
+        this.sslContext = createIdentitySslContext(keyManager, clientTruststoreFile);
         this.certificateFile = certificateFile;
         this.privateKeyFile = privateKeyFile;
+        this.athenzTruststoreFile = athenzTruststoreFile;
+        this.clientTruststoreFile = clientTruststoreFile;
     }
 
     @Override
@@ -73,18 +77,14 @@ public class SiaIdentityProvider extends AbstractComponent implements ServiceIde
     @Override public X509CertificateWithKey getIdentityCertificateWithKey() { return keyManager.getCurrentCertificateWithKey(); }
     @Override public Path certificatePath() { return certificateFile; }
     @Override public Path privateKeyPath() { return privateKeyFile; }
+    @Override public Path athenzTruststorePath() { return athenzTruststoreFile; }
+    @Override public Path clientTruststorePath() { return clientTruststoreFile; }
 
-    private static SSLContext createIdentitySslContext(AutoReloadingX509KeyManager keyManager, Path trustStoreFile,
-                                                       SiaProviderConfig.TrustStoreType.Enum trustStoreType) {
-        var builder = new SslContextBuilder();
-        if (trustStoreType == SiaProviderConfig.TrustStoreType.Enum.pem) {
-            builder = builder.withTrustStore(trustStoreFile);
-        } else if (trustStoreType == SiaProviderConfig.TrustStoreType.Enum.jks) {
-            builder = builder.withTrustStore(trustStoreFile, KeyStoreType.JKS);
-        } else {
-            throw new IllegalArgumentException("Unsupported trust store type: " + trustStoreType);
-        }
-        return builder.withKeyManager(keyManager).build();
+    private static SSLContext createIdentitySslContext(AutoReloadingX509KeyManager keyManager, Path trustStoreFile) {
+        return new SslContextBuilder()
+                .withTrustStore(trustStoreFile)
+                .withKeyManager(keyManager)
+                .build();
     }
 
     @Override

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identityprovider/client/AthenzCredentialsService.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identityprovider/client/AthenzCredentialsService.java
@@ -64,6 +64,9 @@ class AthenzCredentialsService {
         this.clock = clock;
     }
 
+    Path certificatePath() { return SiaUtils.getCertificateFile(VESPA_SIA_DIRECTORY, tenantIdentity); }
+    Path privateKeyPath() { return SiaUtils.getPrivateKeyFile(VESPA_SIA_DIRECTORY, tenantIdentity); }
+
     AthenzCredentials registerInstance() {
         Optional<AthenzCredentials> athenzCredentialsFromDisk = tryReadCredentialsFromDisk();
         if (athenzCredentialsFromDisk.isPresent()) {

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identityprovider/client/AthenzIdentityProviderImpl.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identityprovider/client/AthenzIdentityProviderImpl.java
@@ -184,9 +184,9 @@ public final class AthenzIdentityProviderImpl extends AbstractComponent implemen
         return new X509CertificateWithKey(copy.getCertificate(), copy.getKeyPair().getPrivate());
     }
 
-    // The files should ideally not be used directly, must be implemented later if necessary
-    @Override public Path certificatePath() { throw new UnsupportedOperationException(); }
-    @Override public Path privateKeyPath() { throw new UnsupportedOperationException(); }
+    @Override public Path certificatePath() { return athenzCredentialsService.certificatePath(); }
+
+    @Override public Path privateKeyPath() { return athenzCredentialsService.privateKeyPath(); }
 
     @Override
     public SSLContext getRoleSslContext(String domain, String role) {

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/utils/SiaUtils.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/utils/SiaUtils.java
@@ -53,10 +53,11 @@ public class SiaUtils {
     }
 
     public static Path getCaCertificatesFile() {
-        // The contents of this is the same as /opt/yahoo/share/ssl/certs/athenz_certificate_bundle.pem installed
-        // by the yahoo_certificates_bundle RPM package, except the latter also contains a textual description
-        // (decoded) of the certificates.
-        return DEFAULT_SIA_DIRECTORY.resolve("certs").resolve("ca.cert.pem");
+        return getCaCertificatesFile(DEFAULT_SIA_DIRECTORY);
+    }
+
+    public static Path getCaCertificatesFile(Path root) {
+        return root.resolve("certs").resolve("ca.cert.pem");
     }
 
     public static Optional<PrivateKey> readPrivateKeyFile(AthenzIdentity service) {

--- a/vespa-athenz/src/test/java/com/yahoo/vespa/athenz/identity/SiaIdentityProviderTest.java
+++ b/vespa-athenz/src/test/java/com/yahoo/vespa/athenz/identity/SiaIdentityProviderTest.java
@@ -2,15 +2,11 @@
 package com.yahoo.vespa.athenz.identity;
 
 import com.yahoo.security.KeyAlgorithm;
-import com.yahoo.security.KeyStoreBuilder;
-import com.yahoo.security.KeyStoreType;
-import com.yahoo.security.KeyStoreUtils;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SignatureAlgorithm;
 import com.yahoo.security.X509CertificateBuilder;
 import com.yahoo.security.X509CertificateUtils;
 import com.yahoo.vespa.athenz.api.AthenzService;
-import com.yahoo.yolean.Exceptions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -21,11 +17,11 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.security.KeyPair;
-import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 
+import static com.yahoo.yolean.Exceptions.uncheck;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -55,7 +51,7 @@ public class SiaIdentityProviderTest {
                         keyFile.toPath(),
                         certificateFile.toPath(),
                         trustStoreFile.toPath(),
-                        SiaProviderConfig.TrustStoreType.Enum.jks);
+                        trustStoreFile.toPath());
 
         assertNotNull(provider.getIdentitySslContext());
     }
@@ -79,7 +75,7 @@ public class SiaIdentityProviderTest {
                         keyFile.toPath(),
                         certificateFile.toPath(),
                         trustStoreFile.toPath(),
-                        SiaProviderConfig.TrustStoreType.Enum.pem);
+                        trustStoreFile.toPath());
 
         assertNotNull(provider.getIdentitySslContext());
     }
@@ -109,14 +105,11 @@ public class SiaIdentityProviderTest {
 
     private void createPemTrustStoreFile(X509Certificate certificate, File trustStoreFile) {
         var pemEncoded = X509CertificateUtils.toPem(certificate);
-        Exceptions.uncheck(() -> Files.writeString(trustStoreFile.toPath(), pemEncoded));
+        uncheck(() -> Files.writeString(trustStoreFile.toPath(), pemEncoded));
     }
 
     private void createTrustStoreFile(X509Certificate certificate, File trustStoreFile) {
-        KeyStore keystore = KeyStoreBuilder.withType(KeyStoreType.JKS)
-                .withCertificateEntry("dummy-cert", certificate)
-                .build();
-        KeyStoreUtils.writeKeyStoreToFile(keystore, trustStoreFile.toPath());
+        uncheck(() -> Files.writeString(trustStoreFile.toPath(), X509CertificateUtils.toPem(certificate)));
     }
 
 }

--- a/vespa-athenz/src/test/java/com/yahoo/vespa/athenz/identity/SiaIdentityProviderTest.java
+++ b/vespa-athenz/src/test/java/com/yahoo/vespa/athenz/identity/SiaIdentityProviderTest.java
@@ -52,9 +52,9 @@ public class SiaIdentityProviderTest {
         SiaIdentityProvider provider =
                 new SiaIdentityProvider(
                         new AthenzService("domain", "service-name"),
-                        keyFile,
-                        certificateFile,
-                        trustStoreFile,
+                        keyFile.toPath(),
+                        certificateFile.toPath(),
+                        trustStoreFile.toPath(),
                         SiaProviderConfig.TrustStoreType.Enum.jks);
 
         assertNotNull(provider.getIdentitySslContext());
@@ -76,9 +76,9 @@ public class SiaIdentityProviderTest {
         SiaIdentityProvider provider =
                 new SiaIdentityProvider(
                         new AthenzService("domain", "service-name"),
-                        keyFile,
-                        certificateFile,
-                        trustStoreFile,
+                        keyFile.toPath(),
+                        certificateFile.toPath(),
+                        trustStoreFile.toPath(),
                         SiaProviderConfig.TrustStoreType.Enum.pem);
 
         assertNotNull(provider.getIdentitySslContext());


### PR DESCRIPTION
Extend ServiceIdentityProvider interface with new methods.
Add class that bundles certificate with private key.
Use Path instead of File for better compatibility with mocked file system in unit tests.

FYI @vekterli 