### PR TITLE
Reapply "Upgrade ZooKeeper client library to 3.5.8"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -781,7 +781,7 @@
         <surefire.version>2.22.0</surefire.version>
         <tensorflow.version>1.12.0</tensorflow.version>
         <zookeeper.client.version>3.5.8</zookeeper.client.version>
-        <zookeeper.server.version>3.5.7</zookeeper.server.version>
+        <zookeeper.server.version>3.5.6</zookeeper.server.version>
 
         <doclint>all</doclint>
         <test.hide>true</test.hide>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -780,8 +780,8 @@
         <protobuf.version>3.7.0</protobuf.version>
         <surefire.version>2.22.0</surefire.version>
         <tensorflow.version>1.12.0</tensorflow.version>
-        <zookeeper.client.version>3.5.6</zookeeper.client.version>
-        <zookeeper.server.version>3.5.6</zookeeper.server.version>
+        <zookeeper.client.version>3.5.8</zookeeper.client.version>
+        <zookeeper.server.version>3.5.7</zookeeper.server.version>
 
         <doclint>all</doclint>
         <test.hide>true</test.hide>


### PR DESCRIPTION
Reverts vespa-engine/vespa#13258

Depends on https://github.com/vespa-engine/vespa/pull/13259, please review only