### PR TITLE
Handle when an instance has only declared tests

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/InstanceList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/InstanceList.java
@@ -68,8 +68,8 @@ public class InstanceList extends AbstractFilteringList<ApplicationId, InstanceL
 
     /** Returns the subset of instances which contain declared jobs */
     public InstanceList withDeclaredJobs() {
-        return matching(id -> statuses.get(id).jobSteps().values().stream()
-                                      .anyMatch(job -> job.isDeclared() && job.job().get().application().equals(id)));
+        return matching(id -> instances.get(id).jobSteps().values().stream()
+                                       .anyMatch(job -> job.isDeclared() && job.job().get().application().equals(id)));
     }
 
     /** Returns the subset of instances which have at least one deployment on a lower version than the given one, or which have no production deployments */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/InstanceList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/InstanceList.java
@@ -66,10 +66,17 @@ public class InstanceList extends AbstractFilteringList<ApplicationId, InstanceL
         return matching(id -> instance(id).productionDeployments().size() > 0);
     }
 
-    /** Returns the subset of instances which have at least one deployment on a lower version than the given one */
+    /** Returns the subset of instances which contain declared jobs */
+    public InstanceList withDeclaredJobs() {
+        return matching(id -> statuses.get(id).jobSteps().values().stream()
+                                      .anyMatch(job -> job.isDeclared() && job.job().get().application().equals(id)));
+    }
+
+    /** Returns the subset of instances which have at least one deployment on a lower version than the given one, or which have no production deployments */
     public InstanceList onLowerVersionThan(Version version) {
-        return matching(id -> instance(id).productionDeployments().values().stream()
-                                          .anyMatch(deployment -> deployment.version().isBefore(version)));
+        return matching(id ->    instance(id).productionDeployments().isEmpty()
+                              || instance(id).productionDeployments().values().stream()
+                                             .anyMatch(deployment -> deployment.version().isBefore(version)));
     }
 
     /** Returns the subset of instances which have changes left to deploy; blocked, or deploying */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -420,8 +420,10 @@ public class DeploymentTrigger {
 
         @Override
         public String toString() {
-            return jobType + " for " + instanceId + " on (" + versions.targetPlatform() + ", " +
-                   versions.targetApplication().id() + "), ready since " + availableSince;
+            return jobType + " for " + instanceId +
+                   " on (" + versions.targetPlatform() + versions.sourcePlatform().map(version -> " <-- " + version).orElse("") +
+                   ", " + versions.targetApplication().id()  + versions.sourceApplication().map(version -> " <-- " + version.id()).orElse("") +
+                   "), ready since " + availableSince;
         }
 
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
@@ -107,7 +107,7 @@ public class Upgrader extends ControllerMaintainer {
     /** Returns a list of all production application instances, except those which are pinned, which we should not manipulate here. */
     private InstanceList instances() {
         return InstanceList.from(controller().jobController().deploymentStatuses(ApplicationList.from(controller().applications().readable())))
-                           .withProductionDeployment()
+                           .withDeclaredJobs()
                            .unpinned();
     }
 


### PR DESCRIPTION
@mpolden please review. 

An instance with only declared tests would not qualify as an upgrade target to the Upgrader, making such a pipeline stop. This fixes that by adding declared test jobs also when there aren't (yet, because the next instance with the production job can't upgrade before the current instance, with only the tests) any production jobs waiting tot have their change tested. Not super-pretty, but I couldn't find a better way. 