### PR TITLE
Disable debug logging in jdisc_http_service unit tests

### DIFF
--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -175,6 +175,18 @@
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>abi-check-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>${test.hide}</redirectTestOutputToFile>
+          <systemPropertyVariables>
+            <jdisc.logger.level>INFO</jdisc.logger.level>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+          </systemPropertyVariables>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Reduces surefire output from ~160MB to ~1MB.