### PR TITLE
Make proxy client timeout configurable

### DIFF
--- a/jdisc_http_service/abi-spec.json
+++ b/jdisc_http_service/abi-spec.json
@@ -73,6 +73,7 @@
       "public void <init>(com.yahoo.jdisc.http.ConnectorConfig$HealthCheckProxy)",
       "public com.yahoo.jdisc.http.ConnectorConfig$HealthCheckProxy$Builder enable(boolean)",
       "public com.yahoo.jdisc.http.ConnectorConfig$HealthCheckProxy$Builder port(int)",
+      "public com.yahoo.jdisc.http.ConnectorConfig$HealthCheckProxy$Builder clientTimeout(double)",
       "public com.yahoo.jdisc.http.ConnectorConfig$HealthCheckProxy build()"
     ],
     "fields": []
@@ -87,7 +88,8 @@
     "methods": [
       "public void <init>(com.yahoo.jdisc.http.ConnectorConfig$HealthCheckProxy$Builder)",
       "public boolean enable()",
-      "public int port()"
+      "public int port()",
+      "public double clientTimeout()"
     ],
     "fields": []
   },

--- a/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.connector.def
+++ b/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.connector.def
@@ -101,6 +101,9 @@ healthCheckProxy.enable        bool    default=false
 # Which port to proxy
 healthCheckProxy.port          int     default=8080
 
+# Low-level timeout for proxy client (socket connect, socket read, connection pool). Aggregate timeout will be longer.
+healthCheckProxy.clientTimeout double  default=1.0
+
 # Enable PROXY protocol V1/V2 support (only for https connectors).
 proxyProtocol.enabled          bool    default=false
 


### PR DESCRIPTION
Reduce default timeout to 1 second. Don't spam log with full stack trace.
Don't close connection pool on timeout or other failures (when using sub-second timeout).

@tokle **AND** @baldersheim please review.