### PR TITLE
Hmusum/use remote session repo for finding active session

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -308,7 +308,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
         Tenant tenant = tenantRepository.getTenant(application.tenant());
         if (tenant == null) return Optional.empty();
-        LocalSession activeSession = getActiveSession(tenant, application);
+        RemoteSession activeSession = getActiveSession(tenant, application);
         if (activeSession == null) return Optional.empty();
         TimeoutBudget timeoutBudget = new TimeoutBudget(clock, timeout);
         LocalSession newSession = tenant.getSessionFactory().createSessionFromExisting(activeSession, logger, true, timeoutBudget);
@@ -322,7 +322,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     public Optional<Instant> lastDeployTime(ApplicationId application) {
         Tenant tenant = tenantRepository.getTenant(application.tenant());
         if (tenant == null) return Optional.empty();
-        LocalSession activeSession = getActiveSession(tenant, application);
+        RemoteSession activeSession = getActiveSession(tenant, application);
         if (activeSession == null) return Optional.empty();
         return Optional.of(Instant.ofEpochSecond(activeSession.getCreateTime()));
     }
@@ -610,7 +610,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
      *
      * @return the active session, or null if there is no active session for the given application id.
      */
-    public LocalSession getActiveSession(ApplicationId applicationId) {
+    public RemoteSession getActiveSession(ApplicationId applicationId) {
         return getActiveSession(tenantRepository.getTenant(applicationId.tenant()), applicationId);
     }
 
@@ -648,7 +648,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         Tenant tenant = tenantRepository.getTenant(applicationId.tenant());
         LocalSessionRepo localSessionRepo = tenant.getLocalSessionRepo();
         SessionFactory sessionFactory = tenant.getSessionFactory();
-        LocalSession fromSession = getExistingSession(tenant, applicationId);
+        RemoteSession fromSession = getExistingSession(tenant, applicationId);
         LocalSession session = sessionFactory.createSessionFromExisting(fromSession, logger, internalRedeploy, timeoutBudget);
         localSessionRepo.addSession(session);
         return session.getSessionId();
@@ -730,7 +730,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
     // ---------------- Misc operations ----------------------------------------------------------------
 
-    public ApplicationMetaData getMetadataFromSession(Tenant tenant, long sessionId) {
+    public ApplicationMetaData getMetadataFromLocalSession(Tenant tenant, long sessionId) {
         return getLocalSession(tenant, sessionId).getMetaData();
     }
 
@@ -765,9 +765,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         try {
             long currentActiveSessionId = applicationRepo.requireActiveSessionOf(appId);
             RemoteSession currentActiveSession = getRemoteSession(tenant, currentActiveSessionId);
-            if (currentActiveSession != null) {
-                currentActiveApplicationSet = Optional.ofNullable(currentActiveSession.ensureApplicationLoaded());
-            }
+            currentActiveApplicationSet = Optional.ofNullable(currentActiveSession.ensureApplicationLoaded());
         } catch (IllegalArgumentException e) {
             // Do nothing if we have no currently active session
         }
@@ -798,15 +796,15 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
     }
 
-    private LocalSession getExistingSession(Tenant tenant, ApplicationId applicationId) {
+    private RemoteSession getExistingSession(Tenant tenant, ApplicationId applicationId) {
         TenantApplications applicationRepo = tenant.getApplicationRepo();
-        return getLocalSession(tenant, applicationRepo.requireActiveSessionOf(applicationId));
+        return getRemoteSession(tenant, applicationRepo.requireActiveSessionOf(applicationId));
     }
 
-    private LocalSession getActiveSession(Tenant tenant, ApplicationId applicationId) {
+    private RemoteSession getActiveSession(Tenant tenant, ApplicationId applicationId) {
         TenantApplications applicationRepo = tenant.getApplicationRepo();
         if (applicationRepo.activeApplications().contains(applicationId)) {
-            return tenant.getLocalSessionRepo().getSession(applicationRepo.requireActiveSessionOf(applicationId));
+            return tenant.getRemoteSessionRepo().getSession(applicationRepo.requireActiveSessionOf(applicationId));
         }
         return null;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -18,6 +18,7 @@ import com.yahoo.vespa.config.server.TimeoutBudget;
 import com.yahoo.vespa.config.server.http.InternalServerException;
 import com.yahoo.vespa.config.server.session.LocalSession;
 import com.yahoo.vespa.config.server.session.PrepareParams;
+import com.yahoo.vespa.config.server.session.RemoteSession;
 import com.yahoo.vespa.config.server.session.Session;
 import com.yahoo.vespa.config.server.session.SilentDeployLogger;
 import com.yahoo.vespa.config.server.tenant.Tenant;
@@ -132,7 +133,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
             TimeoutBudget timeoutBudget = new TimeoutBudget(clock, timeout);
 
             ApplicationId applicationId = session.getApplicationId();
-            LocalSession previousActiveSession;
+            RemoteSession previousActiveSession;
             try (Lock lock = tenant.getApplicationRepo().lock(applicationId)) {
                 validateSessionStatus(session);
                 NestedTransaction transaction = new NestedTransaction();
@@ -181,7 +182,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
         }
     }
 
-    private Transaction deactivateCurrentActivateNew(LocalSession active, LocalSession prepared, boolean ignoreStaleSessionFailure) {
+    private Transaction deactivateCurrentActivateNew(RemoteSession active, LocalSession prepared, boolean ignoreStaleSessionFailure) {
         Transaction transaction = prepared.createActivateTransaction();
         if (isValidSession(active)) {
             checkIfActiveHasChanged(prepared, active, ignoreStaleSessionFailure);
@@ -191,11 +192,11 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
         return transaction;
     }
 
-    private boolean isValidSession(LocalSession session) {
+    private boolean isValidSession(RemoteSession session) {
         return session != null;
     }
 
-    private void checkIfActiveHasChanged(LocalSession session, LocalSession currentActiveSession, boolean ignoreStaleSessionFailure) {
+    private void checkIfActiveHasChanged(LocalSession session, RemoteSession currentActiveSession, boolean ignoreStaleSessionFailure) {
         long activeSessionAtCreate = session.getActiveSessionAtCreate();
         log.log(Level.FINE, currentActiveSession.logPre() + "active session id at create time=" + activeSessionAtCreate);
         if (activeSessionAtCreate == 0) return; // No active session at create

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandler.java
@@ -48,7 +48,7 @@ public class SessionActiveHandler extends SessionHandler {
         final Long sessionId = getSessionIdV2(request);
         ApplicationId applicationId = applicationRepository.activate(tenant, sessionId, timeoutBudget,
                                                                      shouldIgnoreSessionStaleFailure(request));
-        ApplicationMetaData metaData = applicationRepository.getMetadataFromSession(tenant, sessionId);
+        ApplicationMetaData metaData = applicationRepository.getMetadataFromLocalSession(tenant, sessionId);
         return new SessionActiveResponse(metaData.getSlime(), request, applicationId, sessionId, zone);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/LocalSession.java
@@ -98,21 +98,12 @@ public class LocalSession extends Session implements Comparable<LocalSession> {
         return transaction;
     }
 
-    public Transaction createDeactivateTransaction() {
-        return createSetStatusTransaction(Status.DEACTIVATE);
-    }
-
     private void markSessionEdited() {
         setStatus(Session.Status.NEW);
     }
 
     public long getActiveSessionAtCreate() {
         return applicationPackage.getMetaData().getPreviousActiveGeneration();
-    }
-
-    // Note: Assumes monotonically increasing session ids
-    public boolean isNewerThan(long sessionId) {
-        return getSessionId() > sessionId;
     }
 
     /** Add transactions to delete this session to the given nested transaction */

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionFactory.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionFactory.java
@@ -33,7 +33,7 @@ public interface SessionFactory {
      * @param timeoutBudget timeout for creating session and waiting for other servers.
      * @return a new session
      */
-    LocalSession createSessionFromExisting(LocalSession existingSession, DeployLogger logger,
+    LocalSession createSessionFromExisting(RemoteSession existingSession, DeployLogger logger,
                                            boolean internalRedeploy, TimeoutBudget timeoutBudget);
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionFactoryImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionFactoryImpl.java
@@ -119,7 +119,7 @@ public class SessionFactoryImpl implements SessionFactory, LocalSessionLoader {
     }
 
     @Override
-    public LocalSession createSessionFromExisting(LocalSession existingSession,
+    public LocalSession createSessionFromExisting(RemoteSession existingSession,
                                                   DeployLogger logger,
                                                   boolean internalRedeploy,
                                                   TimeoutBudget timeoutBudget) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -28,6 +28,7 @@ import com.yahoo.vespa.config.server.http.SessionHandlerTest;
 import com.yahoo.vespa.config.server.http.v2.PrepareResult;
 import com.yahoo.vespa.config.server.session.LocalSession;
 import com.yahoo.vespa.config.server.session.PrepareParams;
+import com.yahoo.vespa.config.server.session.RemoteSession;
 import com.yahoo.vespa.config.server.session.SilentDeployLogger;
 import com.yahoo.vespa.config.server.tenant.ApplicationRolesStore;
 import com.yahoo.vespa.config.server.tenant.Tenant;
@@ -294,7 +295,7 @@ public class ApplicationRepositoryTest {
 
             // No active session or remote session (deleted in step above), but an exception was thrown above
             // A new delete should cleanup and be successful
-            LocalSession activeSession = applicationRepository.getActiveSession(applicationId());
+            RemoteSession activeSession = applicationRepository.getActiveSession(applicationId());
             assertNull(activeSession);
             Tenant tenant = tenantRepository.getTenant(applicationId().tenant());
             assertNull(tenant.getRemoteSessionRepo().getSession(prepareResult.sessionId()));
@@ -468,7 +469,7 @@ public class ApplicationRepositoryTest {
 
     private ApplicationMetaData getApplicationMetaData(ApplicationId applicationId, long sessionId) {
         Tenant tenant = tenantRepository.getTenant(applicationId.tenant());
-        return applicationRepository.getMetadataFromSession(tenant, sessionId);
+        return applicationRepository.getMetadataFromLocalSession(tenant, sessionId);
     }
 
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SessionHandlerTest.java
@@ -30,6 +30,7 @@ import com.yahoo.vespa.config.server.session.DummyTransaction;
 import com.yahoo.vespa.config.server.session.LocalSession;
 import com.yahoo.vespa.config.server.session.MockSessionZKClient;
 import com.yahoo.vespa.config.server.session.PrepareParams;
+import com.yahoo.vespa.config.server.session.RemoteSession;
 import com.yahoo.vespa.config.server.session.Session;
 import com.yahoo.vespa.config.server.session.SessionContext;
 import com.yahoo.vespa.config.server.session.SessionFactory;
@@ -147,11 +148,6 @@ public class SessionHandlerTest {
         }
 
         @Override
-        public Transaction createDeactivateTransaction() {
-            return new DummyTransaction().add((DummyTransaction.RunnableOperation) () -> status = Status.DEACTIVATE);
-        }
-
-        @Override
         public Transaction createActivateTransaction() {
             return new DummyTransaction().add((DummyTransaction.RunnableOperation) () -> status = Status.ACTIVATE);
         }
@@ -219,7 +215,7 @@ public class SessionHandlerTest {
         }
 
         @Override
-        public LocalSession createSessionFromExisting(LocalSession existingSession, DeployLogger logger,
+        public LocalSession createSessionFromExisting(RemoteSession existingSession, DeployLogger logger,
                                                       boolean internalRedeploy, TimeoutBudget timeoutBudget) {
             if (doThrow) {
                 throw new RuntimeException("foo");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -404,11 +404,6 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
         }
 
         @Override
-        public Transaction createDeactivateTransaction() {
-            return null;
-        }
-
-        @Override
         public Transaction createActivateTransaction() {
             return null;
         }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 /**
  * @author Ulf Lilleengen
- * @since 5.1
  */
 public class SessionTest {
 


### PR DESCRIPTION
This is a fix for issues seen where we do e.g. do not restart nodes when there are changes requiring it (we do not compare with previous deployment, since we do not find it).

(First commit is from https://github.com/vespa-engine/vespa/pull/13326)