### PR TITLE
The prometheus metrics returns duplicate HELP and TYPE lines.

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
@@ -28,8 +28,8 @@ public class PrometheusUtil {
 
         List<MetricFamilySamples> metricFamilySamples = new ArrayList<>(packetsByService.size());
 
+        Map<String, List<Sample>> samples = new HashMap<>();
         packetsByService.forEach(((serviceId, packets) -> {
-            Map<String, List<Sample>> samples = new HashMap<>();
 
             var serviceName = Collector.sanitizeMetricName(serviceId.id);
             for (var packet : packets) {


### PR DESCRIPTION
The prometheus metrics returns duplicate HELP and TYPE lines.
We got an error when using prometheus input plugin for Telegraf to collect the metrics from the /prometheus/v1/values.

Error of Telegraf:
```
2020-05-17T23:45:00Z E! [inputs.prometheus]: Error in plugin: error reading metrics for http://localhost:19092/prometheus/v1/values?consumer=Vespa: reading text format failed: text format parsing error in line 125: second TYPE line for metric name "memory_virt", or TYPE reported after samples
```


We think there should be just one HELP and TYPE line per metric name.
Could you please check if there is any problems with this pull request.