### PR TITLE
Remove unneeded LD_PRELOAD setting in fsa unit tests.

### DIFF
--- a/fsa/src/alltest/alltest.sh
+++ b/fsa/src/alltest/alltest.sh
@@ -6,8 +6,6 @@ if [ -z "$SOURCE_DIRECTORY" ]; then
     SOURCE_DIRECTORY="."
 fi
 
-export LD_PRELOAD=../vespa/fsa/libfsa.so:../vespa/fsamanagers/libfsamanagers.so
-
 # first create the FSA
 ./fsa_fsa_create_test_app
 


### PR DESCRIPTION
@vekterli : please review
