### PR TITLE
Delete expired non-active sessions

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -76,6 +76,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -676,7 +677,16 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     }
 
     public void deleteExpiredLocalSessions() {
-        tenantRepository.getAllTenants().forEach(tenant -> tenant.getLocalSessionRepo().purgeOldSessions());
+        Map<Tenant, List<LocalSession>> sessionsPerTenant = new HashMap<>();
+        tenantRepository.getAllTenants().forEach(tenant -> sessionsPerTenant.put(tenant, tenant.getLocalSessionRepo().listSessions()));
+
+        Set<ApplicationId> applicationIds = new HashSet<>();
+        sessionsPerTenant.values().forEach(sessionList -> sessionList.forEach(s -> applicationIds.add(s.getApplicationId())));
+
+        Map<ApplicationId, Long> activeSessions = new HashMap<>();
+        applicationIds.forEach(applicationId -> activeSessions.put(applicationId, getActiveSession(applicationId).getSessionId()));
+
+        sessionsPerTenant.keySet().forEach(tenant -> tenant.getLocalSessionRepo().deleteExpiredSessions(activeSessions));
     }
 
     public int deleteExpiredRemoteSessions(Duration expiryTime) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepo.java
@@ -2,8 +2,8 @@
 package com.yahoo.vespa.config.server.session;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * A generic session repository that can store any type of session that extends the abstract interface.
@@ -37,7 +37,7 @@ public class SessionRepo<SESSIONTYPE extends Session> {
         return sessions.get(id);
     }
 
-    public synchronized Collection<SESSIONTYPE> listSessions() {
+    public synchronized List<SESSIONTYPE> listSessions() {
         return new ArrayList<>(sessions.values());
     }
     

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionRepoTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/LocalSessionRepoTest.java
@@ -3,16 +3,14 @@ package com.yahoo.vespa.config.server.session;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
-import com.yahoo.test.ManualClock;
 import com.yahoo.config.provision.TenantName;
+import com.yahoo.io.IOUtils;
 import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.MockReloadHandler;
 import com.yahoo.vespa.config.server.TestComponentRegistry;
 import com.yahoo.vespa.config.server.application.TenantApplications;
-import com.yahoo.io.IOUtils;
 import com.yahoo.vespa.config.server.host.HostRegistry;
 import com.yahoo.vespa.config.server.http.SessionHandlerTest;
-
 import com.yahoo.vespa.curator.mock.MockCurator;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,8 +20,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
-import java.time.Instant;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -36,7 +32,6 @@ public class LocalSessionRepoTest {
 
     private File testApp = new File("src/test/apps/app");
     private LocalSessionRepo repo;
-    private ManualClock clock;
     private static final TenantName tenantName = TenantName.defaultName();
 
     @Rule
@@ -55,10 +50,8 @@ public class LocalSessionRepoTest {
             IOUtils.copyDirectory(testApp, sessionsPath.resolve("2").toFile());
             IOUtils.copyDirectory(testApp, sessionsPath.resolve("3").toFile());
         }
-        clock = new ManualClock(Instant.ofEpochSecond(1));
         GlobalComponentRegistry globalComponentRegistry = new TestComponentRegistry.Builder()
                 .curator(new MockCurator())
-                .clock(clock)
                 .configServerConfig(new ConfigserverConfig.Builder()
                                             .configServerDBDir(configserverDbDir.getAbsolutePath())
                                             .configDefinitionsDir(temporaryFolder.newFolder().getAbsolutePath())
@@ -81,39 +74,11 @@ public class LocalSessionRepoTest {
     }
 
     @Test
-    public void require_that_old_sessions_are_purged() {
-        clock.advance(Duration.ofSeconds(1));
-        assertNotNull(repo.getSession(1L));
-        assertNotNull(repo.getSession(2L));
-        assertNotNull(repo.getSession(3L));
-        clock.advance(Duration.ofSeconds(1));
-        assertNotNull(repo.getSession(1L));
-        assertNotNull(repo.getSession(2L));
-        assertNotNull(repo.getSession(3L));
-        clock.advance(Duration.ofSeconds(1));
-        addSession(4L, 6);
-        assertNotNull(repo.getSession(1L));
-        assertNotNull(repo.getSession(2L));
-        assertNotNull(repo.getSession(3L));
-        assertNotNull(repo.getSession(4L));
-        clock.advance(Duration.ofSeconds(1));
-        addSession(5L, 10);
-        repo.purgeOldSessions();
-        assertNull(repo.getSession(1L));
-        assertNull(repo.getSession(2L));
-        assertNull(repo.getSession(3L));
-    }
-
-    @Test
     public void require_that_all_sessions_are_deleted() {
         repo.close();
         assertNull(repo.getSession(1L));
         assertNull(repo.getSession(2L));
         assertNull(repo.getSession(3L));
-    }
-
-    private void addSession(long sessionId, long createTime) {
-        repo.addSession(new SessionHandlerTest.MockSession(sessionId, FilesApplicationPackage.fromFile(testApp), createTime));
     }
 
     @Test

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -253,6 +253,11 @@ public class Flags {
             "Expiry time for unused sessions in config server",
             "Takes effect on next run of config server maintainer SessionsMaintainer");
 
+    public static final UnboundLongFlag CONFIGSERVER_LOCAL_SESSIONS_EXPIRY_INTERVAL_IN_DAYS = defineLongFlag(
+            "configserver-local-sessions-expiry-interval-in-days", 21,
+            "Expiry time for expired local sessions in config server",
+            "Takes effect on next run of config server maintainer SessionsMaintainer");
+
     public static final UnboundBooleanFlag USE_CLOUD_INIT_FORMAT = defineFeatureFlag(
             "use-cloud-init", false,
             "Use the cloud-init format when provisioning hosts",


### PR DESCRIPTION
Due to a bug fixed in https://github.com/vespa-engine/vespa/pull/13338
we ended up with sessions that are in state ACTIVATED in zookeeper,
but that was not the latest active session.  These would not be
cleaned up, the changes here will delete these sessions (if they are
expired and not the current active session for an application).

Also deletes a test that was covered by tests in ApplicationRepositoryTest.
