### PR TITLE
Move fastlib testsuite into namespace fast::testsuite.

### DIFF
--- a/fastlib/src/vespa/fastlib/testsuite/suite.h
+++ b/fastlib/src/vespa/fastlib/testsuite/suite.h
@@ -68,6 +68,8 @@
 #include <cassert>
 
 
+namespace fast::testsuite {
+
 class TestSuiteError;
 
 class Suite
@@ -258,3 +260,7 @@ void Suite::Reset()
         m_tests[i]->Reset();
     }
 }
+
+}
+
+using fast::testsuite::Suite;

--- a/fastlib/src/vespa/fastlib/testsuite/test.cpp
+++ b/fastlib/src/vespa/fastlib/testsuite/test.cpp
@@ -2,6 +2,8 @@
 
 #include "test.h"
 
+namespace fast::testsuite {
+
 Test::Test(std::ostream* osptr, const char*name) :
     m_osptr(osptr),
     name_(name),
@@ -134,4 +136,6 @@ long Test::Report(int padSpaces) const
                  << std::endl;
     }
     return m_nFail;
+}
+
 }

--- a/fastlib/src/vespa/fastlib/testsuite/test.h
+++ b/fastlib/src/vespa/fastlib/testsuite/test.h
@@ -73,6 +73,8 @@
     do_equality_test((lhs), (rhs),  #lhs, __FILE__, __LINE__)
 #define _fail(str) do_fail((str), __FILE__, __LINE__)
 
+namespace fast::testsuite {
+
 class Test
 {
 public:
@@ -143,3 +145,7 @@ bool Test::do_equality_test(const t1& lhs, const t2& rhs, const char* lbl,
     }
     return false;
 }
+
+}
+
+using fast::testsuite::Test;


### PR DESCRIPTION
@vekterli : please review

This prevents address sanitizer for clang from complaining about odr-violations.
