### PR TITLE
Properly handle tombstones during read and write repair

### DIFF
--- a/persistence/src/vespa/persistence/dummyimpl/dummypersistence.cpp
+++ b/persistence/src/vespa/persistence/dummyimpl/dummypersistence.cpp
@@ -533,7 +533,10 @@ DummyPersistence::get(const Bucket& b, const document::FieldSet& fieldSet, const
     if (!bc.get()) {
     } else {
         DocEntry::SP entry((*bc)->getEntry(did));
-        if (entry.get() == 0 || entry->isRemove()) {
+        if (!entry) {
+            return GetResult();
+        } else if (entry->isRemove()) {
+            return GetResult::make_for_tombstone(entry->getTimestamp());
         } else {
             Document::UP doc(entry->getDocument()->clone());
             if (fieldSet.getType() != document::FieldSet::ALL) {

--- a/persistence/src/vespa/persistence/spi/result.cpp
+++ b/persistence/src/vespa/persistence/spi/result.cpp
@@ -30,8 +30,17 @@ std::ostream & operator << (std::ostream & os, const Result::ErrorType &errorCod
 GetResult::GetResult(Document::UP doc, Timestamp timestamp)
     : Result(),
       _timestamp(timestamp),
-      _doc(std::move(doc))
-{ }
+      _doc(std::move(doc)),
+      _is_tombstone(false)
+{
+}
+
+GetResult::GetResult(Timestamp removed_at_ts)
+    : _timestamp(removed_at_ts),
+      _doc(),
+      _is_tombstone(true)
+{
+}
 
 GetResult::~GetResult() = default;
 BucketIdListResult::~BucketIdListResult() = default;

--- a/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
@@ -686,6 +686,7 @@ TEST_F("require that get returns the first document found", SimpleFixture) {
     EXPECT_EQUAL(tstamp1, result.getTimestamp());
     ASSERT_TRUE(result.hasDocument());
     EXPECT_EQUAL(*doc1, result.getDocument());
+    EXPECT_FALSE(result.is_tombstone());
 }
 
 TEST_F("require that createIterator does", SimpleFixture) {

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.cpp
@@ -434,7 +434,7 @@ PersistenceEngine::get(const Bucket& b, const document::FieldSet& fields, const 
             search::DocumentMetaData meta = retriever.getDocumentMetaData(did);
             if (meta.timestamp != 0 && meta.bucketId == b.getBucketId()) {
                 if (meta.removed) {
-                    return GetResult();
+                    return GetResult::make_for_tombstone(meta.timestamp);
                 }
                 document::Document::UP doc = retriever.getDocument(meta.lid);
                 if (!doc || doc->getId().getGlobalId() != meta.gid) {

--- a/storage/src/vespa/storage/distributor/operations/external/newest_replica.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/newest_replica.cpp
@@ -7,7 +7,9 @@ namespace storage::distributor {
 std::ostream& operator<<(std::ostream& os, const NewestReplica& nr) {
     os << "NewestReplica(timestamp " << nr.timestamp
        << ", bucket_id " << nr.bucket_id
-       << ", node " << nr.node << ')';
+       << ", node " << nr.node
+       << ", is_tombstone " << nr.is_tombstone
+       << ')';
     return os;
 }
 

--- a/storage/src/vespa/storage/distributor/operations/external/newest_replica.h
+++ b/storage/src/vespa/storage/distributor/operations/external/newest_replica.h
@@ -17,21 +17,24 @@ struct NewestReplica {
     api::Timestamp timestamp {0};
     document::BucketId bucket_id;
     uint16_t node {UINT16_MAX};
+    bool is_tombstone {false};
 
     static NewestReplica of(api::Timestamp timestamp,
                             const document::BucketId& bucket_id,
-                            uint16_t node) noexcept {
-        return {timestamp, bucket_id, node};
+                            uint16_t node,
+                            bool is_tombstone) noexcept {
+        return {timestamp, bucket_id, node, is_tombstone};
     }
 
     static NewestReplica make_empty() {
-        return {api::Timestamp(0), document::BucketId(), 0};
+        return {api::Timestamp(0), document::BucketId(), 0, false};
     }
 
     bool operator==(const NewestReplica& rhs) const noexcept {
         return ((timestamp == rhs.timestamp) &&
                 (bucket_id == rhs.bucket_id) &&
-                (node == rhs.node));
+                (node == rhs.node) &&
+                (is_tombstone == rhs.is_tombstone));
     }
     bool operator!=(const NewestReplica& rhs) const noexcept {
         return !(*this == rhs);

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -463,6 +463,9 @@ void TwoPhaseUpdateOperation::handle_safe_path_received_metadata_get(
     // Timestamps were not in sync, so we have to fetch the document from the highest
     // timestamped replica, apply the update to it and then explicitly Put the result
     // to all replicas.
+    // Note that this timestamp may be for a tombstone (remove) entry, in which case
+    // conditional create-if-missing behavior kicks in as usual.
+    // TODO avoid sending the Get at all if the newest replica is marked as a tombstone.
     _single_get_latency_timer.emplace(_manager.getClock());
     document::Bucket bucket(_updateCmd->getBucket().getBucketSpace(), newest_replica->bucket_id);
     LOG(debug, "Update(%s): sending single payload Get to %s on node %u (had timestamp %" PRIu64 ")",

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -295,7 +295,8 @@ PersistenceThread::handleGet(api::GetCommand& cmd, MessageTracker::UP tracker)
         if (!result.hasDocument()) {
             _env._metrics.get[cmd.getLoadType()].notFound.inc();
         }
-        tracker->setReply(std::make_shared<api::GetReply>(cmd, result.getDocumentPtr(), result.getTimestamp()));
+        tracker->setReply(std::make_shared<api::GetReply>(cmd, result.getDocumentPtr(), result.getTimestamp(),
+                                                          false, result.is_tombstone()));
     }
 
     return tracker;

--- a/storageapi/src/vespa/storageapi/mbusprot/protobuf/feed.proto
+++ b/storageapi/src/vespa/storageapi/mbusprot/protobuf/feed.proto
@@ -73,6 +73,9 @@ message GetResponse {
     uint64     last_modified_timestamp = 2;
     BucketInfo bucket_info             = 3;
     BucketId   remapped_bucket_id      = 4;
+    // Note: last_modified_timestamp and tombstone_timestamp are mutually exclusive.
+    // Tracked separately (rather than being a flag bool) to avoid issues during rolling upgrades.
+    uint64     tombstone_timestamp     = 5;
 }
 
 message RevertRequest {

--- a/storageapi/src/vespa/storageapi/mbusprot/protocolserialization5_0.cpp
+++ b/storageapi/src/vespa/storageapi/mbusprot/protocolserialization5_0.cpp
@@ -168,7 +168,8 @@ ProtocolSerialization5_0::onDecodeUpdateReply(const SCmd& cmd, BBuf& buf) const
 void ProtocolSerialization5_0::onEncode(GBBuf& buf, const api::GetReply& msg) const
 {
     SH::putDocument(msg.getDocument().get(), buf);
-    buf.putLong(msg.getLastModifiedTimestamp());
+    // Old protocol version doesn't understand tombstones. Make it appear as Not Found.
+    buf.putLong(msg.is_tombstone() ? api::Timestamp(0) : msg.getLastModifiedTimestamp());
     onEncodeBucketInfoReply(buf, msg);
 }
 

--- a/storageapi/src/vespa/storageapi/message/persistence.cpp
+++ b/storageapi/src/vespa/storageapi/message/persistence.cpp
@@ -211,14 +211,16 @@ GetCommand::print(std::ostream& out, bool verbose, const std::string& indent) co
 GetReply::GetReply(const GetCommand& cmd,
                    const DocumentSP& doc,
                    Timestamp lastModified,
-                   bool had_consistent_replicas)
+                   bool had_consistent_replicas,
+                   bool is_tombstone)
     : BucketInfoReply(cmd),
       _docId(cmd.getDocumentId()),
       _fieldSet(cmd.getFieldSet()),
       _doc(doc),
       _beforeTimestamp(cmd.getBeforeTimestamp()),
       _lastModifiedTime(lastModified),
-      _had_consistent_replicas(had_consistent_replicas)
+      _had_consistent_replicas(had_consistent_replicas),
+      _is_tombstone(is_tombstone)
 {
 }
 

--- a/storageapi/src/vespa/storageapi/message/persistence.h
+++ b/storageapi/src/vespa/storageapi/message/persistence.h
@@ -224,24 +224,27 @@ class GetReply : public BucketInfoReply {
     Timestamp _beforeTimestamp;
     Timestamp _lastModifiedTime;
     bool _had_consistent_replicas;
-
+    bool _is_tombstone;
 public:
-    GetReply(const GetCommand& cmd,
-             const DocumentSP& doc = DocumentSP(),
-             Timestamp lastModified = 0,
-             bool had_consistent_replicas = false);
+    explicit GetReply(const GetCommand& cmd,
+                      const DocumentSP& doc = DocumentSP(),
+                      Timestamp lastModified = 0,
+                      bool had_consistent_replicas = false,
+                      bool is_tombstone = false);
+
     ~GetReply() override;
 
     const DocumentSP& getDocument() const { return _doc; }
     const document::DocumentId& getDocumentId() const { return _docId; }
     const vespalib::string& getFieldSet() const { return _fieldSet; }
 
-    Timestamp getLastModifiedTimestamp() const { return _lastModifiedTime; }
-    Timestamp getBeforeTimestamp() const { return _beforeTimestamp; }
+    Timestamp getLastModifiedTimestamp() const noexcept { return _lastModifiedTime; }
+    Timestamp getBeforeTimestamp() const noexcept { return _beforeTimestamp; }
 
-    bool had_consistent_replicas() const noexcept { return _had_consistent_replicas; }
+    [[nodiscard]] bool had_consistent_replicas() const noexcept { return _had_consistent_replicas; }
+    [[nodiscard]] bool is_tombstone() const noexcept { return _is_tombstone; }
 
-    bool wasFound() const { return (_doc.get() != 0); }
+    bool wasFound() const { return (_doc.get() != nullptr); }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGEREPLY(GetReply, onGetReply)
 };


### PR DESCRIPTION
@geirst @toregge please review

This alters the internal semantics Get-replies for removed documents to include the timestamp rather than always be zero. This lets higher level logic make explicit choices based on whether the document was not found or deleted (and thus possibly hiding older versions).

Get operation logic in the distributor has been changed to reflect this, allowing newer deletes to properly override older document versions. Since multi-phase updates use the Get operation logic internally, this also transitively fixes its behavior in this scenario.

Protocol serialization logic for tombstones is implemented in a forwards and backwards compatible way; old nodes will interpret tombstone replies as if they were "not found"-replies, as is the legacy behavior.

This is related to #13356 