### PR TITLE
Revert "Setup field match executor shared state."

### DIFF
--- a/searchlib/src/vespa/searchlib/features/fieldmatchfeature.h
+++ b/searchlib/src/vespa/searchlib/features/fieldmatchfeature.h
@@ -13,7 +13,6 @@ namespace search::features {
 class FieldMatchBlueprint : public fef::Blueprint {
 private:
     const fef::FieldInfo * _field;
-    vespalib::string _shared_state_key;
     fieldmatch::Params _params;
 
 public:


### PR DESCRIPTION
Reverts vespa-engine/vespa#13378

About 15 system tests started failing with variants of this error:
`Feature 'fieldMatch(field24).matches' does not have expected score. Expected: 2.0 ~ 0.0001. Actual: 0.0`