### PR TITLE
wrapper for iterators needing TFMDA in constructor

### DIFF
--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
@@ -41,6 +41,8 @@ public:
     std::unique_ptr<queryeval::SearchIterator> createLeafSearch(const fef::TermFieldMatchDataArray & tfmda, bool strict) const override;
 
     void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
+
+    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(bool strict, FilterConstraint) const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
@@ -19,6 +19,7 @@ vespa_add_library(searchlib_queryeval OBJECT
     fake_search.cpp
     fake_searchable.cpp
     field_spec.cpp
+    filter_wrapper.cpp
     full_search.cpp
     get_weight_from_node.cpp
     global_filter.cpp

--- a/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.cpp
@@ -1,0 +1,3 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "filter_wrapper.h"

--- a/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
+++ b/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
@@ -1,0 +1,63 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "searchiterator.h"
+#include "blueprint.h"
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
+#include <vespa/searchlib/fef/termfieldmatchdataarray.h>
+
+namespace search::queryeval {
+
+/**
+ * Wraps an iterator for use as a filter search.
+ * Owns TermFieldMatchData the wrapped iterator
+ * can wire to, and write to if necessary.
+ **/
+class FilterWrapper : public SearchIterator {
+private:
+    std::vector<fef::TermFieldMatchData> _unused_md;
+    fef::TermFieldMatchDataArray _tfmda;
+    std::unique_ptr<SearchIterator> _wrapped_search;
+public:
+    FilterWrapper(const Blueprint::State &state)
+      : _unused_md(state.numFields()),
+        _tfmda(),
+        _wrapped_search()
+    {
+        for (size_t i = 0; i < state.numFields(); ++i) {
+            _tfmda.add(&_unused_md[i]);
+        }
+    }
+    const fef::TermFieldMatchDataArray& tfmda() const { return _tfmda; }
+    void wrap(std::unique_ptr<SearchIterator> wrapped) {
+        _wrapped_search = std::move(wrapped);
+    }
+    void wrap(SearchIterator *wrapped) {
+        _wrapped_search.reset(wrapped);
+    }
+    void doSeek(uint32_t docid) override {
+        _wrapped_search->seek(docid);          // use outer seek for most robustness
+        setDocId(_wrapped_search->getDocId()); // propagate current iterator docid
+    }
+    void doUnpack(uint32_t) override {}
+    void initRange(uint32_t begin_id, uint32_t end_id) override {
+        SearchIterator::initRange(begin_id, end_id);
+        _wrapped_search->initRange(begin_id, end_id);
+        setDocId(_wrapped_search->getDocId());
+    }
+    void or_hits_into(BitVector &result, uint32_t begin_id) override {
+        _wrapped_search->or_hits_into(result, begin_id);
+    }
+    void and_hits_into(BitVector &result, uint32_t begin_id) override {
+        _wrapped_search->and_hits_into(result, begin_id);
+    }
+    BitVector::UP get_hits(uint32_t begin_id) override {
+        return _wrapped_search->get_hits(begin_id);
+    }
+    Trinary is_strict() const override {
+        return _wrapped_search->is_strict();
+    }
+};
+
+} // namespace


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

To get started with the createFilterSearch() implementations, I looked at disktermblueprint, and found it could help to have a wrapper (based on BooleanMatchIteratorWrapper) that owns some unused TermFieldMatchData and make wiring in existing iterators easier.

Longer term we may want to avoid this by making a pure matching filter-only iterator on the lower levels directly, without any match data at all, but this can be used as a bridge for now.

@havardpe @toregge @geirst please take a look
