### PR TITLE
Avoid creating empty instance specs

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -133,6 +133,9 @@ public class DeploymentSpecXmlReader {
                                                              Element instanceTag,
                                                              MutableOptional<String> globalServiceId,
                                                              Element parentTag) {
+        if (isEmptySpec(instanceTag))
+            return List.of();
+
         if (validate)
             validateTagOrder(instanceTag);
 

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
  */
 public class DeploymentSpecXmlReader {
 
+    private static final String deploymentTag = "deployment";
     private static final String instanceTag = "instance";
     private static final String majorVersionTag = "major-version";
     private static final String testTag = "test";
@@ -93,6 +94,9 @@ public class DeploymentSpecXmlReader {
     /** Reads a deployment spec from XML */
     public DeploymentSpec read(String xmlForm) {
         Element root = XML.getDocument(xmlForm).getDocumentElement();
+        if ( ! root.getTagName().equals(deploymentTag))
+            throw new IllegalArgumentException("The root tag must be <deployment>");
+
         if (isEmptySpec(root))
             return DeploymentSpec.empty;
 
@@ -133,7 +137,11 @@ public class DeploymentSpecXmlReader {
                                                              Element instanceTag,
                                                              MutableOptional<String> globalServiceId,
                                                              Element parentTag) {
-        if (isEmptySpec(instanceTag))
+        if (instanceNameString.isBlank())
+            throw new IllegalArgumentException("<instance> attribute 'id' must be specified, and not be blank");
+
+        // If this is an absolutely empty instance, or the implicit "default" instance but without content, ignore it
+        if (XML.getChildren(instanceTag).isEmpty() && (instanceTag.getAttributes().getLength() == 0 || instanceTag == parentTag))
             return List.of();
 
         if (validate)

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -652,7 +652,7 @@ public class DeploymentSpecTest {
     public void deploymentSpecWithIncreasinglyStrictUpgradePoliciesInParallel() {
         StringReader r = new StringReader(
                 "<deployment version='1.0'>" +
-                "  <instance />" +
+                "  <instance id='instance0'/>" +
                 "  <parallel>" +
                 "     <instance id='instance1'>" +
                 "        <upgrade policy='conservative'/>" +
@@ -678,7 +678,7 @@ public class DeploymentSpecTest {
                 "        <upgrade policy='canary'/>" +
                 "     </instance>" +
                 "  </parallel>" +
-                "  <instance />" +
+                "  <instance id='instance3'/>" +
                 "</deployment>"
         );
         DeploymentSpec.fromXml(r);

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -3,6 +3,7 @@ package com.yahoo.config.application.api;
 
 import com.google.common.collect.ImmutableSet;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import org.junit.Test;
 
@@ -419,6 +420,23 @@ public class DeploymentSpecTest {
             // success
             assertEquals("The total delay specified is PT24H1S but max 24 hours is allowed", e.getMessage());
         }
+    }
+
+    @Test
+    public void testOnlyAthenzServiceDefinedInInstance() {
+        StringReader r = new StringReader(
+                "<deployment athenz-domain='domain'>" +
+                "  <instance id='default' athenz-service='service' />" +
+                "</deployment>"
+        );
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+
+        assertEquals("domain", spec.athenzDomain().get().value());
+        assertEquals(1, spec.instances().size());
+
+        DeploymentInstanceSpec instance = spec.instances().get(0);
+        assertEquals("default", instance.name().value());
+        assertEquals("service", instance.athenzService(Environment.prod, RegionName.defaultName()).get().value());
     }
 
     @Test

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
@@ -3,6 +3,7 @@ package com.yahoo.config.application.api;
 
 import com.google.common.collect.ImmutableSet;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import org.junit.Test;
 

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
@@ -326,6 +326,18 @@ public class DeploymentSpecWithoutInstanceTest {
     }
 
     @Test
+    public void testOnlyAthenzServiceDefined() {
+        StringReader r = new StringReader(
+                "<deployment athenz-domain='domain' athenz-service='service'>" +
+                "</deployment>"
+        );
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+
+        assertEquals("domain", spec.athenzDomain().get().value());
+        assertEquals(List.of(), spec.instances());
+    }
+
+    @Test
     public void productionSpecWithParallelDeployments() {
         StringReader r = new StringReader(
                 "<deployment>\n" +


### PR DESCRIPTION
@bratseth please review. 
@tokle FYI.

Allows an application with the deployment spec
```xml
<deployment some-attribute='some-value'>
</deployment>
```
to be deleted — currently this is disallowed, because it has a `"default"` instance. 