### PR TITLE
Remove unused API

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -223,13 +223,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
     }
 
-    public PrepareResult prepareAndActivate(Tenant tenant, long sessionId, PrepareParams prepareParams,
-                                            boolean ignoreSessionStaleFailure, Instant now) {
-        PrepareResult result = prepare(tenant, sessionId, prepareParams, now);
-        activate(tenant, sessionId, prepareParams.getTimeoutBudget(), ignoreSessionStaleFailure);
-        return result;
-    }
-
     public PrepareResult deploy(CompressedApplicationInputStream in, PrepareParams prepareParams) {
         return deploy(in, prepareParams, false, clock.instant());
     }
@@ -255,7 +248,9 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         ApplicationId applicationId = prepareParams.getApplicationId();
         long sessionId = createSession(applicationId, prepareParams.getTimeoutBudget(), applicationPackage);
         Tenant tenant = tenantRepository.getTenant(applicationId.tenant());
-        return prepareAndActivate(tenant, sessionId, prepareParams, ignoreSessionStaleFailure, now);
+        PrepareResult result = prepare(tenant, sessionId, prepareParams, now);
+        activate(tenant, sessionId, prepareParams.getTimeoutBudget(), ignoreSessionStaleFailure);
+        return result;
     }
 
     /**
@@ -566,7 +561,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         String logServerURI = getLogServerURI(applicationId, hostname) + apiParams;
         return logRetriever.getLogs(logServerURI);
     }
-
 
     // ---------------- Methods to do call against tester containers in hosted ------------------------------
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareAndActivateResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareAndActivateResponse.java
@@ -5,8 +5,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.slime.Slime;
-import com.yahoo.vespa.config.server.configchange.ConfigChangeActions;
 import com.yahoo.vespa.config.server.configchange.ConfigChangeActionsSlimeConverter;
 import com.yahoo.vespa.config.server.http.SessionResponse;
 
@@ -17,17 +15,10 @@ import com.yahoo.vespa.config.server.http.SessionResponse;
  */
 class SessionPrepareAndActivateResponse extends SessionResponse {
 
-    SessionPrepareAndActivateResponse(PrepareResult result, TenantName tenantName, HttpRequest request,
-                                      ApplicationId applicationId, Zone zone) {
-        this(result.deployLog(), tenantName, request, result.sessionId(), result.configChangeActions(),
-             zone, applicationId);
-    }
-
-    private SessionPrepareAndActivateResponse(Slime deployLog, TenantName tenantName, HttpRequest request,
-                                              long sessionId, ConfigChangeActions actions, Zone zone,
-                                              ApplicationId applicationId) {
-        super(deployLog, deployLog.get());
-        String message = "Session " + sessionId + " for tenant '" + tenantName.value() + "' prepared and activated.";
+    SessionPrepareAndActivateResponse(PrepareResult result, HttpRequest request, ApplicationId applicationId, Zone zone) {
+        super(result.deployLog(), result.deployLog().get());
+        TenantName tenantName = applicationId.tenant();
+        String message = "Session " + result.sessionId() + " for tenant '" + tenantName.value() + "' prepared and activated.";
         this.root.setString("tenant", tenantName.value());
         root.setString("url", "http://" + request.getHost() + ":" + request.getPort() +
                 "/application/v2/tenant/" + tenantName +
@@ -36,7 +27,7 @@ class SessionPrepareAndActivateResponse extends SessionResponse {
                 "/region/" + zone.region().value() +
                 "/instance/" + applicationId.instance().value());
         root.setString("message", message);
-        new ConfigChangeActionsSlimeConverter(actions).toSlime(root);
+        new ConfigChangeActionsSlimeConverter(result.configChangeActions()).toSlime(root);
     }
 
 }

--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -106,7 +106,6 @@
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.ApplicationApiHandler' bundle='configserver'>
       <binding>http://*/application/v2/tenant/*/prepareandactivate</binding>
-      <binding>http://*/application/v2/tenant/*/session/*/prepareandactivate</binding>
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.SessionContentHandler' bundle='configserver'>
       <binding>http://*/application/v2/tenant/*/session/*/content/*</binding>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.config.server;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.application.api.ApplicationMetaData;
 import com.yahoo.config.model.api.ApplicationRoles;
-import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
@@ -108,8 +107,8 @@ public class ApplicationRepositoryTest {
     }
 
     @Test
-    public void prepareAndActivate() throws IOException {
-        PrepareResult result = prepareAndActivateApp(testApp);
+    public void prepareAndActivate() {
+        PrepareResult result = prepareAndActivate(testApp);
         assertTrue(result.configChangeActions().getRefeedActions().isEmpty());
         assertTrue(result.configChangeActions().getRestartActions().isEmpty());
 
@@ -121,9 +120,9 @@ public class ApplicationRepositoryTest {
     }
 
     @Test
-    public void prepareAndActivateWithRestart() throws IOException {
-        prepareAndActivateApp(testAppJdiscOnly);
-        PrepareResult result = prepareAndActivateApp(testAppJdiscOnlyRestart);
+    public void prepareAndActivateWithRestart() {
+        prepareAndActivate(testAppJdiscOnly);
+        PrepareResult result = prepareAndActivate(testAppJdiscOnlyRestart);
         assertTrue(result.configChangeActions().getRefeedActions().isEmpty());
         assertFalse(result.configChangeActions().getRestartActions().isEmpty());
     }
@@ -404,8 +403,8 @@ public class ApplicationRepositoryTest {
     }
 
     @Test
-    public void require_that_provision_info_can_be_read() throws Exception {
-        prepareAndActivateApp(testAppJdiscOnly);
+    public void require_that_provision_info_can_be_read() {
+        prepareAndActivate(testAppJdiscOnly);
 
         TenantName tenantName = applicationId().tenant();
         Tenant tenant = tenantRepository.getTenant(tenantName);
@@ -455,12 +454,8 @@ public class ApplicationRepositoryTest {
                                          new NullMetric());
     }
 
-    private PrepareResult prepareAndActivateApp(File application) throws IOException {
-        FilesApplicationPackage appDir = FilesApplicationPackage.fromFile(application);
-        ApplicationId applicationId = applicationId();
-        long sessionId = applicationRepository.createSession(applicationId, timeoutBudget, appDir.getAppDir());
-        return applicationRepository.prepareAndActivate(tenantRepository.getTenant(applicationId.tenant()),
-                                                        sessionId, prepareParams(), false, Instant.now());
+    private PrepareResult prepareAndActivate(File application) {
+        return applicationRepository.deploy(application, prepareParams(), false, Instant.now());
     }
 
     private PrepareResult deployApp(File applicationPackage) {


### PR DESCRIPTION
* PUT /application/v2/tenant/*/session/*/prepareandactivate was a step
  towards POST /application/v2/tenant/*/prepareandactivate and has not
  been used or tested for a long time, it has never been been documented
  either.
* Fixed an issue with how we get tenant from request
* Simplified SessionPrepareAndActivateResponse
