### PR TITLE
Add kludge to avoid unresolved symbols with gcc-toolset-9 on RHEL 8.2

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/common/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/common/CMakeLists.txt
@@ -26,3 +26,7 @@ vespa_add_library(searchcore_pcommon STATIC
     searchcore_fconfig
     ${VESPA_STDCXX_FS_LIB}
 )
+
+if(VESPA_OS_DISTRO_COMBINED STREQUAL "rhel 8.2")
+  set_source_files_properties(hw_info_sampler.cpp PROPERTIES COMPILE_FLAGS -DRHEL_8_2_KLUDGE)
+endif()

--- a/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
@@ -157,3 +157,16 @@ HwInfoSampler::sampleDiskWriteSpeed(const vespalib::string &path, const Config &
 }
 
 }
+
+#ifdef RHEL_8_2_KLUDGE
+
+// Kludge to avoid unresolved symbols with gcc-toolset-9 on RHEL 8.2
+#include <codecvt>
+
+namespace std {
+
+template class codecvt_utf8<wchar_t>;
+
+}
+
+#endif


### PR DESCRIPTION
@aressem : please review
