### PR TITLE
Use xxhash64 for bucket-to-stripe distribution

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -14,6 +14,10 @@
 #include <vespa/storageapi/message/stat.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/util/exceptions.h>
+#ifndef XXH_INLINE_ALL
+#  define XXH_INLINE_ALL // Let XXH64 be inlined for fixed hash size (bucket ID)
+#endif
+#include <xxhash.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".persistence.filestor.handler.impl");
@@ -892,6 +896,11 @@ FileStorHandlerImpl::Disk::broadcast()
     for (auto & stripe : _stripes) {
         stripe.broadcast();
     }
+}
+
+uint64_t FileStorHandlerImpl::Disk::dispersed_bucket_bits(const document::Bucket& bucket) noexcept {
+    const uint64_t raw_id = bucket.getBucketId().getId();
+    return XXH64(&raw_id, sizeof(uint64_t), 0);
 }
 
 bool

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -197,12 +197,7 @@ public:
         std::string dumpQueue() const;
         void dumpActiveHtml(std::ostream & os) const;
         void dumpQueueHtml(std::ostream & os) const;
-        static uint64_t dispersed_bucket_bits(const document::Bucket& bucket) noexcept {
-            // Disperse bucket bits by multiplying with the 64-bit FNV-1 prime.
-            // This avoids an inherent affinity between the LSB of a bucket's bits
-            // and the stripe an operation ends up on.
-            return bucket.getBucketId().getId() * 1099511628211ULL;
-        }
+        static uint64_t dispersed_bucket_bits(const document::Bucket& bucket) noexcept;
         // We make a fairly reasonable assumption that there will be less than 64k stripes.
         uint16_t stripe_index(const document::Bucket& bucket) const noexcept {
             return static_cast<uint16_t>(dispersed_bucket_bits(bucket) % _stripes.size());


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

Existing naive prime-based solution was susceptible to scheduling
operations for the subtree of a superbucket in one strand alone,
despite previous attempts to disperse this using prime number
multiplication. This would put a serious limiter on parallelism
for super bucket locality-sensitive reads such as streaming search
visitors.