### PR TITLE
revert back to getting random number in the [0,1) range

### DIFF
--- a/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
@@ -521,15 +521,31 @@ TEST_F(HnswIndexTest, shrink_called_heuristic)
 TEST(LevelGeneratorTest, gives_various_levels)
 {
     InvLogLevelGenerator generator(4);
-    EXPECT_EQ(2u, generator.max_level());
-    EXPECT_EQ(1u, generator.max_level());
-    EXPECT_EQ(0u, generator.max_level());
-    EXPECT_EQ(1u, generator.max_level());
-    EXPECT_EQ(0u, generator.max_level());
-    EXPECT_EQ(1u, generator.max_level());
-    EXPECT_EQ(0u, generator.max_level());
-    EXPECT_EQ(0u, generator.max_level());
-    EXPECT_EQ(0u, generator.max_level());
+    std::vector<uint32_t> got_levels(16);
+    for (auto & v : got_levels) { v = generator.max_level(); }
+    EXPECT_EQ(got_levels, std::vector<uint32_t>({
+        2, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0
+    }));
+    for (auto & v : got_levels) { v = generator.max_level(); }
+    EXPECT_EQ(got_levels, std::vector<uint32_t>({
+        0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    }));
+    for (auto & v : got_levels) { v = generator.max_level(); }
+    EXPECT_EQ(got_levels, std::vector<uint32_t>({
+        0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0
+    }));
+    for (auto & v : got_levels) { v = generator.max_level(); }
+    EXPECT_EQ(got_levels, std::vector<uint32_t>({
+        0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1
+    }));
+    for (auto & v : got_levels) { v = generator.max_level(); }
+    EXPECT_EQ(got_levels, std::vector<uint32_t>({
+        0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 2
+    }));
+    for (auto & v : got_levels) { v = generator.max_level(); }
+    EXPECT_EQ(got_levels, std::vector<uint32_t>({
+        0, 1, 1, 0, 3, 1, 2, 0, 0, 1, 0, 0, 0, 0, 0, 0
+    }));
 
     uint32_t left = 1000000;
     std::vector<uint32_t> hist;

--- a/searchlib/src/vespa/searchlib/tensor/inv_log_level_generator.h
+++ b/searchlib/src/vespa/searchlib/tensor/inv_log_level_generator.h
@@ -29,13 +29,13 @@ public:
     InvLogLevelGenerator(uint32_t m)
       : _rng(0x1234deadbeef5678uLL),
         _mutex(),
-        _uniform(1.0, 0.0),
+        _uniform(0.0, 1.0),
         _levelMultiplier(1.0 / log(1.0 * m))
     {}
 
     uint32_t max_level() override {
         double unif = get_uniform();
-        double r = -log(unif) * _levelMultiplier;
+        double r = -log(1.0-unif) * _levelMultiplier;
         return (uint32_t) r;
     }
 };


### PR DESCRIPTION
* for whatever reason, std::uniform_real_distribution doesn't
  allow a>b when specifying the [a,b) half-open range.  So we
  need to get a number from [0,1) and then do (1.0-unif) to
  convert to the (0,1] range that we want.
* extend the unit test with more initial numbers, and write
  it in a more compact way.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review and merge