### PR TITLE
Use scope 'provided' for builtin jdisc artifacts.

### DIFF
--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -27,6 +27,7 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>component</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
@@ -42,6 +43,7 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/simplemetrics/pom.xml
+++ b/simplemetrics/pom.xml
@@ -25,6 +25,12 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>component</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
- These are already pulled in by the vespaclient-java
  jar via its compile scoped dependency on container-dev.

@freva Please review, do not merge.