### PR TITLE
Revert "Create global routing policy with legacy syntax"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicies.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicies.java
@@ -289,16 +289,12 @@ public class RoutingPolicies {
             if (instanceSpec.isEmpty()) {
                 return Set.of();
             }
-            if (instanceSpec.get().globalServiceId().filter(id -> id.equals(loadBalancer.cluster().value())).isPresent()) {
-                // Legacy assignment always has the default endpoint Id
-                return Set.of(EndpointId.defaultId());
-            }
             return instanceSpec.get().endpoints().stream()
                                .filter(endpoint -> endpoint.containerId().equals(loadBalancer.cluster().value()))
                                .filter(endpoint -> endpoint.regions().contains(deployment.zoneId().region()))
                                .map(com.yahoo.config.application.api.Endpoint::endpointId)
                                .map(EndpointId::of)
-                               .collect(Collectors.toUnmodifiableSet());
+                               .collect(Collectors.toSet());
         }
 
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
@@ -138,27 +138,6 @@ public class RoutingPoliciesTest {
     }
 
     @Test
-    public void global_routing_policies_legacy_global_service_id() {
-        var tester = new RoutingPoliciesTester();
-        var context = tester.newDeploymentContext("tenant1", "app1", "default");
-        int clustersPerZone = 2;
-        int numberOfDeployments = 2;
-        var applicationPackage = applicationPackageBuilder()
-                .region(zone1.region())
-                .region(zone2.region())
-                .globalServiceId("c0")
-                .build();
-        tester.provisionLoadBalancers(clustersPerZone, context.instanceId(), zone1, zone2);
-
-        // Creates alias records
-        context.submit(applicationPackage).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
-        tester.assertTargets(context.instanceId(), EndpointId.defaultId(), 0, zone1, zone2);
-        assertEquals("Routing policy count is equal to cluster count",
-                     numberOfDeployments * clustersPerZone,
-                     tester.policiesOf(context.instance().id()).size());
-    }
-
-    @Test
     public void zone_routing_policies() {
         zone_routing_policies(false);
         zone_routing_policies(true);


### PR DESCRIPTION
Reverts vespa-engine/vespa#13593

Reverting because this uncovered another bug that must be fixed first.

@olaaun 

FYI @tokle 