### PR TITLE
Support "user" and "group" as identifiers in C++ selection parser 

### DIFF
--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -67,6 +67,8 @@ public class DocumentSelectorTestCase {
         manager.registerDocumentType(new DocumentType("andornot"));
         manager.registerDocumentType(new DocumentType("idid"));
         manager.registerDocumentType(new DocumentType("usergroup"));
+        manager.registerDocumentType(new DocumentType("user"));
+        manager.registerDocumentType(new DocumentType("group"));
     }
 
     @Test
@@ -131,6 +133,8 @@ public class DocumentSelectorTestCase {
         assertParse(null, "false or false_t or falsetype");
         assertParse(null, "true or and_t or andtype");
         assertParse(null, "true or or_t or ortype");
+        assertParse(null, "user or group");
+        assertParse(null, "user.foo or group.bar");
     }
 
     @Test

--- a/document/src/vespa/document/select/grammar/parser.yy
+++ b/document/src/vespa/document/select/grammar/parser.yy
@@ -219,8 +219,11 @@ doc_type
       }
     ;
 
+ /* We allow most otherwise reserved tokens to be used as identifiers. */
 ident
     : IDENTIFIER { $$ = $1; }
+    | USER       { $$ = $1; }
+    | GROUP      { $$ = $1; }
     | SCHEME     { $$ = $1; }
     | TYPE       { $$ = $1; }
     | NAMESPACE  { $$ = $1; }


### PR DESCRIPTION
@geirst please review

These were not included in the explicit list of allowed tokens
and would therefore cause parse failures if e.g. a document type
was called "user".

Java parser already has the necessary tokens added.