### PR TITLE
Require vespa-valgrind for CentOS 7 and RHEL 7.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -136,7 +136,9 @@ Requires: perl-LWP-Protocol-https
 Requires: perl-Net-INET6Glue
 Requires: perl-Pod-Usage
 Requires: perl-URI
+%if ! 0%{?el7}
 Requires: valgrind
+%endif
 Requires: Judy
 Requires: xxhash
 Requires: xxhash-libs >= 0.7.3
@@ -161,6 +163,7 @@ Requires: vespa-openssl >= 1.1.1g-1
 Requires: vespa-icu >= 65.1.0-1
 Requires: vespa-protobuf >= 3.7.0-4
 Requires: vespa-telegraf >= 1.1.1-1
+Requires: vespa-valgrind >= 3.16.0-1
 %define _vespa_llvm_version 7
 %define _extra_link_directory /usr/lib64/llvm7.0/lib;%{_vespa_deps_prefix}/lib64
 %define _extra_include_directory /usr/include/llvm7.0;%{_vespa_deps_prefix}/include;/usr/include/openblas


### PR DESCRIPTION
@baldersheim : please review
@geirst , @aressem : FYI
