### PR TITLE
Replace joins with same input with a map

### DIFF
--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/IntermediateOperation.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/IntermediateOperation.java
@@ -312,6 +312,14 @@ public abstract class IntermediateOperation {
         return -1;
     }
 
+    /** Removes outputs if they point to the same operation */
+    public void removeDuplicateOutputsTo(IntermediateOperation op) {
+        int last, first = outputs.indexOf(op);
+        while (first >= 0 && (last = outputs.lastIndexOf(op)) > first) {
+            outputs.remove(last);
+        }
+    }
+
     /**
      * Returns the largest value type among the input value types.
      * This should only be called after it has been verified that input types are available.

--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/Join.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/Join.java
@@ -5,11 +5,14 @@ import ai.vespa.rankingexpression.importer.OrderedTensorType;
 import ai.vespa.rankingexpression.importer.DimensionRenamer;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.functions.Reduce;
+import com.yahoo.tensor.functions.ScalarFunctions;
 import com.yahoo.tensor.functions.TensorFunction;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleUnaryOperator;
 
 public class Join extends IntermediateOperation {
 
@@ -53,6 +56,16 @@ public class Join extends IntermediateOperation {
     protected TensorFunction lazyGetFunction() {
         if ( ! allInputTypesPresent(2)) return null;
         if ( ! allInputFunctionsPresent(2)) return null;
+
+        // Optimization: if inputs are the same, replace with a map function.
+        if (inputs.get(0).equals(inputs.get(1))) {
+            Optional<DoubleUnaryOperator> mapOperator = operatorAsUnary(operator);
+            if (mapOperator.isPresent()) {
+                IntermediateOperation input = inputs.get(0);
+                input.removeDuplicateOutputsTo(this);  // avoids unnecessary function export
+                return new com.yahoo.tensor.functions.Map(input.function().get(), mapOperator.get());
+            }
+        }
 
         IntermediateOperation a = largestInput();
         IntermediateOperation b = smallestInput();
@@ -125,5 +138,28 @@ public class Join extends IntermediateOperation {
 
     @Override
     public String operationName() { return "Join"; }
+
+    private Optional<DoubleUnaryOperator> operatorAsUnary(DoubleBinaryOperator op) {
+        String unaryRep;
+        if      (op instanceof ScalarFunctions.Add) unaryRep = "f(a)(a + a)";
+        else if (op instanceof ScalarFunctions.Multiply) unaryRep = "f(a)(a * a)";
+        else if (op instanceof ScalarFunctions.Subtract) unaryRep = "f(a)(0)";
+        else if (op instanceof ScalarFunctions.Divide) unaryRep = "f(a)(1)";
+        else if (op instanceof ScalarFunctions.Equal) unaryRep = "f(a)(1)";
+        else if (op instanceof ScalarFunctions.Greater) unaryRep = "f(a)(0)";
+        else if (op instanceof ScalarFunctions.Less) unaryRep = "f(a)(0)";
+        else if (op instanceof ScalarFunctions.Max) unaryRep = "f(a)(a)";
+        else if (op instanceof ScalarFunctions.Min) unaryRep = "f(a)(a)";
+        else if (op instanceof ScalarFunctions.Mean) unaryRep = "f(a)(a)";
+        else if (op instanceof ScalarFunctions.Pow) unaryRep = "f(a)(pow(a,a))";
+        else if (op instanceof ScalarFunctions.SquaredDifference) unaryRep = "f(a)(0)";
+        else return Optional.empty();
+        return Optional.of(new DoubleUnaryOperator() {
+            @Override
+            public double applyAsDouble(double operand) { return op.applyAsDouble(operand, operand); }
+            @Override
+            public String toString() { return unaryRep; }
+        });
+    }
 
 }


### PR DESCRIPTION
@bratseth Please review. Most often used when squaring tensors. Allows this to be done in place.