### PR TITLE
Tgm/application package

### DIFF
--- a/python/vespa/notebooks/application_package.ipynb
+++ b/python/vespa/notebooks/application_package.ipynb
@@ -122,10 +122,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "raw",
    "metadata": {},
-   "outputs": [],
    "source": [
     "app_package.deploy_locally(disk_folder=\"~/sample_application\")"
    ]
@@ -156,10 +154,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "raw",
    "metadata": {},
-   "outputs": [],
    "source": [
     "app_package.deploy_locally(disk_folder=\"~/sample_application\")"
    ]

--- a/python/vespa/notebooks/application_package.ipynb
+++ b/python/vespa/notebooks/application_package.ipynb
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create schema"
+    "## Application spec"
    ]
   },
   {
@@ -82,65 +82,138 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Schema API"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "document = Document()\n",
-    "document.add_field(\n",
-    "    Field(name = \"id\", type = \"string\", indexing = [\"attribute\", \"summary\"]),\n",
-    "    Field(name = \"title\", type = \"string\", indexing = [\"index\", \"summary\"], index = [\"enable-bm25\"]),\n",
-    "    Field(name = \"body\", type = \"string\", indexing = [\"index\", \"summary\"], index = [\"enable-bm25\"])\n",
+    "from vespa.package import Document, Field, Schema, FieldSet, RankProfile, ApplicationPackage\n",
+    "\n",
+    "document = Document(\n",
+    "    fields=[\n",
+    "        Field(name = \"id\", type = \"string\", indexing = [\"attribute\", \"summary\"]),\n",
+    "        Field(name = \"title\", type = \"string\", indexing = [\"index\", \"summary\"], index = \"enable-bm25\"),\n",
+    "        Field(name = \"body\", type = \"string\", indexing = [\"index\", \"summary\"], index = \"enable-bm25\")        \n",
+    "    ]\n",
     ")\n",
-    "\n",
-    "default_fieldset = FieldSet(name = \"default\", fields = [\"title\", \"body\"])\n",
-    "\n",
-    "default_rank_profile = RankProfile(name = \"default\", first_phase = \"nativeRank(title, body)\")\n",
     "\n",
     "msmarco_schema = Schema(\n",
     "    name = \"msmarco\", \n",
     "    document = document, \n",
-    "    default_fieldset = default_fieldset,\n",
-    "    default_rank_profile = default_rank_profile\n",
+    "    fieldsets = [FieldSet(name = \"default\", fields = [\"title\", \"body\"])],\n",
+    "    rank_profiles = [RankProfile(name = \"default\", first_phase = \"nativeRank(title, body)\")]\n",
     ")\n",
     "\n",
-    "msmarco_schema.add_rank_profile(\n",
+    "app_package = ApplicationPackage(name = \"msmarco\", schema=msmarco_schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy it locally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for configuration server.\n",
+      "Waiting for configuration server.\n",
+      "Waiting for configuration server.\n",
+      "Waiting for configuration server.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[\"Uploading application '/app/application' using http://localhost:19071/application/v2/tenant/default/session\",\n",
+       " \"Session 2 for tenant 'default' created.\",\n",
+       " 'Preparing session 2 using http://localhost:19071/application/v2/tenant/default/session/2/prepared',\n",
+       " \"WARNING: Host named 'msmarco' may not receive any config since it is not a canonical hostname. Disregard this warning when testing in a Docker container.\",\n",
+       " \"Session 2 for tenant 'default' prepared.\",\n",
+       " 'Activating session 2 using http://localhost:19071/application/v2/tenant/default/session/2/active',\n",
+       " \"Session 2 for tenant 'default' activated.\",\n",
+       " 'Checksum:   971f5eda655137fe7e3b1ae1441e89ae',\n",
+       " 'Timestamp:  1593720925341',\n",
+       " 'Generation: 2',\n",
+       " '']"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "app_package.deploy_locally(disk_folder=\"/Users/tmartins/sample_application\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Change the application package and redeploy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can add a new rank profile and redeploy our application"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_package.schema.add_rank_profile(\n",
     "    RankProfile(name = \"bm25\", inherits = \"default\", first_phase = \"bm25(title) + bm25(body)\")\n",
     ")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create application package"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"Uploading application '/app/application' using http://localhost:19071/application/v2/tenant/default/session\",\n",
+       " \"Session 3 for tenant 'default' created.\",\n",
+       " 'Preparing session 3 using http://localhost:19071/application/v2/tenant/default/session/3/prepared',\n",
+       " \"WARNING: Host named 'msmarco' may not receive any config since it is not a canonical hostname. Disregard this warning when testing in a Docker container.\",\n",
+       " \"Session 3 for tenant 'default' prepared.\",\n",
+       " 'Activating session 3 using http://localhost:19071/application/v2/tenant/default/session/3/active',\n",
+       " \"Session 3 for tenant 'default' activated.\",\n",
+       " 'Checksum:   09e37f616b75ff9c81acbfe411203cdd',\n",
+       " 'Timestamp:  1593720955212',\n",
+       " 'Generation: 3',\n",
+       " '']"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "application_package = ApplicationPackage(name = \"msmarco_app\")\n",
-    "application_package.add_schema(msmarco_schema)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Deploy application package"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "application_package.deploy()"
+    "app_package.deploy_locally(disk_folder=\"/Users/tmartins/projects/vespa/vespa/python/vespa/notebooks/sample_application2\")"
    ]
   }
  ],

--- a/python/vespa/notebooks/application_package.ipynb
+++ b/python/vespa/notebooks/application_package.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hide\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vespa - Application Package\n",
+    "\n",
+    "> Python API to create, modify and deploy application packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our goal is to create, modify and deploy simple application packages using our python API. This enables us to run data analysis experiments that are fully integrated with Vespa. As an example, we want to create the application package we used in our [text search tutorial](https://docs.vespa.ai/documentation/tutorials/text-search.html). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our goal in this section is to create the following `msmarco` schema using our python API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "schema msmarco {\n",
+    "    document msmarco {\n",
+    "        field id type string {\n",
+    "            indexing: attribute | summary\n",
+    "        }\n",
+    "        field title type string {\n",
+    "            indexing: index | summary\n",
+    "            index: enable-bm25\n",
+    "        }\n",
+    "        field body type string {\n",
+    "            indexing: index | summary\n",
+    "            index: enable-bm25\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    fieldset default {\n",
+    "        fields: title, body\n",
+    "    }\n",
+    "\n",
+    "    rank-profile default {\n",
+    "        first-phase {\n",
+    "            expression: nativeRank(title, body)\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    rank-profile bm25 inherits default {\n",
+    "        first-phase {\n",
+    "            expression: bm25(title) + bm25(body)\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "document = Document()\n",
+    "document.add_field(\n",
+    "    Field(name = \"id\", type = \"string\", indexing = [\"attribute\", \"summary\"]),\n",
+    "    Field(name = \"title\", type = \"string\", indexing = [\"index\", \"summary\"], index = [\"enable-bm25\"]),\n",
+    "    Field(name = \"body\", type = \"string\", indexing = [\"index\", \"summary\"], index = [\"enable-bm25\"])\n",
+    ")\n",
+    "\n",
+    "default_fieldset = FieldSet(name = \"default\", fields = [\"title\", \"body\"])\n",
+    "\n",
+    "default_rank_profile = RankProfile(name = \"default\", first_phase = \"nativeRank(title, body)\")\n",
+    "\n",
+    "msmarco_schema = Schema(\n",
+    "    name = \"msmarco\", \n",
+    "    document = document, \n",
+    "    default_fieldset = default_fieldset,\n",
+    "    default_rank_profile = default_rank_profile\n",
+    ")\n",
+    "\n",
+    "msmarco_schema.add_rank_profile(\n",
+    "    RankProfile(name = \"bm25\", inherits = \"default\", first_phase = \"bm25(title) + bm25(body)\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create application package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application_package = ApplicationPackage(name = \"msmarco_app\")\n",
+    "application_package.add_schema(msmarco_schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy application package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application_package.deploy()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "vespa",
+   "language": "python",
+   "name": "vespa"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/vespa/notebooks/application_package.ipynb
+++ b/python/vespa/notebooks/application_package.ipynb
@@ -125,7 +125,10 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "app_package.deploy_locally(disk_folder=\"~/sample_application\")"
+    "from vespa.package import VespaDocker\n",
+    "\n",
+    "vespa_docker = VespaDocker(application_package=app_package)\n",
+    "vespa_docker.deploy(disk_folder=\"/Users/username/sample_application\")"
    ]
   },
   {
@@ -157,7 +160,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "app_package.deploy_locally(disk_folder=\"~/sample_application\")"
+    "vespa_docker.deploy(disk_folder=\"/Users/username/sample_application\")"
    ]
   }
  ],

--- a/python/vespa/notebooks/application_package.ipynb
+++ b/python/vespa/notebooks/application_package.ipynb
@@ -125,40 +125,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[\"Uploading application '/app/application' using http://localhost:19071/application/v2/tenant/default/session\",\n",
-       " \"Session 2 for tenant 'default' created.\",\n",
-       " 'Preparing session 2 using http://localhost:19071/application/v2/tenant/default/session/2/prepared',\n",
-       " \"WARNING: Host named 'msmarco' may not receive any config since it is not a canonical hostname. Disregard this warning when testing in a Docker container.\",\n",
-       " \"Session 2 for tenant 'default' prepared.\",\n",
-       " 'Activating session 2 using http://localhost:19071/application/v2/tenant/default/session/2/active',\n",
-       " \"Session 2 for tenant 'default' activated.\",\n",
-       " 'Checksum:   971f5eda655137fe7e3b1ae1441e89ae',\n",
-       " 'Timestamp:  1593720925341',\n",
-       " 'Generation: 2',\n",
-       " '']"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "app_package.deploy_locally(disk_folder=\"/Users/tmartins/sample_application\")"
+    "app_package.deploy_locally(disk_folder=\"~/sample_application\")"
    ]
   },
   {
@@ -190,30 +159,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[\"Uploading application '/app/application' using http://localhost:19071/application/v2/tenant/default/session\",\n",
-       " \"Session 3 for tenant 'default' created.\",\n",
-       " 'Preparing session 3 using http://localhost:19071/application/v2/tenant/default/session/3/prepared',\n",
-       " \"WARNING: Host named 'msmarco' may not receive any config since it is not a canonical hostname. Disregard this warning when testing in a Docker container.\",\n",
-       " \"Session 3 for tenant 'default' prepared.\",\n",
-       " 'Activating session 3 using http://localhost:19071/application/v2/tenant/default/session/3/active',\n",
-       " \"Session 3 for tenant 'default' activated.\",\n",
-       " 'Checksum:   09e37f616b75ff9c81acbfe411203cdd',\n",
-       " 'Timestamp:  1593720955212',\n",
-       " 'Generation: 3',\n",
-       " '']"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "app_package.deploy_locally(disk_folder=\"/Users/tmartins/projects/vespa/vespa/python/vespa/notebooks/sample_application2\")"
+    "app_package.deploy_locally(disk_folder=\"~/sample_application\")"
    ]
   }
  ],

--- a/python/vespa/settings.ini
+++ b/python/vespa/settings.ini
@@ -21,7 +21,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = requests pandas
+requirements = requests pandas docker
 # Optional. Same format as setuptools console_scripts
 # console_scripts = 
 # Optional. Same format as setuptools dependency-links

--- a/python/vespa/settings.ini
+++ b/python/vespa/settings.ini
@@ -21,7 +21,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = requests pandas docker
+requirements = requests pandas docker jinja2
 # Optional. Same format as setuptools console_scripts
 # console_scripts = 
 # Optional. Same format as setuptools dependency-links

--- a/python/vespa/vespa/json_serialization.py
+++ b/python/vespa/vespa/json_serialization.py
@@ -1,0 +1,77 @@
+import datetime
+import json
+import typing
+
+T = typing.TypeVar("T")
+
+
+class ToJson(object):
+    """
+    Utility mix-in class for serializing an object to JSON.  It does not really
+    do any conversion on its own, but forces serialization into a standardized
+    API.
+
+    The serialized class is put into an envelope with some data to make it easier
+    to understand what has happened.
+
+        {
+          "version": 1,
+          "class": "Field",
+          "serialized_at": "2018-10-24T12:55:32+00:00",
+          "data": { ... }
+        }
+
+        * version: This value is hard-coded to 1.
+        * class: The name of the class we serialized.  For debugging purposes.
+        * serialized_at: The time we serialized the instance of the class.  For debugging purposes.
+        * data: The actual data of the serialized class.
+
+    All serialization is based on converting objects to a `dict` which is then converted
+    to JSON using the standard Python json library.
+    """
+
+    @property
+    def to_dict(self) -> typing.Mapping:
+        raise NotImplementedError
+
+    @property
+    def to_envelope(self) -> typing.Mapping:
+        return {
+            "version": 1,
+            "class": self.__class__.__name__,
+            "serialized_at": datetime.datetime.utcnow().isoformat(),
+            "data": self.to_dict,
+        }
+
+    @property
+    def to_json(self) -> str:
+        mapping = self.to_envelope
+        return json.dumps(mapping)
+
+
+class FromJson(typing.Generic[T]):
+    """
+    A mix-in class for deserializing from JSON to an object that implements this class.
+    All JSON must have the same envelope as ToJson to be able to properly deserialize the
+    contents of the mapping.
+    """
+
+    deserializers: typing.MutableMapping[str, "FromJson"] = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)  # type: ignore
+        FromJson.deserializers[cls.__name__] = cls
+
+    @staticmethod
+    def from_json(json_string: str) -> T:
+        mapping = json.loads(json_string)
+        return FromJson.map(mapping)
+
+    @staticmethod
+    def map(mapping: typing.Mapping) -> T:
+        mapping_class = FromJson.deserializers[mapping["class"]]
+        return mapping_class.from_dict(mapping["data"])
+
+    @staticmethod
+    def from_dict(mapping: typing.Mapping) -> T:
+        raise NotImplementedError

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -214,7 +214,7 @@ class Schema(ToJson, FromJson["Schema"]):
         :param rank_profile: `RankProfile` to be added.
         :return: None.
         """
-        self.rank_profiles.update({rank_profile.name: rank_profile})
+        self.rank_profiles[rank_profile.name] = rank_profile
 
     @staticmethod
     def from_dict(mapping: Mapping) -> "Schema":
@@ -373,7 +373,9 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         )
 
     def create_application_package_files(self, dir_path):
-        Path(os.path.join(dir_path, "application/schemas")).mkdir(parents=True, exist_ok=True)
+        Path(os.path.join(dir_path, "application/schemas")).mkdir(
+            parents=True, exist_ok=True
+        )
         with open(
             os.path.join(
                 dir_path, "application/schemas/{}.sd".format(self.schema.name)

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -86,7 +86,7 @@ class Document(ToJson, FromJson["Document"]):
         :param fields: fields to be added
         :return:
         """
-        self.fields.extend(list(fields))
+        self.fields.extend(fields)
 
     @staticmethod
     def from_dict(mapping: Mapping) -> "Document":

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -1,7 +1,6 @@
 import os
 from time import sleep
 from typing import List, Mapping, Optional
-from tempfile import TemporaryDirectory
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -67,10 +66,10 @@ class Field(ToJson, FromJson["Field"]):
     def __repr__(self):
         return "{0}({1}, {2}, {3}, {4})".format(
             self.__class__.__name__,
-            str(self.name),
-            str(self.type),
-            str(self.indexing),
-            str(self.index),
+            repr(self.name),
+            repr(self.type),
+            repr(self.indexing),
+            repr(self.index),
         )
 
 
@@ -107,7 +106,7 @@ class Document(ToJson, FromJson["Document"]):
 
     def __repr__(self):
         return "{0}({1})".format(
-            self.__class__.__name__, str(self.fields) if self.fields else None
+            self.__class__.__name__, repr(self.fields) if self.fields else None
         )
 
 
@@ -143,7 +142,7 @@ class FieldSet(ToJson, FromJson["FieldSet"]):
 
     def __repr__(self):
         return "{0}({1}, {2})".format(
-            self.__class__.__name__, str(self.name), str(self.fields)
+            self.__class__.__name__, repr(self.name), repr(self.fields)
         )
 
 
@@ -188,9 +187,9 @@ class RankProfile(ToJson, FromJson["RankProfile"]):
     def __repr__(self):
         return "{0}({1}, {2}, {3})".format(
             self.__class__.__name__,
-            str(self.name),
-            str(self.first_phase),
-            str(self.inherits),
+            repr(self.name),
+            repr(self.first_phase),
+            repr(self.inherits),
         )
 
 
@@ -270,12 +269,12 @@ class Schema(ToJson, FromJson["Schema"]):
     def __repr__(self):
         return "{0}({1}, {2}, {3}, {4})".format(
             self.__class__.__name__,
-            str(self.name),
-            str(self.document),
-            str(
+            repr(self.name),
+            repr(self.document),
+            repr(
                 [field for field in self.fieldsets.values()] if self.fieldsets else None
             ),
-            str(
+            repr(
                 [rank_profile for rank_profile in self.rank_profiles.values()]
                 if self.rank_profiles
                 else None
@@ -378,7 +377,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
 
     def __repr__(self):
         return "{0}({1}, {2})".format(
-            self.__class__.__name__, str(self.name), str(self.schema)
+            self.__class__.__name__, repr(self.name), repr(self.schema)
         )
 
 

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -74,10 +74,7 @@ class Document(ToJson, FromJson["Document"]):
         Object representing a Vespa document.
 
         """
-        if not fields:
-            fields = []
-
-        self.fields = fields
+        self.fields = [] if not fields else fields
 
     def add_fields(self, *fields: Field):
         """

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -330,6 +330,36 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
             rank_profiles=self.schema.rank_profiles,
         )
 
+    @property
+    def hosts_to_text(self):
+        env = Environment(
+            loader=PackageLoader("vespa", "templates"),
+            autoescape=select_autoescape(
+                disabled_extensions=("txt",), default_for_string=True, default=True,
+            ),
+        )
+        env.trim_blocks = True
+        env.lstrip_blocks = True
+        schema_template = env.get_template("hosts.xml")
+        return schema_template.render()
+
+    @property
+    def services_to_text(self):
+        env = Environment(
+            loader=PackageLoader("vespa", "templates"),
+            autoescape=select_autoescape(
+                disabled_extensions=("txt",), default_for_string=True, default=True,
+            ),
+        )
+        env.trim_blocks = True
+        env.lstrip_blocks = True
+        schema_template = env.get_template("services.xml")
+        return schema_template.render(
+            application_name=self.name,
+            document_name=self.schema.name,
+        )
+
+
     @staticmethod
     def from_dict(mapping: Mapping) -> "ApplicationPackage":
         schema = mapping.get("schema", None)

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -65,7 +65,13 @@ class Field(ToJson, FromJson["Field"]):
         )
 
     def __repr__(self):
-        return "{0}\n{1}".format(self.__class__.__name__, str(self.to_dict))
+        return "{0}({1}, {2}, {3}, {4})".format(
+            self.__class__.__name__,
+            str(self.name),
+            str(self.type),
+            str(self.indexing),
+            str(self.index),
+        )
 
 
 class Document(ToJson, FromJson["Document"]):
@@ -100,7 +106,9 @@ class Document(ToJson, FromJson["Document"]):
         return self.fields == other.fields
 
     def __repr__(self):
-        return "{0}\n{1}".format(self.__class__.__name__, str(self.to_dict))
+        return "{0}({1})".format(
+            self.__class__.__name__, str(self.fields) if self.fields else None
+        )
 
 
 class FieldSet(ToJson, FromJson["FieldSet"]):
@@ -134,7 +142,9 @@ class FieldSet(ToJson, FromJson["FieldSet"]):
         return self.name == other.name and self.fields == other.fields
 
     def __repr__(self):
-        return "{0}\n{1}".format(self.__class__.__name__, str(self.to_dict))
+        return "{0}({1}, {2})".format(
+            self.__class__.__name__, str(self.name), str(self.fields)
+        )
 
 
 class RankProfile(ToJson, FromJson["RankProfile"]):
@@ -176,7 +186,12 @@ class RankProfile(ToJson, FromJson["RankProfile"]):
         )
 
     def __repr__(self):
-        return "{0}\n{1}".format(self.__class__.__name__, str(self.to_dict))
+        return "{0}({1}, {2}, {3})".format(
+            self.__class__.__name__,
+            str(self.name),
+            str(self.first_phase),
+            str(self.inherits),
+        )
 
 
 class Schema(ToJson, FromJson["Schema"]):
@@ -253,7 +268,19 @@ class Schema(ToJson, FromJson["Schema"]):
         )
 
     def __repr__(self):
-        return "{0}\n{1}".format(self.__class__.__name__, str(self.to_dict))
+        return "{0}({1}, {2}, {3}, {4})".format(
+            self.__class__.__name__,
+            str(self.name),
+            str(self.document),
+            str(
+                [field for field in self.fieldsets.values()] if self.fieldsets else None
+            ),
+            str(
+                [rank_profile for rank_profile in self.rank_profiles.values()]
+                if self.rank_profiles
+                else None
+            ),
+        )
 
 
 class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
@@ -408,4 +435,6 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         return self.name == other.name and self.schema == other.schema
 
     def __repr__(self):
-        return "{0}\n{1}".format(self.__class__.__name__, str(self.to_dict))
+        return "{0}({1}, {2})".format(
+            self.__class__.__name__, str(self.name), str(self.schema)
+        )

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -1,0 +1,53 @@
+import docker
+
+
+class ApplicationPackage(object):
+    def __init__(self, name: str, disk_folder: str) -> None:
+        """
+        Vespa Application Package.
+
+        :param name: Application name.
+        :param disk_folder: Absolute path of the folder containing the application files.
+        """
+        self.name = name
+        self.disk_folder = disk_folder
+        self.container = None
+
+    def run_vespa_engine_container(self, container_memory: str = "4G"):
+        """
+        Run a vespa container.
+
+        :param container_memory: Memory limit of the container
+        :return:
+        """
+        client = docker.from_env()
+        self.container = client.containers.run(
+            "vespaengine/vespa",
+            detach=True,
+            mem_limit=container_memory,
+            name=self.name,
+            hostname=self.name,
+            privileged=True,
+            volumes={self.disk_folder: {"bind": "/app", "mode": "rw"}},
+            ports={8080: 8080, 19112: 19112},
+        )
+
+    def check_configuration_server(self) -> bool:
+        """
+        Check if configuration server is running and ready for deployment
+
+        :return: True if configuration server is running.
+        """
+        return (
+            self.container.exec_run(
+                "bash -c 'curl -s --head http://localhost:19071/ApplicationStatus'"
+            )
+            .output.decode("utf-8")
+            .split("\r\n")[0]
+            == "HTTP/1.1 200 OK"
+        )
+
+    def deploy_application(self):
+        return self.container.exec_run(
+            "bash -c '/opt/vespa/bin/vespa-deploy prepare /app/application && /opt/vespa/bin/vespa-deploy activate'"
+        )

--- a/python/vespa/vespa/templates/hosts.xml
+++ b/python/vespa/vespa/templates/hosts.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<hosts>
+    <host name="localhost">
+        <alias>node1</alias>
+    </host>
+</hosts>

--- a/python/vespa/vespa/templates/schema.txt
+++ b/python/vespa/vespa/templates/schema.txt
@@ -17,7 +17,7 @@ schema {{ schema_name }} {
     }
 {% endfor %}
 {% for key, value in rank_profiles.items() %}
-    rank-profile {{ key }} {
+    rank-profile {{ key }}{% if value.inherits %} inherits {{ value.inherits }}{% endif %} {
         {% if value.first_phase %}
         first-phase {
             expression: {{ value.first_phase }}

--- a/python/vespa/vespa/templates/schema.txt
+++ b/python/vespa/vespa/templates/schema.txt
@@ -1,0 +1,28 @@
+schema {{ schema_name }} {
+    document {{ document_name }} {
+    {% for field in fields %}
+        field {{ field.name }} type {{ field.type }} {
+            {% if field.indexing %}
+            indexing: {{ field.indexing_to_text }}
+            {% endif %}
+            {% if field.index %}
+            index: {{ field.index }}
+            {% endif %}
+        }
+        {% endfor %}
+    }
+{% for key, value in fieldsets.items() %}
+    fieldset {{ key }} {
+        fields: {{ value.fields_to_text }}
+    }
+{% endfor %}
+{% for key, value in rank_profiles.items() %}
+    rank-profile {{ key }} {
+        {% if value.first_phase %}
+        first-phase {
+            expression: {{ value.first_phase }}
+        }
+        {% endif %}
+    }
+{% endfor %}
+}

--- a/python/vespa/vespa/templates/services.xml
+++ b/python/vespa/vespa/templates/services.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services version="1.0">
-    <container id="{{ application_name }}" version="1.0">
+    <container id="{{ application_name }}_container" version="1.0">
         <search></search>
         <document-processing></document-processing>
         <document-api></document-api>
     </container>
-    <content id="{{ application_name }}" version="1.0">
+    <content id="{{ application_name }}_content" version="1.0">
         <redundancy reply-after="1">1</redundancy>
         <documents>
             <document type="{{ document_name }}" mode="index"></document>
-            <document-processing cluster="{{ application_name }}"></document-processing>
+            <document-processing cluster="{{ application_name }}_container"></document-processing>
         </documents>
         <nodes>
             <node distribution-key="0" hostalias="node1"></node>

--- a/python/vespa/vespa/templates/services.xml
+++ b/python/vespa/vespa/templates/services.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services version="1.0">
+    <container id="{{ application_name }}" version="1.0">
+        <search></search>
+        <document-processing></document-processing>
+        <document-api></document-api>
+    </container>
+    <content id="{{ application_name }}" version="1.0">
+        <redundancy reply-after="1">1</redundancy>
+        <documents>
+            <document type="{{ document_name }}" mode="index"></document>
+            <document-processing cluster="{{ application_name }}"></document-processing>
+        </documents>
+        <nodes>
+            <node distribution-key="0" hostalias="node1"></node>
+        </nodes>
+    </content>
+</services>

--- a/python/vespa/vespa/templates/services.xml
+++ b/python/vespa/vespa/templates/services.xml
@@ -2,14 +2,12 @@
 <services version="1.0">
     <container id="{{ application_name }}_container" version="1.0">
         <search></search>
-        <document-processing></document-processing>
         <document-api></document-api>
     </container>
     <content id="{{ application_name }}_content" version="1.0">
         <redundancy reply-after="1">1</redundancy>
         <documents>
             <document type="{{ document_name }}" mode="index"></document>
-            <document-processing cluster="{{ application_name }}_container"></document-processing>
         </documents>
         <nodes>
             <node distribution-key="0" hostalias="node1"></node>

--- a/python/vespa/vespa/test_package.py
+++ b/python/vespa/vespa/test_package.py
@@ -226,14 +226,12 @@ class TestApplicationPackage(unittest.TestCase):
             '<services version="1.0">\n'
             '    <container id="test_app_container" version="1.0">\n'
             "        <search></search>\n"
-            "        <document-processing></document-processing>\n"
             "        <document-api></document-api>\n"
             "    </container>\n"
             '    <content id="test_app_content" version="1.0">\n'
             '        <redundancy reply-after="1">1</redundancy>\n'
             "        <documents>\n"
             '            <document type="msmarco" mode="index"></document>\n'
-            '            <document-processing cluster="test_app_container"></document-processing>\n'
             "        </documents>\n"
             "        <nodes>\n"
             '            <node distribution-key="0" hostalias="node1"></node>\n'

--- a/python/vespa/vespa/test_package.py
+++ b/python/vespa/vespa/test_package.py
@@ -1,6 +1,6 @@
 import unittest
 
-from vespa.package import Field
+from vespa.package import Field, Document, FieldSet
 
 
 class TestField(unittest.TestCase):
@@ -42,4 +42,41 @@ class TestField(unittest.TestCase):
             ),
         )
         self.assertEqual(field, Field.from_dict(field.to_dict))
-        print(str(field))
+
+
+class TestDocument(unittest.TestCase):
+    def test_empty_document(self):
+        document = Document()
+        self.assertEqual(document.fields, [])
+        self.assertEqual(document.to_dict, {"fields": []})
+        self.assertEqual(document, Document.from_dict(document.to_dict))
+
+    def test_document_one_field(self):
+        document = Document()
+        field = Field(name="test_name", type="string")
+        document.add_fields(field)
+        self.assertEqual(document.fields, [field])
+        self.assertEqual(document, Document.from_dict(document.to_dict))
+        self.assertEqual(document, Document([field]))
+
+    def test_document_two_fields(self):
+        document = Document()
+        field_1 = Field(name="test_name", type="string")
+        field_2 = Field(
+            name="body",
+            type="string",
+            indexing=["index", "summary"],
+            index=["enable-bm25"],
+        )
+        document.add_fields(field_1, field_2)
+        self.assertEqual(document.fields, [field_1, field_2])
+        self.assertEqual(document, Document.from_dict(document.to_dict))
+        self.assertEqual(document, Document([field_1, field_2]))
+
+
+class TestFieldSet(unittest.TestCase):
+    def test_fieldset(self):
+        field_set = FieldSet(name="default", fields=["title", "body"])
+        self.assertEqual(field_set.name, "default")
+        self.assertEqual(field_set.fields, ["title", "body"])
+        self.assertEqual(field_set, FieldSet.from_dict(field_set.to_dict))

--- a/python/vespa/vespa/test_package.py
+++ b/python/vespa/vespa/test_package.py
@@ -1,6 +1,6 @@
 import unittest
 
-from vespa.package import Field, Document, FieldSet
+from vespa.package import Field, Document, FieldSet, RankProfile, Schema
 
 
 class TestField(unittest.TestCase):
@@ -80,3 +80,40 @@ class TestFieldSet(unittest.TestCase):
         self.assertEqual(field_set.name, "default")
         self.assertEqual(field_set.fields, ["title", "body"])
         self.assertEqual(field_set, FieldSet.from_dict(field_set.to_dict))
+
+
+class TestRankProfile(unittest.TestCase):
+    def test_rank_profile(self):
+        rank_profile = RankProfile(name="bm25", first_phase="bm25(title) + bm25(body)")
+        self.assertEqual(rank_profile.name, "bm25")
+        self.assertEqual(rank_profile.first_phase, "bm25(title) + bm25(body)")
+        self.assertEqual(rank_profile, RankProfile.from_dict(rank_profile.to_dict))
+
+
+class TestSchema(unittest.TestCase):
+    def test_schema(self):
+        schema = Schema(
+            name="test_schema",
+            document=Document(fields=[Field(name="test_name", type="string")]),
+            fieldsets=[FieldSet(name="default", fields=["title", "body"])],
+            rank_profiles=[
+                RankProfile(name="bm25", first_phase="bm25(title) + bm25(body)")
+            ],
+        )
+        self.assertEqual(schema, Schema.from_dict(schema.to_dict))
+        self.assertDictEqual(
+            schema.rank_profiles,
+            {"bm25": RankProfile(name="bm25", first_phase="bm25(title) + bm25(body)")},
+        )
+        schema.add_rank_profile(
+            RankProfile(name="default", first_phase="NativeRank(title)")
+        )
+        self.assertDictEqual(
+            schema.rank_profiles,
+            {
+                "bm25": RankProfile(
+                    name="bm25", first_phase="bm25(title) + bm25(body)"
+                ),
+                "default": RankProfile(name="default", first_phase="NativeRank(title)"),
+            },
+        )

--- a/python/vespa/vespa/test_package.py
+++ b/python/vespa/vespa/test_package.py
@@ -1,0 +1,45 @@
+import unittest
+
+from vespa.package import Field
+
+
+class TestField(unittest.TestCase):
+    def test_field_name_type(self):
+        field = Field(name="test_name", type="string")
+        self.assertEqual(field.name, "test_name")
+        self.assertEqual(field.type, "string")
+        self.assertEqual(field.to_dict, {"name": "test_name", "type": "string"})
+        self.assertEqual(field, Field(name="test_name", type="string"))
+        self.assertEqual(field, Field.from_dict(field.to_dict))
+
+    def test_field_name_type_indexing_index(self):
+        field = Field(
+            name="body",
+            type="string",
+            indexing=["index", "summary"],
+            index=["enable-bm25"],
+        )
+        self.assertEqual(field.name, "body")
+        self.assertEqual(field.type, "string")
+        self.assertEqual(field.indexing, ["index", "summary"])
+        self.assertEqual(field.index, ["enable-bm25"])
+        self.assertEqual(
+            field.to_dict,
+            {
+                "name": "body",
+                "type": "string",
+                "indexing": ["index", "summary"],
+                "index": ["enable-bm25"],
+            },
+        )
+        self.assertEqual(
+            field,
+            Field(
+                name="body",
+                type="string",
+                indexing=["index", "summary"],
+                index=["enable-bm25"],
+            ),
+        )
+        self.assertEqual(field, Field.from_dict(field.to_dict))
+        print(str(field))

--- a/python/vespa/vespa/test_package.py
+++ b/python/vespa/vespa/test_package.py
@@ -75,7 +75,7 @@ class TestDocument(unittest.TestCase):
             name="body",
             type="string",
             indexing=["index", "summary"],
-            index=["enable-bm25"],
+            index="enable-bm25",
         )
         document.add_fields(field_1, field_2)
         self.assertEqual(document.fields, [field_1, field_2])
@@ -188,3 +188,34 @@ class TestApplicationPackage(unittest.TestCase):
                           "}"
         self.assertEqual(self.app_package.schema_to_text, expected_result)
 
+    def test_hosts_to_text(self):
+        expected_result = '<?xml version="1.0" encoding="utf-8" ?>\n' \
+                          '<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n' \
+                          '<hosts>\n' \
+                          '    <host name="localhost">\n' \
+                          '        <alias>node1</alias>\n' \
+                          '    </host>\n' \
+                          '</hosts>'
+        self.assertEqual(self.app_package.hosts_to_text, expected_result)
+
+    def test_services_to_text(self):
+        expected_result = '<?xml version="1.0" encoding="UTF-8"?>\n' \
+                          '<services version="1.0">\n' \
+                          '    <container id="test_app" version="1.0">\n' \
+                          '        <search></search>\n' \
+                          '        <document-processing></document-processing>\n' \
+                          '        <document-api></document-api>\n' \
+                          '    </container>\n' \
+                          '    <content id="test_app" version="1.0">\n' \
+                          '        <redundancy reply-after="1">1</redundancy>\n' \
+                          '        <documents>\n' \
+                          '            <document type="msmarco" mode="index"></document>\n' \
+                          '            <document-processing cluster="test_app"></document-processing>\n' \
+                          '        </documents>\n' \
+                          '        <nodes>\n' \
+                          '            <node distribution-key="0" hostalias="node1"></node>\n' \
+                          '        </nodes>\n' \
+                          '    </content>\n' \
+                          '</services>'
+
+        self.assertEqual(self.app_package.services_to_text, expected_result)

--- a/python/vespa/vespa/test_package.py
+++ b/python/vespa/vespa/test_package.py
@@ -100,7 +100,9 @@ class TestRankProfile(unittest.TestCase):
         self.assertEqual(rank_profile, RankProfile.from_dict(rank_profile.to_dict))
 
     def test_rank_profile_inherits(self):
-        rank_profile = RankProfile(name="bm25", first_phase="bm25(title) + bm25(body)", inherits="default")
+        rank_profile = RankProfile(
+            name="bm25", first_phase="bm25(title) + bm25(body)", inherits="default"
+        )
         self.assertEqual(rank_profile.name, "bm25")
         self.assertEqual(rank_profile.first_phase, "bm25(title) + bm25(body)")
         self.assertEqual(rank_profile, RankProfile.from_dict(rank_profile.to_dict))
@@ -159,7 +161,11 @@ class TestApplicationPackage(unittest.TestCase):
             fieldsets=[FieldSet(name="default", fields=["title", "body"])],
             rank_profiles=[
                 RankProfile(name="default", first_phase="nativeRank(title, body)"),
-                RankProfile(name="bm25", first_phase="bm25(title) + bm25(body)", inherits="default")
+                RankProfile(
+                    name="bm25",
+                    first_phase="bm25(title) + bm25(body)",
+                    inherits="default",
+                ),
             ],
         )
         self.app_package = ApplicationPackage(name="test_app", schema=test_schema)
@@ -170,64 +176,70 @@ class TestApplicationPackage(unittest.TestCase):
         )
 
     def test_schema_to_text(self):
-        expected_result = "schema msmarco {\n" \
-                          "    document msmarco {\n" \
-                          "        field id type string {\n" \
-                          "            indexing: attribute | summary\n" \
-                          "        }\n" \
-                          "        field title type string {\n" \
-                          "            indexing: index | summary\n" \
-                          "            index: enable-bm25\n" \
-                          "        }\n" \
-                          "        field body type string {\n" \
-                          "            indexing: index | summary\n" \
-                          "            index: enable-bm25\n" \
-                          "        }\n" \
-                          "    }\n" \
-                          "    fieldset default {\n" \
-                          "        fields: title, body\n" \
-                          "    }\n" \
-                          "    rank-profile default {\n" \
-                          "        first-phase {\n" \
-                          "            expression: nativeRank(title, body)\n" \
-                          "        }\n" \
-                          "    }\n" \
-                          "    rank-profile bm25 inherits default {\n" \
-                          "        first-phase {\n" \
-                          "            expression: bm25(title) + bm25(body)\n" \
-                          "        }\n" \
-                          "    }\n" \
-                          "}"
+        expected_result = (
+            "schema msmarco {\n"
+            "    document msmarco {\n"
+            "        field id type string {\n"
+            "            indexing: attribute | summary\n"
+            "        }\n"
+            "        field title type string {\n"
+            "            indexing: index | summary\n"
+            "            index: enable-bm25\n"
+            "        }\n"
+            "        field body type string {\n"
+            "            indexing: index | summary\n"
+            "            index: enable-bm25\n"
+            "        }\n"
+            "    }\n"
+            "    fieldset default {\n"
+            "        fields: title, body\n"
+            "    }\n"
+            "    rank-profile default {\n"
+            "        first-phase {\n"
+            "            expression: nativeRank(title, body)\n"
+            "        }\n"
+            "    }\n"
+            "    rank-profile bm25 inherits default {\n"
+            "        first-phase {\n"
+            "            expression: bm25(title) + bm25(body)\n"
+            "        }\n"
+            "    }\n"
+            "}"
+        )
         self.assertEqual(self.app_package.schema_to_text, expected_result)
 
     def test_hosts_to_text(self):
-        expected_result = '<?xml version="1.0" encoding="utf-8" ?>\n' \
-                          '<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n' \
-                          '<hosts>\n' \
-                          '    <host name="localhost">\n' \
-                          '        <alias>node1</alias>\n' \
-                          '    </host>\n' \
-                          '</hosts>'
+        expected_result = (
+            '<?xml version="1.0" encoding="utf-8" ?>\n'
+            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<hosts>\n"
+            '    <host name="localhost">\n'
+            "        <alias>node1</alias>\n"
+            "    </host>\n"
+            "</hosts>"
+        )
         self.assertEqual(self.app_package.hosts_to_text, expected_result)
 
     def test_services_to_text(self):
-        expected_result = '<?xml version="1.0" encoding="UTF-8"?>\n' \
-                          '<services version="1.0">\n' \
-                          '    <container id="test_app_container" version="1.0">\n' \
-                          '        <search></search>\n' \
-                          '        <document-processing></document-processing>\n' \
-                          '        <document-api></document-api>\n' \
-                          '    </container>\n' \
-                          '    <content id="test_app_content" version="1.0">\n' \
-                          '        <redundancy reply-after="1">1</redundancy>\n' \
-                          '        <documents>\n' \
-                          '            <document type="msmarco" mode="index"></document>\n' \
-                          '            <document-processing cluster="test_app_container"></document-processing>\n' \
-                          '        </documents>\n' \
-                          '        <nodes>\n' \
-                          '            <node distribution-key="0" hostalias="node1"></node>\n' \
-                          '        </nodes>\n' \
-                          '    </content>\n' \
-                          '</services>'
+        expected_result = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<services version="1.0">\n'
+            '    <container id="test_app_container" version="1.0">\n'
+            "        <search></search>\n"
+            "        <document-processing></document-processing>\n"
+            "        <document-api></document-api>\n"
+            "    </container>\n"
+            '    <content id="test_app_content" version="1.0">\n'
+            '        <redundancy reply-after="1">1</redundancy>\n'
+            "        <documents>\n"
+            '            <document type="msmarco" mode="index"></document>\n'
+            '            <document-processing cluster="test_app_container"></document-processing>\n'
+            "        </documents>\n"
+            "        <nodes>\n"
+            '            <node distribution-key="0" hostalias="node1"></node>\n'
+            "        </nodes>\n"
+            "    </content>\n"
+            "</services>"
+        )
 
         self.assertEqual(self.app_package.services_to_text, expected_result)


### PR DESCRIPTION
This PR contains:
* Code and unit tests to create application package files (package.py and test_package.py) 
* Jinja 2 templates for schema.sd, hosts.xml and services.xml
* Jupyter notebook showing a full working example of creating a package and deploying it locally from python.
* Vespa Cloud deployment will be addressed in a future sprint.
* Implemented json serialization for every python object to be able to save and load the application from python.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
