### PR TITLE
Use correct value type for onnx range operator 

### DIFF
--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/Range.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/operations/Range.java
@@ -51,7 +51,7 @@ public class Range extends IntermediateOperation {
         delta = getConstantInput(2, "delta");
         elements = (long) Math.ceil((limit - start) / delta);
 
-        OrderedTensorType type = new OrderedTensorType.Builder()
+        OrderedTensorType type = new OrderedTensorType.Builder(inputs.get(0).type().get().type().valueType())
                 .add(TensorType.Dimension.indexed(vespaName(), elements))
                 .build();
         return type;


### PR DESCRIPTION
@bratseth Please review.
@havardpe FYI.

The tensor value type was not correctly propagated through this range operator that was recently introduced. This causes downstream operations to use double vs float operations, which is not particularly efficient.