### PR TITLE
Handle an existing spantree in exactmatch

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/ExactMatch.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/ExactMatch.java
@@ -58,14 +58,13 @@ public class ExactMatch extends Processor {
             field.addQueryCommand("word");
         } else { // exact
             String exactTerminator = DEFAULT_EXACT_TERMINATOR;
-            if (field.getMatching().getExactMatchTerminator() != null &&
-                ! field.getMatching().getExactMatchTerminator().equals(""))
-            {
+            if (field.getMatching().getExactMatchTerminator() != null
+                && ! field.getMatching().getExactMatchTerminator().equals("")) {
                 exactTerminator = field.getMatching().getExactMatchTerminator();
             } else {
                 warn(search, field,
-                     "With 'exact' matching, an exact-terminator is needed (using \""
-                     + exactTerminator +"\" as terminator)");
+                     "With 'exact' matching, an exact-terminator is needed " +
+                     "(using '" + exactTerminator +"' as terminator)");
             }
             field.addQueryCommand("exact " + exactTerminator);
 
@@ -103,6 +102,7 @@ public class ExactMatch extends Processor {
             }
             return exp;
         }
+
     }
 
 }

--- a/document/src/main/java/com/yahoo/document/annotation/SpanTree.java
+++ b/document/src/main/java/com/yahoo/document/annotation/SpanTree.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * A SpanTree holds a root node of a tree of SpanNodes, and a List of Annotations pointing to these nodes
  * or each other.&nbsp;It also has a name.
  *
- * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
+ * @author Einar M R Rosenvinge
  * @see com.yahoo.document.annotation.SpanNode
  * @see com.yahoo.document.annotation.Annotation
  */
@@ -39,8 +39,7 @@ public class SpanTree implements Iterable<Annotation>, SpanNodeParent, Comparabl
     /**
      * WARNING!&nbsp;Only to be used by deserializers!&nbsp;Creates an empty SpanTree instance.
      */
-    public SpanTree() {
-    }
+    public SpanTree() { }
 
     /**
      * Creates a new SpanTree with a given root node.
@@ -227,18 +226,12 @@ public class SpanTree implements Iterable<Annotation>, SpanNodeParent, Comparabl
         root.setParent(this);
     }
 
-    /**
-     * Returns the name of this span tree.
-     * @return the name of this span tree.
-     */
+    /** Returns the name of this span tree. */
     public String getName() {
         return name;
     }
 
-    /**
-     * Returns the root node of this span tree.
-     * @return the root node of this span tree.
-     */
+    /** Returns the root node of this span tree. */
     public SpanNode getRoot() {
         return root;
     }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExactExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExactExpression.java
@@ -27,24 +27,30 @@ public final class ExactExpression extends Expression {
     @Override
     protected void doExecute(ExecutionContext ctx) {
         StringFieldValue input = (StringFieldValue)ctx.getValue();
-        if (input.getString().isEmpty()) {
-            return;
-        }
+        if (input.getString().isEmpty()) return;
+
         StringFieldValue output = input.clone();
         ctx.setValue(output);
 
         String prev = output.getString();
         String next = toLowerCase(prev);
 
-        SpanList root = new SpanList();
-        SpanTree tree = new SpanTree(SpanTrees.LINGUISTICS, root);
+        SpanTree tree = output.getSpanTree(SpanTrees.LINGUISTICS);
+        SpanList root;
+        if (tree == null) {
+            root = new SpanList();
+            tree = new SpanTree(SpanTrees.LINGUISTICS, root);
+            output.setSpanTree(tree);
+        }
+        else {
+            root = (SpanList)tree.getRoot();
+        }
         SpanNode node = new Span(0, prev.length());
         tree.annotate(node, new Annotation(AnnotationTypes.TERM,
                                            next.equals(prev) ? null : new StringFieldValue(next)));
         tree.annotate(node, new Annotation(AnnotationTypes.TOKEN_TYPE,
                                            new IntegerFieldValue(TokenType.ALPHABETIC.getValue())));
         root.add(node);
-        output.setSpanTree(tree);
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/FlattenExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/FlattenExpression.java
@@ -24,6 +24,7 @@ public final class FlattenExpression extends Expression {
     public FlattenExpression() {
         super(DataType.STRING);
     }
+
     @Override
     protected void doExecute(ExecutionContext ctx) {
         StringFieldValue input = (StringFieldValue)ctx.getValue();


### PR DESCRIPTION
This may happen if a field which is indexed is used as an input for another field indexed as exact match.
