### PR TITLE
make tenant node quota adjustable by feature flag 

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -289,6 +289,13 @@ public class Flags {
             ZONE_ID
     );
 
+    public static final UnboundIntFlag TENANT_NODE_QUOTA = defineIntFlag(
+            "tenant-node-quota", 5,
+            "The number of nodes a tenant is allowed to request",
+            "Takes effect on next deployment",
+            APPLICATION_ID
+    );
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, String description,
                                                        String modificationEffect, FetchVector.Dimension... dimensions) {


### PR DESCRIPTION
Perhaps too simple? But it will allow us to get rid of the strange hashcodes in the next step (for which one can easily produce other matching names ...)