### PR TITLE
Revert "Hide implementation of deployment and endpoint"

### DIFF
--- a/cloud-tenant-cd/src/main/java/ai/vespa/hosted/cd/impl/VespaTestRuntime.java
+++ b/cloud-tenant-cd/src/main/java/ai/vespa/hosted/cd/impl/VespaTestRuntime.java
@@ -7,6 +7,7 @@ import ai.vespa.hosted.api.Properties;
 import ai.vespa.hosted.api.TestConfig;
 import ai.vespa.hosted.cd.Deployment;
 import ai.vespa.hosted.cd.TestRuntime;
+import ai.vespa.hosted.cd.impl.http.HttpDeployment;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -36,7 +37,7 @@ public class VespaTestRuntime implements TestRuntime {
     }
     private VespaTestRuntime(TestConfig config) {
         this.config = config;
-        this.deploymentToTest = new CloudDeployment(config.deployments().get(config.zone()), new ai.vespa.hosted.auth.EndpointAuthenticator(config.system()));
+        this.deploymentToTest = new HttpDeployment(config.deployments().get(config.zone()), new ai.vespa.hosted.auth.EndpointAuthenticator(config.system()));
     }
 
     @Override

--- a/cloud-tenant-cd/src/main/java/ai/vespa/hosted/cd/impl/http/HttpDeployment.java
+++ b/cloud-tenant-cd/src/main/java/ai/vespa/hosted/cd/impl/http/HttpDeployment.java
@@ -1,5 +1,5 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package ai.vespa.hosted.cd.impl;
+package ai.vespa.hosted.cd.impl.http;
 
 import ai.vespa.hosted.api.EndpointAuthenticator;
 import ai.vespa.hosted.cd.Deployment;
@@ -11,19 +11,19 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 /**
- * A remote deployment of a Vespa application, reachable over HTTP. Contains {@link CloudEndpoint}s.
+ * A remote deployment of a Vespa application, reachable over HTTP. Contains {@link HttpEndpoint}s.
  *
  * @author jonmv
  */
-class CloudDeployment implements Deployment {
+public class HttpDeployment implements Deployment {
 
     private final Map<String, Endpoint> endpoints;
 
     /** Creates a representation of the given deployment endpoints, using the authenticator for data plane access. */
-    CloudDeployment(Map<String, URI> endpoints, EndpointAuthenticator authenticator) {
+    public HttpDeployment(Map<String, URI> endpoints, EndpointAuthenticator authenticator) {
         this.endpoints = endpoints.entrySet().stream()
                 .collect(Collectors.toUnmodifiableMap(entry -> entry.getKey(),
-                                                      entry -> new CloudEndpoint(entry.getValue(), authenticator)));
+                                                      entry -> new HttpEndpoint(entry.getValue(), authenticator)));
     }
 
     @Override

--- a/cloud-tenant-cd/src/main/java/ai/vespa/hosted/cd/impl/http/HttpEndpoint.java
+++ b/cloud-tenant-cd/src/main/java/ai/vespa/hosted/cd/impl/http/HttpEndpoint.java
@@ -1,5 +1,5 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package ai.vespa.hosted.cd.impl;
+package ai.vespa.hosted.cd.impl.http;
 
 import ai.vespa.hosted.api.EndpointAuthenticator;
 import ai.vespa.hosted.cd.Endpoint;
@@ -19,17 +19,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A remote endpoint in a {@link CloudDeployment} of a Vespa application, reachable over HTTP.
+ * A remote endpoint in a {@link HttpDeployment} of a Vespa application, reachable over HTTP.
  *
  * @author jonmv
  */
-class CloudEndpoint implements Endpoint {
+public class HttpEndpoint implements Endpoint {
 
     private final URI endpoint;
     private final HttpClient client;
     private final EndpointAuthenticator authenticator;
 
-    CloudEndpoint(URI endpoint, EndpointAuthenticator authenticator) {
+    public HttpEndpoint(URI endpoint, EndpointAuthenticator authenticator) {
         this.endpoint = requireNonNull(endpoint);
         this.authenticator = requireNonNull(authenticator);
         SSLParameters sslParameters = new SSLParameters();


### PR DESCRIPTION
Reverts vespa-engine/vespa#13705

 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project systemtest-framework: Compilation failure: Compilation failure: 
10:26:31 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/tenant/systemtest-framework/src/main/java/com/yahoo/vespa/tenant/systemtest/TestConfig.java:[6,36] package ai.vespa.hosted.cd.impl.http does not exist
10:26:31 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/tenant/systemtest-framework/src/main/java/com/yahoo/vespa/tenant/systemtest/Endpoint.java:[4,36] package ai.vespa.hosted.cd.impl.http does not exist
10:26:31 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/tenant/systemtest-framework/src/main/java/com/yahoo/vespa/tenant/systemtest/base/impl/VespaEndpointImpl.java:[5,36] package ai.vespa.hosted.cd.impl.http does not exist
10:26:31 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/tenant/systemtest-framework/src/main/java/com/yahoo/vespa/tenant/systemtest/TestConfig.java:[58,36] cannot find symbol
10:26:31 [ERROR]   symbol:   class HttpEndpoint
10:26:31 [ERROR]   location: class com.yahoo.vespa.tenant.systemtest.TestConfig
10:26:31 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/tenant/systemtest-framework/src/main/java/com/yahoo/vespa/tenant/systemtest/Endpoint.java:[42,28] cannot find symbol
10:26:31 [ERROR]   symbol:   class HttpEndpoint
10:26:31 [ERROR]   location: class com.yahoo.vespa.tenant.systemtest.Endpoint
10:26:31 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/tenant/systemtest-framework/src/main/java/com/yahoo/vespa/tenant/systemtest/base/impl/VespaEndpointImpl.java:[48,18] cannot find symbol
10:26:31 [ERROR]   symbol:   class HttpEndpoint
10:26:31 [ERROR]   location: class com.yahoo.vespa.tenant.systemtest.base.impl.VespaEndpointImpl
10:26:31 [ERROR] -> [Help 1]