### PR TITLE
filter invalid UTF-8 (including encoded surrogates) to make protobuf …

### DIFF
--- a/logd/src/logd/proto_converter.cpp
+++ b/logd/src/logd/proto_converter.cpp
@@ -62,13 +62,12 @@ ProtoConverter::log_message_to_proto(const LogMessage& message, ProtoLogMessage&
     proto.set_level(convert_level(message.level()));
     const std::string &payload = message.payload();
     vespalib::Utf8Reader reader(payload.c_str(), payload.size());
-    vespalib::string tmp;
-    vespalib::Utf8Writer writer(tmp);
+    std::string filtered_payload;
+    vespalib::Utf8Writer writer(filtered_payload);
     while (reader.hasMore()) {
         uint32_t ch = reader.getChar();
         writer.putChar(ch);
     }
-    std::string filtered_payload(tmp.c_str(), tmp.size());
     proto.set_payload(filtered_payload);
 }
 

--- a/logd/src/logd/proto_converter.cpp
+++ b/logd/src/logd/proto_converter.cpp
@@ -66,10 +66,6 @@ ProtoConverter::log_message_to_proto(const LogMessage& message, ProtoLogMessage&
     vespalib::Utf8Writer writer(tmp);
     while (reader.hasMore()) {
         uint32_t ch = reader.getChar();
-        // surrogates not accepted
-        if (ch >= 0xD800 && ch <= 0xDFFF) {
-            ch = vespalib::Utf8::REPLACEMENT_CHAR;
-        }
         writer.putChar(ch);
     }
     std::string filtered_payload(tmp.c_str(), tmp.size());

--- a/logd/src/logd/proto_converter.cpp
+++ b/logd/src/logd/proto_converter.cpp
@@ -60,15 +60,7 @@ ProtoConverter::log_message_to_proto(const LogMessage& message, ProtoLogMessage&
     proto.set_service(message.service());
     proto.set_component(message.component());
     proto.set_level(convert_level(message.level()));
-    const std::string &payload = message.payload();
-    vespalib::Utf8Reader reader(payload.c_str(), payload.size());
-    std::string filtered_payload;
-    vespalib::Utf8Writer writer(filtered_payload);
-    while (reader.hasMore()) {
-        uint32_t ch = reader.getChar();
-        writer.putChar(ch);
-    }
-    proto.set_payload(filtered_payload);
+    proto.set_payload(vespalib::Utf8::filter_invalid_sequences(message.payload()));
 }
 
 }

--- a/logd/src/tests/proto_converter/proto_converter_test.cpp
+++ b/logd/src/tests/proto_converter/proto_converter_test.cpp
@@ -90,13 +90,13 @@ TEST_F(LogRequestTest, log_messages_are_converted_to_request)
 TEST_F(LogRequestTest, invalid_utf8_is_filtered)
 {
     messages.emplace_back(12345, "foo_host", 3, 5, "foo_service", "foo_component", Logger::info,
-        "valid: \xE2\x82\xAC and \xEF\xBF\xBA; invalid: \xCC surrogate \xED\xBF\xBF overlong \xC1\x81 end"
+        "valid: \xE2\x82\xAC and \xEF\xBF\xBA; semi-valid: \xED\xA0\xBD\xED\xB8\x80; invalid: \xCC surrogate \xED\xBF\xBF overlong \xC1\x81 end"
     );
     convert();
     EXPECT_EQ(1, proto.log_messages_size());
     expect_proto_log_message_equal(12345, "foo_host", 3, 5, "foo_service", "foo_component",
         ProtoLogLevel::LogMessage_Level_INFO,
-        "valid: \xE2\x82\xAC and \xEF\xBF\xBA; invalid: " FFFD " surrogate " FFFD " overlong " FFFD FFFD " end",
+        "valid: \xE2\x82\xAC and \xEF\xBF\xBA; semi-valid: " FFFD FFFD "; invalid: " FFFD " surrogate " FFFD " overlong " FFFD FFFD " end",
         proto.log_messages(0));
 }
 

--- a/vespalib/src/vespa/vespalib/text/utf8.cpp
+++ b/vespalib/src/vespa/vespalib/text/utf8.cpp
@@ -233,5 +233,20 @@ Utf8Writer<Target>::putChar(uint32_t codepoint)
 template class Utf8Writer<vespalib::string>;
 template class Utf8Writer<std::string>;
 
+template <typename T>
+T Utf8::filter_invalid_sequences(const T& input)
+{
+    T retval;
+    Utf8Reader reader(input.c_str(), input.size());
+    Utf8Writer writer(retval);
+    while (reader.hasMore()) {
+        uint32_t ch = reader.getChar();
+        writer.putChar(ch);
+    }
+    return retval;
+}
 
-} // namespace vespalib
+template vespalib::string Utf8::filter_invalid_sequences(const vespalib::string&);
+template std::string Utf8::filter_invalid_sequences(const std::string&);
+
+} // namespace

--- a/vespalib/src/vespa/vespalib/text/utf8.cpp
+++ b/vespalib/src/vespa/vespalib/text/utf8.cpp
@@ -175,8 +175,9 @@ Utf8ReaderForZTS::getComplexChar(unsigned char firstbyte, uint32_t fallback)
 }
 
 
-Utf8Writer&
-Utf8Writer::putChar(uint32_t codepoint)
+template <typename Target>
+Utf8Writer<Target>&
+Utf8Writer<Target>::putChar(uint32_t codepoint)
 {
     if (codepoint < 0x80) {
         _target.push_back((char)codepoint);
@@ -228,6 +229,9 @@ Utf8Writer::putChar(uint32_t codepoint)
     }
     return *this;
 }
+
+template class Utf8Writer<vespalib::string>;
+template class Utf8Writer<std::string>;
 
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/text/utf8.h
+++ b/vespalib/src/vespa/vespalib/text/utf8.h
@@ -321,9 +321,10 @@ public:
 /**
  * @brief Writer class that appends UTF-8 characters to a string
  **/
+template <typename Target>
 class Utf8Writer : public Utf8
 {
-    string &_target;
+    Target &_target;
 public:
     /**
      * construct a writer appending to the given string
@@ -331,7 +332,7 @@ public:
      * that the writer will append to.  Must be writable
      * and must be kept alive while the writer is active.
      **/
-    Utf8Writer(string &target) : _target(target) {}
+    Utf8Writer(Target &target) : _target(target) {}
 
     /**
      * append the given character to the target string.

--- a/vespalib/src/vespa/vespalib/text/utf8.h
+++ b/vespalib/src/vespa/vespalib/text/utf8.h
@@ -155,7 +155,7 @@ protected:
         first_high_surrogate = 0xD800,
         last_high_surrogate = 0xDBFF,
         first_low_surrogate = 0xDC00,
-        last_low_surrogate = 0xDCFF
+        last_low_surrogate = 0xDFFF
     };
 };
 

--- a/vespalib/src/vespa/vespalib/text/utf8.h
+++ b/vespalib/src/vespa/vespalib/text/utf8.h
@@ -28,6 +28,15 @@ public:
     };
 
     /**
+     * Filter a string (std::string or vespalib::string)
+     * and replace any invalid UTF8 sequences with the
+     * standard replacement char U+FFFD; note that any
+     * UTF-8 encoded surrogates are also considered invalid.
+     **/
+    template <typename T>
+    static T filter_invalid_sequences(const T& input);
+
+    /**
      * check if a byte is valid as the first byte of an UTF-8 character.
      * @param c the byte to be checked
      * @return true if a valid UTF-8 character can start with this byte


### PR DESCRIPTION
…happy

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
@havardpe @vekterli FYI

if any of you know where we send "string" type fields through protobuf and it's possible that we can produce invalid UTF-8, we will need to add similar filtering there.