### PR TITLE
Only sort once during ideal group calculations

### DIFF
--- a/vdslib/src/vespa/vdslib/distribution/distribution.cpp
+++ b/vdslib/src/vespa/vdslib/distribution/distribution.cpp
@@ -351,6 +351,7 @@ namespace {
         const Group* _group;
         double _score;
 
+        ScoredGroup() : _group(nullptr), _score(0) {}
         ScoredGroup(const Group* group, double score)
             : _group(group), _score(score) {}
 
@@ -430,40 +431,36 @@ Distribution::getIdealGroups(const document::BucketId& bucket,
                              std::vector<ResultGroup>& results) const
 {
     if (parent.isLeafGroup()) {
-        results.push_back(ResultGroup(parent, redundancy));
+        results.emplace_back(parent, redundancy);
         return;
     }
-    const Group::Distribution& redundancyArray(
-            parent.getDistribution(redundancy));
-    std::vector<ScoredGroup> tmpResults(redundancyArray.size(),
-                                        ScoredGroup(0, 0));
-    uint32_t seed(getGroupSeed(bucket, clusterState, parent));
+    const Group::Distribution& redundancyArray = parent.getDistribution(redundancy);
+    uint32_t seed = getGroupSeed(bucket, clusterState, parent);
     RandomGen random(seed);
     uint32_t currentIndex = 0;
-    const std::map<uint16_t, Group*>& subGroups(parent.getSubGroups());
-    for (std::map<uint16_t, Group*>::const_iterator it = subGroups.begin();
-         it != subGroups.end(); ++it)
-    {
-        while (it->first < currentIndex++) random.nextDouble();
+    const auto& subGroups = parent.getSubGroups();
+    std::vector<ScoredGroup> tmpResults;
+    tmpResults.reserve(subGroups.size());
+    for (const auto& g : subGroups) {
+        while (g.first < currentIndex++) {
+            random.nextDouble();
+        }
         double score = random.nextDouble();
-        if (it->second->getCapacity() != 1) {
-                // Capacity shouldn't possibly be 0.
-                // Verified in Group::setCapacity()
-            score = std::pow(score, 1.0 / it->second->getCapacity().getValue());
+        if (g.second->getCapacity() != 1) {
+            // Capacity shouldn't possibly be 0.
+            // Verified in Group::setCapacity()
+            score = std::pow(score, 1.0 / g.second->getCapacity().getValue());
         }
-        if (score > tmpResults.back()._score) {
-            tmpResults.push_back(ScoredGroup(it->second, score));
-            std::sort(tmpResults.begin(), tmpResults.end());
-            tmpResults.pop_back();
-        }
+        tmpResults.emplace_back(g.second, score);
     }
-    while (tmpResults.back()._group == nullptr) {
-        tmpResults.pop_back();
+    std::sort(tmpResults.begin(), tmpResults.end());
+    if (tmpResults.size() > redundancyArray.size()) {
+        tmpResults.resize(redundancyArray.size());
     }
     for (uint32_t i=0, n=tmpResults.size(); i<n; ++i) {
         ScoredGroup& group(tmpResults[i]);
-            // This should never happen. Config should verify that each group
-            // has enough groups beneath them.
+        // This should never happen. Config should verify that each group
+        // has enough groups beneath them.
         assert(group._group != nullptr);
         getIdealGroups(bucket, clusterState, *group._group,
                        redundancyArray[i], results);


### PR DESCRIPTION
@baldersheim please review. Same as https://github.com/vespa-engine/vespa/pull/13711 with two changes:

1. `tmpResults` is bounded by the calculated group redundancy factor rather than the parent redundancy factor. Means that we don't erroneously return too many groups back to the caller. This was a semantical oversight in the previous PR. A test has been added to verify the new code generates the same output as the old code for the internally failing system test.
2. Reserve `tmpResults` buffer equal to the number of sub-groups, as that's always the number of elements that will be appended prior to sorting and pruning.

Avoids invoking `std::sort` _O(n)_ times in favor of just once.

Benchmark for 150 groups of 1 node each:

* Before: 0.0004381478 seconds per invocation
* After:  0.0000377917 seconds per invocation

