### PR TITLE
Separate documentapi artifacts 2

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -137,7 +137,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>documentapi</artifactId>
+      <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -150,11 +150,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vdslib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -152,7 +152,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>documentapi</artifactId>
+      <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -154,16 +154,6 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.yahoo.vespa</groupId>
-          <artifactId>config</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/container-documentapi/.gitignore
+++ b/container-documentapi/.gitignore
@@ -1,0 +1,4 @@
+container-documentapi.iml
+target
+/pom.xml.build
+Makefile

--- a/container-documentapi/.gitignore
+++ b/container-documentapi/.gitignore
@@ -1,4 +1,3 @@
 container-documentapi.iml
 target
 /pom.xml.build
-Makefile

--- a/container-documentapi/OWNERS
+++ b/container-documentapi/OWNERS
@@ -1,0 +1,1 @@
+gjoranv

--- a/container-documentapi/README.md
+++ b/container-documentapi/README.md
@@ -1,0 +1,8 @@
+<!-- Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+# Documentapi
+
+Dependency artifact for building container bundles.
+To build standalone document clients, use `documentapi` instead.
+
+The actual java code remains in `documentapi`, becuase it uses
+common test files with the C++ code in the same module.

--- a/container-documentapi/pom.xml
+++ b/container-documentapi/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
 
     <dependency>
-      <!-- TODO: this is instead of moving the java code in documentapi to this module,
+      <!-- NOTE: this is instead of moving the java code in documentapi to this module (and turning the deps around),
                  which is made difficult by using common test files with the C++ code. -->
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>documentapi</artifactId>
@@ -27,6 +27,14 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>documentapi-dependencies</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/container-documentapi/pom.xml
+++ b/container-documentapi/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.vespa</groupId>
+    <artifactId>parent</artifactId>
+    <version>7-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>container-documentapi</artifactId>
+  <packaging>container-plugin</packaging>
+  <version>7-SNAPSHOT</version>
+
+  <dependencies>
+
+    <dependency>
+      <!-- TODO: this is instead of moving the java code in documentapi to this module,
+                 which is made difficult by using common test files with the C++ code. -->
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>documentapi</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <!-- Compile scope to pull vdslib into container-core and hence container-disc and container-dev -->
+      <!-- TODO: move to container-core -->
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vdslib</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.yahoo.vespa</groupId>
+        <artifactId>bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/container-documentapi/pom.xml
+++ b/container-documentapi/pom.xml
@@ -29,20 +29,6 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <!-- Compile scope to pull vdslib into container-core and hence container-disc and container-dev -->
-      <!-- TODO: move to container-core -->
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vdslib</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/container-messagebus/pom.xml
+++ b/container-messagebus/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>documentapi</artifactId>
+      <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/container-messagebus/pom.xml
+++ b/container-messagebus/pom.xml
@@ -34,6 +34,12 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>config</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -148,7 +148,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>documentapi</artifactId>
+      <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/documentapi-dependencies/.gitignore
+++ b/documentapi-dependencies/.gitignore
@@ -1,0 +1,3 @@
+documentapi-dependencies.iml
+target
+/pom.xml.build

--- a/documentapi-dependencies/OWNERS
+++ b/documentapi-dependencies/OWNERS
@@ -1,0 +1,1 @@
+gjoranv

--- a/documentapi-dependencies/README.md
+++ b/documentapi-dependencies/README.md
@@ -1,0 +1,6 @@
+<!-- Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+# Documentapi-dependencies
+
+Pom artifact that lists dependencies that are common between `documentapi` and
+`container-documentapi`. These dependencies are provided by the Jdisc container,
+but are needed in scope 'compile' for building standalone document clients.

--- a/documentapi-dependencies/pom.xml
+++ b/documentapi-dependencies/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.vespa</groupId>
+    <artifactId>parent</artifactId>
+    <version>7-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>documentapi-dependencies</artifactId>
+  <packaging>pom</packaging>
+  <version>7-SNAPSHOT</version>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>component</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>config-lib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>configdefinitions</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>document</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>jrt</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>messagebus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vdslib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vespajlib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>yolean</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -13,66 +13,31 @@
   <packaging>jar</packaging>
   <version>7-SNAPSHOT</version>
   <dependencies>
+
+    <!-- WARNING: dependencies (apart from test scoped) must be added to documentapi-dependencies, not here!  -->
+
     <dependency>
-      <!-- Needed because 'document' uses guava collections -->
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>documentapi-dependencies</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <!-- Needed because 'document' uses guava collections, and has guava only in provided scope -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>component</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>messagebus</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vdslib</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespajlib</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>config</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>document</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>configdefinitions</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>annotations</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -10,13 +10,13 @@
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>documentapi</artifactId>
-  <packaging>container-plugin</packaging>
+  <packaging>jar</packaging>
   <version>7-SNAPSHOT</version>
   <dependencies>
     <dependency>
+      <!-- Needed because 'document' uses guava collections -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -78,11 +78,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.yahoo.vespa</groupId>
-        <artifactId>bundle-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -101,6 +96,19 @@
             <phase>generate-sources</phase>
             <goals>
               <goal>javacc</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.yahoo.vespa</groupId>
+        <artifactId>config-class-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>config-gen</id>
+            <goals>
+              <goal>config-gen</goal>
             </goals>
           </execution>
         </executions>

--- a/fat-model-dependencies/pom.xml
+++ b/fat-model-dependencies/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>documentapi</artifactId>
+      <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,9 @@
         <module>docker-api</module>
         <module>docproc</module>
         <module>docprocs</module>
-        <module>documentapi</module>
         <module>document</module>
+        <module>documentapi</module>
+        <module>documentapi-dependencies</module>
         <module>documentgen-test</module>
         <module>fat-model-dependencies</module>
         <module>fileacquirer</module>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>container-dev</module>
         <module>container-di</module>
         <module>container-disc</module>
+        <module>container-documentapi</module>
         <module>container-integration-test</module>
         <module>container-jersey2</module>
         <module>container-messagebus</module>

--- a/simplemetrics/pom.xml
+++ b/simplemetrics/pom.xml
@@ -25,6 +25,12 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>component</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
This replaces #13699 which moved a lot of code files. The original purpose was to make the bundle-plugin fail when a bundle embeds the `component` artifact. 

This simplifies the dependency graph even further than the previous PR, and it should now be possible to deploy `container-documentapi` as a slim bundle. The work required would be to set its scope to 'provided' in container-core (or even removing it) and adding it to container-dev and all the modules that now get it transitively from container-core.