### PR TITLE
Support duplicate regions within same global endpoint

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/LatencyAliasTarget.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/LatencyAliasTarget.java
@@ -44,6 +44,11 @@ public class LatencyAliasTarget extends AliasTarget {
         return Objects.hash(super.hashCode(), zone);
     }
 
+    @Override
+    public String toString() {
+        return "latency target for " + name() + "[id=" + id() + ",dnsZone=" + dnsZone() + "]";
+    }
+
     /** Unpack latency alias from given record data */
     public static LatencyAliasTarget unpack(RecordData data) {
         var parts = data.asString().split("/");

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/WeightedAliasTarget.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/WeightedAliasTarget.java
@@ -47,6 +47,11 @@ public class WeightedAliasTarget extends AliasTarget {
         return Objects.hash(super.hashCode(), weight);
     }
 
+    @Override
+    public String toString() {
+        return "weighted target for " + name() + "[id=" + id() + ",dnsZone=" + dnsZone() + ",weight=" + weight + "]";
+    }
+
     /** Unpack weighted alias from given record data */
     public static WeightedAliasTarget unpack(RecordData data) {
         var parts = data.asString().split("/");

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -82,7 +82,7 @@ public class RoutingController {
         return rotationRepository;
     }
 
-    /** Returns zone-scoped endpoints for given deployment */
+    /** Returns endpoints for given deployment */
     public EndpointList endpointsOf(DeploymentId deployment) {
         var endpoints = new LinkedHashSet<Endpoint>();
         boolean isSystemApplication = SystemApplication.matching(deployment.applicationId()).isPresent();
@@ -93,6 +93,7 @@ public class RoutingController {
             for (var routingMethod :  controller.zoneRegistry().routingMethods(policy.id().zone())) {
                 if (routingMethod.isDirect() && !isSystemApplication && !canRouteDirectlyTo(deployment, application.get())) continue;
                 endpoints.add(policy.endpointIn(controller.system(), routingMethod, controller.zoneRegistry()));
+                endpoints.add(policy.weightedEndpointIn(controller.system(), routingMethod));
             }
         }
         return EndpointList.copyOf(endpoints);
@@ -134,7 +135,7 @@ public class RoutingController {
         return EndpointList.copyOf(endpoints);
     }
 
-    /** Returns all non-global endpoints and corresponding cluster IDs for given deployments, grouped by their zone */
+    /** Returns all zone-scoped endpoints and corresponding cluster IDs for given deployments, grouped by their zone */
     public Map<ZoneId, List<Endpoint>> zoneEndpointsOf(Collection<DeploymentId> deployments) {
         var endpoints = new TreeMap<ZoneId, List<Endpoint>>(Comparator.comparing(ZoneId::value));
         for (var deployment : deployments) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -44,11 +44,11 @@ import com.yahoo.vespa.hosted.controller.api.application.v4.model.configserverbi
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.identifiers.Hostname;
 import com.yahoo.vespa.hosted.controller.api.identifiers.TenantId;
+import com.yahoo.vespa.hosted.controller.api.integration.configserver.Application;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Cluster;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.ConfigServerException;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Log;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
-import com.yahoo.vespa.hosted.controller.api.integration.configserver.Application;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
@@ -95,7 +95,6 @@ import javax.ws.rs.NotAuthorizedException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.math.RoundingMode;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.DigestInputStream;
@@ -104,8 +103,6 @@ import java.security.PublicKey;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.YearMonth;
-import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Comparator;
@@ -116,7 +113,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Scanner;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -975,7 +971,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
 
         // Add zone endpoints
         var endpointArray = response.setArray("endpoints");
-        for (var endpoint : controller.routing().endpointsOf(deploymentId)) {
+        for (var endpoint : controller.routing().endpointsOf(deploymentId).scope(Endpoint.Scope.zone)) {
             toSlime(endpoint, endpoint.name(), endpointArray.addObject());
         }
         // Add global endpoints

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
@@ -74,11 +74,12 @@ public class RoutingPolicy {
         Optional<Endpoint> infraEndpoint = SystemApplication.matching(id.owner())
                                                             .flatMap(app -> app.endpointIn(id.zone(), zoneRegistry));
         if (infraEndpoint.isPresent()) return infraEndpoint.get();
-        return Endpoint.of(id.owner())
-                       .target(id.cluster(), id.zone())
-                       .on(Port.fromRoutingMethod(routingMethod))
-                       .routingMethod(routingMethod)
-                       .in(system);
+        return endpoint(routingMethod).in(system);
+    }
+
+    /** Returns the weighted endpoint of this */
+    public Endpoint weightedEndpointIn(SystemName system, RoutingMethod routingMethod) {
+        return endpoint(routingMethod).weighted().in(system);
     }
 
     @Override
@@ -99,6 +100,13 @@ public class RoutingPolicy {
         return String.format("%s [endpoints: %s%s], %s owned by %s, in %s", canonicalName, endpoints,
                              dnsZone.map(z -> ", DNS zone: " + z).orElse(""), id.cluster(), id.owner().toShortString(),
                              id.zone().value());
+    }
+
+    private Endpoint.EndpointBuilder endpoint(RoutingMethod routingMethod) {
+        return Endpoint.of(id.owner())
+                       .target(id.cluster(), id.zone())
+                       .on(Port.fromRoutingMethod(routingMethod))
+                       .routingMethod(routingMethod);
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/EndpointTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/EndpointTest.java
@@ -228,6 +228,44 @@ public class EndpointTest {
     }
 
     @Test
+    public void weighted_endpoints() {
+        var cluster = ClusterSpec.Id.from("default");
+        Map<String, Endpoint> tests = Map.of(
+                "https://a1.t1.us-north-1-w.public.vespa.oath.cloud/",
+                Endpoint.of(app1)
+                        .target(cluster, ZoneId.from("prod", "us-north-1a"))
+                        .weighted()
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .in(SystemName.Public),
+                "https://a1.t1.us-north-2-w.public.vespa.oath.cloud/",
+                Endpoint.of(app1)
+                        .target(cluster, ZoneId.from("prod", "us-north-2"))
+                        .weighted()
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .in(SystemName.Public),
+                "https://a1.t1.us-north-2-w.test.public.vespa.oath.cloud/",
+                Endpoint.of(app1)
+                        .target(cluster, ZoneId.from("test", "us-north-2"))
+                        .weighted()
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .in(SystemName.Public)
+        );
+        tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
+        Endpoint endpoint = Endpoint.of(app1)
+                                    .target(cluster, ZoneId.from("prod", "us-north-1a"))
+                                    .weighted()
+                                    .routingMethod(RoutingMethod.exclusive)
+                                    .on(Port.tls())
+                                    .in(SystemName.main);
+        assertEquals("Availability zone is removed from region",
+                     "us-north-1",
+                     endpoint.zones().get(0).region().value());
+    }
+
+    @Test
     public void upstream_name() {
         var zone = ZoneId.from("prod", "us-north-1");
         var tests1 = Map.of(

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesLegacyTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesLegacyTest.java
@@ -14,19 +14,15 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.config.provision.zone.ZoneId;
-import com.yahoo.vespa.flags.Flags;
-import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.RoutingController;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.DeployOptions;
-import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.LoadBalancer;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordData;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
-import com.yahoo.vespa.hosted.controller.api.integration.dns.WeightedAliasTarget;
 import com.yahoo.vespa.hosted.controller.application.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.Endpoint;
 import com.yahoo.vespa.hosted.controller.application.EndpointId;
@@ -44,21 +40,23 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
  * @author mortent
  * @author mpolden
  */
-public class RoutingPoliciesTest {
+// TODO(mpolden): Remove when weighted-dns-per-region flag is removed
+public class RoutingPoliciesLegacyTest {
 
     private final ZoneId zone1 = ZoneId.from("prod", "us-west-1");
     private final ZoneId zone2 = ZoneId.from("prod", "us-central-1");
@@ -248,7 +246,10 @@ public class RoutingPoliciesTest {
                 .build();
         context.submit(applicationPackage).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
 
-        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1);
+        var endpoint = "r0.app1.tenant1.global.vespa.oath.cloud";
+        assertEquals(endpoint + " points to c0 in all regions",
+                     List.of("latency/lb-0--tenant1:app1:default--prod.us-west-1/dns-zone-1/prod.us-west-1"),
+                     tester.aliasDataOf(endpoint));
         assertTrue("No rotations assigned", context.application().instances().values().stream()
                                                    .map(Instance::rotations)
                                                    .allMatch(List::isEmpty));
@@ -367,9 +368,9 @@ public class RoutingPoliciesTest {
                                                         GlobalRouting.Agent.tenant);
         context.flushDnsUpdates();
 
-        // Inactive zone is given zero weight
-        tester.assertWeight(0, context.instanceId(), 0, zone1);
-        tester.assertWeight(1, context.instanceId(), 0, zone2);
+        // Inactive zone is removed from global DNS record
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r1"), 0, zone2);
 
         // Status details is stored in policy
         var policy1 = tester.routingPolicies().get(context.deploymentIdIn(zone1)).values().iterator().next();
@@ -386,15 +387,16 @@ public class RoutingPoliciesTest {
         // Next deployment does not affect status
         context.submit(applicationPackage).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
         context.flushDnsUpdates();
-        tester.assertWeight(0, context.instanceId(), 0, zone1);
-        tester.assertWeight(1, context.instanceId(), 0, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r1"), 0, zone2);
 
         // Deployment is set back in
         tester.controllerTester().clock().advance(Duration.ofHours(1));
         changedAt = tester.controllerTester().clock().instant();
         tester.routingPolicies().setGlobalRoutingStatus(context.deploymentIdIn(zone1), GlobalRouting.Status.in, GlobalRouting.Agent.tenant);
         context.flushDnsUpdates();
-        tester.assertWeight(1, context.instanceId(), 0, zone1, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r1"), 0, zone1, zone2);
 
         policy1 = tester.routingPolicies().get(context.deploymentIdIn(zone1)).values().iterator().next();
         assertEquals(GlobalRouting.Status.in, policy1.status().globalRouting().status());
@@ -409,8 +411,8 @@ public class RoutingPoliciesTest {
                 .endpoint("r1", "c0", zone1.region().value(), zone2.region().value())
                 .build();
         context.submit(applicationPackage2).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
-        tester.assertWeight(1, context.instanceId(), 0, zone1);
-        tester.assertWeight(0, context.instanceId(), 0, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r1"), 0, zone1);
 
         // ... back in
         var applicationPackage3 = applicationPackageBuilder()
@@ -420,7 +422,8 @@ public class RoutingPoliciesTest {
                 .endpoint("r1", "c0", zone1.region().value(), zone2.region().value())
                 .build();
         context.submit(applicationPackage3).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
-        tester.assertWeight(1, context.instanceId(), 0, zone1, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
+        tester.assertTargets(context.instanceId(), EndpointId.of("r1"), 0, zone1, zone2);
     }
 
     @Test
@@ -440,14 +443,13 @@ public class RoutingPoliciesTest {
             tester.provisionLoadBalancers(1, context.instanceId(), zone1, zone2);
             context.submit(applicationPackage).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
             tester.assertTargets(context.instanceId(), EndpointId.defaultId(), 0, zone1, zone2);
-            tester.assertWeight(1, context.instanceId(), 0, zone1, zone2);
         }
 
         // Set zone out
         tester.routingPolicies().setGlobalRoutingStatus(zone2, GlobalRouting.Status.out);
         context1.flushDnsUpdates();
-        tester.assertWeight(1, context1.instanceId(), 0, zone1);
-        tester.assertWeight(0, context1.instanceId(), 0, zone2);
+        tester.assertTargets(context1.instanceId(), EndpointId.defaultId(), 0, zone1);
+        tester.assertTargets(context2.instanceId(), EndpointId.defaultId(), 0, zone1);
         for (var context : contexts) {
             var policies = tester.routingPolicies().get(context.instanceId());
             assertTrue("Global routing status for policy remains " + GlobalRouting.Status.in,
@@ -466,8 +468,8 @@ public class RoutingPoliciesTest {
         // Setting status per deployment does not affect status as entire zone is out
         tester.routingPolicies().setGlobalRoutingStatus(context1.deploymentIdIn(zone2), GlobalRouting.Status.in, GlobalRouting.Agent.tenant);
         context1.flushDnsUpdates();
-        tester.assertWeight(0, context1.instanceId(), 0, zone2);
-        tester.assertWeight(0, context2.instanceId(), 0, zone2);
+        tester.assertTargets(context1.instanceId(), EndpointId.defaultId(), 0, zone1);
+        tester.assertTargets(context2.instanceId(), EndpointId.defaultId(), 0, zone1);
 
         // Set single deployment out
         tester.routingPolicies().setGlobalRoutingStatus(context1.deploymentIdIn(zone2), GlobalRouting.Status.out, GlobalRouting.Agent.tenant);
@@ -476,9 +478,8 @@ public class RoutingPoliciesTest {
         // Set zone back in. Deployment set explicitly out, remains out, the rest are in
         tester.routingPolicies().setGlobalRoutingStatus(zone2, GlobalRouting.Status.in);
         context1.flushDnsUpdates();
-        tester.assertWeight(1, context1.instanceId(), 0, zone1);
-        tester.assertWeight(0, context1.instanceId(), 0, zone2);
-        tester.assertWeight(1, context2.instanceId(), 0, zone1, zone2);
+        tester.assertTargets(context1.instanceId(), EndpointId.defaultId(), 0, zone1);
+        tester.assertTargets(context2.instanceId(), EndpointId.defaultId(), 0, zone1, zone2);
     }
 
     @Test
@@ -521,7 +522,63 @@ public class RoutingPoliciesTest {
 
         // Deployment completes
         context.completeRollout();
-        tester.assertTargets(context.instanceId(), endpointId, ClusterSpec.Id.from("default"), 0, prodZone);
+        tester.assertTargets(context.instanceId(), endpointId, 0, prodZone);
+    }
+
+    @Test
+    public void changing_global_routing_status_never_removes_all_members() {
+        var tester = new RoutingPoliciesTester();
+        var context = tester.newDeploymentContext("tenant1", "app1", "default");
+
+        // Provision load balancers and deploy application
+        tester.provisionLoadBalancers(1, context.instanceId(), zone1, zone2);
+        var applicationPackage = applicationPackageBuilder()
+                .region(zone1.region())
+                .region(zone2.region())
+                .endpoint("r0", "c0", zone1.region().value(), zone2.region().value())
+                .build();
+        context.submit(applicationPackage).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
+
+        // Global DNS record is created, pointing to all configured zones
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
+
+        // Global routing status is overridden for one deployment
+        tester.routingPolicies().setGlobalRoutingStatus(context.deploymentIdIn(zone1), GlobalRouting.Status.out,
+                                                        GlobalRouting.Agent.tenant);
+        context.flushDnsUpdates();
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone2);
+
+        // Setting other deployment out implicitly sets all deployments in
+        tester.routingPolicies().setGlobalRoutingStatus(context.deploymentIdIn(zone2), GlobalRouting.Status.out,
+                                                        GlobalRouting.Agent.tenant);
+        context.flushDnsUpdates();
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
+
+        // One inactive deployment is put back in. Global DNS record now points to the only active deployment
+        tester.routingPolicies().setGlobalRoutingStatus(context.deploymentIdIn(zone1), GlobalRouting.Status.in,
+                                                        GlobalRouting.Agent.tenant);
+        context.flushDnsUpdates();
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1);
+
+        // Setting zone (containing active deployment) out puts all deployments in
+        tester.routingPolicies().setGlobalRoutingStatus(zone1, GlobalRouting.Status.out);
+        context.flushDnsUpdates();
+        assertEquals(GlobalRouting.Status.out, tester.routingPolicies().get(zone1).globalRouting().status());
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
+
+        // Setting zone back in removes the currently inactive deployment
+        tester.routingPolicies().setGlobalRoutingStatus(zone1, GlobalRouting.Status.in);
+        context.flushDnsUpdates();
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1);
+
+        // Inactive deployment is set in
+        tester.routingPolicies().setGlobalRoutingStatus(context.deploymentIdIn(zone2), GlobalRouting.Status.in,
+                                                        GlobalRouting.Agent.tenant);
+        context.flushDnsUpdates();
+        for (var policy : tester.routingPolicies().get(context.instanceId()).values()) {
+            assertSame(GlobalRouting.Status.in, policy.status().globalRouting().status());
+        }
+        tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
     }
 
     @Test
@@ -547,7 +604,7 @@ public class RoutingPoliciesTest {
                 .athenzIdentity(AthenzDomain.from("domain"), AthenzService.from("service"))
                 .compileVersion(RoutingController.DIRECT_ROUTING_MIN_VERSION);
     }
-    
+
     private static List<LoadBalancer> createLoadBalancers(ZoneId zone, ApplicationId application, boolean shared, int count) {
         List<LoadBalancer> loadBalancers = new ArrayList<>();
         for (int i = 0; i < count; i++) {
@@ -556,7 +613,7 @@ public class RoutingPoliciesTest {
                 lbHostname = HostName.from("shared-lb--" + zone.value());
             } else {
                 lbHostname = HostName.from("lb-" + i + "--" + application.serializedForm() +
-                                                     "--" + zone.value());
+                                           "--" + zone.value());
             }
             loadBalancers.add(
                     new LoadBalancer("LB-" + i + "-Z-" + zone.value(),
@@ -597,7 +654,6 @@ public class RoutingPoliciesTest {
             this.tester = tester;
             // Make all zones directly routed
             tester.controllerTester().zoneRegistry().exclusiveRoutingIn(tester.controllerTester().zoneRegistry().zones().all().zones());
-            ((InMemoryFlagSource) tester.controllerTester().controller().flagSource()).withBooleanFlag(Flags.WEIGHTED_DNS_PER_REGION.id(), true);
         }
 
         private void provisionLoadBalancers(int clustersPerZone, ApplicationId application, boolean shared, ZoneId... zones) {
@@ -636,53 +692,19 @@ public class RoutingPoliciesTest {
                          .collect(Collectors.toList());
         }
 
-        private void assertWeight(long expected, ApplicationId application, int loadBalancerId, ZoneId... zones) {
-            for (var zone : zones) {
-                Endpoint weighted = tester.controller().routing().endpointsOf(new DeploymentId(application, zone))
-                                          .scope(Endpoint.Scope.weighted)
-                                          .named(EndpointId.of("c" + loadBalancerId))
-                                          .asList()
-                                          .get(0);
-                List<Record> records = tester.controllerTester().nameService().findRecords(Record.Type.ALIAS,
-                                                                                           RecordName.from(weighted.dnsName()));
-                assertEquals(1, records.size());
-                assertEquals("Record " + weighted.dnsName() + " has expected weight",
-                             expected,
-                             WeightedAliasTarget.unpack(records.get(0).data())
-                                                .weight());
-            }
-        }
-
-        private void assertTargets(ApplicationId application, EndpointId endpointId, ClusterSpec.Id clusterId, int loadBalancerId, ZoneId... zones) {
-            Set<String> latencyTargets = new HashSet<>();
-            for (var zone : zones) {
-                Endpoint weighted = tester.controller().routing().endpointsOf(new DeploymentId(application, zone))
-                                          .scope(Endpoint.Scope.weighted)
-                                          .named(EndpointId.of(clusterId.value()))
-                                          .asList()
-                                          .get(0);
-                String latencyTarget = "latency/" + weighted.dnsName() + "/dns-zone-1/" +
-                                       weighted.zones().get(0).value();
-                String weightedTarget = "weighted/lb-" + loadBalancerId + "--" + application.serializedForm() + "--" +
-                                        zone.value() + "/dns-zone-1/" + zone.value() + "/1";
-                assertEquals("Weighted target points to load balancer",
-                             List.of(weightedTarget),
-                             aliasDataOf(weighted.dnsName()));
-                latencyTargets.add(latencyTarget);
-            }
-            String globalEndpoint = tester.controller().routing().endpointsOf(application)
-                                          .named(endpointId)
-                                          .targets(List.of(zones))
-                                          .primary()
-                                          .map(Endpoint::dnsName)
-                                          .orElse("<none>");
-            assertEquals("Global endpoint " + globalEndpoint + " points to expected weighted targets",
-                         latencyTargets, Set.copyOf(aliasDataOf(globalEndpoint)));
-
-        }
-
-        private void assertTargets(ApplicationId application, EndpointId endpointId, int loadBalancerId, ZoneId... zones) {
-            assertTargets(application, endpointId, ClusterSpec.Id.from("c" + loadBalancerId), loadBalancerId, zones);
+        private void assertTargets(ApplicationId application, EndpointId endpointId, int loadBalancerId, ZoneId ...zone) {
+            var endpoint = tester.controller().routing().endpointsOf(application)
+                                 .named(endpointId)
+                                 .targets(List.of(zone))
+                                 .primary()
+                                 .map(Endpoint::dnsName)
+                                 .orElse("<none>");
+            var zoneTargets = Arrays.stream(zone)
+                                    .map(z -> "latency/lb-" + loadBalancerId + "--" + application.serializedForm() + "--" +
+                                              z.value() + "/dns-zone-1/" + z.value())
+                                    .collect(Collectors.toSet());
+            assertEquals("Global endpoint " + endpoint + " points to expected zones", zoneTargets,
+                         Set.copyOf(aliasDataOf(endpoint)));
         }
 
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -295,6 +295,13 @@ public class Flags {
             "Takes effect on next tick"
     );
 
+    public static final UnboundBooleanFlag WEIGHTED_DNS_PER_REGION = defineFeatureFlag(
+            "weighted-dns-per-region", false,
+            "Whether to create weighted DNS records per region in global endpoints",
+            "Takes effect on next deployment through controller",
+            APPLICATION_ID
+    );
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, String description,
                                                        String modificationEffect, FetchVector.Dimension... dimensions) {


### PR DESCRIPTION
To support duplicate regions within a global endpoint we create a combination of
latency and weighted alias targets.

In the following examples an application exists in `us-west-2`, `us-east-1a` and
`us-east-1b`. Before this change global endpoints pointed directly to the
zone endpoint:

```
(latency) ALIAS app1.tenant1.global.vespa.example.com -> app1.tenant1.us-west-2.vespa.example.com
(latency) ALIAS app1.tenant1.global.vespa.example.com -> app1.tenant1.us-east-1a.vespa.example.com
(latency) ALIAS app1.tenant1.global.vespa.example.com -> app1.tenant1.us-east-1b.vespa.example.com
```

After this change we introduce an additional level of names by creating a
weighted record per region:

```
(latency) ALIAS app1.tenant1.global.vespa.example.com -> app1.tenant1.us-west-2-w.vespa.example.com
  |- (weighted) ALIAS app1.tenant1.us-west-2-w.vespa.example.com -> app1.tenant1.us-west-2.vespa.example.com
(latency) ALIAS app1.tenant1.global.vespa.example.com -> app1.tenant1.us-east-1-w.vespa.example.com
  |- (weighted) ALIAS app1.tenant1.us-east-1-w.vespa.example.com -> app1.tenant1.us-east-1a.vespa.example.com
  |- (weighted) ALIAS app1.tenant1.us-east-1-w.vespa.example.com -> app1.tenant1.us-east-1b.vespa.example.com
```

Toggling global routing status now adjusts the weight (`0 = out`) instead of
removing records as this simplified the code.

@tokle