### PR TITLE
Since there is not a well defined contract for the the sendReply inte…

### DIFF
--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -40,8 +40,6 @@ public:
 
 private:
     config::ConfigUri _configUri;
-
-    uint32_t _chunkLevel;
     BucketInfoRequestMap _bucketInfoRequests;
 
     /**

--- a/storage/src/vespa/storage/common/messagesender.cpp
+++ b/storage/src/vespa/storage/common/messagesender.cpp
@@ -16,4 +16,9 @@ MessageSender::send(const std::shared_ptr<api::StorageMessage>& msg)
     }
 }
 
+void
+MessageSender::sendReplyDirectly(const std::shared_ptr<api::StorageReply>& reply) {
+    sendReply(reply);
+}
+
 }

--- a/storage/src/vespa/storage/common/messagesender.h
+++ b/storage/src/vespa/storage/common/messagesender.h
@@ -31,6 +31,8 @@ struct MessageSender {
 
     virtual void sendCommand(const std::shared_ptr<api::StorageCommand>&) = 0;
     virtual void sendReply(const std::shared_ptr<api::StorageReply>&) = 0;
+    // By calling this you certify that it can continue in same thread or be dispatched.
+    virtual void sendReplyDirectly(const std::shared_ptr<api::StorageReply>&);
 
     void send(const std::shared_ptr<api::StorageMessage>&);
 };

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.cpp
@@ -104,6 +104,12 @@ FileStorHandler::sendReply(const api::StorageReply::SP& msg)
 }
 
 void
+FileStorHandler::sendReplyDirectly(const api::StorageReply::SP& msg)
+{
+    _impl->sendReplyDirectly(msg);
+}
+
+void
 FileStorHandler::getStatus(std::ostream& out, const framework::HttpUrlPath& path) const
 {
     _impl->getStatus(out, path);

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -239,6 +239,7 @@ public:
     void sendCommand(const api::StorageCommand::SP&) override;
     /** Send the given reply back out of the persistence layer. */
     void sendReply(const api::StorageReply::SP&) override;
+    void sendReplyDirectly(const std::shared_ptr<api::StorageReply>&) override;
 
     /** Writes status page. */
     void getStatus(std::ostream& out, const framework::HttpUrlPath& path) const;

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -837,6 +837,12 @@ FileStorHandlerImpl::sendReply(const std::shared_ptr<api::StorageReply>& msg)
     _messageSender.sendReply(msg);
 }
 
+void
+FileStorHandlerImpl::sendReplyDirectly(const std::shared_ptr<api::StorageReply>& msg)
+{
+    _messageSender.sendReplyDirectly(msg);
+}
+
 FileStorHandlerImpl::MessageEntry::MessageEntry(const std::shared_ptr<api::StorageMessage>& cmd,
                                                 const document::Bucket &bucket)
     : _command(cmd),

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -254,6 +254,7 @@ public:
     }
     void sendCommand(const std::shared_ptr<api::StorageCommand>&) override;
     void sendReply(const std::shared_ptr<api::StorageReply>&) override;
+    void sendReplyDirectly(const api::StorageReply::SP& msg) override;
 
     void getStatus(std::ostream& out, const framework::HttpUrlPath& path) const;
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -769,6 +769,19 @@ FileStorManager::sendReply(const std::shared_ptr<api::StorageReply>& reply)
 }
 
 void
+FileStorManager::sendReplyDirectly(const std::shared_ptr<api::StorageReply>& reply)
+{
+    LOG(spam, "Sending reply %s", reply->toString().c_str());
+
+    if (reply->getType() == api::MessageType::INTERNAL_REPLY) {
+        std::shared_ptr<api::InternalReply> rep(std::dynamic_pointer_cast<api::InternalReply>(reply));
+        assert(rep.get());
+        if (onInternalReply(rep)) return;
+    }
+    sendUp(reply);
+}
+
+void
 FileStorManager::sendUp(const std::shared_ptr<api::StorageMessage>& msg)
 {
     StorageLinkQueued::sendUp(msg);

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -149,6 +149,7 @@ private:
     void handleAbortBucketOperations(const std::shared_ptr<AbortBucketOperationsCommand>&);
     void sendCommand(const std::shared_ptr<api::StorageCommand>&) override;
     void sendReply(const std::shared_ptr<api::StorageReply>&) override;
+    void sendReplyDirectly(const std::shared_ptr<api::StorageReply>&) override;
     void sendUp(const std::shared_ptr<api::StorageMessage>&) override;
     void onClose() override;
     void onFlush(bool downwards) override;

--- a/storage/src/vespa/storage/persistence/persistenceutil.cpp
+++ b/storage/src/vespa/storage/persistence/persistenceutil.cpp
@@ -99,7 +99,7 @@ MessageTracker::sendReply() {
         }
         LOG(spam, "Sending reply up: %s %" PRIu64,
             getReply().toString().c_str(), getReply().getMsgId());
-        _replySender.sendReply(std::move(_reply));
+        _replySender.sendReplyDirectly(std::move(_reply));
     } else {
         if ( ! _context.getTrace().getRoot().isEmpty()) {
             _msg->getTrace().getRoot().addChild(_context.getTrace().getRoot());


### PR DESCRIPTION
…rface,

I add a stricter sendReplyDirectly interface where the caller guarantees that he has no hidden
requirements that the calle should be aware of.
This will avoid a task switch when propagating the reply.

@vekterli PR
This is a safer alternative to #13766 
