### PR TITLE
improve sync

### DIFF
--- a/staging_vespalib/src/vespa/vespalib/util/adaptive_sequenced_executor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/adaptive_sequenced_executor.h
@@ -113,6 +113,7 @@ private:
     bool exchange_strand(Worker &worker, std::unique_lock<std::mutex> &lock);
     Task::UP next_task(Worker &worker);
     void worker_main();
+    void run_task_in_strand(Task::UP task, Strand &strand, std::unique_lock<std::mutex> &lock);
 public:
     AdaptiveSequencedExecutor(size_t num_strands, size_t num_threads,
                               size_t max_waiting, size_t max_pending);


### PR DESCRIPTION
- lock once to post all sync tasks
- only post to non-idle strands
- let sync tasks bypass blocking based on task limit

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review