### PR TITLE
Add feature flag for content node B-tree bucket DB (and remove distributor B-tree flag)

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -98,7 +98,10 @@ public interface ModelContext {
         // Select sequencer type use while feeding.
         String feedSequencerType();
 
-        boolean useDistributorBtreeDb();
+        // TODO Remove when 7.247 is last
+        default boolean useDistributorBtreeDb() { return true; }
+
+        boolean useContentNodeBtreeDb();
 
         boolean useThreePhaseUpdates();
 

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -37,7 +37,7 @@ public class TestProperties implements ModelContext.Properties {
     private Zone zone;
     private Set<ContainerEndpoint> endpoints = Collections.emptySet();
     private boolean useDedicatedNodeForLogserver = false;
-    private boolean useDistributorBtreeDb = false;
+    private boolean useContentNodeBtreeDb = false;
     private boolean useThreePhaseUpdates = false;
     private double defaultTermwiseLimit = 1.0;
     private double threadPoolSizeFactor = 0.0;
@@ -70,7 +70,7 @@ public class TestProperties implements ModelContext.Properties {
     @Override public double queueSizeFactor() {
         return queueSizeFactor;
     }
-    @Override public boolean useDistributorBtreeDb() { return useDistributorBtreeDb; }
+    @Override public boolean useContentNodeBtreeDb() { return useContentNodeBtreeDb; }
     @Override public boolean useThreePhaseUpdates() { return useThreePhaseUpdates; }
     @Override public Optional<AthenzDomain> athenzDomain() { return Optional.ofNullable(athenzDomain); }
     @Override public Optional<ApplicationRoles> applicationRoles() { return Optional.ofNullable(applicationRoles); }
@@ -88,8 +88,8 @@ public class TestProperties implements ModelContext.Properties {
         return this;
     }
 
-    public TestProperties setUseDistributorBtreeDB(boolean useBtreeDb) {
-        useDistributorBtreeDb = useBtreeDb;
+    public TestProperties setUseContentNodeBtreeDB(boolean useBtreeDb) {
+        useContentNodeBtreeDb = useBtreeDb;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -41,7 +41,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
     private final BucketSplitting bucketSplitting;
     private final GcOptions gc;
     private final boolean hasIndexedDocumentType;
-    private final boolean useBtreeDatabase;
     private final boolean useThreePhaseUpdates;
 
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<DistributorCluster> {
@@ -103,25 +102,23 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
             final ModelElement documentsNode = clusterElement.child("documents");
             final GcOptions gc = parseGcOptions(documentsNode);
             final boolean hasIndexedDocumentType = clusterContainsIndexedDocumentType(documentsNode);
-            boolean useBtreeDb = deployState.getProperties().useDistributorBtreeDb();
             boolean useThreePhaseUpdates = deployState.getProperties().useThreePhaseUpdates();
 
             return new DistributorCluster(parent,
                     new BucketSplitting.Builder().build(new ModelElement(producerSpec)), gc,
-                    hasIndexedDocumentType, useBtreeDb, useThreePhaseUpdates);
+                    hasIndexedDocumentType, useThreePhaseUpdates);
         }
     }
 
     private DistributorCluster(ContentCluster parent, BucketSplitting bucketSplitting,
                                GcOptions gc, boolean hasIndexedDocumentType,
-                               boolean useBtreeDatabase, boolean useThreePhaseUpdates)
+                               boolean useThreePhaseUpdates)
     {
         super(parent, "distributor");
         this.parent = parent;
         this.bucketSplitting = bucketSplitting;
         this.gc = gc;
         this.hasIndexedDocumentType = hasIndexedDocumentType;
-        this.useBtreeDatabase = useBtreeDatabase;
         this.useThreePhaseUpdates = useThreePhaseUpdates;
     }
 
@@ -134,7 +131,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
         }
         builder.enable_revert(parent.getPersistence().supportRevert());
         builder.disable_bucket_activation(hasIndexedDocumentType == false);
-        builder.use_btree_database(useBtreeDatabase);
         builder.enable_metadata_only_fetch_phase_for_inconsistent_updates(useThreePhaseUpdates);
 
         bucketSplitting.getConfig(builder);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorServerProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorServerProducer.java
@@ -10,32 +10,36 @@ import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
  */
 public class StorServerProducer implements StorServerConfig.Producer {
     public static class Builder {
-        StorServerProducer build(ModelElement element) {
+        StorServerProducer build(ModelElement element, boolean useBtreeDatabase) {
             ModelElement tuning = element.child("tuning");
 
             if (tuning == null) {
-                return new StorServerProducer(ContentCluster.getClusterId(element), null, null);
+                return new StorServerProducer(ContentCluster.getClusterId(element), null, null, useBtreeDatabase);
             }
 
             ModelElement merges = tuning.child("merges");
             if (merges == null) {
-                return new StorServerProducer(ContentCluster.getClusterId(element), null, null);
+                return new StorServerProducer(ContentCluster.getClusterId(element), null, null, useBtreeDatabase);
             }
 
             return new StorServerProducer(ContentCluster.getClusterId(element),
                     merges.integerAttribute("max-per-node"),
-                    merges.integerAttribute("max-queue-size"));
+                    merges.integerAttribute("max-queue-size"),
+                    useBtreeDatabase);
         }
     }
 
-    private String clusterName;
-    private Integer maxMergesPerNode;
-    private Integer queueSize;
+    private final String clusterName;
+    private final Integer maxMergesPerNode;
+    private final Integer queueSize;
+    private final boolean useBtreeDatabase;
 
-    public StorServerProducer(String clusterName, Integer maxMergesPerNode, Integer queueSize) {
+    public StorServerProducer(String clusterName, Integer maxMergesPerNode,
+                              Integer queueSize, boolean useBtreeDatabase) {
         this.clusterName = clusterName;
         this.maxMergesPerNode = maxMergesPerNode;
         this.queueSize = queueSize;
+        this.useBtreeDatabase = useBtreeDatabase;
     }
 
     @Override
@@ -52,5 +56,6 @@ public class StorServerProducer implements StorServerConfig.Producer {
         if (queueSize != null) {
             builder.max_merge_queue_size(queueSize);
         }
+        builder.use_content_node_btree_bucket_db(useBtreeDatabase);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
@@ -33,12 +33,13 @@ public class StorageCluster extends AbstractConfigProducer<StorageNode>
         protected StorageCluster doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element producerSpec) {
             final ModelElement clusterElem = new ModelElement(producerSpec);
             final ContentCluster cluster = (ContentCluster)ancestor;
+            boolean useContentNodeBtreeDb = deployState.getProperties().useContentNodeBtreeDb();
 
             return new StorageCluster(ancestor,
                                       ContentCluster.getClusterId(clusterElem),
                                       new FileStorProducer.Builder().build(cluster, clusterElem),
                                       new IntegrityCheckerProducer.Builder().build(cluster, clusterElem),
-                                      new StorServerProducer.Builder().build(clusterElem),
+                                      new StorServerProducer.Builder().build(clusterElem, useContentNodeBtreeDb),
                                       new StorVisitorProducer.Builder().build(clusterElem),
                                       new PersistenceProducer.Builder().build(clusterElem));
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -949,20 +949,20 @@ public class ContentClusterTest extends ContentBaseTest {
         verifyTopKProbabilityPropertiesControl();
     }
 
-    private boolean resolveDistributorBtreeDbConfigWithFeatureFlag(boolean flagEnabledBtreeDb) {
-        VespaModel model = createEnd2EndOneNode(new TestProperties().setUseDistributorBtreeDB(flagEnabledBtreeDb));
+    private boolean resolveContentNodeBtreeDbConfigWithFeatureFlag(boolean flagEnabledBtreeDb) {
+        VespaModel model = createEnd2EndOneNode(new TestProperties().setUseContentNodeBtreeDB(flagEnabledBtreeDb));
 
         ContentCluster cc = model.getContentClusters().get("storage");
-        var builder = new StorDistributormanagerConfig.Builder();
-        cc.getDistributorNodes().getConfig(builder);
+        var builder = new StorServerConfig.Builder();
+        cc.getStorageNodes().getConfig(builder);
 
-        return (new StorDistributormanagerConfig(builder)).use_btree_database();
+        return (new StorServerConfig(builder)).use_content_node_btree_bucket_db();
     }
 
     @Test
-    public void default_distributor_btree_usage_controlled_by_properties() {
-        assertFalse(resolveDistributorBtreeDbConfigWithFeatureFlag(false));
-        assertTrue(resolveDistributorBtreeDbConfigWithFeatureFlag(true));
+    public void default_content_node_btree_usage_controlled_by_properties() {
+        assertFalse(resolveContentNodeBtreeDbConfigWithFeatureFlag(false));
+        assertTrue(resolveContentNodeBtreeDbConfigWithFeatureFlag(true));
     }
 
     private boolean resolveThreePhaseUpdateConfigWithFeatureFlag(boolean flagEnableThreePhase) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -147,7 +147,7 @@ public class ModelContextImpl implements ModelContext {
         private final Set<ContainerEndpoint> endpoints;
         private final boolean isBootstrap;
         private final boolean isFirstTimeDeployment;
-        private final boolean useDistributorBtreeDb;
+        private final boolean useContentNodeBtreeDb;
         private final boolean useThreePhaseUpdates;
         private final Optional<EndpointCertificateSecrets> endpointCertificateSecrets;
         private final double defaultTermwiseLimit;
@@ -188,7 +188,7 @@ public class ModelContextImpl implements ModelContext {
             this.endpointCertificateSecrets = endpointCertificateSecrets;
             defaultTermwiseLimit = Flags.DEFAULT_TERM_WISE_LIMIT.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
-            useDistributorBtreeDb = Flags.USE_DISTRIBUTOR_BTREE_DB.bindTo(flagSource)
+            useContentNodeBtreeDb = Flags.USE_CONTENT_NODE_BTREE_DB.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             useThreePhaseUpdates = Flags.USE_THREE_PHASE_UPDATES.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
@@ -260,8 +260,8 @@ public class ModelContextImpl implements ModelContext {
         }
 
         @Override
-        public boolean useDistributorBtreeDb() {
-            return useDistributorBtreeDb;
+        public boolean useContentNodeBtreeDb() {
+            return useContentNodeBtreeDb;
         }
 
         @Override

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -152,10 +152,10 @@ public class Flags {
             "Takes effect at redeployment",
             ZONE_ID, APPLICATION_ID);
 
-    public static final UnboundBooleanFlag USE_DISTRIBUTOR_BTREE_DB = defineFeatureFlag(
-            "use-distributor-btree-db", true,
-            "Whether to use the new B-tree bucket database in the distributors.",
-            "Takes effect at restart of distributor process",
+    public static final UnboundBooleanFlag USE_CONTENT_NODE_BTREE_DB = defineFeatureFlag(
+            "use-content-node-btree-db", false,
+            "Whether to use the new B-tree bucket database on the content node.",
+            "Takes effect at restart of content node process",
             ZONE_ID, APPLICATION_ID);
 
     public static final UnboundBooleanFlag USE_THREE_PHASE_UPDATES = defineFeatureFlag(


### PR DESCRIPTION
@baldersheim please review. Does this suffice for safely removing the deprecated distributor flag?

