### PR TITLE
Vekterli/basic snapshot support for content node bucket db

### DIFF
--- a/storage/src/tests/bucketdb/lockablemaptest.cpp
+++ b/storage/src/tests/bucketdb/lockablemaptest.cpp
@@ -356,6 +356,22 @@ TYPED_TEST(LockableMapTest, can_abort_during_chunked_iteration) {
     EXPECT_EQ(expected, proc.toString());
 }
 
+TYPED_TEST(LockableMapTest, can_iterate_via_read_guard) {
+    TypeParam map;
+    bool pre_existed;
+    map.insert(16, A(1, 2, 3), "foo", pre_existed);
+    map.insert(11, A(4, 6, 0), "foo", pre_existed);
+    map.insert(14, A(42, 0, 0), "foo", pre_existed);
+    std::string expected("11 - A(4, 6, 0)\n"
+                         "14 - A(42, 0, 0)\n"
+                         "16 - A(1, 2, 3)\n");
+
+    ConstProcessor<TypeParam> cproc;
+    auto guard = map.acquire_read_guard();
+    guard->for_each(std::ref(cproc));
+    EXPECT_EQ(expected, cproc.toString());
+}
+
 TYPED_TEST(LockableMapTest, find_buckets_simple) {
     TypeParam map;
 

--- a/storage/src/tests/distributor/bucketdatabasetest.cpp
+++ b/storage/src/tests/distributor/bucketdatabasetest.cpp
@@ -173,8 +173,7 @@ BucketDatabaseTest::doFindParents(const std::vector<document::BucketId>& ids,
     // TODO remove in favor of only read guard once legacy DB usage has been ported over
     db().getParents(searchId, entries);
 
-    std::vector<BucketDatabase::Entry> checked_entries;
-    db().acquire_read_guard()->find_parents_and_self(searchId, checked_entries);
+    auto checked_entries = db().acquire_read_guard()->find_parents_and_self(searchId);
     if (entries != checked_entries) {
         return "Mismatch between results from getParents() and ReadGuard!";
     }

--- a/storage/src/tests/distributor/bucketdbupdatertest.cpp
+++ b/storage/src/tests/distributor/bucketdbupdatertest.cpp
@@ -2769,8 +2769,7 @@ struct BucketDBUpdaterSnapshotTest : BucketDBUpdaterTest {
         uint32_t found_buckets = 0;
         for_each_bucket(repo, [&](const auto& space, const auto& entry) {
             if (space == bucket_space) {
-                std::vector<BucketDatabase::Entry> entries;
-                guard->find_parents_and_self(entry.getBucketId(), entries);
+                auto entries = guard->find_parents_and_self(entry.getBucketId());
                 if (entries.size() == 1) {
                     ++found_buckets;
                 }

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
@@ -307,7 +307,7 @@ void BTreeLockableMap<T>::do_for_each(std::function<Decision(uint64_t, const map
 }
 
 template <typename T>
-bool BTreeLockableMap<T>::processNextChunk(std::function<Decision(uint64_t, mapped_type&)>& func,
+bool BTreeLockableMap<T>::processNextChunk(std::function<Decision(uint64_t, const mapped_type&)>& func,
                                            key_type& key,
                                            const char* client_id,
                                            const uint32_t chunk_size)
@@ -328,7 +328,7 @@ bool BTreeLockableMap<T>::processNextChunk(std::function<Decision(uint64_t, mapp
 }
 
 template <typename T>
-void BTreeLockableMap<T>::do_for_each_chunked(std::function<Decision(uint64_t, mapped_type&)> func,
+void BTreeLockableMap<T>::do_for_each_chunked(std::function<Decision(uint64_t, const mapped_type&)> func,
                                               const char* client_id,
                                               vespalib::duration yield_time,
                                               uint32_t chunk_size)
@@ -344,6 +344,66 @@ void BTreeLockableMap<T>::do_for_each_chunked(std::function<Decision(uint64_t, m
         // face of blocked point lookups.
         std::this_thread::sleep_for(yield_time);
     }
+}
+
+template <typename T>
+class BTreeLockableMap<T>::ReadGuardImpl final : public bucketdb::ReadGuard<T> {
+    typename ImplType::ReadSnapshot _snapshot;
+public:
+    explicit ReadGuardImpl(const BTreeLockableMap<T>& db);
+    ~ReadGuardImpl() override;
+
+    std::vector<T> find_parents_and_self(const document::BucketId& bucket) const override;
+    std::vector<T> find_parents_self_and_children(const document::BucketId& bucket) const override;
+    void for_each(std::function<void(uint64_t, const T&)> func) const override;
+    [[nodiscard]] uint64_t generation() const noexcept override;
+};
+
+template <typename T>
+BTreeLockableMap<T>::ReadGuardImpl::ReadGuardImpl(const BTreeLockableMap<T>& db)
+    : _snapshot(*db._impl)
+{}
+
+template <typename T>
+BTreeLockableMap<T>::ReadGuardImpl::~ReadGuardImpl() = default;
+
+template <typename T>
+std::vector<T>
+BTreeLockableMap<T>::ReadGuardImpl::find_parents_and_self(const document::BucketId& bucket) const {
+    std::vector<T> entries;
+    _snapshot.template find_parents_and_self<ByConstRef>(
+            bucket,
+            [&entries]([[maybe_unused]] uint64_t key, const T& entry){
+                entries.emplace_back(entry);
+            });
+    return entries;
+}
+
+template <typename T>
+std::vector<T>
+BTreeLockableMap<T>::ReadGuardImpl::find_parents_self_and_children(const document::BucketId& bucket) const {
+    std::vector<T> entries;
+    _snapshot.template find_parents_self_and_children<ByConstRef>(
+            bucket,
+            [&entries]([[maybe_unused]] uint64_t key, const T& entry){
+                entries.emplace_back(entry);
+            });
+    return entries;
+}
+
+template <typename T>
+void BTreeLockableMap<T>::ReadGuardImpl::for_each(std::function<void(uint64_t, const T&)> func) const {
+    _snapshot.template for_each<ByConstRef>(std::move(func));
+}
+
+template <typename T>
+uint64_t BTreeLockableMap<T>::ReadGuardImpl::generation() const noexcept {
+    return _snapshot.generation();
+}
+
+template <typename T>
+std::unique_ptr<ReadGuard<T>> BTreeLockableMap<T>::do_acquire_read_guard() const {
+    return std::make_unique<ReadGuardImpl>(*this);
 }
 
 template <typename T>

--- a/storage/src/vespa/storage/bucketdb/generic_btree_bucket_database.h
+++ b/storage/src/vespa/storage/bucketdb/generic_btree_bucket_database.h
@@ -71,13 +71,6 @@ public:
     GenericBTreeBucketDatabase(GenericBTreeBucketDatabase&&) = delete;
     GenericBTreeBucketDatabase& operator=(GenericBTreeBucketDatabase&&) = delete;
 
-    // TODO move
-    struct EntryProcessor {
-        virtual ~EntryProcessor() = default;
-        /** Return false to stop iterating. */
-        virtual bool process(const typename DataStoreTraitsT::ConstValueRef& e) = 0;
-    };
-
     ValueType entry_from_iterator(const BTreeConstIterator& iter) const;
     ConstValueRef const_value_ref_from_valid_iterator(const BTreeConstIterator& iter) const;
 
@@ -103,14 +96,10 @@ public:
     bool update_by_raw_key(uint64_t bucket_key, const ValueType& new_entry);
 
     template <typename IterValueExtractor, typename Func>
-    void find_parents_and_self(const document::BucketId& bucket,
-                               Func func) const;
+    void find_parents_and_self(const document::BucketId& bucket, Func func) const;
 
     template <typename IterValueExtractor, typename Func>
-    void find_parents_self_and_children(const document::BucketId& bucket,
-                                        Func func) const;
-
-    void for_each(EntryProcessor& proc, const document::BucketId& after) const;
+    void find_parents_self_and_children(const document::BucketId& bucket, Func func) const;
 
     document::BucketId getAppropriateBucket(uint16_t minBits, const document::BucketId& bid) const;
 
@@ -136,6 +125,10 @@ public:
 
         template <typename IterValueExtractor, typename Func>
         void find_parents_and_self(const document::BucketId& bucket, Func func) const;
+        template <typename IterValueExtractor, typename Func>
+        void find_parents_self_and_children(const document::BucketId& bucket, Func func) const;
+        template <typename IterValueExtractor, typename Func>
+        void for_each(Func func) const;
         [[nodiscard]] uint64_t generation() const noexcept;
     };
 private:
@@ -148,6 +141,11 @@ private:
     void find_parents_and_self_internal(const typename BTree::FrozenView& frozen_view,
                                         const document::BucketId& bucket,
                                         Func func) const;
+    template <typename IterValueExtractor, typename Func>
+    void find_parents_self_and_children_internal(const typename BTree::FrozenView& frozen_view,
+                                                 const document::BucketId& bucket,
+                                                 Func func) const;
+
     void commit_tree_changes();
 
     template <typename DataStoreTraitsT2> friend struct BTreeBuilderMerger;

--- a/storage/src/vespa/storage/bucketdb/read_guard.h
+++ b/storage/src/vespa/storage/bucketdb/read_guard.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vespa/document/bucket/bucketid.h>
+#include <functional>
 #include <vector>
 
 namespace storage::bucketdb {
@@ -36,8 +37,9 @@ public:
     ReadGuard(const ReadGuard&) = delete;
     ReadGuard& operator=(const ReadGuard&) = delete;
 
-    virtual void find_parents_and_self(const document::BucketId& bucket,
-                                       std::vector<ValueT>& entries) const = 0;
+    virtual std::vector<ValueT> find_parents_and_self(const document::BucketId& bucket) const = 0;
+    virtual std::vector<ValueT> find_parents_self_and_children(const document::BucketId& bucket) const = 0;
+    virtual void for_each(std::function<void(uint64_t, const ValueT&)> func) const = 0;
     // If the underlying guard represents a snapshot, returns its monotonically
     // increasing generation. Otherwise returns 0.
     [[nodiscard]] virtual uint64_t generation() const noexcept = 0;

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
@@ -138,7 +138,7 @@ void StorBucketDatabase::for_each(
 
 std::unique_ptr<bucketdb::ReadGuard<StorBucketDatabase::Entry>>
 StorBucketDatabase::acquire_read_guard() const {
-    return {};
+    return _impl->acquire_read_guard();
 }
 
 template class JudyMultiMap<bucketdb::StorageBucketInfo>;

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
@@ -136,6 +136,11 @@ void StorBucketDatabase::for_each(
     _impl->for_each(std::move(func), clientId, first, last);
 }
 
+std::unique_ptr<bucketdb::ReadGuard<StorBucketDatabase::Entry>>
+StorBucketDatabase::acquire_read_guard() const {
+    return {};
+}
+
 template class JudyMultiMap<bucketdb::StorageBucketInfo>;
 
 } // storage

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.h
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "abstract_bucket_map.h"
+#include "read_guard.h"
 #include "storagebucketinfo.h"
 #include <vespa/storageapi/defs.h>
 #include <memory>
@@ -67,6 +68,8 @@ public:
                   const char* clientId,
                   const key_type& first = key_type(),
                   const key_type& last = key_type() - 1);
+
+    std::unique_ptr<bucketdb::ReadGuard<Entry>> acquire_read_guard() const;
 
     /**
      * Returns true iff bucket has no superbuckets or sub-buckets in the

--- a/storage/src/vespa/storage/common/content_bucket_space_repo.h
+++ b/storage/src/vespa/storage/common/content_bucket_space_repo.h
@@ -43,6 +43,13 @@ public:
         }
     }
 
+    template <typename Functor>
+    void for_each_bucket(Functor functor) const {
+        for (const auto& elem : _map) {
+            elem.second->bucketDatabase().acquire_read_guard()->for_each(std::move(functor));
+        }
+    }
+
 };
 
 }

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.cpp
@@ -250,8 +250,7 @@ GetOperation::assignTargetNodeGroups(const BucketDatabase::ReadGuard& read_guard
     document::BucketIdFactory bucketIdFactory;
     document::BucketId bid = bucketIdFactory.getBucketId(_msg->getDocumentId());
 
-    std::vector<BucketDatabase::Entry> entries;
-    read_guard.find_parents_and_self(bid, entries);
+    auto entries = read_guard.find_parents_and_self(bid);
 
     for (uint32_t j = 0; j < entries.size(); ++j) {
         const BucketDatabase::Entry& e = entries[j];


### PR DESCRIPTION
@geirst please review. With these changes, metric and status aggregation will be lock-free when running with the B-tree DB implementation.

* Expose `ReadGuard` via `AbstractLockableMap` interface
* Add B-tree snapshot read guard impl
* Add placeholder wrapper read guard for legacy DB
* Enforce value const-ness of existing `for_each_chunked` iteration API
* Return read guard entries by value instead of modifying ref argument
* Replace chunked iteration with read guards for metric and status aggregation
