### PR TITLE
Log failed requests as 'info' instead of 'warning'

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
@@ -104,7 +104,7 @@ class HealthCheckProxyHandler extends HandlerWrapper {
                     }
                 } catch (Exception e) { // Typically timeouts which are reported as SSLHandshakeException
                     String message = String.format("Health check request from port %d to %d failed: %s", localPort, proxyTarget.port, e.getMessage());
-                    log.log(Level.WARNING, message);
+                    log.log(Level.INFO, message);
                     log.log(Level.FINE, e.toString(), e);
                     servletResponse.sendError(Response.Status.INTERNAL_SERVER_ERROR, message);
                     if (Duration.ofSeconds(1).compareTo(proxyTarget.timeout) >= 0) { // TODO bjorncs: remove call to close() if client is correctly pruning bad connections (VESPA-17628)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
