### PR TITLE
Don't log invalid requests for filter execution on servlets

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscFilterInvokerFilter.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscFilterInvokerFilter.java
@@ -55,7 +55,13 @@ class JDiscFilterInvokerFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest)request;
         HttpServletResponse httpResponse = (HttpServletResponse)response;
 
-        URI uri = HttpRequestFactory.getUri(httpRequest);
+        URI uri;
+        try {
+            uri = HttpRequestFactory.getUri(httpRequest);
+        } catch (RequestException e) {
+            httpResponse.sendError(e.getResponseStatus(), e.getMessage());
+            return;
+        }
 
         AtomicReference<Boolean> responseReturned = new AtomicReference<>(null);
 


### PR DESCRIPTION
Fix bug where a malformed uri to servlet/JAX-RS resource would trigger
an unhandled request exception. Jetty logs unhandled exceptions from
filters/servlets as warning with full stack trace.

FYI @gjoranv 