### PR TITLE
Reduce log level of bucket DB pruning elision message

### DIFF
--- a/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
@@ -225,7 +225,7 @@ BucketDBUpdater::removeSuperfluousBuckets(
         if (!is_distribution_config_change
             && db_pruning_may_be_elided(oldClusterState, *new_cluster_state, up_states))
         {
-            LOG(info, "[bucket space '%s']: eliding DB pruning for state transition '%s' -> '%s'",
+            LOG(debug, "[bucket space '%s']: eliding DB pruning for state transition '%s' -> '%s'",
                 document::FixedBucketSpaces::to_string(elem.first).data(),
                 oldClusterState.toString().c_str(), new_cluster_state->toString().c_str());
             continue;


### PR DESCRIPTION
@geirst please review.

Was originally set to `info` to help track down the source of an
assertion failure that should not be possible to trigger and that only
happened once. Many moons later it has yet to reappear, so removing
some log noise that could only be interesting to me.
