### PR TITLE
Handle no active session existing better

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -619,9 +619,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
     private long getSessionIdForApplication(Tenant tenant, ApplicationId applicationId) {
         TenantApplications applicationRepo = tenant.getApplicationRepo();
-        if (applicationRepo == null)
-            throw new NotFoundException("Application repo for tenant '" + tenant.getName() + "' not found");
-
+        if (! applicationRepo.exists(applicationId))
+            throw new NotFoundException("Unknown application id '" + applicationId + "'");
         return applicationRepo.requireActiveSessionOf(applicationId);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -127,11 +127,12 @@ public class TenantApplications implements RequestHandler, HostValidator<Applica
         return curator.exists(applicationPath(id));
     }
 
-    /** Returns the id of the currently active session for the given application, if any. Throws on unknown applications. */
+    /** Returns the active session id for the given application. Returns Optional.empty if application not found or no active session exists. */
     public Optional<Long> activeSessionOf(ApplicationId id) {
-        String data = curator.getData(applicationPath(id)).map(Utf8::toString)
-                             .orElseThrow(() -> new NotFoundException("No active session found for application id: '" + id + "'"));
-        return data.isEmpty() ? Optional.empty() : Optional.of(Long.parseLong(data));
+        Optional<byte[]> data = curator.getData(applicationPath(id));
+        return (data.isEmpty() || data.get().length == 0)
+                ? Optional.empty()
+                : data.map(bytes -> Long.parseLong(Utf8.toString(bytes)));
     }
 
     public boolean hasLocalSession(long sessionId) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -235,7 +235,7 @@ public class ApplicationHandlerTest {
         ApplicationId unknown = new ApplicationId.Builder().applicationName("unknown").tenant("default").build();
         HttpResponse responseForUnknown = fileDistributionStatus(unknown, zone);
         assertEquals(404, responseForUnknown.getStatus());
-        assertEquals("{\"error-code\":\"NOT_FOUND\",\"message\":\"No active session found for application id: 'default.unknown'\"}",
+        assertEquals("{\"error-code\":\"NOT_FOUND\",\"message\":\"Unknown application id 'default.unknown'\"}",
                      getRenderedString(responseForUnknown));
     }
 


### PR DESCRIPTION
* Add check for application existing and throw with exception
  about missing application id if missing
* Do not throw exception in activeSessionOf(), requireActiveSessionOf() does
  that and can be used when necessary
* tenant.getApplicationRepo() can never return null 
