### PR TITLE
Delete expired locks (older than 1 day)

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -688,6 +688,14 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         sessionsPerTenant.keySet().forEach(tenant -> tenant.getSessionRepository().deleteExpiredSessions(activeSessions));
     }
 
+    public int deleteExpiredLocks(Duration expiryTime) {
+        return tenantRepository.getAllTenants()
+                .stream()
+                .map(tenant -> tenant.getSessionRepository().deleteExpiredLocks(clock, expiryTime))
+                .mapToInt(i -> i)
+                .sum();
+    }
+
     public int deleteExpiredRemoteSessions(Duration expiryTime) {
         return deleteExpiredRemoteSessions(clock, expiryTime);
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
@@ -36,7 +36,7 @@ public class ConfigServerMaintenance extends AbstractComponent {
         // TODO: Disabled until we have application metadata
         //tenantsMaintainer = new TenantsMaintainer(applicationRepository, curator, defaults.tenantsMaintainerInterval);
         fileDistributionMaintainer = new FileDistributionMaintainer(applicationRepository, curator, defaults.defaultInterval, configserverConfig);
-        sessionsMaintainer = new SessionsMaintainer(applicationRepository, curator, defaults.defaultInterval);
+        sessionsMaintainer = new SessionsMaintainer(applicationRepository, curator, Duration.ofMinutes(1));
         applicationPackageMaintainer = new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofMinutes(1), configserverConfig, flagSource);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -38,6 +38,6 @@ public class SessionsMaintainer extends ConfigServerMaintainer {
 
         Duration lockExpiryTime = Duration.ofDays(1);
         int deleted = applicationRepository.deleteExpiredLocks(lockExpiryTime);
-        log.log(LogLevel.INFO, "Deleted " + deleted + " expired locks, expiry time " + lockExpiryTime);
+        log.log(LogLevel.INFO, "Deleted " + deleted + " locks older than " + lockExpiryTime);
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -35,5 +35,9 @@ public class SessionsMaintainer extends ConfigServerMaintainer {
             int deleted = applicationRepository.deleteExpiredRemoteSessions(expiryTime);
             log.log(LogLevel.FINE, "Deleted " + deleted + " expired remote sessions, expiry time " + expiryTime);
         }
+
+        Duration lockExpiryTime = Duration.ofDays(1);
+        int deleted = applicationRepository.deleteExpiredLocks(lockExpiryTime);
+        log.log(LogLevel.INFO, "Deleted " + deleted + " expired locks, expiry time " + lockExpiryTime);
     }
 }


### PR DESCRIPTION
* There has never been any cleanup of locks, but until we started taking
  a lock per session this has not been seen as an issue, since there were
  few of them
* Add code to maintainer that deletes locks older than 1 day

Due to the way locks are implemented and (they are removed if there is just one process that takes the lock and releases it) there are no test added for this change.  Tested in a config server cluster in CD.