### PR TITLE
Remove "partofsum" metrics from statereporter consumer

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -711,7 +711,7 @@ public class ContentCluster extends AbstractConfigProducer implements
                         name("statereporter").
                         addedmetrics("*").
                         removedtags("thread").
-                        tags("disk"));
+                        removedtags("partofsum"));
     }
 
     private static final String DEFAULT_BUCKET_SPACE = "default";

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -652,7 +652,8 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals("statereporter", config.consumer(5).name());
         assertEquals("*", config.consumer(5).addedmetrics(0));
         assertEquals("thread", config.consumer(5).removedtags(0));
-        assertEquals("disk", config.consumer(5).tags(0));
+        assertEquals("partofsum", config.consumer(5).removedtags(1));
+        assertEquals(0, config.consumer(5).tags().size());
 
         cluster.getStorageNodes().getConfig(builder);
         config = new MetricsmanagerConfig(builder);


### PR DESCRIPTION
@hmusum please review. I'm not aware of anything or anyone using metrics that are tagged as part of parent sum metrics, though I could be wrong...

Transitively removes per-thread and per-stripe metrics that add a
lot of overhead and aren't used by this consumer.
