### PR TITLE
Remove configuration in maven-bundle-plugin of parent/pom.xml file since the related issue had been already fixed. 

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,12 +82,6 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>${maven-bundle-plugin.version}</version>
-                    <configuration>
-                        <!-- TODO: remove when bundle-plugin understands java 10, https://issues.apache.org/jira/browse/FELIX-5879 -->
-                        <instructions>
-                            <_noee>true</_noee>
-                        </instructions>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -770,7 +764,7 @@
         <commons.math3.version>3.6.1</commons.math3.version>
         <junit.version>5.4.2</junit.version>
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
-        <maven-bundle-plugin.version>3.5.0</maven-bundle-plugin.version>
+        <maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>


### PR DESCRIPTION
According to the link https://issues.apache.org/jira/browse/FELIX-5879, I observed that such issue had already been fixed in maven-bundle-plugin (4.1.0). And based on the comment "TODO: remove when bundle-plugin understands java 10". This configuration is not needed in my opinion.

The configuration and comment:
https://github.com/vespa-engine/vespa/blob/a82b26c3b61b01537439fd2bc1f85e04d899e6f1/parent/pom.xml#L85-L90