### PR TITLE
Use config parameter to find correct path for 'artifacts' subdirectory

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -869,7 +869,12 @@ public class InternalStepRunner implements StepRunner {
                 ?
                 "        <component id=\"" + runtimeProviderClass + "\" bundle=\"" + tenantCdBundle + "\" />\n" +
                         "\n" +
-                        "        <component id=\"com.yahoo.vespa.testrunner.JunitRunner\" bundle=\"vespa-osgi-testrunner\" />\n" +
+                        "        <component id=\"com.yahoo.vespa.testrunner.JunitRunner\" bundle=\"vespa-osgi-testrunner\">\n" +
+                        "            <config name=\"com.yahoo.vespa.testrunner.junit-test-runner\">\n" +
+                        "                <artifactsPath>artifacts</artifactsPath>\n" +
+                        "                <useAthenzCredentials>" + systemUsesAthenz + "</useAthenzCredentials>\n" +
+                        "            </config>\n" +
+                        "        </component>\n" +
                         "\n" +
                         "        <handler id=\"com.yahoo.vespa.testrunner.TestRunnerHandler\" bundle=\"vespa-osgi-testrunner\">\n" +
                         "            <binding>http://*/tester/v1/*</binding>\n" +

--- a/controller-server/src/test/resources/test_runner_services.xml-cd-osgi
+++ b/controller-server/src/test/resources/test_runner_services.xml-cd-osgi
@@ -13,7 +13,12 @@
 
         <component id="ai.vespa.hosted.cd.cloud.impl.VespaTestRuntimeProvider" bundle="cloud-tenant-cd" />
 
-        <component id="com.yahoo.vespa.testrunner.JunitRunner" bundle="vespa-osgi-testrunner" />
+        <component id="com.yahoo.vespa.testrunner.JunitRunner" bundle="vespa-osgi-testrunner">
+            <config name="com.yahoo.vespa.testrunner.junit-test-runner">
+                <artifactsPath>artifacts</artifactsPath>
+                <useAthenzCredentials>true</useAthenzCredentials>
+            </config>
+        </component>
 
         <handler id="com.yahoo.vespa.testrunner.TestRunnerHandler" bundle="vespa-osgi-testrunner">
             <binding>http://*/tester/v1/*</binding>

--- a/vespa-osgi-testrunner/src/main/resources/configdefinitions/junit-test-runner.def
+++ b/vespa-osgi-testrunner/src/main/resources/configdefinitions/junit-test-runner.def
@@ -1,0 +1,5 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package=com.yahoo.vespa.testrunner
+
+artifactsPath          path
+useAthenzCredentials   bool default=false


### PR DESCRIPTION
Introduce new config for junit testrunner.
Remove use of ConfigserverConfig and knowledge about system names.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

FYI @tokle 
