### PR TITLE
Increase JVM heap for logserver-container

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -31,7 +31,7 @@ public class LogserverContainerCluster extends ContainerCluster<LogserverContain
     @Override
     public void getConfig(QrStartConfig.Builder builder) {
         super.getConfig(builder);
-        builder.jvm.heapsize(384);
+        builder.jvm.heapsize(512);
     }
 
     protected boolean messageBusEnabled() { return false; }


### PR DESCRIPTION
We have been seeing out of memory errors for one app in CD. Heap size was reduced in https://github.com/vespa-engine/vespa/pull/12279, but it does not say why it was reduced. Let's see if increasing heap works or leads to other issues.

@baldersheim FYI