### PR TITLE
Shutdown state server and metric manager before service layer

### DIFF
--- a/metrics/src/vespa/metrics/metricmanager.cpp
+++ b/metrics/src/vespa/metrics/metricmanager.cpp
@@ -94,6 +94,9 @@ MetricManager::~MetricManager()
 void
 MetricManager::stop()
 {
+    if (!running()) {
+        return; // Let stop() be idempotent.
+    }
     Runnable::stop();
     {
         vespalib::MonitorGuard sync(_waiter);

--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -252,6 +252,9 @@ App::Main()
                     }
                 }
             }
+            // Ensure metric manager and state server are shut down before we start tearing
+            // down any service layer components that they may end up transitively using.
+            protonUP->perform_pre_service_layer_shutdown_steps();
             if (spiProton) {
                 spiProton->getNode().requestShutdown("controlled shutdown");
                 spiProton->shutdown();

--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -254,7 +254,7 @@ App::Main()
             }
             // Ensure metric manager and state server are shut down before we start tearing
             // down any service layer components that they may end up transitively using.
-            protonUP->perform_pre_service_layer_shutdown_steps();
+            protonUP->shutdown_config_fetching_and_state_exposing_components_once();
             if (spiProton) {
                 spiProton->getNode().requestShutdown("controlled shutdown");
                 spiProton->shutdown();

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -223,6 +223,7 @@ Proton::Proton(const config::ConfigUri & configUri,
       _initStarted(false),
       _initComplete(false),
       _initDocumentDbsInSequence(false),
+      _has_shut_down_config_and_state_components(false),
       _documentDBReferenceRegistry(std::make_shared<DocumentDBReferenceRegistry>()),
       _nodeUpLock(),
       _nodeUp()
@@ -400,16 +401,8 @@ Proton::~Proton()
     if ( ! _initComplete ) {
         LOG(warning, "Initialization of proton was halted. Shutdown sequence has been initiated.");
     }
-    _protonConfigFetcher.close();
-    _protonConfigurer.setAllowReconfig(false);
+    shutdown_config_fetching_and_state_exposing_components_once();
     _executor.sync();
-    _customComponentRootToken.reset();
-    _customComponentBindToken.reset();
-    _stateServer.reset();
-    if (_metricsEngine) {
-        _metricsEngine->removeMetricsHook(_metricsHook);
-        _metricsEngine->stop(); // Idempotent call
-    }
     if (_matchEngine) {
         _matchEngine->close();
     }
@@ -463,12 +456,22 @@ Proton::~Proton()
 }
 
 void
-Proton::perform_pre_service_layer_shutdown_steps()
+Proton::shutdown_config_fetching_and_state_exposing_components_once() noexcept
 {
+    if (_has_shut_down_config_and_state_components) {
+        return;
+    }
+    _protonConfigFetcher.close();
+    _protonConfigurer.setAllowReconfig(false);
+    _executor.sync();
+    _customComponentRootToken.reset();
+    _customComponentBindToken.reset();
     _stateServer.reset();
     if (_metricsEngine) {
-        _metricsEngine->stop(); // Idempotent call
+        _metricsEngine->removeMetricsHook(_metricsHook);
+        _metricsEngine->stop();
     }
+    _has_shut_down_config_and_state_components = true;
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -408,7 +408,7 @@ Proton::~Proton()
     _stateServer.reset();
     if (_metricsEngine) {
         _metricsEngine->removeMetricsHook(_metricsHook);
-        _metricsEngine->stop();
+        _metricsEngine->stop(); // Idempotent call
     }
     if (_matchEngine) {
         _matchEngine->close();
@@ -460,6 +460,15 @@ Proton::~Proton()
     _sharedExecutor.reset();
     _clock.stop();
     LOG(debug, "Explicit destructor done");
+}
+
+void
+Proton::perform_pre_service_layer_shutdown_steps()
+{
+    _stateServer.reset();
+    if (_metricsEngine) {
+        _metricsEngine->stop(); // Idempotent call
+    }
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -124,6 +124,7 @@ private:
     bool                            _initStarted;
     bool                            _initComplete;
     bool                            _initDocumentDbsInSequence;
+    bool                            _has_shut_down_config_and_state_components;
     std::shared_ptr<IDocumentDBReferenceRegistry> _documentDBReferenceRegistry;
     std::mutex                      _nodeUpLock;
     std::set<BucketSpace>           _nodeUp;   // bucketspaces where node is up
@@ -172,8 +173,11 @@ public:
     /**
      * Shuts down metric manager and state server functionality to avoid
      * calls to these during service layer component tear-down.
+     *
+     * Explicitly noexcept to avoid consistency issues between this and the
+     * destructor if something throws during shutdown.
      */
-    void perform_pre_service_layer_shutdown_steps();
+    void shutdown_config_fetching_and_state_exposing_components_once() noexcept;
 
     // 2nd phase init: setup data structures.
     void init(const BootstrapConfig::SP & configSnapshot);

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -169,6 +169,12 @@ public:
      */
     BootstrapConfig::SP init();
 
+    /**
+     * Shuts down metric manager and state server functionality to avoid
+     * calls to these during service layer component tear-down.
+     */
+    void perform_pre_service_layer_shutdown_steps();
+
     // 2nd phase init: setup data structures.
     void init(const BootstrapConfig::SP & configSnapshot);
 


### PR DESCRIPTION
@geirst @toregge please review. I believe this is the most likely reason for a core observed during shutdown on an internal test (I could not get access to the actual core file itself).

Avoids a very small race condition window where metric update hooks
may point into the service layer components even after they have
been destroyed, as these are not explicitly unregistered today.

Another option would be to add unregistering on component destruction,
but that adds another race condition where an external client may
observe partial metric existence during this time window. By shutting
down the metric exporting interfaces first, we should avoid this.

Side note: automatic metric hook unregistering should be added at some point
anyway since they after this change cannot cause partial metric existence.
