### PR TITLE
Emit log warning on repeated content node bucket info fetch failures

### DIFF
--- a/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.h
+++ b/storage/src/vespa/storage/distributor/pending_bucket_space_db_transition.h
@@ -50,6 +50,7 @@ private:
     uint16_t                                  _distributorIndex;
     bool                                      _bucketOwnershipTransfer;
     std::unordered_map<uint16_t, size_t>      _rejectedRequests;
+    std::unordered_map<uint16_t, size_t>      _failed_requests; // Also includes rejections
 
     BucketDatabase::MergingProcessor::Result merge(BucketDatabase::Merger&) override;
     void insert_remaining_at_end(BucketDatabase::TrailingInserter&) override;
@@ -121,6 +122,13 @@ public:
     size_t rejectedRequests(uint16_t node) const {
         auto iter = _rejectedRequests.find(node);
         return ((iter != _rejectedRequests.end()) ? iter->second : 0);
+    }
+    void increment_request_failures(uint16_t node) {
+        _failed_requests[node]++;
+    }
+    [[nodiscard]] size_t request_failures(uint16_t node) const noexcept {
+        auto iter = _failed_requests.find(node);
+        return ((iter != _failed_requests.end()) ? iter->second : 0);
     }
 };
 

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -155,6 +155,10 @@ public:
     std::string requestNodesToString() const;
 
 private:
+    // With 100ms resend timeout, this requires a particular node to have failed
+    // for _at least_ threshold/10 seconds before a log warning is emitted.
+    constexpr static size_t RequestFailureWarningEdgeTriggerThreshold = 20;
+
     /**
      * Creates a pending cluster state that represents
      * a set system state command from the fleet controller.
@@ -211,6 +215,7 @@ private:
     std::string getPrevClusterStateBundleString() const {
         return _prevClusterStateBundle.getBaselineClusterState()->toString();
     }
+    void update_reply_failure_statistics(const api::ReturnCode& result, const BucketSpaceAndNode& source);
 
     std::shared_ptr<api::SetSystemStateCommand> _cmd;
 


### PR DESCRIPTION
@geirst please review

Currently requires a certain number of repeated failures for a given
cluster state transition. Rationale is that problematic nodes usually
fail for a prolonged amount of time, so it's wise to reduce log noise
from more transient failures. Threshold to be adjusted later as needed.
