### PR TITLE
Add per-operation metrics for puts and removes that are part of merges

### DIFF
--- a/storage/src/tests/common/metricstest.cpp
+++ b/storage/src/tests/common/metricstest.cpp
@@ -175,16 +175,16 @@ void MetricsTest::createFakeLoad()
             thread.internalJoin.count.inc(3 * n);
 
             thread.mergeBuckets.count.inc(2 * n);
-            thread.bytesMerged.inc(1000 * n);
             thread.getBucketDiff.count.inc(4 * n);
             thread.getBucketDiffReply.inc(4 * n);
             thread.applyBucketDiff.count.inc(4 * n);
             thread.applyBucketDiffReply.inc(4 * n);
-            thread.mergeLatencyTotal.addValue(300 * n);
-            thread.mergeMetadataReadLatency.addValue(20 * n);
-            thread.mergeDataReadLatency.addValue(40 * n);
-            thread.mergeDataWriteLatency.addValue(50 * n);
-            thread.mergeAverageDataReceivedNeeded.addValue(0.8);
+            thread.merge_handler_metrics.bytesMerged.inc(1000 * n);
+            thread.merge_handler_metrics.mergeLatencyTotal.addValue(300 * n);
+            thread.merge_handler_metrics.mergeMetadataReadLatency.addValue(20 * n);
+            thread.merge_handler_metrics.mergeDataReadLatency.addValue(40 * n);
+            thread.merge_handler_metrics.mergeDataWriteLatency.addValue(50 * n);
+            thread.merge_handler_metrics.mergeAverageDataReceivedNeeded.addValue(0.8);
         }
     }
     for (uint32_t i=0; i<_visitorMetrics->threads.size(); ++i) {

--- a/storage/src/tests/persistence/mergehandlertest.cpp
+++ b/storage/src/tests/persistence/mergehandlertest.cpp
@@ -901,7 +901,7 @@ TEST_F(MergeHandlerTest, apply_bucket_diff_spi_failures) {
         EXPECT_EQ("", doTestSPIException(handler, providerWrapper, invoker, *it));
         // Casual, in-place testing of bug 6752085.
         // This will fail if we give NaN to the metric in question.
-        EXPECT_TRUE(std::isfinite(getEnv()._metrics.mergeAverageDataReceivedNeeded.getLast()));
+        EXPECT_TRUE(std::isfinite(getEnv()._metrics.merge_handler_metrics.mergeAverageDataReceivedNeeded.getLast()));
     }
 }
 

--- a/storage/src/vespa/storage/persistence/filestorage/CMakeLists.txt
+++ b/storage/src/vespa/storage/persistence/filestorage/CMakeLists.txt
@@ -5,6 +5,7 @@ vespa_add_library(storage_filestorpersistence OBJECT
     filestorhandlerimpl.cpp
     filestormanager.cpp
     filestormetrics.cpp
+    merge_handler_metrics.cpp
     mergestatus.cpp
     modifiedbucketchecker.cpp
     DEPENDS

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
@@ -152,23 +152,9 @@ FileStorThreadMetrics::FileStorThreadMetrics(const std::string& name, const std:
       mergeBuckets("mergebuckets", "Number of times buckets have been merged.", this),
       getBucketDiff("getbucketdiff", "Number of getbucketdiff commands that have been processed.", this),
       applyBucketDiff("applybucketdiff", "Number of applybucketdiff commands that have been processed.", this),
-      bytesMerged("bytesmerged", {}, "Total number of bytes merged into this node.", this),
       getBucketDiffReply("getbucketdiffreply", {}, "Number of getbucketdiff replies that have been processed.", this),
       applyBucketDiffReply("applybucketdiffreply", {}, "Number of applybucketdiff replies that have been processed.", this),
-      mergeLatencyTotal("mergelatencytotal", {},
-             "Latency of total merge operation, from master node receives "
-             "it, until merge is complete and master node replies.", this),
-      mergeMetadataReadLatency("mergemetadatareadlatency", {},
-             "Latency of time used in a merge step to check metadata of "
-             "current node to see what data it has.", this),
-      mergeDataReadLatency("mergedatareadlatency", {},
-             "Latency of time used in a merge step to read data other "
-             "nodes need.", this),
-      mergeDataWriteLatency("mergedatawritelatency", {},
-            "Latency of time used in a merge step to write data needed to "
-            "current node.", this),
-      mergeAverageDataReceivedNeeded("mergeavgdatareceivedneeded", {}, "Amount of data transferred from previous node "
-                                     "in chain that we needed to apply locally.", this),
+      merge_handler_metrics(this),
       batchingSize("batchingsize", {}, "Number of operations batched per bucket (only counts "
                    "batches of size > 1)", this)
 { }

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "merge_handler_metrics.h"
 #include <vespa/metrics/metrics.h>
 #include <vespa/documentapi/loadtypes/loadtypeset.h>
 
@@ -99,15 +100,9 @@ struct FileStorThreadMetrics : public metrics::MetricSet
     Op mergeBuckets;
     Op getBucketDiff;
     Op applyBucketDiff;
-
-    metrics::LongCountMetric bytesMerged;
     metrics::LongCountMetric getBucketDiffReply;
     metrics::LongCountMetric applyBucketDiffReply;
-    metrics::DoubleAverageMetric mergeLatencyTotal;
-    metrics::DoubleAverageMetric mergeMetadataReadLatency;
-    metrics::DoubleAverageMetric mergeDataReadLatency;
-    metrics::DoubleAverageMetric mergeDataWriteLatency;
-    metrics::DoubleAverageMetric mergeAverageDataReceivedNeeded;
+    MergeHandlerMetrics merge_handler_metrics;
     metrics::LongAverageMetric batchingSize;
 
     FileStorThreadMetrics(const std::string& name, const std::string& desc, const metrics::LoadTypeSet& lt);

--- a/storage/src/vespa/storage/persistence/filestorage/merge_handler_metrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/merge_handler_metrics.cpp
@@ -1,0 +1,28 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "merge_handler_metrics.h"
+
+namespace storage {
+
+MergeHandlerMetrics::MergeHandlerMetrics(metrics::MetricSet* owner)
+    : bytesMerged("bytesmerged", {}, "Total number of bytes merged into this node.", owner),
+      mergeLatencyTotal("mergelatencytotal", {},
+                        "Latency of total merge operation, from master node receives "
+                        "it, until merge is complete and master node replies.", owner),
+      mergeMetadataReadLatency("mergemetadatareadlatency", {},
+                               "Latency of time used in a merge step to check metadata of "
+                               "current node to see what data it has.", owner),
+      mergeDataReadLatency("mergedatareadlatency", {},
+                           "Latency of time used in a merge step to read data other "
+                           "nodes need.", owner),
+      mergeDataWriteLatency("mergedatawritelatency", {},
+                            "Latency of time used in a merge step to write data needed to "
+                            "current node.", owner),
+      mergeAverageDataReceivedNeeded("mergeavgdatareceivedneeded", {}, "Amount of data transferred from previous node "
+                                                                       "in chain that we needed to apply locally.", owner),
+      put_latency("put_latency", {}, "Latency of individual puts that are part of merge operations", owner),
+      remove_latency("remove_latency", {}, "Latency of individual removes that are part of merge operations", owner)
+{}
+
+MergeHandlerMetrics::~MergeHandlerMetrics() = default;
+
+}

--- a/storage/src/vespa/storage/persistence/filestorage/merge_handler_metrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/merge_handler_metrics.h
@@ -1,0 +1,32 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/metrics/metrics.h>
+
+namespace storage {
+
+// Provides a convenient wrapper for all MergeHandler-related metrics.
+// This is _not_ its own MetricSet; metrics are owned by an explicitly provided
+// parent. This is to prevent metric paths from changing, as external aggregation
+// depends on the existing paths.
+struct MergeHandlerMetrics {
+    metrics::LongCountMetric bytesMerged;
+    // Aggregate metrics:
+    metrics::DoubleAverageMetric mergeLatencyTotal;
+    metrics::DoubleAverageMetric mergeMetadataReadLatency;
+    metrics::DoubleAverageMetric mergeDataReadLatency;
+    metrics::DoubleAverageMetric mergeDataWriteLatency;
+    metrics::DoubleAverageMetric mergeAverageDataReceivedNeeded;
+    // Individual operation metrics. These capture both count and latency sum, so
+    // no need for explicit count metric on the side.
+    metrics::DoubleAverageMetric put_latency;
+    metrics::DoubleAverageMetric remove_latency;
+    // Iteration over metadata and document payload data is already covered by
+    // the merge[Meta]Data(Read|Write)Latency metrics, so not repeated here. Can be
+    // explicitly added if deemed required.
+
+    explicit MergeHandlerMetrics(metrics::MetricSet* owner);
+    ~MergeHandlerMetrics();
+};
+
+}


### PR DESCRIPTION
@geirst please review
@yngveaasheim @baldersheim FYI

Move all merge-related metrics out into a separate wrapper for convenience.