### PR TITLE
Ensure operation counting is thread-safe

### DIFF
--- a/storage/src/tests/persistence/filestorage/operationabortingtest.cpp
+++ b/storage/src/tests/persistence/filestorage/operationabortingtest.cpp
@@ -31,9 +31,9 @@ class BlockingMockProvider : public PersistenceProviderWrapper
 public:
     typedef std::unique_ptr<BlockingMockProvider> UP;
 
-    mutable uint32_t _bucketInfoInvocations;
-    uint32_t _createBucketInvocations;
-    uint32_t _deleteBucketInvocations;
+    mutable std::atomic<uint32_t> _bucketInfoInvocations;
+    std::atomic<uint32_t> _createBucketInvocations;
+    std::atomic<uint32_t> _deleteBucketInvocations;
 
     BlockingMockProvider(spi::PersistenceProvider& wrappedProvider,
                          vespalib::Barrier& queueBarrier,


### PR DESCRIPTION
@toregge please review

With the introduction of async response handling, SPI `getBucketInfo()`
can now be called from multiple threads concurrently. Test was not
originally written with that in mind. Use `std::atomic` instead of unsafe
raw increment.

For future-proofing, also make other counters atomic.
