### PR TITLE
Gjoranv/allow preinstall per bundle

### DIFF
--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -57,12 +57,12 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
     private String mainClass = null;
 
     @Parameter(defaultValue = "false")
-    private boolean buildVespaPlatformBundle;
+    private boolean buildLegacyVespaPlatformBundle;
 
     public void execute() throws MojoExecutionException {
         try {
-            if (discPreInstallBundle != null && ! buildVespaPlatformBundle)
-                throw new MojoExecutionException("The 'discPreInstallBundle' parameter can only be used by Vespa platform bundles.");
+            if (discPreInstallBundle != null && !buildLegacyVespaPlatformBundle)
+                throw new MojoExecutionException("The 'discPreInstallBundle' parameter can only be used by legacy Vespa platform bundles.");
 
             Artifacts.ArtifactSet artifactSet = Artifacts.getArtifacts(project);
             warnOnUnsupportedArtifacts(artifactSet.getNonJarArtifacts());

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -181,7 +181,8 @@
         <artifactId>bundle-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
-          <discApplicationClass>com.yahoo.container.jdisc.ConfiguredApplication</discApplicationClass>
+            <discApplicationClass>com.yahoo.container.jdisc.ConfiguredApplication</discApplicationClass>
+            <buildLegacyVespaPlatformBundle>true</buildLegacyVespaPlatformBundle>
             <discPreInstallBundle>
                 <!-- Vespa bundles -->
                 config-bundle-jar-with-dependencies.jar,

--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -140,6 +140,7 @@
         <artifactId>bundle-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
+          <buildLegacyVespaPlatformBundle>true</buildLegacyVespaPlatformBundle>
           <discPreInstallBundle>
             javax.servlet-api-3.1.0.jar,
             jetty-continuation-${jetty.version}.jar,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -255,7 +255,6 @@
                     <artifactId>bundle-plugin</artifactId>
                     <version>${project.version}</version>
                     <configuration>
-                        <buildLegacyVespaPlatformBundle>true</buildLegacyVespaPlatformBundle>
                         <configGenVersion>${project.version}</configGenVersion>
                         <useCommonAssemblyIds>true</useCommonAssemblyIds>
                     </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -255,7 +255,7 @@
                     <artifactId>bundle-plugin</artifactId>
                     <version>${project.version}</version>
                     <configuration>
-                        <buildVespaPlatformBundle>true</buildVespaPlatformBundle>
+                        <buildLegacyVespaPlatformBundle>true</buildLegacyVespaPlatformBundle>
                         <configGenVersion>${project.version}</configGenVersion>
                         <useCommonAssemblyIds>true</useCommonAssemblyIds>
                     </configuration>

--- a/standalone-container/pom.xml
+++ b/standalone-container/pom.xml
@@ -81,6 +81,7 @@
         <extensions>true</extensions>
         <configuration>
           <discApplicationClass>com.yahoo.container.standalone.StandaloneContainerApplication</discApplicationClass>
+          <buildLegacyVespaPlatformBundle>true</buildLegacyVespaPlatformBundle>
           <discPreInstallBundle>
             configdefinitions-jar-with-dependencies.jar,
             config-provisioning-jar-with-dependencies.jar,


### PR DESCRIPTION
Allowing preinstall should not be default for Vespa bundles, as some of them are used as application bundles

The name change is to make sure that developers don't want to use it.