### PR TITLE
Use plain strings for platform bundles, instead of file references

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -16,11 +16,8 @@ import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.xml.PlatformBundles;
 
-import java.nio.file.Path;
 import java.util.Set;
 import java.util.TreeSet;
-
-import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
 /**
  * Container implementation for cluster-controllers
@@ -106,7 +103,7 @@ public class ClusterControllerContainer extends Container implements
 
     @Override
     public void getConfig(PlatformBundlesConfig.Builder builder) {
-        bundles.forEach(builder::bundles);
+        bundles.forEach(builder::bundlePaths);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -474,7 +474,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public void getConfig(PlatformBundlesConfig.Builder builder) {
         platformBundles.stream()
                 .map(Path::toString)
-                .forEach(builder::bundles);
+                .forEach(builder::bundlePaths);
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -58,8 +58,8 @@ public class MetricsProxyContainerClusterTest {
         var builder = new PlatformBundlesConfig.Builder();
         model.getConfig(builder, CLUSTER_CONFIG_ID);
         PlatformBundlesConfig config = builder.build();
-        assertEquals(1, config.bundles().size());
-        assertThat(config.bundles(0).value(), endsWith(METRICS_PROXY_BUNDLE_FILE.toString()));
+        assertEquals(1, config.bundlePaths().size());
+        assertThat(config.bundlePaths(0), endsWith(METRICS_PROXY_BUNDLE_FILE.toString()));
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.model.container;
 import com.yahoo.cloud.config.ClusterInfoConfig;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.cloud.config.RoutingProviderConfig;
-import com.yahoo.config.FileReference;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -294,7 +293,7 @@ public class ContainerClusterTest {
         ApplicationContainerCluster cluster = new ApplicationContainerCluster(root, "container0", "container1", state);
         var bundleBuilder = new PlatformBundlesConfig.Builder();
         cluster.getConfig(bundleBuilder);
-        List<String> installedBundles = bundleBuilder.build().bundles().stream().map(FileReference::value).collect(Collectors.toList());
+        List<String> installedBundles = bundleBuilder.build().bundlePaths();
 
         assertEquals(expectedBundleNames.size(), installedBundles.size());
         assertThat(installedBundles, containsInAnyOrder(

--- a/container-core/src/main/java/com/yahoo/container/core/config/DiskBundleInstaller.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/DiskBundleInstaller.java
@@ -1,7 +1,6 @@
 // Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.core.config;
 
-import com.yahoo.config.FileReference;
 import com.yahoo.osgi.Osgi;
 import org.osgi.framework.Bundle;
 
@@ -11,18 +10,12 @@ import java.util.List;
 /**
  * @author gjoranv
  */
-public class DiskBundleInstaller implements BundleInstaller {
+public class DiskBundleInstaller {
 
-    @Override
-    public List<Bundle> installBundles(FileReference reference, Osgi osgi) {
-        // TODO: remove when the last model producing 'file:' has rolled out of hosted
-        String referenceFileName = reference.value().startsWith("file:")
-                ? reference.value().substring("file:".length())
-                : reference.value();
-
-        File file = new File(referenceFileName);
+    public List<Bundle> installBundles(String bundlePath, Osgi osgi) {
+        File file = new File(bundlePath);
         if ( ! file.exists()) {
-            throw new IllegalArgumentException("Reference '" + reference.value() + "' not found on disk.");
+            throw new IllegalArgumentException("Bundle file '" + bundlePath + "' not found on disk.");
         }
 
         return osgi.install(file.getAbsolutePath());

--- a/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
@@ -135,9 +135,9 @@ public class HandlersConfigurerDi {
         }
 
         @Override
-        public void installPlatformBundles(Collection<FileReference> bundles) {
+        public void installPlatformBundles(Collection<String> bundlePaths) {
             log.fine("Installing platform bundles.");
-            platformBundleLoader.useBundles(new ArrayList<>(bundles));
+            platformBundleLoader.useBundles(new ArrayList<>(bundlePaths));
         }
 
         @Override

--- a/container-core/src/main/java/com/yahoo/container/core/config/PlatformBundleLoader.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/PlatformBundleLoader.java
@@ -1,6 +1,5 @@
 package com.yahoo.container.core.config;
 
-import com.yahoo.config.FileReference;
 import com.yahoo.osgi.Osgi;
 import org.osgi.framework.Bundle;
 
@@ -38,35 +37,35 @@ public class PlatformBundleLoader {
         this.installer = installer;
     }
 
-    public void useBundles(List<FileReference> fileReferences) {
+    public void useBundles(List<String> bundlePaths) {
         if (hasLoadedBundles) {
             log.fine(() -> "Platform bundles have already been installed." +
                     "\nInstalled bundles: " + installedBundles +
-                    "\nGiven files: " + fileReferences);
+                    "\nGiven files: " + bundlePaths);
             return;
         }
-        installedBundles = install(fileReferences);
+        installedBundles = install(bundlePaths);
         BundleStarter.startBundles(installedBundles);
         hasLoadedBundles = true;
     }
 
-    private Set<Bundle> install(List<FileReference> bundlesToInstall) {
+    private Set<Bundle> install(List<String> bundlesToInstall) {
         var allInstalled = new LinkedHashSet<Bundle>();
-        for (FileReference reference : bundlesToInstall) {
+        for (String bundlePath : bundlesToInstall) {
             try {
-                allInstalled.addAll(installBundleFromDisk(reference));
+                allInstalled.addAll(installBundleFromDisk(bundlePath));
             }
             catch(Exception e) {
-                throw new RuntimeException("Could not install bundle '" + reference + "'", e);
+                throw new RuntimeException("Could not install bundle '" + bundlePath + "'", e);
             }
         }
         return allInstalled;
     }
 
-    private List<Bundle> installBundleFromDisk(FileReference reference) {
-        log.info("Installing bundle from disk with reference '" + reference.value() + "'");
-        List<Bundle> bundles = installer.installBundles(reference, osgi);
-        log.fine("Installed " + bundles.size() + " bundles for file reference " + reference);
+    private List<Bundle> installBundleFromDisk(String bundlePath) {
+        log.info("Installing bundle from disk: " + bundlePath);
+        List<Bundle> bundles = installer.installBundles(bundlePath, osgi);
+        log.fine("Installed " + bundles.size() + " bundles for file " + bundlePath);
         return bundles;
     }
 

--- a/container-core/src/test/java/com/yahoo/container/core/config/PlatformBundleLoaderTest.java
+++ b/container-core/src/test/java/com/yahoo/container/core/config/PlatformBundleLoaderTest.java
@@ -1,6 +1,5 @@
 package com.yahoo.container.core.config;
 
-import com.yahoo.config.FileReference;
 import com.yahoo.osgi.Osgi;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,10 +16,10 @@ import static org.junit.Assert.assertTrue;
  */
 public class PlatformBundleLoaderTest {
 
-    private static final FileReference BUNDLE_1_REF = new FileReference("bundle-1");
-    private static final Bundle BUNDLE_1 = new TestBundle(BUNDLE_1_REF.value());
-    private static final FileReference BUNDLE_2_REF = new FileReference("bundle-2");
-    private static final Bundle BUNDLE_2 = new TestBundle(BUNDLE_2_REF.value());
+    private static final String BUNDLE_1_REF = "bundle-1";
+    private static final Bundle BUNDLE_1 = new TestBundle(BUNDLE_1_REF);
+    private static final String BUNDLE_2_REF = "bundle-2";
+    private static final Bundle BUNDLE_2 = new TestBundle(BUNDLE_2_REF);
 
     private PlatformBundleLoader bundleLoader;
     private TestOsgi osgi;
@@ -52,14 +51,14 @@ public class PlatformBundleLoaderTest {
     }
 
     private static Map<String, Bundle> testBundles() {
-        return Map.of(BUNDLE_1_REF.value(), BUNDLE_1,
-                      BUNDLE_2_REF.value(), BUNDLE_2);
+        return Map.of(BUNDLE_1_REF, BUNDLE_1,
+                      BUNDLE_2_REF, BUNDLE_2);
     }
 
     static class TestBundleInstaller extends DiskBundleInstaller {
         @Override
-        public List<Bundle> installBundles(FileReference reference, Osgi osgi) {
-            return osgi.install(reference.value());
+        public List<Bundle> installBundles(String bundlePath, Osgi osgi) {
+            return osgi.install(bundlePath);
         }
     }
 }

--- a/container-di/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-di/src/main/java/com/yahoo/container/di/Container.java
@@ -4,11 +4,11 @@ package com.yahoo.container.di;
 import com.google.inject.Injector;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.ConfigurationRuntimeException;
-import com.yahoo.config.FileReference;
 import com.yahoo.config.subscription.ConfigInterruptedException;
 import com.yahoo.container.ComponentsConfig;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.di.ConfigRetriever.BootstrapConfigs;
+import com.yahoo.container.di.ConfigRetriever.ComponentsConfigs;
 import com.yahoo.container.di.ConfigRetriever.ConfigSnapshot;
 import com.yahoo.container.di.componentgraph.core.ComponentGraph;
 import com.yahoo.container.di.componentgraph.core.ComponentNode;
@@ -50,7 +50,7 @@ public class Container {
     private final Osgi osgi;
 
     private final ConfigRetriever configurer;
-    private List<FileReference> platformBundles;  // Used to verify that platform bundles don't change.
+    private List<String> platformBundles;  // Used to verify that platform bundles don't change.
     private long previousConfigGeneration = -1L;
     private long leastGeneration = -1L;
 
@@ -106,7 +106,7 @@ public class Container {
                 log.log(FINE, "Got new bootstrap generation\n" + configGenerationsString());
 
                 if (graph.generation() == 0) {
-                    platformBundles = getConfig(platformBundlesConfigKey, snapshot.configs()).bundles();
+                    platformBundles = getConfig(platformBundlesConfigKey, snapshot.configs()).bundlePaths();
                     osgi.installPlatformBundles(platformBundles);
                 } else {
                     throwIfPlatformBundlesChanged(snapshot);
@@ -118,7 +118,7 @@ public class Container {
 
                 // Continues loop
 
-            } else if (snapshot instanceof ConfigRetriever.ComponentsConfigs) {
+            } else if (snapshot instanceof ComponentsConfigs) {
                 break;
             }
         }
@@ -140,7 +140,7 @@ public class Container {
     }
 
     private void throwIfPlatformBundlesChanged(ConfigSnapshot snapshot) {
-        var checkPlatformBundles = getConfig(platformBundlesConfigKey, snapshot.configs()).bundles();
+        var checkPlatformBundles = getConfig(platformBundlesConfigKey, snapshot.configs()).bundlePaths();
         if (! checkPlatformBundles.equals(platformBundles))
             throw new RuntimeException("Platform bundles are not allowed to change!\nOld: " + platformBundles + "\nNew: " + checkPlatformBundles);
     }

--- a/container-di/src/main/java/com/yahoo/container/di/Osgi.java
+++ b/container-di/src/main/java/com/yahoo/container/di/Osgi.java
@@ -25,8 +25,8 @@ public interface Osgi {
         return new BundleClasses(new MockBundle(), Collections.emptySet());
     }
 
-    default void installPlatformBundles(Collection<FileReference> bundles) {
-        System.out.println("installPlatformBundles " + bundles.stream().map(Object::toString).collect(Collectors.joining(", ")));
+    default void installPlatformBundles(Collection<String> bundlePaths) {
+        System.out.println("installPlatformBundles " + bundlePaths);
     }
 
     /**

--- a/container-di/src/main/resources/configdefinitions/platform-bundles.def
+++ b/container-di/src/main/resources/configdefinitions/platform-bundles.def
@@ -1,5 +1,5 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package=com.yahoo.container.di.config
 
-# References to platform bundles to install.
-bundles[] file
+# Paths to platform bundles to install.
+bundlePaths[] string

--- a/standalone-container/src/test/java/com/yahoo/container/standalone/StandaloneSubscriberTest.java
+++ b/standalone-container/src/test/java/com/yahoo/container/standalone/StandaloneSubscriberTest.java
@@ -48,7 +48,7 @@ public class StandaloneSubscriberTest {
             ApplicationBundlesConfig applicationBundlesConfig = (ApplicationBundlesConfig) config.get(applicationBundlesKey);
             ComponentsConfig componentsConfig = (ComponentsConfig) config.get(componentsKey);
 
-            assertThat(platformBundlesConfig.bundles().size(), is(0));
+            assertThat(platformBundlesConfig.bundlePaths().size(), is(0));
             assertThat(applicationBundlesConfig.bundles().size(), is(0));
             assertThat(componentsConfig.components().size(), greaterThan(10));
             return null;


### PR DESCRIPTION
This is safe, because the def file is not yet released, there is no user config involved, and this PR does not change type of an existing field (removes and adds instead).