### PR TITLE
[VESPA-18202] Disable node-agent tasks

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -71,7 +71,8 @@ public class Flags {
 
     public static final UnboundListFlag<String> DISABLED_HOST_ADMIN_TASKS = defineListFlag(
             "disabled-host-admin-tasks", List.of(), String.class,
-            "List of host-admin task names (as they appear in the log, e.g. root>main>UpgradeTask) that should be skipped",
+            "List of host-admin task names (as they appear in the log, e.g. root>main>UpgradeTask), or some node-agent " +
+            "functionality (see NodeAgentTask), that should be skipped",
             "Takes effect on next host admin tick",
             HOSTNAME, NODE_TYPE);
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainer.java
@@ -2,9 +2,9 @@
 package com.yahoo.vespa.hosted.node.admin.maintenance.acl;
 
 import com.google.common.net.InetAddresses;
-import java.util.logging.Level;
 import com.yahoo.vespa.hosted.node.admin.docker.DockerOperations;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
+import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentTask;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.Editor;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.LineEditor;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.IPAddresses;
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.yahoo.yolean.Exceptions.uncheck;
@@ -51,6 +52,8 @@ public class AclMaintainer {
     // ip(6)tables operate while having the xtables lock, run with synchronized to prevent multiple NodeAgents
     // invoking ip(6)tables concurrently.
     public synchronized void converge(NodeAgentContext context) {
+        if (context.isDisabled(NodeAgentTask.AclMaintainer)) return;
+
         // Apply acl to the filter table
         editFlushOnError(context, IPVersion.IPv4, "filter", FilterTableLineEditor.from(context.acl(), IPVersion.IPv4));
         editFlushOnError(context, IPVersion.IPv6, "filter", FilterTableLineEditor.from(context.acl(), IPVersion.IPv6));

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/identity/AthenzCredentialsMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/identity/AthenzCredentialsMaintainer.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.maintenance.identity;
 
-import java.util.logging.Level;
 import com.yahoo.security.KeyAlgorithm;
 import com.yahoo.security.KeyStoreType;
 import com.yahoo.security.KeyUtils;
@@ -24,6 +23,7 @@ import com.yahoo.vespa.athenz.utils.SiaUtils;
 import com.yahoo.vespa.hosted.dockerapi.ContainerName;
 import com.yahoo.vespa.hosted.node.admin.component.ConfigServerInfo;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
+import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentTask;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixPath;
 
@@ -46,6 +46,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -108,6 +109,8 @@ public class AthenzCredentialsMaintainer implements CredentialsMaintainer {
     }
 
     public boolean converge(NodeAgentContext context) {
+        if (context.isDisabled(NodeAgentTask.CredentialsMaintainer)) return false;
+
         try {
             context.log(logger, Level.FINE, "Checking certificate");
             Path containerSiaDirectory = context.pathOnHostFromPathInNode(CONTAINER_SIA_DIRECTORY);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContext.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentContext.java
@@ -44,6 +44,10 @@ public interface NodeAgentContext extends TaskContext {
 
     String vespaUserOnHost();
 
+    default boolean isDisabled(NodeAgentTask task) {
+        return false;
+    };
+
     /**
      * The vcpu value in NodeSpec is multiplied by the speedup factor per cpu core compared to a historical baseline
      * for a particular cpu generation of the host (see flavors.def cpuSpeedup).
@@ -52,7 +56,7 @@ public interface NodeAgentContext extends TaskContext {
      */
     double unscaledVcpu();
 
-    /** The file system used by the NodeAgentContext.  All paths must have the same provider. */
+    /** The file system used by the NodeAgentContext. All paths must have the same provider. */
     FileSystem fileSystem();
 
     /**

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentTask.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentTask.java
@@ -1,0 +1,30 @@
+package com.yahoo.vespa.hosted.node.admin.nodeagent;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum NodeAgentTask {
+
+    // The full task name is prefixed with 'node>', e.g. 'node>DiskCleanup'
+    DiskCleanup,
+    CoreDumps,
+    CredentialsMaintainer,
+    AclMaintainer;
+
+    private static final Map<String, NodeAgentTask> tasksByName = Arrays.stream(NodeAgentTask.values())
+            .collect(Collectors.toUnmodifiableMap(NodeAgentTask::taskName, n -> n));
+
+    private final String taskName;
+    NodeAgentTask() {
+        this.taskName = "node>" + name();
+    }
+
+    public String taskName() { return taskName; }
+
+    public static Set<NodeAgentTask> fromString(List<String> tasks) {
+        return tasks.stream().filter(tasksByName::containsKey).map(tasksByName::get).collect(Collectors.toUnmodifiableSet());
+    }
+}


### PR DESCRIPTION
Long term I hope we will be able to split `NodeAgentImpl` into a proper task chain, but that is a pretty big change due to lots of shared state and dependencies, but also that it would require open-sourcing some of the task chain code currently in host-admin.

This solution makes it pretty easy to declare some new task and disable pretty much any code run by NodeAgent since we pass the `NodeAgentContext` everywhere.

Must be merged with an internal PR.