### PR TITLE
Fix flaky NodeMetricsDbTest

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsDbTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsDbTest.java
@@ -5,6 +5,7 @@ import com.yahoo.test.ManualClock;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,7 +15,7 @@ public class NodeMetricsDbTest {
 
     @Test
     public void testNodeMetricsDb() {
-        ManualClock clock = new ManualClock();
+        ManualClock clock = new ManualClock(Instant.ofEpochSecond(1596102538L));
         NodeMetricsDb db = new NodeMetricsDb();
         List<NodeMetrics.MetricValue> values = new ArrayList<>();
         for (int i = 0; i < 40; i++) {
@@ -22,6 +23,9 @@ public class NodeMetricsDbTest {
             clock.advance(Duration.ofHours(1));
         }
         db.add(values);
+
+        // Avoid off-by-one bug when the below windows starts exactly on one of the above getEpochSecond() timestamps.
+        clock.advance(Duration.ofMinutes(1));
 
         assertEquals(29, db.getWindow(clock.instant().minus(Duration.ofHours(30)), Resource.cpu,    List.of("host0")).measurementCount());
         assertEquals( 0, db.getWindow(clock.instant().minus(Duration.ofHours(30)), Resource.memory, List.of("host0")).measurementCount());


### PR DESCRIPTION
ManualClock is initialized internally to Instant.now().  If this instant has a
zero subsecond part

db.getWindow(clock.instant().minus(Duration.ofHours(30)), Resource.cpu,    List.of("host0")).measurementCount()

returns 30, while otherwise returns 29.  It's hard to say what is correct when
falling exactly on this boundary, so this PR avoids the whole problem by
ensuring the boundary is not hit (by adding an arbitrary 1 minute).