### PR TITLE
Revert "Reapply "Upgrade to Curator 2.13.0""

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -765,7 +765,7 @@
                  find zkfacade/src/main/java/org/apache/curator -name package-info.java | \
                      xargs perl -pi -e 's/major = [0-9]+, minor = [0-9]+, micro = [0-9]+/major = 2, minor = 9, micro = 1/g'
         -->
-        <curator.version>2.13.0</curator.version>
+        <curator.version>2.9.1</curator.version>
         <jna.version>4.5.2</jna.version>
         <commons.math3.version>3.6.1</commons.math3.version>
         <junit.version>5.4.2</junit.version>

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCurator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCurator.java
@@ -14,7 +14,6 @@ import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ACLBackgroundPathAndBytesable;
 import org.apache.curator.framework.api.ACLCreateModeBackgroundPathAndBytesable;
-import org.apache.curator.framework.api.ACLCreateModePathAndBytesable;
 import org.apache.curator.framework.api.ACLPathAndBytesable;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.BackgroundPathAndBytesable;
@@ -26,8 +25,6 @@ import org.apache.curator.framework.api.CreateBuilder;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.api.DeleteBuilder;
-import org.apache.curator.framework.api.ErrorListenerPathAndBytesable;
-import org.apache.curator.framework.api.ErrorListenerPathable;
 import org.apache.curator.framework.api.ExistsBuilder;
 import org.apache.curator.framework.api.ExistsBuilderMain;
 import org.apache.curator.framework.api.GetACLBuilder;
@@ -42,7 +39,6 @@ import org.apache.curator.framework.api.SetDataBackgroundVersionable;
 import org.apache.curator.framework.api.SetDataBuilder;
 import org.apache.curator.framework.api.SyncBuilder;
 import org.apache.curator.framework.api.UnhandledErrorListener;
-import org.apache.curator.framework.api.VersionPathAndBytesable;
 import org.apache.curator.framework.api.WatchPathable;
 import org.apache.curator.framework.api.Watchable;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
@@ -98,7 +94,7 @@ import static com.yahoo.vespa.curator.mock.MemoryFileSystem.Node;
  * Due to the "fluent API" style of Curator managing to break JavaDoc at a fundamental level, there is no
  * documentation on the contract of each method. The behavior here is deduced by observing what using code exists
  * and peeking at the Curator code. It may be incorrect in some corner cases.</p>
- *
+ * 
  * <p>Contains some code from PathUtils in ZooKeeper, licensed under the Apache 2.0 license.</p>
  *
  * @author bratseth
@@ -640,6 +636,30 @@ public class MockCurator extends Curator {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
+        public PathAndBytesable<T> inBackground() {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        public PathAndBytesable<T> inBackground(Object o) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback, Object o) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
+        public PathAndBytesable<T> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
         public ACLBackgroundPathAndBytesable<T> withMode(CreateMode createMode) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
@@ -707,71 +727,37 @@ public class MockCurator extends Curator {
             return createNode(s, bytes, createParents, createMode, fileSystem.root(), listeners);
         }
 
-        @Override
-        public ErrorListenerPathAndBytesable<String> inBackground() {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<String> inBackground(Object o) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback, Object o) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<String> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
     }
 
     private class MockBackgroundPathableBuilder<T> implements BackgroundPathable<T>, Watchable<BackgroundPathable<T>> {
 
         @Override
-        public ErrorListenerPathable<T> inBackground() {
+        public Pathable<T> inBackground() {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public ErrorListenerPathable<T> inBackground(Object o) {
+        public Pathable<T> inBackground(Object o) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback) {
+        public Pathable<T> inBackground(BackgroundCallback backgroundCallback) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback, Object o) {
+        public Pathable<T> inBackground(BackgroundCallback backgroundCallback, Object o) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
+        public Pathable<T> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
         @Override
-        public ErrorListenerPathable<T> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public T forPath(String s) throws Exception {
+        public Pathable<T> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
 
@@ -789,6 +775,11 @@ public class MockCurator extends Curator {
         public BackgroundPathable<T> usingWatcher(CuratorWatcher curatorWatcher) {
             throw new UnsupportedOperationException("Not implemented in MockCurator");
         }
+
+        public T forPath(String path) throws Exception {
+            throw new UnsupportedOperationException("Not implemented in MockCurator");
+        }
+
     }
 
     private class MockGetChildrenBuilder extends MockBackgroundPathableBuilder<List<String>> implements GetChildrenBuilder {
@@ -889,35 +880,6 @@ public class MockCurator extends Curator {
             return null;
         }
 
-        @Override
-        public ErrorListenerPathAndBytesable<Stat> inBackground() {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<Stat> inBackground(Object o) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback, Object o) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
-
-        @Override
-        public ErrorListenerPathAndBytesable<Stat> inBackground(BackgroundCallback backgroundCallback, Object o, Executor executor) {
-            throw new UnsupportedOperationException("Not implemented in MockCurator");
-        }
     }
 
     /** Allows addition of directoryListeners which are never called */
@@ -996,7 +958,7 @@ public class MockCurator extends Curator {
             }
 
             @Override
-            public ACLCreateModePathAndBytesable<CuratorTransactionBridge> compressed() {
+            public ACLPathAndBytesable<CuratorTransactionBridge> compressed() {
                 throw new UnsupportedOperationException("Not implemented in MockCurator");
             }
 
@@ -1038,7 +1000,7 @@ public class MockCurator extends Curator {
         private class MockTransactionSetDataBuilder implements TransactionSetDataBuilder {
 
             @Override
-            public VersionPathAndBytesable<CuratorTransactionBridge> compressed() {
+            public PathAndBytesable<CuratorTransactionBridge> compressed() {
                 throw new UnsupportedOperationException("Not implemented in MockCurator");
             }
 

--- a/zkfacade/src/main/java/org/apache/curator/framework/api/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/api/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.api;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/api/transaction/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/api/transaction/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.api.transaction;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/listen/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/listen/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.listen;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/atomic/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/atomic/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.recipes.atomic;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/barriers/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/barriers/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.recipes.barriers;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/cache/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/cache/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.recipes.cache;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/recipes/locks/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/recipes/locks/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.recipes.locks;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/framework/state/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/framework/state/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.framework.state;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;

--- a/zkfacade/src/main/java/org/apache/curator/retry/package-info.java
+++ b/zkfacade/src/main/java/org/apache/curator/retry/package-info.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage(version = @Version(major = 2, minor = 13, micro = 0))
+@ExportPackage(version = @Version(major = 2, minor = 9, micro = 1))
 package org.apache.curator.retry;
 import com.yahoo.osgi.annotation.ExportPackage;
 import com.yahoo.osgi.annotation.Version;


### PR DESCRIPTION
Reverts vespa-engine/vespa#13955

Fails one system test (and the tests running on the same node after that test will also fail). Need to revert now and come back to investigate at a later time