### PR TITLE
Change default poll frequency when idle form 1000hz to 10hz.

### DIFF
--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/SyncFeedClient.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/SyncFeedClient.java
@@ -25,9 +25,16 @@ public class SyncFeedClient implements AutoCloseable {
     private final FeedClient wrappedClient;
     private final Callback callback;
 
-    public SyncFeedClient(SessionParams sessionParams) {
+    public SyncFeedClient(SessionParams params) {
         callback = new SyncFeedClient.Callback();
-        this.wrappedClient = FeedClientFactory.create(sessionParams, callback);
+        if (params.getFeedParams().getIdlePollFrequency() == null) {
+            params = params.toBuilder()
+                           .setFeedParams(params.getFeedParams().toBuilder()
+                                                                .setIdlePollFrequency(200)
+                                                                .build())
+                           .build();
+        }
+        this.wrappedClient = FeedClientFactory.create(params, callback);
     }
 
     /**

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/SyncFeedClient.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/SyncFeedClient.java
@@ -30,7 +30,7 @@ public class SyncFeedClient implements AutoCloseable {
         if (params.getFeedParams().getIdlePollFrequency() == null) {
             params = params.toBuilder()
                            .setFeedParams(params.getFeedParams().toBuilder()
-                                                                .setIdlePollFrequency(1000)
+                                                                .setIdlePollFrequency(500.0)
                                                                 .build())
                            .build();
         }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/SyncFeedClient.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/SyncFeedClient.java
@@ -30,7 +30,7 @@ public class SyncFeedClient implements AutoCloseable {
         if (params.getFeedParams().getIdlePollFrequency() == null) {
             params = params.toBuilder()
                            .setFeedParams(params.getFeedParams().toBuilder()
-                                                                .setIdlePollFrequency(200)
+                                                                .setIdlePollFrequency(1000)
                                                                 .build())
                            .build();
         }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/ConnectionParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/ConnectionParams.java
@@ -47,7 +47,6 @@ public final class ConnectionParams {
         private boolean printTraceToStdErr = true;
         private boolean useTlsConfigFromEnvironment = false;
         private Duration connectionTimeToLive = Duration.ofSeconds(15);
-        private double idlePollFrequency = 10;
         private Path privateKey;
         private Path certificate;
         private Path caCertificates;
@@ -259,15 +258,6 @@ public final class ConnectionParams {
             return this;
         }
 
-        /**
-         * Set what frequency to poll for async responses. Default is 10 (every 0.1s)
-         * If latency is important, or using it in a synchronous way (which is not recommended as throughput is priority),
-         * you can try increasing the frequency. Note that this will incur significantly higher cpu and bandwidth usage.
-         */
-        public void setIdlePollFrequency(double idlePollFrequency) {
-            this.idlePollFrequency = idlePollFrequency;
-        }
-
         public ConnectionParams build() {
             return new ConnectionParams(
                     sslContext,
@@ -288,8 +278,7 @@ public final class ConnectionParams {
                     traceEveryXOperation,
                     printTraceToStdErr,
                     useTlsConfigFromEnvironment,
-                    connectionTimeToLive,
-                    idlePollFrequency);
+                    connectionTimeToLive);
         }
 
         public int getNumPersistentConnectionsPerEndpoint() {
@@ -360,7 +349,6 @@ public final class ConnectionParams {
     private final boolean printTraceToStdErr;
     private final boolean useTlsConfigFromEnvironment;
     private final Duration connectionTimeToLive;
-    private final double idlePollFrequency;
 
     private ConnectionParams(
             SSLContext sslContext,
@@ -379,8 +367,7 @@ public final class ConnectionParams {
             int traceEveryXOperation,
             boolean printTraceToStdErr,
             boolean useTlsConfigFromEnvironment,
-            Duration connectionTimeToLive,
-            double idlePollFrequency) {
+            Duration connectionTimeToLive) {
         this.sslContext = sslContext;
         this.privateKey = privateKey;
         this.certificate = certificate;
@@ -400,7 +387,6 @@ public final class ConnectionParams {
         this.traceLevel = traceLevel;
         this.traceEveryXOperation = traceEveryXOperation;
         this.printTraceToStdErr = printTraceToStdErr;
-        this.idlePollFrequency = idlePollFrequency;
     }
 
     @JsonIgnore
@@ -468,8 +454,6 @@ public final class ConnectionParams {
     public Duration getConnectionTimeToLive() {
         return connectionTimeToLive;
     }
-
-    public double getIdlePollFrequency() { return idlePollFrequency; }
 
     /**
      * A header provider that provides a header value. {@link #getHeaderValue()} is called each time a new HTTP request

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/ConnectionParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/ConnectionParams.java
@@ -47,6 +47,7 @@ public final class ConnectionParams {
         private boolean printTraceToStdErr = true;
         private boolean useTlsConfigFromEnvironment = false;
         private Duration connectionTimeToLive = Duration.ofSeconds(15);
+        private double idlePollFrequency = 10;
         private Path privateKey;
         private Path certificate;
         private Path caCertificates;
@@ -258,6 +259,15 @@ public final class ConnectionParams {
             return this;
         }
 
+        /**
+         * Set what frequency to poll for async responses. Default is 10 (every 0.1s)
+         * If latency is important, or using it in a synchronous way (which is not recommended as throughput is priority),
+         * you can try increasing the frequency. Note that this will incur significantly higher cpu and bandwidth usage.
+         */
+        public void setIdlePollFrequency(double idlePollFrequency) {
+            this.idlePollFrequency = idlePollFrequency;
+        }
+
         public ConnectionParams build() {
             return new ConnectionParams(
                     sslContext,
@@ -278,7 +288,8 @@ public final class ConnectionParams {
                     traceEveryXOperation,
                     printTraceToStdErr,
                     useTlsConfigFromEnvironment,
-                    connectionTimeToLive);
+                    connectionTimeToLive,
+                    idlePollFrequency);
         }
 
         public int getNumPersistentConnectionsPerEndpoint() {
@@ -349,6 +360,7 @@ public final class ConnectionParams {
     private final boolean printTraceToStdErr;
     private final boolean useTlsConfigFromEnvironment;
     private final Duration connectionTimeToLive;
+    private final double idlePollFrequency;
 
     private ConnectionParams(
             SSLContext sslContext,
@@ -367,7 +379,8 @@ public final class ConnectionParams {
             int traceEveryXOperation,
             boolean printTraceToStdErr,
             boolean useTlsConfigFromEnvironment,
-            Duration connectionTimeToLive) {
+            Duration connectionTimeToLive,
+            double idlePollFrequency) {
         this.sslContext = sslContext;
         this.privateKey = privateKey;
         this.certificate = certificate;
@@ -387,6 +400,7 @@ public final class ConnectionParams {
         this.traceLevel = traceLevel;
         this.traceEveryXOperation = traceEveryXOperation;
         this.printTraceToStdErr = printTraceToStdErr;
+        this.idlePollFrequency = idlePollFrequency;
     }
 
     @JsonIgnore
@@ -454,6 +468,8 @@ public final class ConnectionParams {
     public Duration getConnectionTimeToLive() {
         return connectionTimeToLive;
     }
+
+    public double getIdlePollFrequency() { return idlePollFrequency; }
 
     /**
      * A header provider that provides a header value. {@link #getHeaderValue()} is called each time a new HTTP request

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
@@ -178,10 +178,9 @@ public final class FeedParams {
         }
 
         /**
-         * Set what frequency to poll for async responses. Default is 10 (every 0.1s)
-         * If latency is important, or using it in a synchronous way (which is not recommended as throughput is priority),
-         * you can try increasing the frequency. Note that this will incur significantly higher cpu and bandwidth usage.
+         * Set what frequency to poll for async responses. Default is 10hz (every 0.1s), but 1000hz  when using SyncFeedClient
          */
+        @Beta
         public Builder setIdlePollFrequency(Double idlePollFrequency) {
             this.idlePollFrequency = idlePollFrequency;
             return this;

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
@@ -44,6 +44,7 @@ public final class FeedParams {
         private boolean denyIfBusyV3 = true;
         private long maxSleepTimeMs = 3000;
         private boolean silentUpgrade = true;
+        private Double idlePollFrequency = null;
 
         /**
          * Make server not throw 4xx/5xx for situations that are normal during upgrade as this can esily mask
@@ -177,6 +178,16 @@ public final class FeedParams {
         }
 
         /**
+         * Set what frequency to poll for async responses. Default is 10 (every 0.1s)
+         * If latency is important, or using it in a synchronous way (which is not recommended as throughput is priority),
+         * you can try increasing the frequency. Note that this will incur significantly higher cpu and bandwidth usage.
+         */
+        public Builder setIdlePollFrequency(Double idlePollFrequency) {
+            this.idlePollFrequency = idlePollFrequency;
+            return this;
+        }
+
+        /**
          * Sets the messagebus priority. The allowed values are HIGHEST, VERY_HIGH, HIGH_[1-3],
          * NORMAL_[1-6], LOW_[1-3], VERY_LOW, and LOWEST..
          * @param priority messagebus priority of this message.
@@ -221,7 +232,7 @@ public final class FeedParams {
             return new FeedParams(
                     dataFormat, serverTimeout, clientTimeout, route,
                     maxChunkSizeBytes, maxInFlightRequests, localQueueTimeOut, priority,
-                    denyIfBusyV3, maxSleepTimeMs, silentUpgrade);
+                    denyIfBusyV3, maxSleepTimeMs, silentUpgrade, idlePollFrequency);
         }
 
         public long getClientTimeout(TimeUnit unit) {
@@ -263,11 +274,12 @@ public final class FeedParams {
     private final boolean denyIfBusyV3;
     private final long maxSleepTimeMs;
     private final boolean silentUpgrade;
+    private final Double idlePollFrequency;
 
     private FeedParams(DataFormat dataFormat, long serverTimeout, long clientTimeout, String route,
                        int maxChunkSizeBytes, final int maxInFlightRequests,
                        long localQueueTimeOut, String priority, boolean denyIfBusyV3, long maxSleepTimeMs,
-                       boolean silentUpgrade) {
+                       boolean silentUpgrade, Double idlePollFrequency) {
         this.dataFormat = dataFormat;
         this.serverTimeoutMillis = serverTimeout;
         this.clientTimeoutMillis = clientTimeout;
@@ -279,31 +291,17 @@ public final class FeedParams {
         this.denyIfBusyV3 = denyIfBusyV3;
         this.maxSleepTimeMs = maxSleepTimeMs;
         this.silentUpgrade = silentUpgrade;
+        this.idlePollFrequency = idlePollFrequency;
+
     }
 
-    public DataFormat getDataFormat() {
-        return dataFormat;
-    }
+    public DataFormat getDataFormat() { return dataFormat; }
+    public String getRoute() { return route; }
+    public long getServerTimeout(TimeUnit unit) { return unit.convert(serverTimeoutMillis, TimeUnit.MILLISECONDS); }
+    public long getClientTimeout(TimeUnit unit) { return unit.convert(clientTimeoutMillis, TimeUnit.MILLISECONDS); }
 
-    public String getRoute() {
-        return route;
-    }
-
-    public long getServerTimeout(TimeUnit unit) {
-        return unit.convert(serverTimeoutMillis, TimeUnit.MILLISECONDS);
-    }
-
-    public long getClientTimeout(TimeUnit unit) {
-        return unit.convert(clientTimeoutMillis, TimeUnit.MILLISECONDS);
-    }
-
-    public int getMaxChunkSizeBytes() {
-        return maxChunkSizeBytes;
-    }
-
-    public String getPriority() {
-        return priority;
-    }
+    public int getMaxChunkSizeBytes() { return maxChunkSizeBytes; }
+    public String getPriority() { return priority; }
 
     public String toUriParameters() {
         StringBuilder b = new StringBuilder();
@@ -311,13 +309,9 @@ public final class FeedParams {
         return b.toString();
     }
 
-    public int getMaxInFlightRequests() {
-        return maxInFlightRequests;
-    }
-
-    public long getLocalQueueTimeOut() {
-        return localQueueTimeOut;
-    }
+    public int getMaxInFlightRequests() { return maxInFlightRequests; }
+    public long getLocalQueueTimeOut() { return localQueueTimeOut; }
+    public Double getIdlePollFrequency() { return idlePollFrequency; }
 
     /** Returns a builder initialized to the values of this */
     public FeedParams.Builder toBuilder() {
@@ -332,6 +326,7 @@ public final class FeedParams {
         b.setDenyIfBusyV3(denyIfBusyV3);
         b.setMaxSleepTimeMs(maxSleepTimeMs);
         b.setSilentUpgrade(silentUpgrade);
+        b.setIdlePollFrequency(idlePollFrequency);
         return b;
     }
 

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/SessionParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/SessionParams.java
@@ -102,7 +102,6 @@ public final class SessionParams {
          * @return the minimum number of requests to be used in throttler or zero if throttler is static.
          *
          * @param throttlerMinSize the value of the min size.
-         * @return pointer to the setter.
          */
         public Builder setThrottlerMinSize(int throttlerMinSize) {
             this.throttlerMinSize = throttlerMinSize;

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
@@ -56,6 +56,9 @@ public class ClusterConnection implements AutoCloseable {
         documentQueue = new DocumentQueue(clientQueueSizePerCluster);
         ioThreadGroup = operationProcessor.getIoThreadGroup();
         singleEndpoint = cluster.getEndpoints().size() == 1 ? cluster.getEndpoints().get(0) : null;
+        Double idlePollFrequency = feedParams.getIdlePollFrequency();
+        if (idlePollFrequency == null)
+            idlePollFrequency = 10.0;
         for (Endpoint endpoint : cluster.getEndpoints()) {
             EndpointResultQueue endpointResultQueue = new EndpointResultQueue(operationProcessor,
                                                                               endpoint,
@@ -84,7 +87,7 @@ public class ClusterConnection implements AutoCloseable {
                                                  feedParams.getLocalQueueTimeOut(),
                                                  documentQueue,
                                                  feedParams.getMaxSleepTimeMs(),
-                                                 connectionParams.getIdlePollFrequency() );
+                                                 idlePollFrequency);
                 ioThreads.add(ioThread);
             }
         }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/ClusterConnection.java
@@ -83,7 +83,8 @@ public class ClusterConnection implements AutoCloseable {
                                                  maxInFlightPerSession,
                                                  feedParams.getLocalQueueTimeOut(),
                                                  documentQueue,
-                                                 feedParams.getMaxSleepTimeMs());
+                                                 feedParams.getMaxSleepTimeMs(),
+                                                 connectionParams.getIdlePollFrequency() );
                 ioThreads.add(ioThread);
             }
         }

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
@@ -78,7 +78,6 @@ class IOThread implements Runnable, AutoCloseable {
         this.gatewayThrottler = new GatewayThrottler(maxSleepTimeMs);
         //Ensure that pollInterval is in the range [1us, 10s]
         this.pollIntervalUS = Math.max(1, (long)(1000000.0/Math.max(0.1, idlePollFrequency)));
-        
         this.thread = new Thread(ioThreadGroup, this, "IOThread " + endpoint);
         thread.setDaemon(true);
         this.localQueueTimeOut = localQueueTimeOut;

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/core/communication/IOThread.java
@@ -44,6 +44,7 @@ class IOThread implements Runnable, AutoCloseable {
     private final int maxInFlightRequests;
     private final long localQueueTimeOut;
     private final GatewayThrottler gatewayThrottler;
+    private final long pollIntervalUS;
     private final Random random = new Random();
 
     private enum ThreadState { DISCONNECTED, CONNECTED, SESSION_SYNCED };
@@ -65,7 +66,8 @@ class IOThread implements Runnable, AutoCloseable {
              int maxInFlightRequests,
              long localQueueTimeOut,
              DocumentQueue documentQueue,
-             long maxSleepTimeMs) {
+             long maxSleepTimeMs,
+             double idlePollFrequency) {
         this.documentQueue = documentQueue;
         this.endpoint = client.getEndpoint();
         this.client = client;
@@ -74,6 +76,9 @@ class IOThread implements Runnable, AutoCloseable {
         this.maxChunkSizeBytes = maxChunkSizeBytes;
         this.maxInFlightRequests = maxInFlightRequests;
         this.gatewayThrottler = new GatewayThrottler(maxSleepTimeMs);
+        //Ensure that pollInterval is in the range [1us, 10s]
+        this.pollIntervalUS = Math.max(1, (long)(1000000.0/Math.max(0.1, idlePollFrequency)));
+        
         this.thread = new Thread(ioThreadGroup, this, "IOThread " + endpoint);
         thread.setDaemon(true);
         this.localQueueTimeOut = localQueueTimeOut;
@@ -278,13 +283,13 @@ class IOThread implements Runnable, AutoCloseable {
         return processResponse;
     }
 
-    private ProcessResponse pullAndProcessData(long maxWaitTimeMs) throws ServerResponseException, IOException {
+    private ProcessResponse pullAndProcessData(long maxWaitTimeUS) throws ServerResponseException, IOException {
         int pendingResultQueueSize = resultQueue.getPendingSize();
         pendingDocumentStatusCount.set(pendingResultQueueSize);
 
         List<Document> nextDocsForFeeding = (pendingResultQueueSize > maxInFlightRequests)
                                             ? new ArrayList<>() // The queue is full, will not send more documents
-                                            : getNextDocsForFeeding(maxWaitTimeMs, TimeUnit.MILLISECONDS);
+                                            : getNextDocsForFeeding(maxWaitTimeUS, TimeUnit.MICROSECONDS);
 
         if (nextDocsForFeeding.isEmpty() && pendingResultQueueSize == 0) {
             //we have no unfinished business with the server now.
@@ -349,7 +354,7 @@ class IOThread implements Runnable, AutoCloseable {
                 return ThreadState.SESSION_SYNCED;
             case SESSION_SYNCED:
                 try {
-                    ProcessResponse processResponse = pullAndProcessData(1);
+                    ProcessResponse processResponse = pullAndProcessData(pollIntervalUS);
                     gatewayThrottler.handleCall(processResponse.transitiveErrorCount);
                 }
                 catch (ServerResponseException ser) {


### PR DESCRIPTION
The cost of a poll is huge as it implies sending an http post.
Synchrous usage might want to reduce this.

@bratseth or @bjorncs PR
This reverts the effective change in #9954, but makes it configurable.
Sync usage should use a sync protocol instead.