### PR TITLE
Log stack trace for all exceptions

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -507,9 +507,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             long sessionId = getSessionIdForApplication(tenant, applicationId);
             RemoteSession session = getRemoteSession(tenant, sessionId);
             return session.ensureApplicationLoaded().getForVersionOrLatest(version, clock.instant());
-        } catch (NotFoundException e) {
-            log.log(Level.WARNING, "Failed getting application for '" + applicationId + "': " + e.getMessage());
-            throw e;
         } catch (Exception e) {
             log.log(Level.WARNING, "Failed getting application for '" + applicationId + "'", e);
             throw e;


### PR DESCRIPTION
Trying to track down an issue where it looks like we occasionally use default application id and this fails.
