### PR TITLE
Have URL query parameters handled appropriately to fix URL encoding

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -987,7 +987,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
             toSlime(endpoint, endpointArray.addObject());
         }
 
-        response.setString("nodes", withPath("/zone/v2/" + deploymentId.zoneId().environment() + "/" + deploymentId.zoneId().region() + "/nodes/v2/node/?&recursive=true&application=" + deploymentId.applicationId().tenant() + "." + deploymentId.applicationId().application() + "." + deploymentId.applicationId().instance(), request.getUri()).toString());
+        response.setString("nodes", withPathAndQuery("/zone/v2/" + deploymentId.zoneId().environment() + "/" + deploymentId.zoneId().region() + "/nodes/v2/node/", "recursive=true&application=" + deploymentId.applicationId().tenant() + "." + deploymentId.applicationId().application() + "." + deploymentId.applicationId().instance(), request.getUri()).toString());
         response.setString("yamasUrl", monitoringSystemUri(deploymentId).toString());
         response.setString("version", deployment.version().toFullString());
         response.setString("revision", deployment.applicationVersion().id());
@@ -1693,14 +1693,19 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
         object.setString("url", withPath("/application/v4/tenant/" + tenant.name().value(), requestURI).toString());
     }
 
-    /** Returns a copy of the given URI with the host and port from the given URI and the path set to the given path */
-    private URI withPath(String newPath, URI uri) {
+    /** Returns a copy of the given URI with the host and port from the given URI, the path set to the given path and the query set to given query*/
+    private URI withPathAndQuery(String newPath, String newQuery, URI uri) {
         try {
-            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), newPath, null, null);
+            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), newPath, newQuery, null);
         }
         catch (URISyntaxException e) {
             throw new RuntimeException("Will not happen", e);
         }
+    }
+
+    /** Returns a copy of the given URI with the host and port from the given URI and the path set to the given path */
+    private URI withPath(String newPath, URI uri) {
+        return withPathAndQuery(newPath, null, uri);
     }
 
     private long asLong(String valueOrNull, long defaultWhenNull) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
@@ -20,7 +20,7 @@
       "routingMethod": "shared"
     }
   ],
-  "nodes": "http://localhost:8080/zone/v2/prod/us-west-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
+  "nodes": "http://localhost:8080/zone/v2/prod/us-west-1/nodes/v2/node/?recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-west-1&application=tenant1.application1.instance1",
   "version": "(ignore)",
   "revision": "1.0.1-commit1",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -20,7 +20,7 @@
       "routingMethod": "shared"
     }
   ],
-  "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
+  "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/?recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-central-1&application=tenant1.application1.instance1",
   "version": "(ignore)",
   "revision": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1.json
@@ -13,7 +13,7 @@
       "routingMethod": "shared"
     }
   ],
-  "nodes": "http://localhost:8080/zone/v2/dev/us-east-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
+  "nodes": "http://localhost:8080/zone/v2/dev/us-east-1/nodes/v2/node/?recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=dev&region=us-east-1&application=tenant1.application1.instance1",
   "version": "(ignore)",
   "revision": "(ignore)",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -23,7 +23,7 @@
       "routingMethod": "shared"
     }
   ],
-  "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/%3F&recursive=true&application=tenant1.application1.instance1",
+  "nodes": "http://localhost:8080/zone/v2/prod/us-central-1/nodes/v2/node/?recursive=true&application=tenant1.application1.instance1",
   "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-central-1&application=tenant1.application1.instance1",
   "version": "(ignore)",
   "revision": "(ignore)",


### PR DESCRIPTION
The current `application/v4` API returns broken URLs for the `nodes` field in deployments. This is caused by having URL query parameter (specifically `?&recursive=true&application=(...)`) added as part of the `path` segment in the URI object. As a result, the question mark is URL (path) encoded, and you end up with a URL with path `(...)/node/%3F&recursive=true(...)`. Following this link yields a result like:
```json
{
    "error-code": "NOT_FOUND",
    "message": "No node with hostname '?&recursive=true&application=(...)'"
}
```

By adding the query segment in the appropriate place, you now get a correct URL: `(...)/node/?recursive=true(...)`.

@jonmv / @bratseth : Please review.