### PR TITLE
When allowing weakly consistent get you might try to access attribute…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_populator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_populator.cpp
@@ -47,7 +47,7 @@ DocumentFieldPopulator::~DocumentFieldPopulator()
 void
 DocumentFieldPopulator::handleExisting(uint32_t lid, const std::shared_ptr<Document> &doc)
 {
-    DocumentFieldRetriever::populate(lid, *doc, _fieldName, *_attr, false);
+    DocumentFieldRetriever::populate(lid, *doc, doc->getField(_fieldName), *_attr, false);
     ++_documentsPopulated;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_populator.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_populator.h
@@ -14,24 +14,23 @@ class DocumentFieldPopulator : public IReprocessingRewriter
 {
 private:
     using AttributeVectorSP = std::shared_ptr<search::AttributeVector>;
-    vespalib::string _fieldName;
+    vespalib::string  _fieldName;
     AttributeVectorSP _attr;
-    vespalib::string _subDbName;
-    int64_t _documentsPopulated;
+    vespalib::string  _subDbName;
+    int64_t           _documentsPopulated;
 
 public:
     DocumentFieldPopulator(const vespalib::string &fieldName,
                            AttributeVectorSP attr,
                            const vespalib::string &subDbName);
 
-    ~DocumentFieldPopulator();
+    ~DocumentFieldPopulator() override;
 
     const search::AttributeVector &getAttribute() const {
         return *_attr;
     }
 
-    // Implements IReprocessingRewriter
-    virtual void handleExisting(uint32_t lid, const std::shared_ptr<document::Document> &doc) override;
+    void handleExisting(uint32_t lid, const std::shared_ptr<document::Document> &doc) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_retriever.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_retriever.h
@@ -15,7 +15,7 @@ struct DocumentFieldRetriever
 {
     static void populate(search::DocumentIdT lid,
                          document::Document &doc,
-                         const vespalib::string &fieldName,
+                         const document::Field &field,
                          const search::attribute::IAttributeVector &attr,
                          bool isIndexField);
 };

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -38,6 +38,7 @@ vespa_add_library(searchcore_server STATIC
     emptysearchview.cpp
     executor_thread_service.cpp
     executorthreadingservice.cpp
+    fast_access_document_retriever.cpp
     fast_access_doc_subdb.cpp
     fast_access_doc_subdb_configurer.cpp
     fast_access_feed_view.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/documentretriever.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretriever.h
@@ -16,13 +16,14 @@ namespace proton {
 class DocumentRetriever : public DocumentRetrieverBase {
 public:
     typedef std::vector<std::pair<const document::Field *, vespalib::string>> PositionFields;
-    using AttributeFields = std::vector<std::string>;
+    using AttributeFields = std::vector<const document::Field *>;
     DocumentRetriever(const DocTypeName &docTypeName,
                       const document::DocumentTypeRepo &repo,
                       const search::index::Schema &schema,
                       const IDocumentMetaStoreContext &meta_store,
                       const search::IAttributeManager &attr_manager,
                       const search::IDocumentStore &doc_store);
+    ~DocumentRetriever() override;
 
     document::Document::UP getDocument(search::DocumentIdT lid) const override;
     void visitDocuments(const LidVector & lids, search::IDocumentVisitor & visitor, ReadConsistency) const override;

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_document_retriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_document_retriever.cpp
@@ -1,0 +1,20 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "fast_access_document_retriever.h"
+
+namespace proton {
+
+FastAccessDocumentRetriever::FastAccessDocumentRetriever(FastAccessFeedView::SP feedView, IAttributeManager::SP attrMgr)
+    : DocumentRetriever(feedView->getPersistentParams()._docTypeName,
+                        *feedView->getDocumentTypeRepo(),
+                        *feedView->getSchema(),
+                        *feedView->getDocumentMetaStore(),
+                        *attrMgr,
+                        feedView->getDocumentStore()),
+      _feedView(std::move(feedView)),
+      _attrMgr(std::move(attrMgr))
+{ }
+
+FastAccessDocumentRetriever::~FastAccessDocumentRetriever() = default;
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_document_retriever.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_document_retriever.h
@@ -4,7 +4,6 @@
 #include "documentretriever.h"
 #include "fast_access_feed_view.h"
 #include <vespa/searchcore/proton/attribute/i_attribute_manager.h>
-#include <vespa/searchcore/proton/docsummary/isummarymanager.h>
 
 namespace proton {
 
@@ -21,16 +20,8 @@ private:
     IAttributeManager::SP    _attrMgr;
 
 public:
-    FastAccessDocumentRetriever(const FastAccessFeedView::SP &feedView, const IAttributeManager::SP &attrMgr)
-        : DocumentRetriever(feedView->getPersistentParams()._docTypeName,
-                            *feedView->getDocumentTypeRepo(),
-                            *feedView->getSchema(),
-                            *feedView->getDocumentMetaStore(),
-                            *attrMgr,
-                            feedView->getDocumentStore()),
-          _feedView(feedView),
-          _attrMgr(attrMgr)
-    { }
+    FastAccessDocumentRetriever(FastAccessFeedView::SP feedView, IAttributeManager::SP attrMgr);
+    ~FastAccessDocumentRetriever() override;
     uint32_t getDocIdLimit() const override { return _feedView->getDocIdLimit().get(); }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.h
@@ -5,8 +5,6 @@
 #include "storeonlyfeedview.h"
 #include <vespa/searchcore/proton/attribute/i_attribute_writer.h>
 #include <vespa/searchcore/proton/common/docid_limit.h>
-#include <vespa/searchlib/query/base.h>
-#include <vespa/document/fieldvalue/document.h>
 
 namespace proton {
 
@@ -39,7 +37,7 @@ private:
     const IAttributeWriter::SP _attributeWriter;
     DocIdLimit                 &_docIdLimit;
 
-    void putAttributes(SerialNum serialNum, search::DocumentIdT lid, const document::Document &doc,
+    void putAttributes(SerialNum serialNum, search::DocumentIdT lid, const Document &doc,
                        bool immediateCommit, OnPutDoneType onWriteDone) override;
 
     void updateAttributes(SerialNum serialNum, search::DocumentIdT lid, const document::DocumentUpdate &upd,

--- a/searchcore/src/vespa/searchcore/proton/server/minimal_document_retriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/minimal_document_retriever.cpp
@@ -21,11 +21,15 @@ MinimalDocumentRetriever::MinimalDocumentRetriever(
       _doc_store(doc_store) {
 }
 
-Document::UP MinimalDocumentRetriever::getDocument(DocumentIdT lid) const {
+MinimalDocumentRetriever::~MinimalDocumentRetriever() = default;
+
+Document::UP
+MinimalDocumentRetriever::getDocument(DocumentIdT lid) const {
     return _doc_store.read(lid, *_repo);
 }
 
-void MinimalDocumentRetriever::visitDocuments(const LidVector & lids, search::IDocumentVisitor & visitor, ReadConsistency) const {
+void
+MinimalDocumentRetriever::visitDocuments(const LidVector & lids, search::IDocumentVisitor & visitor, ReadConsistency) const {
     _doc_store.visit(lids, getDocumentTypeRepo(), visitor);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/minimal_document_retriever.h
+++ b/searchcore/src/vespa/searchcore/proton/server/minimal_document_retriever.h
@@ -25,6 +25,7 @@ public:
                              const IDocumentMetaStoreContext &meta_store,
                              const search::IDocumentStore &doc_store,
                              bool hasFields);
+    ~MinimalDocumentRetriever() override;
 
     document::Document::UP getDocument(search::DocumentIdT lid) const override;
     void visitDocuments(const LidVector & lids, search::IDocumentVisitor & visitor, ReadConsistency) const override;

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchcore/proton/documentmetastore/ilidreusedelayer.h>
 #include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
 #include <vespa/vespalib/util/isequencedtaskexecutor.h>
+#include <vespa/document/fieldvalue/document.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.server.searchable_feed_view");
@@ -58,7 +59,7 @@ SearchableFeedView::sync()
 }
 
 void
-SearchableFeedView::putIndexedFields(SerialNum serialNum, search::DocumentIdT lid, const Document::SP &newDoc,
+SearchableFeedView::putIndexedFields(SerialNum serialNum, search::DocumentIdT lid, const DocumentSP &newDoc,
                                      bool immediateCommit, OnOperationDoneType onWriteDone)
 {
     if (!hasIndexedFields()) {
@@ -86,7 +87,7 @@ SearchableFeedView::performIndexPut(SerialNum serialNum, search::DocumentIdT lid
 }
 
 void
-SearchableFeedView::performIndexPut(SerialNum serialNum, search::DocumentIdT lid, const Document::SP &doc,
+SearchableFeedView::performIndexPut(SerialNum serialNum, search::DocumentIdT lid, const DocumentSP &doc,
                                     bool immediateCommit, OnOperationDoneType onWriteDone)
 {
     performIndexPut(serialNum, lid, *doc, immediateCommit, onWriteDone);

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.h
@@ -34,10 +34,10 @@ private:
 
     bool hasIndexedFields() const { return _hasIndexedFields; }
 
-    void performIndexPut(SerialNum serialNum, search::DocumentIdT lid, const document::Document &doc,
+    void performIndexPut(SerialNum serialNum, search::DocumentIdT lid, const Document &doc,
                          bool immediateCommit, OnOperationDoneType onWriteDone);
 
-    void performIndexPut(SerialNum serialNum, search::DocumentIdT lid, const document::Document::SP &doc,
+    void performIndexPut(SerialNum serialNum, search::DocumentIdT lid, const DocumentSP &doc,
                          bool immediateCommit, OnOperationDoneType onWriteDone);
     void performIndexPut(SerialNum serialNum, search::DocumentIdT lid, FutureDoc doc,
                          bool immediateCommit, OnOperationDoneType onWriteDone);
@@ -55,7 +55,7 @@ private:
     void performSync();
     void heartBeatIndexedFields(SerialNum serialNum) override;
 
-    void putIndexedFields(SerialNum serialNum, search::DocumentIdT lid, const document::Document::SP &newDoc,
+    void putIndexedFields(SerialNum serialNum, search::DocumentIdT lid, const DocumentSP &newDoc,
                           bool immediateCommit, OnOperationDoneType onWriteDone) override;
 
     void updateIndexedFields(SerialNum serialNum, search::DocumentIdT lid, FutureDoc newDoc,

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_store.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_store.h
@@ -17,8 +17,8 @@ struct DummyDocumentStore : public search::IDocumentStore
         : _baseDir(baseDir)
     {}
     ~DummyDocumentStore() {}
-    document::Document::UP read(search::DocumentIdT, const document::DocumentTypeRepo &) const override {
-        return document::Document::UP();
+    DocumentUP read(search::DocumentIdT, const document::DocumentTypeRepo &) const override {
+        return DocumentUP();
     }
     void write(uint64_t, search::DocumentIdT, const document::Document &) override {}
     void write(uint64_t, search::DocumentIdT, const vespalib::nbostream &) override {}


### PR DESCRIPTION
…s that are not yet fully populated.

Now we prevent accessing uninitialized memory by guarding each attribute by checking its current commited docid limit.
If not we just clear the field.
Also avoid doing an inefficient Field -> string -> Field lookup.

@geirst or @vekterli or @arnej27959 or @toregge or @havardpe PR
