### PR TITLE
Remove incorrect provenance info

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -6168,6 +6168,8 @@
       "public boolean isQueryProfile()",
       "public com.yahoo.search.query.profile.types.QueryProfileType queryProfileType()",
       "public com.yahoo.search.query.profile.compiled.ValueWithSource withValue(java.lang.Object)",
+      "public com.yahoo.search.query.profile.compiled.ValueWithSource withSource(java.lang.String)",
+      "public com.yahoo.search.query.profile.compiled.ValueWithSource withVariant(java.util.Optional)",
       "public java.util.Optional variant()",
       "public int hashCode()",
       "public boolean equals(java.lang.Object)",

--- a/container-search/src/main/java/com/yahoo/search/query/profile/DimensionValues.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/DimensionValues.java
@@ -21,7 +21,7 @@ public class DimensionValues implements Comparable<DimensionValues> {
     public static final DimensionValues empty = new DimensionValues(new String[] {});
 
     public static DimensionValues createFrom(String[] values) {
-        if (values==null || values.length==0 || containsAllNulls(values)) return empty;
+        if (values == null || values.length == 0 || containsAllNulls(values)) return empty;
         return new DimensionValues(values);
     }
 
@@ -34,10 +34,10 @@ public class DimensionValues implements Comparable<DimensionValues> {
      */
     private DimensionValues(String[] values) {
         if (values == null) throw new NullPointerException("Dimension values cannot be null");
-        this.values=Arrays.copyOf(values, values.length);
+        this.values = Arrays.copyOf(values, values.length);
     }
 
-    /** Returns true if this is has the same value every place it has a value as the givenValues. */
+    /** Returns true if this is has the same value every place it has a value as the given values. */
     public boolean matches(DimensionValues givenValues) {
         for (int i = 0; i < this.size() || i < givenValues.size() ; i++)
             if ( ! matches(this.get(i), givenValues.get(i)))
@@ -73,7 +73,7 @@ public class DimensionValues implements Comparable<DimensionValues> {
 
     /** Helper method which uses compareTo to return whether this is most specific */
     public boolean isMoreSpecificThan(DimensionValues other) {
-        return this.compareTo(other)<0;
+        return this.compareTo(other) < 0;
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfile.java
@@ -180,6 +180,8 @@ public class CompiledQueryProfile extends AbstractComponent implements Cloneable
     public final Object get(CompoundName name, Map<String, String> context, Properties substitution) {
         ValueWithSource value = entries.get(name, context);
         if (value == null) return null;
+        if (name.last().equals("streams"))
+            System.out.println(value);
         return substitute(value.value(), context, substitution);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/compiled/ValueWithSource.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/compiled/ValueWithSource.java
@@ -64,6 +64,14 @@ public class ValueWithSource {
         return new ValueWithSource(value, source, isUnoverridable, isQueryProfile, type, variant);
     }
 
+    public ValueWithSource withSource(String source) {
+        return new ValueWithSource(value, source, isUnoverridable, isQueryProfile, type, variant);
+    }
+
+    public ValueWithSource withVariant(Optional<DimensionValues> variant) {
+        return new ValueWithSource(value, source, isUnoverridable, isQueryProfile, type, variant.orElse(null));
+    }
+
     /** Returns the variant having this value, or empty if it's not in a variant */
     public Optional<DimensionValues> variant() { return Optional.ofNullable(variant); }
 
@@ -87,10 +95,12 @@ public class ValueWithSource {
 
     @Override
     public String toString() {
-        return value +
-               " (from query profile '" + source + "'" +
+        if (source == null && variant == null) return value.toString();
+
+        return value + " (" +
+               ( source != null ? "from query profile '" + source + "'" : "") +
                ( variant != null ? " variant " + variant : "") +
-               ")";
+                ")";
     }
 
 }


### PR DESCRIPTION
When we combine all resolutions of some value the provenance information
carried by the value becomes potentially incorrect. Since we do this
for efficiency and tracking provenance info is just helper functionality,
we remove the provenance info in these cases.
