### PR TITLE
Turn off lint for test marco definitions we can actually use clang-ti…

### DIFF
--- a/document/src/vespa/document/base/globalid.h
+++ b/document/src/vespa/document/base/globalid.h
@@ -77,7 +77,7 @@ public:
     /**
      * Constructs a new global id with all 0 bits.
      */
-    GlobalId() { set("\0\0\0\0\0\0\0\0\0\0\0\0"); }
+    GlobalId() noexcept { set("\0\0\0\0\0\0\0\0\0\0\0\0"); }
 
 
 
@@ -87,7 +87,7 @@ public:
      *
      * @param gid The address to the data to copy.
      */
-    explicit GlobalId(const void *gid) { set(gid); }
+    explicit GlobalId(const void *gid) noexcept { set(gid); }
 
     GlobalId(const GlobalId &rhs) = default;
 
@@ -130,7 +130,7 @@ public:
      *
      * @param id The bytes to set.
      */
-    void set(const void *id) { memcpy(_gid._buffer, id, sizeof(_gid._buffer)); }
+    void set(const void *id) noexcept { memcpy(_gid._buffer, id, sizeof(_gid._buffer)); }
 
     /**
      * Returns the raw byte array that constitutes this global id.

--- a/document/src/vespa/document/bucket/bucketid.h
+++ b/document/src/vespa/document/bucket/bucketid.h
@@ -49,11 +49,11 @@ public:
     using Type = uint64_t;
     using List = bucket::BucketIdList;
     /** Create an initially unset bucket id. */
-    BucketId() : _id(0) {}
+    BucketId() noexcept : _id(0) {}
     /** Create a bucket id with the given raw unchecked content. */
-    explicit BucketId(Type id) : _id(id) {}
+    explicit BucketId(Type id) noexcept : _id(id) {}
     /** Create a bucket id using a set of bits from a raw unchecked value. */
-    BucketId(uint32_t useBits, Type id) : _id(createUsedBits(useBits, id)) { }
+    BucketId(uint32_t useBits, Type id) noexcept : _id(createUsedBits(useBits, id)) { }
 
     bool operator<(const BucketId& id) const {
         return getId() < id.getId();
@@ -175,7 +175,7 @@ private:
         return _stripMasks[getUsedBits()];
     }
 
-    static Type createUsedBits(uint32_t used, Type id) {
+    static Type createUsedBits(uint32_t used, Type id) noexcept {
         uint32_t availBits = maxNumBits;
         Type usedCount(used);
         usedCount <<= availBits;

--- a/document/src/vespa/document/test/make_bucket_space.cpp
+++ b/document/src/vespa/document/test/make_bucket_space.cpp
@@ -4,12 +4,12 @@
 
 namespace document::test {
 
-BucketSpace makeBucketSpace()
+BucketSpace makeBucketSpace() noexcept
 {
     return BucketSpace(1);
 }
 
-BucketSpace makeBucketSpace(const vespalib::string &docTypeName)
+BucketSpace makeBucketSpace(const vespalib::string &docTypeName) noexcept
 {
     // Used by persistence conformance test to map from document type name
     // to bucket space.  See document::TestDocRepo for known document types.

--- a/document/src/vespa/document/test/make_bucket_space.h
+++ b/document/src/vespa/document/test/make_bucket_space.h
@@ -8,7 +8,7 @@ namespace document::test {
 
 // Helper functions used by unit tests
 
-BucketSpace makeBucketSpace();
-BucketSpace makeBucketSpace(const vespalib::string &docTypeName);
+BucketSpace makeBucketSpace() noexcept;
+BucketSpace makeBucketSpace(const vespalib::string &docTypeName) noexcept;
 
 }

--- a/persistence/src/vespa/persistence/spi/bucket.h
+++ b/persistence/src/vespa/persistence/spi/bucket.h
@@ -24,8 +24,8 @@ class Bucket {
     PartitionId _partition;
 
 public:
-    Bucket() : _bucket(document::BucketSpace::invalid(), document::BucketId(0)), _partition(0) {}
-    Bucket(const document::Bucket& b, PartitionId p)
+    Bucket() noexcept : _bucket(document::BucketSpace::invalid(), document::BucketId(0)), _partition(0) {}
+    Bucket(const document::Bucket& b, PartitionId p) noexcept
         : _bucket(b), _partition(p) {}
 
     const document::Bucket &getBucket() const { return _bucket; }

--- a/persistencetypes/src/persistence/spi/types.h
+++ b/persistencetypes/src/persistence/spi/types.h
@@ -27,8 +27,8 @@ namespace document {
       type _value; \
   public: \
       typedef type Type; \
-      name() : _value() {} \
-      explicit name(type v) : _value(v) {} \
+      name() noexcept : _value() {} \
+      explicit name(type v) noexcept : _value(v) {} \
       operator type() const { return _value; } \
       operator type&() { return _value; } \
       type getValue() const { return _value; } \

--- a/vespalib/src/apps/make_fixture_macros/make_fixture_macros.cpp
+++ b/vespalib/src/apps/make_fixture_macros/make_fixture_macros.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <algorithm>
 
 #include <vespa/log/log.h>
@@ -132,7 +132,7 @@ void make_macro_wire(int n) {
             out_opt(ignore, ", true", ", false");
             out_opt(mt, ", threads", ", 1");
             out_list_n(", ", "fixture%d", "", n);
-            out(")\n");
+            out(") // NOLINT\n");
         }
     }
     fprintf(stdout, "\n// test macro variants for %d test fixtures END\n\n", n);

--- a/vespalib/src/vespa/vespalib/stllike/string.h
+++ b/vespalib/src/vespa/vespalib/stllike/string.h
@@ -456,35 +456,35 @@ public:
     small_string& replace ( size_t p1, size_t n1, size_t n2, char c );
     */
 
-    bool operator  <         (const char * s) const { return compare(s, strlen(s)) < 0; }
-    bool operator  <  (const std::string & s) const { return compare(s.data(), s.size()) < 0; }
-    bool operator  < (const small_string & s) const { return compare(s.data(), s.size()) < 0; }
-    bool operator  <    (stringref s) const { return compare(s.data(), s.size()) < 0; }
-    bool operator <=         (const char * s) const { return compare(s, strlen(s)) <= 0; }
-    bool operator <=  (const std::string & s) const { return compare(s.data(), s.size()) <= 0; }
-    bool operator <= (const small_string & s) const { return compare(s.data(), s.size()) <= 0; }
-    bool operator <=    (stringref s) const { return compare(s.data(), s.size()) <= 0; }
-    bool operator ==         (const char * s) const { return compare(s, strlen(s)) == 0; }
-    bool operator ==  (const std::string & s) const { return compare(s.data(), s.size()) == 0; }
-    bool operator == (const small_string & s) const { return compare(s.data(), s.size()) == 0; }
-    bool operator ==    (stringref s) const { return compare(s.data(), s.size()) == 0; }
-    bool operator !=         (const char * s) const { return compare(s, strlen(s)) != 0; }
-    bool operator !=  (const std::string & s) const { return compare(s.data(), s.size()) != 0; }
-    bool operator != (const small_string & s) const { return compare(s.data(), s.size()) != 0; }
-    bool operator !=    (stringref s) const { return compare(s.data(), s.size()) != 0; }
-    bool operator >=         (const char * s) const { return compare(s, strlen(s)) >= 0; }
-    bool operator >=  (const std::string & s) const { return compare(s.data(), s.size()) >= 0; }
-    bool operator >= (const small_string & s) const { return compare(s.data(), s.size()) >= 0; }
-    bool operator >=    (stringref s) const { return compare(s.data(), s.size()) >= 0; }
-    bool operator  >         (const char * s) const { return compare(s, strlen(s)) > 0; }
-    bool operator  >  (const std::string & s) const { return compare(s.data(), s.size()) > 0; }
-    bool operator  > (const small_string & s) const { return compare(s.data(), s.size()) > 0; }
-    bool operator  >    (stringref s) const { return compare(s.data(), s.size()) > 0; }
+    bool operator  <         (const char * s) const noexcept { return compare(s, strlen(s)) < 0; }
+    bool operator  <  (const std::string & s) const noexcept { return compare(s.data(), s.size()) < 0; }
+    bool operator  < (const small_string & s) const noexcept { return compare(s.data(), s.size()) < 0; }
+    bool operator  <            (stringref s) const noexcept { return compare(s.data(), s.size()) < 0; }
+    bool operator <=         (const char * s) const noexcept { return compare(s, strlen(s)) <= 0; }
+    bool operator <=  (const std::string & s) const noexcept { return compare(s.data(), s.size()) <= 0; }
+    bool operator <= (const small_string & s) const noexcept { return compare(s.data(), s.size()) <= 0; }
+    bool operator <=            (stringref s) const noexcept { return compare(s.data(), s.size()) <= 0; }
+    bool operator ==         (const char * s) const noexcept { return compare(s, strlen(s)) == 0; }
+    bool operator ==  (const std::string & s) const noexcept { return compare(s.data(), s.size()) == 0; }
+    bool operator == (const small_string & s) const noexcept { return compare(s.data(), s.size()) == 0; }
+    bool operator ==            (stringref s) const noexcept { return compare(s.data(), s.size()) == 0; }
+    bool operator !=         (const char * s) const noexcept { return compare(s, strlen(s)) != 0; }
+    bool operator !=  (const std::string & s) const noexcept { return compare(s.data(), s.size()) != 0; }
+    bool operator != (const small_string & s) const noexcept { return compare(s.data(), s.size()) != 0; }
+    bool operator !=            (stringref s) const noexcept { return compare(s.data(), s.size()) != 0; }
+    bool operator >=         (const char * s) const noexcept { return compare(s, strlen(s)) >= 0; }
+    bool operator >=  (const std::string & s) const noexcept { return compare(s.data(), s.size()) >= 0; }
+    bool operator >= (const small_string & s) const noexcept { return compare(s.data(), s.size()) >= 0; }
+    bool operator >=            (stringref s) const noexcept { return compare(s.data(), s.size()) >= 0; }
+    bool operator  >         (const char * s) const noexcept { return compare(s, strlen(s)) > 0; }
+    bool operator  >  (const std::string & s) const noexcept { return compare(s.data(), s.size()) > 0; }
+    bool operator  > (const small_string & s) const noexcept { return compare(s.data(), s.size()) > 0; }
+    bool operator  >            (stringref s) const noexcept { return compare(s.data(), s.size()) > 0; }
 
-    template<typename T> bool operator != (const T& s) const { return ! operator == (s); }
+    template<typename T> bool operator != (const T& s) const noexcept { return ! operator == (s); }
 
-    int compare(const small_string & s) const { return compare(s.c_str(), s.size()); }
-    int compare(const char *s, size_t sz) const {
+    int compare(const small_string & s) const noexcept { return compare(s.c_str(), s.size()); }
+    int compare(const char *s, size_t sz) const noexcept {
         int diff(memcmp(buffer(), s, std::min(sz, size())));
         return (diff != 0) ? diff : (size() - sz);
     }

--- a/vespalib/src/vespa/vespalib/testkit/generated_fixture_macros.h
+++ b/vespalib/src/vespa/vespalib/testkit/generated_fixture_macros.h
@@ -24,10 +24,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test::test_entry_point()
 
 // test macro variants for 0 test fixtures BEGIN
 
-#define TEST(name) TEST_IMPL(name, false, 1)
-#define TEST_MT(name, threads) TEST_IMPL(name, false, threads)
-#define IGNORE_TEST(name) TEST_IMPL(name, true, 1)
-#define IGNORE_TEST_MT(name, threads) TEST_IMPL(name, true, threads)
+#define TEST(name) TEST_IMPL(name, false, 1) // NOLINT
+#define TEST_MT(name, threads) TEST_IMPL(name, false, threads) // NOLINT
+#define IGNORE_TEST(name) TEST_IMPL(name, true, 1) // NOLINT
+#define IGNORE_TEST_MT(name, threads) TEST_IMPL(name, true, threads) // NOLINT
 
 // test macro variants for 0 test fixtures END
 
@@ -66,10 +66,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1>::test_entry_point()
 
 // test macro variants for 1 test fixtures BEGIN
 
-#define TEST_F(name, fixture1) TEST_F_IMPL(name, false, 1, fixture1)
-#define TEST_MT_F(name, threads, fixture1) TEST_F_IMPL(name, false, threads, fixture1)
-#define IGNORE_TEST_F(name, fixture1) TEST_F_IMPL(name, true, 1, fixture1)
-#define IGNORE_TEST_MT_F(name, threads, fixture1) TEST_F_IMPL(name, true, threads, fixture1)
+#define TEST_F(name, fixture1) TEST_F_IMPL(name, false, 1, fixture1) // NOLINT
+#define TEST_MT_F(name, threads, fixture1) TEST_F_IMPL(name, false, threads, fixture1) // NOLINT
+#define IGNORE_TEST_F(name, fixture1) TEST_F_IMPL(name, true, 1, fixture1) // NOLINT
+#define IGNORE_TEST_MT_F(name, threads, fixture1) TEST_F_IMPL(name, true, threads, fixture1) // NOLINT
 
 // test macro variants for 1 test fixtures END
 
@@ -115,10 +115,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2>::test_entry_point()
 
 // test macro variants for 2 test fixtures BEGIN
 
-#define TEST_FF(name, fixture1, fixture2) TEST_FF_IMPL(name, false, 1, fixture1, fixture2)
-#define TEST_MT_FF(name, threads, fixture1, fixture2) TEST_FF_IMPL(name, false, threads, fixture1, fixture2)
-#define IGNORE_TEST_FF(name, fixture1, fixture2) TEST_FF_IMPL(name, true, 1, fixture1, fixture2)
-#define IGNORE_TEST_MT_FF(name, threads, fixture1, fixture2) TEST_FF_IMPL(name, true, threads, fixture1, fixture2)
+#define TEST_FF(name, fixture1, fixture2) TEST_FF_IMPL(name, false, 1, fixture1, fixture2) // NOLINT
+#define TEST_MT_FF(name, threads, fixture1, fixture2) TEST_FF_IMPL(name, false, threads, fixture1, fixture2) // NOLINT
+#define IGNORE_TEST_FF(name, fixture1, fixture2) TEST_FF_IMPL(name, true, 1, fixture1, fixture2) // NOLINT
+#define IGNORE_TEST_MT_FF(name, threads, fixture1, fixture2) TEST_FF_IMPL(name, true, threads, fixture1, fixture2) // NOLINT
 
 // test macro variants for 2 test fixtures END
 
@@ -172,10 +172,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3>::test_entry_point()
 
 // test macro variants for 3 test fixtures BEGIN
 
-#define TEST_FFF(name, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, false, 1, fixture1, fixture2, fixture3)
-#define TEST_MT_FFF(name, threads, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, false, threads, fixture1, fixture2, fixture3)
-#define IGNORE_TEST_FFF(name, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, true, 1, fixture1, fixture2, fixture3)
-#define IGNORE_TEST_MT_FFF(name, threads, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, true, threads, fixture1, fixture2, fixture3)
+#define TEST_FFF(name, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, false, 1, fixture1, fixture2, fixture3) // NOLINT
+#define TEST_MT_FFF(name, threads, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, false, threads, fixture1, fixture2, fixture3) // NOLINT
+#define IGNORE_TEST_FFF(name, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, true, 1, fixture1, fixture2, fixture3) // NOLINT
+#define IGNORE_TEST_MT_FFF(name, threads, fixture1, fixture2, fixture3) TEST_FFF_IMPL(name, true, threads, fixture1, fixture2, fixture3) // NOLINT
 
 // test macro variants for 3 test fixtures END
 
@@ -237,10 +237,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3, F4>::test_entry_point()
 
 // test macro variants for 4 test fixtures BEGIN
 
-#define TEST_FFFF(name, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4)
-#define TEST_MT_FFFF(name, threads, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4)
-#define IGNORE_TEST_FFFF(name, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4)
-#define IGNORE_TEST_MT_FFFF(name, threads, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4)
+#define TEST_FFFF(name, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4) // NOLINT
+#define TEST_MT_FFFF(name, threads, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4) // NOLINT
+#define IGNORE_TEST_FFFF(name, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4) // NOLINT
+#define IGNORE_TEST_MT_FFFF(name, threads, fixture1, fixture2, fixture3, fixture4) TEST_FFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4) // NOLINT
 
 // test macro variants for 4 test fixtures END
 
@@ -310,10 +310,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3, F4, F5>::test_entry_point
 
 // test macro variants for 5 test fixtures BEGIN
 
-#define TEST_FFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5)
-#define TEST_MT_FFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5)
-#define IGNORE_TEST_FFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5)
-#define IGNORE_TEST_MT_FFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5)
+#define TEST_FFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5) // NOLINT
+#define TEST_MT_FFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5) // NOLINT
+#define IGNORE_TEST_FFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5) // NOLINT
+#define IGNORE_TEST_MT_FFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5) TEST_FFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5) // NOLINT
 
 // test macro variants for 5 test fixtures END
 
@@ -391,10 +391,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3, F4, F5, F6>::test_entry_p
 
 // test macro variants for 6 test fixtures BEGIN
 
-#define TEST_FFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6)
-#define TEST_MT_FFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6)
-#define IGNORE_TEST_FFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6)
-#define IGNORE_TEST_MT_FFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6)
+#define TEST_FFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) // NOLINT
+#define TEST_MT_FFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) // NOLINT
+#define IGNORE_TEST_FFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) // NOLINT
+#define IGNORE_TEST_MT_FFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) TEST_FFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6) // NOLINT
 
 // test macro variants for 6 test fixtures END
 
@@ -480,10 +480,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3, F4, F5, F6, F7>::test_ent
 
 // test macro variants for 7 test fixtures BEGIN
 
-#define TEST_FFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7)
-#define TEST_MT_FFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7)
-#define IGNORE_TEST_FFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7)
-#define IGNORE_TEST_MT_FFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7)
+#define TEST_FFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) // NOLINT
+#define TEST_MT_FFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) // NOLINT
+#define IGNORE_TEST_FFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) // NOLINT
+#define IGNORE_TEST_MT_FFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) TEST_FFFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7) // NOLINT
 
 // test macro variants for 7 test fixtures END
 
@@ -577,10 +577,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3, F4, F5, F6, F7, F8>::test
 
 // test macro variants for 8 test fixtures BEGIN
 
-#define TEST_FFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8)
-#define TEST_MT_FFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8)
-#define IGNORE_TEST_FFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8)
-#define IGNORE_TEST_MT_FFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8)
+#define TEST_FFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) // NOLINT
+#define TEST_MT_FFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) // NOLINT
+#define IGNORE_TEST_FFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) // NOLINT
+#define IGNORE_TEST_MT_FFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) TEST_FFFFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8) // NOLINT
 
 // test macro variants for 8 test fixtures END
 
@@ -682,10 +682,10 @@ void TEST_CAT(TestKitHook, __LINE__)::Test<F1, F2, F3, F4, F5, F6, F7, F8, F9>::
 
 // test macro variants for 9 test fixtures BEGIN
 
-#define TEST_FFFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9)
-#define TEST_MT_FFFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9)
-#define IGNORE_TEST_FFFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9)
-#define IGNORE_TEST_MT_FFFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9)
+#define TEST_FFFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, false, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) // NOLINT
+#define TEST_MT_FFFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, false, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) // NOLINT
+#define IGNORE_TEST_FFFFFFFFF(name, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, true, 1, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) // NOLINT
+#define IGNORE_TEST_MT_FFFFFFFFF(name, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) TEST_FFFFFFFFF_IMPL(name, true, threads, fixture1, fixture2, fixture3, fixture4, fixture5, fixture6, fixture7, fixture8, fixture9) // NOLINT
 
 // test macro variants for 9 test fixtures END
 

--- a/vespalog/src/vespa/log/log.h
+++ b/vespalog/src/vespa/log/log.h
@@ -21,7 +21,7 @@
 // Used to use anonymous namespaces, but they fail miserably in gdb 5.3
 
 #define LOG_SETUP(...)                          \
-static ns_log::Logger logger(__VA_ARGS__)
+static ns_log::Logger logger(__VA_ARGS__)  // NOLINT
 
 #define LOG_SETUP_INDIRECT(x, id)               \
 static ns_log::Logger *logger=NULL;             \


### PR DESCRIPTION
…dy to cleanup our code.

@hakonhall PR
@vekterli @havardpe @geirst @toregge FYI