### PR TITLE
Extend IndexedSegmentItem instead of SegmentItem in AndSegmentItem

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -313,7 +313,7 @@
     "fields": []
   },
   "com.yahoo.prelude.query.AndSegmentItem": {
-    "superClass": "com.yahoo.prelude.query.SegmentItem",
+    "superClass": "com.yahoo.prelude.query.IndexedSegmentItem",
     "interfaces": [
       "com.yahoo.prelude.query.BlockItem"
     ],
@@ -327,6 +327,9 @@
       "public com.yahoo.prelude.query.Item$ItemType getItemType()",
       "public java.lang.String getName()",
       "public java.lang.String getIndexName()",
+      "public void addItem(com.yahoo.prelude.query.Item)",
+      "public void setIndexName(java.lang.String)",
+      "public java.lang.String getIndexedString()",
       "public void setWeight(int)"
     ],
     "fields": []

--- a/container-search/src/main/java/com/yahoo/prelude/query/AndSegmentItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/AndSegmentItem.java
@@ -9,7 +9,7 @@ import java.util.Iterator;
  *
  * @author Steinar Knutsen
  */
-public class AndSegmentItem extends SegmentItem implements BlockItem {
+public class AndSegmentItem extends IndexedSegmentItem implements BlockItem {
 
     public AndSegmentItem(String rawWord, boolean isFromQuery, boolean stemmed) {
         super(rawWord, rawWord, isFromQuery, stemmed, null);
@@ -50,7 +50,50 @@ public class AndSegmentItem extends SegmentItem implements BlockItem {
         }
     }
 
+    /**
+     * Adds a word subitem. The word will have its index name set to the index name of this phrase.
+     *
+     * @throws IllegalArgumentException if the given item is not a WordItem
+     */
+    @Override
+    public void addItem(Item item) {
+        if (item instanceof WordItem) {
+            addWordItem((WordItem) item);
+        } else {
+            throw new IllegalArgumentException("Can not add " + item + " to a segment phrase");
+        }
+    }
+
+    private void addWordItem(WordItem word) {
+        word.setIndexName(this.getIndexName());
+        super.addItem(word);
+    }
+
+    @Override
+    public void setIndexName(String index) {
+        super.setIndexName(index);
+        for (Iterator<Item> i = getItemIterator(); i.hasNext();) {
+            WordItem word = (WordItem) i.next();
+            word.setIndexName(index);
+        }
+    }
+
     // TODO: Is it necessary to override equals?
+
+    @Override
+    public String getIndexedString() {
+        StringBuilder b = new StringBuilder();
+
+        for (Iterator<Item> i = getItemIterator(); i.hasNext();) {
+            IndexedItem indexedItem = (IndexedItem) i.next();
+
+            b.append(indexedItem.getIndexedString());
+            if (i.hasNext()) {
+                b.append(' ');
+            }
+        }
+        return b.toString();
+    }
 
     public void setWeight(int w) {
         for (Iterator<Item> i = getItemIterator(); i.hasNext();) {

--- a/container-search/src/main/java/com/yahoo/prelude/query/PhraseSegmentItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/PhraseSegmentItem.java
@@ -63,6 +63,7 @@ public class PhraseSegmentItem extends IndexedSegmentItem {
         return "SPHRASE";
     }
 
+    @Override
     public void setIndexName(String index) {
         super.setIndexName(index);
         for (Iterator<Item> i = getItemIterator(); i.hasNext();) {
@@ -81,11 +82,9 @@ public class PhraseSegmentItem extends IndexedSegmentItem {
     }
 
     /**
-     * Adds subitem. The word will have its index name set to the index name
-     * of this phrase. If the item is a word, it will simply be added,
-     * if the item is a phrase, each of the words of the phrase will be added.
+     * Adds a word subitem. The word will have its index name set to the index name of this phrase.
      *
-     * @throws IllegalArgumentException if the given item is not a WordItem or PhraseItem
+     * @throws IllegalArgumentException if the given item is not a WordItem
      */
     @Override
     public void addItem(Item item) {
@@ -180,17 +179,17 @@ public class PhraseSegmentItem extends IndexedSegmentItem {
 
     @Override
     public String getIndexedString() {
-        StringBuilder buf = new StringBuilder();
+        StringBuilder b = new StringBuilder();
 
         for (Iterator<Item> i = getItemIterator(); i.hasNext();) {
             IndexedItem indexedItem = (IndexedItem) i.next();
 
-            buf.append(indexedItem.getIndexedString());
+            b.append(indexedItem.getIndexedString());
             if (i.hasNext()) {
-                buf.append(' ');
+                b.append(' ');
             }
         }
-        return buf.toString();
+        return b.toString();
     }
 
     public boolean isExplicit() {

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -819,11 +819,9 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         } catch (IllegalArgumentException e) {
             return "Invalid query: " + Exceptions.toMessageString(e);
         }
-        /*
         catch (RuntimeException e) {
             return "Unexpected error parsing or serializing query: " + Exceptions.toMessageString(e);
         }
-         */
     }
 
     private void commaSeparated(StringBuilder yql, Set<String> fields) {

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -818,9 +818,12 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
             return "Query currently a placeholder, NullItem encountered.";
         } catch (IllegalArgumentException e) {
             return "Invalid query: " + Exceptions.toMessageString(e);
-        } catch (RuntimeException e) {
+        }
+        /*
+        catch (RuntimeException e) {
             return "Unexpected error parsing or serializing query: " + Exceptions.toMessageString(e);
         }
+         */
     }
 
     private void commaSeparated(StringBuilder yql, Set<String> fields) {

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -1393,8 +1393,7 @@ public class VespaSerializer {
     }
 
     private static String leafAnnotations(TaggableItem item) {
-        // TODO there is no usable API for the general annotations map in the
-        // Item instances
+        // TODO there is no usable API for the general annotations map in the Item instances
         StringBuilder annotation = new StringBuilder();
         int initLen = annotation.length();
         {

--- a/container-search/src/test/java/com/yahoo/prelude/query/ItemsCommonStuffTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/ItemsCommonStuffTestCase.java
@@ -9,8 +9,6 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.regex.PatternSyntaxException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.yahoo.prelude.query.Item.ItemType;
@@ -18,20 +16,12 @@ import com.yahoo.prelude.query.Item.ItemType;
 /**
  * Check basic contracts common to "many" item implementations.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 public class ItemsCommonStuffTestCase {
 
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
     @Test
-    public final void testLoops() {
+    public void testLoops() {
         AndSegmentItem as = new AndSegmentItem("farmyards", false, false);
         boolean caught = false;
         try {
@@ -52,33 +42,24 @@ public class ItemsCommonStuffTestCase {
         a.addItem(as);
         try {
             as.addItem(a);
-        } catch (QueryException e) {
-            caught = true;
-        }
-        assertTrue(caught);
-        caught = false;
-        a.removeItem(as);
-        as.addItem(a);
-        try {
-            a.addItem(as);
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             caught = true;
         }
         assertTrue(caught);
     }
 
     @Test
-    public final void testIndexName() {
+    public void testIndexName() {
         WordItem w = new WordItem("nalle");
         AndItem a = new AndItem();
         a.addItem(w);
-        final String expected = "mobil";
+        String expected = "mobil";
         a.setIndexName(expected);
         assertEquals(expected, w.getIndexName());
     }
 
     @Test
-    public final void testBoundaries() {
+    public void testBoundaries() {
         WordItem w = new WordItem("nalle");
         AndItem a = new AndItem();
         boolean caught = false;
@@ -112,7 +93,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testRemoving() {
+    public void testRemoving() {
         AndItem other = new AndItem();
         WordItem w = new WordItem("nalle");
         AndItem a = new AndItem();
@@ -127,7 +108,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testGeneralMutability() {
+    public void testGeneralMutability() {
         AndItem a = new AndItem();
         assertFalse(a.isLocked());
         a.lock();
@@ -135,7 +116,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testCounting() {
+    public void testCounting() {
         WordItem w = new WordItem("nalle");
         AndItem a = new AndItem();
         WordItem v = new WordItem("bamse");
@@ -149,7 +130,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testIteratorJuggling() {
+    public void testIteratorJuggling() {
         AndItem a = new AndItem();
         WordItem w0 = new WordItem("nalle");
         WordItem w1 = new WordItem("bamse");
@@ -178,9 +159,9 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testIdStuff() {
+    public void testIdStuff() {
         Item i;
-        final String expected = "i";
+        String expected = "i";
         i = new ExactStringItem(expected);
         assertEquals(ItemType.EXACT, i.getItemType());
         assertEquals("EXACTSTRING", i.getName());
@@ -206,7 +187,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testEquivBuilding() {
+    public void testEquivBuilding() {
         WordItem w = new WordItem("nalle");
         WordItem v = new WordItem("bamse");
         w.setConnectivity(v, 1.0);
@@ -220,8 +201,8 @@ public class ItemsCommonStuffTestCase {
         WordItem w = new WordItem("nalle");
         WordItem v = new WordItem("bamse");
         w.setConnectivity(v, 1.0);
-        final String expected = "puppy";
-        final String expected2 = "kvalp";
+        String expected = "puppy";
+        String expected2 = "kvalp";
         EquivItem e = new EquivItem(w, Arrays.asList(new String[] { expected, expected2 }));
         assertEquals(1.0, e.getConnectivity(), 1e-9);
         assertSame(v, e.getConnectedItem());
@@ -230,12 +211,12 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testSegment() {
+    public void testSegment() {
         AndSegmentItem as = new AndSegmentItem("farmyards", false, false);
         assertFalse(as.isLocked());
-        final WordItem firstItem = new WordItem("nalle");
+        WordItem firstItem = new WordItem("nalle");
         as.addItem(firstItem);
-        final WordItem item = new WordItem("bamse");
+        WordItem item = new WordItem("bamse");
         as.addItem(1, item);
         assertTrue(as.removeItem(item));
         assertFalse(as.isFromUser());
@@ -266,7 +247,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testMarkersVsWords() {
+    public void testMarkersVsWords() {
         WordItem mw0 = MarkerWordItem.createEndOfHost();
         WordItem mw1 = MarkerWordItem.createStartOfHost();
         WordItem w0 = new WordItem("$");
@@ -279,11 +260,11 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testNumberBasics() {
-        final String expected = "12";
+    public void testNumberBasics() {
+        String expected = "12";
         IntItem i = new IntItem(expected, "num");
         assertEquals(expected, i.stringValue());
-        final String expected2 = "34";
+        String expected2 = "34";
         i.setNumber(expected2);
         assertEquals(expected2, i.stringValue());
         String expected3 = "56";
@@ -297,7 +278,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testNullItemFailsProperly() {
+    public void testNullItemFailsProperly() {
         NullItem n = new NullItem();
         n.setIndexName("nalle");
         boolean caught = false;
@@ -324,7 +305,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testNearisNotAnd() {
+    public void testNearisNotAnd() {
         AndItem a = new AndItem();
         NearItem n = new NearItem();
         n.setDistance(2);
@@ -343,7 +324,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testPhraseSegmentBasics() {
+    public void testPhraseSegmentBasics() {
         AndSegmentItem a = new AndSegmentItem("gnurk", "gurk", false, false);
         fill(a);
         a.lock();
@@ -365,7 +346,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testPhraseConnectivity() {
+    public void testPhraseConnectivity() {
         WordItem w = new WordItem("a");
         PhraseItem p = new PhraseItem();
         fill(p);
@@ -375,7 +356,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testBaseClassPhraseSegments() {
+    public void testBaseClassPhraseSegments() {
         PhraseSegmentItem p = new PhraseSegmentItem("g", false, true);
         fill(p);
         assertEquals(4, p.encode(ByteBuffer.allocate(5000)));
@@ -386,7 +367,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testTermTypeBasic() {
+    public void testTermTypeBasic() {
         assertFalse(TermType.AND.equals(TermType.DEFAULT));
         assertFalse(TermType.AND.equals(Integer.valueOf(10)));
         assertTrue(TermType.AND.equals(TermType.AND));
@@ -397,7 +378,7 @@ public class ItemsCommonStuffTestCase {
     }
 
     @Test
-    public final void testRegexp() {
+    public void testRegexp() {
         RegExpItem empty = new RegExpItem("a", true, "");
         assertTrue(empty.isFromQuery());
         assertTrue(empty.isStemmed());
@@ -416,5 +397,6 @@ public class ItemsCommonStuffTestCase {
         }
         assertEquals("Dangling meta character '*' near index 0\n" + "*\n" + "^", last.getMessage());
     }
+
 }
 

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
@@ -1665,6 +1665,7 @@ public class ParseTestCase {
         AndSegmentItem segment = (AndSegmentItem) item;
 
         assertEquals(3, segment.getItemCount());
+        System.out.println("segment is " + segment + ", indexname of first item: " + ((WordItem) segment.getItem(0)).getIndexName());
         assertEquals("name:first", segment.getItem(0).toString());
         assertEquals("name:second", segment.getItem(1).toString());
         assertEquals("name:third", segment.getItem(2).toString());

--- a/container-search/src/test/java/com/yahoo/search/yql/MinimalQueryInserterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/MinimalQueryInserterTestCase.java
@@ -342,10 +342,17 @@ public class MinimalQueryInserterTestCase {
     }
 
     @Test
+    public void testAndSegmenting() {
+        Query query = new Query("?yql=select%20%2A%20from%20sources%20%2A%20where%20%5B%7B%22defaultIndex%22%3A%20%22default%22%2C%22grammar%22%3A%20%22web%22%2C%22stem%22%3A%20true%2C%22allowEmpty%22%3A%20true%7D%5DuserInput%28%40animal%29%3B&animal=m%26m%27s&tracelevel=3");
+        execution.search(query);
+        assertEquals("select * from sources * where (default contains \"m\" AND default contains ([{\"origin\": {\"original\": \"m\\'s\", \"offset\": 0, \"length\": 3}, \"andSegmenting\": true}]phrase(\"m\", \"s\")));",
+                     query.yqlRepresentation());
+    }
+
+    @Test
     public void verifyThatWarmupIsSane() {
         assertTrue(MinimalQueryInserter.warmup());
     }
-
 
     private static void assertGrouping(String expected, Query query) {
         List<String> actual = new ArrayList<>();

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -252,10 +252,11 @@ public class VespaSerializerTestCase {
         AndSegmentItem andSegment = new AndSegmentItem("abc", true, false);
         andSegment.addItem(new WordItem("a", "indexNamePlaceholder"));
         andSegment.addItem(new WordItem("b", "indexNamePlaceholder"));
+        andSegment.setIndexName("someIndexName");
         andSegment.setLabel("labeled");
         andSegment.lock();
         String q = VespaSerializer.serialize(andSegment);
-        assertEquals("indexNamePlaceholder contains ([{\"origin\": {\"original\": \"abc\", \"offset\": 0, \"length\": 3}, \"andSegmenting\": true}]phrase(\"a\", \"b\"))", q);
+        assertEquals("someIndexName contains ([{\"origin\": {\"original\": \"abc\", \"offset\": 0, \"length\": 3}, \"andSegmenting\": true}]phrase(\"a\", \"b\"))", q);
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -1036,6 +1036,11 @@ public class YqlParserTestCase {
         // success: parsed without exception
     }
 
+    @Test
+    public void testAndSegmenting() {
+        parse("select * from sources * where (default contains ([{\"stem\": false}]\"m\") AND default contains ([{\"origin\": {\"original\": \"m\'s\", \"offset\": 0, \"length\": 3}, \"andSegmenting\": true}]phrase(\"m\", \"s\"))) timeout 472;");
+    }
+
     private void assertUrlQuery(String field, Query query, boolean startAnchor, boolean endAnchor, boolean endAnchorIsDefault) {
         boolean startAnchorIsDefault = false; // Always
 


### PR DESCRIPTION
@arnej27959 do you know if there was some thinking behind the decision to not make AndSegmentItem indexed?

I stumbled upon this since it breaks an assumption in the serializer leading to a serialization exception.
If this is ok, we should probably also move most of the And/PhraseSegmentItem code into a common superclass.