### PR TITLE
Use tranfer by value and std::move to avoid copying shared pointer to…

### DIFF
--- a/searchcore/src/tests/proton/persistenceengine/persistence_handler_map/persistence_handler_map_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistence_handler_map/persistence_handler_map_test.cpp
@@ -16,7 +16,7 @@ struct DummyPersistenceHandler : public IPersistenceHandler {
     using SP = std::shared_ptr<DummyPersistenceHandler>;
     void initialize() override {}
     void handlePut(FeedToken, const storage::spi::Bucket &, storage::spi::Timestamp, DocumentSP) override {}
-    void handleUpdate(FeedToken, const storage::spi::Bucket &, storage::spi::Timestamp, const document::DocumentUpdate::SP &) override {}
+    void handleUpdate(FeedToken, const storage::spi::Bucket &, storage::spi::Timestamp, DocumentUpdateSP) override {}
     void handleRemove(FeedToken, const storage::spi::Bucket &, storage::spi::Timestamp, const document::DocumentId &) override {}
     void handleListBuckets(IBucketIdListResultHandler &) override {}
     void handleSetClusterState(const storage::spi::ClusterState &, IGenericResultHandler &) override {}

--- a/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
@@ -204,7 +204,7 @@ struct MyHandler : public IPersistenceHandler, IBucketFreezer {
     }
 
     void handleUpdate(FeedToken token, const Bucket& bucket,
-                      Timestamp timestamp, const document::DocumentUpdate::SP& upd) override {
+                      Timestamp timestamp, DocumentUpdateSP upd) override {
         token->setResult(std::make_unique<UpdateResult>(existingTimestamp), existingTimestamp > 0);
         handle(token, bucket, timestamp, upd->getId());
     }

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.cpp
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.cpp
@@ -31,17 +31,19 @@ UpdateOperation::UpdateOperation(Type type)
 
 
 UpdateOperation::UpdateOperation(Type type, const BucketId &bucketId,
-                                 const Timestamp &timestamp, const DocumentUpdate::SP &upd)
+                                 const Timestamp &timestamp, DocumentUpdate::SP upd)
     : DocumentOperation(type, bucketId, timestamp),
-      _upd(upd)
+      _upd(std::move(upd))
 {
 }
 
 
-UpdateOperation::UpdateOperation(const BucketId &bucketId, const Timestamp &timestamp, const DocumentUpdate::SP &upd)
-    : UpdateOperation(FeedOperation::UPDATE, bucketId, timestamp, upd)
+UpdateOperation::UpdateOperation(const BucketId &bucketId, const Timestamp &timestamp, DocumentUpdate::SP upd)
+    : UpdateOperation(FeedOperation::UPDATE, bucketId, timestamp, std::move(upd))
 {
 }
+
+UpdateOperation::~UpdateOperation() = default;
 
 void
 UpdateOperation::serializeUpdate(vespalib::nbostream &os) const

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.h
@@ -17,7 +17,7 @@ private:
     DocumentUpdateSP _upd;
     UpdateOperation(Type type, const document::BucketId &bucketId,
                     const storage::spi::Timestamp &timestamp,
-                    const DocumentUpdateSP &upd);
+                    DocumentUpdateSP upd);
     void serializeUpdate(vespalib::nbostream &os) const;
     void deserializeUpdate(vespalib::nbostream && is, const document::DocumentTypeRepo &repo);
 public:
@@ -25,8 +25,8 @@ public:
     UpdateOperation(Type type);
     UpdateOperation(const document::BucketId &bucketId,
                     const storage::spi::Timestamp &timestamp,
-                    const DocumentUpdateSP &upd);
-    ~UpdateOperation() override {}
+                    DocumentUpdateSP upd);
+    ~UpdateOperation() override;
     const DocumentUpdateSP &getUpdate() const { return _upd; }
     void serialize(vespalib::nbostream &os) const override;
     void deserialize(vespalib::nbostream &is, const document::DocumentTypeRepo &repo) override;

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/ipersistencehandler.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/ipersistencehandler.h
@@ -30,10 +30,7 @@ public:
     IPersistenceHandler(const IPersistenceHandler &) = delete;
     IPersistenceHandler & operator = (const IPersistenceHandler &) = delete;
 
-    /**
-     * Virtual destructor to allow inheritance.
-     */
-    virtual ~IPersistenceHandler() { }
+    virtual ~IPersistenceHandler() = default;
 
     /**
      * Called before all other functions so that the persistence handler
@@ -45,7 +42,7 @@ public:
                            storage::spi::Timestamp timestamp, DocumentSP doc) = 0;
 
     virtual void handleUpdate(FeedToken token, const storage::spi::Bucket &bucket,
-                              storage::spi::Timestamp timestamp, const DocumentUpdateSP &upd) = 0;
+                              storage::spi::Timestamp timestamp, DocumentUpdateSP upd) = 0;
 
     virtual void handleRemove(FeedToken token, const storage::spi::Bucket &bucket,
                               storage::spi::Timestamp timestamp, const document::DocumentId &id) = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.cpp
@@ -44,9 +44,9 @@ PersistenceHandlerProxy::handlePut(FeedToken token, const Bucket &bucket, Timest
 }
 
 void
-PersistenceHandlerProxy::handleUpdate(FeedToken token, const Bucket &bucket, Timestamp timestamp, const DocumentUpdateSP &upd)
+PersistenceHandlerProxy::handleUpdate(FeedToken token, const Bucket &bucket, Timestamp timestamp, DocumentUpdateSP upd)
 {
-    auto op = std::make_unique<UpdateOperation>(bucket.getBucketId().stripUnused(), timestamp, upd);
+    auto op = std::make_unique<UpdateOperation>(bucket.getBucketId().stripUnused(), timestamp, std::move(upd));
     _feedHandler.handleOperation(std::move(token), std::move(op));
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.h
+++ b/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.h
@@ -28,7 +28,7 @@ public:
                    storage::spi::Timestamp timestamp, DocumentSP doc) override;
 
     void handleUpdate(FeedToken token, const storage::spi::Bucket &bucket,
-                      storage::spi::Timestamp timestamp, const DocumentUpdateSP &upd) override;
+                      storage::spi::Timestamp timestamp, DocumentUpdateSP upd) override;
 
     void handleRemove(FeedToken token, const storage::spi::Bucket &bucket,
                       storage::spi::Timestamp timestamp,

--- a/storage/src/vespa/storage/bucketdb/storagebucketinfo.h
+++ b/storage/src/vespa/storage/bucketdb/storagebucketinfo.h
@@ -23,7 +23,7 @@ struct StorageBucketInfo {
         info.setTotalDocumentSize(0);
     }
     bool verifyLegal() const { return (disk != 0xff); }
-    uint32_t getMetaCount() { return info.getMetaCount(); }
+    uint32_t getMetaCount() const { return info.getMetaCount(); }
     void setChecksum(uint32_t crc) { info.setChecksum(crc); }
     bool operator == (const StorageBucketInfo & b) const;
     bool operator != (const StorageBucketInfo & b) const;


### PR DESCRIPTION
… the Update.

@hakonhall PR
