### PR TITLE
[VESPA-18652] Fix retirement loop

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -735,11 +735,11 @@ public class NodeRepository extends AbstractComponent {
         if (node.type() == NodeType.tenant && node.allocation().isPresent())
             illegal(node + " is currently allocated and cannot be removed");
 
-        if (node.flavor().getType() == Flavor.Type.DOCKER_CONTAINER && !removingAsChild) {
+        if (!node.type().isHost() && !removingAsChild) {
             if (node.state() != State.ready)
                 illegal(node + " can not be removed as it is not in the state " + State.ready);
         }
-        else if (node.flavor().getType() == Flavor.Type.DOCKER_CONTAINER) { // removing a child node
+        else if (!node.type().isHost()) { // removing a child node
             Set<State> legalStates = EnumSet.of(State.provisioned, State.failed, State.parked, State.dirty, State.ready);
             if ( ! legalStates.contains(node.state()))
                 illegal(node + " can not be removed as it is not in the states " + legalStates);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -50,7 +50,6 @@ public class GroupPreparer {
      *                           This method will remove from this list if it finds it needs additional nodes
      * @param highestIndex       the current highest node index among all active nodes in this cluster.
      *                           This method will increase this number when it allocates new nodes to the cluster.
-     * @param spareCount         The number of spare docker hosts we want when dynamically allocate docker containers
      * @return the list of nodes this cluster group will have allocated if activated
      */
     // Note: This operation may make persisted changes to the set of reserved and inactive nodes,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -57,7 +57,7 @@ public class GroupPreparer {
     // but it may not change the set of active nodes, as the active nodes must stay in sync with the
     // active config model which is changed on activate
     public List<Node> prepare(ApplicationId application, ClusterSpec cluster, NodeSpec requestedNodes,
-                              List<Node> surplusActiveNodes, MutableInteger highestIndex, int spareCount, int wantedGroups) {
+                              List<Node> surplusActiveNodes, MutableInteger highestIndex, int wantedGroups) {
         boolean dynamicProvisioningEnabled = nodeRepository.canProvisionHosts() && nodeRepository.zone().getCloud().dynamicProvisioning();
         boolean allocateFully = dynamicProvisioningEnabled && preprovisionCapacityFlag.value().isEmpty();
         try (Mutex lock = nodeRepository.lock(application)) {
@@ -74,7 +74,6 @@ public class GroupPreparer {
                                                                   application,
                                                                   cluster,
                                                                   requestedNodes,
-                                                                  spareCount,
                                                                   wantedGroups,
                                                                   allocateFully,
                                                                   nodeRepository);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -371,12 +371,9 @@ class NodeAllocation {
                 .collect(Collectors.toList());
     }
 
-    /** Prefer to retire nodes on spare hosts, otherwise retire higher indexes to minimize redistribution */
+    /** Prefer to retire nodes we want the least */
     private List<PrioritizableNode> byRetiringPriority(Set<PrioritizableNode> nodes) {
-        return nodes.stream()
-                    .sorted(Comparator.comparing((PrioritizableNode n) -> n.violatesSpares)
-                                      .thenComparing(nodeIndexComparator()).reversed())
-                    .collect(Collectors.toList());
+        return nodes.stream().sorted(Comparator.reverseOrder()).collect(Collectors.toList());
     }
 
     /** Prefer to unretire nodes we don't want to retire, and otherwise those with lower index */
@@ -385,10 +382,6 @@ class NodeAllocation {
                     .sorted(Comparator.comparing((PrioritizableNode n) -> n.node.status().wantToRetire())
                                       .thenComparing(n -> n.node.allocation().get().membership().index()))
                     .collect(Collectors.toList());
-    }
-
-    private Comparator<PrioritizableNode> nodeIndexComparator() {
-        return Comparator.comparing((PrioritizableNode n) -> n.node.allocation().get().membership().index());
     }
 
     public String outOfCapacityDetails() {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -51,13 +51,13 @@ public class NodePrioritizer {
     private final Set<Node> spareHosts;
 
     NodePrioritizer(LockedNodeList allNodes, ApplicationId application, ClusterSpec clusterSpec, NodeSpec nodeSpec,
-                    int spares, int wantedGroups, boolean allocateFully, NodeRepository nodeRepository) {
+                    int wantedGroups, boolean allocateFully, NodeRepository nodeRepository) {
         this.allNodes = allNodes;
         this.capacity = new HostCapacity(allNodes, nodeRepository.resourcesCalculator());
         this.requestedNodes = nodeSpec;
         this.clusterSpec = clusterSpec;
         this.application = application;
-        this.spareHosts = capacity.findSpareHosts(allNodes.asList(), spares);
+        this.spareHosts = capacity.findSpareHosts(allNodes.asList(), nodeRepository.spareCount());
         this.allocateFully = allocateFully;
         this.nodeRepository = nodeRepository;
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterResources;
 import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.HostFilter;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.NodeResources;
@@ -71,9 +70,8 @@ public class NodeRepositoryProvisioner implements Provisioner {
                                                                .map(lbService -> new LoadBalancerProvisioner(nodeRepository, lbService, flagSource));
         this.nodeResourceLimits = new NodeResourceLimits(nodeRepository);
         this.preparer = new Preparer(nodeRepository,
-                                     nodeRepository.spareCount(),
-                                     provisionServiceProvider.getHostProvisioner(),
                                      flagSource,
+                                     provisionServiceProvider.getHostProvisioner(),
                                      loadBalancerProvisioner);
         this.activator = new Activator(nodeRepository, loadBalancerProvisioner);
         this.tenantNodeQuota = Flags.TENANT_NODE_QUOTA.bindTo(flagSource);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
@@ -26,13 +26,10 @@ class Preparer {
     private final NodeRepository nodeRepository;
     private final GroupPreparer groupPreparer;
     private final Optional<LoadBalancerProvisioner> loadBalancerProvisioner;
-    private final int spareCount;
 
-    public Preparer(NodeRepository nodeRepository, int spareCount, Optional<HostProvisioner> hostProvisioner,
-                    FlagSource flagSource,
+    public Preparer(NodeRepository nodeRepository, FlagSource flagSource, Optional<HostProvisioner> hostProvisioner,
                     Optional<LoadBalancerProvisioner> loadBalancerProvisioner) {
         this.nodeRepository = nodeRepository;
-        this.spareCount = spareCount;
         this.loadBalancerProvisioner = loadBalancerProvisioner;
         this.groupPreparer = new GroupPreparer(nodeRepository, hostProvisioner, flagSource);
     }
@@ -69,7 +66,7 @@ class Preparer {
             ClusterSpec clusterGroup = cluster.with(Optional.of(ClusterSpec.Group.from(groupIndex)));
             List<Node> accepted = groupPreparer.prepare(application, clusterGroup,
                                                         requestedNodes.fraction(wantedGroups), surplusNodes,
-                                                        highestIndex, spareCount, wantedGroups);
+                                                        highestIndex, wantedGroups);
             replace(acceptedNodes, accepted);
         }
         moveToActiveGroup(surplusNodes, wantedGroups, cluster.group());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/PrioritizableNode.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/PrioritizableNode.java
@@ -123,6 +123,11 @@ class PrioritizableNode implements Comparable<PrioritizableNode> {
         int otherHostStatePri = other.parent.map(host -> HOST_STATE_PRIORITY.indexOf(host.state())).orElse(-2);
         if (thisHostStatePri != otherHostStatePri) return otherHostStatePri - thisHostStatePri;
 
+        // Prefer lower indexes to minimize redistribution
+        if (this.node.allocation().isPresent() && other.node.allocation().isPresent())
+            return Integer.compare(this.node.allocation().get().membership().index(),
+                                   other.node.allocation().get().membership().index());
+
         // All else equal choose hostname alphabetically
         return this.node.hostname().compareTo(other.node.hostname());
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -36,16 +36,17 @@ public class NodeRepositoryTest {
         NodeRepositoryTester tester = new NodeRepositoryTester();
         assertEquals(0, tester.nodeRepository().getNodes().size());
 
-        tester.addNode("id1", "host1", "default", NodeType.tenant);
-        tester.addNode("id2", "host2", "default", NodeType.tenant);
-        tester.addNode("id3", "host3", "default", NodeType.tenant);
+        tester.addNode("id1", "host1", "default", NodeType.host);
+        tester.addNode("id2", "host2", "default", NodeType.host);
+        tester.addNode("id3", "host3", "default", NodeType.host);
 
         assertEquals(3, tester.nodeRepository().getNodes().size());
         
         tester.nodeRepository().park("host2", true, Agent.system, "Parking to unit test");
         tester.nodeRepository().removeRecursively("host2");
 
-        assertEquals(2, tester.nodeRepository().getNodes().size());
+        assertEquals(3, tester.nodeRepository().getNodes().size());
+        assertEquals(1, tester.nodeRepository().getNodes(Node.State.deprovisioned).size());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -90,7 +90,7 @@ public class NodesV2ApiTest {
         // POST new nodes
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
                                    ("[" + asNodeJson("host8.yahoo.com", "default", "127.0.8.1") + "," + // test with only 1 ip address
-                                   asNodeJson("host9.yahoo.com", "large-variant", "127.0.9.1", "::9:1") + "," +
+                                   asHostJson("host9.yahoo.com", "large-variant", Optional.empty(), "127.0.9.1", "::9:1") + "," +
                                    asHostJson("parent2.yahoo.com", "large-variant", Optional.of(TenantName.from("myTenant")), "127.0.127.1", "::127:1") + "," +
                                    asDockerNodeJson("host11.yahoo.com", "parent.host.yahoo.com", "::11") + "]").
                                    getBytes(StandardCharsets.UTF_8),
@@ -137,13 +137,7 @@ public class NodesV2ApiTest {
                                    new byte[0], Request.Method.PUT),
                        "{\"message\":\"Moved host2.yahoo.com to active\"}");
 
-        // PUT a node in parked ...
-        assertResponse(new Request("http://localhost:8080/nodes/v2/state/parked/host8.yahoo.com",
-                                   new byte[0], Request.Method.PUT),
-                       "{\"message\":\"Moved host8.yahoo.com to parked\"}");
-        tester.assertResponseContains(new Request("http://localhost:8080()/nodes/v2/node/host8.yahoo.com"),
-                                     "\"state\":\"parked\"");
-        // ... and delete it
+        // Delete a ready node
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host8.yahoo.com",
                                    new byte[0], Request.Method.DELETE),
                        "{\"message\":\"Removed host8.yahoo.com\"}");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node9.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node9.json
@@ -2,7 +2,7 @@
   "url": "http://localhost:8080/nodes/v2/node/host9.yahoo.com",
   "id": "host9.yahoo.com",
   "state": "provisioned",
-  "type": "tenant",
+  "type": "host",
   "hostname": "host9.yahoo.com",
   "openStackId": "host9.yahoo.com",
   "flavor": "large-variant",


### PR DESCRIPTION
Analysis of the issue in ticket.

It's a bit tricky to write a unit test since the previous retirement followed the reverse allocation priority, so the node with the largest index would be on the host with most free resources, which often is the spare host.