### PR TITLE
Revert "record when endpoint certificates have last been requested"

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMetadata.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMetadata.java
@@ -16,21 +16,19 @@ public class EndpointCertificateMetadata {
     private final String keyName;
     private final String certName;
     private final int version;
-    private final long lastRequested;
     // TODO: make these fields required once all certs have them stored
     private final Optional<String> request_id;
     private final Optional<List<String>> requestedDnsSans;
     private final Optional<String> issuer;
 
-    public EndpointCertificateMetadata(String keyName, String certName, int version, long lastRequested) {
-        this(keyName, certName, version, lastRequested, Optional.empty(), Optional.empty(), Optional.empty());
+    public EndpointCertificateMetadata(String keyName, String certName, int version) {
+        this(keyName, certName, version, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    public EndpointCertificateMetadata(String keyName, String certName, int version, long lastRequested, Optional<String> request_id, Optional<List<String>> requestedDnsSans, Optional<String> issuer) {
+    public EndpointCertificateMetadata(String keyName, String certName, int version, Optional<String> request_id, Optional<List<String>> requestedDnsSans, Optional<String> issuer) {
         this.keyName = keyName;
         this.certName = certName;
         this.version = version;
-        this.lastRequested = lastRequested;
         this.request_id = request_id;
         this.requestedDnsSans = requestedDnsSans;
         this.issuer = issuer;
@@ -46,10 +44,6 @@ public class EndpointCertificateMetadata {
 
     public int version() {
         return version;
-    }
-
-    public long lastRequested() {
-        return lastRequested;
     }
 
     public Optional<String> request_id() {
@@ -69,19 +63,6 @@ public class EndpointCertificateMetadata {
                 this.keyName,
                 this.certName,
                 version,
-                this.lastRequested,
-                this.request_id,
-                this.requestedDnsSans,
-                this.issuer
-        );
-    }
-
-    public EndpointCertificateMetadata withLastRequested(long lastRequested) {
-        return new EndpointCertificateMetadata(
-                this.keyName,
-                this.certName,
-                this.version,
-                lastRequested,
                 this.request_id,
                 this.requestedDnsSans,
                 this.issuer
@@ -94,7 +75,6 @@ public class EndpointCertificateMetadata {
                 "keyName='" + keyName + '\'' +
                 ", certName='" + certName + '\'' +
                 ", version=" + version +
-                ", lastRequested=" + lastRequested +
                 ", request_id=" + request_id +
                 ", requestedDnsSans=" + requestedDnsSans +
                 ", issuer=" + issuer +
@@ -107,7 +87,6 @@ public class EndpointCertificateMetadata {
         if (o == null || getClass() != o.getClass()) return false;
         EndpointCertificateMetadata that = (EndpointCertificateMetadata) o;
         return version == that.version &&
-                lastRequested == that.lastRequested &&
                 keyName.equals(that.keyName) &&
                 certName.equals(that.certName) &&
                 request_id.equals(that.request_id) &&
@@ -117,6 +96,6 @@ public class EndpointCertificateMetadata {
 
     @Override
     public int hashCode() {
-        return Objects.hash(keyName, certName, version, lastRequested, request_id, requestedDnsSans, issuer);
+        return Objects.hash(keyName, certName, version, request_id, requestedDnsSans, issuer);
     }
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMock.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMock.java
@@ -25,7 +25,7 @@ public class EndpointCertificateMock implements EndpointCertificateProvider {
         this.dnsNames.put(applicationId, dnsNames);
         String endpointCertificatePrefix = String.format("vespa.tls.%s.%s.%s", applicationId.tenant(),
                 applicationId.application(), applicationId.instance());
-        return new EndpointCertificateMetadata(endpointCertificatePrefix + "-key", endpointCertificatePrefix + "-cert", 0, 0, Optional.of("mock-id-string"), Optional.of(dnsNames), Optional.of("mockCa"));
+        return new EndpointCertificateMetadata(endpointCertificatePrefix + "-key", endpointCertificatePrefix + "-cert", 0, Optional.of("mock-id-string"), Optional.of(dnsNames), Optional.of("mockCa"));
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificateManager.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificateManager.java
@@ -95,7 +95,6 @@ public class EndpointCertificateManager {
     public Optional<EndpointCertificateMetadata> getEndpointCertificateMetadata(Instance instance, ZoneId zone, Optional<DeploymentInstanceSpec> instanceSpec) {
         var t0 = Instant.now();
         Optional<EndpointCertificateMetadata> metadata = getOrProvision(instance, zone, instanceSpec);
-        metadata.ifPresent(m -> curator.writeEndpointCertificateMetadata(instance.id(), m.withLastRequested(clock.instant().getEpochSecond())));
         Duration duration = Duration.between(t0, Instant.now());
         if (duration.toSeconds() > 30) log.log(Level.INFO, String.format("Getting endpoint certificate metadata for %s took %d seconds!", instance.id().serializedForm(), duration.toSeconds()));
         return metadata;
@@ -186,7 +185,6 @@ public class EndpointCertificateManager {
                             storedMetaData.keyName(),
                             storedMetaData.certName(),
                             storedMetaData.version(),
-                            Instant.now().getEpochSecond(),
                             providerMetadata.request_id(),
                             providerMetadata.requestedDnsSans(),
                             providerMetadata.issuer());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/EndpointCertificateMetadataSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/EndpointCertificateMetadataSerializer.java
@@ -32,7 +32,6 @@ public class EndpointCertificateMetadataSerializer {
     private final static String keyNameField = "keyName";
     private final static String certNameField = "certName";
     private final static String versionField = "version";
-    private final static String lastRequestedField = "lastRequested";
     private final static String requestIdField = "requestId";
     private final static String requestedDnsSansField = "requestedDnsSans";
     private final static String issuerField = "issuer";
@@ -43,7 +42,6 @@ public class EndpointCertificateMetadataSerializer {
         object.setString(keyNameField, metadata.keyName());
         object.setString(certNameField, metadata.certName());
         object.setLong(versionField, metadata.version());
-        object.setLong(lastRequestedField, metadata.lastRequested());
 
         metadata.request_id().ifPresent(id -> object.setString(requestIdField, id));
         metadata.requestedDnsSans().ifPresent(sans -> {
@@ -71,16 +69,10 @@ public class EndpointCertificateMetadataSerializer {
                 Optional.of(inspector.field(issuerField).asString()) :
                 Optional.empty();
 
-        long lastRequested = inspector.field(lastRequestedField).valid() ?
-                inspector.field(lastRequestedField).asLong() :
-                1597200000L; // Wed Aug 12 02:40:00 UTC 2020
-                // Not originally stored, so we default to when field was added
-
         return new EndpointCertificateMetadata(
                 inspector.field(keyNameField).asString(),
                 inspector.field(certNameField).asString(),
                 Math.toIntExact(inspector.field(versionField).asLong()),
-                lastRequested,
                 request_id,
                 requestedDnsSans,
                 issuer);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/EndpointCertificateMetadataSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/EndpointCertificateMetadataSerializerTest.java
@@ -11,21 +11,21 @@ import static org.junit.Assert.*;
 public class EndpointCertificateMetadataSerializerTest {
 
     private final EndpointCertificateMetadata sample =
-            new EndpointCertificateMetadata("keyName", "certName", 1, 0);
+            new EndpointCertificateMetadata("keyName", "certName", 1);
     private final EndpointCertificateMetadata sampleWithRequestMetadata =
-            new EndpointCertificateMetadata("keyName", "certName", 1, 0, Optional.of("requestId"), Optional.of(List.of("SAN1", "SAN2")), Optional.of("issuer"));
+            new EndpointCertificateMetadata("keyName", "certName", 1, Optional.of("requestId"), Optional.of(List.of("SAN1", "SAN2")), Optional.of("issuer"));
 
     @Test
     public void serialize() {
         assertEquals(
-                "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1,\"lastRequested\":0}",
+                "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1}",
                 EndpointCertificateMetadataSerializer.toSlime(sample).toString());
     }
 
     @Test
     public void serializeWithRequestMetadata() {
         assertEquals(
-                "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1,\"lastRequested\":0,\"requestId\":\"requestId\",\"requestedDnsSans\":[\"SAN1\",\"SAN2\"],\"issuer\":\"issuer\"}",
+                "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1,\"requestId\":\"requestId\",\"requestedDnsSans\":[\"SAN1\",\"SAN2\"],\"issuer\":\"issuer\"}",
                 EndpointCertificateMetadataSerializer.toSlime(sampleWithRequestMetadata).toString());
     }
 
@@ -34,7 +34,7 @@ public class EndpointCertificateMetadataSerializerTest {
         assertEquals(
                 sample,
                 EndpointCertificateMetadataSerializer.fromJsonString(
-                        "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1,\"lastRequested\":0}"));
+                        "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1}"));
     }
 
     @Test
@@ -42,14 +42,6 @@ public class EndpointCertificateMetadataSerializerTest {
         assertEquals(
                 sampleWithRequestMetadata,
                 EndpointCertificateMetadataSerializer.fromJsonString(
-                        "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1,\"lastRequested\":0,\"requestId\":\"requestId\",\"requestedDnsSans\":[\"SAN1\",\"SAN2\"],\"issuer\":\"issuer\"}"));
-    }
-
-    @Test
-    public void deserializeFromJsonWithDefaultLastRequested() {
-        assertEquals(
-                new EndpointCertificateMetadata("keyName", "certName", 1, 1597200000),
-                EndpointCertificateMetadataSerializer.fromJsonString(
-                        "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1}"));
+                        "{\"keyName\":\"keyName\",\"certName\":\"certName\",\"version\":1,\"requestId\":\"requestId\",\"requestedDnsSans\":[\"SAN1\",\"SAN2\"],\"issuer\":\"issuer\"}"));
     }
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#14026
``` 
00:10:24 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project controller-clients: Compilation failure: Compilation failure: 
00:10:24 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/controller/controller-clients/src/main/java/com/yahoo/vespa/hosted/clients/tls/CameoEndpointCertificateProvider.java:[101,20] no suitable constructor found for EndpointCertificateMetadata(java.lang.String,java.lang.String,int,java.util.Optional<java.lang.String>,java.util.Optional<java.util.List<java.lang.String>>,java.util.Optional<java.lang.String>)
00:10:24 [ERROR]     constructor com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata.EndpointCertificateMetadata(java.lang.String,java.lang.String,int,long) is not applicable
00:10:24 [ERROR]       (actual and formal argument lists differ in length)
00:10:24 [ERROR]     constructor com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata.EndpointCertificateMetadata(java.lang.String,java.lang.String,int,long,java.util.Optional<java.lang.String>,java.util.Optional<java.util.List<java.lang.String>>,java.util.Optional<java.lang.String>) is not applicable
00:10:24 [ERROR]       (actual and formal argument lists differ in length)
00:10:24 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/controller/controller-clients/src/main/java/com/yahoo/vespa/hosted/clients/tls/CameoEndpointCertificateProvider.java:[120,32] no suitable constructor found for EndpointCertificateMetadata(java.lang.String,java.lang.String,int,java.util.Optional<java.lang.String>,java.util.Optional<java.util.List<java.lang.String>>,java.util.Optional<java.lang.String>)
00:10:24 [ERROR]     constructor com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata.EndpointCertificateMetadata(java.lang.String,java.lang.String,int,long) is not applicable
00:10:24 [ERROR]       (actual and formal argument lists differ in length)
00:10:24 [ERROR]     constructor com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata.EndpointCertificateMetadata(java.lang.String,java.lang.String,int,long,java.util.Optional<java.lang.String>,java.util.Optional<java.util.List<java.lang.String>>,java.util.Optional<java.lang.String>) is not applicable
00:10:24 [ERROR]       (actual and formal argument lists differ in length)
00:10:24 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/controller/controller-clients/src/main/java/com/yahoo/vespa/hosted/clients/tls/CameoEndpointCertificateProvider.java:[121,29] incompatible types: inference variable T has incompatible bounds
00:10:24 [ERROR]     equality constraints: com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata
00:10:24 [ERROR]     lower bounds: java.lang.Object
00:10:24 [ERROR] -> [Help 1]
```