### PR TITLE
Skip logging only for IllegalInputException

### DIFF
--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/NearestNeighborTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/NearestNeighborTestCase.java
@@ -27,9 +27,9 @@ public class NearestNeighborTestCase extends AbstractExportingTestCase {
             Query q = new Query("?ranking.features.query(q_vec)=[1,2,3,4,5,6]", // length is 6, not 5
                                 queryProfiles.getComponent("default"));
             fail("This should fail when q_vec is parsed as a tensor");
-        } catch (IllegalInputException e) {
+        } catch (IllegalArgumentException e) {
             // success
-            assertEquals("Invalid request parameter", e.getMessage());
+            assertEquals("Could not set 'ranking.features.query(q_vec)' to '[1,2,3,4,5,6]'", e.getMessage());
         } catch (RuntimeException e) {
             e.printStackTrace();
             throw e;

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/NearestNeighborTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/NearestNeighborTestCase.java
@@ -2,7 +2,6 @@
 package com.yahoo.searchdefinition.derived;
 
 import com.yahoo.component.ComponentId;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.search.Query;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
 import com.yahoo.search.query.profile.config.QueryProfileConfigurer;
@@ -28,7 +27,7 @@ public class NearestNeighborTestCase extends AbstractExportingTestCase {
             Query q = new Query("?ranking.features.query(q_vec)=[1,2,3,4,5,6]", // length is 6, not 5
                                 queryProfiles.getComponent("default"));
             fail("This should fail when q_vec is parsed as a tensor");
-        } catch (QueryException e) {
+        } catch (IllegalInputException e) {
             // success
             assertEquals("Invalid request parameter", e.getMessage());
         } catch (RuntimeException e) {

--- a/container-search/src/main/java/com/yahoo/prelude/query/BoolItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/BoolItem.java
@@ -1,6 +1,8 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.query;
 
+import com.yahoo.processing.IllegalInputException;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -59,7 +61,7 @@ public class BoolItem extends TermItem {
         switch (stringValue.toLowerCase()) {
             case "true" : return true;
             case "false" : return false;
-            default: throw new IllegalArgumentException("Expected 'true' or 'false', got '" + stringValue + "'");
+            default: throw new IllegalInputException("Expected 'true' or 'false', got '" + stringValue + "'");
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/query/CompositeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/CompositeItem.java
@@ -46,7 +46,7 @@ public abstract class CompositeItem extends Item {
             Item possibleCycle = i.next();
 
             if (this == possibleCycle) {
-                throw new QueryException("Cannot add " + item + " to " + this + " as it would create a cycle");
+                throw new IllegalArgumentException("Cannot add " + item + " to " + this + " as it would create a cycle");
             } else if (possibleCycle instanceof CompositeItem) {
                 ensureNotInSubtree((CompositeItem) possibleCycle);
             }

--- a/container-search/src/main/java/com/yahoo/prelude/query/GeoLocationItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/GeoLocationItem.java
@@ -22,7 +22,7 @@ public class GeoLocationItem extends TermItem {
     public GeoLocationItem(Location location) {
         this(location, location.getAttribute());
         if (! location.hasAttribute()) {
-            throw new IllegalArgumentException("missing attribute on location: "+location);
+            throw new IllegalArgumentException("Missing attribute on location: " + location);
         }
     }
 
@@ -34,13 +34,14 @@ public class GeoLocationItem extends TermItem {
     public GeoLocationItem(Location location, String fieldName) {
         super(fieldName, false);
         if (location.hasAttribute() && ! location.getAttribute().equals(fieldName)) {
-            throw new IllegalArgumentException("inconsistent attribute on location: "+location.getAttribute()+" versus fieldName: "+fieldName);
+            throw new IllegalArgumentException("Inconsistent attribute on location: " + location.getAttribute() +
+                                               " versus fieldName: " + fieldName);
         }
         if (! location.isGeoCircle()) {
-            throw new IllegalArgumentException("GeoLocationItem only supports Geo Circles, got: "+location);
+            throw new IllegalArgumentException("GeoLocationItem only supports Geo Circles, got: " + location);
         }
         if (location.hasBoundingBox()) {
-            throw new IllegalArgumentException("GeoLocationItem does not support bounding box yet, got: "+location);
+            throw new IllegalArgumentException("GeoLocationItem does not support bounding box, got: " + location);
         }
         this.location = new Location(location.toString());
         this.location.setAttribute(null); // keep this in (superclass) indexName only

--- a/container-search/src/main/java/com/yahoo/prelude/query/IntItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/IntItem.java
@@ -111,7 +111,7 @@ public class IntItem extends TermItem {
         }
         catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("'" + expression + "' is not an int item expression: " +
-                    "Expected NUMBER, '<'NUMBER, '>'NUMBER or ('['|'<')NUMBER;NUMBER(;NUMBER)?(']'|'>')", e);
+                                               "Expected NUMBER, '<'NUMBER, '>'NUMBER or ('['|'<')NUMBER;NUMBER(;NUMBER)?(']'|'>')", e);
 
         }
     }

--- a/container-search/src/main/java/com/yahoo/prelude/query/QueryException.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/QueryException.java
@@ -4,10 +4,11 @@ package com.yahoo.prelude.query;
 /**
  * Runtime exception to mark errors in query parsing.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
+ * @deprecated no methods throw this
  */
+@Deprecated // TODO: Remove on Vespa 8
 public class QueryException extends RuntimeException {
-    private static final long serialVersionUID = -2975856668328596533L;
 
     public QueryException(String message) {
         super(message);
@@ -16,4 +17,5 @@ public class QueryException extends RuntimeException {
     public QueryException(String message, Throwable cause) {
         super(message, cause);
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/prelude/query/RegExpItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/RegExpItem.java
@@ -7,9 +7,10 @@ import java.util.regex.Pattern;
 /**
  * Match a field with the contained regular expression.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 public class RegExpItem extends TermItem {
+
     private String expression;
     private Pattern regexp;
 

--- a/container-search/src/main/java/com/yahoo/prelude/query/SegmentItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SegmentItem.java
@@ -102,7 +102,7 @@ public abstract class SegmentItem extends CompositeItem implements BlockItem {
     }
 
     private void dontAdd() {
-        throw new QueryException("Tried to add item to an immutable segment.");
+        throw new IllegalArgumentException("Tried to add item to an immutable segment.");
     }
 
     public Item removeItem(int index) {
@@ -120,7 +120,7 @@ public abstract class SegmentItem extends CompositeItem implements BlockItem {
     }
 
     private void dontRemove() {
-        throw new QueryException("Tried to remove an item from an immutable segment.");
+        throw new IllegalArgumentException("Tried to remove an item from an immutable segment.");
     }
 
     // TODO: Add a getItemIterator which is safe for immutability

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/AdvancedParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/AdvancedParser.java
@@ -206,7 +206,7 @@ public class AdvancedParser extends StructuredParser {
         if (!tokens.currentIs(LBRACE)) return 0;
         tokens.skip(LBRACE);
         if (!tokens.currentIsNoIgnore(NUMBER)) throw new IllegalArgumentException("Expected an integer argument");
-        int distance=Integer.valueOf(tokens.next().image);
+        int distance = Integer.valueOf(tokens.next().image);
         if (!tokens.skip(Token.Kind.RBRACE)) throw new IllegalArgumentException("Expected a right brace following the argument");
         return distance;
     }

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/PhraseMatcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/PhraseMatcher.java
@@ -64,9 +64,9 @@ public class PhraseMatcher {
      * @throws IllegalArgumentException if FSA is null
      */
     public PhraseMatcher(FSA phraseAutomatonFSA,boolean ignorePluralForm) {
-        if(phraseAutomatonFSA==null) throw new IllegalArgumentException("FSA is null");
-        this.ignorePluralForm=ignorePluralForm;
-        phraseFSA=phraseAutomatonFSA;
+        if (phraseAutomatonFSA == null) throw new NullPointerException("FSA is null");
+        this.ignorePluralForm = ignorePluralForm;
+        phraseFSA = phraseAutomatonFSA;
     }
 
     public boolean isEmpty() { return phraseFSA == null; }

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
@@ -359,7 +359,7 @@ public class StemmingSearcher extends Searcher {
             default:
                 throw new IllegalArgumentException("Unknown segmenting rule: " + current.getSegmentingRule() +
                                                    ". This is a bug in Vespa, as the implementation has gotten out of sync." +
-                                                   " Please create a ticket as soon as possible.");
+                                                   " Please create an issue.");
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/PosSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/PosSearcher.java
@@ -75,7 +75,7 @@ public class PosSearcher extends Searcher {
         loc.setAttribute(posAttribute);
 
         try {
-            if (ll == null && xy == null && bb != null) {
+            if (ll == null && xy == null) {
                 parseBoundingBox(bb, loc);
             } else {
                 if (ll != null && xy != null) {

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -10,7 +10,6 @@ import com.yahoo.fs4.MapEncoder;
 import java.util.logging.Level;
 import com.yahoo.prelude.fastsearch.DocumentDatabase;
 import com.yahoo.prelude.query.Highlight;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.prelude.query.textualrepresentation.TextualQueryRepresentation;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.dispatch.Dispatcher;
@@ -413,11 +412,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
             if (field.getType() == FieldType.genericQueryProfileType) { // Generic map
                 CompoundName fullName = prefix.append(field.getName());
                 for (Map.Entry<String, Object> entry : originalProperties.listProperties(fullName, context).entrySet()) {
-                    try {
-                        properties().set(fullName.append(entry.getKey()), entry.getValue(), context);
-                    } catch (IllegalArgumentException e) {
-                        throw new QueryException("Invalid request parameter", e);
-                    }
+                    properties().set(fullName.append(entry.getKey()), entry.getValue(), context);
                 }
             }
             else if (field.getType() instanceof QueryProfileFieldType) { // Nested arguments
@@ -427,11 +422,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
                 CompoundName fullName = prefix.append(field.getName());
                 Object value = originalProperties.get(fullName, context);
                 if (value != null) {
-                    try {
-                        properties().set(fullName, value, context);
-                    } catch (IllegalArgumentException e) {
-                        throw new QueryException("Invalid request parameter", e);
-                    }
+                    properties().set(fullName, value, context);
                 }
             }
         }
@@ -440,13 +431,8 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
     /** Calls properties.set on all entries in requestMap */
     private void setPropertiesFromRequestMap(Map<String, String> requestMap, Properties properties, boolean ignoreSelect) {
         for (var entry : requestMap.entrySet()) {
-            try {
-                if (ignoreSelect && entry.getKey().equals(Select.SELECT)) continue;
-                properties.set(entry.getKey(), entry.getValue(), requestMap);
-            }
-            catch (IllegalArgumentException e) {
-                throw new QueryException("Invalid request parameter", e);
-            }
+            if (ignoreSelect && entry.getKey().equals(Select.SELECT)) continue;
+            properties.set(entry.getKey(), entry.getValue(), requestMap);
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/federation/FederationSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/FederationSearcher.java
@@ -14,6 +14,7 @@ import com.yahoo.concurrent.CopyOnWriteHashMap;
 import com.yahoo.errorhandling.Results;
 import com.yahoo.errorhandling.Results.Builder;
 import com.yahoo.prelude.IndexFacts;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -545,8 +546,8 @@ public class FederationSearcher extends ForkingSearcher {
     private ComponentSpecification asSourceSpec(String source) {
         try {
             return new ComponentSpecification(source);
-        } catch(Exception e) {
-            throw new IllegalArgumentException("The source ref '" + source + "' used for federation is not valid.", e);
+        } catch (Exception e) {
+            throw new IllegalInputException("The source ref '" + source + "' used for federation is not valid.", e);
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/grouping/GroupingValidator.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/GroupingValidator.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
 import com.yahoo.component.chain.dependencies.Provides;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.grouping.request.AttributeMapLookupValue;
 import com.yahoo.vespa.config.search.AttributesConfig;
 import com.yahoo.container.QrSearchersConfig;
@@ -80,14 +81,14 @@ public class GroupingValidator extends Searcher {
         AttributesConfig.Attribute keyAttribute = attributes.get(keyAttributeName);
         AttributesConfig.Attribute keySourceAttribute = attributes.get(keySourceAttributeName);
         if (!keySourceAttribute.datatype().equals(keyAttribute.datatype())) {
-            throw new IllegalArgumentException("Grouping request references key source attribute '" +
-                    keySourceAttributeName + "' with data type '" + keySourceAttribute.datatype() +
-                    "' that is different than data type '" + keyAttribute.datatype() + "' of key attribute '" +
-                    keyAttributeName + "'");
+            throw new IllegalInputException("Grouping request references key source attribute '" +
+                                            keySourceAttributeName + "' with data type '" + keySourceAttribute.datatype() +
+                                            "' that is different than data type '" + keyAttribute.datatype() + "' of key attribute '" +
+                                            keyAttributeName + "'");
         }
         if (!keySourceAttribute.collectiontype().equals(AttributesConfig.Attribute.Collectiontype.Enum.SINGLE)) {
-            throw new IllegalArgumentException("Grouping request references key source attribute '" +
-                    keySourceAttributeName + "' which is not of single value type");
+            throw new IllegalInputException("Grouping request references key source attribute '" +
+                                            keySourceAttributeName + "' which is not of single value type");
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/AddFunction.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/AddFunction.java
@@ -38,9 +38,9 @@ public class AddFunction extends FunctionNode {
     /**
      * Constructs a new instance of this class from a list of arguments.
      *
-     * @param args The arguments to pass to the constructor.
-     * @return The created instance.
-     * @throws IllegalArgumentException Thrown if the number of arguments is less than 2.
+     * @param args the arguments to pass to the constructor.
+     * @return the created instance.
+     * @throws IllegalArgumentException thrown if the number of arguments is less than 2.
      */
     public static AddFunction newInstance(List<GroupingExpression> args) {
         if (args.size() < 2) {

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/BucketResolver.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/BucketResolver.java
@@ -24,9 +24,9 @@ public class BucketResolver {
      * Pushes the given expression onto this bucket resolver. Once all buckets have been pushed using this method, call
      * {@link #resolve(GroupingExpression)} to retrieve to combined grouping expression.
      *
-     * @param val The expression to push.
-     * @param inclusive Whether or not the value is inclusive or not.
-     * @throws IllegalArgumentException Thrown if the expression is incompatible.
+     * @param val the expression to push
+     * @param inclusive whether or not the value is inclusive or not
+     * @throws IllegalArgumentException thrown if the expression is incompatible
      */
     public BucketResolver push(ConstantValue<?> val, boolean inclusive) {
         if (prev == null) {

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/GroupingOperation.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/GroupingOperation.java
@@ -228,8 +228,8 @@ public abstract class GroupingOperation extends GroupingNode {
      * method verifies the input level against the operation type, and recursively resolves the level of all argument
      * expressions.
      *
-     * @param level The level of the input data.
-     * @throws IllegalArgumentException Thrown if a contained expression is invalid for the given level.
+     * @param level the level of the input data
+     * @throws IllegalArgumentException thrown if a contained expression is invalid for the given level
      */
     public void resolveLevel(int level) {
         if (groupBy != null) {
@@ -322,12 +322,7 @@ public abstract class GroupingOperation extends GroupingNode {
         return this;
     }
 
-    /**
-     * Return the accuracy of this.
-     *
-     * @return The accuracy value.
-     * @see #setAccuracy(double)
-     */
+    /** Return the accuracy of this. */
     public double getAccuracy() {
         return accuracy;
     }
@@ -335,8 +330,8 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Adds an expression to the order-by clause of this operation.
      *
-     * @param exp The expressions to add to this.
-     * @return This, to allow chaining.
+     * @param exp the expressions to add to this
+     * @return this, to allow chaining
      */
     public GroupingOperation addOrderBy(GroupingExpression exp) {
         orderBy.add(exp);
@@ -346,11 +341,11 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Convenience method to call {@link #addOrderBy(GroupingExpression)} for each element in the given list.
      *
-     * @param lst The list of expressions to add.
-     * @return This, to allow chaining.
+     * @param list the list of expressions to add
+     * @return this, to allow chaining
      */
-    public GroupingOperation addOrderBy(List<GroupingExpression> lst) {
-        for (GroupingExpression exp : lst) {
+    public GroupingOperation addOrderBy(List<GroupingExpression> list) {
+        for (GroupingExpression exp : list) {
             addOrderBy(exp);
         }
         return this;
@@ -359,7 +354,7 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Returns the number of expressions in the order-by clause of this.
      *
-     * @return The expression count.
+     * @return the expression count
      */
     public int getNumOrderBy() {
         return orderBy.size();
@@ -368,9 +363,9 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Returns the group-by expression at the given index.
      *
-     * @param i The index of the expression to return.
-     * @return The expression at the given index.
-     * @throws IndexOutOfBoundsException If the index is out of range.
+     * @param i the index of the expression to return
+     * @return the expression at the given index
+     * @throws IndexOutOfBoundsException if the index is out of range
      */
     public GroupingExpression getOrderBy(int i) {
         return orderBy.get(i);
@@ -379,7 +374,7 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Returns an immutable view to the order-by clause of this.
      *
-     * @return The expression list.
+     * @return the expression list
      */
     public List<GroupingExpression> getOrderBy() {
         return Collections.unmodifiableList(orderBy);
@@ -388,8 +383,8 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Adds an expression to the output clause of this operation.
      *
-     * @param exp The expressions to add to this.
-     * @return This, to allow chaining.
+     * @param exp the expressions to add to this
+     * @return this, to allow chaining
      */
     public GroupingOperation addOutput(GroupingExpression exp) {
         outputs.add(exp);
@@ -399,8 +394,8 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Convenience method to call {@link #addOutput(GroupingExpression)} for each element in the given list.
      *
-     * @param lst The list of expressions to add.
-     * @return This, to allow chaining.
+     * @param lst the list of expressions to add
+     * @return this, to allow chaining
      */
     public GroupingOperation addOutputs(List<GroupingExpression> lst) {
         for (GroupingExpression exp : lst) {
@@ -412,7 +407,7 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Returns the number of expressions in the output clause of this.
      *
-     * @return The expression count.
+     * @return the expression count
      */
     public int getNumOutputs() {
         return outputs.size();
@@ -421,9 +416,9 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Returns the output expression at the given index.
      *
-     * @param i The index of the expression to return.
-     * @return The expression at the given index.
-     * @throws IndexOutOfBoundsException If the index is out of range.
+     * @param i the index of the expression to return
+     * @return the expression at the given index
+     * @throws IndexOutOfBoundsException If the index is out of range
      */
     public GroupingExpression getOutput(int i) {
         return outputs.get(i);
@@ -432,7 +427,7 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Returns an immutable view to the output clause of this.
      *
-     * @return The expression list.
+     * @return the expression list
      */
     public List<GroupingExpression> getOutputs() {
         return Collections.unmodifiableList(outputs);
@@ -443,8 +438,8 @@ public abstract class GroupingOperation extends GroupingNode {
      * during expression evaluation to give the dispatch-node more data to consider when selecting the N groups that are
      * to be evaluated further.
      *
-     * @param precision The precision to set.
-     * @return This, to allow chaining.
+     * @param precision the precision to set
+     * @return this, to allow chaining
      * @see #setMax(int)
      */
     public GroupingOperation setPrecision(int precision) {
@@ -452,11 +447,7 @@ public abstract class GroupingOperation extends GroupingNode {
         return this;
     }
 
-    /**
-     * Returns the precision clause of this.
-     *
-     * @return The precision.
-     */
+    /** Returns the precision clause of this. */
     public int getPrecision() {
         return precision;
     }
@@ -464,11 +455,11 @@ public abstract class GroupingOperation extends GroupingNode {
     /**
      * Assigns a string as the where clause of this operation.
      *
-     * @param str The string to assign to this.
-     * @return This, to allow chaining.
+     * @param string the string to assign to this
+     * @return this, to allow chaining
      */
-    public GroupingOperation setWhere(String str) {
-        where = str;
+    public GroupingOperation setWhere(String string) {
+        where = string;
         return this;
     }
 
@@ -590,9 +581,9 @@ public abstract class GroupingOperation extends GroupingNode {
      * Convenience method to call {@link #fromStringAsList(String)} and assert that the list contains exactly one
      * grouping operation.
      *
-     * @param str The string to parse.
-     * @return A grouping operation that corresponds to the string.
-     * @throws IllegalArgumentException Thrown if the string could not be parsed as a single operation.
+     * @param str the string to parse
+     * @return a grouping operation that corresponds to the string
+     * @throws IllegalArgumentException thrown if the string could not be parsed as a single operation
      */
     public static GroupingOperation fromString(String str) {
         List<GroupingOperation> lst = fromStringAsList(str);
@@ -606,15 +597,15 @@ public abstract class GroupingOperation extends GroupingNode {
      * Parses the given string as a list of grouping operations. This method never returns null, it either returns a
      * list of valid grouping requests or it throws an exception.
      *
-     * @param str The string to parse.
-     * @return A list of grouping operations that corresponds to the string.
-     * @throws IllegalArgumentException Thrown if the string could not be parsed.
+     * @param string the string to parse
+     * @return a list of grouping operations that corresponds to the string
+     * @throws IllegalArgumentException thrown if the string could not be parsed
      */
-    public static List<GroupingOperation> fromStringAsList(String str) {
-        if (str == null || str.trim().length() == 0) {
+    public static List<GroupingOperation> fromStringAsList(String string) {
+        if (string == null || string.trim().length() == 0) {
             return Collections.emptyList();
         }
-        GroupingParserInput input = new GroupingParserInput(str);
+        GroupingParserInput input = new GroupingParserInput(string);
         try {
             return new GroupingParser(input).requestList();
         } catch (ParseException | TokenMgrException e) {

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/PlaceholderMappingVisitor.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/PlaceholderMappingVisitor.java
@@ -19,16 +19,16 @@ import java.util.Map;
  */
 class PlaceholderMappingVisitor extends PageTemplateVisitor {
 
-    private Map<String, MapChoice> placeholderIdToChoice=new LinkedHashMap<>();
+    private final Map<String, MapChoice> placeholderIdToChoice = new LinkedHashMap<>();
 
     @Override
     public void visit(MapChoice mapChoice) {
-        List<String> placeholderIds=mapChoice.placeholderIds();
+        List<String> placeholderIds = mapChoice.placeholderIds();
         for (String placeholderId : placeholderIds) {
-            MapChoice existingChoice=placeholderIdToChoice.put(placeholderId,mapChoice);
-            if (existingChoice!=null)
+            MapChoice existingChoice = placeholderIdToChoice.put(placeholderId,mapChoice);
+            if (existingChoice != null)
                 throw new IllegalArgumentException("placeholder id '" + placeholderId + "' is referenced by both " +
-                        mapChoice + " and " + existingChoice + ": Only one reference is allowed");
+                                                   mapChoice + " and " + existingChoice + ": Only one reference is allowed");
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/PlaceholderReferenceCreatingVisitor.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/PlaceholderReferenceCreatingVisitor.java
@@ -1,9 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.pagetemplates;
 
-import com.yahoo.search.pagetemplates.model.*;
+import com.yahoo.search.pagetemplates.model.MapChoice;
+import com.yahoo.search.pagetemplates.model.PageTemplateVisitor;
+import com.yahoo.search.pagetemplates.model.Placeholder;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -14,16 +15,16 @@ import java.util.Map;
  */
 class PlaceholderReferenceCreatingVisitor extends PageTemplateVisitor {
 
-    private Map<String, MapChoice> placeholderIdToChoice=new HashMap<>();
+    private final Map<String, MapChoice> placeholderIdToChoice;
 
     public PlaceholderReferenceCreatingVisitor(Map<String, MapChoice> placeholderIdToChoice) {
-        this.placeholderIdToChoice=placeholderIdToChoice;
+        this.placeholderIdToChoice = placeholderIdToChoice;
     }
 
     @Override
     public void visit(Placeholder placeholder) {
-        MapChoice choice=placeholderIdToChoice.get(placeholder.getId());
-        if (choice==null)
+        MapChoice choice = placeholderIdToChoice.get(placeholder.getId());
+        if (choice == null)
             throw new IllegalArgumentException(placeholder + " is not referenced by any choice");
         placeholder.setValueContainer(choice);
     }

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/config/PageTemplateXMLReader.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/config/PageTemplateXMLReader.java
@@ -38,18 +38,18 @@ public class PageTemplateXMLReader {
      * @throws RuntimeException if <code>directory</code> is not a readable directory, or if there is some error in the XML
      */
     public PageTemplateRegistry read(String directory) {
-        List<NamedReader> pageReaders=new ArrayList<>();
+        List<NamedReader> pageReaders = new ArrayList<>();
         try {
-            File dir=new File(directory);
-            if ( !dir.isDirectory() ) throw new IllegalArgumentException("Could not read page templates: '" +
-                    directory + "' is not a valid directory.");
+            File dir = new File(directory);
+            if ( ! dir.isDirectory() ) throw new IllegalArgumentException("Could not read page templates: '" +
+                                                                          directory + "' is not a valid directory.");
 
             for (File file : sortFiles(dir)) {
                 if ( ! file.getName().endsWith(".xml")) continue;
-                pageReaders.add(new NamedReader(file.getName(),new FileReader(file)));
+                pageReaders.add(new NamedReader(file.getName(), new FileReader(file)));
             }
 
-            return read(pageReaders,true);
+            return read(pageReaders, true);
         }
         catch (IOException e) {
             throw new IllegalArgumentException("Could not read page templates from '" + directory + "'",e);
@@ -67,18 +67,18 @@ public class PageTemplateXMLReader {
      * @throws RuntimeException if <code>fileName</code> is not a readable file, or if there is some error in the XML
      */
     public PageTemplate readFile(String fileName) {
-        NamedReader pageReader=null;
+        NamedReader pageReader = null;
         try {
-            File file=new File(fileName);
-            pageReader=new NamedReader(fileName,new FileReader(file));
-            String firstName=file.getName().substring(0,file.getName().length()-4);
-            return read(Collections.singletonList(pageReader),true).getComponent(firstName);
+            File file = new File(fileName);
+            pageReader = new NamedReader(fileName,new FileReader(file));
+            String firstName = file.getName().substring(0, file.getName().length() - 4);
+            return read(Collections.singletonList(pageReader), true).getComponent(firstName);
         }
         catch (IOException e) {
-            throw new IllegalArgumentException("Could not read the page template '" + fileName + "'",e);
+            throw new IllegalArgumentException("Could not read the page template '" + fileName + "'", e);
         }
         finally {
-            if (pageReader!=null)
+            if (pageReader != null)
                 try { pageReader.close(); } catch (IOException e) { }
         }
     }
@@ -130,11 +130,11 @@ public class PageTemplateXMLReader {
     }
 
     /** Throws an exception if the name is not corresponding to the id */
-    private void validateFileName(final String actualName,ComponentId id,String artifactName) {
-        String expectedCanonicalFileName=id.toFileName();
-        String fileName=new File(actualName).getName();
-        fileName=stripXmlEnding(fileName);
-        String canonicalFileName=ComponentId.fromFileName(fileName).toFileName();
+    private void validateFileName(String actualName, ComponentId id, String artifactName) {
+        String expectedCanonicalFileName = id.toFileName();
+        String fileName = new File(actualName).getName();
+        fileName = stripXmlEnding(fileName);
+        String canonicalFileName = ComponentId.fromFileName(fileName).toFileName();
         if ( ! canonicalFileName.equals(expectedCanonicalFileName))
             throw new IllegalArgumentException("The file name of " + artifactName + " '" + id +
                                                "' must be '" + expectedCanonicalFileName + ".xml' but was '" + actualName + "'");
@@ -144,14 +144,14 @@ public class PageTemplateXMLReader {
         if (!fileName.endsWith(".xml"))
             throw new IllegalArgumentException("'" + fileName + "' should have a .xml ending");
         else
-            return fileName.substring(0,fileName.length()-4);
+            return fileName.substring(0, fileName.length() - 4);
     }
 
     private void readPages() {
         for (Map.Entry<ComponentId,Element> pageElement : pageElementsByPageId.entrySet()) {
             try {
-                PageTemplate page=registry.getComponent(pageElement.getValue().getAttribute("id"));
-                readPageContent(pageElement.getValue(),page);
+                PageTemplate page = registry.getComponent(pageElement.getValue().getAttribute("id"));
+                readPageContent(pageElement.getValue(), page);
             }
             catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Could not read page template '" + pageElement.getKey() + "'",e);
@@ -159,16 +159,16 @@ public class PageTemplateXMLReader {
         }
     }
 
-    private void readPageContent(Element pageElement,PageTemplate page) {
+    private void readPageContent(Element pageElement, PageTemplate page) {
         if (page.isFrozen()) return; // Already read
-        Section rootSection=new Section(page.getId().toString());
-        readSection(pageElement,rootSection);
+        Section rootSection = new Section(page.getId().toString());
+        readSection(pageElement, rootSection);
         page.setSection(rootSection);
         page.freeze();
     }
 
     /** Fills a section with attributes and sub-elements from a "section" or "page" element */
-    private Section readSection(Element sectionElement,Section section) {
+    private Section readSection(Element sectionElement, Section section) {
         section.setLayout(Layout.fromString(sectionElement.getAttribute("layout")));
         section.setRegion(sectionElement.getAttribute("region"));
         section.setOrder(Sorting.fromString(sectionElement.getAttribute("order")));
@@ -198,10 +198,10 @@ public class PageTemplateXMLReader {
 
     /** Reads the direct descendant elements of an include */
     private List<PageElement> readInclude(Element element) {
-        PageTemplate included=registry.getComponent(element.getAttribute("idref"));
-        if (included==null)
+        PageTemplate included = registry.getComponent(element.getAttribute("idref"));
+        if (included == null)
             throw new IllegalArgumentException("Could not find page template '" + element.getAttribute("idref"));
-        readPageContent(pageElementsByPageId.get(included.getId()),included);
+        readPageContent(pageElementsByPageId.get(included.getId()), included);
         return included.getSection().elements(Section.class);
     }
 
@@ -223,9 +223,9 @@ public class PageTemplateXMLReader {
     }
 
     private List<Source> readSourceAttribute(Element sectionElement) {
-        List<Source> sources=new ArrayList<>();
-        String sourceAttributeString=sectionElement.getAttribute("source");
-        if (sourceAttributeString!=null) {
+        List<Source> sources = new ArrayList<>();
+        String sourceAttributeString = sectionElement.getAttribute("source");
+        if (sourceAttributeString != null) {
             for (String sourceName : sourceAttributeString.split(" ")) {
                 if (sourceName.isEmpty()) continue;
                 if ("*".equals(sourceName))

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/engine/Organizer.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/engine/Organizer.java
@@ -9,9 +9,7 @@ import com.yahoo.search.query.Sorting;
 import com.yahoo.search.result.*;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Reorganizes and prunes a result as prescribed by a resolved template.
@@ -29,13 +27,13 @@ public class Organizer {
      * @param result the result to organize
      */
     public void organize(Choice templateChoice, Resolution resolution, Result result) {
-        PageTemplate template=(PageTemplate)templateChoice.get(resolution.getResolution(templateChoice)).get(0);
-        SectionHitGroup sectionGroup =toGroup(template.getSection(),resolution,result);
-        ErrorHit errors=result.hits().getErrorHit();
+        PageTemplate template = (PageTemplate)templateChoice.get(resolution.getResolution(templateChoice)).get(0);
+        SectionHitGroup sectionGroup = toGroup(template.getSection(), resolution, result);
+        ErrorHit errors = result.hits().getErrorHit();
 
         // transfer state from existing hit
         sectionGroup.setQuery(result.hits().getQuery());
-        if (errors!=null && errors instanceof DefaultErrorHit)
+        if (errors instanceof DefaultErrorHit)
             sectionGroup.add((DefaultErrorHit)errors);
         result.hits().forEachField((name, value) -> sectionGroup.setField(name, value));
         result.setHits(sectionGroup);

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/engine/Resolution.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/engine/Resolution.java
@@ -40,10 +40,10 @@ public class Resolution {
      *         been resolved in this
      */
     public int getResolution(Choice choice) {
-        if (choice.alternatives().size()==1) return 0;
+        if (choice.alternatives().size() == 1) return 0;
         if (choice.isEmpty()) throw new IllegalArgumentException("Cannot return a resolution of empty " + choice);
-        Integer resolution=choiceResolutions.get(choice);
-        if (resolution==null) throw new IllegalArgumentException(this + " has no resolution of " + choice);
+        Integer resolution = choiceResolutions.get(choice);
+        if (resolution == null) throw new IllegalArgumentException(this + " has no resolution of " + choice);
         return resolution;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/result/PageTemplatesXmlRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/result/PageTemplatesXmlRenderer.java
@@ -271,10 +271,10 @@ public class PageTemplatesXmlRenderer extends AsynchronousSectionedRenderer<Resu
 
     private Result getResult() {
         try {
-            return (Result) getResponse();
+            return (Result)getResponse();
         } catch (ClassCastException e) {
-            throw new IllegalArgumentException("PageTemplatesXmlRenderer attempted used outside a search context, got a " +
-                                               getResponse().getClass().getName());
+            throw new IllegalStateException("PageTemplatesXmlRenderer attempted used outside a search context, got a " +
+                                            getResponse().getClass().getName());
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/Model.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Model.java
@@ -7,6 +7,7 @@ import com.yahoo.language.LocaleFactory;
 import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.TaggableItem;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.query.parser.Parsable;
@@ -236,10 +237,14 @@ public class Model implements Cloneable {
      */
     public QueryTree getQueryTree() {
         if (queryTree == null) {
-            Parser parser = ParserFactory.newInstance(type, ParserEnvironment.fromExecutionContext(execution.context()));
-            queryTree = parser.parse(Parsable.fromQueryModel(this));
-            if (parent.getTraceLevel() >= 2) {
-                parent.trace("Query parsed to: " + parent.yqlRepresentation(), 2);
+            try {
+                Parser parser = ParserFactory.newInstance(type, ParserEnvironment.fromExecutionContext(execution.context()));
+                queryTree = parser.parse(Parsable.fromQueryModel(this));
+                if (parent.getTraceLevel() >= 2)
+                    parent.trace("Query parsed to: " + parent.yqlRepresentation(), 2);
+            }
+            catch (IllegalArgumentException e) {
+                throw new IllegalInputException("Failed parsing query", e);
             }
         }
         return queryTree;

--- a/container-search/src/main/java/com/yahoo/search/query/ParameterParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ParameterParser.java
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query;
 
+import com.yahoo.processing.IllegalInputException;
+
 import static com.yahoo.container.util.Util.quote;
 
 /**
@@ -25,13 +27,8 @@ public class ParameterParser {
      *         representation cannot be parsed as a number followed optionally by time unit
      */
     public static Long asMilliSeconds(Object value, Long defaultValue) {
-        if (value == null) {
-            return defaultValue;
-        }
-        if (value instanceof Number) {
-            Number n = (Number) value;
-            return Long.valueOf(n.longValue() * 1000L);
-        }
+        if (value == null) return defaultValue;
+        if (value instanceof Number) return ((Number)value).longValue() * 1000L;
         return parseTime(value.toString());
     }
 
@@ -43,7 +40,7 @@ public class ParameterParser {
             double multiplier = parseUnit(time.substring(unitOffset));
             return (long) (measure * multiplier);
         } catch (RuntimeException e) {
-            throw new IllegalArgumentException("Error parsing " + quote(time), e);
+            throw new IllegalInputException("Error parsing " + quote(time), e);
         }
     }
 
@@ -58,7 +55,7 @@ public class ParameterParser {
             }
         }
         if (unitOffset == 0) {
-            throw new NumberFormatException("Invalid number " + quote(time));
+            throw new IllegalInputException("Invalid number " + quote(time));
         }
         return unitOffset;
     }

--- a/container-search/src/main/java/com/yahoo/search/query/Sorting.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Sorting.java
@@ -3,6 +3,7 @@ package com.yahoo.search.query;
 
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.ULocale;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.text.Utf8;
 
 import java.nio.ByteBuffer;
@@ -88,7 +89,7 @@ public class Sorting implements Cloneable {
                             } else if (STRENGTH_IDENTICAL.equalsIgnoreCase(s)) {
                                 strength = UcaSorter.Strength.IDENTICAL;
                             } else {
-                                throw new IllegalArgumentException("Unknown collation strength: '" + s + "'");
+                                throw new IllegalInputException("Unknown collation strength: '" + s + "'");
                             }
                             sorter = new UcaSorter(sortString.substring(startPar+1, commaPos), sortString.substring(commaPos+1, commaopt), strength);
                         } else {
@@ -99,9 +100,9 @@ public class Sorting implements Cloneable {
                     }
                 } else {
                     if (funcName.isEmpty()) {
-                        throw new IllegalArgumentException("No sort function specified");
+                        throw new IllegalInputException("No sort function specified");
                     } else {
-                        throw new IllegalArgumentException("Unknown sort function '" + funcName + "'");
+                        throw new IllegalInputException("Unknown sort function '" + funcName + "'");
                     }
                 }
             } else {
@@ -196,7 +197,7 @@ public class Sorting implements Cloneable {
             if (legalAttributeName.matcher(fieldName).matches()) {
                 this.fieldName = fieldName;
             } else {
-                throw new IllegalArgumentException("Illegal attribute name '" + fieldName + "' for sorting. Requires '" + legalAttributeName.pattern() + "'");
+                throw new IllegalInputException("Illegal attribute name '" + fieldName + "' for sorting. Requires '" + legalAttributeName.pattern() + "'");
             }
         }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
@@ -4,6 +4,7 @@ package com.yahoo.search.query.profile;
 import com.google.common.collect.ImmutableList;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.provider.FreezableSimpleComponent;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.processing.request.Properties;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfile;
@@ -451,7 +452,7 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
             setNode(name, value, null, binding, registry);
         }
         catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Could not set '" + name + "' to '" + value + "'", e);
+            throw new IllegalInputException("Could not set '" + name + "' to '" + value + "'", e);
         }
     }
 
@@ -688,15 +689,15 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
         FieldDescription fieldDescription = type.getField(localName);
         if (fieldDescription == null) {
             if (type.isStrict())
-                throw new IllegalArgumentException("'" + localName + "' is not declared in " + type + ", and the type is strict");
+                throw new IllegalInputException("'" + localName + "' is not declared in " + type + ", and the type is strict");
             return value;
         }
 
         if (registry == null && (fieldDescription.getType() instanceof QueryProfileFieldType))
-            throw new IllegalArgumentException("A registry was not passed: Query profile references is not supported");
+            throw new IllegalInputException("A registry was not passed: Query profile references is not supported");
         Object convertedValue = fieldDescription.getType().convertFrom(value, registry);
         if (convertedValue == null)
-            throw new IllegalArgumentException("'" + value + "' is not a " + fieldDescription.getType().toInstanceDescription());
+            throw new IllegalInputException("'" + value + "' is not a " + fieldDescription.getType().toInstanceDescription());
         return convertedValue;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileProperties.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.query.profile;
 
 import com.yahoo.collections.Pair;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.processing.request.properties.PropertyMap;
 import com.yahoo.protect.Validator;
@@ -107,7 +108,7 @@ public class QueryProfileProperties extends Properties {
                     String localName = name.get(i);
                     FieldDescription fieldDescription = type.getField(localName);
                     if (fieldDescription == null && type.isStrict())
-                        throw new IllegalArgumentException("'" + localName + "' is not declared in " + type + ", and the type is strict");
+                        throw new IllegalInputException("'" + localName + "' is not declared in " + type + ", and the type is strict");
 
                     // TODO: In addition to strictness, check legality along the way
 
@@ -115,7 +116,7 @@ public class QueryProfileProperties extends Properties {
                         if (i == name.size() - 1) { // at the end of the path, check the assignment type
                             value = fieldDescription.getType().convertFrom(value, profile.getRegistry());
                             if (value == null)
-                                throw new IllegalArgumentException("'" + value + "' is not a " +
+                                throw new IllegalInputException("'" + value + "' is not a " +
                                                                    fieldDescription.getType().toInstanceDescription());
                         }
                         else if (fieldDescription.getType() instanceof QueryProfileFieldType) {
@@ -129,12 +130,12 @@ public class QueryProfileProperties extends Properties {
 
             if (value instanceof String && value.toString().startsWith("ref:")) {
                 if (profile.getRegistry() == null)
-                    throw new IllegalArgumentException("Runtime query profile references does not work when the " +
+                    throw new IllegalInputException("Runtime query profile references does not work when the " +
                                                        "QueryProfileProperties are constructed without a registry");
                 String queryProfileId = value.toString().substring(4);
                 value = profile.getRegistry().findQueryProfile(queryProfileId);
                 if (value == null)
-                    throw new IllegalArgumentException("Query profile '" + queryProfileId + "' is not found");
+                    throw new IllegalInputException("Query profile '" + queryProfileId + "' is not found");
             }
 
             if (value instanceof CompiledQueryProfile) { // this will be due to one of the two clauses above
@@ -149,7 +150,7 @@ public class QueryProfileProperties extends Properties {
             }
         }
         catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Could not set '" + name + "' to '" + value + "'", e);
+            throw new IllegalInputException("Could not set '" + name + "' to '" + value + "'", e);
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/compiled/Binding.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/compiled/Binding.java
@@ -33,7 +33,6 @@ public class Binding implements Comparable<Binding> {
 
     private final int hashCode;
 
-    @SuppressWarnings("unchecked")
     public static final Binding nullBinding = new Binding(Integer.MAX_VALUE, Collections.<String,String>emptyMap());
 
     public static Binding createFrom(DimensionBinding dimensionBinding) {

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/FieldDescription.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/FieldDescription.java
@@ -97,7 +97,8 @@ public class FieldDescription implements Comparable<FieldDescription> {
         this.type = type;
 
         // Forbidden until we can figure out the right semantics
-        if (name.isCompound() && ! aliases.isEmpty()) throw new IllegalArgumentException("Aliases are not allowed with compound names");
+        if (name.isCompound() && ! aliases.isEmpty())
+            throw new IllegalArgumentException("Aliases are not allowed with compound names");
 
         this.aliases = ImmutableList.copyOf(aliases);
         this.mandatory = mandatory;

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.properties;
 
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 
@@ -317,7 +318,7 @@ public class QueryProperties extends Properties {
             if (e.getMessage() != null && e.getMessage().startsWith("Could not set"))
                 throw e;
             else
-                throw new IllegalArgumentException("Could not set '" + key + "' to '" + value + "'", e);
+                throw new IllegalInputException("Could not set '" + key + "' to '" + value + "'", e);
         }
     }
 
@@ -364,8 +365,8 @@ public class QueryProperties extends Properties {
     }
 
     private void throwIllegalParameter(String key,String namespace) {
-        throw new IllegalArgumentException("'" + key + "' is not a valid property in '" + namespace +
-                                           "'. See the query api for valid keys starting by '" + namespace + "'.");
+        throw new IllegalInputException("'" + key + "' is not a valid property in '" + namespace +
+                                        "'. See the query api for valid keys starting by '" + namespace + "'.");
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/MatchPhase.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/MatchPhase.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.ranking;
 
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.profile.types.FieldDescription;
@@ -84,8 +85,9 @@ public class MatchPhase implements Cloneable {
 
     public void setMaxFilterCoverage(double maxFilterCoverage) {
         if ((maxFilterCoverage < 0.0) || (maxFilterCoverage > 1.0)) {
-            throw new IllegalArgumentException("maxFilterCoverage must be in the range [0.0, 1.0]. It is " + maxFilterCoverage);
+            throw new IllegalInputException("maxFilterCoverage must be in the range [0.0, 1.0]. It is " + maxFilterCoverage);
         }
+
         this.maxFilterCoverage = maxFilterCoverage;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/Matching.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/Matching.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.ranking;
 
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileType;
@@ -59,7 +60,7 @@ public class Matching implements Cloneable {
 
     public void setTermwiselimit(double value) {
         if ((value < 0.0) || (value > 1.0)) {
-            throw new IllegalArgumentException("termwiselimit must be in the range [0.0, 1.0]. It is " + value);
+            throw new IllegalInputException("termwiselimit must be in the range [0.0, 1.0]. It is " + value);
         }
         termwiseLimit = value;
     }

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/SoftTimeout.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/SoftTimeout.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.ranking;
 
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.profile.types.FieldDescription;
@@ -54,7 +55,7 @@ public class SoftTimeout implements Cloneable {
     /** Override the adaptive factor determined on the content nodes */
     public void setFactor(double factor) {
         if ((factor < 0.0) || (factor > 1.0)) {
-            throw new IllegalArgumentException("factor must be in the range [0.0, 1.0], got " + factor);
+            throw new IllegalInputException("factor must be in the range [0.0, 1.0], got " + factor);
         }
         this.factor = factor;
     }
@@ -64,7 +65,7 @@ public class SoftTimeout implements Cloneable {
     /** Override the tail cost factor determined on the content nodes */
     public void setTailcost(double tailcost) {
         if ((tailcost < 0.0) || (tailcost > 1.0)) {
-            throw new IllegalArgumentException("tailcost must be in the range [0.0, 1.0], got " + tailcost);
+            throw new IllegalInputException("tailcost must be in the range [0.0, 1.0], got " + tailcost);
         }
         this.tailcost = tailcost;
     }

--- a/container-search/src/main/java/com/yahoo/search/query/rewrite/rewriters/GenericExpansionRewriter.java
+++ b/container-search/src/main/java/com/yahoo/search/query/rewrite/rewriters/GenericExpansionRewriter.java
@@ -76,9 +76,8 @@ public class GenericExpansionRewriter extends QueryRewriteSearcher {
                              HashMap<String, File> fileList) {
         logger = Logger.getLogger(GenericExpansionRewriter.class.getName());
         FSA fsa = (FSA)rewriterDicts.get(GENERIC_EXPAND_DICT);
-        if(fsa==null) {
-            RewriterUtils.error(logger, "Error retrieving FSA dictionary: " +
-                                              GENERIC_EXPAND_DICT);
+        if (fsa==null) {
+            RewriterUtils.error(logger, "Error retrieving FSA dictionary: " + GENERIC_EXPAND_DICT);
             return false;
         }
         // Create Phrase Matcher

--- a/container-search/src/main/java/com/yahoo/search/query/textserialize/item/ItemContext.java
+++ b/container-search/src/main/java/com/yahoo/search/query/textserialize/item/ItemContext.java
@@ -12,6 +12,7 @@ import java.util.Map;
  * @author Tony Vaagenes
  */
 public class ItemContext {
+
     private class Connectivity {
         final String id;
         final double strength;
@@ -43,7 +44,8 @@ public class ItemContext {
     private Item getItem(String id) {
         Item item = itemById.get(id);
         if (item == null)
-            throw new IllegalArgumentException("No item with id '" + id + "'.");
+            throw new IllegalArgumentException("No item with id '" + id + "'");
         return item;
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/search/query/textserialize/item/TermConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/query/textserialize/item/TermConverter.java
@@ -10,6 +10,7 @@ import com.yahoo.search.query.textserialize.serializer.ItemIdMapper;
  * @author Tony Vaagenes
  */
 public abstract class TermConverter implements ItemFormConverter {
+
     @Override
     public Object formToItem(String name, ItemArguments arguments, ItemContext context) {
         ensureOnlyOneChild(arguments);
@@ -21,7 +22,6 @@ public abstract class TermConverter implements ItemFormConverter {
     }
 
     abstract TermItem newTermItem(String word);
-
 
     private void ensureOnlyOneChild(ItemArguments arguments) {
         if (arguments.children.size() != 1) {
@@ -50,4 +50,5 @@ public abstract class TermConverter implements ItemFormConverter {
     }
 
     protected abstract String getValue(TermItem item);
+
 }

--- a/container-search/src/main/java/com/yahoo/search/query/textserialize/item/TypeCheck.java
+++ b/container-search/src/main/java/com/yahoo/search/query/textserialize/item/TypeCheck.java
@@ -7,6 +7,7 @@ import com.yahoo.protect.Validator;
  * @author Tony Vaagenes
  */
 public class TypeCheck {
+
     public static void ensureInstanceOf(Object object, Class<?> c) {
         Validator.ensureInstanceOf(expectationString(c.getName(), object.getClass().getSimpleName()),
                 object, c);
@@ -24,4 +25,5 @@ public class TypeCheck {
     private static String expectationString(String expected, String got) {
         return "Expected " + expected + ", but got " + got;
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/search/query/textserialize/serializer/Serializer.java
+++ b/container-search/src/main/java/com/yahoo/search/query/textserialize/serializer/Serializer.java
@@ -14,6 +14,7 @@ import static com.yahoo.search.query.textserialize.item.ListUtil.first;
  * @author Tony Vaagenes
  */
 class Serializer {
+
     static String serialize(Object child, ItemIdMapper itemIdMapper) {
         if (child instanceof DispatchForm) {
             return ((DispatchForm) child).serialize(itemIdMapper);
@@ -76,4 +77,5 @@ class Serializer {
     static String serializeItem(Item item, ItemIdMapper itemIdMapper) {
         return ItemExecutorRegistry.getByType(item.getItemType()).itemToForm(item, itemIdMapper).serialize(itemIdMapper);
     }
+
 }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/BooleanAttributeParser.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/BooleanAttributeParser.java
@@ -14,10 +14,10 @@ import java.math.BigInteger;
  * a 64-bit hex number <code>0x1234</code> or a list of bits <code>[0, 2, 43,
  * 22, ...]</code>.
  *
- * @author <a href="mailto:magnarn@yahoo-inc.com">Magnar Nedland</a>
- * @since 5.1.15
+ * @author Magnar Nedland
  */
 abstract class BooleanAttributeParser extends SimpleMapParser {
+
     private boolean isMap = true;
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WandSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WandSearcher.java
@@ -4,6 +4,7 @@ package com.yahoo.search.querytransform;
 import com.yahoo.prelude.Index;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.query.*;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -92,7 +93,7 @@ public class WandSearcher extends Searcher {
         private WandType resolveWandType(IndexFacts.Session indexFacts, Query query) {
             Index index = indexFacts.getIndex(fieldName);
             if (index.isNull()) {
-                throw new IllegalArgumentException("Field '" + fieldName + "' was not found in " + indexFacts);
+                throw new IllegalInputException("Field '" + fieldName + "' was not found in " + indexFacts);
             } else {
                 return WandType.create(query.properties().getString(WAND_TYPE, "vespa"));
             }
@@ -100,15 +101,15 @@ public class WandSearcher extends Searcher {
 
         private int resolveHeapSize(Query query) {
             String defaultHeapSize = "100";
-            return Integer.valueOf(query.properties().getString(WAND_HEAP_SIZE, defaultHeapSize));
+            return Integer.parseInt(query.properties().getString(WAND_HEAP_SIZE, defaultHeapSize));
         }
 
         private double resolveScoreThreshold(Query query) {
-            return Double.valueOf(query.properties().getString(WAND_SCORE_THRESHOLD, "0"));
+            return Double.parseDouble(query.properties().getString(WAND_SCORE_THRESHOLD, "0"));
         }
 
         private double resolveThresholdBoostFactor(Query query) {
-            return Double.valueOf(query.properties().getString(WAND_THRESHOLD_BOOST_FACTOR, "1"));
+            return Double.parseDouble(query.properties().getString(WAND_THRESHOLD_BOOST_FACTOR, "1"));
         }
 
         public boolean hasValidData() {
@@ -166,7 +167,7 @@ public class WandSearcher extends Searcher {
         } else if (inputs.getWandType().equals(WandType.DOT_PRODUCT)) {
             return populate(new DotProductItem(inputs.getFieldName()), inputs.getTokens());
         }
-        throw new IllegalArgumentException("Unknown type '" + inputs.getWandType() + "'");
+        throw new IllegalInputException("Unknown type '" + inputs.getWandType() + "'");
     }
 
     private CompositeItem populate(CompositeItem parent, String fieldName, Map<String,Integer> tokens) {
@@ -195,10 +196,12 @@ public class WandSearcher extends Searcher {
     }
 
     private static class IntegerMapParser extends MapParser<Integer> {
+
         @Override
         protected Integer parseValue(String s) {
             return Integer.parseInt(s);
         }
+
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/rendering/RendererRegistry.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/RendererRegistry.java
@@ -4,6 +4,7 @@ package com.yahoo.search.rendering;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.provider.ComponentRegistry;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.rendering.Renderer;
 import com.yahoo.search.Result;
 import com.yahoo.search.pagetemplates.result.PageTemplatesXmlRenderer;
@@ -103,8 +104,8 @@ public final class RendererRegistry extends ComponentRegistry<com.yahoo.processi
 
         com.yahoo.processing.rendering.Renderer<Result> renderer = getComponent(format);
         if (renderer == null)
-            throw new IllegalArgumentException("No renderer with id or alias '" + format + "'. " +
-                                               "Available renderers are: [" + rendererNames() + "].");
+            throw new IllegalInputException("No renderer with id or alias '" + format + "'. " +
+                                            "Available renderers are: [" + rendererNames() + "].");
         return renderer;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/rendering/XmlRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/XmlRenderer.java
@@ -352,8 +352,8 @@ public final class XmlRenderer extends AsynchronousSectionedRenderer<Result> {
         try {
             return (Result) getResponse();
         } catch (ClassCastException e) {
-            throw new IllegalArgumentException("XmlRenderer attempted used outside a search context, got a " +
-                                               getResponse().getClass().getName());
+            throw new IllegalStateException("XmlRenderer attempted used outside a search context, got a " +
+                                            getResponse().getClass().getName());
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
@@ -56,7 +56,7 @@ public class LocalProviderSpec {
         this.cacheSize = cacheSize;
 
         if (clusterName == null)
-            throw new IllegalArgumentException("Missing cluster name.");
+            throw new IllegalArgumentException("Missing cluster name");
     }
 
     public static boolean includesType(String type) {

--- a/container-search/src/main/java/com/yahoo/search/statistics/PeakQpsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/statistics/PeakQpsSearcher.java
@@ -137,8 +137,8 @@ public class PeakQpsSearcher extends Searcher {
             useMetaHit = false;
             propertyName = null;
         } else {
-            throw new IllegalArgumentException("Config definition out of sync with implementation." +
-                                               " No way to create output for method " + method + ".");
+            throw new IllegalStateException("Config definition out of sync with implementation." +
+                                            " No way to create output for method " + method + ".");
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/yql/OperatorNode.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/OperatorNode.java
@@ -162,7 +162,7 @@ final class OperatorNode<T extends Operator> {
     }
 
     // we are aware only of types used in our logical operator trees -- OperatorNode, List, and constant values
-    private static final Function<Object, Object> COPY = new Function<Object, Object>() {
+    private static final Function<Object, Object> COPY = new Function<>() {
         @Override
         public Object apply(Object input) {
             if (input instanceof List) {

--- a/container-search/src/main/java/com/yahoo/search/yql/ProgramParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/ProgramParser.java
@@ -622,19 +622,19 @@ final class ProgramParser {
     }
 
     private OperatorNode<SequenceOperator> convertMerge(List<Merge_componentContext> mergeComponentList, Scope scope) {
-          Preconditions.checkArgument(mergeComponentList != null);
-          List<OperatorNode<SequenceOperator>> sources = Lists.newArrayListWithExpectedSize(mergeComponentList.size());
-          for (Merge_componentContext mergeComponent:mergeComponentList) {
-              Select_statementContext selectContext = mergeComponent.select_statement();
-              Source_statementContext sourceContext = mergeComponent.source_statement();
-              if (selectContext != null) {
-                  sources.add(convertQuery(selectContext, scope.getRoot()));
-              } else {
-                  sources.add(convertQuery(sourceContext, scope.getRoot()));
-              }
-          }
-          return OperatorNode.create(SequenceOperator.MERGE, sources);
-      }
+        Preconditions.checkArgument(mergeComponentList != null);
+        List<OperatorNode<SequenceOperator>> sources = Lists.newArrayListWithExpectedSize(mergeComponentList.size());
+        for (Merge_componentContext mergeComponent:mergeComponentList) {
+            Select_statementContext selectContext = mergeComponent.select_statement();
+            Source_statementContext sourceContext = mergeComponent.source_statement();
+            if (selectContext != null) {
+                sources.add(convertQuery(selectContext, scope.getRoot()));
+            } else {
+                sources.add(convertQuery(sourceContext, scope.getRoot()));
+            }
+        }
+        return OperatorNode.create(SequenceOperator.MERGE, sources);
+    }
 
     private OperatorNode<SequenceOperator> convertQuery(ParseTree node, Scope scope) {
         if (node instanceof Select_statementContext
@@ -642,7 +642,7 @@ final class ProgramParser {
            || node instanceof Update_statementContext
            || node instanceof Delete_statementContext) {
             return convertSelectOrInsertOrUpdateOrDelete(node, scope.getRoot());
-        } else if (node instanceof Source_statementContext) { //for pipe
+        } else if (node instanceof Source_statementContext) { // for pipe
             Source_statementContext sourceStatementContext = (Source_statementContext)node;
             return convertPipe(sourceStatementContext.query_statement(), sourceStatementContext.pipeline_step(), scope);
         } else if (node instanceof Merge_statementContext) {

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -142,7 +142,7 @@ public class VespaSerializer {
                     escape(((WordItem) current).getIndexedString(), destination).append('"');
                 } else {
                     throw new IllegalArgumentException("Serializing of " + current.getClass().getSimpleName()
-                                    + " in segment AND expressions not implemented, please report this as a bug.");
+                                                       + " in segment AND expressions not implemented, please report this as a bug.");
                 }
             }
         }
@@ -643,7 +643,7 @@ public class VespaSerializer {
                     WordAlternativesSerializer.serialize(destination, (WordAlternativesItem) current, false);
                 } else {
                     throw new IllegalArgumentException("Serializing of " + current.getClass().getSimpleName() +
-                                                      " in phrases not implemented, please report this as a bug.");
+                                                       " in phrases not implemented, please report this as a bug.");
                 }
             }
             destination.append(')');
@@ -1158,7 +1158,7 @@ public class VespaSerializer {
             Serializer doIt = dispatch.get(item.getClass());
 
             if (doIt == null) {
-                throw new IllegalArgumentException(item.getClass() + " not supported for YQL+ marshalling.");
+                throw new IllegalArgumentException(item.getClass() + " not supported for YQL marshalling.");
             }
 
             if (state.peekFirst() != null && state.peekFirst().subItems > 0) {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -67,6 +67,7 @@ import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WeightedSetItem;
 import com.yahoo.prelude.query.WordAlternativesItem;
 import com.yahoo.prelude.query.WordItem;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.Query;
 import com.yahoo.search.grouping.Continuation;
 import com.yahoo.search.grouping.request.GroupingOperation;
@@ -318,10 +319,10 @@ public class YqlParser implements Parser {
     private void connectItems() {
         for (ConnectedItem entry : connectedItems) {
             TaggableItem to = identifiedItems.get(entry.toId);
-            Preconditions.checkNotNull(to,
-                                       "Item '%s' was specified to connect to item with ID %s, which does not "
-                                       + "exist in the query.", entry.fromItem,
-                                       entry.toId);
+            if (to == null)
+                throw new IllegalArgumentException("Item '" + entry.fromItem +
+                                                   "' was specified to connect to item with ID " + entry.toId +
+                                                   ", which does not exist in the query.");
             entry.fromItem.setConnectivity((Item) to, entry.weight);
         }
     }
@@ -782,7 +783,7 @@ public class YqlParser implements Parser {
         try {
             ast = new ProgramParser().parse("query", currentlyParsing.getQuery());
         } catch (Exception e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalInputException(e);
         }
         assertHasOperator(ast, StatementOperator.PROGRAM);
         Preconditions.checkArgument(ast.getArguments().length == 1,

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -163,7 +163,7 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
                                       query.toString(), elapsedMillis / 1000.0)));
             }
             return new Result(query, ErrorMessage.createTimeout(e.getMessage()));
-        } catch (InterruptedException|IllegalArgumentException e) {
+        } catch (InterruptedException | IllegalArgumentException e) {
             return new Result(query, ErrorMessage.createBackendCommunicationError(e.getMessage()));
         }
 

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -346,9 +346,9 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
                 log.log(Level.FINE, "VdsVisitor completed successfully for " + query + " with selection " + params.getDocumentSelection());
             }
         } else {
-            throw new IllegalArgumentException("Query failed: " // TODO: Is it necessary to use a runtime exception?
-                    + params.getControlHandler().getResult().code + ": "
-                    + params.getControlHandler().getResult().message);
+            throw new IllegalArgumentException("Query failed: " +
+                                               params.getControlHandler().getResult().code + ": " +
+                                               params.getControlHandler().getResult().message);
         }
     }
 
@@ -425,7 +425,8 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
             BufferSerializer buf = new BufferSerializer( new GrowableByteBuffer(ByteBuffer.wrap(value)) );
             newGrouping.deserialize(buf);
             if (buf.getBuf().hasRemaining()) {
-                throw new IllegalArgumentException("Failed deserializing grouping. There are still data left. Position = " + buf.position() + ", limit = " + buf.getBuf().limit());
+                throw new IllegalArgumentException("Failed deserializing grouping. There is still data left. " +
+                                                   "Position = " + buf.position() + ", limit = " + buf.getBuf().limit());
             }
 
             synchronized (groupingMap) {

--- a/container-search/src/test/java/com/yahoo/prelude/query/ItemsCommonStuffTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/ItemsCommonStuffTestCase.java
@@ -42,7 +42,7 @@ public class ItemsCommonStuffTestCase {
         a.addItem(as);
         try {
             as.addItem(a);
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             caught = true;
         }
         assertTrue(caught);
@@ -51,7 +51,7 @@ public class ItemsCommonStuffTestCase {
         as.addItem(a);
         try {
             a.addItem(as);
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             caught = true;
         }
         assertTrue(caught);
@@ -235,21 +235,21 @@ public class ItemsCommonStuffTestCase {
         boolean caught = false;
         try {
             as.removeItem(firstItem);
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             caught = true;
         }
         assertTrue(caught);
         caught = false;
         try {
             as.addItem(new WordItem("puppy"));
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             caught= true;
         }
         assertTrue(caught);
         caught = false;
         try {
             as.addItem(1, new WordItem("kvalp"));
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             caught = true;
         }
         assertTrue(caught);

--- a/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
@@ -8,25 +8,21 @@ import com.yahoo.prelude.Index;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.SearchDefinition;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.search.Query;
 import com.yahoo.search.query.Sorting;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.yolean.Exceptions;
 import org.hamcrest.Matcher;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.anyOf;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Tests for query class
@@ -376,7 +372,7 @@ public class QueryTestCase {
         try {
             newQuery(queryString);
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
             assertThat(Exceptions.toMessageString(e), expectedErrorMessage);
         }

--- a/container-search/src/test/java/com/yahoo/search/grouping/UniqueGroupingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/UniqueGroupingSearcherTestCase.java
@@ -2,7 +2,6 @@
 package com.yahoo.search.grouping;
 
 import com.yahoo.component.chain.Chain;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
@@ -41,18 +40,19 @@ public class UniqueGroupingSearcherTestCase {
                                new MockResultProvider(0, false));
         assertEquals(0, result.hits().size());
     }
+
     @Test
     public void testIllegalSortingSpec() {
         try {
             search("?query=foo&unique=fingerprint&sorting=-1",
                     new MockResultProvider(0, true).addGroupList(new GroupList("fingerprint")));
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
             assertThat(
                     Exceptions.toMessageString(e),
                     containsString(
-                            "Invalid request parameter: Could not set 'ranking.sorting' to '-1': " +
+                            "Could not set 'ranking.sorting' to '-1': " +
                             "Illegal attribute name '1' for sorting. Requires '[\\[]*[a-zA-Z_][\\.a-zA-Z0-9_-]*[\\]]*'"));
         }
     }

--- a/container-search/src/test/java/com/yahoo/search/handler/test/JSONSearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/test/JSONSearchHandlerTestCase.java
@@ -169,7 +169,7 @@ public class JSONSearchHandlerTestCase {
         String response = responseHandler.readAll();
         assertThat(responseHandler.getStatus(), is(400));
         assertThat(response, containsString("offset"));
-        assertThat(response, containsString("\"code\":" + com.yahoo.container.protect.Error.INVALID_QUERY_PARAMETER.code));
+        assertThat(response, containsString("\"code\":" + com.yahoo.container.protect.Error.ILLEGAL_QUERY.code));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/handler/test/SearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/test/SearchHandlerTestCase.java
@@ -201,7 +201,7 @@ public class SearchHandlerTestCase {
         String response = responseHandler.readAll();
         assertThat(responseHandler.getStatus(), is(400));
         assertThat(response, containsString("offset"));
-        assertThat(response, containsString("\"code\":" + com.yahoo.container.protect.Error.INVALID_QUERY_PARAMETER.code));
+        assertThat(response, containsString("\"code\":" + com.yahoo.container.protect.Error.ILLEGAL_QUERY.code));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/query/MatchingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/MatchingTestCase.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query;
 
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.search.Query;
 import org.junit.Test;
 
@@ -12,9 +11,10 @@ import static org.junit.Assert.assertEquals;
  * @author baldersheim
  */
 public class MatchingTestCase {
+
     @Test
     public void testDefaultsInQuery() {
-        Query query=new Query("?query=test");
+        Query query = new Query("?query=test");
         assertNull(query.getRanking().getMatching().getTermwiseLimit());
         assertNull(query.getRanking().getMatching().getNumThreadsPerSearch());
         assertNull(query.getRanking().getMatching().getNumSearchPartitions());
@@ -24,7 +24,7 @@ public class MatchingTestCase {
 
     @Test
     public void testQueryOverride() {
-        Query query=new Query("?query=test&ranking.matching.termwiselimit=0.7&ranking.matching.numthreadspersearch=17&ranking.matching.numsearchpartitions=13&ranking.matching.minhitsperthread=3");
+        Query query = new Query("?query=test&ranking.matching.termwiselimit=0.7&ranking.matching.numthreadspersearch=17&ranking.matching.numsearchpartitions=13&ranking.matching.minhitsperthread=3");
         assertEquals(Double.valueOf(0.7), query.getRanking().getMatching().getTermwiseLimit());
         assertEquals(Integer.valueOf(17), query.getRanking().getMatching().getNumThreadsPerSearch());
         assertEquals(Integer.valueOf(13), query.getRanking().getMatching().getNumSearchPartitions());
@@ -40,16 +40,17 @@ public class MatchingTestCase {
     private void verifyException(String key, String value) {
         try {
             new Query("?query=test&ranking.matching."+key+"="+value);
-            assertFalse(true);
-        } catch (QueryException e) {
-            assertEquals("Invalid request parameter", e.getMessage());
-            assertEquals("Could not set 'ranking.matching." + key + "' to '" + value +"'", e.getCause().getMessage());
-            assertEquals(key + " must be in the range [0.0, 1.0]. It is " + value, e.getCause().getCause().getMessage());
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Could not set 'ranking.matching." + key + "' to '" + value +"'", e.getMessage());
+            assertEquals(key + " must be in the range [0.0, 1.0]. It is " + value, e.getCause().getMessage());
         }
     }
+
     @Test
     public void testLimits() {
         verifyException("termwiselimit", "-0.1");
         verifyException("termwiselimit", "1.1");
     }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/query/SoftTimeoutTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/SoftTimeoutTestCase.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query;
 
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.search.Query;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -10,9 +9,10 @@ import static org.junit.Assert.*;
  * @author baldersheim
  */
 public class SoftTimeoutTestCase {
+
     @Test
     public void testDefaultsInQuery() {
-        Query query=new Query("?query=test");
+        Query query = new Query("?query=test");
         assertTrue(query.getRanking().getSoftTimeout().getEnable());
         assertNull(query.getRanking().getSoftTimeout().getFactor());
         assertNull(query.getRanking().getSoftTimeout().getTailcost());
@@ -20,7 +20,7 @@ public class SoftTimeoutTestCase {
 
     @Test
     public void testQueryOverride() {
-        Query query=new Query("?query=test&ranking.softtimeout.factor=0.7&ranking.softtimeout.tailcost=0.3");
+        Query query = new Query("?query=test&ranking.softtimeout.factor=0.7&ranking.softtimeout.tailcost=0.3");
         assertTrue(query.getRanking().getSoftTimeout().getEnable());
         assertEquals(Double.valueOf(0.7), query.getRanking().getSoftTimeout().getFactor());
         assertEquals(Double.valueOf(0.3), query.getRanking().getSoftTimeout().getTailcost());
@@ -49,13 +49,13 @@ public class SoftTimeoutTestCase {
     private void verifyException(String key, String value) {
         try {
             new Query("?query=test&ranking.softtimeout."+key+"="+value);
-            assertFalse(true);
-        } catch (QueryException e) {
-            assertEquals("Invalid request parameter", e.getMessage());
-            assertEquals("Could not set 'ranking.softtimeout." + key + "' to '" + value +"'", e.getCause().getMessage());
-            assertEquals(key + " must be in the range [0.0, 1.0], got " + value, e.getCause().getCause().getMessage());
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Could not set 'ranking.softtimeout." + key + "' to '" + value +"'", e.getMessage());
+            assertEquals(key + " must be in the range [0.0, 1.0], got " + value, e.getCause().getMessage());
         }
     }
+
     @Test
     public void testLimits() {
         verifyException("factor", "-0.1");
@@ -63,4 +63,5 @@ public class SoftTimeoutTestCase {
         verifyException("tailcost", "-0.1");
         verifyException("tailcost", "1.1");
     }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/query/profile/types/test/NativePropertiesTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/types/test/NativePropertiesTestCase.java
@@ -3,7 +3,6 @@ package com.yahoo.search.query.profile.types.test;
 
 import com.yahoo.jdisc.http.HttpRequest.Method;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.search.Query;
 import com.yahoo.search.query.profile.QueryProfile;
 import com.yahoo.search.query.profile.types.QueryProfileType;
@@ -23,22 +22,22 @@ public class NativePropertiesTestCase {
 
     @Test
     public void testNativeInStrict() {
-        QueryProfileType strictType=new QueryProfileType("strict");
+        QueryProfileType strictType = new QueryProfileType("strict");
         strictType.setStrict(true);
-        QueryProfile strict=new QueryProfile("profile");
+        QueryProfile strict = new QueryProfile("profile");
         strict.setType(strictType);
 
         try {
             new Query(HttpRequest.createTestRequest("?hits=10&tracelevel=5", Method.GET), strict.compile(null));
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
         }
 
         try {
             new Query(HttpRequest.createTestRequest("?notnative=5", Method.GET), strict.compile(null));
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
             assertThat(
                     Exceptions.toMessageString(e),

--- a/container-search/src/test/java/com/yahoo/search/query/profile/types/test/QueryProfileTypeTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/types/test/QueryProfileTypeTestCase.java
@@ -2,9 +2,7 @@
 package com.yahoo.search.query.profile.types.test;
 
 import com.yahoo.component.ComponentId;
-import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.yolean.Exceptions;
 import com.yahoo.search.Query;
@@ -434,7 +432,7 @@ public class QueryProfileTypeTestCase {
                                                     com.yahoo.jdisc.http.HttpRequest.Method.GET),
                       profile.compile(null));
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
             assertThat(Exceptions.toMessageString(e),
                        containsString("Could not set 'myUserQueryProfile.nondeclared' to 'someValue': 'nondeclared' is not declared in query profile type 'userStrict', and the type is strict"));
@@ -549,7 +547,7 @@ public class QueryProfileTypeTestCase {
                                                   com.yahoo.jdisc.http.HttpRequest.Method.GET),
                     cRegistry.getComponent("topMap"));
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
             assertThat(Exceptions.toMessageString(e),
                        containsString("Could not set 'subMap.typeProfile.someValue' to 'value': 'someValue' is not declared in query profile type 'testtypeStrict', and the type is strict"));

--- a/container-search/src/test/java/com/yahoo/search/querytransform/test/SortingDegraderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/test/SortingDegraderTestCase.java
@@ -6,7 +6,6 @@ import com.yahoo.prelude.Index;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.SearchDefinition;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
@@ -15,8 +14,6 @@ import com.yahoo.search.query.properties.DefaultProperties;
 import com.yahoo.search.querytransform.SortingDegrader;
 import com.yahoo.search.searchchain.Execution;
 import org.junit.Test;
-
-import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -67,12 +64,10 @@ public class SortingDegraderTestCase {
         try {
             Query query = new Query("?ranking.sorting=-a1%20-a2&ranking.matchPhase.maxFilterCoverage=37");
             assertTrue(false);
-        } catch (QueryException qe) {
-            assertEquals("Invalid request parameter", qe.getMessage());
-            Throwable setE = qe.getCause();
-            assertTrue(setE instanceof IllegalArgumentException);
-            assertEquals("Could not set 'ranking.matchPhase.maxFilterCoverage' to '37'", setE.getMessage());
-            Throwable rootE = setE.getCause();
+        } catch (IllegalArgumentException qe) {
+            assertTrue(qe instanceof IllegalArgumentException);
+            assertEquals("Could not set 'ranking.matchPhase.maxFilterCoverage' to '37'", qe.getMessage());
+            Throwable rootE = qe.getCause();
             assertTrue(rootE instanceof IllegalArgumentException);
             assertEquals("maxFilterCoverage must be in the range [0.0, 1.0]. It is 37.0", rootE.getMessage());
         }

--- a/container-search/src/test/java/com/yahoo/search/searchers/test/InputCheckingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/test/InputCheckingSearcherTestCase.java
@@ -85,7 +85,7 @@ public class InputCheckingSearcherTestCase {
         assertNull(r.hits().getErrorHit());
         r = execution.search(new Query("/search/?query=%22a.b.0.0.0.0.0.0.c%22"));
         assertNotNull(r.hits().getErrorHit());
-        assertEquals("More than 5 ocurrences of term '0' in a row detected in phrase : \"a b 0 0 0 0 0 0 c\"",
+        assertEquals("More than 5 occurrences of term '0' in a row detected in phrase : \"a b 0 0 0 0 0 0 c\"",
                      r.hits().getErrorHit().errorIterator().next().getDetailedMessage());
         r = execution.search(new Query("/search/?query=a.b.0.0.0.1.0.0.0.c"));
         assertNull(r.hits().getErrorHit());
@@ -97,7 +97,7 @@ public class InputCheckingSearcherTestCase {
         assertNull(r.hits().getErrorHit());
         r = execution.search(new Query("/search/?query=%22a.b.0.0.0.0.0.0.c%22"));
         assertNotNull(r.hits().getErrorHit());
-        assertEquals("More than 5 ocurrences of term '0' in a row detected in phrase : \"a b 0 0 0 0 0 0 c\"",
+        assertEquals("More than 5 occurrences of term '0' in a row detected in phrase : \"a b 0 0 0 0 0 0 c\"",
                      r.hits().getErrorHit().errorIterator().next().getDetailedMessage());
         r = execution.search(new Query("/search/?query=%22a.b.0.0.0.1.0.0.0.c%22"));
         assertNull(r.hits().getErrorHit());

--- a/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
@@ -23,7 +23,6 @@ import com.yahoo.prelude.query.IndexedItem;
 import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.OrItem;
-import com.yahoo.prelude.query.QueryException;
 import com.yahoo.prelude.query.RankItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.processing.request.CompoundName;
@@ -47,7 +46,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -289,7 +287,7 @@ public class QueryTestCase {
         try {
             new Query(httpEncode("/search?timeout=nalle"));
             fail("Above statement should throw");
-        } catch (QueryException e) {
+        } catch (IllegalArgumentException e) {
             // As expected.
             assertTrue(Exceptions.toMessageString(e).contains("Could not set 'timeout' to 'nalle': Error parsing 'nalle': Invalid number 'nalle'"));
         }
@@ -865,7 +863,7 @@ public class QueryTestCase {
             root.addItem(child);
             fail("Expected exception");
         }
-        catch (QueryException e) {
+        catch (IllegalArgumentException e) {
             assertEquals("Cannot add OR (AND ) to (AND ) as it would create a cycle", e.getMessage());
         }
 
@@ -875,7 +873,7 @@ public class QueryTestCase {
             child.addItem(root);
             fail("Expected exception");
         }
-        catch (QueryException e) {
+        catch (IllegalArgumentException e) {
             assertEquals("Cannot add (AND (OR )) to (OR ) as it would create a cycle", e.getMessage());
         }
     }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -449,8 +449,8 @@ public class YqlParserTestCase {
                         "title contains ([{\"id\": 1, \"connectivity\": {\"id\": 4, \"weight\": 7.0}}]\"madonna\") " +
                         "and title contains ([{\"id\": 2}]\"saint\") " +
                         "and title contains ([{\"id\": 3}]\"angel\");",
-                        new NullPointerException("Item 'title:madonna' was specified to connect to item with ID 4, " +
-                                                 "which does not exist in the query."));
+                        new IllegalArgumentException("Item 'title:madonna' was specified to connect to item with ID 4, " +
+                                                     "which does not exist in the query."));
     }
 
     @Test

--- a/processing/abi-spec.json
+++ b/processing/abi-spec.json
@@ -1,4 +1,17 @@
 {
+  "com.yahoo.processing.IllegalInputException": {
+    "superClass": "java.lang.IllegalArgumentException",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(java.lang.String)",
+      "public void <init>(java.lang.Throwable)",
+      "public void <init>(java.lang.String, java.lang.Throwable)"
+    ],
+    "fields": []
+  },
   "com.yahoo.processing.Processor": {
     "superClass": "com.yahoo.component.chain.ChainedComponent",
     "interfaces": [],

--- a/processing/src/main/java/com/yahoo/processing/IllegalInputException.java
+++ b/processing/src/main/java/com/yahoo/processing/IllegalInputException.java
@@ -1,0 +1,25 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.processing;
+
+/**
+ * Thrown on illegal input received from the requesting client.
+ * Use this instead of the superclass, IllegalArgumentException
+ * to signal illegal input to the client without causing logging and stack traces,
+ *
+ * @author bratseth
+ */
+public class IllegalInputException extends IllegalArgumentException {
+
+    public IllegalInputException(String message) {
+        super(message);
+    }
+
+    public IllegalInputException(Throwable cause) {
+        super(cause);
+    }
+
+    public IllegalInputException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/processing/src/main/java/com/yahoo/processing/request/CloneHelper.java
+++ b/processing/src/main/java/com/yahoo/processing/request/CloneHelper.java
@@ -84,11 +84,11 @@ public class CloneHelper {
         if (object instanceof FreezableClass)
             return ((FreezableClass)object).clone();
         else if (object instanceof PublicCloneable)
-            return ((PublicCloneable)object).clone();
+            return ((PublicCloneable<?>)object).clone();
         else if (object instanceof LinkedList)
-            return ((LinkedList) object).clone();
+            return ((LinkedList<?>) object).clone();
         else if (object instanceof ArrayList)
-            return ((ArrayList) object).clone();
+            return ((ArrayList<?>) object).clone();
 
         try {
             Method cloneMethod = cloneMethodCache.get(object);

--- a/processing/src/main/java/com/yahoo/processing/response/DefaultIncomingData.java
+++ b/processing/src/main/java/com/yahoo/processing/response/DefaultIncomingData.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing.response;
 
-import com.google.common.util.concurrent.ExecutionList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.yahoo.collections.Tuple2;
@@ -26,14 +25,10 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
 
     private List<Tuple2<Runnable,Executor>> newDataListeners = null;
 
-    /**
-     * If this is completed no more data can be added
-     */
+    /** Whether this is completed, such that no more data can be added */
     private boolean complete = false;
 
-    /**
-     * Creates an instance which must be assigned an owner after creation
-     */
+    /** Creates an instance which must be assigned an owner after creation */
     public DefaultIncomingData() {
         this(null);
     }
@@ -43,9 +38,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
         completionFuture = SettableFuture.create();
     }
 
-    /**
-     * Assigns the owner of this. Throws an exception if the owner is already set.
-     */
+    /** Assigns the owner of this. Throws an exception if the owner is already set. */
     public final void assignOwner(DataList<DATATYPE> owner) {
         if (this.owner != null) throw new NullPointerException("Owner of " + this + " was already assigned");
         this.owner = owner;
@@ -61,42 +54,32 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
         return completionFuture;
     }
 
-    /**
-     * Returns whether the data in this is complete
-     */
+    /** Returns whether the data in this is complete */
     @Override
     public synchronized boolean isComplete() {
         return complete;
     }
 
-    /**
-     * Add new data and mark this as completed
-     */
+    /** Adds new data and marks this as completed */
     @Override
     public synchronized void addLast(DATATYPE data) {
         addLast(Collections.singletonList(data));
     }
 
-    /**
-     * Add new data without completing this
-     */
+    /** Adds new data without completing this */
     @Override
     public synchronized void add(DATATYPE data) {
         add(Collections.singletonList(data));
     }
 
-    /**
-     * Add new data and mark this as completed
-     */
+    /** Adds new data and marks this as completed */
     @Override
     public synchronized void addLast(List<DATATYPE> data) {
         add(data);
         markComplete();
     }
 
-    /**
-     * Add new data without completing this
-     */
+    /** Adds new data without completing this */
     @Override
     public synchronized void add(List<DATATYPE> data) {
         if (complete) throw new IllegalStateException("Attempted to add data to completed " + this);
@@ -105,9 +88,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
         notifyDataListeners();
     }
 
-    /**
-     * Mark this as completed and notify any listeners
-     */
+    /** Marks this as completed and notify any listeners */
     @Override
     public synchronized void markComplete() {
         complete = true;
@@ -115,7 +96,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
     }
 
     /**
-     * Get and remove all the data currently available in this.
+     * Gets and removes all the data currently available in this.
      * The returned list is a modifiable fresh instance owned by the caller.
      */
     public synchronized List<DATATYPE> drain() {


### PR DESCRIPTION
- Add IllegalInputException to signal cases where we know the exception
  is caused by illegal input received from the requestor.
- Only skip logging for IllegalInputException instead of the superclass
  IllegalArgumentException as that is also used to signal illegal
  arguments to methods due to bugs which are otherwise hard to debug.
- Throw IllegalInputException rather than IllegalArgumentException
  where appropriate.
- Deprecated QueryException as it was only used to be able to separate
  between query string and query parameter exceptions, and not doing
  that consistently, and is in a package we don't want more use of.
- Clean up some cases where the wrong exception was thrown.

