### PR TITLE
Revert "Avoid getting session list two times"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -47,6 +47,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -316,7 +317,8 @@ public class SessionRepository {
         getRemoteSessions().forEach(this::sessionAdded);
     }
 
-    private synchronized void sessionsChanged(List<Long> sessions) throws NumberFormatException {
+    private synchronized void sessionsChanged() throws NumberFormatException {
+        List<Long> sessions = getSessionListFromDirectoryCache(directoryCache.getCurrentData());
         checkForRemovedSessions(sessions);
         checkForAddedSessions(sessions);
     }
@@ -416,15 +418,14 @@ public class SessionRepository {
     private void childEvent(CuratorFramework ignored, PathChildrenCacheEvent event) {
         zkWatcherExecutor.execute(() -> {
             log.log(Level.FINE, () -> "Got child event: " + event);
-            List<Long> sessions = getSessionListFromDirectoryCache(directoryCache.getCurrentData());
             switch (event.getType()) {
                 case CHILD_ADDED:
-                    sessionsChanged(sessions);
-                    synchronizeOnNew(sessions);
+                    sessionsChanged();
+                    synchronizeOnNew(getSessionListFromDirectoryCache(Collections.singletonList(event.getData())));
                     break;
                 case CHILD_REMOVED:
                 case CONNECTION_RECONNECTED:
-                    sessionsChanged(sessions);
+                    sessionsChanged();
                     break;
             }
         });


### PR DESCRIPTION
Reverts https://github.com/vespa-engine/vespa/pull/14063

Looks like this change affected performance badly (there is more data to process in `synchronizeOnNew`), reverting