### PR TITLE
return Vespa connection when deploying Vespa app.

### DIFF
--- a/python/vespa/vespa/application.py
+++ b/python/vespa/vespa/application.py
@@ -29,6 +29,12 @@ class Vespa(object):
             self.end_point = str(url).rstrip("/") + ":" + str(port)
         self.search_end_point = self.end_point + "/search/"
 
+    def __repr__(self):
+        if self.port:
+            return "Vespa({}, {})".format(self.url, self.port)
+        else:
+            return "Vespa({})".format(self.url)
+
     def query(
         self,
         body: Optional[Dict] = None,

--- a/python/vespa/vespa/application.py
+++ b/python/vespa/vespa/application.py
@@ -9,12 +9,18 @@ from vespa.evaluation import EvalMetric
 
 
 class Vespa(object):
-    def __init__(self, url: str, port: Optional[int] = None) -> None:
+    def __init__(
+        self,
+        url: str,
+        port: Optional[int] = None,
+        deployment_message: Optional[List[str]] = None,
+    ) -> None:
         """
         Establish a connection with a Vespa application.
 
         :param url: URL
         :param port: Port
+        :param deployment_message: Message returned by Vespa engine after deployment.
 
             >>> Vespa(url = "https://cord19.vespa.ai")
             >>> Vespa(url = "http://localhost", port = 8080)
@@ -22,6 +28,7 @@ class Vespa(object):
         """
         self.url = url
         self.port = port
+        self.deployment_message = deployment_message
 
         if port is None:
             self.end_point = self.url

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -464,5 +464,7 @@ class VespaDocker(object):
             raise RuntimeError(deployment_message)
 
         return Vespa(
-            url="http://localhost", port=8080, deployment_message=deployment_message
+            url="http://localhost",
+            port=self.local_port,
+            deployment_message=deployment_message,
         )

--- a/python/vespa/vespa/package.py
+++ b/python/vespa/vespa/package.py
@@ -7,6 +7,7 @@ from jinja2 import Environment, PackageLoader, select_autoescape
 import docker
 
 from vespa.json_serialization import ToJson, FromJson
+from vespa.application import Vespa
 
 
 class Field(ToJson, FromJson["Field"]):
@@ -390,6 +391,7 @@ class VespaDocker(object):
         """
         self.application_package = application_package
         self.container = None
+        self.local_port = 8080
 
     def run_vespa_engine_container(self, disk_folder: str, container_memory: str):
         """
@@ -412,7 +414,7 @@ class VespaDocker(object):
                     hostname=self.application_package.name,
                     privileged=True,
                     volumes={disk_folder: {"bind": "/app", "mode": "rw"}},
-                    ports={8080: 8080, 19112: 19112},
+                    ports={self.local_port: self.local_port, 19112: 19112},
                 )
 
     def check_configuration_server(self) -> bool:
@@ -432,6 +434,15 @@ class VespaDocker(object):
         )
 
     def deploy(self, disk_folder: str, container_memory: str = "4G"):
+        """
+        Deploy the application into a Vespa container.
+
+        :param disk_folder: Disk folder to save the required Vespa config files.
+        :param container_memory: Docker container memory available to the application.
+
+        :return: A tuple where the first element is the deployment message and the second element is a Vespa connection
+            instance.
+        """
 
         self.application_package.create_application_package_files(dir_path=disk_folder)
 
@@ -446,4 +457,8 @@ class VespaDocker(object):
         deployment = self.container.exec_run(
             "bash -c '/opt/vespa/bin/vespa-deploy prepare /app/application && /opt/vespa/bin/vespa-deploy activate'"
         )
-        return deployment.output.decode("utf-8").split("\n")
+
+        return (
+            deployment.output.decode("utf-8").split("\n"),
+            Vespa(url="http://localhost", port=8080),
+        )


### PR DESCRIPTION
Deploying with `VespaDocker.deploy` now return a `Vespa` app connection in addition to the deployment message.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
