### PR TITLE
ensure that locations are sent down

### DIFF
--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/documentdb-info.cfg
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/test/documentdb-info.cfg
@@ -348,4 +348,6 @@ documentdb[0].summaryclass[6].fields[29].name URLLIST
 documentdb[0].summaryclass[6].fields[29].type string
 documentdb[0].summaryclass[6].fields[30].name WORDS
 documentdb[0].summaryclass[6].fields[30].type integer
-documentdb[0].rankprofile[0]
+documentdb[0].rankprofile[0].name "default"
+documentdb[0].rankprofile[0].hasSummaryFeatures false
+documentdb[0].rankprofile[0].hasRankFeatures false


### PR DESCRIPTION
* when the query tree contains a GeoLocationItem somewhere, it
  is quite likely that this will be used for producing a summary
  field, and therefore summaryNeedsQuery should return true
  in this case.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


@baldersheim please review and merge
@bratseth FYI