### PR TITLE
Initialize _interval member variable in predicate search unit test.

### DIFF
--- a/searchlib/src/tests/queryeval/predicate/predicate_search_test.cpp
+++ b/searchlib/src/tests/queryeval/predicate/predicate_search_test.cpp
@@ -30,11 +30,15 @@ class MyPostingList : public PredicatePostingList {
 public:
     MyPostingList(const vector<pair<uint32_t, uint32_t>> &entries)
         : _entries(entries),
-          _index(0) {
+          _index(0),
+          _interval(0)
+    {
     }
     MyPostingList(std::initializer_list<pair<uint32_t, uint32_t>> ilist)
         : _entries(ilist.begin(), ilist.end()),
-          _index(0) {
+          _index(0),
+          _interval(0)
+    {
     }
 
     bool next(uint32_t doc_id) override {


### PR DESCRIPTION
@baldersheim : please review
