### PR TITLE
Do not move non-tenant-hosts to deprovisioned

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -697,7 +697,7 @@ public class NodeRepository extends AbstractComponent {
                 children.forEach(child -> requireRemovable(child, true, force));
                 db.removeNodes(children);
                 List<Node> removed = new ArrayList<>(children);
-                if (zone.getCloud().dynamicProvisioning())
+                if (zone.getCloud().dynamicProvisioning() || node.type() != NodeType.host)
                     db.removeNodes(List.of(node));
                 else {
                     node = node.with(IP.Config.EMPTY);


### PR DESCRIPTION
Nodes are identified by hostname in node-repo, hostname for non-tenant hosts, the hostname is set by us.
It makes no sense to reuse history/reports/failCount for a potentially different physical host that had this hostname previously, so remove non-tenant-hosts from node-repo instead of moving them to `deprovisioned`. 