### PR TITLE
Add delay before running maintenance the first time 

### DIFF
--- a/logserver/src/main/java/com/yahoo/logserver/handlers/archive/FilesArchived.java
+++ b/logserver/src/main/java/com/yahoo/logserver/handlers/archive/FilesArchived.java
@@ -45,6 +45,8 @@ public class FilesArchived {
 
     private void run() {
         try {
+            // Sleep some time before first maintenance, unit test depend on files not being removed immediately
+            Thread.sleep(1000);
             while (true) {
                 maintenance();
                 waitForTrigger(2000);


### PR DESCRIPTION
Unit tests depend on files not being deleted immediately after
FilesArchived has been started

Issue introduced in https://github.com/vespa-engine/vespa/pull/14039
