### PR TITLE
Revert "Add timestamp when creating tenant to TenantMetaData"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -25,6 +25,7 @@ import com.yahoo.io.IOUtils;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.path.Path;
 import com.yahoo.slime.Slime;
+import com.yahoo.text.Utf8;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.transaction.Transaction;
 import com.yahoo.vespa.config.server.application.Application;
@@ -64,6 +65,8 @@ import com.yahoo.vespa.config.server.tenant.TenantMetaData;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.Lock;
+import com.yahoo.vespa.curator.transaction.CuratorOperations;
+import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FlagSource;
@@ -412,18 +415,24 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
 
         if (useTenantMetaData.value())
-            transaction.add(updateMetaDataWithDeployTimestamp(tenant, clock.instant()));
+            transaction.add(writeTenantMetaData(tenant).operations());
 
         return transaction;
     }
 
-    private List<Transaction.Operation> updateMetaDataWithDeployTimestamp(Tenant tenant, Instant deployTimestamp) {
-        TenantMetaData tenantMetaData = getTenantMetaData(tenant).withLastDeployTimestamp(deployTimestamp);
-        return tenantRepository.createWriteTenantMetaDataTransaction(tenantMetaData).operations();
+    private byte[] createMetaData(Tenant tenant) {
+        return new TenantMetaData(tenant.getSessionRepository().clock().instant()).asJsonBytes();
     }
 
     TenantMetaData getTenantMetaData(Tenant tenant) {
-        return tenantRepository.getTenantMetaData(tenant);
+        Optional<byte[]> data = tenantRepository.getCurator().getData(TenantRepository.getTenantPath(tenant.getName()));
+        return data.map(bytes -> TenantMetaData.fromJsonString(Utf8.toString(bytes))).orElse(new TenantMetaData(tenant.getCreatedTime()));
+    }
+
+    private Transaction writeTenantMetaData(Tenant tenant) {
+        return new CuratorTransaction(tenantRepository.getCurator())
+                .add(CuratorOperations.setData(TenantRepository.getTenantPath(tenant.getName()).getAbsolute(),
+                                               createMetaData(tenant)));
     }
 
     static void checkIfActiveHasChanged(LocalSession session, Session currentActiveSession, boolean ignoreStaleSessionFailure) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -8,18 +8,12 @@ import com.yahoo.concurrent.StripedExecutor;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
-import com.yahoo.text.Utf8;
-import com.yahoo.transaction.Transaction;
 import com.yahoo.vespa.config.server.GlobalComponentRegistry;
 import com.yahoo.vespa.config.server.application.TenantApplications;
 import com.yahoo.vespa.config.server.deploy.TenantFileSystemDirs;
 import com.yahoo.vespa.config.server.monitoring.MetricUpdater;
 import com.yahoo.vespa.config.server.session.SessionRepository;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.curator.transaction.CuratorOperations;
-import com.yahoo.vespa.curator.transaction.CuratorTransaction;
-import com.yahoo.vespa.flags.BooleanFlag;
-import com.yahoo.vespa.flags.Flags;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.state.ConnectionState;
@@ -88,7 +82,6 @@ public class TenantRepository {
     private final ExecutorService bootstrapExecutor;
     private final ScheduledExecutorService checkForRemovedApplicationsService = new ScheduledThreadPoolExecutor(1);
     private final Optional<Curator.DirectoryCache> directoryCache;
-    private final BooleanFlag useTenantMetaData;
 
     /**
      * Creates a new tenant repository
@@ -116,7 +109,6 @@ public class TenantRepository {
         this.tenantListeners.add(componentRegistry.getTenantListener());
         this.zkCacheExecutor = componentRegistry.getZkCacheExecutor();
         this.zkWatcherExecutor = componentRegistry.getZkWatcherExecutor();
-        this.useTenantMetaData = Flags.USE_TENANT_META_DATA.bindTo(componentRegistry.getFlagSource());
         curator.framework().getConnectionStateListenable().addListener(this::stateChanged);
 
         curator.create(tenantsPath);
@@ -148,30 +140,6 @@ public class TenantRepository {
     public synchronized void addTenant(TenantName tenantName) {
         writeTenantPath(tenantName);
         createTenant(tenantName, componentRegistry.getClock().instant());
-    }
-
-    public void createAndWriteTenantMetaData(Tenant tenant) {
-        createWriteTenantMetaDataTransaction(createMetaData(tenant)).commit();
-    }
-
-    public Transaction createWriteTenantMetaDataTransaction(TenantMetaData tenantMetaData) {
-        return new CuratorTransaction(curator).add(
-                CuratorOperations.setData(TenantRepository.getTenantPath(tenantMetaData.tenantName()).getAbsolute(),
-                                          tenantMetaData.asJsonBytes()));
-    }
-
-    private TenantMetaData createMetaData(Tenant tenant) {
-        Instant deployTime = tenant.getSessionRepository().clock().instant();
-        Instant createdTime = getTenantMetaData(tenant).createdTimestamp();
-        if (createdTime.equals(Instant.EPOCH))
-            createdTime = deployTime;
-        return new TenantMetaData(tenant.getName(), deployTime, createdTime);
-    }
-
-    public TenantMetaData getTenantMetaData(Tenant tenant) {
-        Optional<byte[]> data = getCurator().getData(TenantRepository.getTenantPath(tenant.getName()));
-        return data.map(bytes -> TenantMetaData.fromJsonString(tenant.getName(), Utf8.toString(bytes)))
-                .orElse(new TenantMetaData(tenant.getName(), tenant.getCreatedTime(), tenant.getCreatedTime()));
     }
 
      private static Set<TenantName> readTenantsFromZooKeeper(Curator curator) {
@@ -258,8 +226,6 @@ public class TenantRepository {
         Tenant tenant = new Tenant(tenantName, sessionRepository, applicationRepo, applicationRepo, created);
         notifyNewTenant(tenant);
         tenants.putIfAbsent(tenantName, tenant);
-        if (useTenantMetaData.value())
-            createAndWriteTenantMetaData(tenant);
     }
 
     /**

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -167,7 +167,6 @@ public class ApplicationRepositoryTest {
         session.getAllocatedHosts();
 
         assertEquals(Instant.EPOCH, applicationRepository.getTenantMetaData(tenant).lastDeployTimestamp());
-        assertEquals(Instant.EPOCH, applicationRepository.getTenantMetaData(tenant).createdTimestamp());
     }
 
     @Test
@@ -175,7 +174,6 @@ public class ApplicationRepositoryTest {
         FlagSource flagSource = new InMemoryFlagSource().withBooleanFlag(Flags.USE_TENANT_META_DATA.id(), true);
         setup(flagSource);
 
-        Instant startTime = clock.instant();
         Duration duration = Duration.ofHours(1);
         clock.advance(duration);
         Instant deployTime = clock.instant();
@@ -190,8 +188,6 @@ public class ApplicationRepositoryTest {
 
         assertEquals(deployTime.toEpochMilli(),
                      applicationRepository.getTenantMetaData(tenant).lastDeployTimestamp().toEpochMilli());
-        assertEquals(startTime.toEpochMilli(),
-                     applicationRepository.getTenantMetaData(tenant).createdTimestamp().toEpochMilli());
     }
 
     @Test


### PR DESCRIPTION
Reverts vespa-engine/vespa#14149

Need to wait with reading tenant metadata from zookeeper, since e.g. default tenant has IP address in zookeeper for this node (probably written a long time ago).