### PR TITLE
Enforce a minimum vcpu

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
  * Defines the policies for assigning cluster capacity in various environments
  *
  * @author bratseth
+ * @see NodeResourceLimits
  */
 public class CapacityPolicies {
 
@@ -43,13 +44,13 @@ public class CapacityPolicies {
 
         if (capacity.isRequired()) return target;
 
-        // Allow slow storage in zones which are not performance sensitive
-        if (zone.system().isCd() || zone.environment() == Environment.dev || zone.environment() == Environment.test)
-            target = target.with(NodeResources.DiskSpeed.any).with(NodeResources.StorageType.any);
-
         // Dev does not cap the cpu of containers since usage is spotty: Allocate just a small amount exclusively
         if (zone.environment() == Environment.dev && zone.getCloud().allowHostSharing())
             target = target.withVcpu(0.1);
+
+        // Allow slow storage in zones which are not performance sensitive
+        if (zone.system().isCd() || zone.environment() == Environment.dev || zone.environment() == Environment.test)
+            target = target.with(NodeResources.DiskSpeed.any).with(NodeResources.StorageType.any);
 
         return target;
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -521,7 +521,7 @@ public class ProvisioningTest {
     }
 
     @Test
-    public void below_resource_limit() {
+    public void below_memory_resource_limit() {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
 
         ApplicationId application = tester.makeApplicationId();
@@ -531,7 +531,22 @@ public class ProvisioningTest {
                     new NodeResources(2, 2, 10, 2), tester);
         }
         catch (IllegalArgumentException e) {
-            assertEquals("container cluster 'container0': Min memory size is 2.00 Gb but must be at least 4.00 Gb", e.getMessage());
+            assertEquals("container cluster 'container0': Min memoryGb size is 2.00 Gb but must be at least 4.00 Gb", e.getMessage());
+        }
+    }
+
+    @Test
+    public void below_vcpu_resource_limit() {
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
+
+        ApplicationId application = tester.makeApplicationId();
+        tester.makeReadyHosts(10, defaultResources).deployZoneApp();
+        try {
+            prepare(application, 2, 2, 3, 3,
+                    new NodeResources(0.4, 4, 10, 2), tester);
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals("container cluster 'container0': Min vcpu size is 0.40 but must be at least 0.50", e.getMessage());
         }
     }
 


### PR DESCRIPTION
With too little cpu allocated, nodes become unable to perform their duties as citizens
of the cloud, such as responding timely to health probes.

@yngve fyi