### PR TITLE
infer unknown onnx dimension sizes

### DIFF
--- a/eval/src/tests/tensor/onnx_wrapper/.gitattributes
+++ b/eval/src/tests/tensor/onnx_wrapper/.gitattributes
@@ -1,0 +1,1 @@
+/*.onnx binary

--- a/eval/src/tests/tensor/onnx_wrapper/dynamic.onnx
+++ b/eval/src/tests/tensor/onnx_wrapper/dynamic.onnx
@@ -1,0 +1,27 @@
+
+dynamic.py:¦
+0
+query_tensor
+attribute_tensormatmul"MatMul
+-
+bias_tensorreduce"	ReduceSum*
+axes@ 
+
+matmul
+reduceoutput"Adddynamic_scoringZ#
+query_tensor
+
+batch
+Z"
+attribute_tensor
+
+
+Z+
+bias_tensor
+
+batch
+ÿÿÿÿÿÿÿÿÿb
+output
+
+batch
+B

--- a/eval/src/tests/tensor/onnx_wrapper/dynamic.py
+++ b/eval/src/tests/tensor/onnx_wrapper/dynamic.py
@@ -1,0 +1,39 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+import onnx
+from onnx import helper, TensorProto
+
+QUERY_TENSOR = helper.make_tensor_value_info('query_tensor', TensorProto.FLOAT, ['batch', 4])
+ATTRIBUTE_TENSOR = helper.make_tensor_value_info('attribute_tensor', TensorProto.FLOAT, [4, 1])
+BIAS_TENSOR = helper.make_tensor_value_info('bias_tensor', TensorProto.FLOAT, ['batch', -1])
+OUTPUT = helper.make_tensor_value_info('output', TensorProto.FLOAT, ['batch', 1])
+
+nodes = [
+    helper.make_node(
+        'MatMul',
+        ['query_tensor', 'attribute_tensor'],
+        ['matmul'],
+    ),
+    helper.make_node(
+        'ReduceSum',
+        ['bias_tensor'],
+        ['reduce'],
+        axes=[1]
+    ),
+    helper.make_node(
+        'Add',
+        ['matmul', 'reduce'],
+        ['output'],
+    ),
+]
+graph_def = helper.make_graph(
+    nodes,
+    'dynamic_scoring',
+    [
+        QUERY_TENSOR,
+        ATTRIBUTE_TENSOR,
+        BIAS_TENSOR,
+    ],
+    [OUTPUT],
+)
+model_def = helper.make_model(graph_def, producer_name='dynamic.py')
+onnx.save(model_def, 'dynamic.onnx')

--- a/eval/src/tests/tensor/onnx_wrapper/onnx_wrapper_test.cpp
+++ b/eval/src/tests/tensor/onnx_wrapper/onnx_wrapper_test.cpp
@@ -10,83 +10,224 @@ using namespace vespalib::eval;
 using namespace vespalib::tensor;
 
 using vespalib::make_string_short::fmt;
+using TensorInfo = Onnx::TensorInfo;
+using DZ = Onnx::DimSize;
 
 std::string get_source_dir() {
     const char *dir = getenv("SOURCE_DIRECTORY");
     return (dir ? dir : ".");
 }
 std::string source_dir = get_source_dir();
-std::string vespa_dir = source_dir + "/" + "../../../../..";
-std::string simple_model = vespa_dir + "/" + "model-integration/src/test/models/onnx/simple/simple.onnx";
+std::string simple_model = source_dir + "/simple.onnx";
+std::string dynamic_model = source_dir + "/dynamic.onnx";
 
-void dump_info(const char *ctx, const std::vector<OnnxWrapper::TensorInfo> &info) {
+void dump_info(const char *ctx, const std::vector<TensorInfo> &info) {
     fprintf(stderr, "%s:\n", ctx);
     for (size_t i = 0; i < info.size(); ++i) {
         fprintf(stderr, "  %s[%zu]: '%s' %s\n", ctx, i, info[i].name.c_str(), info[i].type_as_string().c_str());
     }
 }
 
-TEST(OnnxWrapperTest, onnx_model_can_be_inspected)
-{
-    OnnxWrapper wrapper(simple_model, OnnxWrapper::Optimize::DISABLE);
-    dump_info("inputs", wrapper.inputs());
-    dump_info("outputs", wrapper.outputs());
-    ASSERT_EQ(wrapper.inputs().size(), 3);
-    ASSERT_EQ(wrapper.outputs().size(), 1);
-    //-------------------------------------------------------------------------
-    EXPECT_EQ(wrapper.inputs()[0].name,             "query_tensor");
-    EXPECT_EQ(wrapper.inputs()[0].type_as_string(), "float[1][4]");
-    //-------------------------------------------------------------------------
-    EXPECT_EQ(wrapper.inputs()[1].name,             "attribute_tensor");
-    EXPECT_EQ(wrapper.inputs()[1].type_as_string(), "float[4][1]");
-    //-------------------------------------------------------------------------
-    EXPECT_EQ(wrapper.inputs()[2].name,             "bias_tensor");
-    EXPECT_EQ(wrapper.inputs()[2].type_as_string(), "float[1][1]");
-    //-------------------------------------------------------------------------
-    EXPECT_EQ(wrapper.outputs()[0].name,             "output");
-    EXPECT_EQ(wrapper.outputs()[0].type_as_string(), "float[1][1]");
+TEST(WirePlannerTest, element_types_must_match) {
+    Onnx::WirePlanner planner;
+    ValueType type1 = ValueType::from_spec("tensor<float>(a[5])");
+    ValueType type2 = ValueType::from_spec("tensor<double>(a[5])");
+    TensorInfo info1 = TensorInfo{"info", {DZ(5)}, TensorInfo::ElementType::FLOAT};
+    TensorInfo info2 = TensorInfo{"info", {DZ(5)}, TensorInfo::ElementType::DOUBLE};
+    EXPECT_TRUE(planner.bind_input_type(type1, info1));
+    EXPECT_FALSE(planner.bind_input_type(type2, info1));
+    EXPECT_FALSE(planner.bind_input_type(type1, info2));
+    EXPECT_TRUE(planner.bind_input_type(type2, info2));
 }
 
-TEST(OnnxWrapperTest, onnx_model_can_be_evaluated)
+TEST(WirePlannerTest, known_dimension_sizes_must_match) {
+    Onnx::WirePlanner planner;
+    ValueType type1 = ValueType::from_spec("tensor<float>(a[5],b[10])");
+    ValueType type2 = ValueType::from_spec("tensor<float>(a[10],b[5])");
+    ValueType type3 = ValueType::from_spec("tensor<float>(a[5],b[5])");
+    TensorInfo info = TensorInfo{"info", {DZ(5),DZ(5)}, TensorInfo::ElementType::FLOAT};
+    EXPECT_FALSE(planner.bind_input_type(type1, info));
+    EXPECT_FALSE(planner.bind_input_type(type2, info));
+    EXPECT_TRUE(planner.bind_input_type(type3, info));
+}
+
+TEST(WirePlannerTest, symbolic_dimension_sizes_must_match) {
+    Onnx::WirePlanner planner;
+    ValueType type1 = ValueType::from_spec("tensor<float>(a[5])");
+    ValueType type2 = ValueType::from_spec("tensor<float>(a[10])");
+    TensorInfo info = TensorInfo{"info", {DZ("dim")}, TensorInfo::ElementType::FLOAT};
+    EXPECT_TRUE(planner.bind_input_type(type1, info)); // binds 'dim' to 5
+    EXPECT_FALSE(planner.bind_input_type(type2, info));
+    EXPECT_TRUE(planner.bind_input_type(type1, info));
+}
+
+TEST(WirePlannerTest, unknown_dimension_sizes_match_anything) {
+    Onnx::WirePlanner planner;
+    ValueType type1 = ValueType::from_spec("tensor<float>(a[5])");
+    ValueType type2 = ValueType::from_spec("tensor<float>(a[10])");
+    TensorInfo info = TensorInfo{"info", {DZ()}, TensorInfo::ElementType::FLOAT};
+    EXPECT_TRUE(planner.bind_input_type(type1, info));
+    EXPECT_TRUE(planner.bind_input_type(type2, info));
+}
+
+TEST(WirePlannerTest, all_output_dimensions_must_be_bound) {
+    Onnx::WirePlanner planner;
+    ValueType type = ValueType::from_spec("tensor<float>(a[5],b[10])");
+    TensorInfo info1 = TensorInfo{"info", {DZ()}, TensorInfo::ElementType::FLOAT};
+    TensorInfo info2 = TensorInfo{"info", {DZ("dim")}, TensorInfo::ElementType::FLOAT};
+    TensorInfo info3 = TensorInfo{"info", {DZ("dim"),DZ()}, TensorInfo::ElementType::FLOAT};
+    EXPECT_TRUE(planner.make_output_type(info1).is_error());
+    EXPECT_TRUE(planner.make_output_type(info2).is_error());
+    EXPECT_TRUE(planner.make_output_type(info3).is_error());
+    EXPECT_TRUE(planner.bind_input_type(type, info3)); // binds 'dim' to 5
+    EXPECT_TRUE(planner.make_output_type(info1).is_error());
+    EXPECT_EQ(planner.make_output_type(info2).to_spec(), "tensor<float>(d0[5])");
+    EXPECT_TRUE(planner.make_output_type(info3).is_error());
+}
+
+TEST(WirePlannerTest, dimensions_resolve_left_to_right) {
+    Onnx::WirePlanner planner;
+    ValueType type1 = ValueType::from_spec("tensor<float>(a[5],b[10])");
+    ValueType type2 = ValueType::from_spec("tensor<float>(a[10],b[10])");
+    ValueType type3 = ValueType::from_spec("tensor<float>(a[5],b[5])");
+    TensorInfo info = TensorInfo{"info", {DZ("dim"),DZ("dim")}, TensorInfo::ElementType::FLOAT};
+    EXPECT_FALSE(planner.bind_input_type(type1, info)); // binds 'dim' to 5, then fails (5 != 10)
+    EXPECT_FALSE(planner.bind_input_type(type2, info));
+    EXPECT_TRUE(planner.bind_input_type(type3, info));
+}
+
+TEST(OnnxTest, simple_onnx_model_can_be_inspected)
 {
-    OnnxWrapper wrapper(simple_model, OnnxWrapper::Optimize::ENABLE);
+    Onnx model(simple_model, Onnx::Optimize::DISABLE);
+    dump_info("inputs", model.inputs());
+    dump_info("outputs", model.outputs());
+    ASSERT_EQ(model.inputs().size(), 3);
+    ASSERT_EQ(model.outputs().size(), 1);
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.inputs()[0].name,             "query_tensor");
+    EXPECT_EQ(model.inputs()[0].type_as_string(), "float[1][4]");
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.inputs()[1].name,             "attribute_tensor");
+    EXPECT_EQ(model.inputs()[1].type_as_string(), "float[4][1]");
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.inputs()[2].name,             "bias_tensor");
+    EXPECT_EQ(model.inputs()[2].type_as_string(), "float[1][1]");
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.outputs()[0].name,             "output");
+    EXPECT_EQ(model.outputs()[0].type_as_string(), "float[1][1]");
+}
+
+TEST(OnnxTest, dynamic_onnx_model_can_be_inspected)
+{
+    Onnx model(dynamic_model, Onnx::Optimize::DISABLE);
+    dump_info("inputs", model.inputs());
+    dump_info("outputs", model.outputs());
+    ASSERT_EQ(model.inputs().size(), 3);
+    ASSERT_EQ(model.outputs().size(), 1);
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.inputs()[0].name,             "query_tensor");
+    EXPECT_EQ(model.inputs()[0].type_as_string(), "float[batch][4]");
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.inputs()[1].name,             "attribute_tensor");
+    EXPECT_EQ(model.inputs()[1].type_as_string(), "float[4][1]");
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.inputs()[2].name,             "bias_tensor");
+    EXPECT_EQ(model.inputs()[2].type_as_string(), "float[batch][]");
+    //-------------------------------------------------------------------------
+    EXPECT_EQ(model.outputs()[0].name,             "output");
+    EXPECT_EQ(model.outputs()[0].type_as_string(), "float[batch][1]");
+}
+
+TEST(OnnxTest, simple_onnx_model_can_be_evaluated)
+{
+    Onnx model(simple_model, Onnx::Optimize::ENABLE);
+    Onnx::WirePlanner planner;
 
     ValueType query_type = ValueType::from_spec("tensor<float>(a[1],b[4])");
     std::vector<float> query_values({1.0, 2.0, 3.0, 4.0});
     DenseTensorView query(query_type, TypedCells(query_values));
-    EXPECT_TRUE(wrapper.inputs()[0].is_compatible(query_type));
-    EXPECT_FALSE(wrapper.inputs()[1].is_compatible(query_type));
-    EXPECT_FALSE(wrapper.inputs()[2].is_compatible(query_type));
+    EXPECT_TRUE(planner.bind_input_type(query_type, model.inputs()[0]));
 
     ValueType attribute_type = ValueType::from_spec("tensor<float>(a[4],b[1])");
     std::vector<float> attribute_values({5.0, 6.0, 7.0, 8.0});
     DenseTensorView attribute(attribute_type, TypedCells(attribute_values));
-    EXPECT_FALSE(wrapper.inputs()[0].is_compatible(attribute_type));
-    EXPECT_TRUE(wrapper.inputs()[1].is_compatible(attribute_type));
-    EXPECT_FALSE(wrapper.inputs()[2].is_compatible(attribute_type));
+    EXPECT_TRUE(planner.bind_input_type(attribute_type, model.inputs()[1]));
 
     ValueType bias_type = ValueType::from_spec("tensor<float>(a[1],b[1])");
     std::vector<float> bias_values({9.0});
     DenseTensorView bias(bias_type, TypedCells(bias_values));
-    EXPECT_FALSE(wrapper.inputs()[0].is_compatible(bias_type));
-    EXPECT_FALSE(wrapper.inputs()[1].is_compatible(bias_type));
-    EXPECT_TRUE(wrapper.inputs()[2].is_compatible(bias_type));
+    EXPECT_TRUE(planner.bind_input_type(bias_type, model.inputs()[2]));
 
-    MutableDenseTensorView output(wrapper.outputs()[0].make_compatible_type());
-    EXPECT_EQ(output.fast_type().to_spec(), "tensor<float>(d0[1],d1[1])");
+    EXPECT_EQ(planner.make_output_type(model.outputs()[0]).to_spec(),
+              "tensor<float>(d0[1],d1[1])");
 
-    OnnxWrapper::Params params;
-    params.bind(0, query);
-    params.bind(1, attribute);
-    params.bind(2, bias);
-    auto result = wrapper.eval(params);
+    Onnx::WireInfo wire_info = planner.get_wire_info(model);
+    Onnx::EvalContext ctx(model, wire_info);
 
-    EXPECT_EQ(result.num_values(), 1);
-    result.get(0, output);
-    auto cells = output.cellsRef();
+    const Value &output = ctx.get_result(0);
+    EXPECT_EQ(output.type().to_spec(), "tensor<float>(d0[1],d1[1])");
+    //-------------------------------------------------------------------------
+    ctx.bind_param(0, query);
+    ctx.bind_param(1, attribute);
+    ctx.bind_param(2, bias);
+    ctx.eval();
+    auto cells = static_cast<const DenseTensorView&>(output).cellsRef();
     EXPECT_EQ(cells.type, ValueType::CellType::FLOAT);
     EXPECT_EQ(cells.size, 1);
     EXPECT_EQ(cells.get(0), 79.0);
+    //-------------------------------------------------------------------------
+    std::vector<float> new_bias_values({10.0});
+    DenseTensorView new_bias(bias_type, TypedCells(new_bias_values));
+    ctx.bind_param(2, new_bias);
+    ctx.eval();
+    EXPECT_EQ(static_cast<const DenseTensorView&>(output).cellsRef().get(0), 80.0);    
+    //-------------------------------------------------------------------------
+}
+
+TEST(OnnxTest, dynamic_onnx_model_can_be_evaluated)
+{
+    Onnx model(dynamic_model, Onnx::Optimize::ENABLE);
+    Onnx::WirePlanner planner;
+
+    ValueType query_type = ValueType::from_spec("tensor<float>(a[1],b[4])");
+    std::vector<float> query_values({1.0, 2.0, 3.0, 4.0});
+    DenseTensorView query(query_type, TypedCells(query_values));
+    EXPECT_TRUE(planner.bind_input_type(query_type, model.inputs()[0]));
+
+    ValueType attribute_type = ValueType::from_spec("tensor<float>(a[4],b[1])");
+    std::vector<float> attribute_values({5.0, 6.0, 7.0, 8.0});
+    DenseTensorView attribute(attribute_type, TypedCells(attribute_values));
+    EXPECT_TRUE(planner.bind_input_type(attribute_type, model.inputs()[1]));
+
+    ValueType bias_type = ValueType::from_spec("tensor<float>(a[1],b[2])");
+    std::vector<float> bias_values({4.0, 5.0});
+    DenseTensorView bias(bias_type, TypedCells(bias_values));
+    EXPECT_TRUE(planner.bind_input_type(bias_type, model.inputs()[2]));
+
+    EXPECT_EQ(planner.make_output_type(model.outputs()[0]).to_spec(),
+              "tensor<float>(d0[1],d1[1])");
+
+    Onnx::WireInfo wire_info = planner.get_wire_info(model);
+    Onnx::EvalContext ctx(model, wire_info);
+
+    const Value &output = ctx.get_result(0);
+    EXPECT_EQ(output.type().to_spec(), "tensor<float>(d0[1],d1[1])");
+    //-------------------------------------------------------------------------
+    ctx.bind_param(0, query);
+    ctx.bind_param(1, attribute);
+    ctx.bind_param(2, bias);
+    ctx.eval();
+    auto cells = static_cast<const DenseTensorView&>(output).cellsRef();
+    EXPECT_EQ(cells.type, ValueType::CellType::FLOAT);
+    EXPECT_EQ(cells.size, 1);
+    EXPECT_EQ(cells.get(0), 79.0);
+    //-------------------------------------------------------------------------
+    std::vector<float> new_bias_values({5.0,6.0});
+    DenseTensorView new_bias(bias_type, TypedCells(new_bias_values));
+    ctx.bind_param(2, new_bias);
+    ctx.eval();
+    EXPECT_EQ(static_cast<const DenseTensorView&>(output).cellsRef().get(0), 81.0);
+    //-------------------------------------------------------------------------
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/eval/src/tests/tensor/onnx_wrapper/simple.onnx
+++ b/eval/src/tests/tensor/onnx_wrapper/simple.onnx
@@ -1,0 +1,23 @@
+	simple.py:ã
+0
+query_tensor
+attribute_tensormatmul"MatMul
+"
+matmul
+bias_tensoroutput"Addsimple_scoringZ
+query_tensor
+
+
+Z"
+attribute_tensor
+
+
+Z
+bias_tensor
+
+
+b
+output
+
+
+B

--- a/eval/src/tests/tensor/onnx_wrapper/simple.py
+++ b/eval/src/tests/tensor/onnx_wrapper/simple.py
@@ -1,0 +1,33 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+import onnx
+from onnx import helper, TensorProto
+
+QUERY_TENSOR = helper.make_tensor_value_info('query_tensor', TensorProto.FLOAT, [1, 4])
+ATTRIBUTE_TENSOR = helper.make_tensor_value_info('attribute_tensor', TensorProto.FLOAT, [4, 1])
+BIAS_TENSOR = helper.make_tensor_value_info('bias_tensor', TensorProto.FLOAT, [1, 1])
+OUTPUT = helper.make_tensor_value_info('output', TensorProto.FLOAT, [1, 1])
+
+nodes = [
+    helper.make_node(
+        'MatMul',
+        ['query_tensor', 'attribute_tensor'],
+        ['matmul'],
+    ),
+    helper.make_node(
+        'Add',
+        ['matmul', 'bias_tensor'],
+        ['output'],
+    ),
+]
+graph_def = helper.make_graph(
+    nodes,
+    'simple_scoring',
+    [
+        QUERY_TENSOR,
+        ATTRIBUTE_TENSOR,
+        BIAS_TENSOR,
+    ],
+    [OUTPUT],
+)
+model_def = helper.make_model(graph_def, producer_name='simple.py')
+onnx.save(model_def, 'simple.onnx')

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
@@ -18,6 +18,7 @@ public:
     using CellsIterator = DenseTensorCellsIterator;
     using Address = std::vector<eval::ValueType::Dimension::size_type>;
 
+    DenseTensorView(const DenseTensorView &rhs) : DenseTensorView(rhs._typeRef, rhs._cellsRef) {}
     DenseTensorView(const eval::ValueType &type_in, TypedCells cells_in)
         : _typeRef(type_in),
           _cellsRef(cells_in)
@@ -55,7 +56,6 @@ protected:
         : _typeRef(type_in),
           _cellsRef()
     {}
-    DenseTensorView(const DenseTensorView &rhs) : DenseTensorView(rhs._typeRef, rhs._cellsRef) {}
 
     void initCellsRef(TypedCells cells_in) {
         assert(_typeRef.cell_type() == cells_in.type);

--- a/eval/src/vespa/eval/tensor/dense/onnx_wrapper.h
+++ b/eval/src/vespa/eval/tensor/dense/onnx_wrapper.h
@@ -2,56 +2,101 @@
 
 #pragma once
 
+#include "dense_tensor_view.h"
 #include <onnxruntime/onnxruntime_cxx_api.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/eval/eval/value_type.h>
 #include <vector>
+#include <map>
+
+namespace vespalib::eval { class Value; }
 
 namespace vespalib::tensor {
 
-class DenseTensorView;
-class MutableDenseTensorView;
-
 /**
  * Wrapper around an ONNX model handeled by onnxruntime.
+ *
+ * Create an Onnx object that will load your model and extract
+ * information about inputs and outputs. Use an Onnx::WirePlanner to
+ * bind vespa value types to each of the onnx model inputs. Ask the
+ * wire planner about the vespa value types corresponding to each of
+ * the model outputs for external wiring. Use the wire planner to make
+ * a WireInfo object which is a simple struct indicating the concrete
+ * onnx and vespa types to be used when converting inputs and
+ * outputs. Create an Onnx::EvalContex based on the model and the wire
+ * plan. Bind actual vespa values to the model inputs, invoke eval and
+ * inspect the results. See the unit test (tests/tensor/onnx_wrapper)
+ * for some examples.
  **/
-class OnnxWrapper {
+class Onnx {
 public:
     // model optimization
     enum class Optimize { ENABLE, DISABLE };
+
+    // the size of a dimension
+    struct DimSize {
+        size_t value;
+        vespalib::string name;
+        DimSize() : value(0), name() {}
+        DimSize(size_t size) : value(size), name() {}
+        DimSize(const vespalib::string &symbol) : value(0), name(symbol) {}
+        bool is_known() const { return (value > 0); }
+        bool is_symbolic() const { return !name.empty(); }
+        vespalib::string as_string() const;
+    };
 
     // information about a single input or output tensor
     struct TensorInfo {
         enum class ElementType { FLOAT, DOUBLE, UNKNOWN };
         vespalib::string name;
-        std::vector<size_t> dimensions;
+        std::vector<DimSize> dimensions;
         ElementType elements;
-        bool is_compatible(const eval::ValueType &type) const;
-        eval::ValueType make_compatible_type() const;
         vespalib::string type_as_string() const;
         ~TensorInfo();
     };
 
-    // used to build model parameters
-    class Params {
-        friend class OnnxWrapper;
-    private:
-        std::vector<Ort::Value> values;
-    public:
-        Params() : values() {}
-        void bind(size_t idx, const DenseTensorView &src);
+    // how the model should be wired with inputs/outputs
+    struct WireInfo {
+        std::vector<std::vector<int64_t>> input_sizes;
+        std::vector<eval::ValueType> output_types;
+        WireInfo() : input_sizes(), output_types() {}
     };
 
-    // used to inspect model results
-    class Result {
-        friend class OnnxWrapper;
+    // planning how we should wire the model based on input types
+    class WirePlanner {
     private:
-        std::vector<Ort::Value> values;
-        Result(std::vector<Ort::Value> values_in) : values(std::move(values_in)) {}
+        std::map<vespalib::string,size_t> _symbolic_sizes;
+        std::map<std::pair<vespalib::string,size_t>,size_t> _unknown_sizes;
     public:
-        static Result make_empty() { return Result({}); }
-        size_t num_values() const { return values.size(); }
-        void get(size_t idx, MutableDenseTensorView &dst);
+        WirePlanner() : _symbolic_sizes(), _unknown_sizes() {}
+        ~WirePlanner();
+        bool bind_input_type(const eval::ValueType &vespa_in, const TensorInfo &onnx_in);
+        eval::ValueType make_output_type(const TensorInfo &onnx_out) const;
+        WireInfo get_wire_info(const Onnx &model) const;
+    };
+
+    // evaluation context; use one per thread and keep model/wire_info alive
+    // all parameter values are expected to be bound per evaluation
+    // output values are pre-allocated and will not change
+    class EvalContext {
+    private:
+        static Ort::AllocatorWithDefaultOptions _alloc;
+
+        const Onnx                      &_model;
+        const WireInfo                  &_wire_info;
+        Ort::MemoryInfo                  _cpu_memory;
+        std::vector<Ort::Value>          _param_values;
+        std::vector<Ort::Value>          _result_values;
+        std::vector<DenseTensorView>     _result_views;
+
+    public:
+        EvalContext(const Onnx &model, const WireInfo &wire_info);
+        ~EvalContext();
+        size_t num_params() const { return _param_values.size(); }
+        size_t num_results() const { return _result_values.size(); }
+        void bind_param(size_t i, const eval::Value &param);
+        void eval();
+        const eval::Value &get_result(size_t i) const;
     };
 
 private:
@@ -76,11 +121,10 @@ private:
     void extract_meta_data();
 
 public:
-    OnnxWrapper(const vespalib::string &model_file, Optimize optimize);
-    ~OnnxWrapper();
+    Onnx(const vespalib::string &model_file, Optimize optimize);
+    ~Onnx();
     const std::vector<TensorInfo> &inputs() const { return _inputs; }
     const std::vector<TensorInfo> &outputs() const { return _outputs; }
-    Result eval(const Params &params) const;
 };
 
 }

--- a/searchlib/src/tests/features/onnx_feature/onnx_feature_test.cpp
+++ b/searchlib/src/tests/features/onnx_feature/onnx_feature_test.cpp
@@ -25,7 +25,8 @@ std::string get_source_dir() {
 }
 std::string source_dir = get_source_dir();
 std::string vespa_dir = source_dir + "/" + "../../../../..";
-std::string simple_model = vespa_dir + "/" + "model-integration/src/test/models/onnx/simple/simple.onnx";
+std::string simple_model = vespa_dir + "/" + "eval/src/tests/tensor/onnx_wrapper/simple.onnx";
+std::string dynamic_model = vespa_dir + "/" + "eval/src/tests/tensor/onnx_wrapper/dynamic.onnx";
 
 uint32_t default_docid = 1;
 
@@ -93,6 +94,18 @@ TEST_F(OnnxFeatureTest, simple_onnx_model_can_be_calculated) {
     compile(onnx_feature("simple"));
     EXPECT_EQ(get(1), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 79.0));
     EXPECT_EQ(get("onnxModel(simple).output", 1), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 79.0));
+    EXPECT_EQ(get(2), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 84.0));
+    EXPECT_EQ(get(3), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 89.0));
+}
+
+TEST_F(OnnxFeatureTest, dynamic_onnx_model_can_be_calculated) {
+    add_expr("query_tensor", "tensor<float>(a[1],b[4]):[[docid,2,3,4]]");
+    add_expr("attribute_tensor", "tensor<float>(a[4],b[1]):[[5],[6],[7],[8]]");
+    add_expr("bias_tensor", "tensor<float>(a[1],b[2]):[[4,5]]");
+    add_onnx("dynamic", dynamic_model);
+    compile(onnx_feature("dynamic"));
+    EXPECT_EQ(get(1), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 79.0));
+    EXPECT_EQ(get("onnxModel(dynamic).output", 1), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 79.0));
     EXPECT_EQ(get(2), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 84.0));
     EXPECT_EQ(get(3), TensorSpec("tensor<float>(d0[1],d1[1])").add({{"d0",0},{"d1",0}}, 89.0));
 }

--- a/searchlib/src/vespa/searchlib/features/onnx_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/onnx_feature.cpp
@@ -3,7 +3,6 @@
 #include "onnx_feature.h"
 #include <vespa/searchlib/fef/properties.h>
 #include <vespa/searchlib/fef/featureexecutor.h>
-#include <vespa/eval/tensor/dense/onnx_wrapper.h>
 #include <vespa/eval/tensor/dense/dense_tensor_view.h>
 #include <vespa/eval/tensor/dense/mutable_dense_tensor_view.h>
 #include <vespa/vespalib/util/stringfmt.h>
@@ -23,7 +22,7 @@ using vespalib::eval::ValueType;
 using vespalib::make_string_short::fmt;
 using vespalib::tensor::DenseTensorView;
 using vespalib::tensor::MutableDenseTensorView;
-using vespalib::tensor::OnnxWrapper;
+using vespalib::tensor::Onnx;
 
 namespace search::features {
 
@@ -33,37 +32,28 @@ namespace search::features {
 class OnnxFeatureExecutor : public FeatureExecutor
 {
 private:
-    const OnnxWrapper                    &_model;
-    OnnxWrapper::Params                   _params;
-    OnnxWrapper::Result                   _result;
-    std::vector<MutableDenseTensorView>   _views;
-
+    Onnx::EvalContext _eval_context;
 public:
-    OnnxFeatureExecutor(const OnnxWrapper &model)
-        : _model(model), _params(), _result(OnnxWrapper::Result::make_empty()), _views()
-    {
-        _views.reserve(_model.outputs().size());
-        for (const auto &output: _model.outputs()) {
-            _views.emplace_back(output.make_compatible_type());
+    OnnxFeatureExecutor(const Onnx &model, const Onnx::WireInfo &wire_info)
+        : _eval_context(model, wire_info) {}
+    bool isPure() override { return true; }
+    void handle_bind_outputs(vespalib::ArrayRef<fef::NumberOrObject>) override {
+        for (size_t i = 0; i < _eval_context.num_results(); ++i) {
+            outputs().set_object(i, _eval_context.get_result(i));
         }
     }
-    bool isPure() override { return true; }
-    void execute(uint32_t) override {       
-        _params = OnnxWrapper::Params();
-        for (size_t i = 0; i < _model.inputs().size(); ++i) {
-            _params.bind(i, static_cast<const DenseTensorView&>(inputs().get_object(i).get()));
+    void execute(uint32_t) override {
+        for (size_t i = 0; i < _eval_context.num_params(); ++i) {
+            _eval_context.bind_param(i, inputs().get_object(i).get());
         }
-        _result = _model.eval(_params);
-        for (size_t i = 0; i < _model.outputs().size(); ++i) {
-            _result.get(i, _views[i]);
-            outputs().set_object(i, _views[i]);
-        }
+        _eval_context.eval();
     }
 };
 
 OnnxBlueprint::OnnxBlueprint()
     : Blueprint("onnxModel"),
-      _model(nullptr)
+      _model(nullptr),
+      _wire_info()
 {
 }
 
@@ -74,24 +64,25 @@ OnnxBlueprint::setup(const IIndexEnvironment &env,
                      const ParameterList &params)
 {
     auto optimize = (env.getFeatureMotivation() == env.FeatureMotivation::VERIFY_SETUP)
-                    ? OnnxWrapper::Optimize::DISABLE
-                    : OnnxWrapper::Optimize::ENABLE;
+                    ? Onnx::Optimize::DISABLE
+                    : Onnx::Optimize::ENABLE;
 
     // Note: Using the fileref property with the model name as
     // fallback to get a file name. This needs to be replaced with an
     // actual file reference obtained through config when available.
     vespalib::string file_name = env.getProperties().lookup(getName(), "fileref").get(params[0].getValue());
     try {
-        _model = std::make_unique<OnnxWrapper>(file_name, optimize);
+        _model = std::make_unique<Onnx>(file_name, optimize);
     } catch (std::exception &ex) {
         return fail("Model setup failed: %s", ex.what());
     }
+    Onnx::WirePlanner planner;
     for (size_t i = 0; i < _model->inputs().size(); ++i) {
         const auto &model_input = _model->inputs()[i];
         if (auto maybe_input = defineInput(fmt("rankingExpression(\"%s\")", model_input.name.c_str()), AcceptInput::OBJECT)) {
             const FeatureType &feature_input = maybe_input.value();
             assert(feature_input.is_object());
-            if (!model_input.is_compatible(feature_input.type())) {
+            if (!planner.bind_input_type(feature_input.type(), model_input)) {
                 return fail("incompatible type for input '%s': %s -> %s", model_input.name.c_str(),
                             feature_input.type().to_spec().c_str(), model_input.type_as_string().c_str());
             }
@@ -99,13 +90,14 @@ OnnxBlueprint::setup(const IIndexEnvironment &env,
     }
     for (size_t i = 0; i < _model->outputs().size(); ++i) {
         const auto &model_output = _model->outputs()[i];
-        ValueType output_type = model_output.make_compatible_type();
+        ValueType output_type = planner.make_output_type(model_output);
         if (output_type.is_error()) {
             return fail("unable to make compatible type for output '%s': %s -> error",
                         model_output.name.c_str(), model_output.type_as_string().c_str());
         }
         describeOutput(model_output.name, "output from onnx model", FeatureType::object(output_type));
     }
+    _wire_info = planner.get_wire_info(*_model);
     return true;
 }
 
@@ -113,7 +105,7 @@ FeatureExecutor &
 OnnxBlueprint::createExecutor(const IQueryEnvironment &, Stash &stash) const
 {
     assert(_model);
-    return stash.create<OnnxFeatureExecutor>(*_model);
+    return stash.create<OnnxFeatureExecutor>(*_model, _wire_info);
 }
 
 }

--- a/searchlib/src/vespa/searchlib/features/onnx_feature.h
+++ b/searchlib/src/vespa/searchlib/features/onnx_feature.h
@@ -3,8 +3,7 @@
 #pragma once
 
 #include <vespa/searchlib/fef/blueprint.h>
-
-namespace vespalib::tensor { class OnnxWrapper; }
+#include <vespa/eval/tensor/dense/onnx_wrapper.h>
 
 namespace search::features {
 
@@ -13,7 +12,9 @@ namespace search::features {
  **/
 class OnnxBlueprint : public fef::Blueprint {
 private:
-    std::unique_ptr<vespalib::tensor::OnnxWrapper> _model;
+    using Onnx = vespalib::tensor::Onnx;
+    std::unique_ptr<Onnx> _model;
+    Onnx::WireInfo _wire_info;
 public:
     OnnxBlueprint();
     ~OnnxBlueprint() override;


### PR DESCRIPTION
also pre-allocate output onnx tensors and generally try to resolve as
much as possible up-front to reduce per-eval overhead.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review
@lesters FYI