### PR TITLE
Extend Document weight attribute interface to use dictionary snapshot

### DIFF
--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -491,7 +491,7 @@ BitVectorTest::test(BasicType bt,
         v->asDocumentWeightAttribute();
     if (dwa != NULL) {
         search::IDocumentWeightAttribute::LookupResult lres = 
-            dwa->lookup(getSearchStr<VectorType>());
+            dwa->lookup(getSearchStr<VectorType>(), dwa->get_dictionary_snapshot());
         typedef search::queryeval::DocumentWeightSearchIterator DWSI;
         typedef search::queryeval::SearchIterator SI;
         TermFieldMatchData md;

--- a/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
+++ b/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
@@ -674,7 +674,7 @@ private:
         MatchParams match_params(_dummy_heap, _dummy_heap.getMinScore(), 1.0, 1);
         std::vector<IDocumentWeightAttribute::LookupResult> dict_entries;
         for (size_t i = 0; i < _num_children; ++i) {
-            dict_entries.push_back(_helper.dwa().lookup(vespalib::make_string("%zu", i).c_str()));
+            dict_entries.push_back(_helper.dwa().lookup(vespalib::make_string("%zu", i).c_str(), _helper.dwa().get_dictionary_snapshot()));
         }
         return create_wand(_use_dwa, _tfmd, match_params, _weights, dict_entries, _helper.dwa(), strict);
     }

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
@@ -26,6 +26,10 @@ struct IDocumentWeightAttribute
     };
     virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const = 0;
     virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const = 0;
+    /*
+     * Collect enum indexes (via callback) where folded
+     * (e.g. lowercased) value equals the folded value for enum_idx.
+     */
     virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const = 0;
     virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
     virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
@@ -26,7 +26,7 @@ struct IDocumentWeightAttribute
     };
     virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const = 0;
     virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const = 0;
-    virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const = 0;
+    virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const = 0;
     virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
     virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
     virtual ~IDocumentWeightAttribute() {}

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
@@ -4,6 +4,8 @@
 
 #include "postinglisttraits.h"
 
+#include <functional>
+
 namespace search {
 
 namespace query { class Node; }
@@ -17,11 +19,14 @@ struct IDocumentWeightAttribute
         const uint32_t posting_size;
         const int32_t min_weight;
         const int32_t max_weight;
-        LookupResult() : posting_idx(), posting_size(0), min_weight(0), max_weight(0) {}
-        LookupResult(vespalib::datastore::EntryRef posting_idx_in, uint32_t posting_size_in, int32_t min_weight_in, int32_t max_weight_in)
-            : posting_idx(posting_idx_in), posting_size(posting_size_in), min_weight(min_weight_in), max_weight(max_weight_in) {}
+        const vespalib::datastore::EntryRef enum_idx;
+        LookupResult() : posting_idx(), posting_size(0), min_weight(0), max_weight(0), enum_idx() {}
+        LookupResult(vespalib::datastore::EntryRef posting_idx_in, uint32_t posting_size_in, int32_t min_weight_in, int32_t max_weight_in, vespalib::datastore::EntryRef enum_idx_in)
+            : posting_idx(posting_idx_in), posting_size(posting_size_in), min_weight(min_weight_in), max_weight(max_weight_in), enum_idx(enum_idx_in) {}
     };
-    virtual LookupResult lookup(const vespalib::string &term) const = 0;
+    virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const = 0;
+    virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const = 0;
+    virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const = 0;
     virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
     virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
     virtual ~IDocumentWeightAttribute() {}

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -35,7 +35,9 @@ private:
     struct DocumentWeightAttributeAdapter : IDocumentWeightAttribute {
         const MultiValueNumericPostingAttribute &self;
         DocumentWeightAttributeAdapter(const MultiValueNumericPostingAttribute &self_in) : self(self_in) {}
-        virtual LookupResult lookup(const vespalib::string &term) const override final;
+        virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const override final;
+        virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override final;
+        virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const override final;
         virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override final;
         virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override final;
     };

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -32,14 +32,14 @@ public:
     using EnumStoreBatchUpdater = typename EnumStore::BatchUpdater;
 
 private:
-    struct DocumentWeightAttributeAdapter : IDocumentWeightAttribute {
+    struct DocumentWeightAttributeAdapter final : IDocumentWeightAttribute {
         const MultiValueNumericPostingAttribute &self;
         DocumentWeightAttributeAdapter(const MultiValueNumericPostingAttribute &self_in) : self(self_in) {}
-        virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const override final;
-        virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override final;
-        virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const override final;
-        virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override final;
-        virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override final;
+        vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
+        LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override;
+        void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
+        void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override;
+        DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override;
     };
     DocumentWeightAttributeAdapter _document_weight_attribute_adapter;
 

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -33,7 +33,9 @@ private:
     struct DocumentWeightAttributeAdapter : IDocumentWeightAttribute {
         const MultiValueStringPostingAttributeT &self;
         DocumentWeightAttributeAdapter(const MultiValueStringPostingAttributeT &self_in) : self(self_in) {}
-        virtual LookupResult lookup(const vespalib::string &term) const override final;
+        virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const override final;
+        virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override final;
+        virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const override final;
         virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override final;
         virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override final;
     };

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -30,14 +30,14 @@ public:
     using EnumStoreBatchUpdater = typename EnumStore::BatchUpdater;
 
 private:
-    struct DocumentWeightAttributeAdapter : IDocumentWeightAttribute {
+    struct DocumentWeightAttributeAdapter final : IDocumentWeightAttribute {
         const MultiValueStringPostingAttributeT &self;
         DocumentWeightAttributeAdapter(const MultiValueStringPostingAttributeT &self_in) : self(self_in) {}
-        virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const override final;
-        virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override final;
-        virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const override final;
-        virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override final;
-        virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override final;
+        vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
+        LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override;
+        void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
+        void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override;
+        DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override;
     };
     DocumentWeightAttributeAdapter _document_weight_attribute_adapter;
 

--- a/searchlib/src/vespa/searchlib/test/weightedchildrenverifiers.h
+++ b/searchlib/src/vespa/searchlib/test/weightedchildrenverifiers.h
@@ -63,7 +63,7 @@ public:
         (void) strict;
         std::vector<DocumentWeightIterator> children;
         for (size_t i = 0; i < _num_children; ++i) {
-            auto dict_entry = _helper.dwa().lookup(vespalib::make_string("%zu", i).c_str());
+            auto dict_entry = _helper.dwa().lookup(vespalib::make_string("%zu", i).c_str(), _helper.dwa().get_dictionary_snapshot());
             _helper.dwa().create(dict_entry.posting_idx, children);
         }
         return create(std::move(children));


### PR DESCRIPTION
(for reproducible lookup) and store enum index for lookup key.

@geirst : please review
