### PR TITLE
- forceCommit feedview when documentdb closes.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -564,6 +564,9 @@ DocumentDB::close()
     // Abort any ongoing maintenance
     stopMaintenance();
 
+    _visibility.commit();
+    _writeService.sync();
+
     // The attributes in the ready sub db is also the total set of attributes.
     DocumentDBTaggedMetrics &metrics = getMetrics();
     _metricsWireService.cleanAttributes(metrics.ready.attributes);
@@ -905,6 +908,10 @@ DocumentDB::syncFeedView()
         return;
     IFeedView::SP oldFeedView(_feedView.get());
     IFeedView::SP newFeedView(_subDBs.getFeedView());
+
+    _visibility.commit();
+    _writeService.sync();
+
     _feedView.set(newFeedView);
     _feedHandler.setActiveFeedView(newFeedView.get());
     _subDBs.createRetrievers();

--- a/searchcore/src/vespa/searchcore/proton/server/feedstates.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/feedstates.cpp
@@ -82,6 +82,8 @@ public:
           _commitTimeTracker(100ms)
     { }
 
+    ~TransactionLogReplayPacketHandler() override = default;
+
     void replay(const PutOperation &op) override {
         _feed_view_ptr->handlePut(FeedToken(), op);
     }
@@ -152,6 +154,8 @@ ReplayTransactionLogState::ReplayTransactionLogState(
       _doc_type_name(name),
       _packet_handler(std::make_unique<TransactionLogReplayPacketHandler>(feed_view_ptr, bucketDBHandler, replay_config, config_store))
 { }
+
+ReplayTransactionLogState::~ReplayTransactionLogState() = default;
 
 void
 ReplayTransactionLogState::receive(const PacketWrapper::SP &wrap, Executor &executor) {

--- a/searchcore/src/vespa/searchcore/proton/server/feedstates.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedstates.h
@@ -55,6 +55,7 @@ public:
             IReplayConfig &replay_config,
             FeedConfigStore &config_store);
 
+    ~ReplayTransactionLogState() override;
     void handleOperation(FeedToken, FeedOperationUP op) override {
         throwExceptionInHandleOperation(_doc_type_name, *op);
     }


### PR DESCRIPTION
- forceCommit feedview when the documentdb does syncViews.
- Prevet chasing the nullptr. (Happens on startup for the initial syncViews

@toregge or @geirst PR