### PR TITLE
Reduce time to keep unused file references from 4 to 2 hours

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -51,9 +51,7 @@ ztsUrl string default=""
 
 # Maintainers
 maintainerIntervalMinutes int default=30
-# TODO: Default set to a high value (1 year) => maintainer will not run, change when maintainer verified out in prod
-tenantsMaintainerIntervalMinutes int default=525600
-keepUnusedFileReferencesHours int default=4
+keepUnusedFileReferencesHours int default=2
 
 # Bootstrapping
 # How long bootstrapping can take before giving up (in seconds)


### PR DESCRIPTION
Remove unused config field
