### PR TITLE
Explicitly enable freelists for content node B-tree DB data store

### DIFF
--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
@@ -69,6 +69,9 @@ struct BTreeBucketDatabase::ReplicaValueTraits {
     using ConstValueRef = ConstEntryRef;
     using DataStoreType = vespalib::datastore::ArrayStore<BucketCopy>;
 
+    static void init_data_store(DataStoreType&) {
+        // No-op; initialized via config provided to ArrayStore constructor.
+    }
     static ValueType make_invalid_value() {
         return Entry::createInvalid();
     }

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
@@ -34,6 +34,9 @@ struct BTreeLockableMap<T>::ValueTraits {
     using ConstValueRef = const T&;
     using DataStoreType = vespalib::datastore::DataStore<ValueType>;
 
+    static void init_data_store(DataStoreType& store) {
+        store.enableFreeLists();
+    }
     static EntryRef entry_ref_from_value(uint64_t value) {
         return EntryRef(value & 0xffffffffULL);
     }

--- a/storage/src/vespa/storage/bucketdb/generic_btree_bucket_database.h
+++ b/storage/src/vespa/storage/bucketdb/generic_btree_bucket_database.h
@@ -64,7 +64,9 @@ public:
     template <typename... DataStoreArgs>
     explicit GenericBTreeBucketDatabase(DataStoreArgs&&... data_store_args)
         : _store(std::forward<DataStoreArgs>(data_store_args)...)
-    {}
+    {
+        DataStoreTraitsT::init_data_store(_store);
+    }
 
     GenericBTreeBucketDatabase(const GenericBTreeBucketDatabase&) = delete;
     GenericBTreeBucketDatabase& operator=(const GenericBTreeBucketDatabase&) = delete;


### PR DESCRIPTION
@geirst @toregge please review

Freelists were unintentionally not enabled due to the difference
in how `ArrayStore` and `DataStore` freelist setup is done. The
existing distributor `ArrayStore` traits set this up implicitly via
the constructor config, while the content node `DataStore` needs to
have freelists explicitly enabled.
