### PR TITLE
Make it possible to pick up jars needed for cpp tests from alternativ…

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -83,7 +83,7 @@ case "$MODE" in
         ;;
     full)
 	echo "Building full set of dependencies."
-        mvn_install -am -pl jrt,linguistics,messagebus
+        mvn_install -am -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -pl jrt,linguistics,messagebus
         ;;
     default)
 	echo "Building default set of dependencies."

--- a/jrt_test/src/binref/compilejava.in
+++ b/jrt_test/src/binref/compilejava.in
@@ -2,7 +2,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
 
-if [ -n $VESPA_CPP_TEST_JARS ]; then
+if [ -n "$VESPA_CPP_TEST_JARS" ]; then
   CLASSPATH=$VESPA_CPP_TEST_JARS/jrt.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar 
 else

--- a/jrt_test/src/binref/compilejava.in
+++ b/jrt_test/src/binref/compilejava.in
@@ -1,10 +1,18 @@
 #!/bin/sh
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
-CLASSPATH=@PROJECT_SOURCE_DIR@/jrt/target/jrt.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar 
+
+if [ -n $VESPA_CPP_TEST_JARS ]; then
+  CLASSPATH=$VESPA_CPP_TEST_JARS/jrt.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar 
+else
+  CLASSPATH=@PROJECT_SOURCE_DIR@/jrt/target/jrt.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar 
+fi
+
 CLASSPATH=$CLASSPATH:@CMAKE_CURRENT_SOURCE_DIR@/../java/classes
 CLASSPATH=$CLASSPATH:.
+
 if [ $# -lt 1 ]; then
   echo "usage: compilejava file ..."
   exit 1

--- a/jrt_test/src/binref/runjava.in
+++ b/jrt_test/src/binref/runjava.in
@@ -2,7 +2,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
 
-if [ -n $VESPA_CPP_TEST_JARS ]; then
+if [ -n "$VESPA_CPP_TEST_JARS" ]; then
   CLASSPATH=$VESPA_CPP_TEST_JARS/jrt.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/security-utils.jar

--- a/jrt_test/src/binref/runjava.in
+++ b/jrt_test/src/binref/runjava.in
@@ -1,11 +1,20 @@
 #!/bin/sh
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
-CLASSPATH=@PROJECT_SOURCE_DIR@/jrt/target/jrt.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/security-utils/target/security-utils.jar
+
+if [ -n $VESPA_CPP_TEST_JARS ]; then
+  CLASSPATH=$VESPA_CPP_TEST_JARS/jrt.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/security-utils/target/security-utils.jar
+else
+  CLASSPATH=@PROJECT_SOURCE_DIR@/jrt/target/jrt.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/security-utils/target/security-utils.jar
+fi
+
 CLASSPATH=$CLASSPATH:@CMAKE_CURRENT_SOURCE_DIR@/../java/classes
 CLASSPATH=$CLASSPATH:.
+
 if [ $# -lt 1 ]; then
   echo "usage: runjava <class> [args]"
   exit 1

--- a/jrt_test/src/binref/runjava.in
+++ b/jrt_test/src/binref/runjava.in
@@ -5,7 +5,7 @@ unset VESPA_LOG_TARGET
 if [ -n $VESPA_CPP_TEST_JARS ]; then
   CLASSPATH=$VESPA_CPP_TEST_JARS/jrt.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
-  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/security-utils/target/security-utils.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/security-utils.jar
 else
   CLASSPATH=@PROJECT_SOURCE_DIR@/jrt/target/jrt.jar
   CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar

--- a/lowercasing_test/src/binref/compilejava.in
+++ b/lowercasing_test/src/binref/compilejava.in
@@ -1,10 +1,18 @@
 #!/bin/sh
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/linguistics/target/linguistics.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar
+
+if [ -n $VESPA_CPP_TEST_JARS ]; then
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/linguistics.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
+else
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/linguistics/target/linguistics.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar
+fi
+
 CLASSPATH=$CLASSPATH:@CMAKE_CURRENT_SOURCE_DIR@/../java/lowercasing_test.jar
 CLASSPATH=$CLASSPATH:.
+
 if [ $# -lt 1 ]; then
   echo "usage: compilejava file ..."
   exit 1

--- a/lowercasing_test/src/binref/compilejava.in
+++ b/lowercasing_test/src/binref/compilejava.in
@@ -2,7 +2,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
 
-if [ -n $VESPA_CPP_TEST_JARS ]; then
+if [ -n "$VESPA_CPP_TEST_JARS" ]; then
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/linguistics.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
 else

--- a/lowercasing_test/src/binref/runjava.in
+++ b/lowercasing_test/src/binref/runjava.in
@@ -1,10 +1,18 @@
 #!/bin/sh
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/linguistics/target/linguistics.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar
+
+if [ -n $VESPA_CPP_TEST_JARS ]; then
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/linguistics.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
+else
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/linguistics/target/linguistics.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/vespajlib/target/vespajlib.jar
+fi
+
 CLASSPATH=$CLASSPATH:@CMAKE_CURRENT_SOURCE_DIR@/../java/lowercasing_test.jar
 CLASSPATH=$CLASSPATH:.
+
 if [ $# -lt 1 ]; then
   echo "usage: runjava <class> [args]"
   exit 1

--- a/lowercasing_test/src/binref/runjava.in
+++ b/lowercasing_test/src/binref/runjava.in
@@ -2,7 +2,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
 
-if [ -n $VESPA_CPP_TEST_JARS ]; then
+if [ -n "$VESPA_CPP_TEST_JARS" ]; then
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/linguistics.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/vespajlib.jar
 else

--- a/messagebus_test/src/binref/compilejava.in
+++ b/messagebus_test/src/binref/compilejava.in
@@ -2,7 +2,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
 
-if [ -n $VESPA_CPP_TEST_JARS ]; then
+if [ -n "$VESPA_CPP_TEST_JARS" ]; then
   CLASSPATH=$VESPA_CPP_TEST_JARS/messagebus-jar-with-dependencies.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/component.jar
 else

--- a/messagebus_test/src/binref/compilejava.in
+++ b/messagebus_test/src/binref/compilejava.in
@@ -1,8 +1,15 @@
 #!/bin/sh
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
-CLASSPATH=@PROJECT_SOURCE_DIR@/messagebus/target/messagebus-jar-with-dependencies.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/component/target/component.jar
+
+if [ -n $VESPA_CPP_TEST_JARS ]; then
+  CLASSPATH=$VESPA_CPP_TEST_JARS/messagebus-jar-with-dependencies.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/component.jar
+else
+  CLASSPATH=@PROJECT_SOURCE_DIR@/messagebus/target/messagebus-jar-with-dependencies.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/component/target/component.jar
+fi
+ 
 CLASSPATH=$CLASSPATH:.
 
 if [ $# -lt 1 ]; then

--- a/messagebus_test/src/binref/runjava.in
+++ b/messagebus_test/src/binref/runjava.in
@@ -3,7 +3,7 @@
 unset VESPA_LOG_TARGET
 unset LD_PRELOAD
 
-if [ -n $VESPA_CPP_TEST_JARS ]; then
+if [ -n "$VESPA_CPP_TEST_JARS" ]; then
   CLASSPATH=$VESPA_CPP_TEST_JARS/messagebus-jar-with-dependencies.jar
   CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/component.jar
 else

--- a/messagebus_test/src/binref/runjava.in
+++ b/messagebus_test/src/binref/runjava.in
@@ -2,9 +2,17 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 unset VESPA_LOG_TARGET
 unset LD_PRELOAD
-CLASSPATH=@PROJECT_SOURCE_DIR@/messagebus/target/messagebus-jar-with-dependencies.jar
-CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/component/target/component.jar
+
+if [ -n $VESPA_CPP_TEST_JARS ]; then
+  CLASSPATH=$VESPA_CPP_TEST_JARS/messagebus-jar-with-dependencies.jar
+  CLASSPATH=$CLASSPATH:$VESPA_CPP_TEST_JARS/component.jar
+else
+  CLASSPATH=@PROJECT_SOURCE_DIR@/messagebus/target/messagebus-jar-with-dependencies.jar
+  CLASSPATH=$CLASSPATH:@PROJECT_SOURCE_DIR@/component/target/component.jar
+fi
+
 CLASSPATH=$CLASSPATH:.
+
 if [ $# -lt 1 ]; then
   echo "usage: runjava <class> [args]"
   exit 1


### PR DESCRIPTION
…e location.

This will make it possible to decouple the C++ testing and Maven deploy (which will rebuild jars used in C++ testing).