### PR TITLE
Revert "Add missing implementation of 'Executor' interface"

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/threadpool/ContainerThreadPool.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/threadpool/ContainerThreadPool.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * @author bratseth
  * @author bjorncs
  */
-public class ContainerThreadPool extends AbstractComponent implements AutoCloseable, Executor {
+public class ContainerThreadPool extends AbstractComponent implements AutoCloseable {
 
     private final ExecutorServiceWrapper threadpool;
 
@@ -50,7 +50,6 @@ public class ContainerThreadPool extends AbstractComponent implements AutoClosea
     }
 
     public Executor executor() { return threadpool; }
-    @Override public void execute(Runnable runnable) { threadpool.execute(runnable); }
     @Override public void close() { closeInternal(); }
     @Override public void deconstruct() { closeInternal(); super.deconstruct(); }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#14221

Broke the build:
`[ERROR] application_with_document_api(com.yahoo.document.restapi.DocumentApiApplicationTest)  Time elapsed: 0.155 s  <<< ERROR!
java.lang.RuntimeException: When resolving dependencies of 'com.yahoo.container.jdisc.LoggingRequestHandler$Context'
Caused by: java.lang.IllegalStateException: Multiple global components with class 'java.util.concurrent.Executor' found`