### PR TITLE
Enable free lists in data store add entry

### DIFF
--- a/searchlib/src/tests/memoryindex/datastore/feature_store_test.cpp
+++ b/searchlib/src/tests/memoryindex/datastore/feature_store_test.cpp
@@ -6,7 +6,6 @@
 #include <vespa/log/log.h>
 LOG_SETUP("feature_store_test");
 
-using namespace vespalib::btree;
 using namespace vespalib::datastore;
 using namespace search::index;
 

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.h
@@ -109,7 +109,7 @@ public:
 
     BitVectorRefPair allocBitVector() {
         return _store.template freeListAllocator<BitVectorEntry,
-            vespalib::btree::DefaultReclaimer<BitVectorEntry> >(BUFFERTYPE_BITVECTOR).alloc();
+            vespalib::datastore::DefaultReclaimer<BitVectorEntry> >(BUFFERTYPE_BITVECTOR).alloc();
     }
 
     /*

--- a/vespalib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/vespalib/src/tests/datastore/datastore/datastore_test.cpp
@@ -337,6 +337,12 @@ operator<<(std::ostream &os, const IntHandle &rhs)
 }
 
 void
+expect_successive_refs(EntryRef first, EntryRef second)
+{
+    EXPECT_EQ(MyRef(first).offset() + 1, MyRef(second).offset());
+}
+
+void
 expect_successive_handles(const IntHandle &first, const IntHandle &second)
 {
     EXPECT_EQ(to_ref(first).offset() + 1, to_ref(second).offset());
@@ -346,30 +352,29 @@ TEST(DataStoreTest, require_that_we_can_use_free_lists)
 {
     MyStore s;
     s.enableFreeLists();
-    auto allocator = s.freeListAllocator<IntReclaimer>();
-    auto h1 = allocator.alloc(1);
-    s.holdElem(h1.ref, 1);
+    auto r1 = s.addEntry(1);
+    s.holdElem(r1, 1);
     s.transferHoldLists(10);
-    auto h2 = allocator.alloc(2);
-    expect_successive_handles(h1, h2);
-    s.holdElem(h2.ref, 1);
+    auto r2 = s.addEntry(2);
+    expect_successive_refs(r1, r2);
+    s.holdElem(r2, 1);
     s.transferHoldLists(20);
     s.trimElemHoldList(11);
-    auto h3 = allocator.alloc(3); // reuse h1.ref
-    EXPECT_EQ(h1, h3);
-    auto h4 = allocator.alloc(4);
-    expect_successive_handles(h2, h4);
+    auto r3 = s.addEntry(3); // reuse r1
+    EXPECT_EQ(r1, r3);
+    auto r4 = s.addEntry(4);
+    expect_successive_refs(r2, r4);
     s.trimElemHoldList(21);
-    auto h5 = allocator.alloc(5); // reuse h2.ref
-    EXPECT_EQ(h2, h5);
-    auto h6 = allocator.alloc(6);
-    expect_successive_handles(h4, h6);
-    EXPECT_EQ(3, s.getEntry(h1.ref));
-    EXPECT_EQ(5, s.getEntry(h2.ref));
-    EXPECT_EQ(3, s.getEntry(h3.ref));
-    EXPECT_EQ(4, s.getEntry(h4.ref));
-    EXPECT_EQ(5, s.getEntry(h5.ref));
-    EXPECT_EQ(6, s.getEntry(h6.ref));
+    auto r5 = s.addEntry(5); // reuse r2
+    EXPECT_EQ(r2, r5);
+    auto r6 = s.addEntry(6);
+    expect_successive_refs(r4, r6);
+    EXPECT_EQ(3, s.getEntry(r1));
+    EXPECT_EQ(5, s.getEntry(r2));
+    EXPECT_EQ(3, s.getEntry(r3));
+    EXPECT_EQ(4, s.getEntry(r4));
+    EXPECT_EQ(5, s.getEntry(r5));
+    EXPECT_EQ(6, s.getEntry(r6));
 }
 
 TEST(DataStoreTest, require_that_we_can_use_free_lists_with_raw_allocator)

--- a/vespalib/src/vespa/vespalib/btree/btreestore.h
+++ b/vespalib/src/vespa/vespalib/btree/btreestore.h
@@ -133,7 +133,7 @@ public:
 
     BTreeTypeRefPair
     allocBTreeCopy(const BTreeType &rhs) {
-        return _store.freeListAllocator<BTreeType, DefaultReclaimer<BTreeType> >(BUFFERTYPE_BTREE).alloc(rhs);
+        return _store.freeListAllocator<BTreeType, datastore::DefaultReclaimer<BTreeType> >(BUFFERTYPE_BTREE).alloc(rhs);
     }
 
     KeyDataTypeRefPair

--- a/vespalib/src/vespa/vespalib/btree/btreestore.hpp
+++ b/vespalib/src/vespa/vespalib/btree/btreestore.hpp
@@ -85,7 +85,7 @@ allocKeyData(uint32_t clusterSize)
 {
     assert(clusterSize >= 1 && clusterSize <= clusterLimit);
     uint32_t typeId = clusterSize - 1;
-    return _store.freeListAllocator<KeyDataType, DefaultReclaimer<KeyDataType>>(typeId).allocArray(clusterSize);
+    return _store.freeListAllocator<KeyDataType, datastore::DefaultReclaimer<KeyDataType>>(typeId).allocArray(clusterSize);
 }
 
 
@@ -111,7 +111,7 @@ allocKeyDataCopy(const KeyDataType *rhs, uint32_t clusterSize)
 {
     assert(clusterSize >= 1 && clusterSize <= clusterLimit);
     uint32_t typeId = clusterSize - 1;
-    return _store.freeListAllocator<KeyDataType, DefaultReclaimer<KeyDataType>>(typeId).
+    return _store.freeListAllocator<KeyDataType, datastore::DefaultReclaimer<KeyDataType>>(typeId).
             allocArray(vespalib::ConstArrayRef<KeyDataType>(rhs, clusterSize));
 }
 

--- a/vespalib/src/vespa/vespalib/datastore/array_store.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/array_store.hpp
@@ -84,7 +84,7 @@ EntryRef
 ArrayStore<EntryT, RefT>::addSmallArray(const ConstArrayRef &array)
 {
     uint32_t typeId = getTypeId(array.size());
-    using NoOpReclaimer = btree::DefaultReclaimer<EntryT>;
+    using NoOpReclaimer = DefaultReclaimer<EntryT>;
     return _store.template freeListAllocator<EntryT, NoOpReclaimer>(typeId).allocArray(array).ref;
 }
 
@@ -92,7 +92,7 @@ template <typename EntryT, typename RefT>
 EntryRef
 ArrayStore<EntryT, RefT>::addLargeArray(const ConstArrayRef &array)
 {
-    using NoOpReclaimer = btree::DefaultReclaimer<LargeArray>;
+    using NoOpReclaimer = DefaultReclaimer<LargeArray>;
     auto handle = _store.template freeListAllocator<LargeArray, NoOpReclaimer>(_largeArrayTypeId)
             .alloc(array.cbegin(), array.cend());
     auto& state = _store.getBufferState(RefT(handle.ref).bufferId());

--- a/vespalib/src/vespa/vespalib/datastore/datastore.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.h
@@ -110,9 +110,6 @@ public:
 
     EntryRef addEntry(const EntryType &e);
     const EntryType &getEntry(EntryRef ref) const;
-
-    template <typename ReclaimerT>
-    FreeListAllocator<EntryType, RefT, ReclaimerT> freeListAllocator();
 };
 
 extern template class DataStoreT<EntryRefT<22> >;

--- a/vespalib/src/vespa/vespalib/datastore/datastore.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.h
@@ -8,18 +8,17 @@
 #include "free_list_raw_allocator.h"
 #include "raw_allocator.h"
 
-namespace vespalib::btree {
+namespace vespalib::datastore {
 
+/**
+ * Default noop reclaimer used together with datastore allocators.
+ */
 template<typename EntryType>
 struct DefaultReclaimer {
     static void reclaim(EntryType *entry) {
         (void) entry;
     }
 };
-
-}
-
-namespace vespalib::datastore {
 
 /**
  * Concrete data store using the given EntryRef type to reference stored data.

--- a/vespalib/src/vespa/vespalib/datastore/datastore.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.hpp
@@ -156,15 +156,9 @@ template <typename EntryType, typename RefT>
 EntryRef
 DataStore<EntryType, RefT>::addEntry(const EntryType &e)
 {
-    ensureBufferCapacity(0, 1);
-    uint32_t activeBufferId = _activeBufferIds[0];
-    BufferState &state = this->getBufferState(activeBufferId);
-    size_t oldSize = state.size();
-    EntryType *be = static_cast<EntryType *>(this->getBuffer(activeBufferId)) + oldSize;
-    new (static_cast<void *>(be)) EntryType(e);
-    RefType ref(oldSize, activeBufferId);
-    state.pushed_back(1);
-    return ref;
+    using NoOpReclaimer = DefaultReclaimer<EntryType>;
+    // Note: This will fallback to regular allocation if free lists are not enabled.
+    return FreeListAllocator<EntryType, RefT, NoOpReclaimer>(*this, 0).alloc(e).ref;
 }
 
 template <typename EntryType, typename RefT>
@@ -174,14 +168,6 @@ DataStore<EntryType, RefT>::getEntry(EntryRef ref) const
     RefType intRef(ref);
     const EntryType *be = this->template getEntry<EntryType>(intRef);
     return *be;
-}
-
-template <typename EntryType, typename RefT>
-template <typename ReclaimerT>
-FreeListAllocator<EntryType, RefT, ReclaimerT>
-DataStore<EntryType, RefT>::freeListAllocator()
-{
-    return FreeListAllocator<EntryType, RefT, ReclaimerT>(*this, 0);
 }
 
 extern template class DataStoreT<EntryRefT<22> >;


### PR DESCRIPTION
This should ensure that free-lists are actually used for content node B-tree DB data store (https://github.com/vespa-engine/vespa/pull/14214)

@toregge please review
@vekterli FYI