### PR TITLE
- Add test for sequencing.

### DIFF
--- a/jdisc_messagebus_service/src/test/java/com/yahoo/messagebus/jdisc/MbusRequestTestCase.java
+++ b/jdisc_messagebus_service/src/test/java/com/yahoo/messagebus/jdisc/MbusRequestTestCase.java
@@ -9,7 +9,9 @@ import org.junit.Test;
 
 import java.net.URI;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Simon Thoresen Hult


### PR DESCRIPTION
- Also sequence multiple operations to the same id as the originating request.

@bratseth PR