### PR TITLE
Include stdexcept to get declaration of std::runtime_error.

### DIFF
--- a/searchlib/src/vespa/searchlib/transactionlog/chunks.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/chunks.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/compressor.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <stdexcept>
 
 using std::runtime_error;
 using std::make_unique;


### PR DESCRIPTION
@baldersheim : please review
