### PR TITLE
Allow setting a request type explicitly

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/SessionContentReadResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/SessionContentReadResponse.java
@@ -14,9 +14,9 @@ import static com.yahoo.jdisc.http.HttpResponse.Status.OK;
  * Represents a response for a request to read contents of a file.
  *
  * @author Ulf Lilleengen
- * @since 5.1
  */
 public class SessionContentReadResponse extends HttpResponse {
+
     private final ApplicationFile file;
 
     public SessionContentReadResponse(ApplicationFile file) {
@@ -35,4 +35,5 @@ public class SessionContentReadResponse extends HttpResponse {
     public String getContentType() {
         return HttpResponse.DEFAULT_MIME_TYPE;
     }
+
 }

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -464,7 +464,9 @@
       "public java.lang.String getCharacterEncoding()",
       "public void populateAccessLogEntry(com.yahoo.container.logging.AccessLogEntry)",
       "public void complete()",
-      "public java.lang.Iterable getLogValues()"
+      "public java.lang.Iterable getLogValues()",
+      "public void setRequestType(com.yahoo.jdisc.Request$RequestType)",
+      "public com.yahoo.jdisc.Request$RequestType getRequestType()"
     ],
     "fields": [
       "public static final java.lang.String DEFAULT_MIME_TYPE",

--- a/container-core/src/main/java/com/yahoo/container/jdisc/HttpResponse.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/HttpResponse.java
@@ -3,6 +3,7 @@ package com.yahoo.container.jdisc;
 
 import com.yahoo.container.logging.AccessLogEntry;
 import com.yahoo.jdisc.HeaderFields;
+import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.Response;
 import com.yahoo.processing.execution.Execution.Trace.LogValue;
 
@@ -18,21 +19,18 @@ import java.util.Collections;
  */
 public abstract class HttpResponse {
 
-    /**
-     * Default response content type; text/plain.
-     */
+    /** Default response content type; text/plain. */
     public static final String DEFAULT_MIME_TYPE = "text/plain";
 
-    /**
-     * Default encoding/character set of a HTTP response; UTF-8.
-     */
+    /** Default encoding/character set of a HTTP response; UTF-8. */
     public static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
-
 
     private final Response parentResponse;
 
+    private Request.RequestType requestType;
+
     /**
-     * Create a new HTTP response.
+     * Creates a new HTTP response
      *
      * @param status the HTTP status code to return with this response (may be changed later)
      * @see Response
@@ -41,13 +39,11 @@ public abstract class HttpResponse {
         parentResponse = com.yahoo.jdisc.http.HttpResponse.newInstance(status);
     }
 
-    /**
-     * Marshal this response to the network layer. The caller is responsible for flushing and closing outputStream.
-     */
+    /** Marshals this response to the network layer. The caller is responsible for flushing and closing outputStream. */
     public abstract void render(OutputStream outputStream) throws IOException;
 
     /**
-     * The numeric HTTP status code, e.g. 200, 404 and so on.
+     * Returns the numeric HTTP status code, e.g. 200, 404 and so on.
      *
      * @return the numeric HTTP status code
      */
@@ -128,5 +124,14 @@ public abstract class HttpResponse {
     public Iterable<LogValue> getLogValues() {
         return Collections::emptyIterator;
     }
+
+    /** Sets the type classification of this request for metric collection purposes */
+    public void setRequestType(Request.RequestType requestType) { this.requestType = requestType; }
+
+    /**
+     * Returns the type classification of this request for metric collection purposes, or null if not set.
+     * When not set, the request type will be "read" for GET requests and "write" for other request methods.
+     */
+    public Request.RequestType getRequestType() { return requestType; }
 
 }

--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
@@ -78,6 +78,7 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
         try {
             channel = new LazyContentChannel(httpRequest, responseHandler, metric, log);
             HttpResponse httpResponse = handle(httpRequest, channel);
+            request.setRequestType(httpResponse.getRequestType());
             channel.setHttpResponse(httpResponse); // may or may not have already been done
             render(httpRequest, httpResponse, channel, jdiscRequest.creationTime(TimeUnit.MILLISECONDS));
         } catch (Exception e) {

--- a/container-search-and-docproc/src/main/java/com/yahoo/container/handler/observability/ApplicationStatusHandler.java
+++ b/container-search-and-docproc/src/main/java/com/yahoo/container/handler/observability/ApplicationStatusHandler.java
@@ -332,4 +332,5 @@ public class ApplicationStatusHandler extends AbstractRequestHandler {
             handler.completed();
         }
     }
+
 }

--- a/container-search-gui/src/main/java/com/yahoo/search/query/gui/GUIHandler.java
+++ b/container-search-gui/src/main/java/com/yahoo/search/query/gui/GUIHandler.java
@@ -40,7 +40,6 @@ import java.util.logging.Level;
  *
  * @author  Henrik Høiness
  */
-
 public class GUIHandler extends LoggingRequestHandler {
 
     private final IndexModel indexModel;

--- a/container-search/src/main/java/com/yahoo/search/Result.java
+++ b/container-search/src/main/java/com/yahoo/search/Result.java
@@ -51,7 +51,7 @@ public final class Result extends com.yahoo.processing.Response implements Clone
      * Headers containing "envelope" meta information to be returned with this result.
      * Used for HTTP getHeaders when the return protocol is HTTP.
      */
-    private ListMap<String,String> headers = null;
+    private ListMap<String, String> headers = null;
 
     /** Creates a new Result where the top level hit group has id "toplevel" */
     public Result(Query query) {
@@ -66,7 +66,6 @@ public final class Result extends com.yahoo.processing.Response implements Clone
      * @param query the query which produced this result
      * @param hits the hit container which this will return from {@link #hits()}
      */
-    @SuppressWarnings("deprecation")
     public Result(Query query, HitGroup hits) {
         super(query);
         if (query==null) throw new NullPointerException("The query reference in a result cannot be null");

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -17,6 +17,7 @@ import com.yahoo.container.jdisc.VespaHeaders;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.io.IOUtils;
 import com.yahoo.jdisc.Metric;
+import com.yahoo.jdisc.Request;
 import com.yahoo.language.Linguistics;
 import java.util.logging.Level;
 import com.yahoo.net.HostName;
@@ -314,6 +315,7 @@ public class SearchHandler extends LoggingRequestHandler {
         HttpSearchResponse response = new HttpSearchResponse(getHttpResponseStatus(request, result),
                                                              result, query, renderer,
                                                              extractTraceNode(query));
+        response.setRequestType(Request.RequestType.READ);
         if (hostResponseHeaderKey.isPresent())
             response.headers().add(hostResponseHeaderKey.get(), selfHostname);
 

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/Request.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/Request.java
@@ -48,6 +48,11 @@ public class Request extends AbstractResource {
     private boolean serverRequest;
     private Long timeout;
     private URI uri;
+    private RequestType requestType;
+
+    public enum RequestType {
+        READ, WRITE, MONITORING
+    }
 
     /**
      * <p>Creates a new instance of this class. As a {@link ServerProvider} you need to inject a {@link
@@ -325,6 +330,12 @@ public class Request extends AbstractResource {
     public long creationTime(TimeUnit unit) {
         return unit.convert(creationTime, TimeUnit.MILLISECONDS);
     }
+
+    /** Sets the type classification of this request for metric collection purposes */
+    public void setRequestType(RequestType requestType) { this.requestType = requestType; }
+
+    /** Returns the type classification of this request for metric collection purposes, or null if not set */
+    public RequestType getRequestType() { return requestType; }
 
     /**
      * <p>Returns whether or not this Request has been cancelled. This can be thought of as the {@link

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServlet.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServlet.java
@@ -33,49 +33,47 @@ class JDiscHttpServlet extends HttpServlet {
     private final static Logger log = Logger.getLogger(JDiscHttpServlet.class.getName());
     private final JDiscContext context;
 
+    private static final Set<String> servletSupportedMethods =
+            Stream.of(Method.OPTIONS, Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE, Method.TRACE)
+                  .map(Method::name)
+                  .collect(Collectors.toSet());
+
     public JDiscHttpServlet(JDiscContext context) {
         this.context = context;
     }
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
     @Override
-    protected void doHead(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doHead(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
     @Override
-    protected void doPut(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
     @Override
-    protected void doDelete(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
     @Override
-    protected void doOptions(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doOptions(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
     @Override
-    protected void doTrace(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doTrace(HttpServletRequest request, HttpServletResponse response) throws IOException {
         dispatchHttpRequest(request, response);
     }
 
@@ -92,11 +90,6 @@ class JDiscHttpServlet extends HttpServlet {
         context.metric.add(JettyHttpServer.Metrics.NUM_REQUESTS, 1, metricContext);
         context.metric.add(JettyHttpServer.Metrics.JDISC_HTTP_REQUESTS, 1, metricContext);
 
-
-        Set<String> servletSupportedMethods =
-                Stream.of(Method.OPTIONS, Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE, Method.TRACE)
-                        .map(Method::name)
-                        .collect(Collectors.toSet());
         String method = request.getMethod().toUpperCase();
         if (servletSupportedMethods.contains(method)) {
             super.service(request, response);
@@ -109,8 +102,6 @@ class JDiscHttpServlet extends HttpServlet {
         }
     }
 
-
-
     static JDiscServerConnector getConnector(HttpServletRequest request) {
         return (JDiscServerConnector)getConnection(request).getConnector();
     }
@@ -121,8 +112,7 @@ class JDiscHttpServlet extends HttpServlet {
         try {
             switch (request.getDispatcherType()) {
                 case REQUEST:
-                    new HttpRequestDispatch(context, accessLogEntry, getMetricContext(request), request, response)
-                            .dispatch();
+                    new HttpRequestDispatch(context, accessLogEntry, getMetricContext(request), request, response).dispatch();
                     break;
                 default:
                     if (log.isLoggable(Level.INFO)) {

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author bjorncs
  */
 class JDiscServerConnector extends ServerConnector {
+
     public static final String REQUEST_ATTRIBUTE = JDiscServerConnector.class.getName();
     private final Metric.Context metricCtx;
     private final Map<RequestDimensions, Metric.Context> requestMetricContextCache = new ConcurrentHashMap<>();

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletRequestReader.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/ServletRequestReader.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
  * it's important that errors are delivered synchronously.
  */
 class ServletRequestReader implements ReadListener {
+
     private enum State {
         READING, ALL_DATA_READ, REQUEST_CONTENT_CLOSED
     }
@@ -136,7 +137,7 @@ class ServletRequestReader implements ReadListener {
             requestContentChannel.write(buf, writeCompletionHandler);
             metricReporter.successfulRead(bytesReceived);
             bytesRead += bytesReceived;
-        } catch (final Throwable t) {
+        } catch (Throwable t) {
             finishedFuture.completeExceptionally(t);
         } finally {
             //decrease due to this method completing.
@@ -145,7 +146,7 @@ class ServletRequestReader implements ReadListener {
     }
 
     private void decreaseOutstandingUserCallsAndCloseRequestContentChannelConditionally() {
-        final boolean shouldCloseRequestContentChannel;
+        boolean shouldCloseRequestContentChannel;
 
         synchronized (monitor) {
             assertStateNotEquals(state, State.REQUEST_CONTENT_CLOSED);
@@ -154,7 +155,7 @@ class ServletRequestReader implements ReadListener {
             numberOfOutstandingUserCalls -= 1;
 
             shouldCloseRequestContentChannel = numberOfOutstandingUserCalls == 0 &&
-                    (finishedFuture.isDone() || state == State.ALL_DATA_READ);
+                                               (finishedFuture.isDone() || state == State.ALL_DATA_READ);
 
             if (shouldCloseRequestContentChannel) {
                 state = State.REQUEST_CONTENT_CLOSED;

--- a/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpResponseStatisticsCollectorTest.java
+++ b/jdisc_http_service/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpResponseStatisticsCollectorTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
  * @author ollivir
  */
 public class HttpResponseStatisticsCollectorTest {
+
     private Connector connector;
     private List<String> monitoringPaths = List.of("/status.html");
     private List<String> searchPaths = List.of("/search");
@@ -41,7 +42,7 @@ public class HttpResponseStatisticsCollectorTest {
     private int httpResponseCode = 500;
 
     @Test
-    public void statistics_are_aggregated_by_category() throws Exception {
+    public void statistics_are_aggregated_by_category() {
         testRequest("http", 300, "GET");
         testRequest("http", 301, "GET");
         testRequest("http", 200, "GET");
@@ -52,7 +53,7 @@ public class HttpResponseStatisticsCollectorTest {
     }
 
     @Test
-    public void statistics_are_grouped_by_http_method_and_scheme() throws Exception {
+    public void statistics_are_grouped_by_http_method_and_scheme() {
         testRequest("http", 200, "GET");
         testRequest("http", 200, "PUT");
         testRequest("http", 200, "POST");
@@ -74,7 +75,7 @@ public class HttpResponseStatisticsCollectorTest {
     }
 
     @Test
-    public void statistics_include_grouped_and_single_statuscodes() throws Exception {
+    public void statistics_include_grouped_and_single_statuscodes() {
         testRequest("http", 401, "GET");
         testRequest("http", 404, "GET");
         testRequest("http", 403, "GET");
@@ -87,7 +88,7 @@ public class HttpResponseStatisticsCollectorTest {
     }
 
     @Test
-    public void retrieving_statistics_resets_the_counters() throws Exception {
+    public void retrieving_statistics_resets_the_counters() {
         testRequest("http", 200, "GET");
         testRequest("http", 200, "GET");
 
@@ -101,7 +102,7 @@ public class HttpResponseStatisticsCollectorTest {
     }
 
     @Test
-    public void statistics_include_request_type_dimension() throws Exception {
+    public void statistics_include_request_type_dimension() {
         testRequest("http", 200, "GET", "/search");
         testRequest("http", 200, "POST", "/search");
         testRequest("http", 200, "POST", "/feed");
@@ -117,7 +118,14 @@ public class HttpResponseStatisticsCollectorTest {
 
         stats = collector.takeStatistics();
         assertStatisticsEntryPresent(stats, "http", "GET", Metrics.RESPONSES_2XX, 1L);
+    }
 
+    @Test
+    public void request_type_can_be_set_explicitly() {
+        testRequest("http", 200, "GET", "/search", com.yahoo.jdisc.Request.RequestType.WRITE);
+
+        var stats = collector.takeStatistics();
+        assertStatisticsEntryWithRequestTypePresent(stats, "http", "GET", Metrics.RESPONSES_2XX, "write", 1L);
     }
 
     @Before
@@ -145,13 +153,19 @@ public class HttpResponseStatisticsCollectorTest {
         server.start();
     }
 
-    private Request testRequest(String scheme, int responseCode, String httpMethod) throws Exception {
+    private Request testRequest(String scheme, int responseCode, String httpMethod) {
         return testRequest(scheme, responseCode, httpMethod, "foo/bar");
     }
-    private Request testRequest(String scheme, int responseCode, String httpMethod, String path) throws Exception {
+    private Request testRequest(String scheme, int responseCode, String httpMethod, String path) {
+        return testRequest(scheme, responseCode, httpMethod, path, null);
+    }
+    private Request testRequest(String scheme, int responseCode, String httpMethod, String path,
+                                com.yahoo.jdisc.Request.RequestType explicitRequestType) {
         HttpChannel channel = new HttpChannel(connector, new HttpConfiguration(), null, new DummyTransport());
         MetaData.Request metaData = new MetaData.Request(httpMethod, new HttpURI(scheme + "://" + path), HttpVersion.HTTP_1_1, new HttpFields());
         Request req = channel.getRequest();
+        if (explicitRequestType != null)
+            req.setAttribute("requestType", explicitRequestType);
         req.setMetaData(metaData);
 
         this.httpResponseCode = responseCode;

--- a/processing/src/main/java/com/yahoo/processing/Response.java
+++ b/processing/src/main/java/com/yahoo/processing/Response.java
@@ -39,16 +39,12 @@ public class Response extends ListenableFreezableClass {
 
     private final DataList<?> data;
 
-    /**
-     * Creates a request containing an empty array data list
-     */
+    /** Creates a request containing an empty array data list */
     public Response(Request request) {
         this(ArrayDataList.create(request));
     }
 
-    /**
-     * Creates a response containing a list of data
-     */
+    /** Creates a response containing a list of data */
     public Response(DataList<?> data) {
         this.data = data;
 
@@ -104,7 +100,7 @@ public class Response extends ListenableFreezableClass {
         return new CompleteAllOnGetFuture<D>(futures);
     }
 
-        @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
     private static <D extends Data> void collectCompletionFutures(DataList<D> dataList, List<ListenableFuture<DataList<D>>> futures) {
         futures.add(dataList.complete());
         for (D data : dataList.asList()) {


### PR DESCRIPTION
This lets handler authors control the requestType explicitly
by setting it on the HttpResponse, which is useful to avoid
misclassification of POST requests to reading handlers as writes.
