### PR TITLE
Optimize for looking up values that are present

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/result/FeatureData.java
+++ b/container-search/src/main/java/com/yahoo/search/result/FeatureData.java
@@ -74,10 +74,14 @@ public class FeatureData implements Inspectable, JsonProducer {
      *                                  (that is, if it is a tensor with nonzero rank)
      */
     public Double getDouble(String featureName) {
-        if (decodedDoubles != null && decodedDoubles.containsKey(featureName))
-            return decodedDoubles.get(featureName);
-        Double value = decodeDouble(featureName);
-        if (decodedDoubles == null)
+        Double value = null;
+        if (decodedDoubles != null)
+            value = decodedDoubles.get(featureName);
+        if (value != null)
+            return value;
+
+        value = decodeDouble(featureName);
+        if (value != null && decodedDoubles == null)
             decodedDoubles = new HashMap<>();
         decodedDoubles.put(featureName, value);
         return value;
@@ -99,10 +103,14 @@ public class FeatureData implements Inspectable, JsonProducer {
      * This will return any feature value: Scalars are returned as a rank 0 tensor.
      */
     public Tensor getTensor(String featureName) {
-        if (decodedTensors != null && decodedTensors.containsKey(featureName))
-            return decodedTensors.get(featureName);
-        Tensor value = decodeTensor(featureName);
-        if (decodedTensors == null)
+        Tensor value = null;
+        if (decodedTensors != null)
+            value = decodedTensors.get(featureName);
+        if (value != null)
+            return value;
+
+        value = decodeTensor(featureName);
+        if (value != null && decodedTensors == null)
             decodedTensors = new HashMap<>();
         decodedTensors.put(featureName, value);
         return value;

--- a/container-search/src/main/java/com/yahoo/search/result/FeatureData.java
+++ b/container-search/src/main/java/com/yahoo/search/result/FeatureData.java
@@ -74,16 +74,15 @@ public class FeatureData implements Inspectable, JsonProducer {
      *                                  (that is, if it is a tensor with nonzero rank)
      */
     public Double getDouble(String featureName) {
-        Double value = null;
-        if (decodedDoubles != null)
-            value = decodedDoubles.get(featureName);
-        if (value != null)
-            return value;
+        if (decodedDoubles == null)
+            decodedDoubles = new HashMap<>();
+
+        Double value = decodedDoubles.get(featureName);
+        if (value != null) return value;
 
         value = decodeDouble(featureName);
-        if (value != null && decodedDoubles == null)
-            decodedDoubles = new HashMap<>();
-        decodedDoubles.put(featureName, value);
+        if (value != null)
+            decodedDoubles.put(featureName, value);
         return value;
     }
 
@@ -103,16 +102,15 @@ public class FeatureData implements Inspectable, JsonProducer {
      * This will return any feature value: Scalars are returned as a rank 0 tensor.
      */
     public Tensor getTensor(String featureName) {
-        Tensor value = null;
-        if (decodedTensors != null)
-            value = decodedTensors.get(featureName);
-        if (value != null)
-            return value;
+        if (decodedTensors == null)
+            decodedTensors = new HashMap<>();
+
+        Tensor value = decodedTensors.get(featureName);
+        if (value != null) return value;
 
         value = decodeTensor(featureName);
-        if (value != null && decodedTensors == null)
-            decodedTensors = new HashMap<>();
-        decodedTensors.put(featureName, value);
+        if (value != null)
+            decodedTensors.put(featureName, value);
         return value;
     }
 

--- a/container-search/src/test/java/com/yahoo/search/result/FeatureDataTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/result/FeatureDataTestCase.java
@@ -33,19 +33,21 @@ public class FeatureDataTestCase {
         FeatureData featureData = new FeatureData(new SlimeAdapter(features));
         assertEquals("scalar1,scalar2,tensor1,tensor2",
                      featureData.featureNames().stream().sorted().collect(Collectors.joining(",")));
+        assertNull(featureData.getDouble("nosuch1"));
         assertEquals(1.5, featureData.getDouble("scalar1"), delta);
         assertEquals(2.5, featureData.getDouble("scalar2"), delta);
         assertEquals("Cached lookup", 2.5, featureData.getDouble("scalar2"), delta);
-        assertNull(featureData.getDouble("nosuch"));
-        assertNull(featureData.getDouble("nosuch"));
+        assertNull(featureData.getDouble("nosuch2"));
+        assertNull(featureData.getDouble("nosuch2"));
 
+        assertNull(featureData.getTensor("nosuch1"));
         assertEquals(Tensor.from(1.5), featureData.getTensor("scalar1"));
         assertEquals(Tensor.from(2.5), featureData.getTensor("scalar2"));
         assertEquals(tensor1, featureData.getTensor("tensor1"));
         assertEquals(tensor2, featureData.getTensor("tensor2"));
         assertEquals("Cached lookup", tensor2, featureData.getTensor("tensor2"));
-        assertNull(featureData.getTensor("nosuch"));
-        assertNull(featureData.getTensor("nosuch"));
+        assertNull(featureData.getTensor("nosuch2"));
+        assertNull(featureData.getTensor("nosuch2"));
 
         String expectedJson =
                 "{" +

--- a/container-search/src/test/java/com/yahoo/search/result/FeatureDataTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/result/FeatureDataTestCase.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author bratseth
@@ -35,11 +36,16 @@ public class FeatureDataTestCase {
         assertEquals(1.5, featureData.getDouble("scalar1"), delta);
         assertEquals(2.5, featureData.getDouble("scalar2"), delta);
         assertEquals("Cached lookup", 2.5, featureData.getDouble("scalar2"), delta);
+        assertNull(featureData.getDouble("nosuch"));
+        assertNull(featureData.getDouble("nosuch"));
+
         assertEquals(Tensor.from(1.5), featureData.getTensor("scalar1"));
         assertEquals(Tensor.from(2.5), featureData.getTensor("scalar2"));
         assertEquals(tensor1, featureData.getTensor("tensor1"));
         assertEquals(tensor2, featureData.getTensor("tensor2"));
         assertEquals("Cached lookup", tensor2, featureData.getTensor("tensor2"));
+        assertNull(featureData.getTensor("nosuch"));
+        assertNull(featureData.getTensor("nosuch"));
 
         String expectedJson =
                 "{" +


### PR DESCRIPTION
At the cost of always attempting to decode a nonexisting value
we can skip the containsKey lookup, making double lookups in FeatureData
about 50% faster and on par with HashMap.
