### PR TITLE
Revert "- Remove unused close() method."

### DIFF
--- a/searchlib/src/vespa/searchlib/transactionlog/common.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/common.h
@@ -72,6 +72,7 @@ public:
     Packet(size_t m=0xf000) : _count(0), _range(), _limit(m), _buf(m) { }
     Packet(const void * buf, size_t sz);
     bool add(const Entry & data);
+    void close() { }
     void clear() { _buf.clear(); _count = 0; _range.from(0); _range.to(0); }
     const SerialNumRange & range() const { return _range; }
     const vespalib::nbostream & getHandle() const { return _buf; }


### PR DESCRIPTION
Reverts vespa-engine/vespa#14256

Build fails with:
` 09:48:09 [ 69%] Building CXX object searchlib/src/tests/true/CMakeFiles/searchlib_true_test_app_object.dir/true.cpp.o
09:48:09 /workdir/vespa/searchlib/src/tests/transactionlog/translogclient_test.cpp: In member function 'bool Test::partialUpdateTest()':
09:48:09 /workdir/vespa/searchlib/src/tests/transactionlog/translogclient_test.cpp:244:8: error: 'class search::transactionlog::Packet' has no member named 'close'
09:48:09   244 |     pa.close();
09:48:09       |        ^~~~~ `