### PR TITLE
Include stdexcept to get declaration of std::runtime_error.

### DIFF
--- a/searchlib/src/vespa/searchlib/transactionlog/common.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/common.cpp
@@ -3,6 +3,7 @@
 #include "common.h"
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/fastos/file.h>
+#include <stdexcept>
 
 namespace search::transactionlog {
 


### PR DESCRIPTION
@baldersheim : please review
