### PR TITLE
Provided junit4 in test scope

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -241,6 +241,7 @@
                                         <include>io.prometheus:simpleclient:0.6.0:jar:test</include>
                                         <include>io.prometheus:simpleclient_common:0.6.0:jar:test</include>
                                         <include>joda-time:joda-time:2.8.1:jar:test</include>
+                                        <include>junit:junit:4.13:jar:test</include>
                                         <include>net.arnx:jsonic:1.2.11:jar:test</include>
                                         <include>net.java.dev.jna:jna:4.5.2:jar:test</include>
                                         <include>org.abego.treelayout:org.abego.treelayout.core:1.0.1:jar:test</include>
@@ -259,6 +260,7 @@
                                         <include>org.eclipse.jetty:jetty-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-servlet:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-servlets:[${jetty.version}]:jar:test</include>
+                                        <include>org.hamcrest:hamcrest-core:1.3:jar:test</include>
                                         <include>org.hdrhistogram:HdrHistogram:2.1.8:jar:test</include>
                                         <include>org.junit.jupiter:junit-jupiter-api:[${junit5.version}]:jar:test</include>
                                         <include>org.junit.jupiter:junit-jupiter-engine:[${junit5.version}]:jar:test</include>

--- a/hosted-tenant-base/pom.xml
+++ b/hosted-tenant-base/pom.xml
@@ -37,7 +37,6 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <junit.version>5.6.2</junit.version> <!-- NOTE: this must be in sync with junit version specified in 'tenant-cd-api' -->
-        <junit4.version>4.13</junit4.version> <!-- NOTE: must be compatible with junit5 vintage engine -->
         <test.categories>!integration</test.categories>
 
         <!-- To allow specialized base pom to include additional "test provided" dependencies -->
@@ -66,14 +65,6 @@
                 <version>${vespaversion}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <!-- Note: applications must manually add junit4 in pom.xml -->
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit4.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -108,21 +99,11 @@
         </dependency>
 
         <dependency>
-            <!-- Allow applications to use Junit4 in unit tests (assuming junit4 is added to application's pom.xml) -->
+            <!-- Allow applications to use Junit4 in unit tests -->
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
IntelliJ fails to run unit tests if vintage-engine is on classpath, but not junit4.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
