### PR TITLE
Add content bucket DB metrics and reduce memory footprint

### DIFF
--- a/storage/src/vespa/storage/bucketdb/abstract_bucket_map.h
+++ b/storage/src/vespa/storage/bucketdb/abstract_bucket_map.h
@@ -5,6 +5,7 @@
 #include <vespa/document/bucket/bucketid.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/util/time.h>
 #include <cassert>
 #include <functional>
@@ -192,6 +193,7 @@ public:
 
     [[nodiscard]] virtual size_type size() const noexcept = 0;
     [[nodiscard]] virtual size_type getMemoryUsage() const noexcept = 0;
+    [[nodiscard]] virtual vespalib::MemoryUsage detailed_memory_usage() const noexcept = 0;
     [[nodiscard]] virtual bool empty() const noexcept = 0;
 
     virtual void showLockClients(vespalib::asciistream& out) const = 0;

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.h
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.h
@@ -46,6 +46,7 @@ public:
     bool operator<(const BTreeLockableMap& other) const;
     size_t size() const noexcept override;
     size_t getMemoryUsage() const noexcept override;
+    vespalib::MemoryUsage detailed_memory_usage() const noexcept override;
     bool empty() const noexcept override;
     void swap(BTreeLockableMap&);
 

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
@@ -150,6 +150,12 @@ size_t BTreeLockableMap<T>::getMemoryUsage() const noexcept {
 }
 
 template <typename T>
+vespalib::MemoryUsage BTreeLockableMap<T>::detailed_memory_usage() const noexcept {
+    std::lock_guard guard(_lock);
+    return _impl->memory_usage();
+}
+
+template <typename T>
 bool BTreeLockableMap<T>::empty() const noexcept {
     std::lock_guard guard(_lock);
     return _impl->empty();

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
@@ -59,7 +59,7 @@ struct BTreeLockableMap<T>::ValueTraits {
 
 template <typename T>
 BTreeLockableMap<T>::BTreeLockableMap()
-    : _impl(std::make_unique<GenericBTreeBucketDatabase<ValueTraits>>())
+    : _impl(std::make_unique<GenericBTreeBucketDatabase<ValueTraits>>(1024/*data store array count*/))
 {}
 
 template <typename T>

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
@@ -263,6 +263,15 @@ BucketManager::updateMetrics(bool updateDocCount)
             }
         }
     }
+    update_bucket_db_memory_usage_metrics();
+}
+
+void BucketManager::update_bucket_db_memory_usage_metrics() {
+    for (auto& space : _component.getBucketSpaceRepo()) {
+        auto bm = _metrics->bucket_spaces.find(space.first);
+        bm->second->bucket_db_metrics.memory_usage.update(
+                space.second->bucketDatabase().detailed_memory_usage());
+    }
 }
 
 void BucketManager::updateMinUsedBits()

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -123,6 +123,7 @@ private:
 
     void updateMetrics(bool updateDocCount);
     void updateMetrics(const MetricLockGuard &) override { updateMetrics(true); }
+    void update_bucket_db_memory_usage_metrics();
     void updateMinUsedBits();
 
     bool onRequestBucketInfo(const std::shared_ptr<api::RequestBucketInfoCommand>&) override;

--- a/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.cpp
@@ -22,13 +22,21 @@ DataStoredMetrics::DataStoredMetrics(const std::string& name, metrics::MetricSet
 
 DataStoredMetrics::~DataStoredMetrics() = default;
 
+ContentBucketDbMetrics::ContentBucketDbMetrics(metrics::MetricSet* owner)
+    : metrics::MetricSet("bucket_db", {}, "", owner),
+      memory_usage(this)
+{}
+
+ContentBucketDbMetrics::~ContentBucketDbMetrics() = default;
+
 BucketSpaceMetrics::BucketSpaceMetrics(const vespalib::string& space_name, metrics::MetricSet* owner)
         : metrics::MetricSet("bucket_space", {{"bucketSpace", space_name}}, "", owner),
           buckets_total("buckets_total", {}, "Total number buckets present in the bucket space (ready + not ready)", this),
           docs("docs", {}, "Documents stored in the bucket space", this),
           bytes("bytes", {}, "Bytes stored across all documents in the bucket space", this),
           active_buckets("active_buckets", {}, "Number of active buckets in the bucket space", this),
-          ready_buckets("ready_buckets", {}, "Number of ready buckets in the bucket space", this)
+          ready_buckets("ready_buckets", {}, "Number of ready buckets in the bucket space", this),
+          bucket_db_metrics(this)
 {}
 
 BucketSpaceMetrics::~BucketSpaceMetrics() = default;

--- a/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanagermetrics.h
@@ -4,6 +4,7 @@
 
 #include <vespa/document/bucket/bucketspace.h>
 #include <vespa/metrics/metrics.h>
+#include <vespa/metrics/common/memory_usage_metrics.h>
 
 #include <unordered_map>
 #include <memory>
@@ -23,6 +24,13 @@ struct DataStoredMetrics : metrics::MetricSet {
     ~DataStoredMetrics() override;
 };
 
+struct ContentBucketDbMetrics : metrics::MetricSet {
+    explicit ContentBucketDbMetrics(metrics::MetricSet* owner);
+    ~ContentBucketDbMetrics() override;
+
+    metrics::MemoryUsageMetrics memory_usage;
+};
+
 struct BucketSpaceMetrics : metrics::MetricSet {
     // Superficially very similar to DataStoredMetrics, but metric naming and dimensions differ
     metrics::LongValueMetric buckets_total;
@@ -30,6 +38,7 @@ struct BucketSpaceMetrics : metrics::MetricSet {
     metrics::LongValueMetric bytes;
     metrics::LongValueMetric active_buckets;
     metrics::LongValueMetric ready_buckets;
+    ContentBucketDbMetrics bucket_db_metrics;
 
     BucketSpaceMetrics(const vespalib::string& space_name, metrics::MetricSet* owner);
     ~BucketSpaceMetrics() override;

--- a/storage/src/vespa/storage/bucketdb/lockablemap.h
+++ b/storage/src/vespa/storage/bucketdb/lockablemap.h
@@ -50,6 +50,7 @@ public:
     bool operator<(const LockableMap& other) const;
     size_t size() const noexcept override;
     size_t getMemoryUsage() const noexcept override;
+    vespalib::MemoryUsage detailed_memory_usage() const noexcept override;
     bool empty() const noexcept override;
     void swap(LockableMap&);
 

--- a/storage/src/vespa/storage/bucketdb/lockablemap.hpp
+++ b/storage/src/vespa/storage/bucketdb/lockablemap.hpp
@@ -85,6 +85,15 @@ LockableMap<Map>::getMemoryUsage() const noexcept
         sizeof(std::mutex) + sizeof(std::condition_variable);
 }
 
+template <typename Map>
+vespalib::MemoryUsage LockableMap<Map>::detailed_memory_usage() const noexcept {
+    // We don't have any details for this map type, just count everything as "allocated".
+    size_t used = getMemoryUsage();
+    vespalib::MemoryUsage mem_usage;
+    mem_usage.incAllocatedBytes(used);
+    return mem_usage;
+}
+
 template<typename Map>
 bool
 LockableMap<Map>::empty() const noexcept

--- a/storage/src/vespa/storage/bucketdb/lockablemap.hpp
+++ b/storage/src/vespa/storage/bucketdb/lockablemap.hpp
@@ -91,6 +91,7 @@ vespalib::MemoryUsage LockableMap<Map>::detailed_memory_usage() const noexcept {
     size_t used = getMemoryUsage();
     vespalib::MemoryUsage mem_usage;
     mem_usage.incAllocatedBytes(used);
+    mem_usage.incUsedBytes(used);
     return mem_usage;
 }
 

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
@@ -91,6 +91,10 @@ size_t StorBucketDatabase::getMemoryUsage() const {
     return _impl->getMemoryUsage();
 }
 
+vespalib::MemoryUsage StorBucketDatabase::detailed_memory_usage() const noexcept {
+    return _impl->detailed_memory_usage();
+}
+
 void StorBucketDatabase::showLockClients(vespalib::asciistream& out) const {
     _impl->showLockClients(out);
 }

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.h
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.h
@@ -5,6 +5,7 @@
 #include "read_guard.h"
 #include "storagebucketinfo.h"
 #include <vespa/storageapi/defs.h>
+#include <vespa/vespalib/util/memoryusage.h>
 #include <memory>
 
 namespace storage {
@@ -79,7 +80,8 @@ public:
      */
     bool isConsistent(const WrappedEntry& entry);
 
-    size_t getMemoryUsage() const;
+    [[nodiscard]] size_t getMemoryUsage() const;
+    [[nodiscard]] vespalib::MemoryUsage detailed_memory_usage() const noexcept;
     void showLockClients(vespalib::asciistream & out) const;
 
 };

--- a/vespalib/src/vespa/vespalib/datastore/datastore.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.h
@@ -108,7 +108,8 @@ public:
     DataStore(const DataStore &rhs) = delete;
     DataStore &operator=(const DataStore &rhs) = delete;
     DataStore();
-    DataStore(BufferTypeUP type);
+    explicit DataStore(uint32_t min_arrays);
+    explicit DataStore(BufferTypeUP type);
     ~DataStore();
 
     EntryRef addEntry(const EntryType &e);

--- a/vespalib/src/vespa/vespalib/datastore/datastore.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.hpp
@@ -138,6 +138,12 @@ DataStore<EntryType, RefT>::DataStore()
 }
 
 template <typename EntryType, typename RefT>
+DataStore<EntryType, RefT>::DataStore(uint32_t min_arrays)
+    : DataStore(std::make_unique<BufferType<EntryType>>(1, min_arrays, RefType::offsetSize()))
+{
+}
+
+template <typename EntryType, typename RefT>
 DataStore<EntryType, RefT>::DataStore(BufferTypeUP type)
     : ParentType(),
       _type(std::move(type))


### PR DESCRIPTION
@geirst please review.

The 2nd commit reduces the initial memory footprint of a content node B-tree bucket DB by three orders of magnitude and then some 🙂 This adds up since there are always two of them present (global/non-global).