### PR TITLE
Act only if the target changes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
@@ -67,11 +67,12 @@ public class AutoscalingMaintainer extends NodeRepositoryMaintainer {
         Optional<Cluster> cluster = application.cluster(clusterId);
         if (cluster.isEmpty()) return;
         Optional<ClusterResources> target = autoscaler.autoscale(cluster.get(), clusterNodes);
-        if ( ! cluster.get().targetResources().equals(target))
+        if ( ! cluster.get().targetResources().equals(target)) { // New target: Log and try to deploy now
             applications().put(application.with(cluster.get().withTarget(target)), deployment.applicationLock().get());
-        if (target.isPresent()) {
-            logAutoscaling(target.get(), applicationId, clusterId, clusterNodes);
-            deployment.activate();
+            if (target.isPresent()) {
+                logAutoscaling(target.get(), applicationId, clusterId, clusterNodes);
+                deployment.activate();
+            }
         }
     }
 


### PR DESCRIPTION
If we have already computed a new target but not successfully changed to it,
the autoscaler will return the same target. Don't take any action (log target,
deploy immediately) when this happens.
