### PR TITLE
Arnej/more time for prepare for restart 

### DIFF
--- a/configd/src/apps/sentinel/config-handler.cpp
+++ b/configd/src/apps/sentinel/config-handler.cpp
@@ -59,6 +59,11 @@ ConfigHandler::terminateServices(bool catchable, bool printDebug)
 {
     for (const auto & entry : _services) {
         Service *service = entry.second.get();
+        service->setAutomatic(false);
+        service->prepare_for_shutdown();
+    }
+    for (const auto & entry : _services) {
+        Service *service = entry.second.get();
         if (printDebug && service->isRunning()) {
             LOG(info, "%s: killing", service->name().c_str());
         }

--- a/configd/src/apps/sentinel/service.h
+++ b/configd/src/apps/sentinel/service.h
@@ -34,7 +34,6 @@ private:
 
     void runChild() __attribute__((noreturn));
     void setState(ServiceState state);
-    void runPreShutdownCommand();
     void runCommand(const std::string & command);
     const char *stateName(ServiceState state) const;
 
@@ -52,6 +51,7 @@ public:
 			StartMetrics &metrics);
     void reconfigure(const SentinelConfig::Service& config);
     int pid() const { return _pid; }
+    void prepare_for_shutdown();
     int terminate(bool catchable, bool dumpState);
     int terminate() {
         return terminate(true, false);

--- a/searchcore/src/apps/vespa-proton-cmd/vespa-proton-cmd.cpp
+++ b/searchcore/src/apps/vespa-proton-cmd/vespa-proton-cmd.cpp
@@ -323,7 +323,7 @@ public:
             }
         } else if (strcmp(_argv[2], "prepareRestart") == 0) {
             _req->SetMethodName("proton.prepareRestart");
-            invokeRPC(false, 86400.0);
+            invokeRPC(false, 600.0);
             invoked = true;
             if (! _req->IsError()) {
                 printf("OK: prepareRestart enabled\n");

--- a/vespalog/src/logger/runserver.cpp
+++ b/vespalog/src/logger/runserver.cpp
@@ -390,16 +390,16 @@ int main(int argc, char *argv[])
             } else {
                 fprintf(stdout, "%s was running with pid %d, sending SIGTERM\n",
                     service, pid);
-                if (killpg(pid, SIGTERM) != 0) {
+                if (kill(pid, SIGTERM) != 0) {
                     fprintf(stderr, "could not signal %d: %s\n", pid,
                             strerror(errno));
                     return 1;
                 }
             }
-            fprintf(stdout, "Waiting for exit (up to 60 seconds)\n");
-            for (int cnt(0); cnt < 1800; cnt++) {
+            fprintf(stdout, "Waiting for exit (up to 15 minutes)\n");
+            for (int cnt(0); cnt < 86400; cnt++) {
                 usleep(100000); // wait 0.1 seconds
-                if ((cnt > 300) && (cnt % 100 == 0)) {
+                if ((cnt > 7200) && (cnt % 100 == 0)) {
                     killpg(pid, SIGTERM);
                 }
                 if (killpg(pid, 0) == 0) {
@@ -411,7 +411,7 @@ int main(int argc, char *argv[])
                     fprintf(stdout, "DONE\n");
                     break;
                 }
-                if (cnt == 900) {
+                if (cnt == 9000) {
                     printf("\ngiving up, sending KILL signal\n");
                     killpg(pid, SIGKILL);
                 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

NOTE: this changes (indirectly) the waiting time for vespa-stop-services, which means that restarting vespa on a node may take 10-15 minutes instead of 1-1.5 minutes.

However, in those cases it will also be much more likely that proton will manage to actually flush all the data it needs to flush in order to restart quickly afterwards, so the total restart time should not become any worse.

@baldersheim please review
