### PR TITLE
Revert "Support 'id' as field name in C++ document selection lexing/parsing" MERGEOK

### DIFF
--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -88,12 +88,8 @@ public class DocumentSelectorTestCase {
         manager.registerDocumentType(new DocumentType("andornot"));
         manager.registerDocumentType(new DocumentType("idid"));
         manager.registerDocumentType(new DocumentType("usergroup"));
-        var userType = new DocumentType("user");
-        userType.addField("id", DataType.INT);
-        manager.registerDocumentType(userType);
-        var groupType = new DocumentType("group");
-        groupType.addField("iD", DataType.INT); // For checking case preservation
-        manager.registerDocumentType(groupType);
+        manager.registerDocumentType(new DocumentType("user"));
+        manager.registerDocumentType(new DocumentType("group"));
     }
 
     @Test
@@ -161,8 +157,6 @@ public class DocumentSelectorTestCase {
         assertParse(null, "true or or_t or ortype");
         assertParse(null, "user or group");
         assertParse(null, "user.foo or group.bar");
-        assertParse("user.id == id.user", "user.id == id.user");
-        assertParse("group.iD == id.user", "group.iD == id.user"); // Casing is preserved
     }
 
     @Test

--- a/document/src/tests/documentselectparsertest.cpp
+++ b/document/src/tests/documentselectparsertest.cpp
@@ -94,11 +94,9 @@ void DocumentSelectParserTest::SetUp()
                      Struct("usergroup.header"),
                      Struct("usergroup.body"));
     builder.document(875463456, "user",
-                     Struct("user.header").addField("id", DataType::T_INT),
-                     Struct("user.body"));
+                     Struct("user.header"), Struct("user.body"));
     builder.document(567463442, "group",
-                     Struct("group.header").addField("iD", DataType::T_INT),
-                     Struct("group.body"));
+                     Struct("group.header"), Struct("group.body"));
     _repo = std::make_unique<DocumentTypeRepo>(builder.config());
 
     _parser = std::make_unique<select::Parser>(*_repo, _bucketIdFactory);
@@ -1457,9 +1455,6 @@ TEST_F(DocumentSelectParserTest, special_tokens_are_allowed_as_freestanding_iden
     EXPECT_EQ("(== (ID id.user) (FIELD user user))", parse_to_tree("id.user == user.user"));
     EXPECT_EQ("(NOT (DOCTYPE group))", parse_to_tree("not group"));
     EXPECT_EQ("(== (ID id.group) (FIELD group group))", parse_to_tree("id.group == group.group"));
-    EXPECT_EQ("(== (FIELD user id) (ID id.user))", parse_to_tree("user.id == id.user"));
-    // Case is preserved for special ID field
-    EXPECT_EQ("(== (FIELD group iD) (ID id.user))", parse_to_tree("group.iD == id.user"));
 }
 
 TEST_F(DocumentSelectParserTest, test_can_build_field_value_from_field_expr_node)

--- a/document/src/vespa/document/select/grammar/lexer.ll
+++ b/document/src/vespa/document/select/grammar/lexer.ll
@@ -119,6 +119,7 @@ SQ_STRING \'(\\([\\tnfr']|x{HEXDIGIT}{2})|[^'\\])*\'
 \[{WS}*(${IDCHARS}|{DECIMAL}){WS}*\]                      STRING_TOKEN(FP_ARRAY_LOOKUP)
 
  /* Primary tokens are case insensitive */
+(?i:"id")    NAMED_TOKEN(ID)
 (?i:"null")  NAMED_TOKEN(NULL)
 (?i:"true")  NAMED_TOKEN(TRUE)
 (?i:"false") NAMED_TOKEN(FALSE)
@@ -127,7 +128,6 @@ SQ_STRING \'(\\([\\tnfr']|x{HEXDIGIT}{2})|[^'\\])*\'
 (?i:"not")   NAMED_TOKEN(NOT)
 
  /* We expose the verbatim input as the token value, as these may also be used for identifiers... */
-(?i:"id")        STRING_TOKEN(ID)
 (?i:"user")      STRING_TOKEN(USER)
 (?i:"group")     STRING_TOKEN(GROUP)
 (?i:"scheme")    STRING_TOKEN(SCHEME)


### PR DESCRIPTION
Reverts vespa-engine/vespa#14338

@vekterli 