### PR TITLE
Wait with starting SessionsMaintainer

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -19,9 +19,7 @@ public class SessionsMaintainer extends ConfigServerMaintainer {
     private final boolean hostedVespa;
 
     SessionsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval, FlagSource flagSource) {
-        // Start this maintainer immediately. It frees disk space, so if disk goes full and config server
-        // restarts this makes sure that cleanup will happen as early as possible
-        super(applicationRepository, curator, flagSource, Duration.ZERO, interval);
+        super(applicationRepository, curator, flagSource, Duration.ofMinutes(5), interval);
         this.hostedVespa = applicationRepository.configserverConfig().hostedVespa();
     }
 


### PR DESCRIPTION
SessionsMaintainer is run explicitly when bootstrapping now, so can
wait a bit before starting it (it will tak application lock when running,
so waiting might avoid some contention).
