### PR TITLE
set omp num threads to 1 when running *proton*

### DIFF
--- a/configd/src/apps/sentinel/service.cpp
+++ b/configd/src/apps/sentinel/service.cpp
@@ -325,6 +325,9 @@ Service::runChild()
     if (_config->affinity.cpuSocket >= 0) {
         setenv("VESPA_AFFINITY_CPU_SOCKET", std::to_string(_config->affinity.cpuSocket).c_str(), 1);
     }
+    if (_config->command.find("proton") != vespalib::string::npos) {
+        setenv("OMP_NUM_THREADS", "1", 1);
+    }
     // ROOT is already set
 
     // Set up file descriptor 0 (1 and 2 should be setup already)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

It seems that the java container uses open mp for something (not sure what). This tries setting the number of threads to 1 for proton only.

@arnej27959 please review and merge
@aressem @toregge @lesters FYI