### PR TITLE
Revert "Compact document meta store lid space when replay is done"

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -179,12 +179,8 @@ void
 StoreOnlyDocSubDB::onReplayDone()
 {
     _dms->constructFreeList();
-    auto stats = _dms->getLidUsageStats();
-    uint32_t docIdLimit = stats.getHighestUsedLid() + 1;
-    assert(docIdLimit <= _dms->getCommittedDocIdLimit());
-    _dms->compactLidSpace(docIdLimit);
-    _dms->unblockShrinkLidSpace();
     _dms->shrinkLidSpace();
+    uint32_t docIdLimit = _dms->getCommittedDocIdLimit();
     auto &docStore = _rSummaryMgr->getBackingStore();
     std::promise<void> promise;
     auto future = promise.get_future();


### PR DESCRIPTION
Reverts vespa-engine/vespa#14343

Observing core dumps in system tests probably related to this 
```
[Current thread is 1 (Thread 0x7f1b6f334700 (LWP 8041))]
#0  0x00007f1b76ba6387 in raise () from /lib64/libc.so.6
#1  0x00007f1b76ba7a78 in abort () from /lib64/libc.so.6
#2  0x00007f1b76b9f1a6 in __assert_fail_base () from /lib64/libc.so.6
#3  0x00007f1b76b9f252 in __assert_fail () from /lib64/libc.so.6
#4  0x00007f1b807498e6 in search::BitVectorIterator::BitVectorIterator(search::BitVector const&, unsigned int, search::fef::TermFieldMatchData&) () from /opt/vespa/lib64/libsearchlib.so
#5  0x00007f1b807499b9 in search::BitVectorIterator::create(search::BitVector const*, unsigned int, search::fef::TermFieldMatchData&, bool, bool) () from /opt/vespa/lib64/libsearchlib.so
#6  0x00000000006f18ba in proton::documentmetastore::(anonymous namespace)::WhiteListBlueprint::createLeafSearch(search::fef::TermFieldMatchDataArray const&, bool) const ()
#7  0x00007f1b8098bc57 in search::queryeval::LeafBlueprint::createSearch(search::fef::MatchData&, bool) const () from /opt/vespa/lib64/libsearchlib.so
#8  0x00007f1b8098c3c5 in search::queryeval::IntermediateBlueprint::createSearch(search::fef::MatchData&, bool) const () from /opt/vespa/lib64/libsearchlib.so
#9  0x00000000006623cc in proton::matching::Query::createSearch(search::fef::MatchData&) const ()
#10 0x00000000006993c2 in proton::matching::MatchTools::setup(std::unique_ptr<search::fef::RankProgram, std::default_delete<search::fef::RankProgram> >, double) ()
#11 0x0000000000699a81 in proton::matching::MatchTools::setup_first_phase() ()
#12 0x000000000069743c in proton::matching::MatchThread::findMatches(proton::matching::MatchTools&) ()
#13 0x0000000000697b7b in proton::matching::MatchThread::run() ()
#14 0x00007f1b7edeb9b7 in vespalib::(anonymous namespace)::PartHook::run() () from /opt/vespa/lib64/libvespalib.so
#15 0x00007f1b7edec654 in vespalib::SimpleThreadBundle::Worker::run() () from /opt/vespa/lib64/libvespalib.so
#16 0x00007f1b7edef090 in vespalib::Thread::Proxy::Run(FastOS_ThreadInterface*, void*) () from /opt/vespa/lib64/libvespalib.so
#17 0x00007f1b7eae86f5 in FastOS_ThreadInterface::Hook() () from /opt/vespa/lib64/libfastos.so
#18 0x00007f1b7eae8879 in FastOS_ThreadHook () from /opt/vespa/lib64/libfastos.so
#19 0x00007f1b82088af9 in mallocThreadProxy () from /opt/vespa/lib64/vespa/malloc/libvespamalloc.so
#20 0x00007f1b7e6aeea5 in start_thread () from /lib64/libpthread.so.0
#21 0x00007f1b76c6e8dd in clone () from /lib64/libc.so.6
```
