### PR TITLE
set env variable in the config model

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
@@ -61,6 +61,9 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
     // If this is true it will dump core when OOM
     private boolean coreOnOOM = false;
 
+    // If greater than 0, controls the number of threads used by open mp
+    private int ompNumThreads = 0;
+
     private String noVespaMalloc = "";
     private String vespaMalloc = "";
     private String vespaMallocDebug = "";
@@ -392,6 +395,8 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
     public void setMMapNoCoreLimit(long noCoreLimit) { this.mmapNoCoreLimit = noCoreLimit; }
     public boolean getCoreOnOOM() { return coreOnOOM; }
     public void setCoreOnOOM(boolean coreOnOOM) { this.coreOnOOM = coreOnOOM; }
+    public int getOmpNumThreads() { return ompNumThreads; }
+    public void setOmpNumThreads(int value) { ompNumThreads = value; }
 
     public String getNoVespaMalloc() { return noVespaMalloc; }
     public String getVespaMalloc() { return vespaMalloc; }
@@ -410,6 +415,11 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
 
     public String getCoreOnOOMEnvVariable() {
         return getCoreOnOOM() ? "" : "VESPA_SILENCE_CORE_ON_OOM=true ";
+    }
+    public String getOmpNumThreadsEnvVariable() {
+        return (getOmpNumThreads() == 0)
+            ? ""
+            : "OMP_NUM_THREADS=" + getOmpNumThreads() + " ";
     }
     public String getNoVespaMallocEnvVariable() {
         return "".equals(getNoVespaMalloc())
@@ -433,7 +443,7 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
     }
 
     public String getEnvVariables() {
-        return getCoreOnOOMEnvVariable() + getMMapNoCoreEnvVariable() + getNoVespaMallocEnvVariable() +
+        return getCoreOnOOMEnvVariable() + getOmpNumThreadsEnvVariable() + getMMapNoCoreEnvVariable() + getNoVespaMallocEnvVariable() +
                 getVespaMallocEnvVariable() + getVespaMallocDebugEnvVariable() + getVespaMallocDebugStackTraceEnvVariable();
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
@@ -125,6 +125,7 @@ public class SearchNode extends AbstractService implements
                        boolean flushOnShutdown, Optional<Tuning> tuning, Optional<ResourceLimits> resourceLimits, boolean isHostedVespa,
                        boolean combined) {
         super(parent, name);
+        setOmpNumThreads(1);
         this.isHostedVespa = isHostedVespa;
         this.combined = combined;
         this.nodeSpec = nodeSpec;
@@ -244,6 +245,9 @@ public class SearchNode extends AbstractService implements
 
     @Override
     public String getStartupCommand() {
+        if (getOmpNumThreads() != 1) {
+            throw new IllegalStateException("ompNumThreads must be 1");
+        }
         String startup = getEnvVariables() + "exec $ROOT/sbin/vespa-proton " + "--identity " + getConfigId();
         if (serviceLayerService != null) {
             startup = startup + " --serviceidentity " + serviceLayerService.getConfigId();

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
@@ -480,7 +480,7 @@ public class ContentBuilderTest extends DomBuilderTest {
             assertEquals("VESPA_USE_VESPAMALLOC_D=\"distributord\" ", n.getVespaMallocDebugEnvVariable());
             assertEquals("storaged", n.getVespaMalloc());
             assertEquals("VESPA_USE_VESPAMALLOC_DST=\"all\" ", n.getVespaMallocDebugStackTraceEnvVariable());
-            assertEquals("VESPA_SILENCE_CORE_ON_OOM=true VESPA_USE_NO_VESPAMALLOC=\"proton\" VESPA_USE_VESPAMALLOC=\"storaged\" VESPA_USE_VESPAMALLOC_D=\"distributord\" VESPA_USE_VESPAMALLOC_DST=\"all\" ", n.getEnvVariables());
+            assertEquals("VESPA_SILENCE_CORE_ON_OOM=true OMP_NUM_THREADS=1 VESPA_USE_NO_VESPAMALLOC=\"proton\" VESPA_USE_VESPAMALLOC=\"storaged\" VESPA_USE_VESPAMALLOC_D=\"distributord\" VESPA_USE_VESPAMALLOC_DST=\"all\" ", n.getEnvVariables());
         }
     }
 
@@ -509,10 +509,10 @@ public class ContentBuilderTest extends DomBuilderTest {
         assertFalse(b.getRootGroup().getVespaMallocDebugStackTrace().isPresent());
 
         assertThat(s.getSearchNodes().size(), is(4));
-        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true VESPA_USE_NO_VESPAMALLOC=\"proton\" ", s.getSearchNodes().get(0).getEnvVariables());
-        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true VESPA_USE_VESPAMALLOC_D=\"distributord\" ", s.getSearchNodes().get(1).getEnvVariables());
-        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true VESPA_USE_VESPAMALLOC_DST=\"all\" ", s.getSearchNodes().get(2).getEnvVariables());
-        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true VESPA_USE_VESPAMALLOC=\"storaged\" ", s.getSearchNodes().get(3).getEnvVariables());
+        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true OMP_NUM_THREADS=1 VESPA_USE_NO_VESPAMALLOC=\"proton\" ", s.getSearchNodes().get(0).getEnvVariables());
+        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true OMP_NUM_THREADS=1 VESPA_USE_VESPAMALLOC_D=\"distributord\" ", s.getSearchNodes().get(1).getEnvVariables());
+        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true OMP_NUM_THREADS=1 VESPA_USE_VESPAMALLOC_DST=\"all\" ", s.getSearchNodes().get(2).getEnvVariables());
+        assertEquals("VESPA_SILENCE_CORE_ON_OOM=true OMP_NUM_THREADS=1 VESPA_USE_VESPAMALLOC=\"storaged\" ", s.getSearchNodes().get(3).getEnvVariables());
     }
 
     @Test

--- a/configd/src/apps/sentinel/service.cpp
+++ b/configd/src/apps/sentinel/service.cpp
@@ -325,9 +325,6 @@ Service::runChild()
     if (_config->affinity.cpuSocket >= 0) {
         setenv("VESPA_AFFINITY_CPU_SOCKET", std::to_string(_config->affinity.cpuSocket).c_str(), 1);
     }
-    if (_config->command.find("proton") != vespalib::string::npos) {
-        setenv("OMP_NUM_THREADS", "1", 1);
-    }
     // ROOT is already set
 
     // Set up file descriptor 0 (1 and 2 should be setup already)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Set environment variable in the config model instead.

Note that we only need this until we are able to make our own onnxruntime without openmp support. Not sure if we can just remove it again or if we are stuck with it until Vespa 8 once it is part of the public api...

@baldersheim please review