### PR TITLE
Allow no argument to install_config_definitions

### DIFF
--- a/chain/CMakeLists.txt
+++ b/chain/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/config-provisioning/CMakeLists.txt
+++ b/config-provisioning/CMakeLists.txt
@@ -1,3 +1,3 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(config-provisioning)
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/container-accesslogging/CMakeLists.txt
+++ b/container-accesslogging/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/container-core/CMakeLists.txt
+++ b/container-core/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()
 
 vespa_install_script(src/main/sh/vespa-load-balancer-status libexec/vespa)

--- a/container-di/CMakeLists.txt
+++ b/container-di/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/container-disc/CMakeLists.txt
+++ b/container-disc/CMakeLists.txt
@@ -3,4 +3,4 @@ install_fat_java_artifact(container-disc)
 
 vespa_install_script(src/main/sh/vespa-start-container-daemon.sh vespa-start-container-daemon bin)
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/container-messagebus/CMakeLists.txt
+++ b/container-messagebus/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/container-search-and-docproc/CMakeLists.txt
+++ b/container-search-and-docproc/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(container-search-and-docproc)
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/container-search/CMakeLists.txt
+++ b/container-search/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/docproc/CMakeLists.txt
+++ b/docproc/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/fileacquirer/CMakeLists.txt
+++ b/fileacquirer/CMakeLists.txt
@@ -10,4 +10,4 @@ vespa_define_module(
     src/vespa/fileacquirer
 )
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/functions.cmake
+++ b/functions.cmake
@@ -652,10 +652,6 @@ function(install_config_definitions)
     install(DIRECTORY ${DEFINITIONS_DIR}/ DESTINATION share/vespa/configdefinitions FILES_MATCHING PATTERN "*.def")
 endfunction()
 
-function(install_config_definitions)
-    install(DIRECTORY ${ARGV0}/ DESTINATION share/vespa/configdefinitions FILES_MATCHING PATTERN "*.def")
-endfunction()
-
 function(install_java_artifact NAME)
     install(FILES "target/${NAME}.jar" DESTINATION lib/jars/)
 endfunction()

--- a/functions.cmake
+++ b/functions.cmake
@@ -644,6 +644,15 @@ function(install_config_definition)
 endfunction()
 
 function(install_config_definitions)
+    if(ARGC EQUAL 0)
+        set(DEFINITIONS_DIR src/main/resources/configdefinitions)
+    else()
+        set(DEFINITIONS_DIR ${ARGV0})
+    endif()
+    install(DIRECTORY ${DEFINITIONS_DIR}/ DESTINATION share/vespa/configdefinitions FILES_MATCHING PATTERN "*.def")
+endfunction()
+
+function(install_config_definitions)
     install(DIRECTORY ${ARGV0}/ DESTINATION share/vespa/configdefinitions FILES_MATCHING PATTERN "*.def")
 endfunction()
 

--- a/jdisc-security-filters/CMakeLists.txt
+++ b/jdisc-security-filters/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(jdisc-security-filters)
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/jdisc_http_service/CMakeLists.txt
+++ b/jdisc_http_service/CMakeLists.txt
@@ -2,4 +2,4 @@
 install_fat_java_artifact(jdisc_http_service)
 install_java_artifact_dependencies(jdisc_http_service)
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/linguistics/CMakeLists.txt
+++ b/linguistics/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/metrics-proxy/CMakeLists.txt
+++ b/metrics-proxy/CMakeLists.txt
@@ -4,4 +4,4 @@ install_fat_java_artifact(metrics-proxy)
 vespa_install_script(src/main/sh/start-telegraf.sh libexec/vespa)
 vespa_install_script(src/main/sh/stop-telegraf.sh libexec/vespa)
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/simplemetrics/CMakeLists.txt
+++ b/simplemetrics/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(simplemetrics)
 
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/statistics/CMakeLists.txt
+++ b/statistics/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/vespa-osgi-testrunner/CMakeLists.txt
+++ b/vespa-osgi-testrunner/CMakeLists.txt
@@ -1,3 +1,3 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(vespa-osgi-testrunner)
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/vespa-testrunner-components/CMakeLists.txt
+++ b/vespa-testrunner-components/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_java_artifact(vespa-testrunner-components)
 install_fat_java_artifact(vespa-testrunner-components)
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()

--- a/vespaclient-core/CMakeLists.txt
+++ b/vespaclient-core/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_config_definitions(src/main/resources/configdefinitions)
+install_config_definitions()


### PR DESCRIPTION
Use src/main/resources/configdefinitions as default when no argument
is given
