### PR TITLE
Make RPC compression configurable and use better defaults

### DIFF
--- a/storage/src/tests/storageserver/rpc/storage_api_rpc_service_test.cpp
+++ b/storage/src/tests/storageserver/rpc/storage_api_rpc_service_test.cpp
@@ -122,7 +122,8 @@ public:
         _shared_rpc_resources = std::make_unique<SharedRpcResources>(_config.getConfigId(), 0, 1);
         // TODO make codec provider into interface so we can test decode-failures more easily?
         _codec_provider = std::make_unique<MessageCodecProvider>(_doc_type_repo, _load_type_set);
-        _service = std::make_unique<StorageApiRpcService>(_messages, *_shared_rpc_resources, *_codec_provider);
+        StorageApiRpcService::Params params;
+        _service = std::make_unique<StorageApiRpcService>(_messages, *_shared_rpc_resources, *_codec_provider, params);
 
         _shared_rpc_resources->start_server_and_register_slobrok(_slobrok_id);
         // Explicitly wait until we are visible in Slobrok. Just waiting for mirror readiness is not enough.

--- a/storage/src/vespa/storage/config/stor-communicationmanager.def
+++ b/storage/src/vespa/storage/config/stor-communicationmanager.def
@@ -62,3 +62,12 @@ use_direct_storageapi_rpc bool default=false
 
 ## The number of network (FNET) threads used by the shared rpc resource.
 rpc.num_network_threads int default=1
+
+# Minimum size of packets to compress (0 means no compression)
+rpc.compress.limit int default=1024
+
+## Compression level for packets
+rpc.compress.level int default=3
+
+## Compression type for packets.
+rpc.compress.type enum {NONE, LZ4, ZSTD} default=LZ4

--- a/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
+++ b/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
@@ -6,6 +6,7 @@
 #include <vespa/fnet/frt/invoker.h>
 #include <vespa/storageapi/messageapi/returncode.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/compressionconfig.h>
 #include <atomic>
 #include <memory>
 
@@ -33,14 +34,24 @@ class MessageCodecProvider;
 class SharedRpcResources;
 
 class StorageApiRpcService : public FRT_Invokable, public FRT_IRequestWait {
+public:
+    struct Params {
+        vespalib::compression::CompressionConfig compression_config;
+
+        Params();
+        ~Params();
+    };
+private:
     MessageDispatcher&    _message_dispatcher;
     SharedRpcResources&   _rpc_resources;
     MessageCodecProvider& _message_codec_provider;
+    const Params          _params;
     std::unique_ptr<CachingRpcTargetResolver> _target_resolver;
 public:
     StorageApiRpcService(MessageDispatcher& message_dispatcher,
                          SharedRpcResources& rpc_resources,
-                         MessageCodecProvider& message_codec_provider);
+                         MessageCodecProvider& message_codec_provider,
+                         const Params& params);
     ~StorageApiRpcService() override;
 
     void RPC_rpc_v1_send(FRT_RPCRequest* req);


### PR DESCRIPTION
@geirst please review

Introduces a dedicated RPC compression sub-config. Default values are the same as for MessageBus compression.