### PR TITLE
Expose orchestratorStatus from node repo

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeFilter;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.orchestrator.status.HostInfo;
+import com.yahoo.vespa.orchestrator.status.HostStatus;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -164,6 +165,10 @@ class NodesResponse extends HttpResponse {
             orchestrator.apply(new HostName(node.hostname()))
                         .ifPresent(info -> {
                             object.setBool("allowedToBeDown", info.status().isSuspended());
+                            // TODO: Remove allowedToBeDown as a special-case of orchestratorHostStatus
+                            if (info.status() != HostStatus.NO_REMARKS) {
+                                object.setString("orchestratorStatus", info.status().asString());
+                            }
                             info.suspendedSince().ifPresent(since -> object.setLong("suspendedSinceMillis", since.toEpochMilli()));
                         });
         });

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
@@ -28,6 +28,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":1.0, "memoryGb":4.0, "diskGb":100.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": true,
+  "orchestratorStatus": "ALLOWED_TO_BE_DOWN",
   "suspendedSinceMillis": 0,
   "rebootGeneration": 3,
   "currentRebootGeneration": 1,


### PR DESCRIPTION
To reduce the node JSON, the orchestratorStatus field will be set only if
suspended, with value either ALLOWED_TO_BE_DOWN or PERMANENTLY_DOWN.