### PR TITLE
Remove stale stop command for config server

### DIFF
--- a/configserver/src/main/sh/stop-configserver
+++ b/configserver/src/main/sh/stop-configserver
@@ -97,9 +97,3 @@ fi
 
 # Try shutting down this way in case of upgrade. Can be removed in later versions.
 vespa-run-as-vespa-user vespa-runserver -s configserver -p $PIDFILE_CONFIGSERVER -S
-
-if [ -e "$PIDFILE_CONFIGSERVER" ]; then
-    export UNPRIVILEGED=1
-    export PID_FILE=$PIDFILE_CONFIGSERVER
-    exec vespa-run-as-vespa-user ${ROOT}/bin/jdisc_container_stop
-fi

--- a/configserver/src/main/sh/stop-configserver
+++ b/configserver/src/main/sh/stop-configserver
@@ -95,5 +95,4 @@ if [ "$cloudconfig_server__multitenant" = "true" ] || [ "$VESPA_CONFIGSERVER_MUL
     vespa-run-as-vespa-user vespa-runserver -s logd -p $PIDFILE_LOGD -S
 fi
 
-# Try shutting down this way in case of upgrade. Can be removed in later versions.
 vespa-run-as-vespa-user vespa-runserver -s configserver -p $PIDFILE_CONFIGSERVER -S


### PR DESCRIPTION
config server is started with `vespa-runserver`, so should be stopped by same command as well. Removed code seems to be leftover from a long time ago.