### PR TITLE
30s down-moratorium before allowing suspension

### DIFF
--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ApplicationInstanceId.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ApplicationInstanceId.java
@@ -12,6 +12,10 @@ import java.util.Objects;
 public class ApplicationInstanceId {
     public static final ApplicationInstanceId CONFIG_SERVER = new ApplicationInstanceId("zone-config-servers");
     public static final ApplicationInstanceId CONTROLLER = new ApplicationInstanceId("controller");
+    // Unfortunately, for config server host the ApplicationInstanceId is: configserver-host:prod:cd-us-central-1:default
+    public boolean isConfigServerHost() { return id.startsWith("configserver-host:"); }
+    public static final ApplicationInstanceId CONTROLLER_HOST = new ApplicationInstanceId("controller-host:prod:default:default");
+    public boolean isTenantHost() { return id.startsWith("tenant-host:"); }
 
     private final String id;
 

--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ApplicationInstanceReference.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ApplicationInstanceReference.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * @author bjorncs
  */
 // TODO: Remove this and use ApplicationId instead (if you need it for the JSON stuff move it to that layer and don't let it leak)
-public class ApplicationInstanceReference {
+public class ApplicationInstanceReference implements Comparable<ApplicationInstanceReference> {
 
     private final TenantId tenantId;
     private final ApplicationInstanceId applicationInstanceId;
@@ -40,6 +40,11 @@ public class ApplicationInstanceReference {
 
     public String asString() {
         return tenantId.s() + ":" + applicationInstanceId.s();
+    }
+
+    @Override
+    public int compareTo(ApplicationInstanceReference o) {
+        return this.asString().compareTo(o.asString());
     }
 
     @Override

--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ClusterId.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ClusterId.java
@@ -12,6 +12,9 @@ public class ClusterId {
 
     public static final ClusterId CONFIG_SERVER = new ClusterId("zone-config-servers");
     public static final ClusterId CONTROLLER = new ClusterId("controller");
+    public static final ClusterId CONFIG_SERVER_HOST = new ClusterId("configserver-host");
+    public static final ClusterId CONTROLLER_HOST = new ClusterId("configserver-host");
+    public static final ClusterId TENANT_HOST = new ClusterId("tenant-host");
 
     private final String id;
 

--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ClusterId.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ClusterId.java
@@ -13,7 +13,7 @@ public class ClusterId {
     public static final ClusterId CONFIG_SERVER = new ClusterId("zone-config-servers");
     public static final ClusterId CONTROLLER = new ClusterId("controller");
     public static final ClusterId CONFIG_SERVER_HOST = new ClusterId("configserver-host");
-    public static final ClusterId CONTROLLER_HOST = new ClusterId("configserver-host");
+    public static final ClusterId CONTROLLER_HOST = new ClusterId("controller-host");
     public static final ClusterId TENANT_HOST = new ClusterId("tenant-host");
 
     private final String id;

--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ServiceInstance.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ServiceInstance.java
@@ -66,6 +66,27 @@ public class ServiceInstance {
                 '}';
     }
 
+    /**
+     * Get a name that can be used in e.g. config server logs that makes it easy to understand which
+     * service instance this is.
+     */
+    public String descriptiveName() {
+        if (getServiceCluster().isController() || getServiceCluster().isConfigServer()) {
+            return getHostnamePrefix();
+        } else if (getServiceCluster().isControllerHost() || getServiceCluster().isConfigServerHost()) {
+            return "host-admin on " + getHostnamePrefix();
+        } else if (getServiceCluster().isTenantHost()) {
+            return "host-admin on " + hostName.s();
+        } else {
+            return configId.s();
+        }
+    }
+
+    private String getHostnamePrefix() {
+        int dotIndex = hostName.s().indexOf('.');
+        return dotIndex == -1 ? hostName().s() : hostName.s().substring(0, dotIndex);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestratorImpl.java
@@ -29,6 +29,7 @@ import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostedVespaClusterPolicy;
 import com.yahoo.vespa.orchestrator.policy.HostedVespaPolicy;
 import com.yahoo.vespa.orchestrator.policy.Policy;
+import com.yahoo.vespa.orchestrator.policy.SuspensionReasons;
 import com.yahoo.vespa.orchestrator.status.ApplicationInstanceStatus;
 import com.yahoo.vespa.orchestrator.status.ApplicationLock;
 import com.yahoo.vespa.orchestrator.status.HostInfo;
@@ -76,13 +77,13 @@ public class OrchestratorImpl implements Orchestrator {
     {
         this(new HostedVespaPolicy(new HostedVespaClusterPolicy(),
                                    clusterControllerClientFactory,
-                                   new ApplicationApiFactory(configServerConfig.zookeeperserver().size())),
+                                   new ApplicationApiFactory(configServerConfig.zookeeperserver().size(), Clock.systemUTC())),
                 clusterControllerClientFactory,
                 statusService,
                 serviceMonitor,
                 orchestratorConfig.serviceMonitorConvergenceLatencySeconds(),
                 Clock.systemUTC(),
-                new ApplicationApiFactory(configServerConfig.zookeeperserver().size()),
+                new ApplicationApiFactory(configServerConfig.zookeeperserver().size(), Clock.systemUTC()),
                 flagSource);
     }
 
@@ -227,6 +228,7 @@ public class OrchestratorImpl implements Orchestrator {
     void suspendGroup(OrchestratorContext context, NodeGroup nodeGroup) throws HostStateChangeDeniedException {
         ApplicationInstanceReference applicationReference = nodeGroup.getApplicationReference();
 
+        final SuspensionReasons suspensionReasons;
         try (ApplicationLock lock = statusService.lockApplication(context, applicationReference)) {
             ApplicationInstanceStatus appStatus = lock.getApplicationInstanceStatus();
             if (appStatus == ApplicationInstanceStatus.ALLOWED_TO_BE_DOWN) {
@@ -235,8 +237,10 @@ public class OrchestratorImpl implements Orchestrator {
 
             ApplicationApi applicationApi = applicationApiFactory.create(
                     nodeGroup, lock, clusterControllerClientFactory);
-            policy.grantSuspensionRequest(context.createSubcontextWithinLock(), applicationApi);
+            suspensionReasons = policy.grantSuspensionRequest(context.createSubcontextWithinLock(), applicationApi);
         }
+
+        suspensionReasons.makeLogMessage().ifPresent(log::info);
     }
 
     @Override

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ApplicationApiFactory.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ApplicationApiFactory.java
@@ -4,21 +4,26 @@ package com.yahoo.vespa.orchestrator.model;
 import com.yahoo.vespa.orchestrator.controller.ClusterControllerClientFactory;
 import com.yahoo.vespa.orchestrator.status.ApplicationLock;
 
+import java.time.Clock;
+
 /**
  * @author mpolden
  */
 public class ApplicationApiFactory {
 
     private final int numberOfConfigServers;
+    private final Clock clock;
 
-    public ApplicationApiFactory(int numberOfConfigServers) {
+    public ApplicationApiFactory(int numberOfConfigServers, Clock clock) {
         this.numberOfConfigServers = numberOfConfigServers;
+        this.clock = clock;
     }
 
     public ApplicationApi create(NodeGroup nodeGroup,
                                  ApplicationLock lock,
                                  ClusterControllerClientFactory clusterControllerClientFactory) {
-        return new ApplicationApiImpl(nodeGroup, lock, clusterControllerClientFactory, numberOfConfigServers);
+        return new ApplicationApiImpl(nodeGroup, lock, clusterControllerClientFactory,
+                numberOfConfigServers, clock);
     }
 
 }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ApplicationApiImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ApplicationApiImpl.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.orchestrator.status.HostInfos;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 import com.yahoo.vespa.orchestrator.status.ApplicationLock;
 
+import java.time.Clock;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -33,16 +34,18 @@ public class ApplicationApiImpl implements ApplicationApi {
     private final ApplicationInstance applicationInstance;
     private final NodeGroup nodeGroup;
     private final ApplicationLock lock;
+    private final Clock clock;
     private final List<ClusterApi> clusterInOrder;
     private final HostInfos hostInfos;
 
     public ApplicationApiImpl(NodeGroup nodeGroup,
                               ApplicationLock lock,
                               ClusterControllerClientFactory clusterControllerClientFactory,
-                              int numberOfConfigServers) {
+                              int numberOfConfigServers, Clock clock) {
         this.applicationInstance = nodeGroup.getApplication();
         this.nodeGroup = nodeGroup;
         this.lock = lock;
+        this.clock = clock;
         Collection<HostName> hosts = getHostsUsedByApplicationInstance(applicationInstance);
         this.hostInfos = lock.getHostInfos();
         this.clusterInOrder = makeClustersInOrder(nodeGroup, hostInfos, clusterControllerClientFactory, numberOfConfigServers);
@@ -122,7 +125,8 @@ public class ApplicationApiImpl implements ApplicationApi {
                         nodeGroup,
                         hostInfos,
                         clusterControllerClientFactory,
-                        numberOfConfigServers))
+                        numberOfConfigServers,
+                        clock))
                 .sorted(ApplicationApiImpl::compareClusters)
                 .collect(Collectors.toList());
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ClusterApi.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ClusterApi.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.orchestrator.model;
 
 import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ServiceType;
+import com.yahoo.vespa.orchestrator.policy.SuspensionReasons;
 
 import java.util.Optional;
 
@@ -17,7 +18,8 @@ public interface ClusterApi {
     ServiceType serviceType();
     boolean isStorageCluster();
 
-    boolean noServicesInGroupIsUp();
+    /** Returns the reasons no services are up in the implied group, or empty if some services are up. */
+    Optional<SuspensionReasons> reasonsForNoServicesInGroupIsUp();
     boolean noServicesOutsideGroupIsDown();
 
     int percentageOfServicesDown();

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/ClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/ClusterPolicy.java
@@ -8,8 +8,10 @@ public interface ClusterPolicy {
      * There's an implicit group of nodes known to clusterApi.  This method answers whether
      * it would be fine, just looking at this cluster (and disregarding Cluster Controller/storage
      * which is handled separately), to allow all services on all the nodes in the group to go down.
+     *
+     * @return notable reasons for why this group is fine with going down.
      */
-    void verifyGroupGoingDownIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException;
+    SuspensionReasons verifyGroupGoingDownIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException;
 
     /**
      * There's an implicit group of nodes known to clusterApi.  This method answers whether

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -4,23 +4,26 @@ package com.yahoo.vespa.orchestrator.policy;
 import com.yahoo.vespa.orchestrator.model.ClusterApi;
 import com.yahoo.vespa.orchestrator.model.VespaModelUtil;
 
+import java.util.Optional;
+
 import static com.yahoo.vespa.orchestrator.policy.HostedVespaPolicy.ENOUGH_SERVICES_UP_CONSTRAINT;
 
 public class HostedVespaClusterPolicy implements ClusterPolicy {
 
     @Override
-    public void verifyGroupGoingDownIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException {
+    public SuspensionReasons verifyGroupGoingDownIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException {
         if (clusterApi.noServicesOutsideGroupIsDown()) {
-            return;
-        }
-
-        if (clusterApi.noServicesInGroupIsUp()) {
-            return;
+            return SuspensionReasons.nothingNoteworthy();
         }
 
         int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi).asPercentage();
         if (clusterApi.percentageOfServicesDownIfGroupIsAllowedToBeDown() <= percentageOfServicesAllowedToBeDown) {
-            return;
+            return SuspensionReasons.nothingNoteworthy();
+        }
+
+        Optional<SuspensionReasons> suspensionReasons = clusterApi.reasonsForNoServicesInGroupIsUp();
+        if (suspensionReasons.isPresent()) {
+            return suspensionReasons.get();
         }
 
         throw new HostStateChangeDeniedException(
@@ -34,7 +37,8 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
     }
 
     @Override
-    public void verifyGroupGoingDownPermanentlyIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException {
+    public void verifyGroupGoingDownPermanentlyIsFine(ClusterApi clusterApi)
+            throws HostStateChangeDeniedException {
         // This policy is similar to verifyGroupGoingDownIsFine, except that services being down in the group
         // is no excuse to allow suspension (like it is for verifyGroupGoingDownIsFine), since if we grant
         // suspension in this case they will permanently be down/removed.

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicy.java
@@ -39,11 +39,13 @@ public class HostedVespaPolicy implements Policy {
     }
 
     @Override
-    public void grantSuspensionRequest(OrchestratorContext context, ApplicationApi application)
+    public SuspensionReasons grantSuspensionRequest(OrchestratorContext context, ApplicationApi application)
             throws HostStateChangeDeniedException {
+        var suspensionReasons = new SuspensionReasons();
+
         // Apply per-cluster policy
         for (ClusterApi cluster : application.getClusters()) {
-            clusterPolicy.verifyGroupGoingDownIsFine(cluster);
+            suspensionReasons.mergeWith(clusterPolicy.verifyGroupGoingDownIsFine(cluster));
         }
 
         // Ask Cluster Controller to set UP storage nodes in maintenance.
@@ -56,6 +58,8 @@ public class HostedVespaPolicy implements Policy {
         for (HostName hostName : application.getNodesInGroupWithStatus(HostStatus.NO_REMARKS)) {
             application.setHostState(context, hostName, HostStatus.ALLOWED_TO_BE_DOWN);
         }
+
+        return suspensionReasons;
     }
 
     @Override

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/Policy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/Policy.java
@@ -15,7 +15,7 @@ public interface Policy {
     /**
      * Decide whether to grant a request for temporarily suspending the services on all hosts in the group.
      */
-    void grantSuspensionRequest(OrchestratorContext context, ApplicationApi applicationApi) throws HostStateChangeDeniedException;
+    SuspensionReasons grantSuspensionRequest(OrchestratorContext context, ApplicationApi applicationApi) throws HostStateChangeDeniedException;
 
     void releaseSuspensionGrant(OrchestratorContext context, ApplicationApi application) throws HostStateChangeDeniedException;
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/SuspensionReasons.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/SuspensionReasons.java
@@ -1,0 +1,83 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.orchestrator.policy;
+
+import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.applicationmodel.ServiceInstance;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Information worth logging when/if suspending a host.
+ *
+ * @author hakon
+ */
+public class SuspensionReasons {
+    private final Map<HostName, List<String>> reasons = new HashMap<>();
+
+    public static SuspensionReasons nothingNoteworthy() { return new SuspensionReasons(); }
+    public static SuspensionReasons isDown(ServiceInstance service) {
+        return new SuspensionReasons().addReason(
+                service.hostName(),
+                service.descriptiveName() + " is down");
+    }
+
+    public static SuspensionReasons downSince(ServiceInstance service, Instant instant, Duration downDuration) {
+        return new SuspensionReasons().addReason(
+                service.hostName(),
+                service.descriptiveName() + " has been down since " +
+                        // Round to whole second
+                        Instant.ofEpochSecond(instant.getEpochSecond()).toString() +
+                        " (" + downDuration.getSeconds() + " seconds)");
+    }
+
+    public SuspensionReasons() {}
+
+    /** An ordered list of all messages, typically useful for testing. */
+    public List<String> getMessagesInOrder() {
+        return reasons.values().stream().flatMap(Collection::stream).sorted().collect(Collectors.toList());
+    }
+
+    public SuspensionReasons mergeWith(SuspensionReasons that) {
+        for (var entry : that.reasons.entrySet()) {
+            for (var reason : entry.getValue()) {
+                addReason(entry.getKey(), reason);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Makes a log message, if there is anything worth logging about the decision to allow suspension,
+     * that can be directly fed to {@link java.util.logging.Logger#info(String) Logger.info(String)}.
+     */
+    public Optional<String> makeLogMessage() {
+        if (reasons.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(reasons.entrySet().stream()
+                .map(entry -> entry.getKey().s() + " suspended because " + String.join(", ", entry.getValue()))
+                .sorted()
+                .collect(Collectors.joining("; ")));
+    }
+
+    /** Package-private for testing. */
+    SuspensionReasons addReason(HostName hostname, String message) {
+        reasons.computeIfAbsent(hostname, h -> new ArrayList<>()).add(message);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return makeLogMessage().orElse("");
+    }
+}

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/OrchestratorImplTest.java
@@ -26,6 +26,7 @@ import com.yahoo.vespa.orchestrator.policy.BatchHostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostedVespaClusterPolicy;
 import com.yahoo.vespa.orchestrator.policy.HostedVespaPolicy;
+import com.yahoo.vespa.orchestrator.policy.SuspensionReasons;
 import com.yahoo.vespa.orchestrator.status.ApplicationLock;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 import com.yahoo.vespa.orchestrator.status.StatusService;
@@ -73,7 +74,8 @@ import static org.mockito.internal.verification.VerificationModeFactory.atLeastO
  */
 public class OrchestratorImplTest {
 
-    private final ApplicationApiFactory applicationApiFactory = new ApplicationApiFactory(3);
+    private final ManualClock clock = new ManualClock();
+    private final ApplicationApiFactory applicationApiFactory = new ApplicationApiFactory(3, clock);
     private final InMemoryFlagSource flagSource = new InMemoryFlagSource();
     private final MockCurator curator = new MockCurator();
     private ZkStatusService statusService = new ZkStatusService(
@@ -344,6 +346,7 @@ public class OrchestratorImplTest {
         var applicationApiFactory = mock(ApplicationApiFactory.class);
         var lock = mock(ApplicationLock.class);
 
+        when(policy.grantSuspensionRequest(any(), any())).thenReturn(SuspensionReasons.nothingNoteworthy());
         when(serviceMonitor.getApplication(any(HostName.class))).thenReturn(Optional.of(applicationInstance));
         when(applicationInstance.reference()).thenReturn(applicationInstanceReference);
         when(zookeeperStatusService.lockApplication(any(), any())).thenReturn(lock);

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.model;
 
+import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.applicationmodel.ApplicationInstance;
 import com.yahoo.vespa.applicationmodel.ApplicationInstanceId;
 import com.yahoo.vespa.applicationmodel.ClusterId;
@@ -8,15 +9,19 @@ import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.applicationmodel.ServiceCluster;
 import com.yahoo.vespa.applicationmodel.ServiceInstance;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
+import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.applicationmodel.TenantId;
 import com.yahoo.vespa.orchestrator.OrchestratorUtil;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostedVespaClusterPolicy;
+import com.yahoo.vespa.orchestrator.policy.SuspensionReasons;
 import com.yahoo.vespa.orchestrator.status.HostInfos;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 import org.junit.Test;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +48,7 @@ public class ClusterApiImplTest {
 
     private final ApplicationApi applicationApi = mock(ApplicationApi.class);
     private final ModelTestUtils modelUtils = new ModelTestUtils();
+    private final ManualClock clock = new ManualClock(Instant.ofEpochSecond(1600436659));
 
     @Test
     public void testServicesDownAndNotInGroup() {
@@ -76,7 +82,7 @@ public class ClusterApiImplTest {
                 serviceCluster,
                 new NodeGroup(modelUtils.createApplicationInstance(new ArrayList<>()), hostName5),
                 modelUtils.getHostInfos(),
-                modelUtils.getClusterControllerClientFactory(), ModelTestUtils.NUMBER_OF_CONFIG_SERVERS);
+                modelUtils.getClusterControllerClientFactory(), ModelTestUtils.NUMBER_OF_CONFIG_SERVERS, clock);
 
         assertEquals("{ clusterId=cluster, serviceType=service-type }", clusterApi.clusterInfo());
         assertFalse(clusterApi.isStorageCluster());
@@ -139,16 +145,30 @@ public class ClusterApiImplTest {
         HostName hostName3 = new HostName("host3");
         HostName hostName4 = new HostName("host4");
         HostName hostName5 = new HostName("host5");
+        HostName hostName6 = new HostName("host6");
+
+        ServiceInstance service2 = modelUtils.createServiceInstance("service-2", hostName2, ServiceStatus.DOWN);
+
+        // Within down moratorium
+        Instant downSince5 = clock.instant().minus(ClusterApiImpl.downMoratorium).plus(Duration.ofSeconds(5));
+        ServiceInstance service5 = modelUtils.createServiceInstance("service-5", hostName5,
+                new ServiceStatusInfo(ServiceStatus.DOWN, downSince5, downSince5, Optional.empty(), Optional.empty()));
+
+        // After down moratorium
+        Instant downSince6 = clock.instant().minus(ClusterApiImpl.downMoratorium).minus(Duration.ofSeconds(5));
+        ServiceInstance service6 = modelUtils.createServiceInstance("service-6", hostName6,
+                new ServiceStatusInfo(ServiceStatus.DOWN, downSince6, downSince6, Optional.empty(), Optional.empty()));
 
         ServiceCluster serviceCluster = modelUtils.createServiceCluster(
                 "cluster",
                 new ServiceType("service-type"),
                 Arrays.asList(
                         modelUtils.createServiceInstance("service-1", hostName1, ServiceStatus.UP),
-                        modelUtils.createServiceInstance("service-2", hostName2, ServiceStatus.DOWN),
+                        service2,
                         modelUtils.createServiceInstance("service-3", hostName3, ServiceStatus.UP),
                         modelUtils.createServiceInstance("service-4", hostName4, ServiceStatus.DOWN),
-                        modelUtils.createServiceInstance("service-5", hostName5, ServiceStatus.UP)
+                        service5,
+                        service6
                 )
         );
         modelUtils.createApplicationInstance(Collections.singletonList(serviceCluster));
@@ -158,21 +178,33 @@ public class ClusterApiImplTest {
         modelUtils.createNode(hostName3, HostStatus.ALLOWED_TO_BE_DOWN);
         modelUtils.createNode(hostName4, HostStatus.ALLOWED_TO_BE_DOWN);
         modelUtils.createNode(hostName5, HostStatus.NO_REMARKS);
+        modelUtils.createNode(hostName6, HostStatus.NO_REMARKS);
 
-        verifyNoServices(serviceCluster, false, false, hostName1);
-        verifyNoServices(serviceCluster, true, false, hostName2);
-        verifyNoServices(serviceCluster, true, false, hostName3);
-        verifyNoServices(serviceCluster, true, false, hostName4);
-        verifyNoServices(serviceCluster, false, false, hostName5);
+        var reason2 = SuspensionReasons.isDown(service2);
+        var reason6 = SuspensionReasons.downSince(service6, downSince6, Duration.ofSeconds(35));
+        var reasons2and6 = new SuspensionReasons().mergeWith(reason2).mergeWith(reason6);
 
-        verifyNoServices(serviceCluster, false, false, hostName1, hostName2);
-        verifyNoServices(serviceCluster, true, false, hostName2, hostName3);
-        verifyNoServices(serviceCluster, true, true, hostName2, hostName3, hostName4);
-        verifyNoServices(serviceCluster, false, true, hostName1, hostName2, hostName3, hostName4);
+        verifyNoServices(serviceCluster, Optional.empty(), false, hostName1);
+        verifyNoServices(serviceCluster, Optional.of(reason2), false, hostName2);
+        verifyNoServices(serviceCluster, Optional.of(SuspensionReasons.nothingNoteworthy()), false, hostName3);
+        verifyNoServices(serviceCluster, Optional.of(SuspensionReasons.nothingNoteworthy()), false, hostName4);
+        verifyNoServices(serviceCluster, Optional.empty(), false, hostName5);
+        verifyNoServices(serviceCluster, Optional.of(reason6), false, hostName6);
+
+        verifyNoServices(serviceCluster, Optional.empty(), false, hostName1, hostName2);
+        verifyNoServices(serviceCluster, Optional.of(reasons2and6), false, hostName2, hostName3, hostName6);
+        verifyNoServices(serviceCluster, Optional.of(reasons2and6), false,
+                hostName2, hostName3, hostName4, hostName6);
+        verifyNoServices(serviceCluster, Optional.empty(), true,
+                hostName2, hostName3, hostName4, hostName5, hostName6);
+        verifyNoServices(serviceCluster, Optional.empty(), false,
+                hostName1, hostName2, hostName3, hostName4, hostName6);
+        verifyNoServices(serviceCluster, Optional.empty(), true,
+                hostName1, hostName2, hostName3, hostName4, hostName5, hostName6);
     }
 
     private void verifyNoServices(ServiceCluster serviceCluster,
-                                  boolean expectedNoServicesInGroupIsUp,
+                                  Optional<SuspensionReasons> expectedNoServicesInGroupIsUp,
                                   boolean expectedNoServicesOutsideGroupIsDown,
                                   HostName... groupNodes) {
         ClusterApiImpl clusterApi = new ClusterApiImpl(
@@ -180,9 +212,10 @@ public class ClusterApiImplTest {
                 serviceCluster,
                 new NodeGroup(modelUtils.createApplicationInstance(new ArrayList<>()), groupNodes),
                 modelUtils.getHostInfos(),
-                modelUtils.getClusterControllerClientFactory(), ModelTestUtils.NUMBER_OF_CONFIG_SERVERS);
+                modelUtils.getClusterControllerClientFactory(), ModelTestUtils.NUMBER_OF_CONFIG_SERVERS, clock);
 
-        assertEquals(expectedNoServicesInGroupIsUp, clusterApi.noServicesInGroupIsUp());
+        assertEquals(expectedNoServicesInGroupIsUp.map(SuspensionReasons::getMessagesInOrder),
+                     clusterApi.reasonsForNoServicesInGroupIsUp().map(SuspensionReasons::getMessagesInOrder));
         assertEquals(expectedNoServicesOutsideGroupIsDown, clusterApi.noServicesOutsideGroupIsDown());
     }
 
@@ -210,7 +243,7 @@ public class ClusterApiImplTest {
                 serviceCluster,
                 new NodeGroup(applicationInstance, hostName1, hostName3),
                 new HostInfos(),
-                modelUtils.getClusterControllerClientFactory(), ModelTestUtils.NUMBER_OF_CONFIG_SERVERS);
+                modelUtils.getClusterControllerClientFactory(), ModelTestUtils.NUMBER_OF_CONFIG_SERVERS, clock);
 
         assertTrue(clusterApi.isStorageCluster());
         assertEquals(Optional.of(hostName1), clusterApi.storageNodeInGroup().map(storageNode -> storageNode.hostName()));
@@ -233,6 +266,9 @@ public class ClusterApiImplTest {
                 ServiceType.CONFIG_SERVER,
                 instances
         );
+        for (var instance : instances) {
+            instance.setServiceCluster(serviceCluster);
+        }
 
         Set<ServiceCluster> serviceClusterSet = Set.of(serviceCluster);
 
@@ -250,7 +286,7 @@ public class ClusterApiImplTest {
                 serviceCluster,
                 new NodeGroup(application, hostnames.get(0)),
                 modelUtils.getHostInfos(),
-                modelUtils.getClusterControllerClientFactory(), clusterSize);
+                modelUtils.getClusterControllerClientFactory(), clusterSize, clock);
 
         assertEquals(clusterSize - serviceStatusList.size(), clusterApi.missingServices());
         assertEquals(clusterSize == serviceStatusList.size(), clusterApi.noServicesOutsideGroupIsDown());

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicyTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/HostedVespaPolicyTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.orchestrator.policy;
 
 
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.orchestrator.OrchestrationException;
 import com.yahoo.vespa.orchestrator.OrchestratorContext;
@@ -34,7 +35,8 @@ public class HostedVespaPolicyTest {
 
     private final ClusterControllerClientFactory clientFactory = mock(ClusterControllerClientFactory.class);
     private final ClusterControllerClient client = mock(ClusterControllerClient.class);
-    private final ApplicationApiFactory applicationApiFactory = new ApplicationApiFactory(3);
+    private final ManualClock clock = new ManualClock();
+    private final ApplicationApiFactory applicationApiFactory = new ApplicationApiFactory(3, clock);
 
     @Before
     public void setUp() {
@@ -44,6 +46,7 @@ public class HostedVespaPolicyTest {
     @Test
     public void testGrantSuspension() throws HostStateChangeDeniedException {
         final HostedVespaClusterPolicy clusterPolicy = mock(HostedVespaClusterPolicy.class);
+        when(clusterPolicy.verifyGroupGoingDownIsFine(any())).thenReturn(SuspensionReasons.nothingNoteworthy());
         final HostedVespaPolicy policy = new HostedVespaPolicy(clusterPolicy, clientFactory, applicationApiFactory);
         final ApplicationApi applicationApi = mock(ApplicationApi.class);
         when(applicationApi.applicationId()).thenReturn(ApplicationId.fromSerializedForm("tenant:app:default"));

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/SuspensionReasonsTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/policy/SuspensionReasonsTest.java
@@ -1,0 +1,40 @@
+package com.yahoo.vespa.orchestrator.policy;// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+import com.yahoo.test.ManualClock;
+import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.applicationmodel.ServiceInstance;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SuspensionReasonsTest {
+    private final ManualClock clock = new ManualClock(Instant.ofEpochMilli(1600440708123L));
+    private final ServiceInstance service = mock(ServiceInstance.class);
+    private final ServiceInstance service2 = mock(ServiceInstance.class);
+
+    @Test
+    public void test() {
+        assertEquals(Optional.empty(), new SuspensionReasons().makeLogMessage());
+        assertEquals(Optional.empty(), SuspensionReasons.nothingNoteworthy().makeLogMessage());
+
+        when(service.hostName()).thenReturn(new HostName("host1"));
+        when(service.descriptiveName()).thenReturn("service1");
+        when(service2.hostName()).thenReturn(new HostName("host2"));
+        when(service2.descriptiveName()).thenReturn("service2");
+
+        var reasons = SuspensionReasons.downSince(service, clock.instant(), Duration.ofSeconds(30));
+        reasons.mergeWith(SuspensionReasons.isDown(service2));
+        assertEquals(Optional.of(
+                "host1 suspended because service1 has been down since 2020-09-18T14:51:48Z (30 seconds); " +
+                "host2 suspended because service2 is down"),
+                reasons.makeLogMessage());
+
+    }
+
+}


### PR DESCRIPTION
If all services of a node are down, we used allow suspension.  If those services are monitored with /state/v1/health, we have the timestamp the service became unhealthy - the "since" timestamp.  Now we will require the services to have been down for at least 30s before allowing suspension based on unhealthiness.

Also, for config servers only, we will log all healthiness transitions to track down some orchestrator issues.