### PR TITLE
Don't log failed requests as info

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
@@ -104,8 +104,7 @@ class HealthCheckProxyHandler extends HandlerWrapper {
                     }
                 } catch (Exception e) { // Typically timeouts which are reported as SSLHandshakeException
                     String message = String.format("Health check request from port %d to %d failed: %s", localPort, proxyTarget.port, e.getMessage());
-                    log.log(Level.INFO, message);
-                    log.log(Level.FINE, e.toString(), e);
+                    log.log(Level.FINE, message, e);
                     servletResponse.sendError(Response.Status.INTERNAL_SERVER_ERROR, message);
                 }
             } else {


### PR DESCRIPTION
These error messages clutters the log and are usually a red herring.
It's typically a read timeout caused by an overloaded container or during warmup.

FYI @yngveaasheim 