### PR TITLE
new value api on top-level

### DIFF
--- a/eval/src/tests/eval/simple_value/simple_value_test.cpp
+++ b/eval/src/tests/eval/simple_value/simple_value_test.cpp
@@ -62,17 +62,17 @@ TensorSpec simple_tensor_join(const TensorSpec &a, const TensorSpec &b, join_fun
 }
 
 TensorSpec simple_value_new_join(const TensorSpec &a, const TensorSpec &b, join_fun_t function) {
-    auto lhs = new_value_from_spec(a, SimpleValueBuilderFactory());
-    auto rhs = new_value_from_spec(b, SimpleValueBuilderFactory());
+    auto lhs = value_from_spec(a, SimpleValueBuilderFactory());
+    auto rhs = value_from_spec(b, SimpleValueBuilderFactory());
     auto result = new_join(*lhs, *rhs, function, SimpleValueBuilderFactory());
-    return spec_from_new_value(*result);
+    return spec_from_value(*result);
 }
 
 TEST(SimpleValueTest, simple_values_can_be_converted_from_and_to_tensor_spec) {
     for (const auto &layout: layouts) {
         TensorSpec expect = spec(layout, N());
-        std::unique_ptr<NewValue> value = new_value_from_spec(expect, SimpleValueBuilderFactory());
-        TensorSpec actual = spec_from_new_value(*value);
+        std::unique_ptr<Value> value = value_from_spec(expect, SimpleValueBuilderFactory());
+        TensorSpec actual = spec_from_value(*value);
         EXPECT_EQ(actual, expect);
     }
 }
@@ -92,7 +92,7 @@ TEST(SimpleValueTest, simple_value_can_be_built_and_inspected) {
         }
         seq += 100.0;
     }
-    std::unique_ptr<NewValue> value = builder->build(std::move(builder));
+    std::unique_ptr<Value> value = builder->build(std::move(builder));
     EXPECT_EQ(value->index().size(), 6);
     auto view = value->index().create_view({0});
     vespalib::stringref query = "b";

--- a/eval/src/tests/tensor/direct_sparse_tensor_builder/direct_sparse_tensor_builder_test.cpp
+++ b/eval/src/tests/tensor/direct_sparse_tensor_builder/direct_sparse_tensor_builder_test.cpp
@@ -54,7 +54,7 @@ TEST("require that tensor can be constructed")
     Tensor::UP tensor = buildTensor();
     const SparseTensor &sparseTensor = dynamic_cast<const SparseTensor &>(*tensor);
     const ValueType &type = sparseTensor.type();
-    const SparseTensor::Cells &cells = sparseTensor.cells();
+    const SparseTensor::Cells &cells = sparseTensor.my_cells();
     EXPECT_EQUAL(2u, cells.size());
     assertCellValue(10, TensorAddress({{"a","1"},{"b","2"}}), type, cells);
     assertCellValue(20, TensorAddress({{"c","3"},{"d","4"}}), type, cells);

--- a/eval/src/tests/tensor/packed_mappings/packed_mappings_test.cpp
+++ b/eval/src/tests/tensor/packed_mappings/packed_mappings_test.cpp
@@ -138,7 +138,7 @@ TEST_F(MappingsBuilderTest, some_random)
 class MixedBuilderTest : public ::testing::Test {
 public:
     std::unique_ptr<PackedMixedBuilder<float>> builder;
-    std::unique_ptr<NewValue> built;
+    std::unique_ptr<Value> built;
 
     MixedBuilderTest() = default;
 

--- a/eval/src/tests/tensor/packed_mappings/packed_mixed_test.cpp
+++ b/eval/src/tests/tensor/packed_mappings/packed_mixed_test.cpp
@@ -26,8 +26,8 @@ std::vector<Layout> layouts = {
 TEST(PackedMixedTest, packed_mixed_tensors_can_be_converted_from_and_to_tensor_spec) {
     for (const auto &layout: layouts) {
         TensorSpec expect = spec(layout, N());
-        std::unique_ptr<NewValue> value = new_value_from_spec(expect, PackedMixedFactory());
-        TensorSpec actual = spec_from_new_value(*value);
+        std::unique_ptr<Value> value = value_from_spec(expect, PackedMixedFactory());
+        TensorSpec actual = spec_from_value(*value);
         EXPECT_EQ(actual, expect);
     }
 }
@@ -47,7 +47,7 @@ TEST(PackedMixedTest, packed_mixed_tensors_can_be_built_and_inspected) {
         }
         seq += 100.0;
     }
-    std::unique_ptr<NewValue> value = builder->build(std::move(builder));
+    std::unique_ptr<Value> value = builder->build(std::move(builder));
     EXPECT_EQ(value->index().size(), 6);
     auto view = value->index().create_view({0});
     vespalib::stringref query = "b";

--- a/eval/src/vespa/eval/eval/simple_tensor.cpp
+++ b/eval/src/vespa/eval/eval/simple_tensor.cpp
@@ -336,7 +336,7 @@ public:
     View(const SimpleTensor &tensor, const IndexList &selector)
         : _less(selector), _refs()
     {
-        for (const auto &cell: tensor.cells()) {
+        for (const auto &cell: tensor.my_cells()) {
             _refs.emplace_back(cell);
         }
         std::sort(_refs.begin(), _refs.end(), _less);
@@ -738,7 +738,7 @@ SimpleTensor::encode(const SimpleTensor &tensor, nbostream &output)
     Format format(meta);
     output.putInt1_4Bytes(format.tag);
     encode_type(output, format, tensor.type(), meta);
-    maybe_encode_num_blocks(output, meta, tensor.cells().size() / meta.block_size);
+    maybe_encode_num_blocks(output, meta, tensor.my_cells().size() / meta.block_size);
     View view(tensor, meta.mapped);
     for (auto block = view.first_range(); !block.empty(); block = view.next_range(block)) {
         encode_mapped_labels(output, meta, block.begin()->get().address);

--- a/eval/src/vespa/eval/eval/simple_tensor.h
+++ b/eval/src/vespa/eval/eval/simple_tensor.h
@@ -79,11 +79,13 @@ public:
     using join_fun_t = double (*)(double, double);
 
     SimpleTensor();
+    TypedCells cells() const override { abort(); }
+    const Index &index() const override { abort(); }
     explicit SimpleTensor(double value);
     SimpleTensor(const ValueType &type_in, Cells cells_in);
     double as_double() const final override;
     const ValueType &type() const override { return _type; }
-    const Cells &cells() const { return _cells; }
+    const Cells &my_cells() const { return _cells; }
     std::unique_ptr<SimpleTensor> map(map_fun_t function) const;
     std::unique_ptr<SimpleTensor> reduce(Aggregator &aggr, const std::vector<vespalib::string> &dimensions) const;
     std::unique_ptr<SimpleTensor> rename(const std::vector<vespalib::string> &from, const std::vector<vespalib::string> &to) const;

--- a/eval/src/vespa/eval/eval/simple_tensor_engine.cpp
+++ b/eval/src/vespa/eval/eval/simple_tensor_engine.cpp
@@ -63,7 +63,7 @@ SimpleTensorEngine::to_spec(const Value &value) const
     const auto &dimensions = value.type().dimensions();
     with_simple(value, [&spec,&dimensions](const SimpleTensor &simple_tensor)
                 {
-                    for (const auto &cell: simple_tensor.cells()) {
+                    for (const auto &cell: simple_tensor.my_cells()) {
                         TensorSpec::Address addr;
                         assert(cell.address.size() == dimensions.size());
                         for (size_t i = 0; i < cell.address.size(); ++i) {

--- a/eval/src/vespa/eval/eval/value.cpp
+++ b/eval/src/vespa/eval/eval/value.cpp
@@ -6,6 +6,40 @@
 namespace vespalib {
 namespace eval {
 
+namespace {
+
+struct TrivialView : Value::Index::View {
+    bool first = false;
+    void lookup(const std::vector<const vespalib::stringref*> &) override { first = true; }
+    bool next_result(const std::vector<vespalib::stringref*> &, size_t &idx_out) override {
+        if (first) {
+            idx_out = 0;
+            first = false;
+            return true;
+        } else {
+            return false;
+        }
+    }
+};
+
+} // <unnamed>
+
+
+TrivialIndex::TrivialIndex() = default;
+TrivialIndex TrivialIndex::_index;
+
+size_t
+TrivialIndex::size() const
+{
+    return 1;
+}
+
+std::unique_ptr<Value::Index::View>
+TrivialIndex::create_view(const std::vector<size_t> &) const
+{
+    return std::make_unique<TrivialView>();
+}
+
 ValueType DoubleValue::_type = ValueType::double_type();
 
 } // namespace vespalib::eval

--- a/eval/src/vespa/eval/eval/value.h
+++ b/eval/src/vespa/eval/eval/value.h
@@ -3,7 +3,10 @@
 #pragma once
 
 #include "value_type.h"
+#include <vespa/eval/tensor/dense/typed_cells.h>
+#include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/traits.h>
+#include <vector>
 #include <memory>
 
 namespace vespalib::eval {
@@ -14,15 +17,71 @@ class Tensor;
  * An abstract Value.
  **/
 struct Value {
-    typedef std::unique_ptr<Value> UP;
-    typedef std::reference_wrapper<const Value> CREF;
+    using UP = std::unique_ptr<Value>;
+    using CREF = std::reference_wrapper<const Value>;
+    using TypedCells = tensor::TypedCells;
+    virtual const ValueType &type() const = 0;
+    virtual ~Value() {}
+
+// ---- new interface enabling separation of values and operations
+    // Root lookup structure for mapping labels to dense subspace indexes
+    struct Index {
+
+        // A view able to look up dense subspace indexes from labels
+        // specifying a partial address for the dimensions given to
+        // create_view. A view is re-usable. Lookups are performed by
+        // calling the lookup function and lookup results are
+        // extracted using the next_result function.
+        struct View {
+
+            // look up dense subspace indexes from labels specifying a
+            // partial address for the dimensions given to
+            // create_view. Results from the lookup is extracted using
+            // the next_result function.
+            virtual void lookup(const std::vector<const vespalib::stringref*> &addr) = 0;
+
+            // Extract the next result (if any) from the previous
+            // lookup into the given partial address and index. Only
+            // the labels for the dimensions NOT specified in
+            // create_view will be extracted here.
+            virtual bool next_result(const std::vector<vespalib::stringref*> &addr_out, size_t &idx_out) = 0;
+
+            virtual ~View() {}
+        };
+
+        // total number of mappings (equal to the number of dense subspaces)
+        virtual size_t size() const = 0;
+
+        // create a view able to look up dense subspaces based on
+        // labels from a subset of the mapped dimensions.
+        virtual std::unique_ptr<View> create_view(const std::vector<size_t> &dims) const = 0;
+
+        virtual ~Index() {}
+    };
+    virtual TypedCells cells() const = 0;
+    virtual const Index &index() const = 0;
+// --- end of new interface
+
+// --- old interface that may be (partially) removed in the future
     virtual bool is_double() const { return false; }
     virtual bool is_tensor() const { return false; }
     virtual double as_double() const { return 0.0; }
     bool as_bool() const { return (as_double() != 0.0); }
     virtual const Tensor *as_tensor() const { return nullptr; }
-    virtual const ValueType &type() const = 0;
-    virtual ~Value() {}
+// --- end of old interface
+};
+
+/**
+ * Common index for values without any mapped dimensions.
+ **/
+class TrivialIndex : public Value::Index {
+private:
+    TrivialIndex();
+    static TrivialIndex _index;
+    size_t size() const override;
+    std::unique_ptr<View> create_view(const std::vector<size_t> &dims) const override;
+public:
+    static const TrivialIndex &get() { return _index; }
 };
 
 class DoubleValue : public Value
@@ -32,6 +91,8 @@ private:
     static ValueType _type;
 public:
     DoubleValue(double value) : _value(value) {}
+    TypedCells cells() const override { return TypedCells(ConstArrayRef<double>(&_value, 1)); }
+    const Index &index() const override { return TrivialIndex::get(); }
     bool is_double() const override { return true; }
     double as_double() const override { return _value; }
     const ValueType &type() const override { return _type; }

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
@@ -28,6 +28,8 @@ public:
 
     const eval::ValueType &fast_type() const { return _typeRef; }
     const TypedCells &cellsRef() const { return _cellsRef; }
+    TypedCells cells() const override { return _cellsRef; }
+    const Index &index() const override { return eval::TrivialIndex::get(); }
     bool operator==(const DenseTensorView &rhs) const;
     CellsIterator cellsIterator() const { return CellsIterator(_typeRef, _cellsRef); }
 

--- a/eval/src/vespa/eval/tensor/join_tensors.h
+++ b/eval/src/vespa/eval/tensor/join_tensors.h
@@ -18,8 +18,8 @@ joinTensors(const TensorImplType &lhs,
             Function &&func)
 {
     DirectSparseTensorBuilder
-        builder(lhs.combineDimensionsWith(rhs), lhs.cells());
-    for (const auto &rhsCell : rhs.cells()) {
+        builder(lhs.combineDimensionsWith(rhs), lhs.my_cells());
+    for (const auto &rhsCell : rhs.my_cells()) {
         builder.insertCell(rhsCell.first, rhsCell.second, func);
     }
     return builder.build();
@@ -36,8 +36,8 @@ joinTensorsNegated(const TensorImplType &lhs,
                    Function &&func)
 {
     DirectSparseTensorBuilder
-        builder(lhs.combineDimensionsWith(rhs), lhs.cells());
-    for (const auto &rhsCell : rhs.cells()) {
+        builder(lhs.combineDimensionsWith(rhs), lhs.my_cells());
+    for (const auto &rhsCell : rhs.my_cells()) {
         builder.insertCell(rhsCell.first, -rhsCell.second, func);
     }
     return builder.build();

--- a/eval/src/vespa/eval/tensor/mixed/packed_mixed_builder.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mixed_builder.cpp
@@ -19,7 +19,7 @@ PackedMixedBuilder<T>::add_subspace(const std::vector<vespalib::stringref> &addr
 
 
 template <typename T>
-std::unique_ptr<NewValue>
+std::unique_ptr<Value>
 PackedMixedBuilder<T>::build(std::unique_ptr<ValueBuilder<T>>)
 {
     size_t self_size = sizeof(PackedMixedTensor);

--- a/eval/src/vespa/eval/tensor/mixed/packed_mixed_builder.h
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mixed_builder.h
@@ -34,7 +34,7 @@ public:
     ~PackedMixedBuilder() override = default;
         
     ArrayRef<T> add_subspace(const std::vector<vespalib::stringref> &addr) override;
-    std::unique_ptr<NewValue> build(std::unique_ptr<ValueBuilder<T>> self) override;
+    std::unique_ptr<Value> build(std::unique_ptr<ValueBuilder<T>> self) override;
 };
 
 } // namespace

--- a/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor.cpp
@@ -6,7 +6,7 @@ namespace vespalib::eval::packed_mixed_tensor {
 
 /*********************************************************************************/
 
-class PackedMixedTensorIndexView : public NewValue::Index::View
+class PackedMixedTensorIndexView : public Value::Index::View
 {
 private:
     const PackedMappings& _mappings;
@@ -92,7 +92,7 @@ PackedMixedTensorIndexView::next_result(const std::vector<vespalib::stringref*> 
 
 /*********************************************************************************/
 
-class PackedMixedTensorLookup : public NewValue::Index::View
+class PackedMixedTensorLookup : public Value::Index::View
 {
 private:
     const PackedMappings& _mappings;
@@ -148,7 +148,7 @@ PackedMixedTensorLookup::next_result(const std::vector<vespalib::stringref*> &ad
 
 /*********************************************************************************/
 
-class PackedMixedTensorAllMappings : public NewValue::Index::View
+class PackedMixedTensorAllMappings : public Value::Index::View
 {
 private:
     const PackedMappings& _mappings;
@@ -194,7 +194,7 @@ PackedMixedTensorAllMappings::next_result(const std::vector<vespalib::stringref*
 
 PackedMixedTensor::~PackedMixedTensor() = default;
 
-std::unique_ptr<NewValue::Index::View>
+std::unique_ptr<Value::Index::View>
 PackedMixedTensor::create_view(const std::vector<size_t> &dims) const
 {
     if (dims.size() == 0) {

--- a/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor.h
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor.h
@@ -12,13 +12,13 @@
 namespace vespalib::eval::packed_mixed_tensor {
 
 /**
- * An implementation of NewValue modeling a mixed tensor,
+ * An implementation of Value modeling a mixed tensor,
  * where all the data (cells and sparse address mappings)
  * can reside in a self-contained, contigous block of memory.
  * Currently must be built by a PackedMixedBuilder.
  * Immutable (all data always const).
  **/
-class PackedMixedTensor : public NewValue, public NewValue::Index
+class PackedMixedTensor : public Value, public Value::Index
 {
 private:
     const ValueType _type;
@@ -38,12 +38,12 @@ private:
 public:
     ~PackedMixedTensor() override;
 
-    // NewValue API:
+    // Value API:
     const ValueType &type() const override { return _type; }
-    const NewValue::Index &index() const override { return *this; }
+    const Value::Index &index() const override { return *this; }
     TypedCells cells() const override { return _cells; }
 
-    // NewValue::Index API:
+    // Value::Index API:
     size_t size() const override { return _mappings.size(); }
     std::unique_ptr<View> create_view(const std::vector<size_t> &dims) const override;
 };

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor.cpp
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor.cpp
@@ -204,18 +204,18 @@ SparseTensor::merge(join_fun_t function, const Tensor &arg) const
     const SparseTensor *rhs = dynamic_cast<const SparseTensor *>(&arg);
     assert(rhs && (fast_type().dimensions() == rhs->fast_type().dimensions()));
     DirectSparseTensorBuilder builder(eval::ValueType::merge(fast_type(), rhs->fast_type()));
-    builder.reserve(cells().size() + rhs->cells().size());
-    for (const auto &cell: cells()) {
-        auto pos = rhs->cells().find(cell.first);
-        if (pos == rhs->cells().end()) {
+    builder.reserve(my_cells().size() + rhs->my_cells().size());
+    for (const auto &cell: my_cells()) {
+        auto pos = rhs->my_cells().find(cell.first);
+        if (pos == rhs->my_cells().end()) {
             builder.insertCell(cell.first, cell.second);
         } else {
             builder.insertCell(cell.first, function(cell.second, pos->second));
         }
     }
-    for (const auto &cell: rhs->cells()) {
-        auto pos = cells().find(cell.first);
-        if (pos == cells().end()) {
+    for (const auto &cell: rhs->my_cells()) {
+        auto pos = my_cells().find(cell.first);
+        if (pos == my_cells().end()) {
             builder.insertCell(cell.first, cell.second);
         }
     }

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor.h
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor.h
@@ -34,8 +34,10 @@ private:
 public:
     explicit SparseTensor(const eval::ValueType &type_in, const Cells &cells_in);
     SparseTensor(eval::ValueType &&type_in, Cells &&cells_in, Stash &&stash_in);
+    TypedCells cells() const override { abort(); }
+    const Index &index() const override { abort(); }
     ~SparseTensor() override;
-    const Cells &cells() const { return _cells; }
+    const Cells &my_cells() const { return _cells; }
     const eval::ValueType &fast_type() const { return _type; }
     bool operator==(const SparseTensor &rhs) const;
     eval::ValueType combineDimensionsWith(const SparseTensor &rhs) const;

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor_apply.hpp
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor_apply.hpp
@@ -14,13 +14,13 @@ apply(const SparseTensor &lhs, const SparseTensor &rhs, Function &&func)
 {
     DirectSparseTensorBuilder builder(lhs.combineDimensionsWith(rhs));
     TensorAddressCombiner addressCombiner(lhs.fast_type(), rhs.fast_type());
-    size_t estimatedCells = (lhs.cells().size() * rhs.cells().size());
+    size_t estimatedCells = (lhs.my_cells().size() * rhs.my_cells().size());
     if (addressCombiner.numOverlappingDimensions() != 0) {
-        estimatedCells = std::min(lhs.cells().size(), rhs.cells().size());
+        estimatedCells = std::min(lhs.my_cells().size(), rhs.my_cells().size());
     }
     builder.reserve(estimatedCells*2);
-    for (const auto &lhsCell : lhs.cells()) {
-        for (const auto &rhsCell : rhs.cells()) {
+    for (const auto &lhsCell : lhs.my_cells()) {
+        for (const auto &rhsCell : rhs.my_cells()) {
             bool combineSuccess = addressCombiner.combine(lhsCell.first, rhsCell.first);
             if (combineSuccess) {
                 builder.insertCell(addressCombiner.getAddressRef(),

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor_match.cpp
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor_match.cpp
@@ -12,10 +12,10 @@ namespace vespalib::tensor {
 void
 SparseTensorMatch::fastMatch(const TensorImplType &lhs, const TensorImplType &rhs)
 {
-    _builder.reserve(lhs.cells().size());
-    for (const auto &lhsCell : lhs.cells()) {
-        auto rhsItr = rhs.cells().find(lhsCell.first);
-        if (rhsItr != rhs.cells().end()) {
+    _builder.reserve(lhs.my_cells().size());
+    for (const auto &lhsCell : lhs.my_cells()) {
+        auto rhsItr = rhs.my_cells().find(lhsCell.first);
+        if (rhsItr != rhs.my_cells().end()) {
             _builder.insertCell(lhsCell.first, lhsCell.second * rhsItr->second);
         }
     }
@@ -28,7 +28,7 @@ SparseTensorMatch::SparseTensorMatch(const TensorImplType &lhs, const TensorImpl
     assert (lhs.fast_type().dimensions().size() == _builder.fast_type().dimensions().size());
 
     // Ensure that first tensor to fastMatch has fewest cells.
-    if (lhs.cells().size() <= rhs.cells().size()) {
+    if (lhs.my_cells().size() <= rhs.my_cells().size()) {
         fastMatch(lhs, rhs);
     } else {
         fastMatch(rhs, lhs);

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor_reduce.hpp
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor_reduce.hpp
@@ -12,8 +12,8 @@ std::unique_ptr<Tensor>
 reduceAll(const SparseTensor &tensor,
           DirectSparseTensorBuilder &builder, Function &&func)
 {
-    auto itr = tensor.cells().begin();
-    auto itrEnd = tensor.cells().end();
+    auto itr = tensor.my_cells().begin();
+    auto itrEnd = tensor.my_cells().end();
     double result = 0.0;
     if (itr != itrEnd) {
         result = itr->second;
@@ -47,8 +47,8 @@ reduce(const SparseTensor &tensor,
         return reduceAll(tensor, builder, func);
     }
     TensorAddressReducer addressReducer(tensor.fast_type(), dimensions);
-    builder.reserve(tensor.cells().size()*2);
-    for (const auto &cell : tensor.cells()) {
+    builder.reserve(tensor.my_cells().size()*2);
+    for (const auto &cell : tensor.my_cells()) {
         addressReducer.reduce(cell.first);
         builder.insertCell(addressReducer.getAddressRef(), cell.second, func);
     }

--- a/eval/src/vespa/eval/tensor/tensor_apply.cpp
+++ b/eval/src/vespa/eval/tensor/tensor_apply.cpp
@@ -10,7 +10,7 @@ TensorApply<TensorT>::TensorApply(const TensorImplType &tensor,
                                   const CellFunction &func)
     : Parent(tensor.fast_type())
 {
-    for (const auto &cell : tensor.cells()) {
+    for (const auto &cell : tensor.my_cells()) {
         _builder.insertCell(cell.first, func.apply(cell.second));
     }
 }

--- a/eval/src/vespa/eval/tensor/wrapped_simple_tensor.cpp
+++ b/eval/src/vespa/eval/tensor/wrapped_simple_tensor.cpp
@@ -41,7 +41,7 @@ WrappedSimpleTensor::accept(TensorVisitor &visitor) const
 {
     TensorAddressBuilder addr;
     const auto &dimensions = _tensor.type().dimensions();
-    for (const auto &cell: _tensor.cells()) {
+    for (const auto &cell: _tensor.my_cells()) {
         addr.clear();
         for (size_t i = 0; i < dimensions.size(); ++i) {
             if (dimensions[i].is_indexed()) {
@@ -70,7 +70,7 @@ WrappedSimpleTensor::get_memory_usage() const
 Tensor::UP
 WrappedSimpleTensor::clone() const
 {
-    auto tensor = std::make_unique<eval::SimpleTensor>(_tensor.type(), _tensor.cells());
+    auto tensor = std::make_unique<eval::SimpleTensor>(_tensor.type(), _tensor.my_cells());
     return std::make_unique<WrappedSimpleTensor>(std::move(tensor));
 }
 

--- a/eval/src/vespa/eval/tensor/wrapped_simple_tensor.h
+++ b/eval/src/vespa/eval/tensor/wrapped_simple_tensor.h
@@ -26,6 +26,8 @@ public:
         : _space(), _tensor(tensor) {}
     explicit WrappedSimpleTensor(std::unique_ptr<eval::SimpleTensor> tensor)
         : _space(std::move(tensor)), _tensor(*_space) {}
+    TypedCells cells() const override { abort(); }
+    const Index &index() const override { abort(); }
     ~WrappedSimpleTensor() {}
     const eval::SimpleTensor &get() const { return _tensor; }
     const eval::ValueType &type() const override { return _tensor.type(); }


### PR DESCRIPTION
- use common TrivialIndex for dense values

- added aborts for non-implementing subclasses:
SimpleTensor, WrappedSimpleTensor, SparseTensor

- renamed conflicting 'cells' functions to 'my_cells'

@arnej27959 @geirst please review

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
