### PR TITLE
Remove the use of optional in stream expression

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/QuotaValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/QuotaValidator.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.vespa.model.VespaModel;
 
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -23,16 +22,15 @@ public class QuotaValidator extends Validator {
     }
 
     private void validateBudget(int budget, VespaModel model) {
-        Optional<Double> spend = model.allClusters().stream()
+        var spend = model.allClusters().stream()
                 .map(clusterId -> model.provisioned().all().get(clusterId))
                 .map(Capacity::maxResources)
                 .map(clusterCapacity -> clusterCapacity.nodeResources().cost() * clusterCapacity.nodes())
-                .reduce(Double::sum);
+                .reduce(0.0, Double::sum);
 
-        if(spend.isPresent() && spend.get() > budget)
-            throw new IllegalArgumentException(
-                    String.format("Hourly spend for maximum specified resources ($%.2f) exceeds budget from quota ($%d)!",
-                            spend.get(), budget));
+        if (spend > budget) {
+            throwBudgetExceeded(spend, budget);
+        }
     }
 
     /** Check that all clusters in the application do not exceed the quota max cluster size. */
@@ -50,5 +48,10 @@ public class QuotaValidator extends Validator {
             var clusterNames = String.join(", ", invalidClusters);
             throw new IllegalArgumentException("Clusters " + clusterNames + " exceeded max cluster size of " + maxClusterSize);
         }
+    }
+
+    private void throwBudgetExceeded(double spend, double budget) {
+        var message = String.format("Hourly spend for maximum specified resources ($%.2f) exceeds budget from quota ($%.2f)!", spend, budget);
+        throw new IllegalArgumentException(message);
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
@@ -42,7 +42,7 @@ public class QuotaValidatorTest {
             tester.deploy(null, getServices("testCluster", 10), Environment.prod, null);
             fail();
         } catch (RuntimeException e) {
-            assertEquals("Hourly spend for maximum specified resources ($1.60) exceeds budget from quota ($1)!", e.getMessage());
+            assertEquals("Hourly spend for maximum specified resources ($1.60) exceeds budget from quota ($1.00)!", e.getMessage());
         }
     }
 


### PR DESCRIPTION
No longer use optional in validator by providing a identity value for `.reduce()`.  Also put throw + message in separate method.