### PR TITLE
Store vespa version in ZooKeeper as well

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/version/VersionState.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/version/VersionState.java
@@ -46,7 +46,6 @@ public class VersionState {
     }
 
     public boolean isUpgraded() {
-        System.out.println("current version: " + currentVersion() + ", stored version: " + storedVersion());
         return currentVersion().compareTo(storedVersion()) > 0;
     }
 
@@ -67,16 +66,14 @@ public class VersionState {
         if (distributeApplicationPackage.value()) {
             Optional<byte[]> version = curator.getData(versionPath);
             if(version.isPresent()) {
-                System.out.println("Found version in zk ");
                 try {
                     return Version.fromString(Utf8.toString(version.get()));
                 } catch (Exception e) {
-                    return new Version(0, 0, 0); // Use an old value to signal we don't know
+                    // continue, use value in file
                 }
             }
         }
         try (FileReader reader = new FileReader(versionFile)) {
-            System.out.println("Found version in file ");
             return Version.fromString(IOUtils.readAll(reader));
         } catch (Exception e) {
             return new Version(0, 0, 0); // Use an old value to signal we don't know

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -25,6 +25,7 @@ import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.version.VersionState;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -56,6 +57,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ConfigServerBootstrapTest {
 
+    private final MockCurator curator = new MockCurator();
+
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -66,8 +69,7 @@ public class ConfigServerBootstrapTest {
         DeployTester tester = new DeployTester(List.of(createHostedModelFactory()), configserverConfig, provisioner);
         tester.deployApp("src/test/apps/hosted/");
 
-        File versionFile = temporaryFolder.newFile();
-        VersionState versionState = new VersionState(versionFile);
+        VersionState versionState = createVersionState();
         assertTrue(versionState.isUpgraded());
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
@@ -99,8 +101,7 @@ public class ConfigServerBootstrapTest {
         DeployTester tester = new DeployTester(List.of(createHostedModelFactory()), configserverConfig, provisioner);
         tester.deployApp("src/test/apps/hosted/");
 
-        File versionFile = temporaryFolder.newFile();
-        VersionState versionState = new VersionState(versionFile);
+        VersionState versionState = createVersionState();
         assertTrue(versionState.isUpgraded());
 
         RpcServer rpcServer = createRpcServer(configserverConfig);
@@ -124,8 +125,7 @@ public class ConfigServerBootstrapTest {
         DeployTester tester = new DeployTester(List.of(createHostedModelFactory()), configserverConfig);
         tester.deployApp("src/test/apps/hosted/");
 
-        File versionFile = temporaryFolder.newFile();
-        VersionState versionState = new VersionState(versionFile);
+        VersionState versionState = createVersionState();
         assertTrue(versionState.isUpgraded());
 
         // Manipulate application package so that it will fail deployment when config server starts
@@ -168,8 +168,7 @@ public class ConfigServerBootstrapTest {
         tester.deployApp("src/test/apps/app/", vespaVersion, Instant.now());
         ApplicationId applicationId = tester.applicationId();
 
-        File versionFile = temporaryFolder.newFile();
-        VersionState versionState = new VersionState(versionFile);
+        VersionState versionState = createVersionState();
         assertTrue(versionState.isUpgraded());
 
         // Ugly hack, but I see no other way of doing it:
@@ -240,6 +239,10 @@ public class ConfigServerBootstrapTest {
                              new VipStatusConfig.Builder().build(),
                              new ClustersStatus(),
                              stateMonitor);
+    }
+
+    private VersionState createVersionState() throws IOException {
+        return new VersionState(temporaryFolder.newFile(), curator, new InMemoryFlagSource());
     }
 
     public static class MockRpcServer extends com.yahoo.vespa.config.server.rpc.MockRpcServer {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/version/VersionStateTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/version/VersionStateTest.java
@@ -4,12 +4,16 @@ package com.yahoo.vespa.config.server.version;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
 import com.yahoo.io.IOUtils;
+import com.yahoo.vespa.curator.mock.MockCurator;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -20,27 +24,48 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  */
 public class VersionStateTest {
+    InMemoryFlagSource flagSource = new InMemoryFlagSource();
 
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
+    private final MockCurator curator = new MockCurator();
 
     @Test
     public void upgrade() throws IOException {
+        upgrade(true);
+        upgrade(false);
+    }
+
+    public void upgrade(boolean distributeApplicationPackage) throws IOException {
+        flagSource.withBooleanFlag(Flags.CONFIGSERVER_DISTRIBUTE_APPLICATION_PACKAGE.id(), distributeApplicationPackage);
         Version unknownVersion = new Version(0, 0, 0);
-        File versionFile = tempDir.newFile();
-        VersionState state = new VersionState(versionFile);
+
+        VersionState state = createVersionState();
         assertThat(state.storedVersion(), is(unknownVersion));
         assertTrue(state.isUpgraded());
         state.saveNewVersion();
         assertFalse(state.isUpgraded());
 
-        IOUtils.writeFile(versionFile, "badversion", false);
+        state.saveNewVersion("badversion");
         assertThat(state.storedVersion(), is(unknownVersion));
         assertTrue(state.isUpgraded());
 
-        IOUtils.writeFile(versionFile, "5.0.0", false);
+        state.saveNewVersion("5.0.0");
         assertThat(state.storedVersion(), is(new Version(5, 0, 0)));
         assertTrue(state.isUpgraded());
+
+        // Remove zk node, should find version in ZooKeeper
+        curator.delete(VersionState.versionPath);
+        assertThat(state.storedVersion(), is(new Version(5, 0, 0)));
+        assertTrue(state.isUpgraded());
+
+        // Save new version, remove version in file, should find version in ZooKeeper
+        state.saveNewVersion("6.0.0");
+        if (distributeApplicationPackage) {
+            Files.delete(state.versionFile().toPath());
+            assertThat(state.storedVersion(), is(new Version(6, 0, 0)));
+            assertTrue(state.isUpgraded());
+        }
 
         state.saveNewVersion();
         assertThat(state.currentVersion(), is(state.storedVersion()));
@@ -50,12 +75,18 @@ public class VersionStateTest {
     @Test
     public void serverdbfile() throws IOException {
         File dbDir = tempDir.newFolder();
-        VersionState state = new VersionState(new ConfigserverConfig(new ConfigserverConfig.Builder().configServerDBDir(dbDir.getAbsolutePath())));
+        VersionState state = new VersionState(new ConfigserverConfig.Builder().configServerDBDir(dbDir.getAbsolutePath()).build(),
+                                              curator,
+                                              new InMemoryFlagSource());
         state.saveNewVersion();
         File versionFile = new File(dbDir, "vespa_version");
         assertTrue(versionFile.exists());
         Version stored = Version.fromString(IOUtils.readFile(versionFile));
         assertThat(stored, is(state.currentVersion()));
+    }
+
+    private VersionState createVersionState() throws IOException {
+        return new VersionState(tempDir.newFile(), curator, flagSource);
     }
 
 }


### PR DESCRIPTION
Use version in ZooKeeper if configserver-distribute-application-package is true,
fallback to version in file. Will always write to ZooKeeper so this can be
the only source in the future.

This means that if configserver-distribute-application-package is true
and version data is found in ZooKeeper, redeployment of appplication packages
will only be done on one config server.
