### PR TITLE
Cache node objects

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -404,6 +404,12 @@ public class Flags {
             "Takes effect at next run of maintainer",
             APPLICATION_ID);
 
+    public static final UnboundLongFlag NODE_OBJECT_CACHE_SIZE = defineLongFlag(
+            "node-object-cache-size",
+            1000,
+            "The number of deserialized Node objects to store in-memory.",
+            "Takes effect on config server restart");
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, String description,
                                                        String modificationEffect, FetchVector.Dimension... dimensions) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -155,7 +155,8 @@ public class NodeRepository extends AbstractComponent {
                           int spareCount) {
         // Flag is read once here as it shouldn't not change at runtime
         this.useConfigServerLock = Flags.USE_CONFIG_SERVER_LOCK.bindTo(flagSource).value();
-        this.db = new CuratorDatabaseClient(flavors, curator, clock, zone, useCuratorClientCache, useConfigServerLock);
+        long nodeObjectCacheSize = Flags.NODE_OBJECT_CACHE_SIZE.bindTo(flagSource).value();
+        this.db = new CuratorDatabaseClient(flavors, curator, clock, zone, useCuratorClientCache, useConfigServerLock, nodeObjectCacheSize);
         this.zone = zone;
         this.clock = clock;
         this.flavors = flavors;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -15,6 +15,7 @@ import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.History;
+import com.yahoo.vespa.hosted.provision.persistence.NodeSerializer;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.service.monitor.ServiceModel;
 import com.yahoo.vespa.service.monitor.ServiceMonitor;
@@ -68,7 +69,15 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
         updateMaintenanceMetrics();
         updateDockerMetrics(nodes);
         updateTenantUsageMetrics(nodes);
+        updateNodeSerializerCacheMetrics();
         return true;
+    }
+
+    private void updateNodeSerializerCacheMetrics() {
+        NodeSerializer.CacheStats cacheStats = nodeRepository().database().nodeSerializerCacheStats();
+        metric.set("cache.nodeObject.hitRate", cacheStats.hitRate(), null);
+        metric.set("cache.nodeObject.evictionCount", cacheStats.evictionCount(), null);
+        metric.set("cache.nodeObject.size", cacheStats.size(), null);
     }
 
     private void updateMaintenanceMetrics() {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -79,8 +79,9 @@ public class CuratorDatabaseClient {
     private final CuratorCounter provisionIndexCounter;
     private final boolean logStackTracesOnLockTimeout;
 
-    public CuratorDatabaseClient(NodeFlavors flavors, Curator curator, Clock clock, Zone zone, boolean useCache, boolean logStackTracesOnLockTimeout) {
-        this.nodeSerializer = new NodeSerializer(flavors);
+    public CuratorDatabaseClient(NodeFlavors flavors, Curator curator, Clock clock, Zone zone, boolean useCache, boolean logStackTracesOnLockTimeout,
+                                 long nodeObjectCacheSize) {
+        this.nodeSerializer = new NodeSerializer(flavors, nodeObjectCacheSize);
         this.zone = zone;
         this.db = new CuratorDatabase(curator, root, useCache);
         this.clock = clock;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -588,6 +588,10 @@ public class CuratorDatabaseClient {
                 .collect(Collectors.toList());
     }
 
+    public NodeSerializer.CacheStats nodeSerializerCacheStats() {
+        return nodeSerializer.cacheStats();
+    }
+
     private <T> Optional<T> read(Path path, Function<byte[], T> mapper) {
         return db.getData(path).filter(data -> data.length > 0).map(mapper);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -1,7 +1,11 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.persistence;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Hashing;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
@@ -32,11 +36,13 @@ import com.yahoo.vespa.hosted.provision.node.Reports;
 import com.yahoo.vespa.hosted.provision.node.Status;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.function.UnaryOperator;
 
 /**
@@ -106,6 +112,12 @@ public class NodeSerializer {
 
     // Network port fields
     private static final String networkPortsKey = "networkPorts";
+
+    // A cache of deserialized Node objects. The cache is keyed on the hash of serialized node data.
+    //
+    // Deserializing a Node from slime is expensive, and happens frequently. Node instances that have already been
+    // deserialized are returned from this cache instead of being deserialized again.
+    private final Cache<Long, Node> cache = CacheBuilder.newBuilder().maximumSize(1000).build();
 
     // ---------------- Serialization ----------------------------------------------------
 
@@ -196,7 +208,15 @@ public class NodeSerializer {
     // ---------------- Deserialization --------------------------------------------------
 
     public Node fromJson(Node.State state, byte[] data) {
-        return nodeFromSlime(state, SlimeUtils.jsonToSlime(data).get());
+        var key = Hashing.sipHash24().newHasher()
+                         .putString(state.name(), StandardCharsets.UTF_8)
+                         .putBytes(data).hash()
+                         .asLong();
+        try {
+            return cache.get(key, () -> nodeFromSlime(state, SlimeUtils.jsonToSlime(data).get()));
+        } catch (ExecutionException e) {
+            throw new UncheckedExecutionException(e);
+        }
     }
 
     private Node nodeFromSlime(Node.State state, Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -117,12 +117,13 @@ public class NodeSerializer {
     //
     // Deserializing a Node from slime is expensive, and happens frequently. Node instances that have already been
     // deserialized are returned from this cache instead of being deserialized again.
-    private final Cache<Long, Node> cache = CacheBuilder.newBuilder().maximumSize(1000).build();
+    private final Cache<Long, Node> cache;
 
     // ---------------- Serialization ----------------------------------------------------
 
-    public NodeSerializer(NodeFlavors flavors) {
+    public NodeSerializer(NodeFlavors flavors, long cacheSize) {
         this.flavors = flavors;
+        this.cache = CacheBuilder.newBuilder().maximumSize(cacheSize).build();
     }
 
     public byte[] toJson(Node node) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -136,6 +136,12 @@ public class NodeSerializer {
         }
     }
 
+    /** Returns cache statistics for this serializer */
+    public CacheStats cacheStats() {
+        com.google.common.cache.CacheStats cacheStats = cache.stats();
+        return new CacheStats(cacheStats.hitRate(), cacheStats.evictionCount(), cache.size());
+    }
+
     private void toSlime(Node node, Cursor object) {
         object.setString(hostnameKey, node.hostname());
         toSlime(node.ipConfig().primary(), object.setArray(ipAddressesKey), IP.Config::require);
@@ -474,6 +480,33 @@ public class NodeSerializer {
             case devhost: return "devhost";
         }
         throw new IllegalArgumentException("Serialized form of '" + type + "' not defined");
+    }
+
+    /** Cache statistics for this serializer's object cache */
+    public static class CacheStats {
+
+        private final double hitRate;
+        private final long evictionCount;
+        private final long size;
+
+        public CacheStats(double hitRate, long evictionCount, long size) {
+            this.hitRate = hitRate;
+            this.evictionCount = evictionCount;
+            this.size = size;
+        }
+
+        public double hitRate() {
+            return hitRate;
+        }
+
+        public long evictionCount() {
+            return evictionCount;
+        }
+
+        public long size() {
+            return size;
+        }
+
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -123,6 +123,10 @@ public class MetricsReporterTest {
         expectedMetrics.put("suspendedSeconds", 123L);
         expectedMetrics.put("numberOfServices", 0L);
 
+        expectedMetrics.put("cache.nodeObject.hitRate", 1.0D);
+        expectedMetrics.put("cache.nodeObject.evictionCount", 0L);
+        expectedMetrics.put("cache.nodeObject.size", 2L);
+
         ManualClock clock = new ManualClock(Instant.ofEpochSecond(124));
 
         Orchestrator orchestrator = mock(Orchestrator.class);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClientTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClientTest.java
@@ -26,7 +26,7 @@ public class CuratorDatabaseClientTest {
 
     private final Curator curator = new MockCurator();
     private final CuratorDatabaseClient zkClient = new CuratorDatabaseClient(
-            FlavorConfigBuilder.createDummies("default"), curator, Clock.systemUTC(), Zone.defaultZone(), true, false);
+            FlavorConfigBuilder.createDummies("default"), curator, Clock.systemUTC(), Zone.defaultZone(), true, false, 1000);
 
     @Test
     public void can_read_stored_host_information() throws Exception {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 public class NodeSerializerTest {
 
     private final NodeFlavors nodeFlavors = FlavorConfigBuilder.createDummies("default", "large", "ugccloud-container");
-    private final NodeSerializer nodeSerializer = new NodeSerializer(nodeFlavors);
+    private final NodeSerializer nodeSerializer = new NodeSerializer(nodeFlavors, 1000);
     private final ManualClock clock = new ManualClock();
 
     @Test


### PR DESCRIPTION
I suggest we do this first and consider handling it in `CuratorDatabase` if we
can think of a safe way to update that cache.

Reduces test run time in this module by 5 seconds on my machine.

@bratseth or @baldersheim