### PR TITLE
Revert "Support multiple levels of directories for flags"

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
@@ -45,11 +45,6 @@ import static com.yahoo.yolean.Exceptions.uncheck;
  * The flag files must reside in a 'flags/' root directory containing a directory for each flag name:
  * {@code ./flags/<flag-id>/*.json}
  *
- * Optionally, there can be an arbitrary number of directories "between" 'flags/' root directory and
- * the flag name directory:
- * {@code ./flags/onelevel/<flag-id>/*.json}
- * {@code ./flags/onelevel/anotherlevel/<flag-id>/*.json}
- *
  * @author bjorncs
  */
 public class SystemFlagsDataArchive {
@@ -160,7 +155,7 @@ public class SystemFlagsDataArchive {
         if (!filename.endsWith(".json")) {
             throw new IllegalArgumentException(String.format("Only JSON files are allowed in 'flags/' directory (found '%s')", filePath.toString()));
         }
-        FlagId directoryDeducedFlagId = new FlagId(filePath.getName(filePath.getNameCount()-2).toString());
+        FlagId directoryDeducedFlagId = new FlagId(filePath.getName(1).toString());
         FlagData flagData;
         if (rawData.isBlank()) {
             flagData = new FlagData(directoryDeducedFlagId);
@@ -183,13 +178,6 @@ public class SystemFlagsDataArchive {
                         "\nSee https://git.ouroath.com/vespa/hosted-feature-flags for more info on the JSON syntax");
             }
         }
-
-        if (builder.hasFile(filename, flagData)) {
-            throw new IllegalArgumentException(
-                String.format("Flag data file in '%s' contains redundant flag data for id '%s' already set in another directory!",
-                              filePath, flagData.id()));
-        }
-
         builder.addFile(filename, flagData);
     }
 
@@ -246,10 +234,6 @@ public class SystemFlagsDataArchive {
         public Builder addFile(String filename, FlagData data) {
             files.computeIfAbsent(data.id(), k -> new TreeMap<>()).put(filename, data);
             return this;
-        }
-
-        public boolean hasFile(String filename, FlagData data) {
-            return files.containsKey(data.id()) && files.get(data.id()).containsKey(filename);
         }
 
         public SystemFlagsDataArchive build() {

--- a/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchiveTest.java
+++ b/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchiveTest.java
@@ -84,19 +84,6 @@ public class SystemFlagsDataArchiveTest {
     }
 
     @Test
-    public void supports_multi_level_flags_directory() {
-        var archive = SystemFlagsDataArchive.fromDirectory(Paths.get("src/test/resources/system-flags-multi-level/"));
-        assertFlagDataHasValue(archive, MY_TEST_FLAG, mainControllerTarget, "default");
-    }
-
-    @Test
-    public void duplicated_flagdata_is_detected() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Flag data file in 'flags/group-1/my-test-flag/default.json' contains redundant flag data for id 'my-test-flag' already set in another directory!");
-        var archive = SystemFlagsDataArchive.fromDirectory(Paths.get("src/test/resources/system-flags-multi-level-with-duplicated-flagdata/"));
-    }
-
-    @Test
     public void empty_files_are_handled_as_no_flag_data_for_target() {
         var archive = SystemFlagsDataArchive.fromDirectory(Paths.get("src/test/resources/system-flags/"));
         assertNoFlagData(archive, FLAG_WITH_EMPTY_DATA, mainControllerTarget);

--- a/controller-api/src/test/resources/system-flags-multi-level-with-duplicated-flagdata/flags/group-1/my-test-flag/default.json
+++ b/controller-api/src/test/resources/system-flags-multi-level-with-duplicated-flagdata/flags/group-1/my-test-flag/default.json
@@ -1,8 +1,0 @@
-{
-  "id" : "my-test-flag",
-  "rules" : [
-    {
-      "value" : "default"
-    }
-  ]
-}

--- a/controller-api/src/test/resources/system-flags-multi-level-with-duplicated-flagdata/flags/group-2/my-test-flag/default.json
+++ b/controller-api/src/test/resources/system-flags-multi-level-with-duplicated-flagdata/flags/group-2/my-test-flag/default.json
@@ -1,8 +1,0 @@
-{
-  "id" : "my-test-flag",
-  "rules" : [
-    {
-      "value" : "default"
-    }
-  ]
-}

--- a/controller-api/src/test/resources/system-flags-multi-level/flags/group-1/my-test-flag/default.json
+++ b/controller-api/src/test/resources/system-flags-multi-level/flags/group-1/my-test-flag/default.json
@@ -1,8 +1,0 @@
-{
-  "id" : "my-test-flag",
-  "rules" : [
-    {
-      "value" : "default"
-    }
-  ]
-}

--- a/controller-api/src/test/resources/system-flags-multi-level/flags/group-2/my-other-test-flag/default.json
+++ b/controller-api/src/test/resources/system-flags-multi-level/flags/group-2/my-other-test-flag/default.json
@@ -1,8 +1,0 @@
-{
-  "id" : "my-other-test-flag",
-  "rules" : [
-    {
-      "value" : "default"
-    }
-  ]
-}


### PR DESCRIPTION
Reverts vespa-engine/vespa#13977

Works locally, fails on factory, I guess order of directories is arbitrary:
`17:31:53 Expected: (an instance of java.lang.IllegalArgumentException and exception with message a string containing "Flag data file in 'flags/group-1/my-test-flag/default.json' contains redundant flag data for id 'my-test-flag' already set in another directory!")
17:31:53      but: exception with message a string containing "Flag data file in 'flags/group-1/my-test-flag/default.json' contains redundant flag data for id 'my-test-flag' already set in another directory!" message was "Flag data file in 'flags/group-2/my-test-flag/default.json' contains redundant flag data for id 'my-test-flag' already set in another directory!"
17:31:53 Stacktrace was: java.lang.IllegalArgumentException: Flag data file in 'flags/group-2/my-test-flag/default.json' contains redundant flag data for id 'my-test-flag' already set in another directory!`