### PR TITLE
Report feeding_blocked.max metric value

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -405,6 +405,7 @@ public class VespaMetricSet {
         metrics.add(new Metric("content.proton.resource_usage.transient_memory.average"));
         metrics.add(new Metric("content.proton.resource_usage.memory_mappings.max"));
         metrics.add(new Metric("content.proton.resource_usage.open_file_descriptors.max"));
+        metrics.add(new Metric("content.proton.resource_usage.feeding_blocked.max"));
         metrics.add(new Metric("content.proton.documentdb.attribute.resource_usage.enum_store.average"));
         metrics.add(new Metric("content.proton.documentdb.attribute.resource_usage.multi_value.average"));
         metrics.add(new Metric("content.proton.documentdb.attribute.resource_usage.feeding_blocked.last")); // TODO: Remove in Vespa 8


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

We should stop reporting content.proton.resource_usage.feeding_blocked.last as part of the default metric set and rather report this one. The problem is that the current metric typically fails to report problems feed_blocked situations than one minute. 

This PR does not change the above, but exposes the value for use in hosted Vespa.

@gjoranv Please review and merge.