### PR TITLE
Fix typo in flag name

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -417,7 +417,7 @@ public class Flags {
             "Takes effect on config server restart");
 
     public static final UnboundBooleanFlag USE_NEW_RESTAPI_HANDLER = defineFeatureFlag(
-            "use-restapi-handler",
+            "use-new-restapi-handler",
             false,
             "Whether application containers should use the new restapi handler implementation",
             "Takes effect on next internal redeployment");


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
