### PR TITLE
Delete session without lock

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -478,7 +478,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             Optional<Long> activeSession = tenantApplications.activeSessionOf(applicationId);
             if (activeSession.isEmpty()) return false;
 
-            // Deleting an application is done by deleting the remote session, other config
+            // Deleting an application is done by deleting the remote session, all config
             // servers will pick this up and clean up through the watcher in this class
             try {
                 RemoteSession remoteSession = getRemoteSession(tenant, activeSession.get());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -475,8 +475,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
         TenantApplications tenantApplications = tenant.getApplicationRepo();
         try (Lock lock = tenantApplications.lock(applicationId)) {
-            if ( ! tenantApplications.exists(applicationId)) return false;
-
             Optional<Long> activeSession = tenantApplications.activeSessionOf(applicationId);
             if (activeSession.isEmpty()) return false;
 
@@ -630,17 +628,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    private boolean sessionHasBeenDeleted(ApplicationId applicationId, long sessionId, Duration waitTime) {
-        SessionRepository sessionRepository = getTenant(applicationId).getSessionRepository();
-        Instant end = Instant.now().plus(waitTime);
-        do {
-            if (sessionRepository.getRemoteSession(sessionId) == null) return true;
-            try { Thread.sleep(10); } catch (InterruptedException e) { /* ignored */}
-        } while (Instant.now().isBefore(end));
-
-        return false;
     }
 
     public Optional<String> getApplicationPackageReference(ApplicationId applicationId) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -469,17 +469,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
      * @return true if the application was found and deleted, false if it was not present
      * @throws RuntimeException if the delete transaction fails. This method is exception safe.
      */
-    boolean delete(ApplicationId applicationId) {
-        return delete(applicationId, Duration.ofSeconds(60));
-    }
-
-    /**
-     * Deletes an application
-     *
-     * @return true if the application was found and deleted, false if it was not present
-     * @throws RuntimeException if the delete transaction fails. This method is exception safe.
-     */
-    public boolean delete(ApplicationId applicationId, Duration waitTime) {
+    public boolean delete(ApplicationId applicationId) {
         Tenant tenant = getTenant(applicationId);
         if (tenant == null) return false;
 
@@ -490,26 +480,12 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             Optional<Long> activeSession = tenantApplications.activeSessionOf(applicationId);
             if (activeSession.isEmpty()) return false;
 
-            // Deleting an application is done by deleting the remote session and waiting
-            // until the config server where the deployment happened picks it up and deletes
-            // the local session
-            long sessionId = activeSession.get();
-
-            RemoteSession remoteSession;
+            // Deleting an application is done by deleting the remote session, other config
+            // servers will pick this up and clean up through the watcher in this class
             try {
-                remoteSession = getRemoteSession(tenant, sessionId);
-                Transaction deleteTransaction = remoteSession.createDeleteTransaction();
-                deleteTransaction.commit();
-                log.log(Level.INFO, TenantRepository.logPre(applicationId) + "Waiting for session " + sessionId + " to be deleted");
-
-                if ( ! waitTime.isZero() && localSessionHasBeenDeleted(applicationId, sessionId, waitTime)) {
-                    log.log(Level.INFO, TenantRepository.logPre(applicationId) + "Session " + sessionId + " deleted");
-                } else {
-                    deleteTransaction.rollbackOrLog();
-                    throw new InternalServerException(applicationId + " was not deleted (waited " + waitTime + "), session " + sessionId);
-                }
+                RemoteSession remoteSession = getRemoteSession(tenant, activeSession.get());
+                tenant.getSessionRepository().delete(remoteSession);
             } catch (NotFoundException e) {
-                // For the case where waiting timed out in a previous attempt at deleting the application, continue and do the steps below
                 log.log(Level.INFO, TenantRepository.logPre(applicationId) + "Active session exists, but has not been deleted properly. Trying to cleanup");
             }
 
@@ -656,7 +632,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
     }
 
-    private boolean localSessionHasBeenDeleted(ApplicationId applicationId, long sessionId, Duration waitTime) {
+    private boolean sessionHasBeenDeleted(ApplicationId applicationId, long sessionId, Duration waitTime) {
         SessionRepository sessionRepository = getTenant(applicationId).getSessionRepository();
         Instant end = Instant.now().plus(waitTime);
         do {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -478,7 +478,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             Optional<Long> activeSession = tenantApplications.activeSessionOf(applicationId);
             if (activeSession.isEmpty()) return false;
 
-            // Deleting an application is done by deleting the remote session, all config
+            // Deleting an application is done by deleting the remote session, other config
             // servers will pick this up and clean up through the watcher in this class
             try {
                 RemoteSession remoteSession = getRemoteSession(tenant, activeSession.get());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -72,13 +72,11 @@ public class ApplicationHandler extends HttpHandler {
     @Override
     public HttpResponse handleDELETE(HttpRequest request) {
         ApplicationId applicationId = getApplicationIdFromRequest(request);
-        // TODO: Add support for timeout in request
-        boolean deleted = applicationRepository.delete(applicationId, Duration.ofSeconds(60));
+        boolean deleted = applicationRepository.delete(applicationId);
         if ( ! deleted)
             return HttpErrorResponse.notFoundError("Unable to delete " + applicationId.toFullString() + ": Not found");
         return new DeleteApplicationResponse(Response.Status.OK, applicationId);
     }
-
 
     @Override
     public HttpResponse handleGET(HttpRequest request) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSession.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/RemoteSession.java
@@ -76,10 +76,6 @@ public class RemoteSession extends Session {
         applicationSet = null;
     }
 
-    public Transaction createDeleteTransaction() {
-        return sessionZooKeeperClient.createWriteStatusTransaction(Status.DELETE);
-    }
-    
     void confirmUpload() {
         Curator.CompletionWaiter waiter = sessionZooKeeperClient.getUploadWaiter();
         log.log(Level.FINE, "Notifying upload waiter for session " + getSessionId());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
@@ -75,6 +75,7 @@ public abstract class Session implements Comparable<Session>  {
      * The status of this session.
      */
     public enum Status {
+        // Remove DELETE when 7.294 has been released
         NEW, PREPARE, ACTIVATE, DEACTIVATE, DELETE, NONE;
 
         public static Status parse(String data) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -215,18 +215,7 @@ public class SessionRepository {
         SessionStateWatcher watcher = sessionStateWatchers.remove(sessionId);
         if (watcher != null) watcher.close();
         localSessionCache.remove(sessionId);
-        deletePersistentData(sessionId);
-    }
-
-    private void deletePersistentData(long sessionId) {
         NestedTransaction transaction = new NestedTransaction();
-        SessionZooKeeperClient sessionZooKeeperClient = createSessionZooKeeperClient(sessionId);
-
-        // We will try to delete data from zookeeper from several servers, but since we take a lock
-        // and the transaction will either delete everything or nothing (which will happen if it has been done
-        // on another server) this works fine
-        transaction.add(sessionZooKeeperClient.deleteTransaction(), FileTransaction.class);
-
         transaction.add(FileTransaction.from(FileOperations.delete(getSessionAppDir(sessionId).getAbsolutePath())));
         transaction.commit();
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -352,27 +352,6 @@ public class ApplicationRepositoryTest {
 
             assertTrue(applicationRepository.delete(applicationId()));
         }
-
-        {
-            PrepareResult prepareResult = deployApp(testApp);
-
-            assertNotNull(applicationRepository.getActiveSession(applicationId()));
-            assertNotNull(sessionRepository.getLocalSession(prepareResult.sessionId()));
-
-            try {
-                applicationRepository.delete(applicationId(), Duration.ZERO);
-                fail("Should have gotten an exception");
-            } catch (InternalServerException e) {
-                assertEquals("test1.testapp was not deleted (waited PT0S), session " + prepareResult.sessionId(), e.getMessage());
-            }
-
-            // No active session or remote session (deleted in step above), but an exception was thrown above
-            // A new delete should cleanup and be successful
-            assertNull(applicationRepository.getActiveSession(applicationId()));
-            assertNull(sessionRepository.getLocalSession(prepareResult.sessionId()));
-
-            assertTrue(applicationRepository.delete(applicationId()));
-        }
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -32,7 +32,6 @@ import com.yahoo.vespa.config.protocol.VespaVersion;
 import com.yahoo.vespa.config.server.application.OrchestratorMock;
 import com.yahoo.vespa.config.server.deploy.DeployTester;
 import com.yahoo.vespa.config.server.deploy.TenantFileSystemDirs;
-import com.yahoo.vespa.config.server.http.InternalServerException;
 import com.yahoo.vespa.config.server.http.SessionHandlerTest;
 import com.yahoo.vespa.config.server.http.v2.PrepareResult;
 import com.yahoo.vespa.config.server.session.LocalSession;
@@ -83,7 +82,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author hmusum
@@ -395,10 +393,11 @@ public class ApplicationRepositoryTest {
         LocalSession localSession = localSessions.get(0);
         assertEquals(3, localSession.getSessionId());
 
-        // There should be no expired remote sessions in the common case
-        assertEquals(0, tester.applicationRepository().deleteExpiredRemoteSessions(clock, Duration.ofSeconds(0)));
-
-        assertEquals(1, sessionRepository.getLocalSessions().size());
+        // All sessions except 3 should be removed after the call to deleteExpiredRemoteSessions
+        assertEquals(2, tester.applicationRepository().deleteExpiredRemoteSessions(clock, Duration.ofSeconds(0)));
+        ArrayList<Long> remoteSessions = new ArrayList<>(sessionRepository.getRemoteSessions());
+        RemoteSession remoteSession = sessionRepository.getRemoteSession(remoteSessions.get(0));
+        assertEquals(3, remoteSession.getSessionId());
 
         // Deploy, but do not activate
         Optional<com.yahoo.config.provision.Deployment> deployment4 = tester.redeployFromLocalActive();


### PR DESCRIPTION
Two things has changed:
* Do not use lock when deleting, it's not necessary, nobody else takes the lock
* Delete remote session data in zookeeper immediately, watchers on other config servers will be notified and internal state cleaned up (also local session state)