### PR TITLE
Ensure that the ErrorMessage class has been loaded prior to shutdown

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcPing.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcPing.java
@@ -22,6 +22,7 @@ public class RpcPing implements Pinger, Client.ResponseReceiver {
     private static final Logger log = Logger.getLogger(RpcPing.class.getName());
     private static final String RPC_METHOD = "vespa.searchprotocol.ping";
     private static final CompressionType PING_COMPRESSION = CompressionType.NONE;
+    private static final boolean triggeredClassLoading = ErrorMessage.createBackendCommunicationError("TriggerClassLoading") instanceof ErrorMessage;
 
     private final Node node;
     private final RpcResourcePool resourcePool;
@@ -86,7 +87,7 @@ public class RpcPing implements Pinger, Client.ResponseReceiver {
 
     @Override
     public void receive(ResponseOrError<ProtobufResponse> response) {
-        if (clusterMonitor.isClosed()) return;
+        if (clusterMonitor.isClosed() && ! triggeredClassLoading) return;
         if (node.isLastReceivedPong(pingSequenceId)) {
             pongHandler.handle(toPong(response));
         } else {


### PR DESCRIPTION
…close to avoid classloading issue when bundle is gone.

@hmusum PR
The other protection I added did not seem to help.