### PR TITLE
Cleanup use of DeployLogger 

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server;
 
 import com.google.inject.Inject;
@@ -123,7 +123,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     private final ConfigConvergenceChecker convergeChecker;
     private final HttpProxy httpProxy;
     private final Clock clock;
-    private final DeployLogger logger = new SilentDeployLogger();
     private final ConfigserverConfig configserverConfig;
     private final FileDistributionStatus fileDistributionStatus = new FileDistributionStatus();
     private final Orchestrator orchestrator;
@@ -290,7 +289,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return new PrepareResult(sessionId, deployment.configChangeActions(), logger);
     }
 
-    private Deployment prepare(Tenant tenant, long sessionId, PrepareParams prepareParams, DeployHandlerLogger logger) {
+    private Deployment prepare(Tenant tenant, long sessionId, PrepareParams prepareParams, DeployLogger logger) {
         validateThatLocalSessionIsNotActive(tenant, sessionId);
         LocalSession session = getLocalSession(tenant, sessionId);
         ApplicationId applicationId = prepareParams.getApplicationId();
@@ -303,21 +302,25 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     }
 
     public PrepareResult deploy(CompressedApplicationInputStream in, PrepareParams prepareParams) {
+        DeployHandlerLogger logger = DeployHandlerLogger.forPrepareParams(prepareParams);
         File tempDir = uncheck(() -> Files.createTempDirectory("deploy")).toFile();
         PrepareResult prepareResult;
         try {
-            prepareResult = deploy(decompressApplication(in, tempDir), prepareParams);
+            prepareResult = deploy(decompressApplication(in, tempDir), prepareParams, logger);
         } finally {
-            cleanupTempDirectory(tempDir);
+            cleanupTempDirectory(tempDir, logger);
         }
         return prepareResult;
     }
 
     public PrepareResult deploy(File applicationPackage, PrepareParams prepareParams) {
+        return deploy(applicationPackage, prepareParams, DeployHandlerLogger.forPrepareParams(prepareParams));
+    }
+
+    public PrepareResult deploy(File applicationPackage, PrepareParams prepareParams, DeployHandlerLogger logger) {
         ApplicationId applicationId = prepareParams.getApplicationId();
         long sessionId = createSession(applicationId, prepareParams.getTimeoutBudget(), applicationPackage);
         Tenant tenant = getTenant(applicationId);
-        DeployHandlerLogger logger = DeployHandlerLogger.forPrepareParams(prepareParams);
         Deployment deployment = prepare(tenant, sessionId, prepareParams, logger);
         deployment.activate();
 
@@ -380,6 +383,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         if (activeSession == null) return Optional.empty();
         TimeoutBudget timeoutBudget = new TimeoutBudget(clock, timeout);
         SessionRepository sessionRepository = tenant.getSessionRepository();
+        DeployLogger logger = new SilentDeployLogger();
         LocalSession newSession = sessionRepository.createSessionFromExisting(activeSession, logger, true, timeoutBudget);
         sessionRepository.addLocalSession(newSession);
         boolean internalRestart = deployWithInternalRestart.with(FetchVector.Dimension.APPLICATION_ID, application.serializedForm()).value();
@@ -401,6 +405,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                                   long sessionId,
                                   TimeoutBudget timeoutBudget,
                                   boolean force) {
+        DeployLogger logger = new SilentDeployLogger();
         LocalSession localSession = getLocalSession(tenant, sessionId);
         Deployment deployment = Deployment.prepared(localSession, this, hostProvisioner, tenant, logger, timeoutBudget.timeout(), clock, false, force);
         deployment.activate();
@@ -809,13 +814,14 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return session.getSessionId();
     }
 
-    public long createSession(ApplicationId applicationId, TimeoutBudget timeoutBudget, InputStream in, String contentType) {
+    public long createSession(ApplicationId applicationId, TimeoutBudget timeoutBudget, InputStream in,
+                              String contentType, DeployLogger logger) {
         File tempDir = uncheck(() -> Files.createTempDirectory("deploy")).toFile();
         long sessionId;
         try {
             sessionId = createSession(applicationId, timeoutBudget, decompressApplication(in, contentType, tempDir));
         } finally {
-            cleanupTempDirectory(tempDir);
+            cleanupTempDirectory(tempDir, logger);
         }
         return sessionId;
     }
@@ -986,8 +992,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
     }
 
-    private void cleanupTempDirectory(File tempDir) {
-        logger.log(Level.FINE, "Deleting tmp dir '" + tempDir + "'");
+    private void cleanupTempDirectory(File tempDir, DeployLogger logger) {
         if (!IOUtils.recursiveDeleteDir(tempDir)) {
             logger.log(Level.WARNING, "Not able to delete tmp dir '" + tempDir + "'");
         }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLogger.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLogger.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.deploy;
 
 import com.yahoo.config.application.api.DeployLogger;
@@ -18,7 +18,6 @@ import java.util.logging.Logger;
  * A {@link DeployLogger} which persists messages as a {@link Slime} tree, and holds a tenant and application name.
  * 
  * @author Ulf Lilleengen
- * @since 5.1
  */
 public class DeployHandlerLogger implements DeployLogger {
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandler.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http.v2;
 
 import com.google.inject.Inject;
@@ -59,7 +59,8 @@ public class SessionCreateHandler extends SessionHandler {
             logger = DeployHandlerLogger.forTenant(tenantName, verbose);
             // TODO: Avoid using application id here at all
             ApplicationId applicationId = ApplicationId.from(tenantName, ApplicationName.defaultName(), InstanceName.defaultName());
-            sessionId = applicationRepository.createSession(applicationId, timeoutBudget, request.getData(), request.getHeader(ApplicationApiHandler.contentTypeHeader));
+            sessionId = applicationRepository.createSession(applicationId, timeoutBudget, request.getData(),
+                                                            request.getHeader(ApplicationApiHandler.contentTypeHeader), logger);
         }
         return new SessionCreateResponse(logger.slime(), tenantName, request.getHost(), request.getPort(), sessionId);
     }


### PR DESCRIPTION
Use existing logger when possible and create SilentDeployLogger when
we should not add log to response.
