### PR TITLE
Quota as BigDecimals in the controller  

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/MockBillingController.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/MockBillingController.java
@@ -33,7 +33,7 @@ public class MockBillingController implements BillingController {
 
     @Override
     public Optional<Quota> getQuota(TenantName tenant, Environment environment) {
-        return Optional.of(new Quota(5));
+        return Optional.of(Quota.unlimited().withMaxClusterSize(5));
     }
 
     @Override

--- a/flags/src/main/java/com/yahoo/vespa/flags/BigDecimalFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/BigDecimalFlag.java
@@ -1,0 +1,15 @@
+// Copyright 2020 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import java.math.BigDecimal;
+
+/**
+ * @author ogronnesby
+ */
+public class BigDecimalFlag extends FlagImpl<BigDecimal, BigDecimalFlag> {
+    public BigDecimalFlag(FlagId id, BigDecimal defaultValue, FetchVector fetchVector, FlagSerializer<BigDecimal> serializer, FlagSource source) {
+        super(id, defaultValue, fetchVector, serializer, source, BigDecimalFlag::new);
+    }
+
+    public BigDecimal value() { return boxedValue(); }
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -5,6 +5,7 @@ import com.yahoo.component.Vtag;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.flags.custom.HostCapacity;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -330,8 +331,8 @@ public class Flags {
             APPLICATION_ID
     );
 
-    public static final UnboundIntFlag TENANT_BUDGET_QUOTA = defineIntFlag(
-            "tenant-budget-quota", 5,
+    public static final UnboundBigDecimalFlag TENANT_BUDGET_QUOTA = defineBigDecimalFlag(
+            "tenant-budget-quota", new BigDecimal("5.00"),
             "The budget in $/hr a tenant is allowed spend per instance, as calculated by NodeResources",
             "Only takes effect on next deployment, if set to a value other than the default for flag!",
             APPLICATION_ID
@@ -444,6 +445,12 @@ public class Flags {
     public static UnboundDoubleFlag defineDoubleFlag(String flagId, double defaultValue, String description,
                                                      String modificationEffect, FetchVector.Dimension... dimensions) {
         return define(UnboundDoubleFlag::new, flagId, defaultValue, description, modificationEffect, dimensions);
+    }
+
+    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    public static UnboundBigDecimalFlag defineBigDecimalFlag(String flagId, BigDecimal defaultValue, String description,
+                                                             String modificationEffect, FetchVector.Dimension... dimensions) {
+        return define(UnboundBigDecimalFlag::new, flagId, defaultValue, description, modificationEffect, dimensions);
     }
 
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */

--- a/flags/src/main/java/com/yahoo/vespa/flags/UnboundBigDecimalFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/UnboundBigDecimalFlag.java
@@ -1,0 +1,18 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+
+import java.math.BigDecimal;
+
+/**
+ * @author ogronnesby
+ */
+public class UnboundBigDecimalFlag extends UnboundFlagImpl<BigDecimal, BigDecimalFlag, UnboundBigDecimalFlag>  {
+    public UnboundBigDecimalFlag(FlagId id, BigDecimal defaultValue, FetchVector defaultFetchVector) {
+        super(id, defaultValue, defaultFetchVector,
+                new SimpleFlagSerializer<>(DecimalNode::valueOf, JsonNode::isBigDecimal, JsonNode::decimalValue),
+                UnboundBigDecimalFlag::new, BigDecimalFlag::new);
+    }
+}


### PR DESCRIPTION
- Added support for BigDecimal flags
- Changed internal representation of quota budget to BigDecimal
- Changed flag type for TENANT_BUDGET_QUOTA to BigDecimal.  Since flag
  is not in use this should not cause any issues.
