### PR TITLE
Add StorageAPI RPC trace events

### DIFF
--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.h
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.h
@@ -48,6 +48,7 @@ public:
 
     // Hostname of host node is running on.
     [[nodiscard]] const vespalib::string& hostname() const noexcept { return _hostname; }
+    [[nodiscard]] const vespalib::string handle() const noexcept { return _handle; }
 
     const RpcTargetFactory& target_factory() const;
 private:

--- a/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
+++ b/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
@@ -58,14 +58,13 @@ public:
     [[nodiscard]] bool target_supports_direct_rpc(const api::StorageMessageAddress& addr) const noexcept;
 
     void RPC_rpc_v1_send(FRT_RPCRequest* req);
-    void encode_rpc_v1_response(FRT_RPCRequest& request, const api::StorageReply& reply);
+    void encode_rpc_v1_response(FRT_RPCRequest& request, api::StorageReply& reply);
     void send_rpc_v1_request(std::shared_ptr<api::StorageCommand> cmd);
 
     static constexpr const char* rpc_v1_method_name() noexcept {
         return "storageapi.v1.send";
     }
 private:
-    // TODO dedupe
     void detach_and_forward_to_enqueuer(std::shared_ptr<api::StorageMessage> cmd, FRT_RPCRequest* req);
 
     struct RpcRequestContext {


### PR DESCRIPTION
@geirst please review

Trace event set should roughly match that of MessageBus, but contains
more information (such as hostnames and payload size) for debugging
purposes.
