### PR TITLE
Revert "Clock.systemUTC() instead of non-existent injected Clock"

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -115,15 +115,15 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
     private final Map<String, Map<Method, Handler>> handlers;
 
     @Inject
-    public DocumentV1ApiHandler(Metric metric,
+    public DocumentV1ApiHandler(Clock clock,
+                                Metric metric,
                                 MetricReceiver metricReceiver,
                                 VespaDocumentAccess documentAccess,
                                 DocumentmanagerConfig documentManagerConfig,
                                 ClusterListConfig clusterListConfig,
                                 AllClustersBucketSpacesConfig bucketSpacesConfig,
                                 DocumentOperationExecutorConfig executorConfig) {
-        this(Clock.systemU
-             TC(),
+        this(clock,
              new DocumentOperationExecutorImpl(clusterListConfig, bucketSpacesConfig, executorConfig, documentAccess, clock),
              new DocumentOperationParser(documentManagerConfig),
              metric,


### PR DESCRIPTION
Reverts vespa-engine/vespa#14663

Build fails:
`15:47:15 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project vespaclient-container-plugin: Compilation failure: Compilation failure: 
15:47:15 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java:[125,27] ')' expected`
