### PR TITLE
Don't reactivate on retired hosts

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -29,8 +28,6 @@ import java.util.stream.Collectors;
  * @author bratseth
  */
 class Activator {
-
-    private static final Logger logger = Logger.getLogger(Activator.class.getName());
 
     private final NodeRepository nodeRepository;
     private final Optional<LoadBalancerProvisioner> loadBalancerProvisioner;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -136,6 +136,7 @@ public class NodePrioritizer {
                 .filter(node -> legalStates.contains(node.state()))
                 .filter(node -> node.allocation().isPresent())
                 .filter(node -> node.allocation().get().owner().equals(application))
+                .filter(node -> node.state() == Node.State.active || canStillAllocateToParentOf(node))
                 .map(node -> candidateFrom(node, false))
                 .forEach(candidate -> nodes.add(candidate));
     }
@@ -175,6 +176,19 @@ public class NodePrioritizer {
         if (nodeFailedNodes == 0) return false;
 
         return requestedNodes.fulfilledBy(nofNodesInCluster - nodeFailedNodes);
+    }
+
+    /**
+     * Even though a node is allocated to a parent, we may regret it and not offer it to the application
+     * now, if the node is currently not active. E.g if we want to retire the host.
+     *
+     * @return true if we still want to allocate the given node to its parent
+     */
+    private boolean canStillAllocateToParentOf(Node node) {
+        if (node.parentHostname().isEmpty()) return true;
+        Optional<Node> parent = node.parentHostname().flatMap(nodeRepository::getNode);
+        if (parent.isEmpty()) return false;
+        return nodeRepository.canAllocateTenantNodeTo(parent.get());
     }
 
     private static NodeResources resources(NodeSpec requestedNodes) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -179,8 +179,8 @@ public class NodePrioritizer {
     }
 
     /**
-     * Even though a node is allocated to a parent, we may regret it and not offer it to the application
-     * now, if the node is currently not active. E.g if we want to retire the host.
+     * We may regret that a non-active node is allocated to a host and not offer it to the application
+     * now, e.g if we want to retire the host.
      *
      * @return true if we still want to allocate the given node to its parent
      */


### PR DESCRIPTION
With this it became less legal to have tenant nodes with nonexisting parents so I had to update some tests, but this is an improvement I think.