### PR TITLE
Move StorageLink::print member function definition to cpp file.

### DIFF
--- a/storage/src/vespa/storage/common/storagelink.cpp
+++ b/storage/src/vespa/storage/common/storagelink.cpp
@@ -213,6 +213,12 @@ bool StorageLink::onUp(const shared_ptr<StorageMessage> & msg)
     return msg->callHandler(*this, msg);
 }
 
+void
+StorageLink::print(std::ostream& out, bool, const std::string&) const
+{
+    out << getName();
+}
+
 const char*
 StorageLink::stateToString(State state)
 {

--- a/storage/src/vespa/storage/common/storagelink.h
+++ b/storage/src/vespa/storage/common/storagelink.h
@@ -126,9 +126,7 @@ public:
      */
     virtual bool onUp(const api::StorageMessage::SP&);
 
-    void print(std::ostream& out, bool, const std::string&) const override {
-        out << getName();
-    }
+    void print(std::ostream& out, bool, const std::string&) const override;
 
     static const char* stateToString(State state);
 


### PR DESCRIPTION
@baldersheim : please review
