### PR TITLE
Remove unused Utf8 methods

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -3061,10 +3061,8 @@
     "methods": [
       "public void <init>()",
       "public static java.nio.charset.Charset getCharset()",
-      "public static java.lang.String toStringStd(byte[])",
       "public static java.lang.String toString(byte[], int, int)",
       "public static java.lang.String toString(java.nio.ByteBuffer)",
-      "public static byte[] toBytesStd(java.lang.String)",
       "public static byte[] toAsciiBytes(long)",
       "public static byte[] toAsciiBytes(boolean)",
       "public static byte[] toBytes(java.lang.String)",

--- a/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
+++ b/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
@@ -1,25 +1,23 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io;
 
 
 import java.io.*;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.nio.charset.Charset;
 import java.nio.ByteBuffer;
 
-
 /**
- * <p>Some static io convenience methods.</p>
+ * Some static I/O convenience methods.
  *
- * @author  bratseth
- * @author  Bjorn Borud
+ * @author bratseth
+ * @author Bjorn Borud
  */
 public abstract class IOUtils {
-
-    static private final Charset utf8Charset = Charset.forName("utf-8");
 
     /** Closes a writer, or does nothing if the writer is null */
     public static void closeWriter(Writer writer) {
@@ -329,7 +327,7 @@ public abstract class IOUtils {
      * Encodes string as UTF-8 into ByteBuffer
      */
     public static ByteBuffer utf8ByteBuffer(String s) {
-        return utf8Charset.encode(s);
+        return StandardCharsets.UTF_8.encode(s);
     }
 
     /**
@@ -341,7 +339,7 @@ public abstract class IOUtils {
     public static String readFile(File file) throws IOException {
         try {
             if (file == null) return null;
-            return new String(Files.readAllBytes(file.toPath()), "utf-8");
+            return Files.readString(file.toPath());
         }
         catch (NoSuchFileException e) {
             throw new NoSuchFileException("Could not find file '" + file.getAbsolutePath() + "'");

--- a/vespajlib/src/main/java/com/yahoo/io/ReadLine.java
+++ b/vespajlib/src/main/java/com/yahoo/io/ReadLine.java
@@ -1,10 +1,9 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io;
 
 import java.nio.Buffer;
-import java.nio.charset.Charset;
 import java.nio.ByteBuffer;
-
+import java.nio.charset.StandardCharsets;
 
 /**
  * Conventient utility for reading lines from ByteBuffers.  Please
@@ -12,11 +11,10 @@ import java.nio.ByteBuffer;
  * ByteBuffer abstraction is somewhat clumsy and thus usage of this
  * code requires that you understand the semantics clearly.
  *
- * @author <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
+ * @author Bjorn Borud
  *
  */
 public class ReadLine {
-    static private Charset charset = Charset.forName("latin1");
 
     /**
      * Extract next line from a byte buffer.  Looks for EOL characters
@@ -49,7 +47,7 @@ public class ReadLine {
                 // The downcast to Buffer is done to avoid "redundant cast" warning on Java 9.
                 // TODO: when Java 8 is gone, remove the casts and above comments.
                 // extract string between start and i.
-                String line = charset.decode((ByteBuffer) ((Buffer)buffer.slice()).limit(i - start)).toString();
+                String line = StandardCharsets.ISO_8859_1.decode((ByteBuffer) ((Buffer)buffer.slice()).limit(i - start)).toString();
 
                 // skip remaining
                 for (; (i < buffer.limit()) && isEolChar(buffer.get(i)); i++) {
@@ -80,4 +78,5 @@ public class ReadLine {
     static boolean isEolChar(byte b) {
         return ((10 == b) || (13 == b));
     }
+
 }

--- a/vespajlib/src/main/java/com/yahoo/text/StringUtilities.java
+++ b/vespajlib/src/main/java/com/yahoo/text/StringUtilities.java
@@ -1,9 +1,9 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.text;
 
 import com.google.common.collect.ImmutableSet;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.io.ByteArrayOutputStream;
@@ -18,8 +18,6 @@ import java.util.Set;
  */
 // TODO: Text utilities should which are still needed should move to Text. This should be deprecated.
 public class StringUtilities {
-
-    private static Charset UTF8 = Charset.forName("utf8");
 
     private static byte toHex(int val) { return (byte) (val < 10 ? '0' + val : 'a' + (val - 10)); }
 
@@ -65,7 +63,7 @@ public class StringUtilities {
      * @return The escaped string
      */
     public static String escape(String source, char delimiter) {
-        byte bytes[] = source.getBytes(UTF8);
+        byte bytes[] = source.getBytes(StandardCharsets.UTF_8);
         ByteArrayOutputStream result = new ByteArrayOutputStream();
         for (byte b : bytes) {
             int val = b;
@@ -86,11 +84,11 @@ public class StringUtilities {
                 result.write(replacementCharacters.replacement2[val]);
             }
         }
-        return new String(result.toByteArray(), UTF8);
+        return new String(result.toByteArray(), StandardCharsets.UTF_8);
     }
 
     public static String unescape(String source) {
-        byte bytes[] = source.getBytes(UTF8);
+        byte bytes[] = source.getBytes(StandardCharsets.UTF_8);
         ByteArrayOutputStream result = new ByteArrayOutputStream();
         for (int i=0; i<bytes.length; ++i) {
             if (bytes[i] != '\\') {
@@ -120,7 +118,7 @@ public class StringUtilities {
             result.write((byte) Integer.parseInt(hexdigits, 16));
             i += 3;
         }
-        return new String(result.toByteArray(), UTF8);
+        return new String(result.toByteArray(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/vespajlib/src/main/java/com/yahoo/text/Utf8.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Utf8.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.text;
 
 import java.io.IOException;
@@ -31,11 +31,6 @@ public final class Utf8 {
         return StandardCharsets.UTF_8;
     }
 
-    /** To be used instead of String.String(byte[] bytes) */
-    public static String toStringStd(byte[] data) {
-        return new String(data, StandardCharsets.UTF_8);
-    }
-
     /**
      * Utility method as toString(byte[]).
      *
@@ -63,13 +58,6 @@ public final class Utf8 {
     public static String toString(ByteBuffer data) {
         CharBuffer c = StandardCharsets.UTF_8.decode(data);
         return c.toString();
-    }
-
-    /**
-     * Uses String.getBytes directly.
-     */
-    public static byte[] toBytesStd(String str) {
-        return str.getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/vespajlib/src/test/java/com/yahoo/io/ByteWriterTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/io/ByteWriterTestCase.java
@@ -1,23 +1,23 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.yahoo.text.Utf8;
+import com.yahoo.text.Utf8Array;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.IdentityHashMap;
 
-import com.yahoo.text.Utf8;
-import com.yahoo.text.Utf8Array;
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test the ByteWriter class. ByteWriter is also implicitly tested in
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class ByteWriterTestCase {
 
-    private final CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+    private final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
     private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
     /**
@@ -281,7 +281,7 @@ public class ByteWriterTestCase {
     @Test
     public void testUnMappableCharacter() throws java.io.IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        ByteWriter writer = new ByteWriter(stream, Charset.forName("ascii").newEncoder());
+        ByteWriter writer = new ByteWriter(stream, StandardCharsets.US_ASCII.newEncoder());
         writer.write("yahoo\u9999bahoo");
         writer.close();
         assertTrue(stream.toString("ascii").contains("yahoo"));

--- a/vespajlib/src/test/java/com/yahoo/io/FileReadTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/io/FileReadTestCase.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io;
 
 import org.junit.Test;
@@ -6,7 +6,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -16,15 +16,15 @@ public class FileReadTestCase {
     @Test
     public void testReadByteArray() throws IOException {
         byte[] thisFile = IOUtils.readFileBytes(new File("src/test/java/com/yahoo/io/FileReadTestCase.java"));
-        String str = new String(thisFile, Charset.forName("US-ASCII"));
-        assertTrue(str.startsWith("// Copyright 2017 Yahoo Holdings."));
+        String str = new String(thisFile, StandardCharsets.US_ASCII);
+        assertTrue(str.startsWith("// Copyright Verizon Media."));
         assertTrue(str.endsWith("// Yeppers\n"));
     }
 
     @Test
     public void testReadString() throws IOException {
         String str = IOUtils.readFile(new File("src/test/java/com/yahoo/io/FileReadTestCase.java"));
-        assertTrue(str.startsWith("// Copyright 2017 Yahoo Holdings."));
+        assertTrue(str.startsWith("// Copyright Verizon Media."));
         assertTrue(str.endsWith("// Yeppers\n"));
     }
 

--- a/vespajlib/src/test/java/com/yahoo/io/HexDumpTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/io/HexDumpTestCase.java
@@ -1,27 +1,18 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io;
 
 import org.junit.Test;
 
-import com.yahoo.text.Utf8;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
  * @author Simon Thoresen Hult
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 public class HexDumpTestCase {
-
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-    private static final Charset UTF16 = Charset.forName("UTF-16");
 
     @Test
     public void requireThatToHexStringAcceptsNull() {
@@ -31,10 +22,10 @@ public class HexDumpTestCase {
     @Test
     public void requireThatToHexStringIsUnformatted() {
         assertEquals("6162636465666768696A6B6C6D6E6F707172737475767778797A",
-                     HexDump.toHexString("abcdefghijklmnopqrstuvwxyz".getBytes(UTF8)));
+                     HexDump.toHexString("abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8)));
         assertEquals("FEFF006100620063006400650066006700680069006A006B006C00" +
                      "6D006E006F0070007100720073007400750076007700780079007A",
-                     HexDump.toHexString("abcdefghijklmnopqrstuvwxyz".getBytes(UTF16)));
+                     HexDump.toHexString("abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_16)));
     }
 
 }

--- a/vespajlib/src/test/java/com/yahoo/io/SlowInflateTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/io/SlowInflateTestCase.java
@@ -1,20 +1,20 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io;
-
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-import java.util.zip.Deflater;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import com.yahoo.text.Utf8;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.Deflater;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Check decompressor used among other things for packed summary fields.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 public class SlowInflateTestCase {
 
@@ -27,7 +27,7 @@ public class SlowInflateTestCase {
     @Before
     public void setUp() throws Exception {
         value = "000000000000000000000000000000000000000000000000000000000000000";
-        raw = Utf8.toBytesStd(value);
+        raw = value.getBytes(StandardCharsets.UTF_8);
         output = new byte[raw.length * 2];
         Deflater compresser = new Deflater();
         compresser.setInput(raw);

--- a/vespajlib/src/test/java/com/yahoo/slime/JsonFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/slime/JsonFormatTestCase.java
@@ -1,8 +1,7 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.slime;
 
 import com.yahoo.text.Utf8;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -201,7 +200,7 @@ public class JsonFormatTestCase {
     public void testDecodeUnicodeAmp() {
         final String json = "{\"body\":\"some text\\u0026more text\"}";
         Slime slime = new Slime();
-        new JsonDecoder().decode(slime, Utf8.toBytesStd(json));
+        new JsonDecoder().decode(slime, json.getBytes(StandardCharsets.UTF_8));
         Cursor a = slime.get().field("body");
         assertThat(a.asString(), is("some text&more text"));
     }
@@ -224,7 +223,7 @@ public class JsonFormatTestCase {
                 "        }\n";
 
         Slime slime = new Slime();
-        slime = new JsonDecoder().decode(slime, Utf8.toBytesStd(json));
+        slime = new JsonDecoder().decode(slime, json.getBytes(StandardCharsets.UTF_8));
         Cursor a = slime.get().field("rules");
         assertThat(a.asString(), is(str));
     }
@@ -261,7 +260,7 @@ public class JsonFormatTestCase {
     private void verifyEncodeDecode(String json, boolean compact) {
         try {
             Slime slime = new Slime();
-            new JsonDecoder().decode(slime, Utf8.toBytesStd(json));
+            new JsonDecoder().decode(slime, json.getBytes(StandardCharsets.UTF_8));
             ByteArrayOutputStream a = new ByteArrayOutputStream();
             new JsonFormat(compact).encode(a, slime);
             assertEquals(json, Utf8.toString(a.toByteArray()));

--- a/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.text;
 
 import com.google.common.collect.ImmutableMap;
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author <a href="mailto:borud@yahoo-inc.com">Bjorn Borud</a>
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Bjorn Borud
+ * @author Steinar Knutsen
  */
 public class Utf8TestCase {
 
@@ -322,7 +322,7 @@ public class Utf8TestCase {
             for (char c=0; c < i; c++) {
                 sb.append(c);
             }
-            assertTrue(Arrays.equals(Utf8.toBytesStd(sb.toString()), Utf8.toBytes(sb.toString())));
+            assertTrue(Arrays.equals(sb.toString().getBytes(StandardCharsets.UTF_8), Utf8.toBytes(sb.toString())));
         }
     }
 


### PR DESCRIPTION
Only used in a few tests, and are now equivalent to `toString`/`toBytes`.

@baldersheim