### PR TITLE
Don't use request headers for remote address/port in hosted Vespa

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
@@ -12,8 +12,8 @@ import com.yahoo.vespa.model.container.component.AccessLogComponent;
  */
 public class LogserverContainer extends Container {
 
-    public LogserverContainer(AbstractConfigProducer parent) {
-        super(parent, "" + 0, 0);
+    public LogserverContainer(AbstractConfigProducer parent, boolean isHostedVespa) {
+        super(parent, "" + 0, 0, isHostedVespa);
         addComponent(new AccessLogComponent(AccessLogComponent.AccessLogType.jsonAccessLog, ((LogserverContainerCluster) parent).getName(), true));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -34,7 +34,7 @@ public class ClusterControllerContainer extends Container implements
     private final Set<String> bundles = new TreeSet<>();
 
     public ClusterControllerContainer(AbstractConfigProducer parent, int index, boolean runStandaloneZooKeeper, boolean isHosted) {
-        super(parent, "" + index, index);
+        super(parent, "" + index, index, isHosted);
         addHandler("clustercontroller-status",
                    "com.yahoo.vespa.clustercontroller.apps.clustercontroller.StatusHandler",
                    "/clustercontroller-status/*");

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -40,7 +40,7 @@ public class MetricsProxyContainer extends Container implements
     final boolean isHostedVespa;
 
     public MetricsProxyContainer(AbstractConfigProducer parent, String hostname, int index, boolean isHostedVespa) {
-        super(parent, hostname, index);
+        super(parent, hostname, index, isHostedVespa);
         this.isHostedVespa = isHostedVespa;
         setProp("clustertype", "admin");
         setProp("index", String.valueOf(index));

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
@@ -6,7 +6,6 @@ import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.ClusterSpec;
-import java.util.logging.Level;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.HostSystem;
 import com.yahoo.vespa.model.admin.Admin;
@@ -22,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -105,7 +105,7 @@ public class DomAdminV4Builder extends DomAdminBuilderBase {
         ContainerModel logserverClusterModel = new ContainerModel(context.withParent(admin).withId(logServerCluster.getSubId()));
         logserverClusterModel.setCluster(logServerCluster);
 
-        LogserverContainer container = new LogserverContainer(logServerCluster);
+        LogserverContainer container = new LogserverContainer(logServerCluster, deployState.isHosted());
         container.setHostResource(hostResource);
         container.initService(deployState.getDeployLogger());
         logServerCluster.addContainer(container);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -26,7 +26,7 @@ public final class ApplicationContainer extends Container implements QrStartConf
     }
 
     public ApplicationContainer(AbstractConfigProducer parent, String name, boolean retired, int index, boolean isHostedVespa) {
-        super(parent, name, retired, index);
+        super(parent, name, retired, index, isHostedVespa);
         this.isHostedVespa = isHostedVespa;
 
         addComponent(getFS4ResourcePool()); // TODO Remove when FS4 based search protocol is gone

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -73,19 +73,19 @@ public abstract class Container extends AbstractService implements
     private final ComponentGroup<Handler<?>> handlers = new ComponentGroup<>(this, "handler");
     private final ComponentGroup<Component<?, ?>> components = new ComponentGroup<>(this, "components");
 
-    private final JettyHttpServer defaultHttpServer = new JettyHttpServer(new ComponentId("DefaultHttpServer"));
+    private final JettyHttpServer defaultHttpServer;
 
-    protected Container(AbstractConfigProducer parent, String name, int index) {
-        this(parent, name, false, index);
+    protected Container(AbstractConfigProducer parent, String name, int index, boolean isHostedVespa) {
+        this(parent, name, false, index, isHostedVespa);
     }
 
-    protected Container(AbstractConfigProducer parent, String name, boolean retired, int index) {
+    protected Container(AbstractConfigProducer parent, String name, boolean retired, int index, boolean isHostedVespa) {
         super(parent, name);
         this.name = name;
         this.parent = parent;
         this.retired = retired;
         this.index = index;
-
+        this.defaultHttpServer = new JettyHttpServer(new ComponentId("DefaultHttpServer"), isHostedVespa);
         if (getHttp() == null) {
             addChild(defaultHttpServer);
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyHttpServerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyHttpServerBuilder.java
@@ -17,7 +17,7 @@ public class JettyHttpServerBuilder extends VespaDomBuilder.DomConfigProducerBui
 
     @Override
     protected JettyHttpServer doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element http) {
-        JettyHttpServer jettyHttpServer = new JettyHttpServer(new ComponentId("jdisc-jetty"));
+        JettyHttpServer jettyHttpServer = new JettyHttpServer(new ComponentId("jdisc-jetty"), deployState.isHosted());
         for (Element serverSpec: XML.getChildren(http, "server")) {
             ConnectorFactory connectorFactory = new JettyConnectorBuilder().build(deployState, ancestor, serverSpec);
             jettyHttpServer.addConnector(connectorFactory);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -353,7 +353,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             cluster.setHttp(new Http(new FilterChains(cluster)));
         }
         if(cluster.getHttp().getHttpServer().isEmpty()) {
-            JettyHttpServer defaultHttpServer = new JettyHttpServer(new ComponentId("DefaultHttpServer"));
+            JettyHttpServer defaultHttpServer = new JettyHttpServer(new ComponentId("DefaultHttpServer"), cluster.isHostedVespa());
             cluster.getHttp().setHttpServer(defaultHttpServer);
             defaultHttpServer.addConnector(new ConnectorFactory("SearchServer", Defaults.getDefaults().vespaWebServicePort()));
         }

--- a/jdisc_http_service/abi-spec.json
+++ b/jdisc_http_service/abi-spec.json
@@ -682,6 +682,44 @@
     ],
     "fields": []
   },
+  "com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder": {
+    "superClass": "java.lang.Object",
+    "interfaces": [
+      "com.yahoo.config.ConfigBuilder"
+    ],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>()",
+      "public void <init>(com.yahoo.jdisc.http.ServerConfig$AccessLog)",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder remoteAddressHeaders(java.lang.String)",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder remoteAddressHeaders(java.util.Collection)",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder remotePortHeaders(java.lang.String)",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder remotePortHeaders(java.util.Collection)",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog build()"
+    ],
+    "fields": [
+      "public java.util.List remoteAddressHeaders",
+      "public java.util.List remotePortHeaders"
+    ]
+  },
+  "com.yahoo.jdisc.http.ServerConfig$AccessLog": {
+    "superClass": "com.yahoo.config.InnerNode",
+    "interfaces": [],
+    "attributes": [
+      "public",
+      "final"
+    ],
+    "methods": [
+      "public void <init>(com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder)",
+      "public java.util.List remoteAddressHeaders()",
+      "public java.lang.String remoteAddressHeaders(int)",
+      "public java.util.List remotePortHeaders()",
+      "public java.lang.String remotePortHeaders(int)"
+    ],
+    "fields": []
+  },
   "com.yahoo.jdisc.http.ServerConfig$Builder": {
     "superClass": "java.lang.Object",
     "interfaces": [
@@ -704,6 +742,7 @@
       "public com.yahoo.jdisc.http.ServerConfig$Builder stopTimeout(double)",
       "public com.yahoo.jdisc.http.ServerConfig$Builder jmx(com.yahoo.jdisc.http.ServerConfig$Jmx$Builder)",
       "public com.yahoo.jdisc.http.ServerConfig$Builder metric(com.yahoo.jdisc.http.ServerConfig$Metric$Builder)",
+      "public com.yahoo.jdisc.http.ServerConfig$Builder accessLog(com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder)",
       "public final boolean dispatchGetConfig(com.yahoo.config.ConfigInstance$Producer)",
       "public final java.lang.String getDefMd5()",
       "public final java.lang.String getDefName()",
@@ -713,7 +752,8 @@
     "fields": [
       "public java.util.List filter",
       "public com.yahoo.jdisc.http.ServerConfig$Jmx$Builder jmx",
-      "public com.yahoo.jdisc.http.ServerConfig$Metric$Builder metric"
+      "public com.yahoo.jdisc.http.ServerConfig$Metric$Builder metric",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog$Builder accessLog"
     ]
   },
   "com.yahoo.jdisc.http.ServerConfig$Filter$Builder": {
@@ -854,7 +894,8 @@
       "public int maxWorkerThreads()",
       "public double stopTimeout()",
       "public com.yahoo.jdisc.http.ServerConfig$Jmx jmx()",
-      "public com.yahoo.jdisc.http.ServerConfig$Metric metric()"
+      "public com.yahoo.jdisc.http.ServerConfig$Metric metric()",
+      "public com.yahoo.jdisc.http.ServerConfig$AccessLog accessLog()"
     ],
     "fields": [
       "public static final java.lang.String CONFIG_DEF_MD5",

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -147,7 +147,7 @@ public class JettyHttpServer extends AbstractServerProvider {
 
         server = new Server();
         server.setStopTimeout((long)(serverConfig.stopTimeout() * 1000.0));
-        server.setRequestLog(new AccessLogRequestLog(accessLog));
+        server.setRequestLog(new AccessLogRequestLog(accessLog, serverConfig.accessLog()));
         setupJmx(server, serverConfig);
         ((QueuedThreadPool)server.getThreadPool()).setMaxThreads(serverConfig.maxWorkerThreads());
 

--- a/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.jdisc.http.server.def
+++ b/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.jdisc.http.server.def
@@ -44,3 +44,9 @@ metric.monitoringHandlerPaths[]       string
 
 # Paths that should be reported with search dimensions where applicable
 metric.searchHandlerPaths[]           string
+
+# HTTP request headers that contain remote address
+accessLog.remoteAddressHeaders[]      string
+
+# HTTP request headers that contain remote port
+accessLog.remotePortHeaders[]         string


### PR DESCRIPTION
Control which headers are used for remote address/port in access log through config model.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
