### PR TITLE
Stop taking config lock exclusively in node-repository

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -368,13 +368,6 @@ public class Flags {
             "Takes effect on next internal redeployment",
             APPLICATION_ID);
 
-    public static final UnboundBooleanFlag USE_CONFIG_SERVER_LOCK = defineFeatureFlag(
-            "use-config-server-lock",
-            false,
-            "Whether the node-repository should take the same application lock as the config server when making changes to nodes",
-            "Takes effect on config server restart"
-    );
-
     public static final UnboundBooleanFlag HIDE_SHARED_ROUTING_ENDPOINT = defineFeatureFlag(
             "hide-shared-routing-endpoint",
             false,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Applications.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Applications.java
@@ -25,7 +25,10 @@ public class Applications {
         // read and write all to make sure they are stored in the latest version of the serialized format
         for (ApplicationId id : ids()) {
             try (Mutex lock = db.lock(id)) {
-                get(id).ifPresent(application -> put(application, lock));
+                // TODO(mpolden): Remove inner lock
+                try (Mutex innerLock = db.configLock(id)) {
+                    get(id).ifPresent(application -> put(application, lock));
+                }
             }
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
@@ -124,10 +124,13 @@ public class LoadBalancerExpirer extends NodeRepositoryMaintainer {
     private void withLoadBalancersIn(LoadBalancer.State state, Consumer<LoadBalancer> operation) {
         for (var id : db.readLoadBalancerIds()) {
             try (var lock = db.lock(id.application())) {
-                var loadBalancer = db.readLoadBalancer(id);
-                if (loadBalancer.isEmpty()) continue;              // Load balancer was removed during loop
-                if (loadBalancer.get().state() != state) continue; // Wrong state
-                operation.accept(loadBalancer.get());
+                // TODO(mpolden): Remove inner lock
+                try (var innerLock = db.configLock(id.application())) {
+                    var loadBalancer = db.readLoadBalancer(id);
+                    if (loadBalancer.isEmpty()) continue;              // Load balancer was removed during loop
+                    if (loadBalancer.get().state() != state) continue; // Wrong state
+                    operation.accept(loadBalancer.get());
+                }
             }
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -60,8 +60,11 @@ public class LoadBalancerProvisioner {
         // Read and write all load balancers to make sure they are stored in the latest version of the serialization format
         for (var id : db.readLoadBalancerIds()) {
             try (var lock = db.lock(id.application())) {
-                var loadBalancer = db.readLoadBalancer(id);
-                loadBalancer.ifPresent(db::writeLoadBalancer);
+                // TODO(mpolden): Remove inner lock
+                try (var innerLock = db.configLock(id.application())) {
+                    var loadBalancer = db.readLoadBalancer(id);
+                    loadBalancer.ifPresent(db::writeLoadBalancer);
+                }
             }
         }
     }
@@ -80,9 +83,12 @@ public class LoadBalancerProvisioner {
         if (!canForwardTo(requestedNodes.type(), cluster)) return; // Nothing to provision for this node and cluster type
         if (application.instance().isTester()) return; // Do not provision for tester instances
         try (var lock = db.lock(application)) {
-            ClusterSpec.Id clusterId = effectiveId(cluster);
-            List<Node> nodes = nodesOf(clusterId, application);
-            provision(application, clusterId, nodes,false, lock);
+            // TODO(mpolden): Remove inner lock
+            try (var innerLock = db.configLock(application)) {
+                ClusterSpec.Id clusterId = effectiveId(cluster);
+                List<Node> nodes = nodesOf(clusterId, application);
+                provision(application, clusterId, nodes, false, lock);
+            }
         }
     }
 
@@ -99,15 +105,18 @@ public class LoadBalancerProvisioner {
     public void activate(ApplicationId application, Set<ClusterSpec> clusters,
                          @SuppressWarnings("unused") Mutex applicationLock, NestedTransaction transaction) {
         try (var lock = db.lock(application)) {
-            for (var cluster : loadBalancedClustersOf(application).entrySet()) {
-                // Provision again to ensure that load balancer instance is re-configured with correct nodes
-                provision(application, cluster.getKey(), cluster.getValue(), true, lock);
+            // TODO(mpolden): Remove inner lock
+            try (var innerLock = db.configLock(application)) {
+                for (var cluster : loadBalancedClustersOf(application).entrySet()) {
+                    // Provision again to ensure that load balancer instance is re-configured with correct nodes
+                    provision(application, cluster.getKey(), cluster.getValue(), true, lock);
+                }
+                // Deactivate any surplus load balancers, i.e. load balancers for clusters that have been removed
+                var surplusLoadBalancers = surplusLoadBalancersOf(application, clusters.stream()
+                                                                                       .map(LoadBalancerProvisioner::effectiveId)
+                                                                                       .collect(Collectors.toSet()));
+                deactivate(surplusLoadBalancers, transaction);
             }
-            // Deactivate any surplus load balancers, i.e. load balancers for clusters that have been removed
-            var surplusLoadBalancers = surplusLoadBalancersOf(application, clusters.stream()
-                                                                                   .map(LoadBalancerProvisioner::effectiveId)
-                                                                                   .collect(Collectors.toSet()));
-            deactivate(surplusLoadBalancers, transaction);
         }
     }
 
@@ -116,8 +125,9 @@ public class LoadBalancerProvisioner {
      * load balancer(s).
      */
     public void deactivate(ApplicationId application, NestedTransaction transaction) {
-        try (var applicationLock = nodeRepository.lock(application)) {
-            try (var lock = db.lock(application)) {
+        try (var lock = nodeRepository.lock(application)) {
+            // TODO(mpolden): Remove inner lock
+            try (var innerLock = db.configLock(application)) {
                 deactivate(nodeRepository.loadBalancers(application).asList(), transaction);
             }
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClientTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClientTest.java
@@ -8,7 +8,6 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.curator.mock.MockCurator;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.provisioning.FlavorConfigBuilder;
@@ -42,19 +41,16 @@ public class CuratorDatabaseClientTest {
     public void locks_can_be_acquired_and_released() {
         ApplicationId app = ApplicationId.from(TenantName.from("testTenant"), ApplicationName.from("testApp"), InstanceName.from("testInstance"));
 
-        try (Lock mutex1 = zkClient.lock(app)) {
-            mutex1.toString(); // reference to avoid warning
+        try (var ignored = zkClient.lock(app)) {
             throw new RuntimeException();
         }
         catch (RuntimeException expected) {
         }
 
-        try (Lock mutex2 = zkClient.lock(app)) {
-            mutex2.toString(); // reference to avoid warning
+        try (var ignored = zkClient.lock(app)) {
         }
 
-        try (Lock mutex3 = zkClient.lock(app)) {
-            mutex3.toString(); // reference to avoid warning
+        try (var ignored = zkClient.lock(app)) {
         }
 
     }


### PR DESCRIPTION
We believe we've identified how locking should behave, at least in the
short-term:

1) Migrate existing use of `/config/v2/locks/<application-id>` inside
node-repository to only use `/provision/v1/locks/<application-id>`. This ensures
that prepare only acquires `/provision/v1/locks/<application-id>` on the
node-repository side. Locks and node repo writes always happen together, i.e.
we're not building a list of transactions that are committed at some later point.

2) Ensure that transactional operations such as `active` and `deactivate` holds
both `/config/v2/locks/<application-id>` and
`/provision/v1/locks/<application-id>` until the transaction is committed.

@hakonhall

FYI @hmusum