### PR TITLE
Make GroupHash and GroupEqual assignable.

### DIFF
--- a/searchlib/src/vespa/searchlib/grouping/groupengine.h
+++ b/searchlib/src/vespa/searchlib/grouping/groupengine.h
@@ -12,20 +12,20 @@ class GroupEngine : protected Collect
 public:
     class GroupHash {
     public:
-        GroupHash(const GroupEngine & engine) : _engine(engine) { }
-        uint32_t operator () (GroupRef a) const { return _engine.hash(a); }
+        GroupHash(const GroupEngine & engine) : _engine(&engine) { }
+        uint32_t operator () (GroupRef a) const { return _engine->hash(a); }
         uint32_t operator () (const expression::ResultNode & a) const { return a.hash(); }
     private:
-        const GroupEngine & _engine;
+        const GroupEngine * _engine;
     };
     class GroupEqual {
     public:
-        GroupEqual(const GroupEngine & engine) : _engine(engine) { }
-        bool operator () (GroupRef a, GroupRef b) const { return _engine.cmpId(a, b) == 0; }
-        bool operator () (const expression::ResultNode & a, GroupRef b) const { return a.cmpFast(_engine.getGroupId(b)) == 0; }
-        bool operator () (GroupRef a, const expression::ResultNode & b) const { return _engine.getGroupId(a).cmpFast(b) == 0; }
+        GroupEqual(const GroupEngine & engine) : _engine(&engine) { }
+        bool operator () (GroupRef a, GroupRef b) const { return _engine->cmpId(a, b) == 0; }
+        bool operator () (const expression::ResultNode & a, GroupRef b) const { return a.cmpFast(_engine->getGroupId(b)) == 0; }
+        bool operator () (GroupRef a, const expression::ResultNode & b) const { return _engine->getGroupId(a).cmpFast(b) == 0; }
     private:
-        const GroupEngine & _engine;
+        const GroupEngine * _engine;
     };
     class GroupIdLess {
     public:


### PR DESCRIPTION
@baldersheim : please review

An alternate approach is to adjust the `noexcept` specifier for `hash_set(operator=(hash_set &&)` in `vespalib/src/vespa/vespalib/stllike/hash_set.h`  to use `std::is_nothrow_move_assignable<HashTable>::value`.
Just removing the `noexcept` specifier might also work.