### PR TITLE
Avoid even small double-counting of locked time

### DIFF
--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Lock.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Lock.java
@@ -57,12 +57,15 @@ public class Lock implements Mutex {
 
     @Override
     public void close() {
+        ThreadLockStats threadLockStats = LockStats.getForCurrentThread();
+        // Update metrics now before release() to avoid double-counting time in locked state.
+        threadLockStats.preRelease();
         try {
             mutex.release();
-            LockStats.getForCurrentThread().lockReleased();
+            threadLockStats.postRelease();
         }
         catch (Exception e) {
-            LockStats.getForCurrentThread().lockReleaseFailed();
+            threadLockStats.releaseFailed();
             throw new RuntimeException("Exception releasing lock '" + lockPath + "'");
         }
     }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockAttempt.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockAttempt.java
@@ -115,14 +115,17 @@ public class LockAttempt {
         activeLockedInterval = lockMetrics.lockAcquired(activeAcquireInterval);
     }
 
-    void released() {
-        setTerminalState(LockState.RELEASED);
-        lockMetrics.release(activeLockedInterval);
+    void preRelease() {
+        lockMetrics.preRelease(activeLockedInterval);
     }
 
-    void releasedWithError() {
+    void postRelease() {
+        setTerminalState(LockState.RELEASED);
+    }
+
+    void releaseFailed() {
         setTerminalState(LockState.RELEASED_WITH_ERROR);
-        lockMetrics.releaseFailed(activeLockedInterval);
+        lockMetrics.releaseFailed();
     }
 
     void setTerminalState(LockState terminalState) { setTerminalState(terminalState, Instant.now()); }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockMetrics.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockMetrics.java
@@ -1,6 +1,8 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.curator.stats;
 
+import com.yahoo.vespa.curator.stats.LatencyStats.ActiveInterval;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -27,39 +29,38 @@ public class LockMetrics {
     private final LatencyStats lockedStats = new LatencyStats();
 
     /** Returns a Runnable that must be invoked when the acquire() finishes. */
-    LatencyStats.ActiveInterval acquireInvoked() {
+    ActiveInterval acquireInvoked() {
         acquireCount.incrementAndGet();
         cumulativeAcquireCount.incrementAndGet();
         return acquireStats.startNewInterval();
     }
 
-    void acquireFailed(LatencyStats.ActiveInterval acquireInterval) {
+    void acquireFailed(ActiveInterval acquireInterval) {
         acquireInterval.close();
         acquireFailedCount.incrementAndGet();
         cumulativeAcquireFailedCount.incrementAndGet();
     }
 
-    void acquireTimedOut(LatencyStats.ActiveInterval acquireInterval) {
+    void acquireTimedOut(ActiveInterval acquireInterval) {
         acquireInterval.close();
         acquireTimedOutCount.incrementAndGet();
         cumulativeAcquireTimedOutCount.incrementAndGet();
     }
 
-    LatencyStats.ActiveInterval lockAcquired(LatencyStats.ActiveInterval acquireInterval) {
+    ActiveInterval lockAcquired(ActiveInterval acquireInterval) {
         acquireInterval.close();
         acquireSucceededCount.incrementAndGet();
         cumulativeAcquireSucceededCount.incrementAndGet();
         return lockedStats.startNewInterval();
     }
 
-    void release(LatencyStats.ActiveInterval lockedInterval) {
+    void preRelease(ActiveInterval lockedInterval) {
         lockedInterval.close();
         releaseCount.incrementAndGet();
         cumulativeReleaseCount.incrementAndGet();
     }
 
-    void releaseFailed(LatencyStats.ActiveInterval lockedInterval) {
-        release(lockedInterval);
+    void releaseFailed() {
         releaseFailedCount.incrementAndGet();
         cumulativeReleaseFailedCount.incrementAndGet();
     }


### PR DESCRIPTION
This is to track down the cause of >1 load in the metrics graphs.  I found >1 even in the metrics reported, which is hopefully fixed with this PR.