### PR TITLE
Upgrade Jetty to 9.4.32

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -30,7 +30,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.30.v20200611</jetty.version>
+        <jetty.version>9.4.32.v20200930</jetty.version>
         <junit5.version>5.6.2</junit5.version>
         <junit5.platform.version>1.6.2</junit5.platform.version>
         <org.lz4.version>1.7.1</org.lz4.version>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -446,7 +446,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.30.v20200611</jetty.version>
+        <jetty.version>9.4.32.v20200930</jetty.version>
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.5</slf4j.version>

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
@@ -3,9 +3,9 @@ package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.http.ConnectorConfig;
+import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnectionStatistics;
 import org.eclipse.jetty.server.ServerConnector;
 
 import javax.servlet.ServletRequest;
@@ -25,7 +25,7 @@ class JDiscServerConnector extends ServerConnector {
     public static final String REQUEST_ATTRIBUTE = JDiscServerConnector.class.getName();
     private final Metric.Context metricCtx;
     private final Map<RequestDimensions, Metric.Context> requestMetricContextCache = new ConcurrentHashMap<>();
-    private final ServerConnectionStatistics statistics;
+    private final ConnectionStatistics statistics;
     private final ConnectorConfig config;
     private final boolean tcpKeepAlive;
     private final boolean tcpNoDelay;
@@ -43,7 +43,7 @@ class JDiscServerConnector extends ServerConnector {
         this.listenPort = config.listenPort();
         this.metricCtx = metric.createContext(createConnectorDimensions(listenPort, connectorName));
 
-        this.statistics = new ServerConnectionStatistics();
+        this.statistics = new ConnectionStatistics();
         addBean(statistics);
         ConnectorConfig.Throttling throttlingConfig = config.throttling();
         if (throttlingConfig.enabled()) {
@@ -61,7 +61,7 @@ class JDiscServerConnector extends ServerConnector {
         }
     }
 
-    public ServerConnectionStatistics getStatistics() {
+    public ConnectionStatistics getStatistics() {
         return statistics;
     }
 

--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -15,12 +15,12 @@ import com.yahoo.jdisc.http.server.FilterBindings;
 import com.yahoo.jdisc.service.AbstractServerProvider;
 import com.yahoo.jdisc.service.CurrentContainer;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.ConnectorServer;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnectionStatistics;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.AbstractHandlerContainer;
@@ -381,7 +381,7 @@ public class JettyHttpServer extends AbstractServerProvider {
     }
 
     private void setConnectorMetrics(JDiscServerConnector connector) {
-        ServerConnectionStatistics statistics = connector.getStatistics();
+        ConnectionStatistics statistics = connector.getStatistics();
         metric.set(Metrics.NUM_CONNECTIONS, statistics.getConnectionsTotal(), connector.getConnectorMetricContext());
         metric.set(Metrics.NUM_OPEN_CONNECTIONS, statistics.getConnections(), connector.getConnectorMetricContext());
         metric.set(Metrics.NUM_CONNECTIONS_OPEN_MAX, statistics.getConnectionsMax(), connector.getConnectorMetricContext());


### PR DESCRIPTION
ServerConnectionStatistics is deprecated - using ConnectionStatistics instead.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
