### PR TITLE
fast value to enable inlined sparse operations

### DIFF
--- a/eval/src/tests/eval/simple_sparse_map/simple_sparse_map_test.cpp
+++ b/eval/src/tests/eval/simple_sparse_map/simple_sparse_map_test.cpp
@@ -24,7 +24,7 @@ public:
         }
     }
     ~StringList();
-    const std::vector<vespalib::string> direct_str() const { return _str_list; }
+    ConstArrayRef<vespalib::string> direct_str() const { return _str_list; }
     ConstArrayRef<vespalib::stringref> direct_ref() const { return _ref_list; }
     ConstArrayRef<const vespalib::stringref *> indirect_ref() const { return _ref_ptr_list; }
 };
@@ -55,10 +55,12 @@ TEST(SimpleSparseMapTest, simple_sparse_map_basic_usage_works) {
     EXPECT_EQ(map.lookup(a4.direct_ref()), map.npos());
     EXPECT_EQ(map.lookup(a4.indirect_ref()), map.npos());
     EXPECT_EQ(SimpleSparseMap::npos(), map.npos());
-    SL expect_labels({"a","a","a",
-                      "a","a","b",
-                      "a","b","a"});
-    EXPECT_EQ(map.labels(), expect_labels.direct_str());
+    EXPECT_EQ(map.labels().size(), 9);
+    auto dump = [&](auto addr_tag, auto subspace, auto hash) {
+        auto addr = map.make_addr(addr_tag);
+        fprintf(stderr, "   [%s,%s,%s]: %u (%zu)\n", addr[0].label.c_str(), addr[1].label.c_str(), addr[2].label.c_str(), subspace, hash);
+    };
+    map.each_map_entry(dump);
 }
 
 TEST(SimpleSparseMapTest, simple_sparse_map_works_with_no_labels) {

--- a/eval/src/tests/tensor/instruction_benchmark/instruction_benchmark.cpp
+++ b/eval/src/tests/tensor/instruction_benchmark/instruction_benchmark.cpp
@@ -21,6 +21,7 @@
 // verifying that all implementations produce the same result.
 
 #include <vespa/eval/eval/simple_value.h>
+#include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/interpreted_function.h>
 #include <vespa/eval/instruction/generic_join.h>
 #include <vespa/eval/instruction/generic_reduce.h>
@@ -127,11 +128,12 @@ struct EngineImpl : Impl {
 
 //-----------------------------------------------------------------------------
 
-EngineImpl  simple_tensor_engine_impl(4, " SimpleTensorEngine", " SimpleT", SimpleTensorEngine::ref());
+EngineImpl  simple_tensor_engine_impl(5, " SimpleTensorEngine", " SimpleT", SimpleTensorEngine::ref());
 EngineImpl default_tensor_engine_impl(1, "DefaultTensorEngine", "OLD PROD", DefaultTensorEngine::ref());
-ValueImpl           simple_value_impl(3, "        SimpleValue", " SimpleV", SimpleValueBuilderFactory::get());
-ValueImpl    packed_mixed_tensor_impl(2, "  PackedMixedTensor", "  Packed", PackedMixedTensorBuilderFactory::get());
-ValueImpl   default_tensor_value_impl(0, "       DefaultValue", "NEW PROD", DefaultValueBuilderFactory::get());
+ValueImpl           simple_value_impl(2, "        SimpleValue", " SimpleV", SimpleValueBuilderFactory::get());
+ValueImpl             fast_value_impl(0, "          FastValue", "NEW PROD", FastValueBuilderFactory::get());
+ValueImpl    packed_mixed_tensor_impl(4, "  PackedMixedTensor", "  Packed", PackedMixedTensorBuilderFactory::get());
+ValueImpl   default_tensor_value_impl(3, "       DefaultValue", "DefaultV", DefaultValueBuilderFactory::get());
 vespalib::string                                   short_header("--------");
 
 constexpr double budget = 5.0;
@@ -142,6 +144,7 @@ constexpr double good_limit = 1.10; // GOOD: new prod has performance higher tha
 std::vector<CREF<Impl>> impl_list = {simple_tensor_engine_impl,
                                      default_tensor_engine_impl,
                                      simple_value_impl,
+                                     fast_value_impl,
                                      packed_mixed_tensor_impl,
                                      default_tensor_value_impl};
 

--- a/eval/src/vespa/eval/eval/CMakeLists.txt
+++ b/eval/src/vespa/eval/eval/CMakeLists.txt
@@ -8,6 +8,7 @@ vespa_add_library(eval_eval OBJECT
     delete_node.cpp
     double_value_builder.cpp
     fast_forest.cpp
+    fast_value.cpp
     function.cpp
     gbdt.cpp
     interpreted_function.cpp

--- a/eval/src/vespa/eval/eval/fast_value.cpp
+++ b/eval/src/vespa/eval/eval/fast_value.cpp
@@ -1,0 +1,38 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "fast_value.h"
+#include <vespa/vespalib/util/typify.h>
+#include "fast_value.hpp"
+
+namespace vespalib::eval {
+
+//-----------------------------------------------------------------------------
+
+namespace {
+
+struct CreateFastValueBuilderBase {
+    template <typename T> static std::unique_ptr<ValueBuilderBase> invoke(const ValueType &type,
+            size_t num_mapped_dims, size_t subspace_size, size_t expected_subspaces)
+    {
+        assert(check_cell_type<T>(type.cell_type()));
+        return std::make_unique<FastValue<T>>(type, num_mapped_dims, subspace_size, expected_subspaces);
+    }
+};
+
+} // namespace <unnamed>
+
+//-----------------------------------------------------------------------------
+
+FastValueBuilderFactory::FastValueBuilderFactory() = default;
+FastValueBuilderFactory FastValueBuilderFactory::_factory;
+
+std::unique_ptr<ValueBuilderBase>
+FastValueBuilderFactory::create_value_builder_base(const ValueType &type, size_t num_mapped_dims, size_t subspace_size,
+                                                     size_t expected_subspaces) const
+{
+    return typify_invoke<1,TypifyCellType,CreateFastValueBuilderBase>(type.cell_type(), type, num_mapped_dims, subspace_size, expected_subspaces);
+}
+
+//-----------------------------------------------------------------------------
+
+}

--- a/eval/src/vespa/eval/eval/fast_value.h
+++ b/eval/src/vespa/eval/eval/fast_value.h
@@ -1,0 +1,25 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "value.h"
+
+namespace vespalib::eval {
+
+/**
+ * A fast value is a value that uses a FastValueIndex to store its
+ * sparse mappings. A FastValueIndex uses the same implementation as a
+ * SimpleValueIndex but adds extra inlined functions that can be
+ * called directly from various instruction implementations.
+ **/
+class FastValueBuilderFactory : public ValueBuilderFactory {
+private:
+    FastValueBuilderFactory();
+    static FastValueBuilderFactory _factory;
+    std::unique_ptr<ValueBuilderBase> create_value_builder_base(const ValueType &type,
+            size_t num_mapped_dims, size_t subspace_size, size_t expected_subspaces) const override;
+public:
+    static const FastValueBuilderFactory &get() { return _factory; }
+};
+
+}

--- a/eval/src/vespa/eval/eval/fast_value.hpp
+++ b/eval/src/vespa/eval/eval/fast_value.hpp
@@ -1,0 +1,81 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "simple_value.h"
+#include "inline_operation.h"
+#include <vespa/eval/instruction/generic_join.h>
+#include <vespa/vespalib/stllike/hash_map.hpp>
+
+namespace vespalib::eval {
+
+//-----------------------------------------------------------------------------
+
+// This is the class instructions will look for when optimizing sparse
+// operations by calling inline functions directly.
+
+struct FastValueIndex final : SimpleValueIndex {
+    FastValueIndex(size_t num_mapped_dims_in, size_t expected_subspaces_in)
+        : SimpleValueIndex(num_mapped_dims_in, expected_subspaces_in) {}
+
+    template <typename LCT, typename RCT, typename OCT, typename Fun>
+        static const Value &sparse_full_overlap_join(const ValueType &res_type, const Fun &fun,
+                const FastValueIndex &lhs, const FastValueIndex &rhs,
+                ConstArrayRef<LCT> lhs_cells, ConstArrayRef<RCT> rhs_cells, Stash &stash);
+};
+
+//-----------------------------------------------------------------------------
+
+template <typename T>
+struct FastValue final : Value, ValueBuilder<T> {
+
+    ValueType my_type;
+    size_t my_subspace_size;
+    FastValueIndex my_index;
+    std::vector<T> my_cells;
+
+    FastValue(const ValueType &type_in, size_t num_mapped_dims_in, size_t subspace_size_in, size_t expected_subspaces_in)
+        : my_type(type_in), my_subspace_size(subspace_size_in), my_index(num_mapped_dims_in, expected_subspaces_in), my_cells()
+    {
+        my_cells.reserve(subspace_size_in * expected_subspaces_in);
+    }
+    ~FastValue() override;
+    const ValueType &type() const override { return my_type; }
+    const Value::Index &index() const override { return my_index; }
+    TypedCells cells() const override { return TypedCells(ConstArrayRef<T>(my_cells)); }
+    ArrayRef<T> add_subspace(ConstArrayRef<vespalib::stringref> addr) override {
+        size_t old_size = my_cells.size();
+        my_index.map.add_mapping(addr);
+        my_cells.resize(old_size + my_subspace_size);
+        return ArrayRef<T>(&my_cells[old_size], my_subspace_size);
+    }
+    std::unique_ptr<Value> build(std::unique_ptr<ValueBuilder<T>> self) override {
+        ValueBuilder<T>* me = this;
+        assert(me == self.get());
+        self.release();
+        return std::unique_ptr<Value>(this);
+    }
+};
+template <typename T> FastValue<T>::~FastValue() = default;
+
+//-----------------------------------------------------------------------------
+
+template <typename LCT, typename RCT, typename OCT, typename Fun>
+const Value &
+FastValueIndex::sparse_full_overlap_join(const ValueType &res_type, const Fun &fun,
+                                         const FastValueIndex &lhs, const FastValueIndex &rhs,
+                                         ConstArrayRef<LCT> lhs_cells, ConstArrayRef<RCT> rhs_cells, Stash &stash)
+{
+    auto &result = stash.create<FastValue<OCT>>(res_type, lhs.map.num_dims(), 1, lhs.map.size());
+    lhs.map.each_map_entry([&](auto addr_tag, auto lhs_subspace, auto hash)
+                           {
+                               auto rhs_subspace = rhs.map.lookup(hash);
+                               if (rhs_subspace != SimpleSparseMap::npos()) {
+                                   result.my_index.map.add_mapping(lhs.map.make_addr(addr_tag), hash);
+                                   result.my_cells.push_back(fun(lhs_cells[lhs_subspace], rhs_cells[rhs_subspace]));
+                               }
+                           });
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+
+}

--- a/eval/src/vespa/eval/eval/simple_value.h
+++ b/eval/src/vespa/eval/eval/simple_value.h
@@ -15,29 +15,37 @@ namespace vespalib::eval {
 class TensorSpec;
 
 /**
+ * Implements the Value::Index API using a SimpleSparseMap.
+ **/
+struct SimpleValueIndex : Value::Index {
+    SimpleSparseMap map;
+    SimpleValueIndex(size_t num_mapped_dims_in, size_t expected_subspaces_in)
+        : map(num_mapped_dims_in, expected_subspaces_in) {}
+    size_t size() const override { return map.size(); }
+    std::unique_ptr<View> create_view(const std::vector<size_t> &dims) const override;   
+};
+
+/**
  * A simple implementation of a generic value that can also be used to
  * build new values. This class focuses on simplicity and is intended
  * as a reference implementation that can also be used to test the
  * correctness of tensor operations as they are moved away from the
  * implementation of individual tensor classes.
  **/
-class SimpleValue : public Value, public Value::Index
+class SimpleValue : public Value
 {
 private:
     ValueType _type;
-    size_t _num_mapped_dims;
     size_t _subspace_size;
-    SimpleSparseMap _index;
+    SimpleValueIndex _index;
 protected:
     size_t subspace_size() const { return _subspace_size; }
-    void add_mapping(ConstArrayRef<vespalib::stringref> addr) { _index.add_mapping(addr); }
+    void add_mapping(ConstArrayRef<vespalib::stringref> addr) { _index.map.add_mapping(addr); }
 public:
     SimpleValue(const ValueType &type, size_t num_mapped_dims_in, size_t subspace_size_in, size_t expected_subspaces_in);
     ~SimpleValue() override;
     const ValueType &type() const override { return _type; }
-    const Value::Index &index() const override { return *this; }
-    size_t size() const override { return _index.size(); }
-    std::unique_ptr<View> create_view(const std::vector<size_t> &dims) const override;
+    const Value::Index &index() const override { return _index; }
 };
 
 /**

--- a/eval/src/vespa/eval/instruction/generic_join.h
+++ b/eval/src/vespa/eval/instruction/generic_join.h
@@ -79,6 +79,28 @@ struct SparseJoinState {
     ~SparseJoinState();
 };
 
+/**
+ * Full set of parameters passed to low-level generic join function
+ **/
+struct JoinParam {
+    ValueType res_type;
+    SparseJoinPlan sparse_plan;
+    DenseJoinPlan dense_plan;
+    join_fun_t function;
+    const ValueBuilderFactory &factory;
+    JoinParam(const ValueType &lhs_type, const ValueType &rhs_type,
+             join_fun_t function_in, const ValueBuilderFactory &factory_in)
+        : res_type(ValueType::join(lhs_type, rhs_type)),
+          sparse_plan(lhs_type, rhs_type),
+          dense_plan(lhs_type, rhs_type),
+          function(function_in),
+          factory(factory_in)
+    {
+        assert(!res_type.is_error());
+    }
+    ~JoinParam();
+};
+
 //-----------------------------------------------------------------------------
 
 } // namespace


### PR DESCRIPTION
use full overlap sparse join as initial test of full inlining.

also improve simple sparse map performance by pre-calculating string
hashes and using hash values for equality checks.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review
@geirst FYI

NB: I think we want to fork the SimpleValue and FastValue implementations and use a string-based std::map for the simple one, and rename SimpleSparseMap to FastSparseMap. I will do that as a follow-up.
