### PR TITLE
Track test-and-set condition mismatches as own backend metric

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -44,6 +44,17 @@ struct FileStorThreadMetrics : public metrics::MetricSet
                           MetricSet* owner, bool includeUnused) const override;
     };
 
+    template <typename BaseOp>
+    struct OpWithTestAndSetFailed : BaseOp {
+        metrics::LongCountMetric test_and_set_failed;
+
+        OpWithTestAndSetFailed(const std::string& id, const std::string& name, MetricSet* owner = nullptr);
+        ~OpWithTestAndSetFailed() override;
+
+        MetricSet * clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
+                          MetricSet* owner, bool includeUnused) const override;
+    };
+
     struct OpWithNotFound : Op {
         metrics::LongCountMetric notFound;
 
@@ -53,7 +64,7 @@ struct FileStorThreadMetrics : public metrics::MetricSet
                          MetricSet* owner, bool includeUnused) const override;
     };
 
-    struct Update : OpWithRequestSize<OpWithNotFound> {
+    struct Update : OpWithTestAndSetFailed<OpWithRequestSize<OpWithNotFound>> {
         metrics::LongAverageMetric latencyRead;
 
         explicit Update(MetricSet* owner = nullptr);
@@ -73,11 +84,16 @@ struct FileStorThreadMetrics : public metrics::MetricSet
                          MetricSet* owner, bool includeUnused) const override;
     };
 
+    // FIXME this daisy-chaining approach to metric set variants is not the prettiest...
+    using PutMetricType    = OpWithTestAndSetFailed<OpWithRequestSize<Op>>;
+    using GetMetricType    = OpWithRequestSize<OpWithNotFound>;
+    using RemoveMetricType = OpWithTestAndSetFailed<OpWithRequestSize<OpWithNotFound>>;
+
     metrics::LongCountMetric operations;
     metrics::LongCountMetric failedOperations;
-    metrics::LoadMetric<OpWithRequestSize<Op>> put;
-    metrics::LoadMetric<OpWithRequestSize<OpWithNotFound>> get;
-    metrics::LoadMetric<OpWithRequestSize<OpWithNotFound>> remove;
+    metrics::LoadMetric<PutMetricType> put;
+    metrics::LoadMetric<GetMetricType> get;
+    metrics::LoadMetric<RemoveMetricType> remove;
     metrics::LoadMetric<Op> removeLocation;
     metrics::LoadMetric<Op> statBucket;
     metrics::LoadMetric<Update> update;

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -177,6 +177,9 @@ PersistenceThread::handlePut(api::PutCommand& cmd, MessageTracker::UP trackerUP)
     metrics.request_size.addValue(cmd.getApproxByteSize());
 
     if (tasConditionExists(cmd) && !tasConditionMatches(cmd, tracker, tracker.context())) {
+        // Will also count condition parse failures etc as TaS failures, but
+        // those results _will_ increase the error metrics as well.
+        metrics.test_and_set_failed.inc();
         return trackerUP;
     }
 
@@ -204,6 +207,7 @@ PersistenceThread::handleRemove(api::RemoveCommand& cmd, MessageTracker::UP trac
     metrics.request_size.addValue(cmd.getApproxByteSize());
 
     if (tasConditionExists(cmd) && !tasConditionMatches(cmd, tracker, tracker.context())) {
+        metrics.test_and_set_failed.inc();
         return trackerUP;
     }
 
@@ -243,6 +247,7 @@ PersistenceThread::handleUpdate(api::UpdateCommand& cmd, MessageTracker::UP trac
     metrics.request_size.addValue(cmd.getApproxByteSize());
 
     if (tasConditionExists(cmd) && !tasConditionMatches(cmd, tracker, tracker.context(), cmd.getUpdate()->getCreateIfNonExistent())) {
+        metrics.test_and_set_failed.inc();
         return trackerUP;
     }
 

--- a/storage/src/vespa/storage/persistence/persistenceutil.h
+++ b/storage/src/vespa/storage/persistence/persistenceutil.h
@@ -78,6 +78,9 @@ public:
 private:
     MessageTracker(PersistenceUtil & env, MessageSender & replySender, bool updateBucketInfo,
                    FileStorHandler::BucketLockInterface::SP bucketLock, api::StorageMessage::SP msg);
+
+    [[nodiscard]] bool count_result_as_failure() const noexcept;
+
     bool                                     _sendReply;
     bool                                     _updateBucketInfo;
     FileStorHandler::BucketLockInterface::SP _bucketLock;


### PR DESCRIPTION
@geirst please review

Avoids polluting the generic failure metric with condition mismatches,
making it easier to discern when real service problems are occurring.
