### PR TITLE
Use -Wnoexcept

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -36,7 +36,7 @@ endif()
 # Warnings that are specific to C++ compilation
 # Note: this is not a union of C_WARN_OPTS, since CMAKE_CXX_FLAGS already includes CMAKE_C_FLAGS, which in turn includes C_WARN_OPTS transitively
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-  set(CXX_SPECIFIC_WARN_OPTS "-Wnoexcept -Wnon-virtual-dtor -Wformat-security -Wno-overloaded-virtual")
+  set(CXX_SPECIFIC_WARN_OPTS "-Wnon-virtual-dtor -Wformat-security -Wno-overloaded-virtual")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-delete-null-pointer-checks")
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
     set(VESPA_ATOMIC_LIB "")

--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -36,7 +36,7 @@ endif()
 # Warnings that are specific to C++ compilation
 # Note: this is not a union of C_WARN_OPTS, since CMAKE_CXX_FLAGS already includes CMAKE_C_FLAGS, which in turn includes C_WARN_OPTS transitively
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-  set(CXX_SPECIFIC_WARN_OPTS "-Wnon-virtual-dtor -Wformat-security -Wno-overloaded-virtual")
+  set(CXX_SPECIFIC_WARN_OPTS "-Wnoexcept -Wnon-virtual-dtor -Wformat-security -Wno-overloaded-virtual")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-delete-null-pointer-checks")
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
     set(VESPA_ATOMIC_LIB "")
@@ -53,7 +53,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" ST
     endif()
   endif()
 else()
-  set(CXX_SPECIFIC_WARN_OPTS "-Wsuggest-override -Wnon-virtual-dtor -Wformat-security")
+  set(CXX_SPECIFIC_WARN_OPTS "-Wnoexcept -Wsuggest-override -Wnon-virtual-dtor -Wformat-security")
   if(VESPA_OS_DISTRO_COMBINED STREQUAL "centos 8" OR
       (VESPA_OS_DISTRO STREQUAL "rhel" AND
 	VESPA_OS_DISTRO_VERSION VERSION_GREATER_EQUAL "8" AND

--- a/staging_vespalib/src/tests/metrics/mock_tick.h
+++ b/staging_vespalib/src/tests/metrics/mock_tick.h
@@ -15,8 +15,9 @@ class MockTick : public Tick {
 private:
     using Guard = std::unique_lock<std::mutex>;
     struct Value {
-        TimeStamp value{0.0};
-        bool    valid{false};
+        Value() noexcept : value(0.0), valid(false) {}
+        TimeStamp value;
+        bool    valid;
     };
 
     TimeStamp               _first_value;
@@ -55,7 +56,7 @@ private:
     }
 
 public:
-    explicit MockTick(TimeStamp first_value)
+    explicit MockTick(TimeStamp first_value) noexcept
         : _first_value(first_value), _lock(), _cond(), _alive(true), _prev(), _next() {}
     TimeStamp first() override { return _first_value; }
     TimeStamp next(TimeStamp prev) override {


### PR DESCRIPTION
@toregge PR

I get some very odd messages with this one. It would be good if you could take a look.
```
In file included from /home/balder/git/vespa/staging_vespalib/src/tests/metrics/simple_metrics_test.cpp:9:
/home/balder/git/vespa/staging_vespalib/src/tests/metrics/mock_tick.h: In constructor ‘vespalib::metrics::MockTick::MockTick(vespalib::metrics::TimeStamp)’:
/home/balder/git/vespa/staging_vespalib/src/tests/metrics/mock_tick.h:59:85: error: noexcept-expression evaluates to ‘false’ because of a call to ‘constexpr std::chrono::duration<_Rep, _Period>::duration(const _Rep2&) [with _Rep2 = double; <template-parameter-2-2> = void; _Rep = double; _Period = std::ratio<1>]’ [-Werror=noexcept]
   59 |         : _first_value(first_value), _lock(), _cond(), _alive(true), _prev(), _next() {}
      |                                                                                     ^
/opt/rh/devtoolset-9/root/usr/include/c++/9/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = vespalib::metrics::MockTick; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}; _Tp = vespalib::metrics::MockTick]’:
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/alloc_traits.h:482:2:   required from ‘static void std::allocator_traits<std::allocator<_Tp1> >::construct(std::allocator_traits<std::allocator<_Tp1> >::allocator_type&, _Up*, _Args&& ...) [with _Up = vespalib::metrics::MockTick; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}; _Tp = vespalib::metrics::MockTick; std::allocator_traits<std::allocator<_Tp1> >::allocator_type = std::allocator<vespalib::metrics::MockTick>]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:548:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {std::chrono::duration<double, std::ratio<1, 1> >}; _Tp = vespalib::metrics::MockTick; _Alloc = std::allocator<vespalib::metrics::MockTick>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:679:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = vespalib::metrics::MockTick; _Alloc = std::allocator<vespalib::metrics::MockTick>; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:1344:71:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<vespalib::metrics::MockTick>; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}; _Tp = vespalib::metrics::MockTick; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr.h:359:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<vespalib::metrics::MockTick>; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}; _Tp = vespalib::metrics::MockTick]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr.h:701:14:   required from ‘std::shared_ptr<_Tp> std::allocate_shared(const _Alloc&, _Args&& ...) [with _Tp = vespalib::metrics::MockTick; _Alloc = std::allocator<vespalib::metrics::MockTick>; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr.h:717:39:   required from ‘std::shared_ptr<_Tp> std::make_shared(_Args&& ...) [with _Tp = vespalib::metrics::MockTick; _Args = {std::chrono::duration<double, std::ratio<1, 1> >}]’
/home/balder/git/vespa/staging_vespalib/src/tests/metrics/simple_metrics_test.cpp:125:81:   required from here
/home/balder/git/vespa/staging_vespalib/src/tests/metrics/mock_tick.h:58:14: error: but ‘vespalib::metrics::MockTick::MockTick(vespalib::metrics::TimeStamp)’ does not throw; perhaps it should be declared ‘noexcept’ [-Werror=noexcept]
   58 |     explicit MockTick(TimeStamp first_value)
```
