### PR TITLE
Arnej/less needless casting

### DIFF
--- a/eval/src/tests/tensor/dense_replace_type_function/dense_replace_type_function_test.cpp
+++ b/eval/src/tests/tensor/dense_replace_type_function/dense_replace_type_function_test.cpp
@@ -16,7 +16,7 @@ using namespace vespalib;
 const TensorEngine &engine = DefaultTensorEngine::ref();
 
 TypedCells getCellsRef(const eval::Value &value) {
-    return static_cast<const DenseTensorView &>(value).cellsRef();
+    return value.cells();
 }
 
 struct ChildMock : Leaf {

--- a/eval/src/tests/tensor/direct_dense_tensor_builder/direct_dense_tensor_builder_test.cpp
+++ b/eval/src/tests/tensor/direct_dense_tensor_builder/direct_dense_tensor_builder_test.cpp
@@ -29,9 +29,8 @@ void assertTensor(const vespalib::string &type_spec,
                   const std::vector<double> &expCells,
                   const Tensor &tensor)
 {
-    const DenseTensorView &realTensor = dynamic_cast<const DenseTensorView &>(tensor);
-    EXPECT_EQUAL(ValueType::from_spec(type_spec), realTensor.type());
-    EXPECT_EQUAL(expCells, dispatch_1<CallMakeVector>(realTensor.cellsRef()));
+    EXPECT_EQUAL(ValueType::from_spec(type_spec), tensor.type());
+    EXPECT_EQUAL(expCells, dispatch_1<CallMakeVector>(tensor.cells()));
 }
 
 void assertTensorSpec(const TensorSpec &expSpec, const Tensor &tensor) {

--- a/eval/src/tests/tensor/onnx_wrapper/onnx_wrapper_test.cpp
+++ b/eval/src/tests/tensor/onnx_wrapper/onnx_wrapper_test.cpp
@@ -162,7 +162,7 @@ TEST(OnnxTest, simple_onnx_model_can_be_evaluated)
     ctx.bind_param(1, attribute);
     ctx.bind_param(2, bias);
     ctx.eval();
-    auto cells = static_cast<const DenseTensorView&>(output).cellsRef();
+    auto cells = output.cells();
     EXPECT_EQ(cells.type, ValueType::CellType::FLOAT);
     EXPECT_EQ(cells.size, 1);
     EXPECT_EQ(GetCell::from(cells, 0), 79.0);
@@ -208,7 +208,7 @@ TEST(OnnxTest, dynamic_onnx_model_can_be_evaluated)
     ctx.bind_param(1, attribute);
     ctx.bind_param(2, bias);
     ctx.eval();
-    auto cells = static_cast<const DenseTensorView&>(output).cellsRef();
+    auto cells = output.cells();
     EXPECT_EQ(cells.type, ValueType::CellType::FLOAT);
     EXPECT_EQ(cells.size, 1);
     EXPECT_EQ(GetCell::from(cells, 0), 79.0);
@@ -254,7 +254,7 @@ TEST(OnnxTest, int_types_onnx_model_can_be_evaluated)
     ctx.bind_param(1, attribute);
     ctx.bind_param(2, bias);
     ctx.eval();
-    auto cells = static_cast<const DenseTensorView&>(output).cellsRef();
+    auto cells = output.cells();
     EXPECT_EQ(cells.type, ValueType::CellType::DOUBLE);
     EXPECT_EQ(cells.size, 1);
     EXPECT_EQ(GetCell::from(cells, 0), 79.0);

--- a/eval/src/vespa/eval/tensor/default_tensor_engine.cpp
+++ b/eval/src/vespa/eval/tensor/default_tensor_engine.cpp
@@ -445,8 +445,7 @@ struct CallAppendVector {
 template <typename OCT>
 void append_vector(OCT *&pos, const Value &value) {
     if (auto tensor = value.as_tensor()) {
-        const DenseTensorView *view = static_cast<const DenseTensorView *>(tensor);
-        dispatch_1<CallAppendVector<OCT> >(view->cellsRef(), pos);
+        dispatch_1<CallAppendVector<OCT> >(tensor->cells(), pos);
     } else {
         *pos++ = value.as_double();
     }

--- a/eval/src/vespa/eval/tensor/dense/dense_generic_join.hpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_generic_join.hpp
@@ -53,14 +53,10 @@ template <typename Function>
 std::unique_ptr<Tensor>
 generic_join(const DenseTensorView &lhs, const Tensor &rhs, Function &&func)
 {
-    const DenseTensorView *view = dynamic_cast<const DenseTensorView *>(&rhs);
-    if (view) {
-        DenseDimensionCombiner combiner(lhs.fast_type(), view->fast_type());
-        TypedCells lhsCells = lhs.cellsRef();
-        TypedCells rhsCells = view->cellsRef();
-        return dispatch_2<CallGenericJoin>(lhsCells, rhsCells, combiner, std::move(func));
-    }
-    return Tensor::UP();
+    DenseDimensionCombiner combiner(lhs.fast_type(), rhs.type());
+    TypedCells lhsCells = lhs.cells();
+    TypedCells rhsCells = rhs.cells();
+    return dispatch_2<CallGenericJoin>(lhsCells, rhsCells, combiner, std::move(func));
 }
 
 }

--- a/eval/src/vespa/eval/tensor/dense/dense_replace_type_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_replace_type_function.cpp
@@ -15,14 +15,9 @@ using namespace eval::tensor_function;
 
 namespace {
 
-TypedCells getCellsRef(const eval::Value &value) {
-    const DenseTensorView &denseTensor = static_cast<const DenseTensorView &>(value);
-    return denseTensor.cellsRef();
-}
-
 void my_replace_type_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const ValueType *type = (const ValueType *)(param);
-    TypedCells cells = getCellsRef(state.peek(0));
+    TypedCells cells = state.peek(0).cells();
     state.pop_push(state.stash.create<DenseTensorView>(*type, cells));
 }
 

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
@@ -52,10 +52,10 @@ public:
     }
 
     template <typename T> static ConstArrayRef<T> typify_cells(const eval::Value &self) {
-        return static_cast<const DenseTensorView &>(self).cellsRef().typify<T>();
+        return self.cells().typify<T>();
     }
     template <typename T> static ConstArrayRef<T> unsafe_typify_cells(const eval::Value &self) {
-        return static_cast<const DenseTensorView &>(self).cellsRef().unsafe_typify<T>();
+        return self.cells().unsafe_typify<T>();
     }
 protected:
     explicit DenseTensorView(const eval::ValueType &type_in)

--- a/eval/src/vespa/eval/tensor/dense/onnx_wrapper.cpp
+++ b/eval/src/vespa/eval/tensor/dense/onnx_wrapper.cpp
@@ -346,7 +346,7 @@ template <typename T>
 void
 Onnx::EvalContext::adapt_param(EvalContext &self, size_t idx, const eval::Value &param)
 {
-    const auto &cells_ref = static_cast<const DenseTensorView &>(param).cellsRef();
+    const auto &cells_ref = param.cells();
     auto cells = unconstify(cells_ref.typify<T>());
     const auto &sizes = self._wire_info.onnx_inputs[idx].dimensions;
     self._param_values[idx] = Ort::Value::CreateTensor<T>(self._cpu_memory, cells.begin(), cells.size(), sizes.data(), sizes.size());
@@ -356,7 +356,7 @@ template <typename SRC, typename DST>
 void
 Onnx::EvalContext::convert_param(EvalContext &self, size_t idx, const eval::Value &param)
 {
-    auto cells = static_cast<const DenseTensorView &>(param).cellsRef().typify<SRC>();
+    auto cells = param.cells().typify<SRC>();
     size_t n = cells.size();
     const SRC *src = cells.begin();
     DST *dst = self._param_values[idx].GetTensorMutableData<DST>();
@@ -369,7 +369,7 @@ template <typename SRC, typename DST>
 void
 Onnx::EvalContext::convert_result(EvalContext &self, size_t idx)
 {
-    const auto &cells_ref = static_cast<const DenseTensorView &>(*self._results[idx]).cellsRef();
+    const auto &cells_ref = (*self._results[idx]).cells();
     auto cells = unconstify(cells_ref.typify<DST>());
     size_t n = cells.size();
     DST *dst = cells.begin();


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

now that we have cells() on value, casting to DenseTensorView in order to call cellsRef() seems ugly

@havardpe please review
