### PR TITLE
Make vespalib hash functors noexcept

### DIFF
--- a/document/src/vespa/document/base/field.h
+++ b/document/src/vespa/document/base/field.h
@@ -97,13 +97,13 @@ public:
 
     const DataType &getDataType() const { return *_dataType; }
 
-    int getId() const { return _fieldId; }
+    int getId() const noexcept { return _fieldId; }
 
     vespalib::string toString(bool verbose=false) const;
     bool contains(const FieldSet& fields) const override;
     Type getType() const override { return Type::FIELD; }
     bool valid() const { return _fieldId != 0; }
-    uint32_t hash() const { return getId(); }
+    uint32_t hash() const noexcept { return getId(); }
 private:
     int calculateIdV7();
 

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor_address_ref.h
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor_address_ref.h
@@ -38,7 +38,7 @@ public:
           _hash(rhs._hash)
     {}
 
-    uint32_t hash() const { return _hash; }
+    uint32_t hash() const noexcept { return _hash; }
 
     uint32_t calcHash() const noexcept;
 

--- a/searchlib/src/vespa/searchlib/docstore/visitcache.h
+++ b/searchlib/src/vespa/searchlib/docstore/visitcache.h
@@ -23,7 +23,7 @@ public:
     KeySet() : _keys() { }
     KeySet(uint32_t key);
     explicit KeySet(const IDocumentStore::LidVector &keys);
-    uint32_t hash() const { return _keys.empty() ? 0 : _keys[0]; }
+    uint32_t hash() const noexcept { return _keys.empty() ? 0 : _keys[0]; }
     bool operator==(const KeySet &rhs) const { return _keys == rhs._keys; }
     bool operator<(const KeySet &rhs) const { return _keys < rhs._keys; }
     bool contains(const KeySet &rhs) const;

--- a/vespalib/src/vespa/vespalib/stllike/hash_fun.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/hash_fun.cpp
@@ -6,7 +6,7 @@
 namespace vespalib {
 
 size_t
-hashValue(const char *str)
+hashValue(const char *str) noexcept
 {
     return hashValue(str, strlen(str));
 }
@@ -20,7 +20,7 @@ hashValue(const char *str)
  * @return hash value of input
  **/
 size_t
-hashValue(const void * buf, size_t sz)
+hashValue(const void * buf, size_t sz) noexcept
 {
     return XXH64(buf, sz, 0);
 }

--- a/vespalib/src/vespa/vespalib/stllike/hash_fun.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_fun.h
@@ -8,71 +8,71 @@ namespace vespalib {
 
 template<typename K> struct hash {
     // specializations operate as functor for known key types
-    size_t operator() (const K & v) const {
+    size_t operator() (const K & v) const noexcept(noexcept(v.hash())) {
         return v.hash();
     }
 };
 
 template<> struct hash<char> {
-    size_t operator() (char arg) const { return arg; }
+    size_t operator() (char arg) const noexcept { return arg; }
 };
 template<> struct hash<signed char> {
-    size_t operator() (signed char arg) const { return arg; }
+    size_t operator() (signed char arg) const noexcept { return arg; }
 };
 template<> struct hash<short> {
-    size_t operator() (short arg) const { return arg; }
+    size_t operator() (short arg) const noexcept { return arg; }
 };
 template<> struct hash<int> {
-    size_t operator() (int arg) const { return arg; }
+    size_t operator() (int arg) const noexcept { return arg; }
 };
 template<> struct hash<long> {
-    size_t operator() (long arg) const { return arg; }
+    size_t operator() (long arg) const noexcept { return arg; }
 };
 template<> struct hash<long long> {
-    size_t operator() (long long arg) const { return arg; }
+    size_t operator() (long long arg) const noexcept { return arg; }
 };
 
 template<> struct hash<unsigned char> {
-    size_t operator() (unsigned char arg) const { return arg; }
+    size_t operator() (unsigned char arg) const noexcept { return arg; }
 };
 template<> struct hash<unsigned short> {
-    size_t operator() (unsigned short arg) const { return arg; }
+    size_t operator() (unsigned short arg) const noexcept { return arg; }
 };
 template<> struct hash<unsigned int> {
-    size_t operator() (unsigned int arg) const { return arg; }
+    size_t operator() (unsigned int arg) const noexcept { return arg; }
 };
 template<> struct hash<unsigned long> {
-    size_t operator() (unsigned long arg) const { return arg; }
+    size_t operator() (unsigned long arg) const noexcept { return arg; }
 };
 template<> struct hash<unsigned long long> {
-    size_t operator() (unsigned long long arg) const { return arg; }
+    size_t operator() (unsigned long long arg) const noexcept { return arg; }
 };
 
 template<> struct hash<float> {
     union U { float f; uint32_t i; };
-    size_t operator() (float arg) const { U t; t.f = arg; return t.i; }
+    size_t operator() (float arg) const noexcept { U t; t.f = arg; return t.i; }
 };
 template<> struct hash<double> {
     union U { double f; uint64_t i; };
-    size_t operator() (double arg) const { U t; t.f = arg; return t.i; }
+    size_t operator() (double arg) const noexcept { U t; t.f = arg; return t.i; }
 };
 
 template<typename T> struct hash<T *> {
-    size_t operator() (const T * arg) const { return size_t(arg); }
+    size_t operator() (const T * arg) const noexcept { return size_t(arg); }
 };
 template<typename T> struct hash<const T *> {
-    size_t operator() (const T * arg) const { return size_t(arg); }
+    size_t operator() (const T * arg) const noexcept { return size_t(arg); }
 };
 
 // reuse old string hash function
-size_t hashValue(const char *str);
-size_t hashValue(const void *str, size_t sz);
+size_t hashValue(const char *str) noexcept;
+size_t hashValue(const void *str, size_t sz) noexcept;
 
 struct hash_strings {
-    size_t operator() (const vespalib::string & arg) const { return hashValue(arg.c_str()); }
-    size_t operator() (vespalib::stringref arg) const { return hashValue(arg.data(), arg.size()); }
-    size_t operator() (const char * arg) const { return hashValue(arg); }
-    size_t operator() (const std::string& arg) const { return hashValue(arg.c_str()); }
+    size_t operator() (const vespalib::string & arg) const noexcept { return hashValue(arg.c_str()); }
+    size_t operator() (vespalib::stringref arg) const noexcept { return hashValue(arg.data(), arg.size()); }
+    size_t operator() (const char * arg) const noexcept { return hashValue(arg); }
+    size_t operator() (const std::string& arg) const noexcept { return hashValue(arg.c_str()); }
 };
 
 template<> struct hash<const char *> : hash_strings { };
@@ -81,11 +81,11 @@ template<> struct hash<vespalib::string> : hash_strings {};
 template<> struct hash<std::string> : hash_strings {};
 
 template<typename V> struct size {
-    size_t operator() (const V & arg) const { return arg.size(); }
+    size_t operator() (const V & arg) const noexcept { return arg.size(); }
 };
 
 template<typename V> struct zero {
-    size_t operator() (const V & ) const { return 0; }
+    size_t operator() (const V & ) const noexcept { return 0; }
 };
 
 } // namespace vespalib


### PR DESCRIPTION
@baldersheim please review

Make ducktyped functor conditionally noexcept on `hash()` member function.
Follow up on `-Werror=noexcept` warnings indicating where `noexcept` can
be trivially added for such functions.
