### PR TITLE
Update container CPU resources without orchestration

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -363,8 +363,6 @@ public class NodeAgentImpl implements NodeAgent {
         context.log(logger, "Container should be running with different CPU allocation, wanted: %s, current: %s",
                 wantedContainerResources.toStringCpu(), existingContainer.resources.toStringCpu());
 
-        orchestratorSuspendNode(context);
-
         // Only update CPU resources
         containerOperations.updateContainer(context, wantedContainerResources.withMemoryBytes(existingContainer.resources.memoryBytes()));
         return containerOperations.getContainer(context).orElseThrow(() ->

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -223,25 +223,25 @@ public class NodeAgentImplTest {
         ContainerResources resourcesAfterThird = ContainerResources.from(0, 4, 16);
         mockGetContainer(dockerImage, resourcesAfterThird, true);
 
-        inOrder.verify(orchestrator).suspend(any(String.class));
+        inOrder.verify(orchestrator, never()).suspend(any());
         inOrder.verify(containerOperations).updateContainer(eq(thirdContext), eq(resourcesAfterThird));
         inOrder.verify(containerOperations, never()).removeContainer(any(), any());
         inOrder.verify(containerOperations, never()).startContainer(any());
-        inOrder.verify(orchestrator).resume(any(String.class));
+        inOrder.verify(orchestrator, never()).resume(any());
 
         // No changes
         nodeAgent.converge(thirdContext);
-        inOrder.verify(orchestrator, never()).suspend(any(String.class));
+        inOrder.verify(orchestrator, never()).suspend(any());
         inOrder.verify(containerOperations, never()).updateContainer(eq(thirdContext), any());
         inOrder.verify(containerOperations, never()).removeContainer(any(), any());
-        inOrder.verify(orchestrator, never()).resume(any(String.class));
+        inOrder.verify(orchestrator, never()).resume(any());
 
         // Set the feature flag
         flagSource.withDoubleFlag(Flags.CONTAINER_CPU_CAP.id(), 2.3);
 
         nodeAgent.doConverge(thirdContext);
         inOrder.verify(containerOperations).updateContainer(eq(thirdContext), eq(ContainerResources.from(9.2, 4, 16)));
-        inOrder.verify(orchestrator).resume(any(String.class));
+        inOrder.verify(orchestrator, never()).resume(any());
     }
 
     @Test
@@ -645,18 +645,18 @@ public class NodeAgentImplTest {
         clock.advance(Duration.ofSeconds(31));
         nodeAgent.doConverge(context);
 
-        inOrder.verify(orchestrator).suspend(hostName);
+        inOrder.verify(orchestrator, never()).suspend(any());
         inOrder.verify(containerOperations).updateContainer(eq(context), eq(ContainerResources.from(0, 2, 16)));
         inOrder.verify(containerOperations, never()).removeContainer(any(), any());
         inOrder.verify(containerOperations, never()).startContainer(any());
-        inOrder.verify(orchestrator).resume(any(String.class));
+        inOrder.verify(orchestrator, never()).resume(any());
 
         // No changes
         nodeAgent.converge(context);
-        inOrder.verify(orchestrator, never()).suspend(any(String.class));
+        inOrder.verify(orchestrator, never()).suspend(any());
         inOrder.verify(containerOperations, never()).updateContainer(eq(context), any());
         inOrder.verify(containerOperations, never()).removeContainer(any(), any());
-        inOrder.verify(orchestrator, never()).resume(any(String.class));
+        inOrder.verify(orchestrator, never()).resume(any());
     }
 
     @Test


### PR DESCRIPTION
Motivation:
* Changes to config, that may be based on CPU resources, are rolled out unorchestrated
* Updating container CPU resources is a simple operation that shouldn't fail