### PR TITLE
remove typify_cells

### DIFF
--- a/eval/src/vespa/eval/tensor/dense/dense_cell_range_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_cell_range_function.cpp
@@ -18,7 +18,7 @@ namespace {
 template <typename CT>
 void my_cell_range_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const auto *self = (const DenseCellRangeFunction *)(param);
-    auto old_cells = DenseTensorView::typify_cells<CT>(state.peek(0));
+    auto old_cells = state.peek(0).cells().typify<CT>();
     ConstArrayRef<CT> new_cells(&old_cells[self->offset()], self->length());
     state.pop_push(state.stash.create<DenseTensorView>(self->result_type(), TypedCells(new_cells)));
 }

--- a/eval/src/vespa/eval/tensor/dense/dense_dot_product_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_dot_product_function.cpp
@@ -21,8 +21,8 @@ namespace {
 
 template <typename LCT, typename RCT>
 void my_dot_product_op(eval::InterpretedFunction::State &state, uint64_t) {
-    auto lhs_cells = DenseTensorView::typify_cells<LCT>(state.peek(1));
-    auto rhs_cells = DenseTensorView::typify_cells<RCT>(state.peek(0));
+    auto lhs_cells = state.peek(1).cells().typify<LCT>();
+    auto rhs_cells = state.peek(0).cells().typify<RCT>();
     double result = 0.0;
     const LCT *lhs = lhs_cells.cbegin();
     const RCT *rhs = rhs_cells.cbegin();
@@ -33,15 +33,15 @@ void my_dot_product_op(eval::InterpretedFunction::State &state, uint64_t) {
 }
 
 void my_cblas_double_dot_product_op(eval::InterpretedFunction::State &state, uint64_t) {
-    auto lhs_cells = DenseTensorView::typify_cells<double>(state.peek(1));
-    auto rhs_cells = DenseTensorView::typify_cells<double>(state.peek(0));
+    auto lhs_cells = state.peek(1).cells().typify<double>();
+    auto rhs_cells = state.peek(0).cells().typify<double>();
     double result = cblas_ddot(lhs_cells.size(), lhs_cells.cbegin(), 1, rhs_cells.cbegin(), 1);
     state.pop_pop_push(state.stash.create<eval::DoubleValue>(result));
 }
 
 void my_cblas_float_dot_product_op(eval::InterpretedFunction::State &state, uint64_t) {
-    auto lhs_cells = DenseTensorView::typify_cells<float>(state.peek(1));
-    auto rhs_cells = DenseTensorView::typify_cells<float>(state.peek(0));
+    auto lhs_cells = state.peek(1).cells().typify<float>();
+    auto rhs_cells = state.peek(0).cells().typify<float>();
     double result = cblas_sdot(lhs_cells.size(), lhs_cells.cbegin(), 1, rhs_cells.cbegin(), 1);
     state.pop_pop_push(state.stash.create<eval::DoubleValue>(result));
 }

--- a/eval/src/vespa/eval/tensor/dense/dense_lambda_peek_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_lambda_peek_function.cpp
@@ -34,7 +34,7 @@ template <typename DST_CT, typename SRC_CT>
 void my_lambda_peek_op(InterpretedFunction::State &state, uint64_t param) {
     const auto *self = (const Self *)(param);
     const std::vector<uint32_t> &lookup_table = self->table_token->get();
-    auto src_cells = DenseTensorView::typify_cells<SRC_CT>(state.peek(0));
+    auto src_cells = state.peek(0).cells().typify<SRC_CT>();
     ArrayRef<DST_CT> dst_cells = state.stash.create_array<DST_CT>(lookup_table.size());
     DST_CT *dst = &dst_cells[0];
     for (uint32_t idx: lookup_table) {

--- a/eval/src/vespa/eval/tensor/dense/dense_matmul_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_matmul_function.cpp
@@ -36,8 +36,8 @@ template <typename LCT, typename RCT, bool lhs_common_inner, bool rhs_common_inn
 void my_matmul_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const DenseMatMulFunction::Self &self = *((const DenseMatMulFunction::Self *)(param));
     using OCT = typename eval::UnifyCellTypes<LCT,RCT>::type;
-    auto lhs_cells = DenseTensorView::typify_cells<LCT>(state.peek(1));
-    auto rhs_cells = DenseTensorView::typify_cells<RCT>(state.peek(0));
+    auto lhs_cells = state.peek(1).cells().typify<LCT>();
+    auto rhs_cells = state.peek(0).cells().typify<RCT>();
     auto dst_cells = state.stash.create_array<OCT>(self.lhs_size * self.rhs_size);
     OCT *dst = dst_cells.begin();
     const LCT *lhs = lhs_cells.cbegin();
@@ -55,8 +55,8 @@ void my_matmul_op(eval::InterpretedFunction::State &state, uint64_t param) {
 template <bool lhs_common_inner, bool rhs_common_inner>
 void my_cblas_double_matmul_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const DenseMatMulFunction::Self &self = *((const DenseMatMulFunction::Self *)(param));
-    auto lhs_cells = DenseTensorView::typify_cells<double>(state.peek(1));
-    auto rhs_cells = DenseTensorView::typify_cells<double>(state.peek(0));
+    auto lhs_cells = state.peek(1).cells().typify<double>();
+    auto rhs_cells = state.peek(0).cells().typify<double>();
     auto dst_cells = state.stash.create_array<double>(self.lhs_size * self.rhs_size);
     cblas_dgemm(CblasRowMajor, lhs_common_inner ? CblasNoTrans : CblasTrans, rhs_common_inner ? CblasTrans : CblasNoTrans,
                 self.lhs_size, self.rhs_size, self.common_size, 1.0,
@@ -69,8 +69,8 @@ void my_cblas_double_matmul_op(eval::InterpretedFunction::State &state, uint64_t
 template <bool lhs_common_inner, bool rhs_common_inner>
 void my_cblas_float_matmul_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const DenseMatMulFunction::Self &self = *((const DenseMatMulFunction::Self *)(param));
-    auto lhs_cells = DenseTensorView::typify_cells<float>(state.peek(1));
-    auto rhs_cells = DenseTensorView::typify_cells<float>(state.peek(0));
+    auto lhs_cells = state.peek(1).cells().typify<float>();
+    auto rhs_cells = state.peek(0).cells().typify<float>();
     auto dst_cells = state.stash.create_array<float>(self.lhs_size * self.rhs_size);
     cblas_sgemm(CblasRowMajor, lhs_common_inner ? CblasNoTrans : CblasTrans, rhs_common_inner ? CblasTrans : CblasNoTrans,
                 self.lhs_size, self.rhs_size, self.common_size, 1.0,

--- a/eval/src/vespa/eval/tensor/dense/dense_multi_matmul_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_multi_matmul_function.cpp
@@ -32,8 +32,8 @@ void my_cblas_double_multi_matmul_op(InterpretedFunction::State &state, uint64_t
     size_t rhs_block_size = self.rhs_size() * self.common_size();
     size_t dst_block_size = self.lhs_size() * self.rhs_size();
     size_t num_blocks = self.matmul_cnt();
-    const CT *lhs = DenseTensorView::typify_cells<CT>(state.peek(1)).cbegin();
-    const CT *rhs = DenseTensorView::typify_cells<CT>(state.peek(0)).cbegin();
+    const CT *lhs = state.peek(1).cells().typify<CT>().cbegin();
+    const CT *rhs = state.peek(0).cells().typify<CT>().cbegin();
     auto dst_cells = state.stash.create_array<CT>(dst_block_size * num_blocks);
     CT *dst = dst_cells.begin();
     for (size_t i = 0; i < num_blocks; ++i, lhs += lhs_block_size, rhs += rhs_block_size, dst += dst_block_size) {
@@ -53,8 +53,8 @@ void my_cblas_float_multi_matmul_op(InterpretedFunction::State &state, uint64_t 
     size_t rhs_block_size = self.rhs_size() * self.common_size();
     size_t dst_block_size = self.lhs_size() * self.rhs_size();
     size_t num_blocks = self.matmul_cnt();
-    const CT *lhs = DenseTensorView::typify_cells<CT>(state.peek(1)).cbegin();
-    const CT *rhs = DenseTensorView::typify_cells<CT>(state.peek(0)).cbegin();
+    const CT *lhs = state.peek(1).cells().typify<CT>().cbegin();
+    const CT *rhs = state.peek(0).cells().typify<CT>().cbegin();
     auto dst_cells = state.stash.create_array<CT>(dst_block_size * num_blocks);
     CT *dst = dst_cells.begin();
     for (size_t i = 0; i < num_blocks; ++i, lhs += lhs_block_size, rhs += rhs_block_size, dst += dst_block_size) {

--- a/eval/src/vespa/eval/tensor/dense/dense_number_join_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_number_join_function.cpp
@@ -44,7 +44,7 @@ void my_number_join_op(State &state, uint64_t param) {
     OP my_op((join_fun_t)param);
     const Value &tensor = state.peek(swap ? 0 : 1);
     CT number = state.peek(swap ? 1 : 0).as_double();
-    auto src_cells = DenseTensorView::typify_cells<CT>(tensor);
+    auto src_cells = tensor.cells().typify<CT>();
     auto dst_cells = make_dst_cells<CT, inplace>(src_cells, state.stash);
     apply_op2_vec_num(dst_cells.begin(), src_cells.begin(), number, dst_cells.size(), my_op);
     if (inplace) {

--- a/eval/src/vespa/eval/tensor/dense/dense_simple_expand_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_simple_expand_function.cpp
@@ -48,8 +48,8 @@ void my_simple_expand_op(State &state, uint64_t param) {
     using OP = typename std::conditional<rhs_inner,SwapArgs2<Fun>,Fun>::type;
     const ExpandParams &params = *(ExpandParams*)param;
     OP my_op(params.function);
-    auto inner_cells = DenseTensorView::typify_cells<ICT>(state.peek(rhs_inner ? 0 : 1));
-    auto outer_cells = DenseTensorView::typify_cells<OCT>(state.peek(rhs_inner ? 1 : 0));
+    auto inner_cells = state.peek(rhs_inner ? 0 : 1).cells().typify<ICT>();
+    auto outer_cells = state.peek(rhs_inner ? 1 : 0).cells().typify<OCT>();
     auto dst_cells = state.stash.create_array<DCT>(params.result_size);
     DCT *dst = dst_cells.begin();
     for (OCT outer_cell: outer_cells) {

--- a/eval/src/vespa/eval/tensor/dense/dense_simple_join_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_simple_join_function.cpp
@@ -70,8 +70,8 @@ void my_simple_join_op(State &state, uint64_t param) {
     using OP = typename std::conditional<swap,SwapArgs2<Fun>,Fun>::type;
     const JoinParams &params = *(JoinParams*)param;
     OP my_op(params.function);
-    auto pri_cells = DenseTensorView::typify_cells<PCT>(state.peek(swap ? 0 : 1));
-    auto sec_cells = DenseTensorView::typify_cells<SCT>(state.peek(swap ? 1 : 0));
+    auto pri_cells = state.peek(swap ? 0 : 1).cells().typify<PCT>();
+    auto sec_cells = state.peek(swap ? 1 : 0).cells().typify<SCT>();
     auto dst_cells = make_dst_cells<OCT, pri_mut>(pri_cells, state.stash);
     if (overlap == Overlap::FULL) {
         apply_op2_vec_vec(dst_cells.begin(), pri_cells.begin(), sec_cells.begin(), dst_cells.size(), my_op);

--- a/eval/src/vespa/eval/tensor/dense/dense_simple_map_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_simple_map_function.cpp
@@ -40,7 +40,7 @@ template <typename CT, typename Fun, bool inplace>
 void my_simple_map_op(State &state, uint64_t param) {
     Fun my_fun((map_fun_t)param);
     auto const &child = state.peek(0);
-    auto src_cells = DenseTensorView::typify_cells<CT>(child);
+    auto src_cells = child.cells().typify<CT>();
     auto dst_cells = make_dst_cells<CT, inplace>(src_cells, state.stash);
     apply_op1_vec(dst_cells.begin(), src_cells.begin(), dst_cells.size(), my_fun);
     if (!inplace) {

--- a/eval/src/vespa/eval/tensor/dense/dense_single_reduce_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_single_reduce_function.cpp
@@ -55,7 +55,7 @@ CT reduce_cells(const CT *src, size_t dim_size, size_t stride, AGGR &aggr) {
 template <typename CT, typename AGGR>
 void my_single_reduce_op(InterpretedFunction::State &state, uint64_t param) {
     const auto &params = *(const Params *)(param);
-    const CT *src = DenseTensorView::typify_cells<CT>(state.peek(0)).cbegin();
+    const CT *src = state.peek(0).cells().typify<CT>().cbegin();
     auto dst_cells = state.stash.create_array<CT>(params.outer_size * params.inner_size);
     AGGR aggr;
     CT *dst = dst_cells.begin();

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_peek_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_peek_function.cpp
@@ -36,7 +36,7 @@ void my_tensor_peek_op(eval::InterpretedFunction::State &state, uint64_t param) 
         }
         factor *= dim.second;
     }
-    auto cells = DenseTensorView::typify_cells<CT>(state.peek(0));
+    auto cells = state.peek(0).cells().typify<CT>();
     state.stack.pop_back();
     const Value &result = state.stash.create<DoubleValue>(valid ? cells[idx] : 0.0);
     state.stack.emplace_back(result);

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_view.h
@@ -51,12 +51,6 @@ public:
         return MemoryUsage(sz, sz, 0, 0);
     }
 
-    template <typename T> static ConstArrayRef<T> typify_cells(const eval::Value &self) {
-        return self.cells().typify<T>();
-    }
-    template <typename T> static ConstArrayRef<T> unsafe_typify_cells(const eval::Value &self) {
-        return self.cells().unsafe_typify<T>();
-    }
 protected:
     explicit DenseTensorView(const eval::ValueType &type_in)
         : _typeRef(type_in),

--- a/eval/src/vespa/eval/tensor/dense/dense_xw_product_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_xw_product_function.cpp
@@ -36,8 +36,8 @@ template <typename LCT, typename RCT, bool common_inner>
 void my_xw_product_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const DenseXWProductFunction::Self &self = *((const DenseXWProductFunction::Self *)(param));
     using OCT = typename eval::UnifyCellTypes<LCT,RCT>::type;
-    auto vector_cells = DenseTensorView::typify_cells<LCT>(state.peek(1));
-    auto matrix_cells = DenseTensorView::typify_cells<RCT>(state.peek(0));
+    auto vector_cells = state.peek(1).cells().typify<LCT>();
+    auto matrix_cells = state.peek(0).cells().typify<RCT>();
     auto dst_cells = state.stash.create_array<OCT>(self.result_size);
     OCT *dst = dst_cells.begin();
     const RCT *matrix = matrix_cells.cbegin();
@@ -51,8 +51,8 @@ void my_xw_product_op(eval::InterpretedFunction::State &state, uint64_t param) {
 template <bool common_inner>
 void my_cblas_double_xw_product_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const DenseXWProductFunction::Self &self = *((const DenseXWProductFunction::Self *)(param));
-    auto vector_cells = DenseTensorView::typify_cells<double>(state.peek(1));
-    auto matrix_cells = DenseTensorView::typify_cells<double>(state.peek(0));
+    auto vector_cells = state.peek(1).cells().typify<double>();
+    auto matrix_cells = state.peek(0).cells().typify<double>();
     auto dst_cells = state.stash.create_array<double>(self.result_size);
     cblas_dgemv(CblasRowMajor, common_inner ? CblasNoTrans : CblasTrans,
                 common_inner ? self.result_size : self.vector_size,
@@ -65,8 +65,8 @@ void my_cblas_double_xw_product_op(eval::InterpretedFunction::State &state, uint
 template <bool common_inner>
 void my_cblas_float_xw_product_op(eval::InterpretedFunction::State &state, uint64_t param) {
     const DenseXWProductFunction::Self &self = *((const DenseXWProductFunction::Self *)(param));
-    auto vector_cells = DenseTensorView::typify_cells<float>(state.peek(1));
-    auto matrix_cells = DenseTensorView::typify_cells<float>(state.peek(0));
+    auto vector_cells = state.peek(1).cells().typify<float>();
+    auto matrix_cells = state.peek(0).cells().typify<float>();
     auto dst_cells = state.stash.create_array<float>(self.result_size);
     cblas_sgemv(CblasRowMajor, common_inner ? CblasNoTrans : CblasTrans,
                 common_inner ? self.result_size : self.vector_size,


### PR DESCRIPTION
* replace: DenseTensorView::typify_cells<T>(foo)
     with: foo.cells().typify<T>()
* costs one extra virtual function call
* also remove DenseTensorView::unsafe_typify_cells (was unused)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review
