### PR TITLE
require newer xxhash

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -110,7 +110,7 @@ BuildRequires: gtest-devel
 BuildRequires: gmock-devel
 %endif
 %endif
-BuildRequires: xxhash-devel >= 0.7.3
+BuildRequires: xxhash-devel >= 0.8.0
 BuildRequires: openblas-devel
 BuildRequires: zlib-devel
 BuildRequires: re2-devel

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -151,7 +151,7 @@ Requires: valgrind
 %endif
 Requires: Judy
 Requires: xxhash
-Requires: xxhash-libs >= 0.7.3
+Requires: xxhash-libs >= 0.8.0
 %if 0%{?el8}
 Requires: openblas
 %else
@@ -252,7 +252,7 @@ Vespa - The open big data serving engine - base
 
 Summary: Vespa - The open big data serving engine - base C++ libs
 
-Requires: xxhash-libs >= 0.7.3
+Requires: xxhash-libs >= 0.8.0
 %if 0%{?el7}
 Requires: vespa-openssl >= 1.1.1g-1
 %else


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

with the recent change to vespalib::hash some unit tests failed for me:
```
staging_vespalib_adaptive_sequenced_executor_test_app 
adaptive_sequenced_executor_test.cpp: info:  running test suite 'adaptive_sequenced_executor_test.cpp'
[...]
adaptive_sequenced_executor_test.cpp: info:  status_for_test 'require that task with same string component id are serialized': PASS
adaptive_sequenced_executor_test.cpp:177: error: check failure #1: 'tryCnt < 100' in thread '0(1)' (adaptive_sequenced_executor_test.cpp)
    STATE[0]: 'require that task with different string component ids are not serialized' (adaptive_sequenced_executor_test.cpp:174)
adaptive_sequenced_executor_test.cpp: ERROR: status_for_test 'require that task with different string component ids are not serialized': FAIL
```

dist/vespa.spec claimed xxhash 0.7.3 should work, but I had to upgrade to 0.8.0.

@vekterli please review
@aressem @geirst FYI
