### PR TITLE
Take StateMonitor snapshot every 60s

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -50,7 +50,7 @@ public class VipStatus {
 
     /** For testing */
     public VipStatus(QrSearchersConfig dispatchers, ClustersStatus clustersStatus) {
-        this(dispatchers, new VipStatusConfig.Builder().build(), clustersStatus, new StateMonitor());
+        this(dispatchers, new VipStatusConfig.Builder().build(), clustersStatus, StateMonitor.createForTesting());
     }
 
     @Inject

--- a/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
@@ -1,13 +1,15 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.handler;
 
-import static org.junit.Assert.*;
-
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.core.VipStatusConfig;
 import com.yahoo.container.jdisc.state.StateMonitor;
 import com.yahoo.jdisc.core.SystemTimer;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author bratseth
@@ -142,7 +144,7 @@ public class VipStatusTestCase {
             Thread thread = new Thread(runnable, "StateMonitor");
             thread.setDaemon(true);
             return thread;
-        });
+        }, true);
     }
 
     private static void removeFromRotation(String[] clusters, VipStatus v) {

--- a/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
@@ -4,7 +4,6 @@ package com.yahoo.container.handler;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.core.VipStatusConfig;
 import com.yahoo.container.jdisc.state.StateMonitor;
-import com.yahoo.jdisc.core.SystemTimer;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -140,11 +139,9 @@ public class VipStatusTestCase {
     }
 
     private static StateMonitor createStateMonitor(StateMonitor.Status startState) {
-        return new StateMonitor(1000, startState, new SystemTimer(), runnable -> {
-            Thread thread = new Thread(runnable, "StateMonitor");
-            thread.setDaemon(true);
-            return thread;
-        }, true);
+        StateMonitor stateMonitor = StateMonitor.createForTesting();
+        stateMonitor.status(startState);
+        return stateMonitor;
     }
 
     private static void removeFromRotation(String[] clusters, VipStatus v) {

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/MetricsPacketsHandlerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/MetricsPacketsHandlerTest.java
@@ -17,7 +17,6 @@ import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.PACKET_SEPAR
 import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.STATUS_CODE_KEY;
 import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.STATUS_MSG_KEY;
 import static com.yahoo.container.jdisc.state.MetricsPacketsHandler.TIMESTAMP_KEY;
-import static com.yahoo.container.jdisc.state.StateHandlerTestBase.SNAPSHOT_INTERVAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -123,7 +122,7 @@ public class MetricsPacketsHandlerTest extends StateHandlerTestBase {
     }
     
     private List<JsonNode> incrementTimeAndGetJsonPackets() throws Exception {
-        incrementCurrentTimeAndAssertSnapshot(SNAPSHOT_INTERVAL);
+        advanceToNextSnapshot();
         String response = requestAsString("http://localhost/metrics-packets");
 
         return toJsonPackets(response);

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/StateHandlerTestBase.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/StateHandlerTestBase.java
@@ -22,14 +22,12 @@ import org.junit.Before;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Simon Thoresen Hult
@@ -59,8 +57,7 @@ public class StateHandlerTestBase {
                         new HealthMonitorConfig.Builder()
                                 .snapshot_interval(TimeUnit.MILLISECONDS.toSeconds(SNAPSHOT_INTERVAL))
                                 .initialStatus("up"));
-        ThreadFactory threadFactory = ignored -> mock(Thread.class);
-        this.monitor = new StateMonitor(healthMonitorConfig, timer, threadFactory);
+        this.monitor = new StateMonitor(healthMonitorConfig, timer, null);
         builder.guiceModules().install(new AbstractModule() {
 
             @Override

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/StateHandlerTestBase.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/StateHandlerTestBase.java
@@ -110,9 +110,9 @@ public class StateHandlerTestBase {
         return mapper.readTree(mapper.getFactory().createParser(requestAsString(requestUri)));
     }
 
-    void incrementCurrentTimeAndAssertSnapshot(long val) {
-        currentTimeMillis.addAndGet(val);
-        assertTrue("Expected a new snapshot to be generated", monitor.checkTime());
+    void advanceToNextSnapshot() {
+        currentTimeMillis.addAndGet(SNAPSHOT_INTERVAL);
+        monitor.updateSnapshot();
     }
 
 }

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/StateMonitorBenchmarkTest.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/StateMonitorBenchmarkTest.java
@@ -2,12 +2,10 @@
 package com.yahoo.container.jdisc.state;
 
 import com.google.inject.Provider;
-import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.application.ContainerThread;
 import com.yahoo.jdisc.application.MetricConsumer;
 import com.yahoo.jdisc.application.MetricProvider;
-import com.yahoo.jdisc.core.SystemTimer;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -32,8 +30,7 @@ public class StateMonitorBenchmarkTest {
 
     @Test
     public void requireThatHealthMonitorDoesNotBlockMetricThreads() throws Exception {
-        StateMonitor monitor = new StateMonitor(new HealthMonitorConfig(new HealthMonitorConfig.Builder()),
-                                                new SystemTimer());
+        StateMonitor monitor = StateMonitor.createForTesting();
         Provider<MetricConsumer> provider = MetricConsumerProviders.wrap(monitor);
         performUpdates(provider, 8);
         for (int i = 1; i <= NUM_THREADS; i *= 2) {

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/metric/MetricConsumerProviders.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/metric/MetricConsumerProviders.java
@@ -4,11 +4,9 @@ package com.yahoo.container.jdisc.metric;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.container.jdisc.MetricConsumerFactory;
-import com.yahoo.container.jdisc.config.HealthMonitorConfig;
-import com.yahoo.metrics.MetricsPresentationConfig;
 import com.yahoo.container.jdisc.state.StateMonitor;
 import com.yahoo.jdisc.application.MetricConsumer;
-import com.yahoo.jdisc.core.SystemTimer;
+import com.yahoo.metrics.MetricsPresentationConfig;
 
 /**
  * @author Simon Thoresen Hult
@@ -26,13 +24,13 @@ class MetricConsumerProviders {
     public static MetricConsumerProvider newInstance(MetricConsumerFactory... factories) {
         return new MetricConsumerProvider(newComponentRegistry(factories),
                                           new MetricsPresentationConfig(new MetricsPresentationConfig.Builder()),
-                                          newStateMonitor());
+                                          StateMonitor.createForTesting());
     }
 
     public static MetricConsumerProvider newDefaultInstance() {
         return new MetricConsumerProvider(newComponentRegistry(),
                                           new MetricsPresentationConfig(new MetricsPresentationConfig.Builder()),
-                                          newStateMonitor());
+                                          StateMonitor.createForTesting());
     }
 
     public static ComponentRegistry<MetricConsumerFactory> newComponentRegistry(MetricConsumerFactory... factories) {
@@ -41,11 +39,6 @@ class MetricConsumerProviders {
             registry.register(new ComponentId(String.valueOf(factory.hashCode())), factory);
         }
         return registry;
-    }
-
-    public static StateMonitor newStateMonitor() {
-        return new StateMonitor(new HealthMonitorConfig(new HealthMonitorConfig.Builder()),
-                                new SystemTimer());
     }
 
 }


### PR DESCRIPTION
Using Executors simplifies the code and fixes the following 2 small problems:
 - A tiny drift of the 1m interval: It starts the next snapshot 1m + the time
   before wait() return + the time until currentTimeMillis().
 - May potentially (but unlikely) invoke wait() with negative (throws
   exception) or 0 argument (waits forever).