### PR TITLE
Deadlock detection

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -245,6 +245,10 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
                     metric.set("lockAttempt.release", lockMetrics.getAndResetReleaseCount(), context);
                     metric.set("lockAttempt.releaseFailed", lockMetrics.getAndResetReleaseFailedCount(), context);
                     metric.set("lockAttempt.reentry", lockMetrics.getAndResetReentryCount(), context);
+                    metric.set("lockAttempt.deadlock", lockMetrics.getAndResetDeadlockCount(), context);
+                    metric.set("lockAttempt.nakedRelease", lockMetrics.getAndResetNakedReleaseCount(), context);
+                    metric.set("lockAttempt.acquireWithoutRelease", lockMetrics.getAndResetAcquireWithoutReleaseCount(), context);
+                    metric.set("lockAttempt.foreignRelease", lockMetrics.getAndResetForeignReleaseCount(), context);
 
                     setLockLatencyMetrics("acquire", lockMetrics.getAndResetAcquireLatencyMetrics(), context);
                     setLockLatencyMetrics("locked", lockMetrics.getAndResetLockedLatencyMetrics(), context);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LocksResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LocksResponse.java
@@ -62,6 +62,10 @@ public class LocksResponse extends HttpResponse {
             lockPathCursor.setLong("releaseCount", lockMetrics.getCumulativeReleaseCount());
             lockPathCursor.setLong("releaseFailedCount", lockMetrics.getCumulativeReleaseFailedCount());
             lockPathCursor.setLong("reentryCount", lockMetrics.getCumulativeReentryCount());
+            lockPathCursor.setLong("deadlock", lockMetrics.getCumulativeDeadlockCount());
+            lockPathCursor.setLong("nakedRelease", lockMetrics.getCumulativeNakedReleaseCount());
+            lockPathCursor.setLong("acquireWithoutRelease", lockMetrics.getCumulativeAcquireWithoutReleaseCount());
+            lockPathCursor.setLong("foreignRelease", lockMetrics.getCumulativeForeignReleaseCount());
 
             setLatency(lockPathCursor, "acquire", lockMetrics.getAcquireLatencyMetrics());
             setLatency(lockPathCursor, "locked", lockMetrics.getLockedLatencyMetrics());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -187,7 +187,9 @@ public class NodeRepositoryTest {
         host1 = host1.withFirmwareVerifiedAt(tester.clock().instant());
         host1 = host1.with(host1.status().withIncreasedFailCount());
         host1 = host1.with(host1.reports().withReport(Report.basicReport("id", Report.Type.HARD_FAIL, tester.clock().instant(), "Test report")));
-        tester.nodeRepository().write(host1, tester.nodeRepository().lock(host1));
+        try (var lock = tester.nodeRepository().lock(host1)) {
+            tester.nodeRepository().write(host1, lock);
+        }
         tester.nodeRepository().removeRecursively("host1");
 
         // Host 1 is deprovisioned and unwanted properties are cleared

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/applications/ApplicationsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/applications/ApplicationsTest.java
@@ -19,7 +19,6 @@ public class ApplicationsTest {
 
     @Test
     public void testApplications() {
-        NodeRepositoryTester tester = new NodeRepositoryTester();
         Applications applications = new NodeRepositoryTester().nodeRepository().applications();
         ApplicationId app1 = ApplicationId.from("t1", "a1", "i1");
         ApplicationId app2 = ApplicationId.from("t1", "a2", "i1");
@@ -27,34 +26,34 @@ public class ApplicationsTest {
 
         assertTrue(applications.get(app1).isEmpty());
         assertEquals(List.of(), applications.ids());
-        applications.put(new Application(app1), tester.nodeRepository().lock(app1));
+        applications.put(new Application(app1), () -> {});
         assertEquals(app1, applications.get(app1).get().id());
         assertEquals(List.of(app1), applications.ids());
         NestedTransaction t = new NestedTransaction();
-        applications.remove(app1, t, provisionLock(app1, tester));
+        applications.remove(app1, t, provisionLock(app1));
         t.commit();
         assertTrue(applications.get(app1).isEmpty());
         assertEquals(List.of(), applications.ids());
 
-        applications.put(new Application(app1), tester.nodeRepository().lock(app1));
-        applications.put(new Application(app2), tester.nodeRepository().lock(app1));
+        applications.put(new Application(app1), () -> {});
+        applications.put(new Application(app2), () -> {});
         t = new NestedTransaction();
-        applications.put(new Application(app3), t, tester.nodeRepository().lock(app1));
+        applications.put(new Application(app3), t, () -> {});
         assertEquals(List.of(app1, app2), applications.ids());
         t.commit();
         assertEquals(List.of(app1, app2, app3), applications.ids());
         t = new NestedTransaction();
-        applications.remove(app1, t, provisionLock(app1, tester));
-        applications.remove(app2, t, provisionLock(app2, tester));
-        applications.remove(app3, t, provisionLock(app3, tester));
+        applications.remove(app1, t, provisionLock(app1));
+        applications.remove(app2, t, provisionLock(app2));
+        applications.remove(app3, t, provisionLock(app3));
         assertEquals(List.of(app1, app2, app3), applications.ids());
         t.commit();
         assertTrue(applications.get(app1).isEmpty());
         assertEquals(List.of(), applications.ids());
     }
 
-    private ProvisionLock provisionLock(ApplicationId application, NodeRepositoryTester tester) {
-        return new ProvisionLock(application, tester.nodeRepository().lock(application));
+    private ProvisionLock provisionLock(ApplicationId application) {
+        return new ProvisionLock(application, () -> {});
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
@@ -158,7 +158,9 @@ class AutoscalingTester {
                                                            ClusterResources min, ClusterResources max) {
         Application application = nodeRepository().applications().get(applicationId).orElse(new Application(applicationId))
                                                   .withCluster(clusterId, false, min, max);
-        nodeRepository().applications().put(application, nodeRepository().lock(applicationId));
+        try (Mutex lock = nodeRepository().lock(applicationId)) {
+            nodeRepository().applications().put(application, lock);
+        }
         return autoscaler.autoscale(application.clusters().get(clusterId),
                                     nodeRepository().getNodes(applicationId, Node.State.active));
     }
@@ -167,7 +169,9 @@ class AutoscalingTester {
                                                            ClusterResources min, ClusterResources max) {
         Application application = nodeRepository().applications().get(applicationId).orElse(new Application(applicationId))
                                                   .withCluster(clusterId, false, min, max);
-        nodeRepository().applications().put(application, nodeRepository().lock(applicationId));
+        try (Mutex lock = nodeRepository().lock(applicationId)) {
+            nodeRepository().applications().put(application, lock);
+        }
         return autoscaler.suggest(application.clusters().get(clusterId),
                                   nodeRepository().getNodes(applicationId, Node.State.active));
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -161,6 +161,10 @@ public class MetricsReporterTest {
         verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.release", 3);
         verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.releaseFailed", 0);
         verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.reentry", 0);
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.deadlock", 0);
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.nakedRelease", 0);
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.acquireWithoutRelease", 0);
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.foreignRelease", 0);
         metric.remove("lockAttempt.acquireLatency");
         metric.remove("lockAttempt.acquireMaxActiveLatency");
         metric.remove("lockAttempt.acquireHz");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.test.ManualClock;
+import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.applicationmodel.ApplicationInstance;
 import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
@@ -205,12 +206,16 @@ public class MetricsReporterTest {
         Node container1 = Node.createDockerNode(Set.of("::2"), "container1",
                                                 "dockerHost", new NodeResources(1, 3, 2, 1), NodeType.tenant);
         container1 = container1.with(allocation(Optional.of("app1"), container1).get());
-        nodeRepository.addDockerNodes(new LockedNodeList(List.of(container1), nodeRepository.lockUnallocated()));
+        try (Mutex lock = nodeRepository.lockUnallocated()) {
+            nodeRepository.addDockerNodes(new LockedNodeList(List.of(container1), lock));
+        }
 
         Node container2 = Node.createDockerNode(Set.of("::3"), "container2",
                                                 "dockerHost", new NodeResources(2, 4, 4, 1), NodeType.tenant);
         container2 = container2.with(allocation(Optional.of("app2"), container2).get());
-        nodeRepository.addDockerNodes(new LockedNodeList(List.of(container2), nodeRepository.lockUnallocated()));
+        try (Mutex lock = nodeRepository.lockUnallocated()) {
+            nodeRepository.addDockerNodes(new LockedNodeList(List.of(container2), lock));
+        }
 
         NestedTransaction transaction = new NestedTransaction();
         nodeRepository.activate(nodeRepository.getNodes(NodeType.host), transaction);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -23,6 +23,7 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
 import com.yahoo.test.ManualClock;
+import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
@@ -188,7 +189,9 @@ public class ProvisioningTester {
             Node node = nodeRepository.getNode(prepared.hostname()).get();
             if (node.ipConfig().primary().isEmpty()) {
                 node = node.with(new IP.Config(Set.of("::" + 0 + ":0"), Set.of()));
-                nodeRepository.write(node, nodeRepository.lock(node));
+                try (Mutex lock = nodeRepository.lock(node)) {
+                    nodeRepository.write(node, lock);
+                }
             }
             if (node.parentHostname().isEmpty()) continue;
             Node parent = nodeRepository.getNode(node.parentHostname().get()).get();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -7,7 +7,6 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.applicationmodel.HostName;
-import com.yahoo.vespa.curator.stats.LockStats;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.maintenance.OsUpgradeActivator;
 import com.yahoo.vespa.hosted.provision.maintenance.TestMetric;
@@ -40,7 +39,6 @@ public class NodesV2ApiTest {
 
     @Before
     public void createTester() {
-        LockStats.clearForTesting();
         tester = new RestApiTester();
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.curator.stats.LockStats;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.maintenance.OsUpgradeActivator;
 import com.yahoo.vespa.hosted.provision.maintenance.TestMetric;
@@ -39,6 +40,7 @@ public class NodesV2ApiTest {
 
     @Before
     public void createTester() {
+        LockStats.clearForTesting();
         tester = new RestApiTester();
     }
 

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockAttempt.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockAttempt.java
@@ -32,12 +32,6 @@ public class LockAttempt {
     private volatile Optional<Instant> terminalStateInstant = Optional.empty();
     private volatile Optional<String> stackTrace = Optional.empty();
 
-    public static LockAttempt invokingAcquire(ThreadLockStats threadLockStats, String lockPath,
-                                              Duration timeout, LockMetrics lockMetrics,
-                                              boolean reentry) {
-        return new LockAttempt(threadLockStats, lockPath, timeout, Instant.now(), lockMetrics, reentry);
-    }
-
     public enum LockState {
         ACQUIRING(false), ACQUIRE_FAILED(true), TIMED_OUT(true), ACQUIRED(false), RELEASED(true),
         RELEASED_WITH_ERROR(true);
@@ -50,6 +44,12 @@ public class LockAttempt {
     }
 
     private volatile LockState lockState = LockState.ACQUIRING;
+
+    public static LockAttempt invokingAcquire(ThreadLockStats threadLockStats, String lockPath,
+                                              Duration timeout, LockMetrics lockMetrics,
+                                              boolean reentry) {
+        return new LockAttempt(threadLockStats, lockPath, timeout, Instant.now(), lockMetrics, reentry);
+    }
 
     private LockAttempt(ThreadLockStats threadLockStats, String lockPath, Duration timeout,
                         Instant callAcquireInstant, LockMetrics lockMetrics, boolean reentry) {
@@ -66,8 +66,10 @@ public class LockAttempt {
     public String getLockPath() { return lockPath; }
     public Instant getTimeAcquiredWasInvoked() { return callAcquireInstant; }
     public Duration getAcquireTimeout() { return timeout; }
+    public boolean getReentry() { return reentry; }
     public LockState getLockState() { return lockState; }
     public Optional<Instant> getTimeLockWasAcquired() { return lockAcquiredInstant; }
+    public boolean isAcquiring() { return lockAcquiredInstant.isEmpty(); }
     public Instant getTimeAcquireEndedOrNow() {
         return lockAcquiredInstant.orElseGet(() -> getTimeTerminalStateWasReached().orElseGet(Instant::now));
     }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockMetrics.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockMetrics.java
@@ -30,6 +30,16 @@ public class LockMetrics {
     private final LatencyStats acquireStats = new LatencyStats();
     private final LatencyStats lockedStats = new LatencyStats();
 
+    private final AtomicInteger deadlockCount = new AtomicInteger(0);
+    private final AtomicInteger acquireWithoutReleaseCount = new AtomicInteger(0);
+    private final AtomicInteger nakedReleaseCount = new AtomicInteger(0);
+    private final AtomicInteger foreignReleaseCount = new AtomicInteger(0);
+
+    private final AtomicInteger cumulativeDeadlockCount = new AtomicInteger(0);
+    private final AtomicInteger cumulativeAcquireWithoutReleaseCount = new AtomicInteger(0);
+    private final AtomicInteger cumulativeNakedReleaseCount = new AtomicInteger(0);
+    private final AtomicInteger cumulativeForeignReleaseCount = new AtomicInteger(0);
+
     /** Returns a Runnable that must be invoked when the acquire() finishes. */
     ActiveInterval acquireInvoked(boolean reentry) {
         if (reentry) {
@@ -78,6 +88,26 @@ public class LockMetrics {
         cumulativeReleaseFailedCount.incrementAndGet();
     }
 
+    void incrementDeadlockCount() {
+        deadlockCount.incrementAndGet();
+        cumulativeDeadlockCount.incrementAndGet();
+    }
+
+    void incrementAcquireWithoutReleaseCount() {
+        acquireWithoutReleaseCount.incrementAndGet();
+        cumulativeAcquireWithoutReleaseCount.incrementAndGet();
+    }
+
+    void incrementNakedReleaseCount() {
+        nakedReleaseCount.incrementAndGet();
+        cumulativeNakedReleaseCount.incrementAndGet();
+    }
+
+    void incrementForeignReleaseCount() {
+        foreignReleaseCount.incrementAndGet();
+        cumulativeForeignReleaseCount.incrementAndGet();
+    }
+
     public int getAndResetAcquireCount() { return acquireCount.getAndSet(0); }
     public int getAndResetAcquireFailedCount() { return acquireFailedCount.getAndSet(0); }
     public int getAndResetAcquireTimedOutCount() { return acquireTimedOutCount.getAndSet(0); }
@@ -85,6 +115,10 @@ public class LockMetrics {
     public int getAndResetReleaseCount() { return releaseCount.getAndSet(0); }
     public int getAndResetReleaseFailedCount() { return releaseFailedCount.getAndSet(0); }
     public int getAndResetReentryCount() { return reentryCount.getAndSet(0); }
+    public int getAndResetDeadlockCount() { return deadlockCount.getAndSet(0); }
+    public int getAndResetAcquireWithoutReleaseCount() { return acquireWithoutReleaseCount.getAndSet(0); }
+    public int getAndResetNakedReleaseCount() { return nakedReleaseCount.getAndSet(0); }
+    public int getAndResetForeignReleaseCount() { return foreignReleaseCount.getAndSet(0); }
 
     public int getCumulativeAcquireCount() { return cumulativeAcquireCount.get(); }
     public int getCumulativeAcquireFailedCount() { return cumulativeAcquireFailedCount.get(); }
@@ -93,6 +127,10 @@ public class LockMetrics {
     public int getCumulativeReleaseCount() { return cumulativeReleaseCount.get(); }
     public int getCumulativeReleaseFailedCount() { return cumulativeReleaseFailedCount.get(); }
     public int getCumulativeReentryCount() { return cumulativeReentryCount.get(); }
+    public int getCumulativeDeadlockCount() { return cumulativeDeadlockCount.get(); }
+    public int getCumulativeAcquireWithoutReleaseCount() { return cumulativeAcquireWithoutReleaseCount.get(); }
+    public int getCumulativeNakedReleaseCount() { return cumulativeNakedReleaseCount.get(); }
+    public int getCumulativeForeignReleaseCount() { return cumulativeForeignReleaseCount.get(); }
 
     public LatencyMetrics getAcquireLatencyMetrics() { return acquireStats.getLatencyMetrics(); }
     public LatencyMetrics getLockedLatencyMetrics() { return lockedStats.getLatencyMetrics(); }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockStats.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LockStats.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.curator.stats;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -17,6 +18,9 @@ public class LockStats {
     private static LockStats stats = new LockStats();
 
     private final ConcurrentHashMap<Thread, ThreadLockStats> statsByThread = new ConcurrentHashMap<>();
+
+    /** Modified only by Thread actually holding the lock on the path (key). */
+    private final ConcurrentHashMap<String, Thread> lockPathsHeld = new ConcurrentHashMap<>();
 
     private final LockAttemptSamples completedLockAttemptSamples = new LockAttemptSamples(3);
 
@@ -33,9 +37,7 @@ public class LockStats {
     public static LockStats getGlobal() { return stats; }
 
     /** Returns stats tied to the current thread. */
-    public static ThreadLockStats getForCurrentThread() {
-        return stats.statsByThread.computeIfAbsent(Thread.currentThread(), ThreadLockStats::new);
-    }
+    public static ThreadLockStats getForCurrentThread() { return stats.getForThread(Thread.currentThread()); }
 
     public static void clearForTesting() {
         stats = new LockStats();
@@ -51,6 +53,42 @@ public class LockStats {
         synchronized (interestingRecordingsMonitor) {
             return List.copyOf(interestingRecordings);
         }
+    }
+
+    /** Non-private for testing. */
+    ThreadLockStats getForThread(Thread thread) {
+        return statsByThread.computeIfAbsent(thread, ThreadLockStats::new);
+    }
+
+    /** Must be invoked only after the first and non-reentry acquisition of the lock. */
+    void notifyOfThreadHoldingLock(Thread currentThread, String lockPath) {
+        Thread oldThread = lockPathsHeld.put(lockPath, currentThread);
+        if (oldThread != null) {
+            throw new IllegalStateException("Thread " + currentThread.getName() +
+                    " reports it has the lock on " + lockPath + ", but thread " + oldThread.getName() +
+                    " has not reported it released the lock");
+        }
+    }
+
+    /** Must be invoked only before the last and non-reentry release of the lock. */
+    void notifyOfThreadReleasingLock(Thread currentThread, String lockPath) {
+        Thread oldThread = lockPathsHeld.remove(lockPath);
+        if (oldThread == null) {
+            throw new IllegalStateException("Thread " + currentThread.getName() +
+                    " is releasing the lock " + lockPath + ", but nobody own that lock");
+        } else if (oldThread != currentThread) {
+            throw new IllegalStateException("Thread " + currentThread.getName() +
+                    " is releasing the lock " + lockPath + ", but it was owned by thread "
+                    + oldThread.getName());
+        }
+    }
+
+    /**
+     * Returns the ThreadLockStats holding the lock on the path, but the info may be outdated already
+     * on return, either no-one holds the lock or another thread may hold the lock.
+     */
+    Optional<ThreadLockStats> getThreadLockStatsHolding(String lockPath) {
+        return Optional.ofNullable(lockPathsHeld.get(lockPath)).map(statsByThread::get);
     }
 
     LockMetrics getLockMetrics(String lockPath) {


### PR DESCRIPTION
Just before Lock.acquire() is invoked, the locks within the process is queried
to see if a "deadlock" will occur: The current thread waiting to acquire lock
path P1, which is held by thread T1 waiting on acquiring a lock at path P2,
etc, until a thread is waiting for a lock already held by another thread in this chain.

This PR adds metrics to detect, and logging to debug deadlocks.  Eventually I hope to
put in place automatic deadlock resolution:  by throwing a timeout exception when detected,
but that may break tests.

Some tests are changed in this PR: Tests that take the lock but do not release it.  This breaks
deadlock detection since lock stats are global and the same VM runs later tests.  411aa57 broke on 
SD with this, but I was unable to reproduce it locally.  I'll take another stab at locating more
tests later.