### PR TITLE
Defer changes until restart

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -117,11 +117,11 @@ public class Validation {
         for (var clusterToRestart : clustersToBeRestarted) {
             var containerCluster = model.getContainerClusters().get(clusterToRestart.value());
             if (containerCluster != null)
-                containerCluster.deferChangesUntilRestart();
+                containerCluster.setDeferChangesUntilRestart(true);
 
             var contentCluster = model.getContentClusters().get(clusterToRestart.value());
             if (contentCluster != null)
-                contentCluster.deferChangesUntilRestart();
+                contentCluster.setDeferChangesUntilRestart(true);
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ContainerRestartValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ContainerRestartValidator.java
@@ -7,7 +7,6 @@ import com.yahoo.container.QrConfig;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.vespa.model.container.ApplicationContainer;
-import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
 
@@ -15,8 +14,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Returns a restart action for each container that has turned on {@link QrConfig#restartOnDeploy()}.

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -147,7 +147,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private final ComponentGroup<Component<?, ?>> componentGroup;
     private final boolean isHostedVespa;
 
-    private Map<String, String> concreteDocumentTypes = new LinkedHashMap<>();
+    private final Map<String, String> concreteDocumentTypes = new LinkedHashMap<>();
 
     private ApplicationMetaData applicationMetaData = null;
 
@@ -157,6 +157,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private String hostClusterId = null;
     private String jvmGCOptions = null;
     private String environmentVars = null;
+
+    private boolean deferChangesUntilRestart = false;
 
     public ContainerCluster(AbstractConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState) {
         super(parent, configSubId);
@@ -288,6 +290,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     }
 
     public void addContainer(CONTAINER container) {
+        container.setOwner(this);
         container.setClusterName(name);
         container.setProp("clustername", name)
                  .setProp("index", this.containers.size());
@@ -618,11 +621,13 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     protected abstract boolean messageBusEnabled();
 
     /**
-     * Mark that the config emitted by this cluster currently should be applied by clients already running with
+     * Mark whether the config emitted by this cluster currently should be applied by clients already running with
      * a previous generation of it only by restarting the consuming processes.
      */
-    public void deferChangesUntilRestart() {
-
+    public void setDeferChangesUntilRestart(boolean deferChangesUntilRestart) {
+        this.deferChangesUntilRestart = deferChangesUntilRestart;
     }
+
+    public boolean getDeferChangesUntilRestart() { return deferChangesUntilRestart; }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -744,11 +744,10 @@ public class ContentCluster extends AbstractConfigProducer implements
     }
 
     /**
-     * Mark that the config emitted by this cluster currently should be applied by clients already running with
+     * Mark whether the config emitted by this cluster currently should be applied by clients already running with
      * a previous generation of it only by restarting the consuming processes.
      */
-    public void deferChangesUntilRestart() {
-
+    public void setDeferChangesUntilRestart(boolean deferChangesUntilRestart) {
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/config/model/deploy/DeployStateTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/deploy/DeployStateTest.java
@@ -38,7 +38,7 @@ public class DeployStateTest {
     @Test
     public void testProvisionerIsSet() {
         DeployState.Builder builder = new DeployState.Builder();
-        HostProvisioner provisioner = new InMemoryProvisioner(true, "foo.yahoo.com");
+        HostProvisioner provisioner = new InMemoryProvisioner(true, false, "foo.yahoo.com");
         builder.modelHostProvisioner(provisioner);
         DeployState state = builder.build();
         assertThat(state.getProvisioner(), is(provisioner));

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -103,7 +103,7 @@ public class ModelProvisioningTest {
                 + " </host>"
                 + "</hosts>";
         VespaModelCreatorWithMockPkg creator = new VespaModelCreatorWithMockPkg(null, services);
-        VespaModel model = creator.create(new DeployState.Builder().modelHostProvisioner(new InMemoryProvisioner(Hosts.readFrom(new StringReader(hosts)), true)));
+        VespaModel model = creator.create(new DeployState.Builder().modelHostProvisioner(new InMemoryProvisioner(Hosts.readFrom(new StringReader(hosts)), true, false)));
         ApplicationContainerCluster mydisc = model.getContainerClusters().get("mydisc");
         ApplicationContainerCluster mydisc2 = model.getContainerClusters().get("mydisc2");
         assertEquals(3, mydisc.getContainers().size());

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
@@ -236,7 +236,7 @@ public class DedicatedAdminV4Test {
                 .build();
         return new VespaModel(new NullConfigModelRegistry(), deployStateBuilder
                 .applicationPackage(app)
-                .modelHostProvisioner(new InMemoryProvisioner(Hosts.readFrom(app.getHosts()), true))
+                .modelHostProvisioner(new InMemoryProvisioner(Hosts.readFrom(app.getHosts()), true, false))
                 .build());
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
@@ -20,13 +20,13 @@ public class QuotaValidatorTest {
 
     @Test
     public void test_deploy_under_quota() {
-        var tester = new ValidationTester(5, new TestProperties().setHostedVespa(true).setQuota(quota));
+        var tester = new ValidationTester(5, false, new TestProperties().setHostedVespa(true).setQuota(quota));
         tester.deploy(null, getServices("testCluster", 5), Environment.prod, null);
     }
 
     @Test
     public void test_deploy_above_quota_clustersize() {
-        var tester = new ValidationTester(11, new TestProperties().setHostedVespa(true).setQuota(quota));
+        var tester = new ValidationTester(11, false, new TestProperties().setHostedVespa(true).setQuota(quota));
         try {
             tester.deploy(null, getServices("testCluster", 11), Environment.prod, null);
             fail();
@@ -37,7 +37,7 @@ public class QuotaValidatorTest {
 
     @Test
     public void test_deploy_above_quota_budget() {
-        var tester = new ValidationTester(10, new TestProperties().setHostedVespa(true).setQuota(quota));
+        var tester = new ValidationTester(10, false, new TestProperties().setHostedVespa(true).setQuota(quota));
         try {
             tester.deploy(null, getServices("testCluster", 10), Environment.prod, null);
             fail();

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationTester.java
@@ -40,8 +40,8 @@ public class ValidationTester {
     }
 
     /** Creates a validation tester with number of nodes available and the given test properties */
-    public ValidationTester(int nodeCount, TestProperties properties) {
-        this(new InMemoryProvisioner(nodeCount), properties);
+    public ValidationTester(int nodeCount, boolean sharedHosts, TestProperties properties) {
+        this(new InMemoryProvisioner(nodeCount, sharedHosts), properties);
     }
 
     /** Creates a validation tester with a given host provisioner */
@@ -51,7 +51,7 @@ public class ValidationTester {
 
     /** Creates a validation tester with a number of nodes available */
     public ValidationTester(int nodeCount) {
-        this(new InMemoryProvisioner(nodeCount), new TestProperties().setHostedVespa(true));
+        this(new InMemoryProvisioner(nodeCount, false), new TestProperties().setHostedVespa(true));
     }
 
     /** Creates a validation tester with a given host provisioner */

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ClusterSizeReductionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ClusterSizeReductionValidatorTest.java
@@ -43,16 +43,6 @@ public class ClusterSizeReductionValidatorTest {
         tester.deploy(previous, getServices(2), Environment.prod, null);
     }
 
-    /*
-    @Test
-    public void testSizeReductionTo50PercentIsAllowed() throws IOException, SAXException {
-        ValidationTester tester = new ValidationTester(30);
-
-        VespaModel previous = tester.deploy(null, getServices(30), null).getFirst();
-        tester.deploy(previous, getServices(15), null);
-    }
-    */
-
     @Test
     public void testOverridingSizereductionValidation() {
         ValidationTester tester = new ValidationTester(30);

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.fail;
  */
 public class ResourcesReductionValidatorTest {
 
-    private final InMemoryProvisioner provisioner = new InMemoryProvisioner(30, new NodeResources(64, 128, 1000, 10));
+    private final InMemoryProvisioner provisioner = new InMemoryProvisioner(30, new NodeResources(64, 128, 1000, 10), false);
     private final ValidationTester tester = new ValidationTester(provisioner);
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartChangesDefersConfigChangesTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartChangesDefersConfigChangesTest.java
@@ -1,0 +1,48 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation.change;
+
+import com.yahoo.config.model.provision.InMemoryProvisioner;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.container.QrConfig;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.application.validation.ValidationTester;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author bratseth
+ */
+public class RestartChangesDefersConfigChangesTest {
+
+    @Test
+    public void changes_requiring_restart_defers_config_changes() {
+        ValidationTester tester = new ValidationTester(new InMemoryProvisioner(5,
+                                                                               new NodeResources(1, 3, 9, 1),
+                                                                               true));
+        VespaModel gen1 = tester.deploy(null, getServices(5, 3), Environment.prod, null).getFirst();
+
+        // Change node count - no restart
+        VespaModel gen2 = tester.deploy(gen1, getServices(4, 3), Environment.prod, null).getFirst();
+        var config2 = new QrConfig.Builder();
+        gen2.getContainerClusters().get("default").getContainers().get(0).getConfig(config2);
+        assertFalse(config2.build().restartOnDeploy());
+
+        // Change memory amount - requires restart
+        VespaModel gen3 = tester.deploy(gen2, getServices(4, 2), Environment.prod, null).getFirst();
+        var config3 = new QrConfig.Builder();
+        gen3.getContainerClusters().get("default").getContainers().get(0).getConfig(config3);
+        assertTrue(config3.build().restartOnDeploy());
+    }
+
+    private static String getServices(int nodes, int memory) {
+        return "<services version='1.0'>" +
+               "  <container id='default' version='1.0'>" +
+               "    <nodes count='" + nodes + "'><resources vcpu='1' memory='" + memory + "Gb' disk='9Gb'/></nodes>" +
+               "   </container>" +
+               "</services>";
+    }
+
+}

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/search/ImplicitIndexingClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/search/ImplicitIndexingClusterTest.java
@@ -50,7 +50,7 @@ public class ImplicitIndexingClusterTest {
         ModelContext.Properties properties = new TestProperties().setMultitenant(true).setHostedVespa(true);
         DeployState.Builder deployStateBuilder = new DeployState.Builder()
                 .properties(properties)
-                .modelHostProvisioner(new InMemoryProvisioner(true, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com"));
+                .modelHostProvisioner(new InMemoryProvisioner(true, false, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com"));
 
         return new VespaModelCreatorWithMockPkg(new MockApplicationPackage.Builder()
                 .withServices("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + servicesXml)

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -618,7 +618,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         String servicesXml = "<container id='default' version='1.0' />";
         ApplicationPackage applicationPackage = new MockApplicationPackage.Builder().withServices(servicesXml).build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
-                .modelHostProvisioner(new InMemoryProvisioner(true, "host1.yahoo.com", "host2.yahoo.com"))
+                .modelHostProvisioner(new InMemoryProvisioner(true, false, "host1.yahoo.com", "host2.yahoo.com"))
                 .applicationPackage(applicationPackage)
                 .properties(new TestProperties()
                         .setMultitenant(true)

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/utils/ContentClusterUtils.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/utils/ContentClusterUtils.java
@@ -46,7 +46,7 @@ public class ContentClusterUtils {
     }
 
     public static MockRoot createMockRoot(String[] hosts, List<String> schemas) {
-        return createMockRoot(new InMemoryProvisioner(true, hosts), schemas);
+        return createMockRoot(new InMemoryProvisioner(true, false, hosts), schemas);
     }
 
     public static MockRoot createMockRoot(List<String> schemas) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTestCase.java
@@ -276,7 +276,7 @@ public class VespaModelTestCase {
                 .build();
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(applicationPackage)
-                .modelHostProvisioner(new InMemoryProvisioner(true, "host1.yahoo.com"))
+                .modelHostProvisioner(new InMemoryProvisioner(true, false, "host1.yahoo.com"))
                 .properties(new TestProperties()
                         .setConfigServerSpecs(Arrays.asList(new TestProperties.Spec("cfghost", 1234, 1236)))
                         .setMultitenant(true))

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -138,6 +138,7 @@ public class VespaModelTester {
 
         HostProvisioner provisioner = hosted ?
                                       new InMemoryProvisioner(hostsByResources, failOnOutOfCapacity, useMaxResources,
+                                                              false,
                                                               startIndexForClusters, retiredHostNames) :
                                       new SingleNodeProvisioner();
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -63,7 +63,7 @@ public class ConfigServerBootstrapTest {
     @Test
     public void testBootstrap() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
-        InMemoryProvisioner provisioner = new InMemoryProvisioner(true, "host0", "host1", "host3", "host4");
+        InMemoryProvisioner provisioner = new InMemoryProvisioner(true, false, "host0", "host1", "host3", "host4");
         DeployTester tester = new DeployTester.Builder().modelFactory(createHostedModelFactory())
                 .configserverConfig(configserverConfig).hostProvisioner(provisioner).build();
         tester.deployApp("src/test/apps/hosted/");
@@ -96,7 +96,7 @@ public class ConfigServerBootstrapTest {
     @Test
     public void testBootstrapWithVipStatusFile() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
-        InMemoryProvisioner provisioner = new InMemoryProvisioner(true, "host0", "host1", "host3", "host4");
+        InMemoryProvisioner provisioner = new InMemoryProvisioner(true, false, "host0", "host1", "host3", "host4");
         DeployTester tester = new DeployTester.Builder().modelFactory(createHostedModelFactory())
                 .configserverConfig(configserverConfig).hostProvisioner(provisioner).build();
         tester.deployApp("src/test/apps/hosted/");
@@ -163,7 +163,7 @@ public class ConfigServerBootstrapTest {
         Curator curator = new MockCurator();
         DeployTester tester = new DeployTester.Builder()
                 .modelFactory(DeployTester.createModelFactory(Version.fromString(vespaVersion)))
-                .hostProvisioner(new InMemoryProvisioner(new Hosts(hosts), true))
+                .hostProvisioner(new InMemoryProvisioner(new Hosts(hosts), true, false))
                 .configserverConfig(configserverConfig)
                 .zone(new Zone(Environment.dev, RegionName.defaultName()))
                 .curator(curator)

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -186,7 +186,7 @@ public class DeployTester {
     }
 
     private static HostProvisioner createProvisioner() {
-        return new InMemoryProvisioner(true, "host0", "host1", "host2", "host3", "host4", "host5");
+        return new InMemoryProvisioner(true, false, "host0", "host1", "host2", "host3", "host4", "host5");
     }
 
     private TestComponentRegistry createComponentRegistry(Curator curator, Metrics metrics,

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -428,7 +428,7 @@ public class HostedDeployTest {
                 .configserverConfig(createConfigserverConfig(prodZone))
                 .clock(clock)
                 .zone(prodZone)
-                .hostProvisioner(new InMemoryProvisioner(new Hosts(hosts), true)).build();
+                .hostProvisioner(new InMemoryProvisioner(new Hosts(hosts), true, false)).build();
     }
 
     private static class ConfigChangeActionsModelFactory extends TestModelFactory {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/MaintainerTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/MaintainerTester.java
@@ -40,7 +40,7 @@ class MaintainerTester {
 
     MaintainerTester(Clock clock, TemporaryFolder temporaryFolder) throws IOException {
         this.curator = new MockCurator();
-        InMemoryProvisioner hostProvisioner = new InMemoryProvisioner(true, "host0", "host1", "host2", "host3", "host4");
+        InMemoryProvisioner hostProvisioner = new InMemoryProvisioner(true, false, "host0", "host1", "host2", "host3", "host4");
         ProvisionerAdapter provisioner = new ProvisionerAdapter(hostProvisioner);
         ConfigserverConfig configserverConfig = new ConfigserverConfig.Builder()
                 .hostedVespa(true)

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
@@ -27,7 +27,7 @@ public class StaticProvisionerTest {
     @Test
     public void sameHostsAreProvisioned() throws IOException, SAXException {
         ApplicationPackage app = FilesApplicationPackage.fromFile(new File("src/test/apps/hosted"));
-        InMemoryProvisioner inMemoryHostProvisioner = new InMemoryProvisioner(false, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com", "host4.yahoo.com");
+        InMemoryProvisioner inMemoryHostProvisioner = new InMemoryProvisioner(false, false, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com", "host4.yahoo.com");
         VespaModel firstModel = createModel(app, inMemoryHostProvisioner);
 
         StaticProvisioner staticProvisioner = new StaticProvisioner(firstModel.allocatedHosts(), null);


### PR DESCRIPTION
In container clusters, if it is determined that a restart is required to swicth
to a new config generation, mark that config as applicable only after a restart.

This avoids wasting resources on a config change just before a restart, and the
potential of prematurely applying config changes which depend on other changes
which are not effective before a restart has been done.
