### PR TITLE
Rebalance nodes to exclusive switches

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeHistory.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeHistory.java
@@ -45,7 +45,8 @@ public class NodeHistory {
         Rebalancer,
         ReservationExpirer,
         RetiringUpgrader,
-        SpareCapacityMaintainer
+        SpareCapacityMaintainer,
+        SwitchRebalancer,
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/LockedNodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/LockedNodeList.java
@@ -1,38 +1,25 @@
-// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision;
 
 import com.yahoo.transaction.Mutex;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.collectingAndThen;
 
 /**
- * A type-safe wrapper for {@link NodeList}. Callers that have a reference to this can safely be assumed to holding the
- * write lock for the node repository.
+ * A type-safe wrapper for {@link NodeList}. Callers that have a reference to this can safely be assumed to be holding
+ * the allocation lock for the node repository.
  *
- * This is typically used in situations where modifying a node object depends on inspecting a consistent state of other
+ * This is typically used in situations where modifying a node object depends on inspecting a consistent state of all
  * nodes in the repository.
  *
  * @author mpolden
  */
-public class LockedNodeList extends NodeList {
-
-    private final Mutex lock;
+public final class LockedNodeList extends NodeList {
 
     public LockedNodeList(List<Node> nodes, Mutex lock) {
         super(nodes, false);
-        this.lock = Objects.requireNonNull(lock, "lock must be non-null");
-    }
-
-    public LockedNodeList filter(Predicate<Node> predicate) {
-        return asList().stream()
-                       .filter(predicate)
-                       .collect(collectingAndThen(Collectors.toList(),
-                                                  (nodes) -> new LockedNodeList(nodes, lock)));
+        Objects.requireNonNull(lock, "lock must be non-null");
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -157,7 +157,7 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
     }
 
     /** Returns the parent nodes of the given child nodes */
-    public NodeList parentsOf(Collection<Node> children) {
+    public NodeList parentsOf(NodeList children) {
         return children.stream()
                        .map(this::parentOf)
                        .filter(Optional::isPresent)

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -324,7 +324,7 @@ public class NodeRepository extends AbstractComponent {
                 trustedNodes.addAll(candidates.nodeType(NodeType.config).asList());
                 trustedNodes.addAll(candidates.nodeType(NodeType.proxy).asList());
                 node.allocation().ifPresent(allocation ->
-                        trustedNodes.addAll(candidates.parentsOf(candidates.owner(allocation.owner()).asList()).asList()));
+                        trustedNodes.addAll(candidates.parentsOf(candidates.owner(allocation.owner())).asList()));
 
                 if (node.state() == State.ready) {
                     // Tenant nodes in state ready, trust:

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -7,10 +7,6 @@ import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.TransientException;
 import com.yahoo.jdisc.Metric;
-
-import java.util.Objects;
-import java.util.function.Supplier;
-import java.util.logging.Level;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -20,7 +16,10 @@ import com.yahoo.yolean.Exceptions;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMover.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMover.java
@@ -1,0 +1,78 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Deployer;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.jdisc.Metric;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.provisioning.HostCapacity;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Base class for maintainers that move nodes.
+ *
+ * @author mpolden
+ */
+public abstract class NodeMover<MOVE> extends NodeRepositoryMaintainer {
+
+    static final Duration waitTimeAfterPreviousDeployment = Duration.ofMinutes(10);
+
+    private final Deployer deployer;
+    private final MOVE emptyMove;
+
+    public NodeMover(Deployer deployer, NodeRepository nodeRepository, Duration interval, Metric metric, MOVE emptyMove) {
+        super(nodeRepository, interval, metric);
+        this.deployer = deployer;
+        this.emptyMove = emptyMove;
+    }
+
+    /** Returns a suggested move for given node */
+    protected abstract MOVE suggestedMove(Node node, Node fromHost, Node toHost, NodeList allNodes);
+
+    /** Find the best possible move */
+    protected final MOVE findBestMove(NodeList allNodes) {
+        HostCapacity capacity = new HostCapacity(allNodes, nodeRepository().resourcesCalculator());
+        MOVE bestMove = emptyMove;
+        NodeList activeNodes = allNodes.nodeType(NodeType.tenant).state(Node.State.active);
+        for (Node node : activeNodes) {
+            if (node.parentHostname().isEmpty()) continue;
+            ApplicationId applicationId = node.allocation().get().owner();
+            if (applicationId.instance().isTester()) continue;
+            if (deployedRecently(applicationId)) continue;
+            for (Node toHost : allNodes.matching(nodeRepository()::canAllocateTenantNodeTo)) {
+                if (toHost.hostname().equals(node.parentHostname().get())) continue;
+                if ( ! capacity.freeCapacityOf(toHost).satisfies(node.resources())) continue;
+
+                MOVE suggestedMove = suggestedMove(node, allNodes.parentOf(node).get(), toHost, allNodes);
+                bestMove = bestMoveOf(bestMove, suggestedMove);
+            }
+        }
+        return bestMove;
+    }
+
+    /** Returns the best move of given moves */
+    protected abstract MOVE bestMoveOf(MOVE a, MOVE b);
+
+    private boolean deployedRecently(ApplicationId application) {
+        Instant now = nodeRepository().clock().instant();
+        return deployer.lastDeployTime(application)
+                       .map(lastDeployTime -> lastDeployTime.isAfter(now.minus(waitTimeAfterPreviousDeployment)))
+                       // We only know last deploy time for applications that were deployed on this config server,
+                       // the rest will be deployed on another config server
+                       .orElse(true);
+    }
+
+    /** Returns true if no active nodes are retiring or about to be retired */
+    static boolean zoneIsStable(NodeList allNodes) {
+        NodeList active = allNodes.state(Node.State.active);
+        if (active.stream().anyMatch(node -> node.allocation().get().membership().retired())) return false;
+        if (active.stream().anyMatch(node -> node.status().wantToRetire())) return false;
+        return true;
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SpareCapacityMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SpareCapacityMaintainer.java
@@ -150,7 +150,7 @@ public class SpareCapacityMaintainer extends NodeRepositoryMaintainer {
                 overcommittedHosts.size(),
                 overcommittedHosts.stream().map(Node::hostname).collect(Collectors.joining(", "))));
 
-        if (!Rebalancer.zoneIsStable(allNodes)) return;
+        if (!NodeMover.zoneIsStable(allNodes)) return;
 
         // Find an active node on a overcommited host and retire it
         Optional<Node> nodeToRetire = overcommittedHosts.stream().flatMap(parent -> allNodes.childrenOf(parent).stream())

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SwitchRebalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SwitchRebalancer.java
@@ -1,0 +1,92 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Deployer;
+import com.yahoo.jdisc.Metric;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.maintenance.MaintenanceDeployment.Move;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Ensure that nodes within a cluster a spread across hosts on exclusive network switches.
+ *
+ * @author mpolden
+ */
+public class SwitchRebalancer extends NodeMover<Move> {
+
+    private final Metric metric;
+    private final Deployer deployer;
+
+    public SwitchRebalancer(NodeRepository nodeRepository, Duration interval, Metric metric, Deployer deployer) {
+        super(deployer, nodeRepository, interval, metric, Move.empty());
+        this.deployer = deployer;
+        this.metric = metric;
+    }
+
+    @Override
+    protected boolean maintain() {
+        boolean success = true;
+        // Using node list without holding lock as strong consistency is not needed here
+        NodeList allNodes = nodeRepository().list();
+        if (!zoneIsStable(allNodes)) return success;
+        findBestMove(allNodes).execute(false, Agent.SwitchRebalancer, deployer, metric, nodeRepository());
+        return success;
+    }
+
+    @Override
+    protected Move suggestedMove(Node node, Node fromHost, Node toHost, NodeList allNodes) {
+        NodeList clusterNodes = clusterOf(node, allNodes);
+        NodeList clusterHosts = allNodes.parentsOf(clusterNodes);
+        if (isBalanced(clusterNodes, clusterHosts)) return Move.empty();
+        if (switchInUse(toHost, clusterHosts)) return Move.empty();
+        return new Move(node, fromHost, toHost);
+    }
+
+    @Override
+    protected Move bestMoveOf(Move a, Move b) {
+        if (b.isEmpty()) return a;
+        return b;
+    }
+
+    private NodeList clusterOf(Node node, NodeList allNodes) {
+        ApplicationId application = node.allocation().get().owner();
+        ClusterSpec.Id cluster = node.allocation().get().membership().cluster().id();
+        return allNodes.state(Node.State.active)
+                       .owner(application)
+                       .cluster(cluster);
+    }
+
+    /** Returns whether switch of host is already in use by given cluster */
+    private boolean switchInUse(Node host, NodeList clusterHosts) {
+        if (host.switchHostname().isEmpty()) return false;
+        for (var clusterHost : clusterHosts) {
+            if (clusterHost.switchHostname().isEmpty()) continue;
+            if (clusterHost.switchHostname().get().equals(host.switchHostname().get())) return true;
+        }
+        return false;
+    }
+
+    /** Returns whether given cluster nodes are balanced optimally on exclusive switches */
+    private boolean isBalanced(NodeList clusterNodes, NodeList clusterHosts) {
+        Set<String> switches = new HashSet<>();
+        int exclusiveSwitches = 0;
+        for (var host : clusterHosts) {
+            if (host.switchHostname().isEmpty()) {
+                exclusiveSwitches++; // Unknown switch counts as exclusive
+            } else {
+                switches.add(host.switchHostname().get());
+            }
+        }
+        exclusiveSwitches += switches.size();
+        return clusterNodes.size() <= exclusiveSwitches;
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
@@ -22,6 +22,7 @@ public enum Agent {
     ReservationExpirer,
     DynamicProvisioningMaintainer,
     RetiringUpgrader,
-    SpareCapacityMaintainer
+    SpareCapacityMaintainer,
+    SwitchRebalancer,
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -431,6 +431,7 @@ public class NodeSerializer {
             case "ReservationExpirer" : return Agent.ReservationExpirer;
             case "RetiringUpgrader" : return Agent.RetiringUpgrader;
             case "SpareCapacityMaintainer": return Agent.SpareCapacityMaintainer;
+            case "SwitchRebalancer": return Agent.SwitchRebalancer;
         }
         throw new IllegalArgumentException("Unknown node event agent '" + eventAgentField.asString() + "'");
     }
@@ -449,6 +450,7 @@ public class NodeSerializer {
             case ReservationExpirer : return "ReservationExpirer";
             case RetiringUpgrader: return "RetiringUpgrader";
             case SpareCapacityMaintainer: return "SpareCapacityMaintainer";
+            case SwitchRebalancer: return "SwitchRebalancer";
         }
         throw new IllegalArgumentException("Serialized form of '" + agent + "' not defined");
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostCapacity.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostCapacity.java
@@ -12,8 +12,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Capacity calculation for docker hosts.
- * <p>
+ * Capacity calculation for hosts.
+ *
  * The calculations are based on an immutable copy of nodes that represents
  * all capacities in the system - i.e. all nodes in the node repo.
  *

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -199,10 +199,10 @@ public class NodePrioritizer {
         return true;
     }
 
-    private boolean isReplacement(int nofNodesInCluster, int nodeFailedNodes) {
-        if (nodeFailedNodes == 0) return false;
-
-        return requestedNodes.fulfilledBy(nofNodesInCluster - nodeFailedNodes);
+    /** Returns whether we are allocating to replace a failed node */
+    private boolean isReplacement(int nodesInCluster, int failedNodesInCluster) {
+        if (failedNodesInCluster == 0) return false;
+        return requestedNodes.fulfilledBy(nodesInCluster - failedNodesInCluster);
     }
 
     /**

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RebalancerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RebalancerTest.java
@@ -151,7 +151,7 @@ public class RebalancerTest {
                     cpuApp, new MockDeployer.ApplicationContext(cpuApp, clusterSpec("c"), Capacity.from(new ClusterResources(1, 1, cpuResources))),
                     memoryApp, new MockDeployer.ApplicationContext(memoryApp, clusterSpec("c"), Capacity.from(new ClusterResources(1, 1, memResources))));
             deployer = new MockDeployer(tester.provisioner(), tester.clock(), apps);
-            rebalancer = new Rebalancer(deployer, tester.nodeRepository(), metric, tester.clock(), Duration.ofMinutes(1));
+            rebalancer = new Rebalancer(deployer, tester.nodeRepository(), metric, Duration.ofMinutes(1));
             tester.makeReadyNodes(3, "flat", NodeType.host, 8);
             tester.activateTenantHosts();
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/SwitchRebalancerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/SwitchRebalancerTest.java
@@ -1,0 +1,116 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.Capacity;
+import com.yahoo.config.provision.ClusterResources;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.transaction.NestedTransaction;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
+import com.yahoo.vespa.hosted.provision.testutils.MockDeployer;
+import com.yahoo.vespa.hosted.provision.testutils.MockDeployer.ApplicationContext;
+import com.yahoo.vespa.hosted.provision.testutils.MockDeployer.ClusterContext;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mpolden
+ */
+public class SwitchRebalancerTest {
+
+    private static final ApplicationId app = ApplicationId.from("t1", "a1", "i1");
+
+    @Test
+    public void rebalance() {
+        ClusterSpec.Id cluster1 = ClusterSpec.Id.from("c1");
+        ClusterSpec.Id cluster2 = ClusterSpec.Id.from("c2");
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
+        MockDeployer deployer = deployer(tester, cluster1, cluster2);
+        SwitchRebalancer rebalancer = new SwitchRebalancer(tester.nodeRepository(), Duration.ofDays(1), new TestMetric(), deployer);
+
+        // Provision initial hosts on same switch
+        NodeResources hostResources = new NodeResources(48, 128, 500, 10);
+        List<Node> hosts0 = tester.makeReadyNodes(3, hostResources, NodeType.host, 5);
+        tester.activateTenantHosts();
+        String switch0 = "switch0";
+        tester.patchNodes(hosts0, (host) -> host.withSwitchHostname(switch0));
+
+        // Deploy application
+        deployer.deployFromLocalActive(app).get().activate();
+        tester.assertSwitches(Set.of(switch0), app, cluster1);
+        tester.assertSwitches(Set.of(switch0), app, cluster2);
+
+        // Rebalancing does nothing as there are no better moves to perform
+        tester.clock().advance(SwitchRebalancer.waitTimeAfterPreviousDeployment);
+        assertNoMoves(rebalancer, tester);
+
+        // Provision hosts on distinct switches
+        List<Node> hosts1 = tester.makeReadyNodes(3, hostResources, NodeType.host, 5);
+        tester.activateTenantHosts();
+        for (int i = 0; i < hosts1.size(); i++) {
+            String switchHostname = "switch" + (i + 1);
+            tester.patchNode(hosts1.get(i), (host) -> host.withSwitchHostname(switchHostname));
+        }
+
+        // Application is redeployed
+        deployer.deployFromLocalActive(app).get().activate();
+
+        // Rebalancer does nothing as not enough time has passed since previous deployment
+        assertNoMoves(rebalancer, tester);
+
+        // Rebalancer retires one node from non-exclusive switch in each cluster, and allocates a new one
+        for (var cluster : List.of(cluster1, cluster2)) {
+            tester.clock().advance(SwitchRebalancer.waitTimeAfterPreviousDeployment);
+            rebalancer.maintain();
+            NodeList allNodes = tester.nodeRepository().list();
+            NodeList clusterNodes = allNodes.owner(app).cluster(cluster).state(Node.State.active);
+            assertEquals("Node is retired in " + cluster, 1, clusterNodes.retired().size());
+            assertEquals("Cluster " + cluster + " allocates nodes on distinct switches", 2,
+                         tester.switchesOf(clusterNodes, allNodes).size());
+
+            // Retired node becomes inactive and makes zone stable
+            try (var lock = tester.provisioner().lock(app)) {
+                NestedTransaction removeTransaction = new NestedTransaction();
+                tester.nodeRepository().deactivate(clusterNodes.retired().asList(), removeTransaction, lock);
+                removeTransaction.commit();
+            }
+        }
+
+        // Next run does nothing
+        tester.clock().advance(SwitchRebalancer.waitTimeAfterPreviousDeployment);
+        assertNoMoves(rebalancer, tester);
+    }
+
+    private void assertNoMoves(SwitchRebalancer rebalancer, ProvisioningTester tester) {
+        NodeList nodes0 = tester.nodeRepository().list(Node.State.active).owner(app);
+        rebalancer.maintain();
+        NodeList nodes1 = tester.nodeRepository().list(Node.State.active).owner(app);
+        assertEquals("Node allocation is unchanged", nodes0.asList(), nodes1.asList());
+        assertEquals("No nodes are retired", List.of(), nodes1.retired().asList());
+    }
+
+    private static MockDeployer deployer(ProvisioningTester tester, ClusterSpec.Id cluster1, ClusterSpec.Id cluster2) {
+        NodeResources resources = new NodeResources(2, 4, 50, 1);
+        Capacity capacity = Capacity.from(new ClusterResources(2, 1, resources));
+        ClusterSpec spec1 = ClusterSpec.request(ClusterSpec.Type.container, cluster1).vespaVersion("1").build();
+        ClusterSpec spec2 = ClusterSpec.request(ClusterSpec.Type.content, cluster2).vespaVersion("1").build();
+        List<ClusterContext> clusterContexts = List.of(new ClusterContext(app, spec1, capacity),
+                                                       new ClusterContext(app, spec2, capacity));
+        ApplicationContext context = new ApplicationContext(app, clusterContexts);
+        return new MockDeployer(tester.provisioner(), tester.clock(), Map.of(app, context));
+    }
+
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
@@ -20,6 +20,7 @@ import com.yahoo.config.provisioning.FlavorsConfig;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.Node.State;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.IP;
@@ -67,7 +68,7 @@ public class DynamicDockerAllocationTest {
                                                                     .build();
         tester.makeReadyNodes(4, "host-small", NodeType.host, 32);
         tester.activateTenantHosts();
-        List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
+        List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, State.active);
         NodeResources flavor = new NodeResources(1, 4, 100, 1);
 
         // Application 1
@@ -88,7 +89,7 @@ public class DynamicDockerAllocationTest {
 
         // Assert that we have two spare nodes (two hosts that are don't have allocations)
         Set<String> hostsWithChildren = new HashSet<>();
-        for (Node node : tester.nodeRepository().getNodes(NodeType.tenant, Node.State.active)) {
+        for (Node node : tester.nodeRepository().getNodes(NodeType.tenant, State.active)) {
             if (!isInactiveOrRetired(node)) {
                 hostsWithChildren.add(node.parentHostname().get());
             }
@@ -110,7 +111,7 @@ public class DynamicDockerAllocationTest {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).flavorsConfig(flavorsConfig()).build();
         tester.makeReadyNodes(5, "host-small", NodeType.host, 32);
         tester.activateTenantHosts();
-        List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
+        List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, State.active);
         NodeResources resources = new NodeResources(1, 4, 100, 0.3);
 
         // Application 1
@@ -202,7 +203,7 @@ public class DynamicDockerAllocationTest {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).flavorsConfig(flavorsConfig()).build();
         tester.makeReadyNodes(2, "host-small", NodeType.host, 32);
         tester.activateTenantHosts();
-        List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, Node.State.active);
+        List<Node> dockerHosts = tester.nodeRepository().getNodes(NodeType.host, State.active);
         NodeResources flavor = new NodeResources(1, 4, 100, 1);
 
         // Application 1
@@ -216,7 +217,7 @@ public class DynamicDockerAllocationTest {
 
         // Assert that we have two spare nodes (two hosts that are don't have allocations)
         Set<String> hostsWithChildren = new HashSet<>();
-        for (Node node : tester.nodeRepository().getNodes(NodeType.tenant, Node.State.active)) {
+        for (Node node : tester.nodeRepository().getNodes(NodeType.tenant, State.active)) {
             if (!isInactiveOrRetired(node)) {
                 hostsWithChildren.add(node.parentHostname().get());
             }
@@ -301,7 +302,7 @@ public class DynamicDockerAllocationTest {
     public void allocation_should_fail_when_host_is_not_in_allocatable_state() {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).flavorsConfig(flavorsConfig()).build();
         tester.makeProvisionedNodes(3, "host-small", NodeType.host, 32).forEach(node ->
-                tester.nodeRepository().fail(node.hostname(), Agent.system, getClass().getSimpleName()));
+                                                                                        tester.nodeRepository().fail(node.hostname(), Agent.system, getClass().getSimpleName()));
 
         ApplicationId application = ProvisioningTester.makeApplicationId();
         tester.prepare(application, clusterSpec("myContent.t2.a2"), 2, 1, new NodeResources(1, 40, 100, 1));
@@ -414,6 +415,81 @@ public class DynamicDockerAllocationTest {
         assertEquals(hosts1, hosts2);
     }
 
+    @Test
+    public void testPreferExclusiveNetworkSwitch() {
+        // Hosts are provisioned, without switch information
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).flavorsConfig(flavorsConfig()).build();
+        NodeResources hostResources = new NodeResources(32, 128, 2000, 10);
+        List<Node> hosts0 = tester.makeReadyNodes(3, hostResources, NodeType.host, 5);
+        tester.activateTenantHosts();
+
+        // Application is deployed
+        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("test")).vespaVersion("1").build();
+        NodeResources resources = new NodeResources(2, 4, 50, 1);
+        ApplicationId app1 = ApplicationId.from("t1", "a1", "i1");
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(2, 1, resources))));
+        tester.assertSwitches(Set.of(), app1, cluster.id());
+
+        // One host is provisioned on a known switch
+        String switch0 = "switch0";
+        List<Node> hosts1 = tester.makeReadyNodes(1, hostResources, NodeType.host, 5);
+        tester.activateTenantHosts();
+        tester.patchNodes(hosts1, (host) -> host.withSwitchHostname(switch0));
+
+        // Redeploy does not change allocation as a host with switch information is no better or worse than hosts
+        // without switch information
+        NodeList allocatedNodes = tester.nodeRepository().list().owner(app1);
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(2, 1, resources))));
+        assertEquals("Allocation unchanged", allocatedNodes.asList(), tester.nodeRepository().getNodes(app1));
+
+        // Initial hosts are attached to the same switch
+        tester.patchNodes(hosts0, (host) -> host.withSwitchHostname(switch0));
+
+        // Redeploy does not change allocation
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(2, 1, resources))));
+        assertEquals("Allocation unchanged", allocatedNodes.asList(), tester.nodeRepository().getNodes(app1));
+
+        // Additional hosts are provisioned on distinct switches
+        List<Node> hosts2 = tester.makeReadyNodes(2, hostResources, NodeType.host, 5);
+        tester.activateTenantHosts();
+        for (var i = 0; i < hosts2.size(); i++) {
+            String switchHostname = "switch" + (i + 1);
+            tester.patchNode(hosts2.get(i), (host) -> host.withSwitchHostname(switchHostname));
+        }
+
+        // Redeploy does not change allocation as we prefer to keep our already active nodes
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(2, 1, resources))));
+        tester.assertSwitches(Set.of(switch0), app1, cluster.id());
+
+        // A node is retired
+        tester.patchNode(tester.nodeRepository().list().owner(app1).asList().get(0),
+                         (node) -> node.withWantToRetire(true, Agent.system, tester.clock().instant()));
+
+        // Redeploy allocates new node on a distinct switch
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(2, 1, resources))));
+        String switch2 = "switch2";
+        tester.assertSwitches(Set.of(switch0, switch2), app1, cluster.id());
+
+        // Growing cluster picks new node on exclusive switch
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(3, 1, resources))));
+        String switch1 = "switch1";
+        tester.assertSwitches(Set.of(switch0, switch1, switch2), app1, cluster.id());
+
+        // Growing cluster further can reuse switches as we're now out of exclusive ones
+        tester.activate(app1, tester.prepare(app1, cluster, Capacity.from(new ClusterResources(4, 1, resources))));
+        tester.assertSwitches(Set.of(switch0, switch1, switch2), app1, cluster.id());
+
+        // Additional cluster can reuse switches of existing cluster
+        ClusterSpec cluster2 = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("content")).vespaVersion("1").build();
+        tester.activate(app1, tester.prepare(app1, cluster2, Capacity.from(new ClusterResources(3, 1, resources))));
+        tester.assertSwitches(Set.of(switch0, switch1, switch2), app1, cluster2.id());
+
+        // Another application is deployed on exclusive switches
+        ApplicationId app2 = ApplicationId.from("t2", "a2", "i2");
+        tester.activate(app2, tester.prepare(app2, cluster, Capacity.from(new ClusterResources(3, 1, resources))));
+        tester.assertSwitches(Set.of(switch0, switch1, switch2), app2, cluster.id());
+    }
+
     private ApplicationId makeApplicationId(String tenant, String appName) {
         return ApplicationId.from(tenant, appName, "default");
     }
@@ -438,7 +514,7 @@ public class DynamicDockerAllocationTest {
     }
 
     private List<Node> findSpareCapacity(ProvisioningTester tester) {
-        List<Node> nodes = tester.nodeRepository().getNodes(Node.State.values());
+        List<Node> nodes = tester.nodeRepository().getNodes(State.values());
         NodeList nl = NodeList.copyOf(nodes);
         return nodes.stream()
                     .filter(n -> n.type() == NodeType.host)
@@ -457,7 +533,7 @@ public class DynamicDockerAllocationTest {
     }
 
     private boolean isInactiveOrRetired(Node node) {
-        boolean isInactive = node.state().equals(Node.State.inactive);
+        boolean isInactive = node.state().equals(State.inactive);
         boolean isRetired = false;
         if (node.allocation().isPresent()) {
             isRetired = node.allocation().get().membership().retired();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
@@ -90,10 +90,8 @@ public class DynamicDockerAllocationTest {
 
         // Assert that we have two spare nodes (two hosts that are don't have allocations)
         Set<String> hostsWithChildren = new HashSet<>();
-        for (Node node : tester.nodeRepository().getNodes(NodeType.tenant, State.active)) {
-            if (!isInactiveOrRetired(node)) {
-                hostsWithChildren.add(node.parentHostname().get());
-            }
+        for (Node node : tester.nodeRepository().list(State.active).nodeType(NodeType.tenant).not().state(State.inactive).not().retired()) {
+            hostsWithChildren.add(node.parentHostname().get());
         }
         assertEquals(4 - spareCount, hostsWithChildren.size());
 
@@ -218,10 +216,8 @@ public class DynamicDockerAllocationTest {
 
         // Assert that we have two spare nodes (two hosts that are don't have allocations)
         Set<String> hostsWithChildren = new HashSet<>();
-        for (Node node : tester.nodeRepository().getNodes(NodeType.tenant, State.active)) {
-            if (!isInactiveOrRetired(node)) {
-                hostsWithChildren.add(node.parentHostname().get());
-            }
+        for (Node node : tester.nodeRepository().list(State.active).nodeType(NodeType.tenant).not().state(State.inactive).not().retired()) {
+            hostsWithChildren.add(node.parentHostname().get());
         }
         assertEquals(2, hostsWithChildren.size());
     }
@@ -543,16 +539,6 @@ public class DynamicDockerAllocationTest {
         b.addFlavor("cpu", 40, 20, 400, 3, Flavor.Type.BARE_METAL);
         b.addFlavor("mem", 20, 40, 400, 3, Flavor.Type.BARE_METAL);
         return b.build();
-    }
-
-    private boolean isInactiveOrRetired(Node node) {
-        boolean isInactive = node.state().equals(State.inactive);
-        boolean isRetired = false;
-        if (node.allocation().isPresent()) {
-            isRetired = node.allocation().get().membership().retired();
-        }
-
-        return isInactive || isRetired;
     }
 
     private ClusterSpec clusterSpec(String clusterId) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
@@ -25,19 +25,19 @@ import static org.junit.Assert.assertEquals;
 public class NodeCandidateTest {
 
     @Test
-    public void test_order() {
+    public void testOrdering() {
         List<NodeCandidate> expected = List.of(
-                new NodeCandidate.ConcreteNodeCandidate(node("01", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), false, true, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("02", Node.State.active), new NodeResources(2, 2, 2, 2), Optional.empty(), true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("04", Node.State.reserved), new NodeResources(2, 2, 2, 2), Optional.empty(), true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("03", Node.State.inactive), new NodeResources(2, 2, 2, 2), Optional.empty(), true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("05", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.active)), true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("06", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.ready)), true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("07", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.provisioned)), true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("08", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.failed)), true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("09", Node.State.ready), new NodeResources(1, 1, 1, 1), Optional.empty(), true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("10", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("11", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), true, false, true, false)
+                new NodeCandidate.ConcreteNodeCandidate(node("01", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), false, true, true, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("02", Node.State.active), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("04", Node.State.reserved), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("03", Node.State.inactive), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("05", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.active)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("06", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.ready)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("07", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.provisioned)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("08", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.failed)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("09", Node.State.ready), new NodeResources(1, 1, 1, 1), Optional.empty(), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("10", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("11", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false)
         );
         assertOrder(expected);
     }
@@ -108,6 +108,18 @@ public class NodeCandidateTest {
         assertOrder(expected);
     }
 
+    @Test
+    public void testOrderingByExclusiveSwitch() {
+        List<NodeCandidate> expected = List.of(
+                node("1", true),
+                node("2", true),
+                node("3", false),
+                node("4", false),
+                node("5", false)
+        );
+        assertOrder(expected);
+    }
+
     private void assertOrder(List<NodeCandidate> expected) {
         List<NodeCandidate> copy = new ArrayList<>(expected);
         Collections.shuffle(copy);
@@ -133,7 +145,8 @@ public class NodeCandidateTest {
     private static NodeCandidate node(String hostname,
                                       NodeResources nodeResources,
                                       NodeResources allocatedHostResources, // allocated before adding nodeResources
-                                      NodeResources totalHostResources) {
+                                      NodeResources totalHostResources,
+                                      boolean exclusiveSwitch) {
         Node node = new Node(hostname, new IP.Config(Set.of("::1"), Set.of()), hostname, Optional.of(hostname + "parent"),
                              new Flavor(nodeResources),
                              Status.initial(), Node.State.ready, Optional.empty(), History.empty(), NodeType.tenant,
@@ -143,7 +156,20 @@ public class NodeCandidateTest {
                                Status.initial(), Node.State.ready, Optional.empty(), History.empty(), NodeType.host,
                                new Reports(), Optional.empty(), Optional.empty(), Optional.empty());
         return new NodeCandidate.ConcreteNodeCandidate(node, totalHostResources.subtract(allocatedHostResources), Optional.of(parent),
-                                                       false, false, true, false);
+                                                       false, exclusiveSwitch, false, true, false);
+    }
+
+    private static NodeCandidate node(String hostname, NodeResources nodeResources,
+                                      NodeResources allocatedHostResources, NodeResources totalHostResources) {
+        return node(hostname, nodeResources, allocatedHostResources, totalHostResources, false);
+    }
+
+    private static NodeCandidate node(String hostname, boolean exclusiveSwitch) {
+        return node(hostname,
+                    node(2, 10),
+                    host(20, 20),
+                    host(40, 40),
+                    exclusiveSwitch);
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -568,7 +568,7 @@ public class ProvisioningTester {
         assertEquals(expectedSwitches, switchesOf(activeNodes, allNodes));
     }
 
-    private Set<String> switchesOf(NodeList applicationNodes, NodeList allNodes) {
+    public Set<String> switchesOf(NodeList applicationNodes, NodeList allNodes) {
         assertTrue("All application nodes are children", applicationNodes.stream().allMatch(node -> node.parentHostname().isPresent()));
         Set<String> switches = new HashSet<>();
         for (var parent : allNodes.parentsOf(applicationNodes)) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/maintenance.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/maintenance.json
@@ -56,6 +56,9 @@
     },
     {
       "name": "SpareCapacityMaintainer"
+    },
+    {
+      "name": "SwitchRebalancer"
     }
   ],
   "inactive": []


### PR DESCRIPTION
`SwitchRebalancer` drives the balancing using the same mechanism as the existing
`Rebalancer`.

Node movers may second-guess each other, but that appears to already be case for
`Rebalancer` and `SpareCapacityMaintainer`. Haven't thought of a good solution
for that yet.

@bratseth