### PR TITLE
use vespalib::eval::operation::op1_t and op2_t as canonical

### DIFF
--- a/eval/src/vespa/eval/eval/simple_tensor.h
+++ b/eval/src/vespa/eval/eval/simple_tensor.h
@@ -6,6 +6,7 @@
 #include "tensor.h"
 #include "tensor_spec.h"
 #include "aggr.h"
+#include "operation.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/stash.h>
 #include <memory>
@@ -75,8 +76,8 @@ private:
     Cells _cells;
 
 public:
-    using map_fun_t = double (*)(double);
-    using join_fun_t = double (*)(double, double);
+    using map_fun_t = vespalib::eval::operation::op1_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
 
     SimpleTensor();
     TypedCells cells() const override { abort(); }

--- a/eval/src/vespa/eval/eval/tensor_engine.h
+++ b/eval/src/vespa/eval/eval/tensor_engine.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "aggr.h"
+#include "operation.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <memory>
 #include <vector>
@@ -36,8 +37,8 @@ struct TensorEngine
     using TensorSpec = eval::TensorSpec;
     using Value = eval::Value;
     using ValueType = eval::ValueType;
-    using join_fun_t = double (*)(double, double);
-    using map_fun_t = double (*)(double);
+    using map_fun_t = vespalib::eval::operation::op1_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
 
     virtual TensorSpec to_spec(const Value &value) const = 0;
     virtual std::unique_ptr<Value> from_spec(const TensorSpec &spec) const = 0;

--- a/eval/src/vespa/eval/eval/tensor_function.h
+++ b/eval/src/vespa/eval/eval/tensor_function.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "tensor_spec.h"
+#include "operation.h"
 #include "lazy_params.h"
 #include "value_type.h"
 #include "value.h"
@@ -126,8 +127,8 @@ const T *as(const TensorFunction &node) { return dynamic_cast<const T *>(&node);
 
 namespace tensor_function {
 
-using map_fun_t = double (*)(double);
-using join_fun_t = double (*)(double, double);
+using map_fun_t = vespalib::eval::operation::op1_t;
+using join_fun_t = vespalib::eval::operation::op2_t;
 
 class Node : public TensorFunction
 {

--- a/eval/src/vespa/eval/eval/test/tensor_model.hpp
+++ b/eval/src/vespa/eval/eval/test/tensor_model.hpp
@@ -17,8 +17,8 @@ namespace eval {
 namespace test {
 
 using CellType = ValueType::CellType;
-using map_fun_t = TensorEngine::map_fun_t;
-using join_fun_t = TensorEngine::join_fun_t;
+using map_fun_t = vespalib::eval::operation::op1_t;
+using join_fun_t = vespalib::eval::operation::op2_t;
 
 // Random access sequence of numbers
 struct Sequence {

--- a/eval/src/vespa/eval/eval/visit_stuff.h
+++ b/eval/src/vespa/eval/eval/visit_stuff.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "operation.h"
 #include <vespa/vespalib/objects/visit.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <vector>
@@ -12,8 +13,8 @@ namespace eval {
 enum class Aggr;
 struct TensorFunction;
 namespace visit {
-using map_fun_t = double (*)(double);
-using join_fun_t = double (*)(double, double);
+using map_fun_t = vespalib::eval::operation::op1_t;
+using join_fun_t = vespalib::eval::operation::op2_t;
 struct DimList {
     const std::vector<vespalib::string> &list;
     DimList(const std::vector<vespalib::string> &list_in)

--- a/eval/src/vespa/eval/instruction/generic_join.h
+++ b/eval/src/vespa/eval/instruction/generic_join.h
@@ -4,6 +4,7 @@
 
 #include <vespa/eval/eval/nested_loop.h>
 #include <vespa/eval/eval/value_type.h>
+#include <vespa/eval/eval/operation.h>
 #include <vespa/eval/eval/interpreted_function.h>
 
 namespace vespalib { class Stash; }
@@ -11,7 +12,7 @@ namespace vespalib::eval { struct ValueBuilderFactory; }
 
 namespace vespalib::eval::instruction {
 
-using join_fun_t = double (*)(double, double);
+using join_fun_t = vespalib::eval::operation::op2_t;
 
 //-----------------------------------------------------------------------------
 

--- a/eval/src/vespa/eval/tensor/default_tensor_engine.cpp
+++ b/eval/src/vespa/eval/tensor/default_tensor_engine.cpp
@@ -51,8 +51,8 @@ using CellType = eval::ValueType::CellType;
 using vespalib::IllegalArgumentException;
 using vespalib::make_string;
 
-using map_fun_t = eval::TensorEngine::map_fun_t;
-using join_fun_t = eval::TensorEngine::join_fun_t;
+using map_fun_t = vespalib::eval::operation::op1_t;
+using join_fun_t = vespalib::eval::operation::op2_t;
 
 namespace {
 

--- a/eval/src/vespa/eval/tensor/dense/dense_number_join_function.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_number_join_function.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vespa/eval/eval/tensor_function.h>
+#include <vespa/eval/eval/operation.h>
 
 namespace vespalib::tensor {
 
@@ -14,7 +15,7 @@ class DenseNumberJoinFunction : public eval::tensor_function::Join
 {
 public:
     enum class Primary : uint8_t { LHS, RHS };
-    using join_fun_t = ::vespalib::eval::tensor_function::join_fun_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
 private:
     Primary _primary;
 public:

--- a/eval/src/vespa/eval/tensor/dense/dense_simple_expand_function.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_simple_expand_function.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vespa/eval/eval/tensor_function.h>
+#include <vespa/eval/eval/operation.h>
 
 namespace vespalib::tensor {
 
@@ -20,7 +21,7 @@ class DenseSimpleExpandFunction : public eval::tensor_function::Join
     using Super = eval::tensor_function::Join;
 public:
     enum class Inner : uint8_t { LHS, RHS };
-    using join_fun_t = ::vespalib::eval::tensor_function::join_fun_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
 private:
     Inner _inner;
 public:

--- a/eval/src/vespa/eval/tensor/dense/dense_simple_join_function.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_simple_join_function.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vespa/eval/eval/tensor_function.h>
+#include <vespa/eval/eval/operation.h>
 
 namespace vespalib::tensor {
 
@@ -15,7 +16,7 @@ class DenseSimpleJoinFunction : public eval::tensor_function::Join
 public:
     enum class Primary : uint8_t { LHS, RHS };
     enum class Overlap : uint8_t { INNER, OUTER, FULL };
-    using join_fun_t = ::vespalib::eval::tensor_function::join_fun_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
 private:
     Primary _primary;
     Overlap _overlap;

--- a/eval/src/vespa/eval/tensor/dense/dense_simple_map_function.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_simple_map_function.h
@@ -12,7 +12,7 @@ namespace vespalib::tensor {
 class DenseSimpleMapFunction : public eval::tensor_function::Map
 {
 public:
-    using map_fun_t = ::vespalib::eval::tensor_function::map_fun_t;
+    using map_fun_t = vespalib::eval::operation::op1_t;
     DenseSimpleMapFunction(const eval::ValueType &result_type,
                            const TensorFunction &child,
                            map_fun_t function_in);

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_modify.h
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_modify.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/eval/eval/operation.h>
 #include <vespa/eval/tensor/tensor_visitor.h>
 #include "dense_tensor_view.h"
 
@@ -15,7 +16,7 @@ namespace vespalib::tensor {
 template <class CT>
 class DenseTensorModify : public TensorVisitor
 {
-    using join_fun_t = Tensor::join_fun_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
     join_fun_t             _op;
     const eval::ValueType &_type;
     std::vector<CT>        _cells;

--- a/eval/src/vespa/eval/tensor/dense/dense_tensor_view.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_tensor_view.cpp
@@ -315,7 +315,7 @@ DenseTensorView::reduce(join_fun_t op, const std::vector<vespalib::string> &dime
 
 struct CallModify
 {
-    using join_fun_t = DenseTensorView::join_fun_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
 
     template <typename CT>
     static std::unique_ptr<Tensor>

--- a/eval/src/vespa/eval/tensor/partial_update.cpp
+++ b/eval/src/vespa/eval/tensor/partial_update.cpp
@@ -1,6 +1,7 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "partial_update.h"
+#include <vespa/eval/eval/operation.h>
 #include <vespa/vespalib/util/overload.h>
 #include <vespa/vespalib/util/typify.h>
 #include <vespa/vespalib/util/visit_ranges.h>
@@ -16,7 +17,7 @@ namespace vespalib::tensor {
 
 namespace {
 
-using join_fun_t = double (*)(double, double);
+using join_fun_t = vespalib::eval::operation::op2_t;
 
 static constexpr size_t npos() { return -1; }
 

--- a/eval/src/vespa/eval/tensor/partial_update.h
+++ b/eval/src/vespa/eval/tensor/partial_update.h
@@ -3,11 +3,12 @@
 #pragma once
 
 #include <vespa/eval/eval/value.h>
+#include <vespa/eval/eval/operation.h>
 
 namespace vespalib::tensor {
 
 struct TensorPartialUpdate {
-    using join_fun_t = double (*)(double, double);
+    using join_fun_t = vespalib::eval::operation::op2_t;
     using Value = vespalib::eval::Value;
     using ValueBuilderFactory = vespalib::eval::ValueBuilderFactory;
 

--- a/eval/src/vespa/eval/tensor/sparse/sparse_tensor_modify.h
+++ b/eval/src/vespa/eval/tensor/sparse/sparse_tensor_modify.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/eval/eval/operation.h>
 #include <vespa/eval/tensor/tensor_visitor.h>
 #include "sparse_tensor.h"
 #include "sparse_tensor_t.h"
@@ -17,7 +18,7 @@ namespace vespalib::tensor {
 template<typename T>
 class SparseTensorModify : public TensorVisitor
 {
-    using join_fun_t = Tensor::join_fun_t;
+    using join_fun_t = vespalib::eval::operation::op2_t;
     join_fun_t             _op;
     eval::ValueType        _type;
     SparseTensorIndex      _index;

--- a/eval/src/vespa/eval/tensor/tensor.h
+++ b/eval/src/vespa/eval/tensor/tensor.h
@@ -6,6 +6,7 @@
 #include "tensor_address.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/memoryusage.h>
+#include <vespa/eval/eval/operation.h>
 #include <vespa/eval/eval/tensor.h>
 #include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/value_type.h>
@@ -28,7 +29,7 @@ class Tensor : public eval::Tensor
 public:
     typedef std::unique_ptr<Tensor> UP;
     typedef std::reference_wrapper<const Tensor> CREF;
-    using join_fun_t = double (*)(double, double);
+    using join_fun_t = vespalib::eval::operation::op2_t;
 
     Tensor();
     virtual ~Tensor() {}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review
