### PR TITLE
Hide shared endpoints when feature flag is set

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/EndpointList.java
@@ -64,6 +64,11 @@ public class EndpointList extends AbstractFilteringList<Endpoint, EndpointList> 
         return matching(endpoint -> endpoint.scope() == scope);
     }
 
+    /** Returns the subset of endpoints that use direct routing */
+    public EndpointList direct() {
+        return matching(endpoint -> endpoint.routingMethod().isDirect());
+    }
+
     public static EndpointList copyOf(Collection<Endpoint> endpoints) {
         return new EndpointList(endpoints, false);
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -20,6 +20,8 @@ import com.yahoo.vespa.athenz.api.AthenzPrincipal;
 import com.yahoo.vespa.athenz.api.AthenzUser;
 import com.yahoo.vespa.athenz.api.OktaAccessToken;
 import com.yahoo.vespa.athenz.api.OktaIdentityToken;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.Instance;
@@ -1474,6 +1476,14 @@ public class ApplicationApiTest extends ControllerContainerTest {
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-west-1/instance/instance1", GET)
                                       .userIdentity(USER_ID),
                               new File("deployment-with-routing-policy.json"));
+
+        // Hide shared endpoints
+        ((InMemoryFlagSource) tester.controller().flagSource()).withBooleanFlag(Flags.HIDE_SHARED_ROUTING_ENDPOINT.id(), true);
+
+        // GET deployment
+        tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/environment/prod/region/us-west-1/instance/instance1", GET)
+                                      .userIdentity(USER_ID),
+                              new File("deployment-without-shared-endpoints.json"));
     }
 
     private MultiPartStreamer createApplicationDeployData(ApplicationPackage applicationPackage, boolean deployDirectly) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-without-shared-endpoints.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-without-shared-endpoints.json
@@ -1,0 +1,45 @@
+{
+  "tenant": "tenant1",
+  "application": "application1",
+  "instance": "instance1",
+  "environment": "prod",
+  "region": "us-west-1",
+  "endpoints": [
+    {
+      "cluster": "default",
+      "tls": true,
+      "url": "https://instance1.application1.tenant1.us-west-1.vespa.oath.cloud/",
+      "scope": "zone",
+      "routingMethod": "exclusive"
+    }
+  ],
+  "nodes": "http://localhost:8080/zone/v2/prod/us-west-1/nodes/v2/node/?recursive=true&application=tenant1.application1.instance1",
+  "yamasUrl": "http://monitoring-system.test/?environment=prod&region=us-west-1&application=tenant1.application1.instance1",
+  "version": "6.1.0",
+  "revision": "1.0.1-commit1",
+  "deployTimeEpochMs": "(ignore)",
+  "screwdriverId": "1000",
+  "gitRepository": "repository1",
+  "gitBranch": "master",
+  "gitCommit": "commit1",
+  "applicationVersion": {
+    "hash": "1.0.1-commit1",
+    "build": 1,
+    "source": {
+      "gitRepository": "repository1",
+      "gitBranch": "master",
+      "gitCommit": "commit1"
+    },
+    "sourceUrl": "repository1/tree/commit1",
+    "commit": "commit1"
+  },
+  "status": "complete",
+  "activity": {},
+  "metrics": {
+    "queriesPerSecond": 0.0,
+    "writesPerSecond": 0.0,
+    "documentCount": 0.0,
+    "queryLatencyMillis": 0.0,
+    "writeLatencyMillis": 0.0
+  }
+}


### PR DESCRIPTION
Since DNS updates use endpoint lists, they cannot be hidden implicitly in
`RoutingController`.

@tokle