### PR TITLE
Drain all messages on flush to avoid the odd signaling on every message.

### DIFF
--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -956,7 +956,7 @@ PersistenceThread::run(framework::ThreadHandle& thread)
 void
 PersistenceThread::flush()
 {
-    while (_env._fileStorHandler.getQueueSize() != 0) {
+    while (_env._fileStorHandler.getQueueSize(_stripeId) != 0) {
         std::this_thread::sleep_for(1ms);
     }
 }

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -956,7 +956,8 @@ PersistenceThread::run(framework::ThreadHandle& thread)
 void
 PersistenceThread::flush()
 {
-    while (_env._fileStorHandler.getQueueSize(_stripeId) != 0) {
+    //TODO Only need to check for this stripe.
+    while (_env._fileStorHandler.getQueueSize() != 0) {
         std::this_thread::sleep_for(1ms);
     }
 }

--- a/storage/src/vespa/storage/persistence/persistencethread.h
+++ b/storage/src/vespa/storage/persistence/persistencethread.h
@@ -56,8 +56,6 @@ private:
     ServiceLayerComponent::UP _component;
     framework::Thread::UP     _thread;
     std::unique_ptr<BucketOwnershipNotifier> _bucketOwnershipNotifier;
-    vespalib::Monitor         _flushMonitor;
-    bool                      _closed;
 
     bool checkProviderBucketInfoMatches(const spi::Bucket&, const api::BucketInfo&) const;
 


### PR DESCRIPTION
@vekterli and @geirst PR