### PR TITLE
Make sure we don't send quota budget to older apps

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/Quota.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/Quota.java
@@ -47,6 +47,10 @@ public class Quota {
         return withBudget(BigDecimal.valueOf(budget));
     }
 
+    public Quota withoutBudget() {
+        return new Quota(maxClusterSize, Optional.empty());
+    }
+
     /** Maximum number of nodes in a cluster in a Vespa deployment */
     public OptionalInt maxClusterSize() {
         return maxClusterSize;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -537,6 +537,13 @@ public class ApplicationController {
 
             Optional<Quota> quota = billingController.getQuota(application.tenant(), zone.environment());
 
+            if (platform.isBefore(Version.fromString("7.299"))) {
+                // there is a bug in the configuration model that makes the QuotaValidator fail if the budget
+                // parameter is used.  make sure we don't send budget to deployments with these old versions.
+                // TODO: Remove once < 7.299 is no longer deployed in public and publiccd
+                quota = quota.map(Quota::withoutBudget);
+            }
+
             if (zone.environment().isManuallyDeployed())
                 controller.applications().applicationStore().putMeta(new DeploymentId(application, zone),
                                                                      clock.instant(),


### PR DESCRIPTION
Work around the budget validation in older Vespa models.